### PR TITLE
fix: close Java structured-output schema (#1230) + warn on unwired dependency slots (#1231)

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandler.java
@@ -872,13 +872,23 @@ public interface LlmProviderHandler {
                 result.remove(keyword);
             }
 
+            Set<String> required = requiredKeys(result);
+
             // Recursively process nested schemas
             Map<String, Object> properties = (Map<String, Object>) result.get("properties");
             if (properties != null) {
                 Map<String, Object> sanitizedProperties = new LinkedHashMap<>();
                 for (Map.Entry<String, Object> entry : properties.entrySet()) {
                     Map<String, Object> fieldSchema = (Map<String, Object>) entry.getValue();
-                    sanitizedProperties.put(entry.getKey(), sanitizeSchema(fieldSchema));
+                    Map<String, Object> sanitizedField = sanitizeSchema(fieldSchema);
+                    // Issue #1230 (defense-in-depth): drop the stale
+                    // anyOf:[{type:null}, X] nullable branch on REQUIRED fields so
+                    // a vendor can't satisfy "required" with null (Anthropic hint
+                    // mode bypasses makeStrict, so strip here too).
+                    if (required.contains(entry.getKey())) {
+                        sanitizedField = collapseRequiredNullBranch(sanitizedField);
+                    }
+                    sanitizedProperties.put(entry.getKey(), sanitizedField);
                 }
                 result.put("properties", sanitizedProperties);
             }
@@ -953,13 +963,22 @@ public interface LlmProviderHandler {
                 }
             }
 
+            Set<String> required = requiredKeys(result);
+
             // Recursively process nested schemas
             Map<String, Object> properties = (Map<String, Object>) result.get("properties");
             if (properties != null) {
                 Map<String, Object> strictProperties = new LinkedHashMap<>();
                 for (Map.Entry<String, Object> entry : properties.entrySet()) {
                     Map<String, Object> fieldSchema = (Map<String, Object>) entry.getValue();
-                    strictProperties.put(entry.getKey(), makeSchemaStrict(fieldSchema, addAllRequired));
+                    Map<String, Object> strictField = makeSchemaStrict(fieldSchema, addAllRequired);
+                    // Issue #1230 (defense-in-depth): a required field must not keep
+                    // its anyOf:[{type:null}, X] branch — collapse it so the vendor
+                    // can't satisfy "required" with null and silently drop content.
+                    if (required.contains(entry.getKey())) {
+                        strictField = collapseRequiredNullBranch(strictField);
+                    }
+                    strictProperties.put(entry.getKey(), strictField);
                 }
                 result.put("properties", strictProperties);
             }
@@ -982,6 +1001,61 @@ public interface LlmProviderHandler {
             }
 
             return result;
+        }
+
+        /** Collect the {@code required} string keys of a schema object (empty if absent). */
+        @SuppressWarnings("unchecked")
+        private static Set<String> requiredKeys(Map<String, Object> schema) {
+            Object req = schema.get("required");
+            if (!(req instanceof List)) {
+                return Set.of();
+            }
+            Set<String> keys = new LinkedHashSet<>();
+            for (Object r : (List<Object>) req) {
+                if (r instanceof String s) {
+                    keys.add(s);
+                }
+            }
+            return keys;
+        }
+
+        /**
+         * Issue #1230 (defense-in-depth): collapse a
+         * {@code {"anyOf"|"oneOf":[{"type":"null"}, X]}} field schema to {@code X}
+         * (sibling keys overlaid). Returns the input unchanged for any other shape.
+         */
+        @SuppressWarnings("unchecked")
+        private static Map<String, Object> collapseRequiredNullBranch(Map<String, Object> field) {
+            String combinator = field.containsKey("anyOf") ? "anyOf"
+                : field.containsKey("oneOf") ? "oneOf" : null;
+            if (combinator == null) {
+                return field;
+            }
+            Object branchesObj = field.get(combinator);
+            if (!(branchesObj instanceof List) || ((List<Object>) branchesObj).size() != 2) {
+                return field;
+            }
+            List<Object> branches = (List<Object>) branchesObj;
+            Map<String, Object> nonNull = null;
+            boolean sawNull = false;
+            for (Object b : branches) {
+                if (b instanceof Map && "null".equals(((Map<String, Object>) b).get("type"))) {
+                    sawNull = true;
+                } else if (b instanceof Map) {
+                    nonNull = (Map<String, Object>) b;
+                }
+            }
+            if (!sawNull || nonNull == null) {
+                return field;
+            }
+            Map<String, Object> collapsed = new LinkedHashMap<>(nonNull);
+            for (Map.Entry<String, Object> e : field.entrySet()) {
+                if (combinator.equals(e.getKey())) {
+                    continue;
+                }
+                collapsed.putIfAbsent(e.getKey(), e.getValue());
+            }
+            return collapsed;
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandler.java
@@ -971,13 +971,18 @@ public interface LlmProviderHandler {
                 Map<String, Object> strictProperties = new LinkedHashMap<>();
                 for (Map.Entry<String, Object> entry : properties.entrySet()) {
                     Map<String, Object> fieldSchema = (Map<String, Object>) entry.getValue();
-                    Map<String, Object> strictField = makeSchemaStrict(fieldSchema, addAllRequired);
                     // Issue #1230 (defense-in-depth): a required field must not keep
                     // its anyOf:[{type:null}, X] branch — collapse it so the vendor
                     // can't satisfy "required" with null and silently drop content.
+                    // Collapse BEFORE strictifying so that when X is a nested object
+                    // the inlined schema still flows through makeSchemaStrict and
+                    // gets additionalProperties:false + its own required expansion;
+                    // collapsing after strictification would let X bypass strict
+                    // treatment entirely.
                     if (required.contains(entry.getKey())) {
-                        strictField = collapseRequiredNullBranch(strictField);
+                        fieldSchema = collapseRequiredNullBranch(fieldSchema);
                     }
+                    Map<String, Object> strictField = makeSchemaStrict(fieldSchema, addAllRequired);
                     strictProperties.put(entry.getKey(), strictField);
                 }
                 result.put("properties", strictProperties);

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/OutputSchemaTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/OutputSchemaTest.java
@@ -670,6 +670,56 @@ class OutputSchemaTest {
         }
 
         @Test
+        @DisplayName("makeStrict(true): required field whose non-null branch is a nested object is fully strictified after collapse")
+        @SuppressWarnings("unchecked")
+        void requiredNestedObjectBranchIsStrictifiedAfterCollapse() {
+            // `address` is required and nullable: anyOf:[{type:null}, {object...}].
+            // After collapsing the null branch, the inlined OBJECT must still flow
+            // through makeSchemaStrict so it gets additionalProperties:false and its
+            // own required expansion — not just be inlined and bypass strictification.
+            Map<String, Object> addressObject = new LinkedHashMap<>();
+            addressObject.put("type", "object");
+            addressObject.put("properties", new LinkedHashMap<>(Map.of(
+                "street", Map.of("type", "string"),
+                "city", Map.of("type", "string")
+            )));
+
+            Map<String, Object> address = new LinkedHashMap<>();
+            address.put("anyOf", List.of(
+                Map.of("type", "null"),
+                addressObject
+            ));
+
+            Map<String, Object> properties = new LinkedHashMap<>();
+            properties.put("address", address);
+
+            Map<String, Object> schema = new LinkedHashMap<>();
+            schema.put("type", "object");
+            schema.put("required", List.of("address"));
+            schema.put("properties", properties);
+
+            OutputSchema output = OutputSchema.fromSchema("Nested", schema);
+            Map<String, Object> strict = output.makeStrict(true);
+
+            Map<String, Object> props = (Map<String, Object>) strict.get("properties");
+            Map<String, Object> out = (Map<String, Object>) props.get("address");
+
+            assertFalse(out.containsKey("anyOf"),
+                "required address must have its anyOf null branch collapsed. Got: " + out);
+            assertEquals("object", out.get("type"),
+                "collapsed address must retain the nested object type. Got: " + out);
+            // The crux of the fix: the inlined object is fully strictified.
+            assertEquals(false, out.get("additionalProperties"),
+                "collapsed nested object must get additionalProperties:false (full strictify, "
+                    + "not bare inline). Got: " + out);
+            List<String> nestedRequired = (List<String>) out.get("required");
+            assertNotNull(nestedRequired,
+                "collapsed nested object must get its own required expansion. Got: " + out);
+            assertTrue(nestedRequired.contains("street") && nestedRequired.contains("city"),
+                "nested object's components must be expanded into required. Got: " + nestedRequired);
+        }
+
+        @Test
         @DisplayName("makeStrict(true): newly-required field also gets its null branch stripped")
         @SuppressWarnings("unchecked")
         void addAllRequiredAlsoStripsNullBranch() {

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/OutputSchemaTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/OutputSchemaTest.java
@@ -601,4 +601,99 @@ class OutputSchemaTest {
             assertNull(addressSchema.get("required"));
         }
     }
+
+    // =========================================================================
+    // #1230: strip the nullable anyOf branch on REQUIRED fields (defense-in-depth)
+    // =========================================================================
+
+    @Nested
+    @DisplayName("#1230 required-field null-branch strip")
+    class RequiredNullBranchStrip {
+
+        /** A plain-record-shaped schema: `summary` required + carrying a stale null branch. */
+        private Map<String, Object> plainRecordSchema() {
+            Map<String, Object> summary = new LinkedHashMap<>();
+            summary.put("anyOf", List.of(
+                Map.of("type", "null"),
+                Map.of("type", "string")
+            ));
+            Map<String, Object> note = new LinkedHashMap<>();
+            note.put("anyOf", List.of(
+                Map.of("type", "null"),
+                Map.of("type", "string")
+            ));
+            Map<String, Object> properties = new LinkedHashMap<>();
+            properties.put("summary", summary);
+            properties.put("note", note);
+
+            Map<String, Object> schema = new LinkedHashMap<>();
+            schema.put("type", "object");
+            schema.put("required", List.of("summary")); // note is Optional -> not required
+            schema.put("properties", properties);
+            return schema;
+        }
+
+        @Test
+        @DisplayName("makeStrict(true) drops {type:null} on required field, collapses to {type:string}")
+        @SuppressWarnings("unchecked")
+        void makeStrictStripsRequiredNullBranch() {
+            OutputSchema output = OutputSchema.fromSchema("Plain", plainRecordSchema());
+            Map<String, Object> strict = output.makeStrict(true);
+
+            Map<String, Object> props = (Map<String, Object>) strict.get("properties");
+            Map<String, Object> summary = (Map<String, Object>) props.get("summary");
+            assertFalse(summary.containsKey("anyOf"),
+                "required summary must have its anyOf null branch collapsed. Got: " + summary);
+            assertEquals("string", summary.get("type"),
+                "required summary must collapse to {type:string}. Got: " + summary);
+        }
+
+        @Test
+        @DisplayName("sanitize() drops {type:null} on required field but leaves non-required nullable")
+        @SuppressWarnings("unchecked")
+        void sanitizeStripsRequiredNullBranchOnly() {
+            OutputSchema output = OutputSchema.fromSchema("Plain", plainRecordSchema());
+            Map<String, Object> sanitized = output.sanitize();
+
+            Map<String, Object> props = (Map<String, Object>) sanitized.get("properties");
+
+            // required `summary` -> collapsed.
+            Map<String, Object> summary = (Map<String, Object>) props.get("summary");
+            assertFalse(summary.containsKey("anyOf"),
+                "required summary anyOf should be collapsed. Got: " + summary);
+            assertEquals("string", summary.get("type"));
+
+            // non-required `note` (Optional escape hatch) -> stays nullable.
+            Map<String, Object> note = (Map<String, Object>) props.get("note");
+            assertTrue(note.containsKey("anyOf"),
+                "non-required note must stay nullable (escape hatch). Got: " + note);
+        }
+
+        @Test
+        @DisplayName("makeStrict(true): newly-required field also gets its null branch stripped")
+        @SuppressWarnings("unchecked")
+        void addAllRequiredAlsoStripsNullBranch() {
+            // No explicit `required` -> makeStrict(true) marks ALL props required,
+            // so even the previously-optional-shaped null branch must be stripped.
+            Map<String, Object> field = new LinkedHashMap<>();
+            field.put("anyOf", List.of(
+                Map.of("type", "null"),
+                Map.of("type", "string")
+            ));
+            Map<String, Object> properties = new LinkedHashMap<>();
+            properties.put("field", field);
+            Map<String, Object> schema = new LinkedHashMap<>();
+            schema.put("type", "object");
+            schema.put("properties", properties);
+
+            OutputSchema output = OutputSchema.fromSchema("AllReq", schema);
+            Map<String, Object> strict = output.makeStrict(true);
+
+            Map<String, Object> props = (Map<String, Object>) strict.get("properties");
+            Map<String, Object> out = (Map<String, Object>) props.get("field");
+            assertFalse(out.containsKey("anyOf"),
+                "field is now required (addAllRequired) so its null branch must be stripped. Got: " + out);
+            assertEquals("string", out.get("type"));
+        }
+    }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
@@ -200,7 +200,19 @@ public final class JobsRuntimeManager implements SmartLifecycle {
             // submitter. Without one, leave the slot empty (user code
             // tolerates null per the DDDI contract).
             List<MeshToolRegistry.DependencyInfo> deps = meta.dependencies();
-            if (deps == null || deps.isEmpty()) continue;
+            if (deps == null || deps.isEmpty()) {
+                // Issue #1231: a MeshJob-typed param can show "resolved" in the
+                // registry's provider-matching while its MeshJobSubmitter slot was
+                // never wired — null is injected silently and the developer only
+                // discovers it at call time. Make the unwired slot prescriptive at
+                // startup: a MeshJob submitter is wired off a DECLARED dependency,
+                // so with no dependencies there is nothing to bind it to.
+                log.warn("Consumer {} has a MeshJob parameter but declares no dependencies — "
+                        + "its MeshJobSubmitter slot will be injected as null. Declare a dependency "
+                        + "whose capability the MeshJob param maps to so the submitter can be wired.",
+                    meta.capability());
+                continue;
+            }
             // Bind the submitter to the DECLARED dependency the user typed
             // the MeshJob slot for. The wrapper paired the MeshJob param
             // positionally with one declared dependency index at
@@ -225,8 +237,15 @@ public final class JobsRuntimeManager implements SmartLifecycle {
                 depCapability = pickTaskBackedDependency(deps);
             }
             if (depCapability == null) {
-                log.debug("Consumer {} declares MeshJob slot but no declared dependency backs it; " +
-                    "skipping submitter wiring", meta.capability());
+                // Issue #1231: the MeshJob slot resolved as a param but no declared
+                // dependency is positionally paired with it (and no local task-backed
+                // dep matched the fallback), so the MeshJobSubmitter slot stays null
+                // and the developer hits null at call time. Promote from debug to warn
+                // so the unwired slot is visible at startup with a concrete remedy.
+                log.warn("Consumer {} declares a MeshJob parameter but no declared dependency backs "
+                        + "it — its MeshJobSubmitter slot will be injected as null. Declare a "
+                        + "dependency whose capability the MeshJob param maps to (positionally paired "
+                        + "with the slot) so the submitter can be wired.", meta.capability());
                 continue;
             }
             try {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -1114,7 +1114,13 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
             node = MeshSchemaSupport.rewriteRootSelfRefs(node, type);
             Map<String, Object> schema =
                 objectMapper.convertValue(node, new TypeReference<Map<String, Object>>() {});
-            return MeshSchemaSupport.inlineRefs(schema);
+            // Issue #1230: close the structured-output schema — strip the stale
+            // `anyOf:[{type:null}, X]` nullable branch from REQUIRED record
+            // components so the LLM can't satisfy "required" by returning null
+            // (which silently drops the field). Optional<T> fields are left out of
+            // `required` upstream and stay nullable (escape hatch intact).
+            return MeshSchemaSupport.stripRequiredNullBranches(
+                MeshSchemaSupport.inlineRefs(schema));
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshSchemaSupport.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshSchemaSupport.java
@@ -742,6 +742,149 @@ public final class MeshSchemaSupport {
         return node;
     }
 
+    /**
+     * Issue #1230: close the structured-output schema by stripping the stale
+     * nullable {@code anyOf} branch from REQUIRED record components.
+     *
+     * <p>The shared {@link #generator()} emits {@code NULLABLE_FIELDS_BY_DEFAULT}
+     * + {@code NULLABLE_ALWAYS_AS_ANYOF}, so a plain (non-{@code Optional},
+     * non-{@code @NotNull}) record component like {@code String summary} is
+     * generated as {@code "summary":{"anyOf":[{"type":"null"},{"type":"string"}]}}
+     * even though {@code summary} IS in the enclosing object's {@code required}
+     * array. An LLM can then satisfy "required" by returning {@code null} and the
+     * field's content is silently dropped. Pydantic (the parity target) emits no
+     * null branch for a required field ({@code "summary":{"type":"string"}}).
+     *
+     * <p>This walks the schema and, for any object node, collapses a property
+     * whose key is in that object's {@code required} array and whose schema is
+     * {@code {"anyOf"|"oneOf":[{"type":"null"}, X]}} (exactly two branches, one of
+     * which is the bare null type) down to {@code X} — preserving any sibling keys
+     * on the property (e.g. {@code description}). Properties NOT in {@code required}
+     * (the {@code Optional<T>} escape hatch) are left untouched so they stay
+     * nullable+optional. Recurses into {@code properties}, {@code items} (object or
+     * array form), and the {@code $defs}/{@code definitions} maps. Null/shape-safe;
+     * returns a new tree (does not mutate the input).
+     *
+     * <p>Scoped to the OUTPUT path ({@link MeshLlmAgentProxy} structured output);
+     * the shared generator config is deliberately NOT changed because
+     * {@link #generator()} also feeds {@link #buildToolInputSchema} whose
+     * cross-runtime dep-hash equality (see {@code MeshSchemaSupportTest}) depends
+     * on the current anyOf shape.
+     *
+     * @param schema schema Map (possibly null)
+     * @return a new schema Map with required-field null branches stripped, or {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> stripRequiredNullBranches(Map<String, Object> schema) {
+        if (schema == null) {
+            return null;
+        }
+        return (Map<String, Object>) stripRequiredNullBranchesNode(schema);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object stripRequiredNullBranchesNode(Object node) {
+        if (node instanceof Map<?, ?> mapNode) {
+            Map<String, Object> obj = (Map<String, Object>) mapNode;
+            Map<String, Object> out = new java.util.LinkedHashMap<>();
+
+            java.util.Set<String> required = new java.util.LinkedHashSet<>();
+            Object req = obj.get("required");
+            if (req instanceof List<?> reqList) {
+                for (Object r : reqList) {
+                    if (r instanceof String s) {
+                        required.add(s);
+                    }
+                }
+            }
+
+            for (Map.Entry<String, Object> e : obj.entrySet()) {
+                String key = e.getKey();
+                Object value = e.getValue();
+                if ("properties".equals(key) && value instanceof Map<?, ?> propsMap) {
+                    Map<String, Object> props = (Map<String, Object>) propsMap;
+                    Map<String, Object> newProps = new java.util.LinkedHashMap<>();
+                    for (Map.Entry<String, Object> pe : props.entrySet()) {
+                        Object propSchema = stripRequiredNullBranchesNode(pe.getValue());
+                        if (required.contains(pe.getKey())) {
+                            propSchema = collapseNullBranch(propSchema);
+                        }
+                        newProps.put(pe.getKey(), propSchema);
+                    }
+                    out.put(key, newProps);
+                } else {
+                    out.put(key, stripRequiredNullBranchesNode(value));
+                }
+            }
+            return out;
+        }
+        if (node instanceof List<?> listNode) {
+            List<Object> out = new ArrayList<>(listNode.size());
+            for (Object item : listNode) {
+                out.add(stripRequiredNullBranchesNode(item));
+            }
+            return out;
+        }
+        return node;
+    }
+
+    /**
+     * Collapse a {@code {"anyOf"|"oneOf":[{"type":"null"}, X]}} property schema to
+     * {@code X} (with the property's sibling keys overlaid onto X). When the shape
+     * is anything else (more than two branches, no null branch, not an anyOf/oneOf),
+     * the node is returned unchanged.
+     */
+    @SuppressWarnings("unchecked")
+    private static Object collapseNullBranch(Object node) {
+        if (!(node instanceof Map<?, ?> mapNode)) {
+            return node;
+        }
+        Map<String, Object> obj = (Map<String, Object>) mapNode;
+        String combinatorKey = obj.containsKey("anyOf") ? "anyOf"
+            : obj.containsKey("oneOf") ? "oneOf" : null;
+        if (combinatorKey == null) {
+            return node;
+        }
+        Object branchesObj = obj.get(combinatorKey);
+        if (!(branchesObj instanceof List<?> branches) || branches.size() != 2) {
+            return node;
+        }
+        Object nonNull = null;
+        boolean sawNull = false;
+        for (Object b : branches) {
+            if (isBareNullType(b)) {
+                sawNull = true;
+            } else {
+                nonNull = b;
+            }
+        }
+        if (!sawNull || nonNull == null) {
+            return node;
+        }
+        if (!(nonNull instanceof Map<?, ?> nnMap)) {
+            return nonNull;
+        }
+        Map<String, Object> collapsed = new java.util.LinkedHashMap<>((Map<String, Object>) nnMap);
+        // Overlay the property's sibling keys (description, etc.) without
+        // letting them clobber the kept branch's own type/structure keys.
+        for (Map.Entry<String, Object> e : obj.entrySet()) {
+            if (combinatorKey.equals(e.getKey())) {
+                continue;
+            }
+            collapsed.putIfAbsent(e.getKey(), e.getValue());
+        }
+        return collapsed;
+    }
+
+    /** True when {@code node} is exactly {@code {"type":"null"}} (its only meaningful key). */
+    private static boolean isBareNullType(Object node) {
+        if (!(node instanceof Map<?, ?> m)) {
+            return false;
+        }
+        Object type = m.get("type");
+        return "null".equals(type);
+    }
+
     /** Extract {@code <Name>} from {@code "#/$defs/<Name>"} or {@code "#/definitions/<Name>"}. */
     private static String refDefName(String ref) {
         if (ref == null) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/JobsRuntimeManagerConsumerWiringTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/JobsRuntimeManagerConsumerWiringTest.java
@@ -182,6 +182,110 @@ class JobsRuntimeManagerConsumerWiringTest {
     }
 
     /**
+     * Issue #1231 (scope A): a {@code MeshJob}-typed slot that resolves as a
+     * parameter but is never wired (no declared dependency backs it) must surface
+     * a prescriptive {@code WARN} at startup — not the previous silent
+     * {@code continue} / {@code log.debug}. Otherwise "N/N deps resolved"
+     * (registry provider-matching) masks a null MeshJobSubmitter that the
+     * developer only discovers at call time.
+     */
+    @SuppressWarnings("unused")
+    public static class NoDepConsumer {
+        public Map<String, Object> run(@Param("x") String x, MeshJob worker) {
+            return Map.of();
+        }
+    }
+
+    @Test
+    void meshJobSlotWithNoDependency_staysUnwired_andWarns() throws Exception {
+        NoDepConsumer bean = new NoDepConsumer();
+        Method method = NoDepConsumer.class.getMethod("run", String.class, MeshJob.class);
+        // No declared dependencies — the MeshJob slot cannot be backed.
+        MeshToolWrapper wrapper = new MeshToolWrapper(
+            NoDepConsumer.class.getName() + ".run",
+            "nodep_consumer",
+            "test",
+            bean,
+            method,
+            List.of(),
+            JsonMapper.builder().build(),
+            false);
+
+        MeshToolRegistry toolRegistry = new MeshToolRegistry();
+        MeshToolWrapperRegistry wrapperRegistry =
+            new MeshToolWrapperRegistry(new McpMeshToolProxyFactory(new McpHttpClient()));
+        wrapperRegistry.registerWrapper(wrapper);
+        seedToolMetadata(toolRegistry, new MeshToolRegistry.ToolMetadata(
+            "nodep_consumer", "", "1.0.0", new java.util.ArrayList<>(),
+            // No dependencies declared.
+            List.of(), Map.of(), null, true, false, bean, method));
+
+        MeshRuntime runtime = new MeshRuntime(
+            new AgentSpec("c3", "http://localhost:8000").agentId("c3-id"));
+
+        LogCapture capture = LogCapture.attach(JobsRuntimeManager.class);
+        try {
+            new JobsRuntimeManager(runtime, toolRegistry, wrapperRegistry)
+                .wireConsumers("c3-id", "http://localhost:8000");
+        } finally {
+            capture.detach();
+        }
+
+        // (1) The slot stays unwired (the silent behavior is preserved — user
+        // code still tolerates null per the DDDI contract).
+        assertNull(wrapper.getJobSubmitter(),
+            "no declared dependency backs the MeshJob slot, so it must stay unwired");
+
+        // (2) ...but the developer now sees a prescriptive WARN at startup.
+        boolean warned = capture.events.stream().anyMatch(e ->
+            "WARN".equals(e.level())
+                && e.message().contains("nodep_consumer")
+                && e.message().contains("MeshJob")
+                && e.message().toLowerCase().contains("null"));
+        assertTrue(warned,
+            "unwired MeshJob slot must produce a prescriptive WARN naming the tool, the "
+                + "MeshJob parameter, and the null outcome. Captured: " + capture.events);
+    }
+
+    /**
+     * Minimal Logback appender capturing level + formatted message of events
+     * from a target logger (mirrors {@code MeshDependsOnIntegrationTest.LogCapture}).
+     */
+    static final class LogCapture {
+        final java.util.List<LogEvent> events = new java.util.concurrent.CopyOnWriteArrayList<>();
+        private final ch.qos.logback.classic.Logger target;
+        private final ch.qos.logback.core.AppenderBase<ch.qos.logback.classic.spi.ILoggingEvent> appender;
+
+        private LogCapture(ch.qos.logback.classic.Logger target) {
+            this.target = target;
+            this.appender = new ch.qos.logback.core.AppenderBase<>() {
+                @Override
+                protected void append(ch.qos.logback.classic.spi.ILoggingEvent event) {
+                    events.add(new LogEvent(
+                        event.getLevel().toString(), event.getFormattedMessage()));
+                }
+            };
+        }
+
+        static LogCapture attach(Class<?> loggerClass) {
+            ch.qos.logback.classic.Logger logger =
+                (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(loggerClass);
+            LogCapture capture = new LogCapture(logger);
+            capture.appender.setContext(logger.getLoggerContext());
+            capture.appender.start();
+            logger.addAppender(capture.appender);
+            return capture;
+        }
+
+        void detach() {
+            target.detachAppender(appender);
+            appender.stop();
+        }
+
+        record LogEvent(String level, String message) {}
+    }
+
+    /**
      * MeshToolRegistry has no public bulk seeder; register via the public
      * registerTool path is annotation-driven. The wireConsumers loop reads
      * getAllTools(), so seed through reflection on the private map — the

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/JobsRuntimeManagerConsumerWiringTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/JobsRuntimeManagerConsumerWiringTest.java
@@ -236,15 +236,102 @@ class JobsRuntimeManagerConsumerWiringTest {
         assertNull(wrapper.getJobSubmitter(),
             "no declared dependency backs the MeshJob slot, so it must stay unwired");
 
-        // (2) ...but the developer now sees a prescriptive WARN at startup.
+        // (2) ...but the developer now sees a prescriptive WARN at startup,
+        // worded for the SPECIFIC no-declared-dependencies cause (distinct from
+        // the "no declared dependency backs it" cause exercised below).
         boolean warned = capture.events.stream().anyMatch(e ->
             "WARN".equals(e.level())
                 && e.message().contains("nodep_consumer")
-                && e.message().contains("MeshJob")
-                && e.message().toLowerCase().contains("null"));
+                && e.message().contains("MeshJob parameter")
+                && e.message().contains("declares no dependencies")
+                && e.message().contains("injected as null")
+                && e.message().contains("Declare a dependency"));
         assertTrue(warned,
-            "unwired MeshJob slot must produce a prescriptive WARN naming the tool, the "
-                + "MeshJob parameter, and the null outcome. Captured: " + capture.events);
+            "unwired MeshJob slot (empty-deps cause) must produce the SPECIFIC "
+                + "\"declares no dependencies\" WARN naming the tool, the MeshJob parameter, "
+                + "and the null outcome. Captured: " + capture.events);
+    }
+
+    /**
+     * Issue #1231 (scope A), OTHER branch: a {@code MeshJob}-typed slot whose
+     * consumer DOES declare dependencies, but where none is positionally paired
+     * with the MeshJob param (more eligible param positions than declared deps)
+     * AND none resolves to a local {@code task=true} tool, must surface the
+     * DISTINCT {@code depCapability == null} WARN — naming a different cause
+     * ("no declared dependency backs it") than the empty-deps branch above.
+     */
+    @SuppressWarnings("unused")
+    public static class UnpairedMeshJobConsumer {
+        public Map<String, Object> run(
+                @Param("x") String x,
+                McpMeshTool<String> toolA,
+                McpMeshTool<String> toolB,
+                MeshJob worker) {
+            return Map.of();
+        }
+    }
+
+    @Test
+    void meshJobSlotWithDepsButNoneBacksIt_staysUnwired_andWarnsDistinctly() throws Exception {
+        UnpairedMeshJobConsumer bean = new UnpairedMeshJobConsumer();
+        Method method = UnpairedMeshJobConsumer.class.getMethod(
+            "run", String.class, McpMeshTool.class, McpMeshTool.class, MeshJob.class);
+
+        // Eligible positions (McpMeshTool + MeshJob) = [1, 2, 3]; only TWO deps
+        // declared, so they pair with the two McpMeshTool slots — the MeshJob
+        // param at eligible index 2 is left unpaired → getMeshJobDependencyCapability() null.
+        MeshToolWrapper wrapper = new MeshToolWrapper(
+            UnpairedMeshJobConsumer.class.getName() + ".run",
+            "unpaired_consumer",
+            "test",
+            bean,
+            method,
+            List.of("tool_a", "tool_b"),
+            JsonMapper.builder().build(),
+            false);
+
+        // Precondition for THIS branch: the MeshJob slot has no positionally
+        // paired declared capability (distinct from the empty-deps case).
+        assertNull(wrapper.getMeshJobDependencyCapability(),
+            "MeshJob param must be unpaired (more eligible positions than declared deps)");
+
+        MeshToolRegistry toolRegistry = new MeshToolRegistry();
+        MeshToolWrapperRegistry wrapperRegistry =
+            new MeshToolWrapperRegistry(new McpMeshToolProxyFactory(new McpHttpClient()));
+        wrapperRegistry.registerWrapper(wrapper);
+        // Two declared deps (so pickTaskBackedDependency's single-dep fallback
+        // does NOT fire) and neither is a local task=true tool (so the local
+        // task probe finds nothing) → depCapability stays null.
+        seedToolMetadata(toolRegistry, new MeshToolRegistry.ToolMetadata(
+            "unpaired_consumer", "", "1.0.0", new java.util.ArrayList<>(),
+            List.of(dep("tool_a"), dep("tool_b")), Map.of(), null, true, false, bean, method));
+
+        MeshRuntime runtime = new MeshRuntime(
+            new AgentSpec("c4", "http://localhost:8000").agentId("c4-id"));
+
+        LogCapture capture = LogCapture.attach(JobsRuntimeManager.class);
+        try {
+            new JobsRuntimeManager(runtime, toolRegistry, wrapperRegistry)
+                .wireConsumers("c4-id", "http://localhost:8000");
+        } finally {
+            capture.detach();
+        }
+
+        assertNull(wrapper.getJobSubmitter(),
+            "no declared dependency backs the MeshJob slot, so it must stay unwired");
+
+        // DISTINCT wording for the "deps declared but none backs the slot" cause.
+        boolean warned = capture.events.stream().anyMatch(e ->
+            "WARN".equals(e.level())
+                && e.message().contains("unpaired_consumer")
+                && e.message().contains("MeshJob parameter")
+                && e.message().contains("no declared dependency backs")
+                && e.message().contains("injected as null")
+                && e.message().contains("positionally paired"));
+        assertTrue(warned,
+            "unwired MeshJob slot (no-backing-dep cause) must produce the DISTINCT "
+                + "\"no declared dependency backs it\" WARN — naming a different cause than "
+                + "the empty-deps branch. Captured: " + capture.events);
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshSchemaSupportTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshSchemaSupportTest.java
@@ -520,4 +520,130 @@ class MeshSchemaSupportTest {
         assertFalse(items.containsKey("properties"),
             "Cycle placeholder should be bounded (no further expansion). Got: " + out);
     }
+
+    // =========================================================================
+    // stripRequiredNullBranches — issue #1230 (close the structured-output schema)
+    // =========================================================================
+
+    /** Recursively assert no {@code {"type":"null"}} anyOf/oneOf branch survives. */
+    @SuppressWarnings("unchecked")
+    private static void assertNoNullBranch(Object node) {
+        if (node instanceof Map<?, ?> m) {
+            Map<String, Object> obj = (Map<String, Object>) m;
+            for (String combinator : List.of("anyOf", "oneOf")) {
+                Object branches = obj.get(combinator);
+                if (branches instanceof List<?> l) {
+                    for (Object b : l) {
+                        if (b instanceof Map<?, ?> bm) {
+                            assertFalse("null".equals(((Map<String, Object>) bm).get("type")),
+                                "Unexpected {type:null} branch in " + combinator + " at: " + obj);
+                        }
+                    }
+                }
+            }
+            for (Object v : obj.values()) {
+                assertNoNullBranch(v);
+            }
+        } else if (node instanceof List<?> l) {
+            for (Object item : l) {
+                assertNoNullBranch(item);
+            }
+        }
+    }
+
+    /** Plain record: every component non-Optional, non-@NotNull. */
+    public record Analysis(String summary, List<String> insights) {}
+
+    /** Escape hatch: an Optional<T> component stays nullable + optional. */
+    public record WithOptional(String summary, java.util.Optional<String> note) {}
+
+    /** Nested plain record exercising recursion through $defs/properties. */
+    public record Inner(String detail) {}
+    public record Outer(String title, Inner inner) {}
+
+    /** Build the structured-output schema exactly as MeshLlmAgentProxy.buildJsonSchema does. */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> outputSchema(Class<?> type) {
+        JsonNode node = MeshSchemaSupport.generator().generateSchema(type);
+        node = MeshSchemaSupport.rewriteRootSelfRefs(node, type);
+        ObjectMapper mapper = io.mcpmesh.core.MeshObjectMappers.create();
+        Map<String, Object> schema =
+            mapper.convertValue(node, new TypeReference<Map<String, Object>>() {});
+        return MeshSchemaSupport.stripRequiredNullBranches(MeshSchemaSupport.inlineRefs(schema));
+    }
+
+    @Test
+    @DisplayName("plain record: required components present AND no {type:null} branch (Pydantic parity)")
+    @SuppressWarnings("unchecked")
+    void stripRequiredNullBranches_plainRecord() {
+        Map<String, Object> out = outputSchema(Analysis.class);
+
+        // (1) Both components are in `required` (regression guard — the issue's
+        // original "fields not required" framing was wrong; they always were).
+        List<String> required = (List<String>) out.get("required");
+        assertNotNull(required, "Plain record should carry a `required` array. Got: " + out);
+        assertTrue(required.contains("summary"), "summary must be required. Got: " + out);
+        assertTrue(required.contains("insights"), "insights must be required. Got: " + out);
+
+        // (2) Pydantic-parity: NO {type:null} anyOf branch on any required field.
+        assertNoNullBranch(out);
+
+        // `summary` collapses to a bare {type:string}, not an anyOf.
+        Map<String, Object> props = (Map<String, Object>) out.get("properties");
+        Map<String, Object> summary = (Map<String, Object>) props.get("summary");
+        assertEquals("string", summary.get("type"),
+            "summary should collapse to {type:string}, no null branch. Got: " + out);
+        assertFalse(summary.containsKey("anyOf"), "summary should have no anyOf. Got: " + out);
+    }
+
+    @Test
+    @DisplayName("Optional<T> escape hatch: `note` stays out of required AND remains nullable")
+    @SuppressWarnings("unchecked")
+    void stripRequiredNullBranches_optionalUntouched() {
+        Map<String, Object> out = outputSchema(WithOptional.class);
+
+        List<String> required = (List<String>) out.get("required");
+        assertTrue(required != null && required.contains("summary"),
+            "summary (plain) must be required. Got: " + out);
+        assertFalse(required != null && required.contains("note"),
+            "Optional<String> note must NOT be required. Got: " + out);
+
+        // `summary` (required) has its null branch stripped...
+        Map<String, Object> props = (Map<String, Object>) out.get("properties");
+        Map<String, Object> summary = (Map<String, Object>) props.get("summary");
+        assertEquals("string", summary.get("type"), "summary null branch stripped. Got: " + out);
+
+        // ...but `note` (not required) stays nullable (escape hatch intact).
+        Map<String, Object> note = (Map<String, Object>) props.get("note");
+        boolean noteNullable =
+            note.containsKey("anyOf") || note.containsKey("oneOf") || "null".equals(note.get("type"));
+        assertTrue(noteNullable,
+            "Optional<String> note must remain nullable (not collapsed). Got: " + note);
+    }
+
+    @Test
+    @DisplayName("nested plain record: null branch stripped at depth (recursion)")
+    @SuppressWarnings("unchecked")
+    void stripRequiredNullBranches_nestedRecursion() {
+        Map<String, Object> out = outputSchema(Outer.class);
+
+        // No {type:null} branch survives anywhere — including the nested
+        // Inner.detail one (proves recursion into the inlined nested object).
+        assertNoNullBranch(out);
+
+        Map<String, Object> props = (Map<String, Object>) out.get("properties");
+        Map<String, Object> inner = (Map<String, Object>) props.get("inner");
+        // `inner` itself is required and collapses to the object schema.
+        Map<String, Object> innerProps = (Map<String, Object>) inner.get("properties");
+        assertNotNull(innerProps, "Nested Inner properties should be present. Got: " + out);
+        Map<String, Object> detail = (Map<String, Object>) innerProps.get("detail");
+        assertEquals("string", detail.get("type"),
+            "Nested Inner.detail should collapse to {type:string}. Got: " + out);
+    }
+
+    @Test
+    @DisplayName("stripRequiredNullBranches(null) returns null")
+    void stripRequiredNullBranches_nullSafe() {
+        assertNull(MeshSchemaSupport.stripRequiredNullBranches(null));
+    }
 }

--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -899,9 +899,21 @@ def _prepare_injection_kwargs(
                     f"for capability={dep_name!r} into param={param_name!r}"
                 )
             else:
-                log.warning(
-                    f"{tp}MeshJob param {param_name!r} on {func.__name__} "
-                    f"could not be wired: MCP_MESH_REGISTRY_URL not set"
+                # The registry provider-match ("N/N deps resolved") does NOT
+                # guarantee this slot wires: a MeshJob submitter needs the
+                # registry URL to build, and without it the param is left
+                # None silently (#1231). Route through warn_or_raise so the
+                # diagnostic rides MCP_MESH_STRICT_DI and the text can't drift.
+                warn_or_raise(
+                    log,
+                    f"{tp}⚠️ MeshJob parameter {param_name!r} on "
+                    f"'{func.__name__}' resolved its capability but its "
+                    f"submitter was NOT wired: MCP_MESH_REGISTRY_URL is not "
+                    f"set, so no MeshJobSubmitter could be constructed and "
+                    f"the parameter stays None. A registry match ('N/N deps "
+                    f"resolved') reflects provider availability, not slot "
+                    f"injection. Fix: set MCP_MESH_REGISTRY_URL so the "
+                    f"submitter for capability {dep_name!r} can be built.",
                 )
                 # Set the slot explicitly to None so the user function's
                 # call signature is satisfied even when the MeshJob param

--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -899,21 +899,21 @@ def _prepare_injection_kwargs(
                     f"for capability={dep_name!r} into param={param_name!r}"
                 )
             else:
-                # The registry provider-match ("N/N deps resolved") does NOT
-                # guarantee this slot wires: a MeshJob submitter needs the
-                # registry URL to build, and without it the param is left
-                # None silently (#1231). Route through warn_or_raise so the
-                # diagnostic rides MCP_MESH_STRICT_DI and the text can't drift.
+                # This branch knows only two facts: the MeshJob slot was
+                # matched to the declared dependency dep_name, and no
+                # registry URL is available to build a submitter — so the
+                # param is left None silently (#1231). It does NOT verify
+                # provider/capability resolution, so the message must not
+                # claim it did. Route through warn_or_raise so the diagnostic
+                # rides MCP_MESH_STRICT_DI and the text can't drift.
                 warn_or_raise(
                     log,
                     f"{tp}⚠️ MeshJob parameter {param_name!r} on "
-                    f"'{func.__name__}' resolved its capability but its "
-                    f"submitter was NOT wired: MCP_MESH_REGISTRY_URL is not "
-                    f"set, so no MeshJobSubmitter could be constructed and "
-                    f"the parameter stays None. A registry match ('N/N deps "
-                    f"resolved') reflects provider availability, not slot "
-                    f"injection. Fix: set MCP_MESH_REGISTRY_URL so the "
-                    f"submitter for capability {dep_name!r} can be built.",
+                    f"'{func.__name__}' was matched to dependency "
+                    f"{dep_name!r}, but no MeshJobSubmitter could be injected "
+                    f"because MCP_MESH_REGISTRY_URL is not set; the parameter "
+                    f"stays None. Fix: set MCP_MESH_REGISTRY_URL so the "
+                    f"submitter for dependency {dep_name!r} can be built.",
                 )
                 # Set the slot explicitly to None so the user function's
                 # call signature is satisfied even when the MeshJob param

--- a/src/runtime/python/tests/unit/test_12_dependency_injector.py
+++ b/src/runtime/python/tests/unit/test_12_dependency_injector.py
@@ -1798,23 +1798,30 @@ class TestPrescriptiveDiagnosticsAndStrictDI:
         async def submit(user_id: str, job: MeshJob = None):
             return job
 
+        # The exact diagnostic body (everything after the trace prefix) for
+        # the 'job' param + dependency 'run_workflow' + unset registry URL
+        # case. Asserting the single string in BOTH paths makes any drift
+        # between the permissive warn and the strict raise fail the test.
+        expected = (
+            "MeshJob parameter 'job' on 'submit' was matched to dependency "
+            "'run_workflow', but no MeshJobSubmitter could be injected "
+            "because MCP_MESH_REGISTRY_URL is not set; the parameter stays "
+            "None. Fix: set MCP_MESH_REGISTRY_URL so the submitter for "
+            "dependency 'run_workflow' can be built."
+        )
+
         # Permissive: prescriptive warning, slot left None, no raise.
         with caplog.at_level(logging.WARNING):
             final_kwargs, count = self._prep(submit, ["run_workflow"])
         assert final_kwargs["job"] is None
         assert count == 0
-        text = caplog.text
-        assert "MeshJob parameter 'job'" in text
-        assert "MCP_MESH_REGISTRY_URL is not set" in text
-        assert "run_workflow" in text
+        assert expected in caplog.text
 
         # Strict: the SAME diagnostic raises StrictDIError with the same text.
         self._enable_strict(monkeypatch)
-        with pytest.raises(
-            StrictDIError, match="MCP_MESH_REGISTRY_URL is not set"
-        ) as exc_info:
+        with pytest.raises(StrictDIError) as exc_info:
             self._prep(submit, ["run_workflow"])
-        assert "MeshJob parameter 'job'" in str(exc_info.value)
+        assert expected in str(exc_info.value)
 
     def test_strict_untyped_single_param_zero_deps_does_not_raise(
         self, monkeypatch

--- a/src/runtime/python/tests/unit/test_12_dependency_injector.py
+++ b/src/runtime/python/tests/unit/test_12_dependency_injector.py
@@ -1777,6 +1777,45 @@ class TestPrescriptiveDiagnosticsAndStrictDI:
 
         assert "will remain None" in caplog.text
 
+    def test_meshjob_unwired_submitter_routes_through_warn_or_raise(
+        self, caplog, monkeypatch
+    ):
+        """#1231: a MeshJob slot whose capability resolved at the registry
+        but whose submitter could not be built (MCP_MESH_REGISTRY_URL
+        unset) is the clear unwired-slot case. It must route through
+        ``warn_or_raise`` — a prescriptive permissive warning by default,
+        and a ``StrictDIError`` with the SAME text under
+        ``MCP_MESH_STRICT_DI``. 'N/N deps resolved' is registry
+        provider-matching, not slot injection, so this silent-None must be
+        surfaced."""
+        from mesh.types import MeshJob
+        from _mcp_mesh.engine.strict_di import StrictDIError
+
+        # The unwired condition: capability declared (so the MeshJob branch
+        # is reached) but no registry URL to construct the submitter.
+        monkeypatch.delenv("MCP_MESH_REGISTRY_URL", raising=False)
+
+        async def submit(user_id: str, job: MeshJob = None):
+            return job
+
+        # Permissive: prescriptive warning, slot left None, no raise.
+        with caplog.at_level(logging.WARNING):
+            final_kwargs, count = self._prep(submit, ["run_workflow"])
+        assert final_kwargs["job"] is None
+        assert count == 0
+        text = caplog.text
+        assert "MeshJob parameter 'job'" in text
+        assert "MCP_MESH_REGISTRY_URL is not set" in text
+        assert "run_workflow" in text
+
+        # Strict: the SAME diagnostic raises StrictDIError with the same text.
+        self._enable_strict(monkeypatch)
+        with pytest.raises(
+            StrictDIError, match="MCP_MESH_REGISTRY_URL is not set"
+        ) as exc_info:
+            self._prep(submit, ["run_workflow"])
+        assert "MeshJob parameter 'job'" in str(exc_info.value)
+
     def test_strict_untyped_single_param_zero_deps_does_not_raise(
         self, monkeypatch
     ):

--- a/src/runtime/python/tests/unit/test_health_check_manager.py
+++ b/src/runtime/python/tests/unit/test_health_check_manager.py
@@ -2,7 +2,6 @@
 Unit tests for health check manager functionality.
 """
 
-import asyncio
 from datetime import UTC, datetime
 from typing import Any
 
@@ -106,25 +105,52 @@ async def test_health_check_function_failure_returns_degraded(agent_config):
 
 
 @pytest.mark.asyncio
-async def test_health_check_cache_expiration():
-    """Test that cache expires after TTL."""
+async def test_health_check_cache_expiration(monkeypatch):
+    """Test that cache expires after TTL.
+
+    Hermetic by construction (issue #1225):
+
+    - Uses a unique agent_id so no other coroutine in the suite can touch
+      this test's cache key. The shared "test-agent" id is health-checked by
+      a persistent background refresh loop spawned in fastapiserver_setup
+      (``_refresh_health_loop``, ttl=15) when sibling tests configure a
+      ``health_check``; a leaked instance of that loop can repopulate
+      ``health:test-agent`` during a real sleep window, turning the second
+      call into a cache HIT.
+    - Drives a controlled monotonic clock instead of ``asyncio.sleep(2)`` so
+      TTL expiry is explicit and instantaneous — deterministic, fast, and
+      immune to any concurrent repopulation. The cache reads
+      ``time.monotonic()`` (health_check_manager.py); we patch that.
+    """
+    agent_id = "test-agent-cache-expiration"
     call_count = 0
 
     async def health_check_fn() -> HealthStatus:
         nonlocal call_count
         call_count += 1
         return HealthStatus(
-            agent_name="test-agent",
+            agent_name=agent_id,
             status=HealthStatusType.HEALTHY,
             capabilities=["test"],
             timestamp=datetime.now(UTC),
         )
 
-    agent_config = {"name": "test-agent", "capabilities": ["test"]}
+    agent_config = {"name": agent_id, "capabilities": ["test"]}
 
-    # First call - cache miss
+    # Controlled monotonic clock — advanced explicitly so TTL expiry is
+    # deterministic without any wall-clock sleep.
+    fake_now = {"t": 1000.0}
+
+    def fake_monotonic() -> float:
+        return fake_now["t"]
+
+    monkeypatch.setattr(
+        "_mcp_mesh.shared.health_check_manager.time.monotonic", fake_monotonic
+    )
+
+    # First call - cache miss (stores expiry = 1000.0 + 1 = 1001.0)
     await get_health_status_with_cache(
-        agent_id="test-agent",
+        agent_id=agent_id,
         health_check_fn=health_check_fn,
         agent_config=agent_config,
         startup_context={},
@@ -133,12 +159,12 @@ async def test_health_check_cache_expiration():
 
     assert call_count == 1
 
-    # Wait for cache to expire
-    await asyncio.sleep(2)
+    # Advance the clock past the stored expiry so the cache is expired.
+    fake_now["t"] = 1002.0
 
     # Second call - cache expired, should call again
     await get_health_status_with_cache(
-        agent_id="test-agent",
+        agent_id=agent_id,
         health_check_fn=health_check_fn,
         agent_config=agent_config,
         startup_context={},

--- a/src/runtime/typescript/src/__tests__/unwired-slot-warn.spec.ts
+++ b/src/runtime/typescript/src/__tests__/unwired-slot-warn.spec.ts
@@ -1,12 +1,12 @@
 /**
  * Unwired typed-dependency-slot diagnostics (issue #1231).
  *
- * "N/N deps resolved" is registry provider-matching, not slot injection: a
- * typed dependency slot can resolve at the registry yet never receive an
- * injected proxy, leaving the parameter silently null. The deps array is
- * rebuilt PER CALL, so the diagnostic must warn ONCE per tool+slot (a
- * per-call warning would spam) and only AFTER the settle latch has flipped
- * (during settling the proxy may still land).
+ * A declared typed dependency slot can remain null after the settle window
+ * closes — no proxy was ever injected — leaving the parameter silently null.
+ * The deps array is rebuilt PER CALL, so the diagnostic must warn ONCE per
+ * tool+slot (a per-call warning would spam) and only AFTER the settle latch
+ * has flipped (during settling the proxy may still land). The same warn-once
+ * dedupe spans BOTH the inbound HTTP path and the claim-dispatch path.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { z } from "zod";
@@ -69,7 +69,7 @@ afterEach(() => {
 function unwiredWarnings(): string[] {
   return (warnSpy?.mock.calls ?? [])
     .map((call) => String(call[0]))
-    .filter((msg) => msg.includes("resolved but no proxy was injected"));
+    .filter((msg) => msg.includes("no proxy was injected"));
 }
 
 describe("unwired typed-slot warning (#1231)", () => {
@@ -133,5 +133,67 @@ describe("unwired typed-slot warning (#1231)", () => {
 
     expect(await execute({})).toBe("wired");
     expect(unwiredWarnings()).toHaveLength(0);
+  });
+
+  it("warns ONCE for an unwired slot on the claim-dispatch path", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, {
+      name: "claim-agent",
+      httpPort: 0,
+    });
+    agent.addTool({
+      name: "task_tool",
+      task: true,
+      parameters: z.object({}),
+      dependencies: [{ capability: "missing_cap" }],
+      execute: async (_args: unknown, dep: unknown) =>
+        dep ? "wired" : "unwired",
+    });
+
+    // The claim-dispatch path is exercised via the registered ClaimHandler
+    // (one per task: true tool), not via FastMCP's execute().
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { handler } = (agent as any)._taskHandlers.get("task_tool");
+    // meshJobParamIndex is unset, so the dummy controller is never spliced
+    // into callArgs — the user execute() only sees (payload, dep).
+    for (let i = 0; i < 3; i++) {
+      expect(await handler({}, {} as never)).toBe("unwired");
+    }
+
+    const warnings = unwiredWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("missing_cap");
+    expect(warnings[0]).toContain("task_tool");
+    expect(warnings[0]).toContain("slot 0");
+  });
+
+  it("dedupes the unwired warning ACROSS the inbound and claim paths", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, {
+      name: "both-paths-agent",
+      httpPort: 0,
+    });
+    agent.addTool({
+      name: "task_tool",
+      task: true,
+      parameters: z.object({}),
+      dependencies: [{ capability: "missing_cap" }],
+      execute: async (_args: unknown, dep: unknown) =>
+        dep ? "wired" : "unwired",
+    });
+
+    const execute = fastmcp.addTool.mock.calls[0][0].execute as (
+      args: unknown,
+    ) => Promise<string>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { handler } = (agent as any)._taskHandlers.get("task_tool");
+
+    // Exercise the same tool+slot via BOTH paths — the shared
+    // _unwiredSlotWarned Set must dedupe to a single warning total.
+    expect(await execute({})).toBe("unwired");
+    expect(await handler({}, {} as never)).toBe("unwired");
+    expect(await execute({})).toBe("unwired");
+
+    expect(unwiredWarnings()).toHaveLength(1);
   });
 });

--- a/src/runtime/typescript/src/__tests__/unwired-slot-warn.spec.ts
+++ b/src/runtime/typescript/src/__tests__/unwired-slot-warn.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * Unwired typed-dependency-slot diagnostics (issue #1231).
+ *
+ * "N/N deps resolved" is registry provider-matching, not slot injection: a
+ * typed dependency slot can resolve at the registry yet never receive an
+ * injected proxy, leaving the parameter silently null. The deps array is
+ * rebuilt PER CALL, so the diagnostic must warn ONCE per tool+slot (a
+ * per-call warning would spam) and only AFTER the settle latch has flipped
+ * (during settling the proxy may still land).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { z } from "zod";
+import { MeshAgent, __resetUnwiredSlotWarnedForTests } from "../agent.js";
+import { RouteRegistry } from "../route.js";
+import { resetSettleStateForTests } from "../settle.js";
+
+function makeFastMCPStub() {
+  return {
+    addTool: vi.fn(),
+    start: vi.fn(),
+    getApp: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+let autoStartSpy: ReturnType<typeof vi.spyOn> | null = null;
+let warnSpy: ReturnType<typeof vi.spyOn> | null = null;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  autoStartSpy = vi
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .spyOn(MeshAgent.prototype as any, "_autoStart")
+    .mockImplementation(async () => {
+      /* no-op */
+    });
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    /* swallow */
+  });
+  savedEnv.MCP_MESH_SETTLE_TIMEOUT = process.env.MCP_MESH_SETTLE_TIMEOUT;
+  savedEnv.MCP_MESH_TOOL_ISOLATION = process.env.MCP_MESH_TOOL_ISOLATION;
+  process.env.MCP_MESH_TOOL_ISOLATION = "false";
+  // Disable the settle grace so the agent is settled immediately — a null
+  // slot here is genuinely unwired, exactly the case the warning targets.
+  process.env.MCP_MESH_SETTLE_TIMEOUT = "0";
+  resetSettleStateForTests();
+  RouteRegistry.reset();
+  __resetUnwiredSlotWarnedForTests();
+});
+
+afterEach(() => {
+  if (autoStartSpy) {
+    autoStartSpy.mockRestore();
+    autoStartSpy = null;
+  }
+  if (warnSpy) {
+    warnSpy.mockRestore();
+    warnSpy = null;
+  }
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetSettleStateForTests();
+  RouteRegistry.reset();
+  __resetUnwiredSlotWarnedForTests();
+});
+
+function unwiredWarnings(): string[] {
+  return (warnSpy?.mock.calls ?? [])
+    .map((call) => String(call[0]))
+    .filter((msg) => msg.includes("resolved but no proxy was injected"));
+}
+
+describe("unwired typed-slot warning (#1231)", () => {
+  it("warns ONCE per tool+slot across multiple calls, not per-call", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, {
+      name: "unwired-agent",
+      httpPort: 0,
+    });
+    agent.addTool({
+      name: "consumer_tool",
+      parameters: z.object({}),
+      dependencies: [{ capability: "missing_cap" }],
+      // Defensive user idiom — the dep slot is never resolved, so it stays
+      // null on every call.
+      execute: async (_args: unknown, dep: unknown) =>
+        dep ? "wired" : "unwired",
+    });
+    const execute = fastmcp.addTool.mock.calls[0][0].execute as (
+      args: unknown,
+    ) => Promise<string>;
+
+    for (let i = 0; i < 3; i++) {
+      expect(await execute({})).toBe("unwired");
+    }
+
+    const warnings = unwiredWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("missing_cap");
+    expect(warnings[0]).toContain("consumer_tool");
+    expect(warnings[0]).toContain("slot 0");
+  });
+
+  it("does not warn when the slot actually wires", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, {
+      name: "wired-agent",
+      httpPort: 0,
+    });
+    agent.addTool({
+      name: "wired_tool",
+      parameters: z.object({}),
+      dependencies: [{ capability: "present_cap" }],
+      execute: async (_args: unknown, dep: unknown) =>
+        dep ? "wired" : "unwired",
+    });
+    const execute = fastmcp.addTool.mock.calls[0][0].execute as (
+      args: unknown,
+    ) => Promise<string>;
+
+    // Resolve the dependency so a real proxy lands in the slot.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).handleDependencyAvailable(
+      "present_cap",
+      "http://localhost:19999",
+      "remote_fn",
+      "provider-agent",
+      "wired_tool",
+      0,
+    );
+
+    expect(await execute({})).toBe("wired");
+    expect(unwiredWarnings()).toHaveLength(0);
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -48,7 +48,11 @@ import {
   spliceJobController,
 } from "./inbound-job-dispatch.js";
 import { MeshJobSubmitter } from "./mesh-job-submitter.js";
-import { getSettleState, type PendingSettleDep } from "./settle.js";
+import {
+  getSettleState,
+  type PendingSettleDep,
+  type SettleState,
+} from "./settle.js";
 import {
   ClaimDispatcher,
   stopDispatchers,
@@ -650,41 +654,11 @@ export class MeshAgent {
       // MeshJobSubmitter targeting that dep's capability. We bind the
       // submitter to the live registryUrl/agentId so it can submit
       // jobs without needing access to the agent instance.
-      const depsArray: (McpMeshTool | MeshJobSubmitter | null)[] = normalizedDeps.map(
-        (dep, depIndex) => {
-          if (depIndex === meshJobDepIndex) {
-            // Build the submitter lazily per call so we always pick
-            // up the current registryUrl (test harnesses sometimes
-            // mutate it between calls).
-            return new MeshJobSubmitter(
-              dep.capability,
-              this.agentId,
-              this.config.registryUrl,
-            );
-          }
-          const proxy =
-            this.resolvedDeps.get(`${toolName}:dep_${depIndex}`) ?? null;
-          // #1231: a typed dep slot that resolved at the registry but never
-          // got a proxy injected stays null silently. Warn ONCE per
-          // tool+slot (per-call would spam — the array is rebuilt every
-          // call). Settle-gated: while the agent is still settling the dep
-          // may yet resolve, so only warn once the latch has flipped.
-          if (proxy === null && settleState.isSettled()) {
-            const slotKey = `${toolName}:dep_${depIndex}`;
-            if (!_unwiredSlotWarned.has(slotKey)) {
-              _unwiredSlotWarned.add(slotKey);
-              console.warn(
-                `[mesh-tool] dependency '${dep.capability}' on '${toolName}' ` +
-                  `resolved but no proxy was injected into positional slot ` +
-                  `${depIndex} — the parameter stays null after settling. A ` +
-                  `registry match ('N/N deps resolved') reflects provider ` +
-                  `availability, not slot injection. Fix: ensure the provider ` +
-                  `for '${dep.capability}' is reachable.`,
-              );
-            }
-          }
-          return proxy;
-        },
+      const depsArray = this._buildDepSlots(
+        toolName,
+        normalizedDeps,
+        meshJobDepIndex,
+        settleState,
       );
       const injectedCount = depsArray.filter((d) => d !== null).length;
 
@@ -971,17 +945,11 @@ export class MeshAgent {
             await settleState.awaitPending(pendingSettle);
           }
         }
-        const liveDeps: (McpMeshTool | MeshJobSubmitter | null)[] = normalizedDeps.map(
-          (dep, depIndex) => {
-            if (depIndex === meshJobDepIndex) {
-              return new MeshJobSubmitter(
-                dep.capability,
-                this.agentId,
-                this.config.registryUrl,
-              );
-            }
-            return this.resolvedDeps.get(`${toolName}:dep_${depIndex}`) ?? null;
-          },
+        const liveDeps = this._buildDepSlots(
+          toolName,
+          normalizedDeps,
+          meshJobDepIndex,
+          settleState,
         );
         const callArgs = spliceJobController(
           payload,
@@ -1144,6 +1112,60 @@ export class MeshAgent {
       this._bearerIds.set(bearer, id);
     }
     return id;
+  }
+
+  /**
+   * Build the positional dependency-slot array for one tool call, shared by
+   * BOTH the inbound HTTP wrapper (wrappedExecute) and the claim-dispatch
+   * path (the ClaimHandler for task:true tools). Centralising this keeps the
+   * two slot-assembly sites identical:
+   *   - the MeshJob slot (meshJobDepIndex) → a freshly-bound MeshJobSubmitter
+   *   - every other slot → resolvedDeps.get(`${toolName}:dep_${index}`) ?? null
+   *
+   * #1231: a typed dep slot can resolve at the registry yet never receive an
+   * injected proxy, leaving the parameter null. Once the settle latch has
+   * flipped (during settling the proxy may still land), warn ONCE per
+   * tool+slot — the array is rebuilt per call, so a per-call warning would
+   * spam. The warn-once dedupe keys on `${toolName}:dep_${index}` via the
+   * module-level `_unwiredSlotWarned` Set, so a tool exercised via BOTH the
+   * inbound and claim paths warns at most once total.
+   */
+  private _buildDepSlots(
+    toolName: string,
+    normalizedDeps: NormalizedDependency[],
+    meshJobDepIndex: number | undefined,
+    settleState: SettleState,
+  ): (McpMeshTool | MeshJobSubmitter | null)[] {
+    return normalizedDeps.map((dep, depIndex) => {
+      if (depIndex === meshJobDepIndex) {
+        // Build the submitter lazily per call so we always pick up the
+        // current registryUrl (test harnesses sometimes mutate it between
+        // calls).
+        return new MeshJobSubmitter(
+          dep.capability,
+          this.agentId,
+          this.config.registryUrl,
+        );
+      }
+      const slotKey = `${toolName}:dep_${depIndex}`;
+      const proxy = this.resolvedDeps.get(slotKey) ?? null;
+      // #1231: a declared typed dep slot that is still null AFTER settling
+      // never received an injected proxy. Warn ONCE per tool+slot. Note this
+      // is a post-settle null — there is no per-slot "resolved" signal here,
+      // so the message must not claim registry resolution.
+      if (proxy === null && settleState.isSettled()) {
+        if (!_unwiredSlotWarned.has(slotKey)) {
+          _unwiredSlotWarned.add(slotKey);
+          console.warn(
+            `[mesh-tool] dependency '${dep.capability}' on '${toolName}' ` +
+              `is still null after settling — no proxy was injected into ` +
+              `positional slot ${depIndex}. Fix: ensure the provider for ` +
+              `'${dep.capability}' is registered and reachable.`,
+          );
+        }
+      }
+      return proxy;
+    });
   }
 
   private _getOrBuildA2AClient(config: A2AClientConfig): A2AClient {

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -149,6 +149,18 @@ let autoStartScheduled = false;
 // async boundaries (e.g. one agent per test in a harness) stay allowed.
 let constructionGuardName: string | null = null;
 
+// #1231: warn-once dedupe for typed dependency slots that resolved at the
+// registry ("N/N deps resolved") but did not actually wire — the proxy was
+// never injected and the slot stays null. The deps array is rebuilt PER
+// CALL, so a per-call warn would spam; this set keys on `${toolName}:${dep}`
+// so each unwired slot warns exactly once per process.
+const _unwiredSlotWarned = new Set<string>();
+
+/** Test support: drop the warn-once dedupe so a fresh suite warns again. */
+export function __resetUnwiredSlotWarnedForTests(): void {
+  _unwiredSlotWarned.clear();
+}
+
 // Schedule auto-start after module loading completes
 function scheduleAutoStart(): void {
   if (autoStartScheduled) return;
@@ -650,7 +662,28 @@ export class MeshAgent {
               this.config.registryUrl,
             );
           }
-          return this.resolvedDeps.get(`${toolName}:dep_${depIndex}`) ?? null;
+          const proxy =
+            this.resolvedDeps.get(`${toolName}:dep_${depIndex}`) ?? null;
+          // #1231: a typed dep slot that resolved at the registry but never
+          // got a proxy injected stays null silently. Warn ONCE per
+          // tool+slot (per-call would spam — the array is rebuilt every
+          // call). Settle-gated: while the agent is still settling the dep
+          // may yet resolve, so only warn once the latch has flipped.
+          if (proxy === null && settleState.isSettled()) {
+            const slotKey = `${toolName}:dep_${depIndex}`;
+            if (!_unwiredSlotWarned.has(slotKey)) {
+              _unwiredSlotWarned.add(slotKey);
+              console.warn(
+                `[mesh-tool] dependency '${dep.capability}' on '${toolName}' ` +
+                  `resolved but no proxy was injected into positional slot ` +
+                  `${depIndex} — the parameter stays null after settling. A ` +
+                  `registry match ('N/N deps resolved') reflects provider ` +
+                  `availability, not slot injection. Fix: ensure the provider ` +
+                  `for '${dep.capability}' is reachable.`,
+              );
+            }
+          }
+          return proxy;
         },
       );
       const injectedCount = depsArray.filter((d) => d !== null).length;


### PR DESCRIPTION
## Summary

Two related "stop silent failures" fixes — a structured-output correctness gap and a wiring-visibility gap. Both push the runtimes toward Python parity and toward the project's "runtime warning is the discovery surface" principle.

## #1230 — Java structured-output schema let the LLM return `null` for required fields

The issue's original framing was wrong (verified empirically): record components **were** already in `required`. The real defect: each plain (non-`Optional`) component carried a stale `anyOf: [{"type":"null"}, X]` nullable branch, so the LLM satisfied "required" by returning `null` and the field content was **silently dropped**. Pydantic (the parity target) emits no null branch.

**Fix:** `MeshSchemaSupport.stripRequiredNullBranches` collapses `anyOf/oneOf:[{type:null}, X]` → `X` for any property in the enclosing object's `required` (recursing `properties`/`items`/`$defs`), wired into `MeshLlmAgentProxy.buildJsonSchema` on the **output path only** — the shared victools generator config is untouched, so cross-runtime dependency-schema hashes are unchanged. Defense-in-depth in the vendor handler sanitizers covers Anthropic hint-mode (which bypasses `makeStrict`). `Optional<T>` stays the escape hatch for genuinely-nullable output fields. +7 tests.

## #1231 — "N/N resolved" didn't mean "wired" (scope A: runtime warning)

A resolved dependency count is registry provider-matching, not runtime slot injection — a MeshJob-typed param could show resolved while its submitter slot was left `null` silently, forcing SDK-source spelunking to diagnose. Now surfaced at the point of failure:
- **Java** — `JobsRuntimeManager.wireConsumers` promotes two silent skip branches to a prescriptive `log.warn` (tool + MeshJob param + remedy).
- **Python** — the unwired-MeshJob-submitter case routes through the existing `warn_or_raise` (strict-DI #1199), so it rides `MCP_MESH_STRICT_DI`.
- **TypeScript** — warn-once-per-tool (deduped, settle-gated) on an unwired McpMeshTool slot.

### Deferred (deliberately, with rationale)
- **meshctl/audit surface (option C):** injection state isn't reported to the registry — surfacing it needs a heartbeat field + ent migration + CLI column (multi-PR). The runtime warning already achieves the issue's goal.
- **Python McpMeshTool-`None` warning:** routing it through `warn_or_raise` conflicts with the pinned #1196 contract (call-time unfilled-slot diagnostics stay permissive even under strict; decoration-time owns the strict-raise). Needs a design decision — left out rather than break the contract.
- **TS claim-path twin + MeshJob-falsy case:** fast-follow.

## Verification
Java: full Maven reactor build green (spring-boot-starter 461, spring-ai 159, 0 failures). Python: full unit suite green (incl. the new strict-DI case). TypeScript: 948 tests pass. No Go changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured output schema handling so required fields with nullable branches are now treated as non-nullable, while optional nullable fields still behave as expected.
  * Added clearer warnings when a job or tool dependency cannot be wired, including cases where setup is incomplete or a proxy is missing after settling.
  * Made missing dependency wiring behavior more consistent across Java, Python, and TypeScript runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->