### PR TITLE
feat: MeshJob stale-job reaping + request_input() primitive (closes #1229)

### DIFF
--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -514,6 +514,15 @@ export DEFAULT_EVICTION_THRESHOLD=60  # Evict stale agents (seconds)
 # rows). Event rows are governed by a separate hardcoded 100k row cap.
 export MCP_MESH_RETENTION=1h
 
+# MeshJob default total-runtime ceiling. Go duration string (e.g. "2h",
+# "30m"). Applies a DEFAULT total_deadline — measured from a job's
+# submission time — to jobs that did NOT set their own total_deadline; a
+# job that exceeds it is marked failed with a "stale: ..." reason and a
+# synthetic `stale` event. Jobs that set their own total_deadline are
+# unaffected. Default: off (unset / "0") — jobs without an explicit
+# total_deadline run unbounded, subject only to lease recovery.
+export MCP_MESH_JOB_STALE_TIMEOUT=2h
+
 # CORS
 export ENABLE_CORS=true
 export ALLOWED_ORIGINS="*"

--- a/src/core/cli/man/content/jobs.md
+++ b/src/core/cli/man/content/jobs.md
@@ -293,6 +293,23 @@ registry waits a small grace window before issuing the cancel-forward
 (default 200ms, tunable via `MCP_MESH_CANCEL_EVENT_GRACE_MS`, capped
 at 10s) so the synthetic event lands before the cancel token fires.
 
+**Synthetic stale event**. When the registry reaps a job for exceeding
+the `MCP_MESH_JOB_STALE_TIMEOUT` default ceiling (see **Reaping and
+lease recovery**), it writes a synthetic
+`{"type": "stale", "payload": {"reason": "stale", "detail": "..."}}`
+event into the log as it transitions the job to `failed`. A handler
+parked on `recv_event(types=["stale", ...])` observes the reaping and
+can unwind cleanly:
+
+```python
+event = await job.recv_event(types=["stale", "cancelled"], timeout_secs=30.0)
+if event and event["type"] == "stale":
+    return {"status": "aborted", "reason": event["payload"]["detail"]}
+```
+
+No SDK change is needed — `stale` is an ordinary event type, so the
+existing `recv_event` / stream paths surface it across every runtime.
+
 ## Stream subscription
 
 Non-destructive observer iterator. Multiple subscribers can mirror
@@ -348,6 +365,37 @@ deadline regardless of depth.
 The header is on the default `MCP_MESH_PROPAGATE_HEADERS` allowlist
 alongside `X-Mesh-Job-Id` and `X-Mesh-Trace-Id` — no per-agent
 configuration is needed.
+
+## Reaping and lease recovery
+
+A registry cron sweep keeps the job pool healthy without operator
+intervention:
+
+- **Orphan reroute.** A job whose owner replica is gone (deregistered
+  or gone unhealthy) is returned to the claimable pool so any peer with
+  the matching capability picks it up. Jobs parked in `input_required`
+  are covered too — a job waiting on a consumer answer whose owner then
+  dies is reclaimed, not stranded.
+- **Lease recovery.** Every accepted progress/heartbeat delta extends
+  the owner's lease. A job whose lease expires with no further deltas —
+  a wedged or silently-crashed handler — is reset to claimable while
+  retries remain, or marked `failed` once the retry budget is spent.
+  This includes jobs parked in `input_required`: if the producer stops
+  extending the lease while waiting for an answer that never comes, the
+  job is reclaimed rather than held forever.
+- **Total-deadline ceiling.** A job that set `total_deadline` is failed
+  with `deadline_exceeded` once that wall-clock deadline passes.
+- **Default stale ceiling (opt-in).** Set `MCP_MESH_JOB_STALE_TIMEOUT`
+  (a duration, e.g. `2h`) on the registry to apply a *default*
+  total-runtime ceiling, measured from submission, to jobs that did
+  **not** set their own `total_deadline`. Such a job is marked `failed`
+  with a `stale: ...` error once it exceeds the ceiling. Unset (the
+  default) leaves the feature off — jobs without an explicit
+  `total_deadline` run unbounded (subject only to lease recovery).
+  Jobs that set their own `total_deadline` are unaffected.
+
+Reaping is observable in-handler via a synthetic `stale` event — see
+**Event injection** below.
 
 ## Out-of-band inspection
 

--- a/src/core/cli/man/content/jobs.md
+++ b/src/core/cli/man/content/jobs.md
@@ -28,6 +28,7 @@ behavior change for non-job tools.
 | Injected type              | `job: MeshJob = None`             | `<dep_name>: MeshJob = None`            |
 | Concrete injection         | `JobController` (or `None`)       | `MeshJobSubmitter`                      |
 | Progress                   | `await job.update_progress(f, m)` | (read via `__mesh_job_status`)          |
+| Request input              | `await job.request_input(prompt)` | (status → `input_required`; answer via `post_event`) |
 | Terminal success           | `await job.complete(payload)`     | `await proxy.wait(timeout_secs=N)`      |
 | Terminal failure           | `await job.fail(reason)`          | `wait()` raises                         |
 | Transient retry            | `raise OSError(...)` w/ `retry_on=(OSError,)` | (registry hands to peer in ~5s) |
@@ -309,6 +310,44 @@ if event and event["type"] == "stale":
 
 No SDK change is needed — `stale` is an ordinary event type, so the
 existing `recv_event` / stream paths surface it across every runtime.
+
+**Request input — pause for an external answer.** A `task=True` handler
+that needs a human (or another agent) to supply something mid-run calls
+`request_input(prompt)` to transition the job to `input_required`, then
+parks on `recv_event` for the answer:
+
+```python
+@app.tool()
+@mesh.tool(capability="approve_spend", task=True)
+async def approve_spend(amount: float, job: mesh.MeshJob = None) -> dict:
+    # 1. Signal the consumer we're blocked on input. The prompt rides the
+    #    job's progress_message field; status flips to "input_required".
+    await job.request_input(f"Approve ${amount}? Reply yes/no.")
+
+    # 2. Park on the answer (no busy-wait — long-polls the event log).
+    event = await job.recv_event(types=["answer"], timeout_secs=300.0)
+    if event is None:
+        return await job.fail("timed out waiting for approval")
+
+    # 3. Resume and finish. complete()/fail() exit input_required.
+    if event["payload"].get("approved"):
+        return {"status": "approved"}
+    return {"status": "denied"}
+```
+
+An external party answers by posting the matching event:
+
+```python
+await mesh.jobs.post_event(job_id, "answer", {"approved": True})
+```
+
+`request_input` is **status-only**: it posts the `input_required`
+transition (flushing immediately, since the consumer is blocked on it)
+and returns — it does not await the answer. Awaiting is composed with
+the existing `recv_event` / `post_event` event primitives, as above.
+The transition is **non-terminal**: the handler keeps running.
+`complete()` / `fail()` exit `input_required` (a mid-flight
+resume-to-`working` primitive is a future follow-up).
 
 ## Stream subscription
 

--- a/src/core/cli/man/content/jobs_java.md
+++ b/src/core/cli/man/content/jobs_java.md
@@ -454,6 +454,26 @@ by tying cancel observation to the event channel. The registry waits
 a small grace window before issuing the cancel-forward (default
 200ms, tunable via `MCP_MESH_CANCEL_EVENT_GRACE_MS`, capped at 10s).
 
+**Synthetic stale event**. When the registry reaps a job for exceeding
+the `MCP_MESH_JOB_STALE_TIMEOUT` default ceiling (see **Reaping and
+lease recovery**), it writes a synthetic
+`{ "type": "stale", "payload": { "reason": "stale", "detail": "..." } }`
+event into the log as it transitions the job to `failed`. A handler
+parked on `recvEvent(List.of("stale", ...), ...)` observes the reaping
+and can unwind cleanly:
+
+```java
+Map<String, Object> event =
+    controller.recvEvent(List.of("stale", "cancelled"), Duration.ofSeconds(30));
+if (event != null && "stale".equals(event.get("type"))) {
+  Map<String, Object> payload = (Map<String, Object>) event.get("payload");
+  return Map.of("status", "aborted", "reason", payload.get("detail"));
+}
+```
+
+No SDK change is needed — `stale` is an ordinary event type, so the
+existing `recvEvent` / stream paths surface it across every runtime.
+
 ## Stream subscription
 
 Non-destructive observer iterator. Multiple subscribers can mirror
@@ -523,6 +543,37 @@ deadline regardless of depth.
 The header is on the default `MCP_MESH_PROPAGATE_HEADERS` allowlist
 alongside `X-Mesh-Job-Id` and `X-Mesh-Trace-Id` — no per-agent
 configuration is needed.
+
+## Reaping and lease recovery
+
+A registry cron sweep keeps the job pool healthy without operator
+intervention:
+
+- **Orphan reroute.** A job whose owner replica is gone (deregistered
+  or gone unhealthy) is returned to the claimable pool so any peer with
+  the matching capability picks it up. Jobs parked in `input_required`
+  are covered too — a job waiting on a consumer answer whose owner then
+  dies is reclaimed, not stranded.
+- **Lease recovery.** Every accepted progress/heartbeat delta extends
+  the owner's lease. A job whose lease expires with no further deltas —
+  a wedged or silently-crashed handler — is reset to claimable while
+  retries remain, or marked `failed` once the retry budget is spent.
+  This includes jobs parked in `input_required`: if the producer stops
+  extending the lease while waiting for an answer that never comes, the
+  job is reclaimed rather than held forever.
+- **Total-deadline ceiling.** A job that set `totalDeadline` is failed
+  with `deadline_exceeded` once that wall-clock deadline passes.
+- **Default stale ceiling (opt-in).** Set `MCP_MESH_JOB_STALE_TIMEOUT`
+  (a duration, e.g. `2h`) on the registry to apply a *default*
+  total-runtime ceiling, measured from submission, to jobs that did
+  **not** set their own `totalDeadline`. Such a job is marked `failed`
+  with a `stale: ...` error once it exceeds the ceiling. Unset (the
+  default) leaves the feature off — jobs without an explicit
+  `totalDeadline` run unbounded (subject only to lease recovery). Jobs
+  that set their own `totalDeadline` are unaffected.
+
+Reaping is observable in-handler via a synthetic `stale` event — see
+**Event injection** above.
 
 ## Out-of-band inspection
 

--- a/src/core/cli/man/content/jobs_java.md
+++ b/src/core/cli/man/content/jobs_java.md
@@ -29,6 +29,7 @@ request-response — no behavior change for non-job tools.
 | Injected type        | `MeshJob` (cast to `JobController`)         | `MeshJob` (cast to `MeshJobSubmitter`)             |
 | Concrete injection   | `JobController` (or `null`)                 | `MeshJobSubmitter`                                 |
 | Progress             | `controller.updateProgress(f, m)`           | (read via `__mesh_job_status`)                     |
+| Request input        | `controller.requestInput(prompt)`           | (status → `input_required`; answer via `postEvent`) |
 | Terminal success     | `controller.complete(payload)`              | `proxy.await(timeoutSeconds)`                      |
 | Terminal failure     | `controller.fail(reason)`                   | `await()` throws                                   |
 | Transient retry      | `throw new IOException(...)` w/ `retryOn`   | (registry hands to peer in ~5s)                    |
@@ -369,6 +370,52 @@ LRU cache keyed by `(registryUrl, jobId)` (default cap 256; tune via
 
 - `JobNotFoundException` — job swept or id typo
 - `JobTerminalException` — job already terminal, no more events accepted
+
+**Request input — pause for an external answer.** A `task = true`
+handler that needs a human (or another agent) to supply something
+mid-run calls `requestInput(prompt)` to transition the job to
+`input_required`, then parks on `recvEvent` for the answer:
+
+```java
+@MeshTool(capability = "approve_spend", task = true)
+public Map<String, Object> approveSpend(
+    @Param("amount") double amount,
+    MeshJob job) throws Exception {
+  JobController controller = (JobController) job;
+
+  // 1. Signal the consumer we're blocked on input. The prompt rides the
+  //    job's progress_message field; status flips to "input_required".
+  controller.requestInput("Approve $" + amount + "? Reply yes/no.");
+
+  // 2. Park on the answer (no busy-wait — long-polls the event log).
+  Map<String, Object> event = controller.recvEvent(
+      List.of("answer"), Duration.ofSeconds(300));
+  if (event == null) {
+    controller.fail("timed out waiting for approval");
+    return Map.of("status", "timeout");
+  }
+
+  // 3. Resume and finish. complete()/fail() exit input_required.
+  @SuppressWarnings("unchecked")
+  Map<String, Object> payload = (Map<String, Object>) event.get("payload");
+  boolean approved = payload != null && Boolean.TRUE.equals(payload.get("approved"));
+  return Map.of("status", approved ? "approved" : "denied");
+}
+```
+
+An external party answers by posting the matching event:
+
+```java
+MeshJobs.postEvent(jobId, "answer", Map.of("approved", true));
+```
+
+`requestInput` is **status-only**: it posts the `input_required`
+transition (flushing immediately, since the consumer is blocked on it)
+and returns — it does not await the answer. Awaiting is composed with
+the existing `recvEvent` / `postEvent` event primitives, as above. The
+transition is **non-terminal**: the handler keeps running.
+`complete()` / `fail()` exit `input_required` (a mid-flight
+resume-to-`working` primitive is a future follow-up).
 
 ## Lifecycle facades by `jobId`
 

--- a/src/core/cli/man/content/jobs_typescript.md
+++ b/src/core/cli/man/content/jobs_typescript.md
@@ -30,6 +30,7 @@ no behavior change for non-job tools.
 | Injected type        | `job: MeshJob \| null = null`             | `<dep>: MeshJob \| null = null`           |
 | Concrete injection   | `JobController` (or `null`)               | `MeshJobSubmitter`                        |
 | Progress             | `await job?.updateProgress(f, m)`         | (read via `__mesh_job_status`)            |
+| Request input        | `await job?.requestInput(prompt)`         | (status → `input_required`; answer via `postEvent`) |
 | Terminal success     | `await job?.complete(payload)`            | `await proxy.wait(timeoutSecs)`           |
 | Terminal failure     | `await job?.fail(reason)`                 | `wait()` rejects                          |
 | Transient retry      | `throw new TransientError(...)` w/ `retryOn` | (registry hands to peer in ~5s)        |
@@ -349,6 +350,53 @@ if (event && event.type === "stale") {
 
 No SDK change is needed — `stale` is an ordinary event type, so the
 existing `recvEvent` / stream paths surface it across every runtime.
+
+**Request input — pause for an external answer.** A `task: true` handler
+that needs a human (or another agent) to supply something mid-run calls
+`requestInput(prompt)` to transition the job to `input_required`, then
+parks on `recvEvent` for the answer:
+
+```typescript
+agent.addTool({
+  name: "approve_spend",
+  capability: "approve_spend",
+  task: true,
+  parameters: z.object({ amount: z.number() }),
+  meshJobParamIndex: 1,
+  execute: async ({ amount }, job: MeshJob | null = null) => {
+    if (!job) throw new Error("job slot is not bound");
+
+    // 1. Signal the consumer we're blocked on input. The prompt rides the
+    //    job's progress_message field; status flips to "input_required".
+    await job.requestInput?.(`Approve $${amount}? Reply yes/no.`);
+
+    // 2. Park on the answer (no busy-wait — long-polls the event log).
+    const event = await job.recvEvent?.(["answer"], 300);
+    if (!event) {
+      await job.fail?.("timed out waiting for approval");
+      return { status: "timeout" };
+    }
+
+    // 3. Resume and finish. complete()/fail() exit input_required.
+    const payload = event.payload as Record<string, unknown> | null;
+    return { status: payload?.approved ? "approved" : "denied" };
+  },
+});
+```
+
+An external party answers by posting the matching event:
+
+```typescript
+await mesh.jobs.postEvent(jobId, "answer", { approved: true });
+```
+
+`requestInput` is **status-only**: it posts the `input_required`
+transition (flushing immediately, since the consumer is blocked on it)
+and resolves — it does not await the answer. Awaiting is composed with
+the existing `recvEvent` / `postEvent` event primitives, as above. The
+transition is **non-terminal**: the handler keeps running. `complete()`
+/ `fail()` exit `input_required` (a mid-flight resume-to-`working`
+primitive is a future follow-up).
 
 ## Stream subscription
 

--- a/src/core/cli/man/content/jobs_typescript.md
+++ b/src/core/cli/man/content/jobs_typescript.md
@@ -333,6 +333,23 @@ relying on the `AbortSignal`. The registry waits a small grace window
 before issuing the cancel-forward (default 200ms, tunable via
 `MCP_MESH_CANCEL_EVENT_GRACE_MS`, capped at 10s).
 
+**Synthetic stale event**. When the registry reaps a job for exceeding
+the `MCP_MESH_JOB_STALE_TIMEOUT` default ceiling (see **Reaping and
+lease recovery**), it writes a synthetic
+`{ type: "stale", payload: { reason: "stale", detail: "..." } }` event
+into the log as it transitions the job to `failed`. A handler parked on
+`recvEvent(["stale", ...])` observes the reaping and can unwind cleanly:
+
+```typescript
+const event = await job.recvEvent(["stale", "cancelled"], 30);
+if (event && event.type === "stale") {
+  return { status: "aborted", reason: event.payload.detail };
+}
+```
+
+No SDK change is needed — `stale` is an ordinary event type, so the
+existing `recvEvent` / stream paths surface it across every runtime.
+
 ## Stream subscription
 
 Non-destructive observer iterator. Multiple subscribers can mirror
@@ -387,6 +404,37 @@ deadline regardless of depth.
 The header is on the default `MCP_MESH_PROPAGATE_HEADERS` allowlist
 alongside `X-Mesh-Job-Id` and `X-Mesh-Trace-Id` — no per-agent
 configuration is needed.
+
+## Reaping and lease recovery
+
+A registry cron sweep keeps the job pool healthy without operator
+intervention:
+
+- **Orphan reroute.** A job whose owner replica is gone (deregistered
+  or gone unhealthy) is returned to the claimable pool so any peer with
+  the matching capability picks it up. Jobs parked in `input_required`
+  are covered too — a job waiting on a consumer answer whose owner then
+  dies is reclaimed, not stranded.
+- **Lease recovery.** Every accepted progress/heartbeat delta extends
+  the owner's lease. A job whose lease expires with no further deltas —
+  a wedged or silently-crashed handler — is reset to claimable while
+  retries remain, or marked `failed` once the retry budget is spent.
+  This includes jobs parked in `input_required`: if the producer stops
+  extending the lease while waiting for an answer that never comes, the
+  job is reclaimed rather than held forever.
+- **Total-deadline ceiling.** A job that set `totalDeadline` is failed
+  with `deadline_exceeded` once that wall-clock deadline passes.
+- **Default stale ceiling (opt-in).** Set `MCP_MESH_JOB_STALE_TIMEOUT`
+  (a duration, e.g. `2h`) on the registry to apply a *default*
+  total-runtime ceiling, measured from submission, to jobs that did
+  **not** set their own `totalDeadline`. Such a job is marked `failed`
+  with a `stale: ...` error once it exceeds the ceiling. Unset (the
+  default) leaves the feature off — jobs without an explicit
+  `totalDeadline` run unbounded (subject only to lease recovery). Jobs
+  that set their own `totalDeadline` are unaffected.
+
+Reaping is observable in-handler via a synthetic `stale` event — see
+**Event injection** above.
 
 ## Out-of-band inspection
 

--- a/src/core/registry/ent_service_jobs.go
+++ b/src/core/registry/ent_service_jobs.go
@@ -872,21 +872,40 @@ func (s *EntService) ResetOrphanedJobs(ctx context.Context) (reset, exhausted in
 			continue
 		}
 
+		// Guarded update (mirrors ReclaimExpiredLeaseJobs): the row must still
+		// be in a live, owner-bearing state with the SAME owner we observed as
+		// orphaned. Candidates are scanned outside any transaction, so a job
+		// can change between the query and this update — the owner could have
+		// completed it, a heartbeat could have landed, or another sweep phase
+		// could have retired it. The guard makes the mutation a no-op
+		// (Affected=0) in all those cases so we never overwrite a row that
+		// moved on under us.
+		guard := []predicate.Job{
+			job.IDEQ(j.ID),
+			job.StatusIn(job.StatusWorking, job.StatusInputRequired),
+			job.OwnerInstanceIDEQ(*j.OwnerInstanceID),
+		}
+
 		if j.AttemptCount > j.MaxRetries {
-			if _, uerr := s.entDB.Client.Job.UpdateOneID(j.ID).
+			affected, uerr := s.entDB.Client.Job.Update().
+				Where(guard...).
 				SetStatus(job.StatusFailed).
 				SetError("orphaned: max retries exceeded").
 				ClearLeaseExpiresAt().
 				ClearOwnerInstanceID().
 				SetLastHeartbeatAt(now).
-				Save(ctx); uerr != nil {
+				Save(ctx)
+			if uerr != nil {
 				return reset, exhausted, fmt.Errorf("mark exhausted job %s: %w", j.ID, uerr)
 			}
-			exhausted++
+			if affected > 0 {
+				exhausted++
+			}
 			continue
 		}
 
-		if _, uerr := s.entDB.Client.Job.UpdateOneID(j.ID).
+		affected, uerr := s.entDB.Client.Job.Update().
+			Where(guard...).
 			// Normalize to working so the row is claimable again — see the
 			// matching note in ReclaimExpiredLeaseJobs. A reclaimed
 			// input_required orphan would otherwise never be re-claimed.
@@ -894,10 +913,13 @@ func (s *EntService) ResetOrphanedJobs(ctx context.Context) (reset, exhausted in
 			ClearOwnerInstanceID().
 			ClearLeaseExpiresAt().
 			ClearLastHeartbeatAt().
-			Save(ctx); uerr != nil {
+			Save(ctx)
+		if uerr != nil {
 			return reset, exhausted, fmt.Errorf("reset orphan job %s: %w", j.ID, uerr)
 		}
-		reset++
+		if affected > 0 {
+			reset++
+		}
 	}
 	return reset, exhausted, nil
 }
@@ -1049,6 +1071,65 @@ var ErrJobTerminal = fmt.Errorf("job is already in a terminal state")
 // handful of attempts converges quickly.
 const postEventMaxAttempts = 5
 
+// insertJobEventTx assigns the next per-job seq (max+1) and inserts the event
+// into the job's event log, all on the supplied transaction client. It is the
+// shared insert body for both PostJobEvent (which wraps it with the parent
+// existence/terminal check + UNIQUE-violation retry) and the sweep's
+// status-flip-plus-event atomic paths (e.g. ExpireStaleJobs), which post a
+// synthetic event in the SAME transaction as the terminal status update so the
+// two commit or roll back together. A UNIQUE (job_id, seq) violation surfaces
+// to the caller as an ent constraint error.
+func insertJobEventTx(
+	ctx context.Context,
+	tx *ent.Tx,
+	jobID string,
+	eventType string,
+	payload interface{},
+	traceContext map[string]interface{},
+	postedBy string,
+) (int64, time.Time, error) {
+	// Find the current max seq for this job. A previously-empty log produces
+	// an aggregate result with no rows; the Scan-into-struct pattern below
+	// handles the NULL case by yielding 0.
+	var maxRow []struct {
+		Max *int64 `json:"max"`
+	}
+	if err := tx.JobEvent.Query().
+		Where(jobevent.JobID(jobID)).
+		Aggregate(ent.Max(jobevent.FieldSeq)).
+		Scan(ctx, &maxRow); err != nil {
+		return 0, time.Time{}, fmt.Errorf("query max seq: %w", err)
+	}
+	next := int64(1)
+	if len(maxRow) > 0 && maxRow[0].Max != nil {
+		next = *maxRow[0].Max + 1
+	}
+
+	builder := tx.JobEvent.Create().
+		SetSeq(next).
+		SetJobID(jobID).
+		SetType(eventType)
+	if payload != nil {
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			return 0, time.Time{}, fmt.Errorf("marshal event payload: %w", err)
+		}
+		builder = builder.SetPayload(raw)
+	}
+	if traceContext != nil {
+		builder = builder.SetTraceContext(traceContext)
+	}
+	if postedBy != "" {
+		builder = builder.SetPostedBy(postedBy)
+	}
+
+	row, err := builder.Save(ctx)
+	if err != nil {
+		return 0, time.Time{}, err
+	}
+	return row.Seq, row.CreatedAt, nil
+}
+
 // PostJobEvent atomically assigns the next per-job seq and inserts the
 // event into the job's event log. Returns the assigned seq and the
 // registry-side creation timestamp.
@@ -1108,47 +1189,12 @@ func (s *EntService) PostJobEvent(
 				return ErrJobTerminal
 			}
 
-			// Find the current max seq for this job. A previously-empty log
-			// produces an aggregate result with no rows; the Scan-into-struct
-			// pattern below handles the NULL case by yielding 0.
-			var maxRow []struct {
-				Max *int64 `json:"max"`
-			}
-			if err := tx.JobEvent.Query().
-				Where(jobevent.JobID(jobID)).
-				Aggregate(ent.Max(jobevent.FieldSeq)).
-				Scan(ctx, &maxRow); err != nil {
-				return fmt.Errorf("query max seq: %w", err)
-			}
-			next := int64(1)
-			if len(maxRow) > 0 && maxRow[0].Max != nil {
-				next = *maxRow[0].Max + 1
-			}
-
-			builder := tx.JobEvent.Create().
-				SetSeq(next).
-				SetJobID(jobID).
-				SetType(eventType)
-			if payload != nil {
-				raw, err := json.Marshal(payload)
-				if err != nil {
-					return fmt.Errorf("marshal event payload: %w", err)
-				}
-				builder = builder.SetPayload(raw)
-			}
-			if traceContext != nil {
-				builder = builder.SetTraceContext(traceContext)
-			}
-			if postedBy != "" {
-				builder = builder.SetPostedBy(postedBy)
-			}
-
-			row, err := builder.Save(ctx)
+			seq, created, err := insertJobEventTx(ctx, tx, jobID, eventType, payload, traceContext, postedBy)
 			if err != nil {
 				return err
 			}
-			assignedSeq = row.Seq
-			createdAt = row.CreatedAt
+			assignedSeq = seq
+			createdAt = created
 			return nil
 		})
 		if txErr == nil {
@@ -1397,48 +1443,66 @@ func (s *EntService) ExpireStaleJobs(ctx context.Context, staleTimeout time.Dura
 
 	staled := 0
 	for _, j := range candidates {
-		affected, uerr := s.entDB.Client.Job.Update().
-			Where(
-				job.IDEQ(j.ID),
-				job.StatusNotIn(job.StatusCompleted, job.StatusFailed, job.StatusCancelled),
-				job.TotalDeadlineIsNil(),
-			).
-			SetStatus(job.StatusFailed).
-			SetError(staleJobError).
-			ClearLeaseExpiresAt().
-			ClearOwnerInstanceID().
-			SetLastHeartbeatAt(now).
-			Save(ctx)
-		if uerr != nil {
-			return staled, fmt.Errorf("expire stale job %s: %w", j.ID, uerr)
+		// The guarded status flip AND the synthetic `stale` event insert run
+		// in ONE transaction per row: either both commit or neither does.
+		// Unlike cancel — where the cancel HTTP-forward is the primary signal
+		// and the synthetic event is supplementary — the `stale` event is the
+		// ONLY notification a reaped handler parked on
+		// recv_event(types=["stale"]) ever receives, so losing it must not be
+		// possible. If the txn fails the row stays non-terminal and the NEXT
+		// sweep tick re-reaps it and re-emits the event (self-healing retry;
+		// no outbox needed). allowTerminal semantics don't apply here: the
+		// status flip and the event share a tx, so the row is still
+		// non-terminal at insert time.
+		var affected int
+		txErr := s.entDB.Transaction(ctx, func(tx *ent.Tx) error {
+			a, uerr := tx.Job.Update().
+				Where(
+					job.IDEQ(j.ID),
+					job.StatusNotIn(job.StatusCompleted, job.StatusFailed, job.StatusCancelled),
+					job.TotalDeadlineIsNil(),
+				).
+				SetStatus(job.StatusFailed).
+				SetError(staleJobError).
+				ClearLeaseExpiresAt().
+				ClearOwnerInstanceID().
+				SetLastHeartbeatAt(now).
+				Save(ctx)
+			if uerr != nil {
+				return fmt.Errorf("expire stale job %s: %w", j.ID, uerr)
+			}
+			affected = a
+			if a == 0 {
+				// Lost a race: a concurrent completion, an explicit
+				// total_deadline set, or an earlier sweep phase already
+				// retired the row. Don't event; the txn commits a no-op.
+				return nil
+			}
+			if _, _, evErr := insertJobEventTx(
+				ctx,
+				tx,
+				j.ID,
+				"stale",
+				map[string]interface{}{"reason": "stale", "detail": staleJobError},
+				nil,
+				"",
+			); evErr != nil {
+				return fmt.Errorf("post synthetic stale event for job %s: %w", j.ID, evErr)
+			}
+			return nil
+		})
+		if txErr != nil {
+			// Roll back leaves the row non-terminal → next sweep re-reaps and
+			// re-emits. Log at ERROR but keep sweeping the rest of the batch.
+			if s.logger != nil {
+				s.logger.Error("ExpireStaleJobs: atomic reap+event failed for job %s, will retry next sweep: %v", j.ID, txErr)
+			}
+			continue
 		}
 		if affected == 0 {
-			// Lost a race: a concurrent completion, an explicit
-			// total_deadline set, or an earlier sweep phase already
-			// retired the row. Don't count, don't event.
 			continue
 		}
 		staled++
-
-		// Synthetic `stale` event so handlers parked on
-		// recv_event(types=["stale"]) observe the reaping. The row is now
-		// terminal, so allowTerminal=true bypasses PostJobEvent's terminal
-		// guard (same opt-out CancelJob uses for `cancelled`). Best-effort:
-		// the reap already landed; a failed event post must not abort the
-		// rest of the sweep batch.
-		if _, _, evErr := s.PostJobEvent(
-			ctx,
-			j.ID,
-			"stale",
-			map[string]interface{}{"reason": "stale", "detail": staleJobError},
-			nil,
-			"",
-			true,
-		); evErr != nil {
-			if s.logger != nil {
-				s.logger.Warning("ExpireStaleJobs: failed to post synthetic stale event for job %s: %v", j.ID, evErr)
-			}
-		}
 	}
 	return staled, nil
 }

--- a/src/core/registry/ent_service_jobs.go
+++ b/src/core/registry/ent_service_jobs.go
@@ -792,8 +792,8 @@ func (s *EntService) CountPendingJobsForAgent(ctx context.Context, agentID strin
 }
 
 // ResetOrphanedJobs handles the orphan-reroute phase of the registry sweep.
-// For every working job whose owner_instance_id no longer maps to a
-// registered agent row, the job is either:
+// For every live (working OR input_required) job whose owner_instance_id no
+// longer maps to a registered agent row, the job is either:
 //
 //   - reset to claimable (owner=NULL, lease cleared) when attempt_count <=
 //     max_retries — the next live replica picks it up via POST /jobs/claim.
@@ -822,7 +822,7 @@ func (s *EntService) ResetOrphanedJobs(ctx context.Context) (reset, exhausted in
 	// Collect candidate orphan jobs: working + has an owner.
 	candidates, err := s.entDB.Client.Job.Query().
 		Where(
-			job.StatusEQ(job.StatusWorking),
+			job.StatusIn(job.StatusWorking, job.StatusInputRequired),
 			job.OwnerInstanceIDNotNil(),
 		).
 		All(ctx)
@@ -887,6 +887,10 @@ func (s *EntService) ResetOrphanedJobs(ctx context.Context) (reset, exhausted in
 		}
 
 		if _, uerr := s.entDB.Client.Job.UpdateOneID(j.ID).
+			// Normalize to working so the row is claimable again — see the
+			// matching note in ReclaimExpiredLeaseJobs. A reclaimed
+			// input_required orphan would otherwise never be re-claimed.
+			SetStatus(job.StatusWorking).
 			ClearOwnerInstanceID().
 			ClearLeaseExpiresAt().
 			ClearLastHeartbeatAt().
@@ -915,8 +919,8 @@ func (s *EntService) ResetOrphanedJobs(ctx context.Context) (reset, exhausted in
 // the still-running job, and its eventual completion delta is rejected
 // not_owner.
 //
-// For every working job whose lease_expires_at has passed, the job is
-// either:
+// For every live (working OR input_required) job whose lease_expires_at has
+// passed, the job is either:
 //
 //   - reset to claimable (owner=NULL, lease cleared, last_heartbeat_at
 //     cleared) when attempt_count <= max_retries — identical field-reset
@@ -953,7 +957,7 @@ func (s *EntService) ReclaimExpiredLeaseJobs(ctx context.Context) (reset, exhaus
 
 	candidates, err := s.entDB.Client.Job.Query().
 		Where(
-			job.StatusEQ(job.StatusWorking),
+			job.StatusIn(job.StatusWorking, job.StatusInputRequired),
 			job.LeaseExpiresAtNotNil(),
 			job.LeaseExpiresAtLT(now),
 		).
@@ -971,10 +975,14 @@ func (s *EntService) ReclaimExpiredLeaseJobs(ctx context.Context) (reset, exhaus
 		}
 
 		// Guard predicate shared by both branches: the row must still be
-		// working AND still carry the exact expired lease we observed.
+		// in a live, lease-bearing state (working OR input_required) AND
+		// still carry the exact expired lease we observed. input_required
+		// is included because the producer extends its lease while parked
+		// waiting for a consumer answer (see ApplyJobDeltas); a parked job
+		// whose lease then expires must be reclaimed just like a working one.
 		guard := []predicate.Job{
 			job.IDEQ(j.ID),
-			job.StatusEQ(job.StatusWorking),
+			job.StatusIn(job.StatusWorking, job.StatusInputRequired),
 			job.LeaseExpiresAtEQ(*j.LeaseExpiresAt),
 		}
 
@@ -998,6 +1006,12 @@ func (s *EntService) ReclaimExpiredLeaseJobs(ctx context.Context) (reset, exhaus
 
 		affected, uerr := s.entDB.Client.Job.Update().
 			Where(guard...).
+			// Normalize to working so the row is claimable again. A
+			// reclaimed input_required job would otherwise stay
+			// input_required with no owner — and ClaimNextJob only
+			// claims status=working, so it would never be picked back
+			// up. No-op for rows already working.
+			SetStatus(job.StatusWorking).
 			ClearOwnerInstanceID().
 			ClearLeaseExpiresAt().
 			ClearLastHeartbeatAt().
@@ -1327,4 +1341,104 @@ func (s *EntService) ExpireDeadlinedJobs(ctx context.Context) (int, error) {
 		expired++
 	}
 	return expired, nil
+}
+
+// staleJobError is the error string stamped on jobs reaped by
+// ExpireStaleJobs. Mirrors the "deadline_exceeded" / "orphaned: ..."
+// reason-string style so operators can grep all sweep-reap paths the same
+// way.
+const staleJobError = "stale: no total_deadline set and exceeded MCP_MESH_JOB_STALE_TIMEOUT default ceiling"
+
+// ExpireStaleJobs enforces a DEFAULT total-runtime ceiling for jobs that did
+// NOT set their own total_deadline. It is the opt-in companion to
+// ExpireDeadlinedJobs: where that phase enforces an explicit per-job
+// total_deadline, this one applies the operator-wide MCP_MESH_JOB_STALE_TIMEOUT
+// as a default deadline measured from submitted_at. Jobs that set their own
+// total_deadline are left to ExpireDeadlinedJobs (the total_deadline IS NULL
+// filter below excludes them).
+//
+// For every non-terminal job with a NULL total_deadline whose submitted_at is
+// older than `now - staleTimeout`, the row is marked failed with the
+// `stale:` reason and its lease/owner cleared. No new terminal state is
+// introduced — `failed` + the reason string IS the signal.
+//
+// Each reap uses the guarded-update discipline (WHERE id=? AND status NOT IN
+// terminal AND total_deadline IS NULL) so a concurrent completion / explicit
+// deadline-set / earlier sweep phase that already handled the row produces
+// Affected=0 and we skip it without counting or eventing. Successfully-reaped
+// rows get a synthetic `stale` event posted (allowTerminal=true, since the row
+// is now terminal) so handlers parked on recv_event(types=["stale"]) observe
+// the reaping — the same mechanism CancelJob uses for its synthetic
+// `cancelled` event.
+//
+// Phase ordering (see SweepJob.runOnce): this must run AFTER both
+// ReclaimExpiredLeaseJobs and ExpireDeadlinedJobs so a row those already
+// retired isn't double-processed.
+func (s *EntService) ExpireStaleJobs(ctx context.Context, staleTimeout time.Duration, now time.Time) (int, error) {
+	if staleTimeout <= 0 {
+		return 0, nil
+	}
+
+	cutoff := now.Add(-staleTimeout)
+
+	candidates, err := s.entDB.Client.Job.Query().
+		Where(
+			job.StatusNotIn(job.StatusCompleted, job.StatusFailed, job.StatusCancelled),
+			job.TotalDeadlineIsNil(),
+			job.SubmittedAtLT(cutoff),
+		).
+		All(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("query stale jobs: %w", err)
+	}
+	if len(candidates) == 0 {
+		return 0, nil
+	}
+
+	staled := 0
+	for _, j := range candidates {
+		affected, uerr := s.entDB.Client.Job.Update().
+			Where(
+				job.IDEQ(j.ID),
+				job.StatusNotIn(job.StatusCompleted, job.StatusFailed, job.StatusCancelled),
+				job.TotalDeadlineIsNil(),
+			).
+			SetStatus(job.StatusFailed).
+			SetError(staleJobError).
+			ClearLeaseExpiresAt().
+			ClearOwnerInstanceID().
+			SetLastHeartbeatAt(now).
+			Save(ctx)
+		if uerr != nil {
+			return staled, fmt.Errorf("expire stale job %s: %w", j.ID, uerr)
+		}
+		if affected == 0 {
+			// Lost a race: a concurrent completion, an explicit
+			// total_deadline set, or an earlier sweep phase already
+			// retired the row. Don't count, don't event.
+			continue
+		}
+		staled++
+
+		// Synthetic `stale` event so handlers parked on
+		// recv_event(types=["stale"]) observe the reaping. The row is now
+		// terminal, so allowTerminal=true bypasses PostJobEvent's terminal
+		// guard (same opt-out CancelJob uses for `cancelled`). Best-effort:
+		// the reap already landed; a failed event post must not abort the
+		// rest of the sweep batch.
+		if _, _, evErr := s.PostJobEvent(
+			ctx,
+			j.ID,
+			"stale",
+			map[string]interface{}{"reason": "stale", "detail": staleJobError},
+			nil,
+			"",
+			true,
+		); evErr != nil {
+			if s.logger != nil {
+				s.logger.Warning("ExpireStaleJobs: failed to post synthetic stale event for job %s: %v", j.ID, evErr)
+			}
+		}
+	}
+	return staled, nil
 }

--- a/src/core/registry/sweep.go
+++ b/src/core/registry/sweep.go
@@ -81,6 +81,12 @@ func readSweepIntervalFromEnv() time.Duration {
 // no goroutine is launched, no agents or events are purged).
 type SweepConfig struct {
 	Retention time.Duration
+
+	// JobStaleTimeout is a DEFAULT total-runtime ceiling applied to jobs that
+	// did NOT set their own total_deadline, measured from submitted_at. 0
+	// (the default) DISABLES the stale-job phase entirely — it is opt-in, so
+	// most deployments scan zero rows. See ExpireStaleJobs.
+	JobStaleTimeout time.Duration
 }
 
 // LoadSweepConfigFromEnv reads sweep configuration from the environment.
@@ -106,6 +112,30 @@ func LoadSweepConfigFromEnv(log *logger.Logger) SweepConfig {
 			}
 		} else if log != nil {
 			log.Warning("Invalid MCP_MESH_RETENTION %q, using default %s: %v", v, cfg.Retention, err)
+		}
+	}
+
+	// MCP_MESH_JOB_STALE_TIMEOUT: a DEFAULT total-runtime ceiling for jobs
+	// that didn't set their own total_deadline (measured from submitted_at).
+	// Parsed exactly like MCP_MESH_RETENTION except the default is 0
+	// (DISABLED) — the feature is opt-in, so unset means the stale-job phase
+	// scans zero rows.
+	//   - unset / empty: 0 (disabled)
+	//   - positive duration (e.g. "2h", "30m"): use that value
+	//   - "0" / "0s": disabled (same as unset)
+	//   - negative: warn and stay disabled (likely a typo)
+	//   - invalid: warn and stay disabled
+	if v := os.Getenv("MCP_MESH_JOB_STALE_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			if d < 0 {
+				if log != nil {
+					log.Warning("Invalid MCP_MESH_JOB_STALE_TIMEOUT %q: negative durations are not allowed (use 0 / unset to disable); leaving stale-job sweep disabled", v)
+				}
+			} else {
+				cfg.JobStaleTimeout = d
+			}
+		} else if log != nil {
+			log.Warning("Invalid MCP_MESH_JOB_STALE_TIMEOUT %q, leaving stale-job sweep disabled: %v", v, err)
 		}
 	}
 
@@ -243,6 +273,7 @@ type sweepResult struct {
 	jobsLeaseReset   int // expired-lease jobs returned to the pool for re-claim
 	jobsLeaseFailed  int // expired-lease jobs that ran out of retries (status=failed)
 	jobsDeadlined    int // total_deadline-exceeded jobs (status=failed)
+	jobsStaled       int // default-ceiling stale jobs (status=failed, no total_deadline)
 	jobEventsPurged  int // JobEvent rows GC'd for terminal jobs past retention
 }
 
@@ -264,12 +295,12 @@ func (s *SweepJob) tick(ctx context.Context) {
 		anyWork := res.agentsPurged > 0 || res.eventsPurged > 0 || res.schemasPurged > 0 ||
 			res.jobsReset > 0 || res.jobsExhausted > 0 ||
 			res.jobsLeaseReset > 0 || res.jobsLeaseFailed > 0 || res.jobsDeadlined > 0 ||
-			res.jobEventsPurged > 0
+			res.jobsStaled > 0 || res.jobEventsPurged > 0
 		if anyWork {
-			s.logger.Info("sweep: purged %d agents, %d events, %d orphan schemas; jobs: %d reset, %d exhausted, %d lease-reset, %d lease-failed, %d deadlined, %d job_events purged (took %s)",
+			s.logger.Info("sweep: purged %d agents, %d events, %d orphan schemas; jobs: %d reset, %d exhausted, %d lease-reset, %d lease-failed, %d deadlined, %d staled, %d job_events purged (took %s)",
 				res.agentsPurged, res.eventsPurged, res.schemasPurged,
 				res.jobsReset, res.jobsExhausted, res.jobsLeaseReset, res.jobsLeaseFailed,
-				res.jobsDeadlined, res.jobEventsPurged, took)
+				res.jobsDeadlined, res.jobsStaled, res.jobEventsPurged, took)
 		} else {
 			s.logger.Debug("sweep: nothing to purge (took %s)", took)
 		}
@@ -288,8 +319,12 @@ func (s *SweepJob) tick(ctx context.Context) {
 //     the lease on the rows it resets) so only leases held by a still-live
 //     owner are considered.
 //  4. Total-deadline expiry — independent of agent liveness.
-//  5. Event cap enforcement.
-//  6. Orphan schema_entry purge.
+//  5. Stale-job expiry — default total-runtime ceiling for jobs with no
+//     explicit total_deadline (opt-in via MCP_MESH_JOB_STALE_TIMEOUT). Runs
+//     after the lease/deadline phases so a row those retired isn't
+//     double-processed.
+//  6. Event cap enforcement.
+//  7. Orphan schema_entry purge.
 func (s *SweepJob) runOnce(ctx context.Context) (sweepResult, error) {
 	var res sweepResult
 	now := s.clock()
@@ -343,6 +378,20 @@ func (s *SweepJob) runOnce(ctx context.Context) (sweepResult, error) {
 		res.jobsDeadlined = expired
 		if err != nil {
 			return res, fmt.Errorf("expire deadlined jobs: %w", err)
+		}
+
+		// Default total-runtime ceiling (opt-in: MCP_MESH_JOB_STALE_TIMEOUT,
+		// 0 = disabled). Applies a default total_deadline measured from
+		// submitted_at to jobs that did NOT set their own. Runs AFTER the
+		// lease-reclaim and explicit-deadline phases so a row those already
+		// retired isn't double-processed (the guarded update would no-op
+		// anyway, but skipping the scan keeps the common disabled case free).
+		if s.cfg.JobStaleTimeout > 0 {
+			staled, err := s.service.ExpireStaleJobs(ctx, s.cfg.JobStaleTimeout, now)
+			res.jobsStaled = staled
+			if err != nil {
+				return res, fmt.Errorf("expire stale jobs: %w", err)
+			}
 		}
 
 		// JobEvent GC. Events outlive their parent job by the retention

--- a/src/core/registry/sweep_jobs_test.go
+++ b/src/core/registry/sweep_jobs_test.go
@@ -899,6 +899,12 @@ func TestSweep_ReclaimExpiredLeaseJobs_InputRequiredReclaimedExhausted(t *testin
 	if got.Error == nil || *got.Error != "lease expired: no completion within lease window" {
 		t.Errorf("expected lease-expired error, got %v", got.Error)
 	}
+	if got.OwnerInstanceID != nil {
+		t.Errorf("expected owner cleared on exhausted lease, got %v", *got.OwnerInstanceID)
+	}
+	if got.LeaseExpiresAt != nil {
+		t.Errorf("expected lease cleared on exhausted lease, got %v", got.LeaseExpiresAt)
+	}
 }
 
 // TestSweep_ResetOrphanedJobs_InputRequiredOrphanReclaimed verifies the C1

--- a/src/core/registry/sweep_jobs_test.go
+++ b/src/core/registry/sweep_jobs_test.go
@@ -13,7 +13,23 @@ import (
 	"mcp-mesh/src/core/ent"
 	"mcp-mesh/src/core/ent/agent"
 	"mcp-mesh/src/core/ent/job"
+	"mcp-mesh/src/core/ent/jobevent"
 )
+
+// countJobEventsOfType returns how many JobEvent rows of the given type
+// exist for a job. Used by the stale-reaping tests to assert exactly one
+// synthetic `stale` event is posted (and re-running the sweep doesn't add
+// another).
+func countJobEventsOfType(t *testing.T, client *ent.Client, jobID, eventType string) int {
+	t.Helper()
+	n, err := client.JobEvent.Query().
+		Where(jobevent.JobID(jobID), jobevent.TypeEQ(eventType)).
+		Count(context.Background())
+	if err != nil {
+		t.Fatalf("count %s events for %s: %v", eventType, jobID, err)
+	}
+	return n
+}
 
 // seedJobRow inserts a Job row directly via Ent so tests can pin every
 // field (owner, attempts, status, total_deadline) deterministically.
@@ -564,12 +580,16 @@ func TestSweep_ReclaimExpiredLeaseJobs_DeltaExtendedLeaseUntouched(t *testing.T)
 }
 
 // TestSweep_ReclaimExpiredLeaseJobs_InputRequiredResumeExtendsLease covers
-// the input_required round trip: a job pauses in input_required longer
-// than its lease window (the paused row is never touched — the lease
-// phase only targets status=working), then resumes via an accepted
-// status=working delta. The resume delta must extend the stale claim-time
-// lease so the freshly resumed job is not instantly reclaimed on the next
-// sweep tick.
+// the input_required round trip: a job parked in input_required with a
+// still-valid lease is not reclaimed (the producer extends the lease while
+// waiting for a consumer answer), then resumes via an accepted
+// status=working delta. The resume delta must extend the lease so the
+// freshly resumed job is not instantly reclaimed on the next sweep tick.
+//
+// Note: an input_required job whose lease has genuinely EXPIRED *is* now
+// reclaimed by the lease phase (issue #1229 C1 — see
+// TestSweep_ReclaimExpiredLeaseJobs_InputRequiredReclaimedRetryable). This
+// test keeps the lease valid during tick 1 so the park is legitimate.
 func TestSweep_ReclaimExpiredLeaseJobs_InputRequiredResumeExtendsLease(t *testing.T) {
 	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
 	cfg := SweepConfig{Retention: 1 * time.Hour}
@@ -582,21 +602,21 @@ func TestSweep_ReclaimExpiredLeaseJobs_InputRequiredResumeExtendsLease(t *testin
 	owner := "paused-owner"
 	j := seedJobRow(t, client, "job-input-required", "render", &owner, job.StatusInputRequired, 1, 3, now.Add(-30*time.Minute))
 
-	// Claim-time lease that lapsed while the job sat in input_required.
+	// Still-valid lease: the producer's input_required delta extended it
+	// while the job waits for a consumer answer.
 	if _, err := client.Job.UpdateOneID(j.ID).
-		SetLeaseExpiresAt(time.Now().UTC().Add(-20 * time.Minute)).
+		SetLeaseExpiresAt(time.Now().UTC().Add(20 * time.Minute)).
 		Save(ctx); err != nil {
 		t.Fatalf("seed lease: %v", err)
 	}
 
-	// Tick 1: the paused job must NOT be reclaimed despite the expired
-	// lease — input_required is not status=working.
+	// Tick 1: the parked job must NOT be reclaimed — its lease is valid.
 	res1, err := sweep.runOnce(ctx)
 	if err != nil {
 		t.Fatalf("runOnce (paused): %v", err)
 	}
 	if res1.jobsLeaseReset != 0 || res1.jobsLeaseFailed != 0 {
-		t.Fatalf("expected paused job untouched, got reset=%d failed=%d", res1.jobsLeaseReset, res1.jobsLeaseFailed)
+		t.Fatalf("expected parked job untouched, got reset=%d failed=%d", res1.jobsLeaseReset, res1.jobsLeaseFailed)
 	}
 
 	// Resume: owner posts status=working. The accepted delta must extend
@@ -776,5 +796,384 @@ func TestSweep_ExpireDeadlinedJobs_TerminalUntouched(t *testing.T) {
 	}
 	if got.Status != job.StatusCompleted {
 		t.Errorf("expected status=completed preserved, got %s", got.Status)
+	}
+}
+
+// TestSweep_ReclaimExpiredLeaseJobs_InputRequiredReclaimedRetryable is the
+// C1 bug-fix coverage: an input_required job whose lease has expired (the
+// producer posted an input_required delta — which extends the lease — then
+// parked waiting for a consumer answer that never came, and the lease
+// lapsed) is reclaimed by the lease phase exactly like a working job. Before
+// the StatusIn(working, input_required) filter change this row orphaned
+// forever holding a claim slot.
+func TestSweep_ReclaimExpiredLeaseJobs_InputRequiredReclaimedRetryable(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Healthy owner so the orphan reroute doesn't fire — only the lease
+	// phase can act, and only because input_required is now in scope.
+	seedAgent(t, client, "parked-owner", agent.StatusHealthy, now)
+	owner := "parked-owner"
+	j := seedJobRow(t, client, "job-ir-lease-retry", "render", &owner, job.StatusInputRequired, 1, 3, now.Add(-30*time.Minute))
+
+	// Expired lease, UTC-pinned to match the production comparison path.
+	if _, err := client.Job.UpdateOneID(j.ID).
+		SetLeaseExpiresAt(time.Now().UTC().Add(-5 * time.Minute)).
+		Save(ctx); err != nil {
+		t.Fatalf("seed lease: %v", err)
+	}
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsLeaseReset != 1 {
+		t.Errorf("expected 1 input_required job reclaimed (reset), got %d", res.jobsLeaseReset)
+	}
+	if res.jobsLeaseFailed != 0 {
+		t.Errorf("expected 0 lease-failed, got %d", res.jobsLeaseFailed)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusWorking {
+		t.Errorf("expected status=working (claimable) after reclaim, got %s", got.Status)
+	}
+	if got.OwnerInstanceID != nil {
+		t.Errorf("expected owner cleared, got %v", *got.OwnerInstanceID)
+	}
+	if got.LeaseExpiresAt != nil {
+		t.Errorf("expected lease cleared, got %v", got.LeaseExpiresAt)
+	}
+	if got.AttemptCount != 1 {
+		t.Errorf("expected attempt_count unchanged at 1, got %d", got.AttemptCount)
+	}
+}
+
+// TestSweep_ReclaimExpiredLeaseJobs_InputRequiredReclaimedExhausted verifies
+// the exhausted branch of the C1 fix: an input_required job past its retry
+// budget with an expired lease is marked failed rather than recycled.
+func TestSweep_ReclaimExpiredLeaseJobs_InputRequiredReclaimedExhausted(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "parked-owner-2", agent.StatusHealthy, now)
+	owner := "parked-owner-2"
+	// attempt_count=4, max_retries=3 → strictly exceeded → exhausted.
+	j := seedJobRow(t, client, "job-ir-lease-exhausted", "render", &owner, job.StatusInputRequired, 4, 3, now.Add(-30*time.Minute))
+
+	if _, err := client.Job.UpdateOneID(j.ID).
+		SetLeaseExpiresAt(time.Now().UTC().Add(-5 * time.Minute)).
+		Save(ctx); err != nil {
+		t.Fatalf("seed lease: %v", err)
+	}
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsLeaseReset != 0 {
+		t.Errorf("expected 0 lease-reset, got %d", res.jobsLeaseReset)
+	}
+	if res.jobsLeaseFailed != 1 {
+		t.Errorf("expected 1 lease-failed (exhausted input_required), got %d", res.jobsLeaseFailed)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusFailed {
+		t.Errorf("expected status=failed, got %s", got.Status)
+	}
+	if got.Error == nil || *got.Error != "lease expired: no completion within lease window" {
+		t.Errorf("expected lease-expired error, got %v", got.Error)
+	}
+}
+
+// TestSweep_ResetOrphanedJobs_InputRequiredOrphanReclaimed verifies the C1
+// fix for the orphan-reroute phase: an input_required job whose owner agent
+// has been purged is reset to claimable (previously left orphaned forever).
+func TestSweep_ResetOrphanedJobs_InputRequiredOrphanReclaimed(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "ir-orphan-owner", agent.StatusUnhealthy, now.Add(-3*time.Hour))
+	owner := "ir-orphan-owner"
+	j := seedJobRow(t, client, "job-ir-orphan", "render", &owner, job.StatusInputRequired, 1, 3, now.Add(-10*time.Minute))
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsReset != 1 {
+		t.Errorf("expected 1 input_required orphan reset, got %d", res.jobsReset)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusWorking {
+		t.Errorf("expected status=working after orphan reset, got %s", got.Status)
+	}
+	if got.OwnerInstanceID != nil {
+		t.Errorf("expected owner cleared, got %v", *got.OwnerInstanceID)
+	}
+}
+
+// TestSweep_ExpireStaleJobs_NoDeadlineReaped is the core C2 case: a non-
+// terminal job with total_deadline=NULL whose submitted_at is older than the
+// stale timeout is marked failed with the `stale:` reason AND a synthetic
+// `stale` JobEvent is posted.
+func TestSweep_ExpireStaleJobs_NoDeadlineReaped(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour, JobStaleTimeout: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Live owner so this is NOT an orphan; no lease so the lease phase
+	// skips it; no total_deadline so ExpireDeadlinedJobs skips it. The
+	// stale phase is the only one that can act.
+	seedAgent(t, client, "stale-owner", agent.StatusHealthy, now)
+	owner := "stale-owner"
+	// submitted_at 2h ago > 1h stale timeout → reaped.
+	j := seedJobRow(t, client, "job-stale", "render", &owner, job.StatusWorking, 1, 3, now.Add(-2*time.Hour))
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsStaled != 1 {
+		t.Errorf("expected 1 job staled, got %d", res.jobsStaled)
+	}
+	if res.jobsDeadlined != 0 {
+		t.Errorf("expected 0 deadlined (no total_deadline), got %d", res.jobsDeadlined)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusFailed {
+		t.Errorf("expected status=failed, got %s", got.Status)
+	}
+	if got.Error == nil || *got.Error != staleJobError {
+		t.Errorf("expected error %q, got %v", staleJobError, got.Error)
+	}
+	if got.LeaseExpiresAt != nil {
+		t.Errorf("expected lease cleared, got %v", got.LeaseExpiresAt)
+	}
+	if got.OwnerInstanceID != nil {
+		t.Errorf("expected owner cleared, got %v", *got.OwnerInstanceID)
+	}
+
+	if n := countJobEventsOfType(t, client, j.ID, "stale"); n != 1 {
+		t.Errorf("expected exactly 1 synthetic stale event, got %d", n)
+	}
+}
+
+// TestSweep_ExpireStaleJobs_InputRequiredReaped verifies the stale ceiling
+// also covers input_required jobs (non-terminal, no total_deadline).
+func TestSweep_ExpireStaleJobs_InputRequiredReaped(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour, JobStaleTimeout: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "stale-ir-owner", agent.StatusHealthy, now)
+	owner := "stale-ir-owner"
+	j := seedJobRow(t, client, "job-stale-ir", "render", &owner, job.StatusInputRequired, 1, 3, now.Add(-2*time.Hour))
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsStaled != 1 {
+		t.Errorf("expected 1 input_required job staled, got %d", res.jobsStaled)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusFailed {
+		t.Errorf("expected status=failed, got %s", got.Status)
+	}
+	if n := countJobEventsOfType(t, client, j.ID, "stale"); n != 1 {
+		t.Errorf("expected 1 stale event, got %d", n)
+	}
+}
+
+// TestSweep_ExpireStaleJobs_DeadlineSetUntouched verifies that a job which
+// DID set its own total_deadline is NOT touched by the stale phase — it is
+// left to ExpireDeadlinedJobs. The stale ceiling is a default for jobs that
+// didn't opt into an explicit deadline.
+func TestSweep_ExpireStaleJobs_DeadlineSetUntouched(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour, JobStaleTimeout: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "deadline-owner", agent.StatusHealthy, now)
+	owner := "deadline-owner"
+	// Old submitted_at (would be stale) BUT total_deadline is set in the
+	// FUTURE — ExpireStaleJobs must skip it (total_deadline IS NULL filter),
+	// and ExpireDeadlinedJobs must skip it too (deadline not yet passed).
+	j := seedJobRow(t, client, "job-has-deadline", "render", &owner, job.StatusWorking, 1, 3, now.Add(-2*time.Hour))
+	if _, err := client.Job.UpdateOneID(j.ID).
+		SetTotalDeadline(time.Now().UTC().Add(1 * time.Hour)).
+		Save(ctx); err != nil {
+		t.Fatalf("seed deadline: %v", err)
+	}
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsStaled != 0 {
+		t.Errorf("expected 0 staled (job set its own total_deadline), got %d", res.jobsStaled)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusWorking {
+		t.Errorf("expected status=working preserved, got %s", got.Status)
+	}
+	if n := countJobEventsOfType(t, client, j.ID, "stale"); n != 0 {
+		t.Errorf("expected no stale event, got %d", n)
+	}
+}
+
+// TestSweep_ExpireStaleJobs_FreshJobUntouched verifies that a job submitted
+// recently (within the stale timeout) is NOT reaped.
+func TestSweep_ExpireStaleJobs_FreshJobUntouched(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour, JobStaleTimeout: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "fresh-owner", agent.StatusHealthy, now)
+	owner := "fresh-owner"
+	// submitted_at 10m ago < 1h timeout → untouched.
+	j := seedJobRow(t, client, "job-fresh", "render", &owner, job.StatusWorking, 1, 3, now.Add(-10*time.Minute))
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsStaled != 0 {
+		t.Errorf("expected 0 staled (fresh job), got %d", res.jobsStaled)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusWorking {
+		t.Errorf("expected status=working preserved, got %s", got.Status)
+	}
+}
+
+// TestSweep_ExpireStaleJobs_DisabledByZeroTimeout verifies that with
+// JobStaleTimeout==0 (the default) the stale phase does not run at all — an
+// old, deadline-less job is left untouched.
+func TestSweep_ExpireStaleJobs_DisabledByZeroTimeout(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour} // JobStaleTimeout left at 0
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "disabled-owner", agent.StatusHealthy, now)
+	owner := "disabled-owner"
+	j := seedJobRow(t, client, "job-stale-disabled", "render", &owner, job.StatusWorking, 1, 3, now.Add(-5*time.Hour))
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsStaled != 0 {
+		t.Errorf("expected 0 staled (phase disabled), got %d", res.jobsStaled)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusWorking {
+		t.Errorf("expected status=working preserved when disabled, got %s", got.Status)
+	}
+	if n := countJobEventsOfType(t, client, j.ID, "stale"); n != 0 {
+		t.Errorf("expected no stale event when disabled, got %d", n)
+	}
+}
+
+// TestSweep_ExpireStaleJobs_Idempotent verifies that re-running the sweep
+// over an already-reaped (now terminal) job does not double-fail it or post
+// a second stale event — the guarded update no-ops on the terminal row.
+func TestSweep_ExpireStaleJobs_Idempotent(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 1 * time.Hour, JobStaleTimeout: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "idem-owner", agent.StatusHealthy, now)
+	owner := "idem-owner"
+	j := seedJobRow(t, client, "job-stale-idem", "render", &owner, job.StatusWorking, 1, 3, now.Add(-2*time.Hour))
+
+	res1, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce (1): %v", err)
+	}
+	if res1.jobsStaled != 1 {
+		t.Fatalf("first tick: expected 1 staled, got %d", res1.jobsStaled)
+	}
+
+	res2, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce (2): %v", err)
+	}
+	if res2.jobsStaled != 0 {
+		t.Errorf("second tick: expected 0 staled (already terminal), got %d", res2.jobsStaled)
+	}
+
+	if n := countJobEventsOfType(t, client, j.ID, "stale"); n != 1 {
+		t.Errorf("expected exactly 1 stale event after two ticks, got %d", n)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Error == nil || *got.Error != staleJobError {
+		t.Errorf("expected stale error preserved, got %v", got.Error)
 	}
 }

--- a/src/core/registry/sweep_test.go
+++ b/src/core/registry/sweep_test.go
@@ -547,6 +547,46 @@ func TestLoadSweepConfigFromEnv(t *testing.T) {
 			t.Errorf("Retention with negative value = %s, want %s (default)", cfg.Retention, defaultRetention)
 		}
 	})
+
+	t.Run("stale timeout disabled by default", func(t *testing.T) {
+		t.Setenv("MCP_MESH_JOB_STALE_TIMEOUT", "")
+		cfg := LoadSweepConfigFromEnv(nil)
+		if cfg.JobStaleTimeout != 0 {
+			t.Errorf("JobStaleTimeout default = %s, want 0 (disabled)", cfg.JobStaleTimeout)
+		}
+	})
+
+	t.Run("stale timeout custom value parsed", func(t *testing.T) {
+		t.Setenv("MCP_MESH_JOB_STALE_TIMEOUT", "30m")
+		cfg := LoadSweepConfigFromEnv(nil)
+		if cfg.JobStaleTimeout != 30*time.Minute {
+			t.Errorf("JobStaleTimeout = %s, want 30m", cfg.JobStaleTimeout)
+		}
+	})
+
+	t.Run("stale timeout zero stays disabled", func(t *testing.T) {
+		t.Setenv("MCP_MESH_JOB_STALE_TIMEOUT", "0s")
+		cfg := LoadSweepConfigFromEnv(nil)
+		if cfg.JobStaleTimeout != 0 {
+			t.Errorf("JobStaleTimeout = %s, want 0 (disabled)", cfg.JobStaleTimeout)
+		}
+	})
+
+	t.Run("stale timeout invalid stays disabled", func(t *testing.T) {
+		t.Setenv("MCP_MESH_JOB_STALE_TIMEOUT", "not-a-duration")
+		cfg := LoadSweepConfigFromEnv(nil)
+		if cfg.JobStaleTimeout != 0 {
+			t.Errorf("JobStaleTimeout with invalid value = %s, want 0 (disabled)", cfg.JobStaleTimeout)
+		}
+	})
+
+	t.Run("stale timeout negative stays disabled", func(t *testing.T) {
+		t.Setenv("MCP_MESH_JOB_STALE_TIMEOUT", "-1h")
+		cfg := LoadSweepConfigFromEnv(nil)
+		if cfg.JobStaleTimeout != 0 {
+			t.Errorf("JobStaleTimeout with negative value = %s, want 0 (disabled)", cfg.JobStaleTimeout)
+		}
+	})
 }
 
 // seedSchemaEntryAt inserts a schema_entry directly via Ent with the given

--- a/src/runtime/core/include/mcp_mesh_core.h
+++ b/src/runtime/core/include/mcp_mesh_core.h
@@ -798,6 +798,29 @@ int32_t mesh_job_controller_fail(struct JobControllerHandle *handle, const char 
 // of Python's / TS's release_lease contract).
 int32_t mesh_job_controller_release_lease(struct JobControllerHandle *handle, const char *reason);
 
+// Transition the job to `input_required`, signalling the consumer that the
+// handler is blocked awaiting an external answer. STATUS-ONLY primitive: it
+// posts the `input_required` delta (with `prompt` carried on the existing
+// `progress_message` field) and returns once posted — it does NOT await the
+// answer. Compose it with the existing event primitives for a full
+// request-and-await: call `mesh_job_controller_request_input(prompt)`, then
+// park on `mesh_job_controller_recv_event(["answer"])`; an external party
+// answers via `mesh_job_proxy_send_event("answer", ...)`; the handler
+// resumes and calls `mesh_job_controller_complete(...)`.
+//
+// `prompt` may be NULL ("no prompt"); an empty string is passed through as
+// `Some("")` for parity with `mesh_job_controller_release_lease`.
+//
+// See [`crate::jobs::JobController::request_input`] for full semantics.
+// Flushes IMMEDIATELY (not via the coalescing batch tick) because the
+// consumer is blocked on this control-plane transition. NON-terminal: the
+// handler keeps running; `complete` / `fail` exit `input_required`.
+//
+// # Safety
+// `handle` must come from [`mesh_job_controller_new`] and must not yet have
+// been freed.
+int32_t mesh_job_controller_request_input(struct JobControllerHandle *handle, const char *prompt);
+
 // Whether `complete` / `fail` has already been called on this controller.
 //
 // # Returns

--- a/src/runtime/core/src/jobs.rs
+++ b/src/runtime/core/src/jobs.rs
@@ -353,8 +353,26 @@ impl JobController {
         // land at the registry AFTER the input_required transition on the next
         // batching tick. We do NOT set the terminal sentinel: the job stays
         // live and later progress/terminal deltas are still valid.
+        //
+        // Guard on the terminal sentinel UNDER the same lock first, mirroring
+        // `update_progress` / `flush_terminal` / `release_lease`: a helper task
+        // that calls `request_input` AFTER the controller went terminal
+        // (`complete` / `fail` / `release_lease`) must NOT submit a late
+        // `input_required` delta — the job is already done, and the registry
+        // would reject it (or it would stomp the terminal status). Unlike
+        // `update_progress` (which returns `()` and can only drop silently),
+        // this method returns a `Result`, so we surface `JobTerminal` — the
+        // same variant `send_event` raises for the identical "acted on an
+        // already-terminal job" condition, with SDK re-classification already
+        // wired across Python / TS / Java / FFI.
         {
             let mut q = self.queue.lock().await;
+            if self.terminal.load(Ordering::SeqCst) {
+                return Err(JobError::JobTerminal(format!(
+                    "request_input on terminal job {}",
+                    self.job_id
+                )));
+            }
             q.pending.remove(&self.job_id);
         }
         self.backend
@@ -1634,6 +1652,62 @@ mod tests {
         // The controller is still usable: complete() works from
         // input_required (mirrors the registry's accepted transition).
         ctrl.complete(serde_json::json!({"ok": true})).await.unwrap();
+        let job = backend.get_job(&resp.id).await.unwrap();
+        assert_eq!(job.status, JobStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn request_input_after_terminal_is_guarded() {
+        // A helper task calling request_input AFTER the controller went
+        // terminal (complete/fail) must NOT submit a late input_required
+        // delta — mirrors the update_progress/release_lease terminal guard.
+        // request_input returns a Result, so the guard surfaces JobTerminal
+        // (same variant send_event raises) rather than dropping silently.
+        let backend = MockBackend::new();
+        let queue = new_coalescing_queue();
+        let resp = backend
+            .create_job(CreateJobRequest {
+                capability: "cap".into(),
+                submitted_payload: serde_json::json!({}),
+                submitted_by: "inst-1".into(),
+                max_retries: None,
+                max_duration: None,
+                total_deadline: None,
+                owner_instance_id: None,
+            })
+            .await
+            .unwrap();
+        let ctrl = JobController::new(
+            resp.id.clone(),
+            "inst-1".to_string(),
+            backend.clone() as Arc<dyn TaskBackend>,
+            queue.clone(),
+        );
+
+        ctrl.complete(serde_json::json!({"done": true})).await.unwrap();
+        assert!(ctrl.is_terminal().await);
+        // Exactly one batch so far — the terminal one.
+        assert_eq!(backend.batch_count(), 1);
+
+        // Late request_input: must be rejected with JobTerminal and must
+        // NOT submit another batch.
+        let err = ctrl
+            .request_input(Some("too late".into()))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, JobError::JobTerminal(_)),
+            "expected JobTerminal, got {:?}",
+            err
+        );
+
+        // No additional batch flushed — the registry never saw a
+        // post-terminal input_required delta.
+        assert_eq!(backend.batch_count(), 1);
+        let (_, deltas) = backend.last_batch().unwrap();
+        assert!(deltas[0].is_terminal());
+
+        // Job status unchanged — still Completed, not InputRequired.
         let job = backend.get_job(&resp.id).await.unwrap();
         assert_eq!(job.status, JobStatus::Completed);
     }

--- a/src/runtime/core/src/jobs.rs
+++ b/src/runtime/core/src/jobs.rs
@@ -323,6 +323,46 @@ impl JobController {
         q.enqueue(delta);
     }
 
+    /// Transition the job to `input_required`, signalling the consumer that
+    /// the handler is blocked awaiting an external answer. STATUS-ONLY
+    /// primitive: it posts the `input_required` delta (with `prompt` carried
+    /// on the existing `progress_message` field) and returns once posted — it
+    /// does NOT await the answer. The canonical flow composes this with the
+    /// existing event primitives: the handler calls `request_input(prompt)`,
+    /// then parks on `recv_event(types=[...])`; an external party answers via
+    /// `JobProxy::send_event`; the handler resumes and `complete()`s (or
+    /// `fail()`s).
+    ///
+    /// Flushes IMMEDIATELY via the same `submit_batch` path `flush_terminal`
+    /// uses — NOT the coalescing batch tick — because this is a control-plane
+    /// transition the consumer is blocked on; it must not wait up to a tick
+    /// interval. Unlike `flush_terminal`, it does NOT set the terminal
+    /// sentinel: `input_required` is non-terminal, the handler keeps running,
+    /// and a subsequent `update_progress`/`complete`/`fail` is still valid.
+    /// The registry lease-extends on this delta (`ApplyJobDeltas`).
+    ///
+    /// Exit: `complete()` / `fail()` already transition out of
+    /// `input_required` (the registry confirms). There is no mid-flight
+    /// resume-to-`working` primitive in v1 — a `resume_working()` is a future
+    /// follow-up.
+    pub async fn request_input(&self, prompt: Option<String>) -> Result<(), JobError> {
+        let delta = JobDelta::input_required(self.job_id.clone(), prompt);
+        // Evict any pending coalesced progress delta for this job UNDER the
+        // queue lock before the immediate flush — same fence `flush_terminal`
+        // uses — so a stale progress delta queued just before this call can't
+        // land at the registry AFTER the input_required transition on the next
+        // batching tick. We do NOT set the terminal sentinel: the job stays
+        // live and later progress/terminal deltas are still valid.
+        {
+            let mut q = self.queue.lock().await;
+            q.pending.remove(&self.job_id);
+        }
+        self.backend
+            .submit_batch(&self.instance_id, vec![delta])
+            .await?;
+        Ok(())
+    }
+
     /// Mark the job complete with the given result. Flushes immediately
     /// (terminal status — application is done).
     pub async fn complete(&self, result: serde_json::Value) -> Result<(), JobError> {
@@ -1538,6 +1578,64 @@ mod tests {
         let job = backend.get_job(&resp.id).await.unwrap();
         assert_eq!(job.status, JobStatus::Completed);
         assert_eq!(job.result, Some(serde_json::json!({"ans": 42})));
+    }
+
+    #[tokio::test]
+    async fn request_input_flushes_immediately_non_terminal() {
+        let backend = MockBackend::new();
+        let queue = new_coalescing_queue();
+        let resp = backend
+            .create_job(CreateJobRequest {
+                capability: "cap".into(),
+                submitted_payload: serde_json::json!({}),
+                submitted_by: "inst-1".into(),
+                max_retries: None,
+                max_duration: None,
+                total_deadline: None,
+                owner_instance_id: None,
+            })
+            .await
+            .unwrap();
+        let ctrl = JobController::new(
+            resp.id.clone(),
+            "inst-1".to_string(),
+            backend.clone() as Arc<dyn TaskBackend>,
+            queue.clone(),
+        );
+        // A pending progress delta should be evicted by request_input so it
+        // can't land after the input_required transition.
+        ctrl.update_progress(0.4, Some("pre".into())).await;
+        ctrl.request_input(Some("need approval".into()))
+            .await
+            .unwrap();
+
+        // Queue drained (pending progress evicted under the lock).
+        {
+            let q = queue.lock().await;
+            assert_eq!(q.len(), 0);
+        }
+
+        // Exactly one batch flushed immediately — the input_required delta.
+        assert_eq!(backend.batch_count(), 1);
+        let (instance, deltas) = backend.last_batch().unwrap();
+        assert_eq!(instance, "inst-1");
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].status, Some(JobStatus::InputRequired));
+        assert_eq!(deltas[0].progress_message.as_deref(), Some("need approval"));
+        // NON-terminal: the controller stays live.
+        assert!(!deltas[0].is_terminal());
+        assert!(!ctrl.is_terminal().await);
+
+        // Registry reflects input_required + the prompt on progress_message.
+        let job = backend.get_job(&resp.id).await.unwrap();
+        assert_eq!(job.status, JobStatus::InputRequired);
+        assert_eq!(job.progress_message.as_deref(), Some("need approval"));
+
+        // The controller is still usable: complete() works from
+        // input_required (mirrors the registry's accepted transition).
+        ctrl.complete(serde_json::json!({"ok": true})).await.unwrap();
+        let job = backend.get_job(&resp.id).await.unwrap();
+        assert_eq!(job.status, JobStatus::Completed);
     }
 
     #[tokio::test]

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -421,6 +421,51 @@ pub unsafe extern "C" fn mesh_job_controller_release_lease(
         .unwrap_or_else(jobs_set_err)
 }
 
+/// Transition the job to `input_required`, signalling the consumer that the
+/// handler is blocked awaiting an external answer. STATUS-ONLY primitive: it
+/// posts the `input_required` delta (with `prompt` carried on the existing
+/// `progress_message` field) and returns once posted — it does NOT await the
+/// answer. Compose it with the existing event primitives for a full
+/// request-and-await: call `mesh_job_controller_request_input(prompt)`, then
+/// park on `mesh_job_controller_recv_event(["answer"])`; an external party
+/// answers via `mesh_job_proxy_send_event("answer", ...)`; the handler
+/// resumes and calls `mesh_job_controller_complete(...)`.
+///
+/// `prompt` may be NULL ("no prompt"); an empty string is passed through as
+/// `Some("")` for parity with `mesh_job_controller_release_lease`.
+///
+/// See [`crate::jobs::JobController::request_input`] for full semantics.
+/// Flushes IMMEDIATELY (not via the coalescing batch tick) because the
+/// consumer is blocked on this control-plane transition. NON-terminal: the
+/// handler keeps running; `complete` / `fail` exit `input_required`.
+///
+/// # Safety
+/// `handle` must come from [`mesh_job_controller_new`] and must not yet have
+/// been freed.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_controller_request_input(
+    handle: *mut JobControllerHandle,
+    prompt: *const c_char,
+) -> i32 {
+    take_last_error();
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+    let handle = &*handle;
+    // `prompt` is optional — NULL means "no prompt". Empty string is passed
+    // through as `Some("")` for parity with `mesh_job_controller_release_lease`.
+    let prompt_opt: Option<String> = match opt_cstr(prompt, "prompt") {
+        Ok(opt) => opt.map(str::to_string),
+        Err(()) => return -1,
+    };
+    let inner = handle.inner.clone();
+    jobs_runtime()
+        .block_on(async move { inner.request_input(prompt_opt).await })
+        .map(|_| 0)
+        .unwrap_or_else(jobs_set_err)
+}
+
 /// Whether `complete` / `fail` has already been called on this controller.
 ///
 /// # Returns

--- a/src/runtime/core/src/jobs_napi.rs
+++ b/src/runtime/core/src/jobs_napi.rs
@@ -257,6 +257,31 @@ impl JsJobController {
         Ok(())
     }
 
+    /// Transition the job to `input_required`, signalling the consumer
+    /// that the handler is blocked awaiting an external answer. STATUS-ONLY
+    /// primitive: it posts the `input_required` delta (with `prompt`
+    /// carried on the existing `progress_message` field) and resolves once
+    /// posted — it does NOT await the answer. Compose it with the existing
+    /// event primitives for a full request-and-await: call
+    /// `await job.requestInput(prompt)`, then park on
+    /// `await job.recvEvent(["answer"])`; an external party answers via
+    /// `proxy.sendEvent("answer", ...)`; the handler resumes and
+    /// `await job.complete(...)`s.
+    ///
+    /// Flushes IMMEDIATELY (not via the coalescing batch tick) because the
+    /// consumer is blocked on this control-plane transition. NON-terminal:
+    /// the handler keeps running and may still call `updateProgress` /
+    /// `complete` / `fail` afterwards. `complete` / `fail` exit
+    /// `input_required` (the registry confirms the transition).
+    #[napi]
+    pub async fn request_input(&self, prompt: Option<String>) -> Result<()> {
+        self.inner
+            .request_input(prompt)
+            .await
+            .map_err(job_error_to_napi)?;
+        Ok(())
+    }
+
     /// Wait for the next event posted into this job's event log.
     ///
     /// Mirrors [`JobController::recv_event`]. Returns the event as a JS

--- a/src/runtime/core/src/jobs_py.rs
+++ b/src/runtime/core/src/jobs_py.rs
@@ -269,6 +269,37 @@ impl PyJobController {
         })
     }
 
+    /// Transition the job to ``input_required``, signalling the consumer
+    /// that the handler is blocked awaiting an external answer. STATUS-ONLY
+    /// primitive: it posts the ``input_required`` delta (with ``prompt``
+    /// carried on the existing ``progress_message`` field) and returns once
+    /// posted — it does NOT await the answer. Compose it with the existing
+    /// event primitives for a full request-and-await: call
+    /// ``await job.request_input(prompt)``, then park on
+    /// ``await job.recv_event(types=["answer"])``; an external party answers
+    /// via ``proxy.send_event("answer", ...)``; the handler resumes and
+    /// ``await job.complete(...)``s.
+    ///
+    /// Flushes IMMEDIATELY (not via the coalescing batch tick) because the
+    /// consumer is blocked on this control-plane transition. NON-terminal:
+    /// the handler keeps running and may still call ``update_progress`` /
+    /// ``complete`` / ``fail`` afterwards. ``complete`` / ``fail`` exit
+    /// ``input_required`` (the registry confirms the transition).
+    ///
+    /// Signature: ``request_input(prompt: Optional[str] = None) -> None``
+    #[pyo3(signature = (prompt=None))]
+    fn request_input<'py>(
+        &self,
+        py: Python<'py>,
+        prompt: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            inner.request_input(prompt).await.map_err(job_error_to_py)?;
+            Ok(())
+        })
+    }
+
     /// Whether ``complete`` / ``fail`` has already been called on this
     /// controller. The Python dispatch wrapper uses this to decide
     /// whether a returning user function needs an auto-``complete`` —

--- a/src/runtime/core/src/task_backend.rs
+++ b/src/runtime/core/src/task_backend.rs
@@ -95,6 +95,24 @@ impl JobDelta {
         }
     }
 
+    /// Construct an `input_required` delta (non-terminal). Transitions a
+    /// running job to `input_required` status, signalling the consumer that
+    /// the handler is blocked awaiting an external answer (typically supplied
+    /// via `post_event` + drained by `recv_event`). The optional `message`
+    /// rides the existing `progress_message` field — no new wire field. The
+    /// registry lease-extends on this delta (`ApplyJobDeltas` in
+    /// `ent_service_jobs.go`); the job stays live, so this is NOT terminal.
+    pub fn input_required(id: impl Into<String>, message: Option<String>) -> Self {
+        Self {
+            id: id.into(),
+            status: Some(JobStatus::InputRequired),
+            progress: None,
+            progress_message: message,
+            result: None,
+            error: None,
+        }
+    }
+
     /// Construct a terminal `completed` delta with a result payload.
     pub fn completed(id: impl Into<String>, result: serde_json::Value) -> Self {
         Self {
@@ -741,6 +759,33 @@ mod tests {
         assert_eq!(d.progress_message.as_deref(), Some("halfway"));
         assert!(d.status.is_none());
         assert!(!d.is_terminal());
+    }
+
+    #[test]
+    fn job_delta_input_required_constructor() {
+        let d = JobDelta::input_required("job-1", Some("need approval".into()));
+        assert_eq!(d.id, "job-1");
+        assert_eq!(d.status, Some(JobStatus::InputRequired));
+        assert_eq!(d.progress_message.as_deref(), Some("need approval"));
+        assert!(d.progress.is_none());
+        assert!(d.result.is_none());
+        assert!(d.error.is_none());
+        // input_required is NON-terminal — the handler keeps running.
+        assert!(!d.is_terminal());
+        // Status serializes as snake_case "input_required".
+        let v = serde_json::to_value(&d).unwrap();
+        assert_eq!(v["status"], serde_json::json!("input_required"));
+        assert_eq!(v["progress_message"], serde_json::json!("need approval"));
+    }
+
+    #[test]
+    fn job_delta_input_required_omits_message_when_none() {
+        let d = JobDelta::input_required("job-1", None);
+        assert_eq!(d.status, Some(JobStatus::InputRequired));
+        assert!(d.progress_message.is_none());
+        let s = serde_json::to_string(&d).unwrap();
+        assert!(s.contains("\"status\":\"input_required\""));
+        assert!(!s.contains("progress_message"));
     }
 
     #[test]

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
@@ -531,6 +531,27 @@ public interface MeshCore {
     int mesh_job_controller_release_lease(Pointer handle, String reason);
 
     /**
+     * Transition the job to {@code input_required}, signalling the consumer
+     * that the handler is blocked awaiting an external answer. STATUS-ONLY:
+     * posts the {@code input_required} delta (with {@code prompt} carried on
+     * the existing {@code progress_message} field) and returns once posted —
+     * it does NOT await the answer. Compose it with the event primitives for
+     * request-and-await: call {@code mesh_job_controller_request_input(prompt)},
+     * then park on {@code mesh_job_controller_recv_event(["answer"])}; an
+     * external party answers via {@code mesh_job_proxy_send_event}; the handler
+     * resumes and calls {@code mesh_job_controller_complete}.
+     *
+     * <p>Flushes IMMEDIATELY (not via the coalescing batch tick) because the
+     * consumer is blocked on this control-plane transition. NON-terminal: the
+     * handler keeps running; complete / fail exit {@code input_required}.
+     *
+     * @param handle Controller handle
+     * @param prompt Optional prompt (may be null for "no prompt")
+     * @return 0 on success, -1 on error
+     */
+    int mesh_job_controller_request_input(Pointer handle, String prompt);
+
+    /**
      * Whether complete / fail has already been called on this controller.
      *
      * @param handle Controller handle

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
@@ -203,6 +203,41 @@ public final class JobController implements MeshJob, AutoCloseable {
     }
 
     /**
+     * Transition the job to {@code input_required}, signalling the consumer
+     * that the handler is blocked awaiting an external answer. STATUS-ONLY:
+     * posts the transition ({@code prompt} rides the {@code progress_message}
+     * field), flushes immediately, and returns — it does NOT await the answer.
+     * Compose it with {@link #recvEvent} for request-and-await: call
+     * {@code requestInput(prompt)}, then park on
+     * {@code recvEvent(List.of("answer"), timeout)}; an external party answers
+     * via {@code MeshJobs.postEvent(jobId, "answer", ...)}; the handler resumes
+     * and {@link #complete}s.
+     *
+     * <p>Flushes IMMEDIATELY (not via the coalescing batch tick) because the
+     * consumer is blocked on this control-plane transition. NON-terminal: the
+     * handler keeps running and may still call {@link #updateProgress} /
+     * {@link #complete} / {@link #fail} afterwards. {@code complete} /
+     * {@code fail} exit {@code input_required} (the registry confirms the
+     * transition).
+     *
+     * <p>Mirrors Python's {@code job.request_input(prompt)} and TypeScript's
+     * {@code job.requestInput(prompt)}.
+     *
+     * @param prompt short human-readable prompt (may be {@code null} for
+     *               "no prompt").
+     * @throws MeshException if the controller is closed or the native call fails
+     */
+    public void requestInput(String prompt) {
+        synchronized (lock) {
+            ensureOpen();
+            int rc = core.mesh_job_controller_request_input(handle, prompt);
+            if (rc != 0) {
+                throw new MeshException("mesh_job_controller_request_input failed: " + lastError(core));
+            }
+        }
+    }
+
+    /**
      * Whether {@link #complete} / {@link #fail} has already been called on
      * this controller. The dispatch wrapper uses this to decide whether a
      * returning user method needs an auto-{@code complete} (the

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJob.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJob.java
@@ -13,8 +13,12 @@ package io.mcpmesh;
  *       {@code @MeshTool(task = true)} receives a {@code JobController} via
  *       this slot when invoked through the job-dispatch path
  *       ({@code X-Mesh-Job-Id} header present, or claimed from the pull
- *       queue). The user calls {@code updateProgress() / complete() / fail()}
- *       on it.</li>
+ *       queue). The user calls {@code updateProgress() / requestInput() /
+ *       complete() / fail()} on it. {@code requestInput(prompt)} transitions
+ *       the job to {@code input_required} (status-only; flushes immediately)
+ *       so the handler can park on {@code recvEvent(List.of("answer"), ...)}
+ *       for an external party to answer via
+ *       {@code MeshJobs.postEvent(jobId, "answer", ...)}.</li>
  *   <li><b>Consumer side</b> — a method depending on a {@code task = true}
  *       capability receives a {@code MeshJobSubmitter} via this slot. The
  *       user calls {@code .submit(...)} on it to start a job and

--- a/src/runtime/python/mesh/types.py
+++ b/src/runtime/python/mesh/types.py
@@ -237,6 +237,16 @@ class MeshJob(Protocol):
 
     On the producer side the injected object exposes:
         - ``await job.update_progress(progress, message=None)`` — coalesced delta.
+        - ``await job.request_input(prompt=None)`` *(since v2.6)* —
+          transition the job to ``input_required``, signalling the consumer
+          that the handler is blocked awaiting an external answer. STATUS-ONLY:
+          posts the transition (``prompt`` rides the ``progress_message``
+          field), flushes immediately, and returns — it does NOT await the
+          answer. Compose with ``recv_event`` for request-and-await:
+          ``await job.request_input(prompt)`` then
+          ``await job.recv_event(types=["answer"])``; an external party answers
+          via ``proxy.send_event("answer", ...)``. Non-terminal — the handler
+          keeps running; ``complete`` / ``fail`` exit ``input_required``.
         - ``await job.complete(result)`` — terminal success.
         - ``await job.fail(error)`` — terminal failure.
         - ``await job.recv_event(types=None, timeout_secs=None)`` *(since v2.2)* —

--- a/src/runtime/typescript/src/jobs.ts
+++ b/src/runtime/typescript/src/jobs.ts
@@ -18,10 +18,14 @@
  *     error-message substrings ("job is terminal" / "job not found").
  *
  * The `JobController` / `JobProxy` napi-rs classes from `@mcpmesh/core`
- * already expose `recvEvent` / `sendEvent` methods directly — application
- * code calls them via the `MeshJob`-typed parameter the framework
- * injects. This module just adds the helper + error classes around that
- * surface, mirroring Python's `mesh.jobs.post_event` API one-for-one.
+ * already expose `recvEvent` / `sendEvent` / `requestInput` methods
+ * directly — application code calls them via the `MeshJob`-typed parameter
+ * the framework injects. In particular `await job.requestInput(prompt)`
+ * transitions the job to `input_required` (status-only; flushes
+ * immediately) so a handler can park on `await job.recvEvent(["answer"])`
+ * for an external party to answer via {@link postEvent} / `proxy.sendEvent`.
+ * This module just adds the helper + error classes around that surface,
+ * mirroring Python's `mesh.jobs.post_event` API one-for-one.
  */
 
 import { JobProxy } from "@mcpmesh/core";

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -115,6 +115,20 @@ export interface MeshJob {
   // Producer-side surface (when injected as JobController):
   jobId?: string;
   updateProgress?(progress: number, message?: string): Promise<void>;
+  /**
+   * Transition the job to `input_required`, signalling the consumer that
+   * the handler is blocked awaiting an external answer. STATUS-ONLY:
+   * posts the transition (`prompt` rides the `progress_message` field),
+   * flushes immediately, and resolves — it does NOT await the answer.
+   * Compose with `recvEvent` for request-and-await:
+   * `await job.requestInput(prompt)` then
+   * `await job.recvEvent(["answer"])`; an external party answers via
+   * `proxy.sendEvent("answer", ...)`. Non-terminal — the handler keeps
+   * running; `complete` / `fail` exit `input_required`.
+   *
+   * Mirrors Python's `MeshJob.request_input`.
+   */
+  requestInput?(prompt?: string): Promise<void>;
   complete?(result: unknown): Promise<void>;
   fail?(error: string): Promise<void>;
   /**

--- a/tests/integration/suites/uc21_meshjob/fixtures/long-task-consumer/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/long-task-consumer/main.py
@@ -541,6 +541,38 @@ async def commission_subscribe_observer(
     }
 
 
+# ---------------------------------------------------------------------------
+# input_required lease-reclaim submitter (tc29 / C1, #1229)
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.tool(
+    capability="commission_awaits_input",
+    dependencies=["awaits_input_forever"],
+    description="Submit awaits_input_forever with a small max_duration and max_retries=0; never posts the answer.",
+)
+async def commission_awaits_input(
+    user_id: str = "alice",
+    max_duration: int = 2,
+    awaits_input_forever: MeshJob = None,
+) -> dict:
+    if awaits_input_forever is None:
+        return {"error": "awaits_input_forever submitter not injected"}
+    # Small max_duration sizes the LEASE window so it lapses quickly once the
+    # producer parks in input_required without heartbeating. max_retries=0
+    # makes the lease lapse terminal on the first reclaim pass (status=failed,
+    # error="lease expired: ..."), avoiding a reset→reclaim race that a
+    # non-zero retry budget would introduce. We deliberately NEVER post the
+    # "answer" event the producer is parked on.
+    proxy = await awaits_input_forever.submit(
+        user_id=user_id,
+        max_duration=max_duration,
+        max_retries=0,
+    )
+    return {"job_id": getattr(proxy, "job_id", None)}
+
+
 import os  # noqa: E402  (kept here for clarity that env-port is the only env hook)
 
 

--- a/tests/integration/suites/uc21_meshjob/fixtures/long-task-provider/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/long-task-provider/main.py
@@ -480,6 +480,56 @@ async def run_until_cancel(
     return {"status": "loop_exhausted", "events_seen": events_seen}
 
 
+# ---------------------------------------------------------------------------
+# input_required parking — exercises C1 lease-reclaim of input_required jobs
+# (#1229). The producer transitions the row to ``input_required`` and then
+# parks indefinitely WITHOUT posting any further progress.
+# ---------------------------------------------------------------------------
+#
+# The injected JobController exposes ``request_input(prompt)`` — the SDK
+# primitive that transitions the owned job to ``input_required`` (status-only,
+# non-terminal, flushed immediately). It uses the controller's own job context
+# and lease ownership, so no registry-URL / instance-id plumbing is needed.
+#
+# After signalling input_required the handler parks on recv_event for an
+# "answer" event that never arrives, posting NO progress. Because progress
+# deltas are what extend the lease, the silent park lets the lease lapse so
+# the registry's ReclaimExpiredLeaseJobs phase (now input_required-scoped)
+# can reap it — the whole point of the C1 test.
+
+
+@app.tool()
+@mesh.tool(
+    capability="awaits_input_forever",
+    task=True,
+    description="Transitions the job to input_required, then parks on recv_event for an answer that never arrives — never posts progress, never completes.",
+)
+async def awaits_input_forever(
+    user_id: str,
+    job: MeshJob = None,
+) -> dict[str, Any]:
+    if job is None:
+        return {"status": "no_job_ctx"}
+    # Transition the row to input_required via the SDK primitive (the injected
+    # controller is the lease owner, so no manual owner-check plumbing needed).
+    await job.request_input(f"waiting on input for {user_id}")
+    # Park waiting for an "answer" event that the consumer never posts.
+    # CRITICAL: do NOT call update_progress here — a progress delta would
+    # extend the lease and defeat the lease-reclaim test. recv_event is a
+    # pure long-poll read; it does not heartbeat the lease. We loop on the
+    # long-poll so the handler stays parked well past the lease window; the
+    # registry reaps the row out from under us via ReclaimExpiredLeaseJobs.
+    for _ in range(60):
+        event = await job.recv_event(types=["answer"], timeout_secs=15.0)
+        if event is not None:
+            # An answer arrived (not expected in the C1 test) — complete so
+            # the fixture is still well-behaved if ever exercised that way.
+            payload = {"status": "got_answer", "payload": event["payload"]}
+            await job.complete(payload)
+            return payload
+    return {"status": "never_answered"}
+
+
 @mesh.agent(
     name="long-task-provider",
     version="1.0.0",

--- a/tests/integration/suites/uc21_meshjob/routines.yaml
+++ b/tests/integration/suites/uc21_meshjob/routines.yaml
@@ -78,6 +78,67 @@ routines:
         capture: registry_start
         timeout: 30
 
+  # Start the registry with the stale-job reaping phase ENABLED.
+  #
+  # Clones start_registry_with_fast_sweep but adds
+  # ``MCP_MESH_JOB_STALE_TIMEOUT=3s`` — the opt-in default total-runtime
+  # ceiling for jobs that did NOT set their own ``total_deadline`` (#1229).
+  # A non-terminal job with a NULL total_deadline whose ``submitted_at`` is
+  # older than 3s is reaped by the new ExpireStaleJobs sweep phase → marked
+  # ``failed`` with error ``"stale: ..."``, owner/lease cleared, and a
+  # synthetic ``stale`` JobEvent posted.
+  #
+  # The sweep tick is tightened to ``MCP_MESH_SWEEP_INTERVAL=2s`` so the
+  # stale cutoff is enforced within a couple of ticks; the RETENTION +
+  # health knobs are kept identical to the fast-sweep routine so the
+  # lease/orphan phases still behave as in the shared routine.
+  #
+  # ISOLATION: this routine is used ONLY by the C2 tc (tc28). A suite-wide
+  # stale timeout would reap every other tc's still-working jobs, so the
+  # shared start_registry_with_fast_sweep routine is deliberately left
+  # untouched — each stale-reaping tc spins up its own isolated registry.
+  #
+  # The registry does NOT emit a dedicated startup log line for the stale
+  # timeout (it is folded into LoadSweepConfigFromEnv silently), so the
+  # post-start guard keeps the existing ``[sweep] using MCP_MESH_SWEEP_INTERVAL``
+  # assertion — that line proves the sweep config (including the stale
+  # knob parsed in the same pass) took effect.
+  start_registry_with_stale_reaping:
+    description: "Start the mesh registry with the stale-job reaping phase enabled (MCP_MESH_JOB_STALE_TIMEOUT=3s)"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: |
+          MCP_MESH_SWEEP_INTERVAL=2s \
+          MCP_MESH_JOB_STALE_TIMEOUT=3s \
+          MCP_MESH_RETENTION=10s \
+          MCP_MESH_HEALTH_CHECK_INTERVAL=5 \
+          DEFAULT_TIMEOUT_THRESHOLD=15 \
+            meshctl start --registry-only -d
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "registry ready after ${i}s"
+              # Verify the sweep override actually stamped its log line.
+              # The stale timeout is parsed in the same LoadSweepConfigFromEnv
+              # pass as MCP_MESH_SWEEP_INTERVAL, so this guard confirms the
+              # whole sweep config (including the stale knob) took effect.
+              # Tail the log so a stale match from an earlier run in the
+              # same shell session can't make a misconfigured current run
+              # look healthy.
+              tail -n 200 ~/.mcp-mesh/logs/registry.log \
+                | grep -qE '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
+                || { echo "FAIL: MCP_MESH_SWEEP_INTERVAL override did not take effect"; exit 1; }
+              echo "[setup] confirmed sweep override active (stale reaping enabled)"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: registry did not become ready in 20s"
+          tail -50 ~/.mcp-mesh/logs/registry.log 2>/dev/null || true
+          exit 1
+        capture: registry_start
+        timeout: 30
+
   # Stop everything started by this test (agents + registry).
   stop_all:
     description: "Stop all mesh processes started by this test"

--- a/tests/integration/suites/uc21_meshjob/tc28_stale_job_reaped/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc28_stale_job_reaped/test.yaml
@@ -1,0 +1,163 @@
+# tc28_stale_job_reaped — default stale-ceiling sweep reaps a long-running
+# job that did NOT set its own total_deadline (#1229, C2).
+#
+# The new ExpireStaleJobs sweep phase is opt-in via
+# ``MCP_MESH_JOB_STALE_TIMEOUT`` (this tc's isolated registry sets it to 3s
+# via start_registry_with_stale_reaping). It applies a DEFAULT total-runtime
+# ceiling — measured from submitted_at — to jobs that did NOT set their own
+# ``total_deadline``. A non-terminal such job older than the ceiling is
+# marked ``failed`` with error ``"stale: ..."``, its lease/owner cleared, and
+# a synthetic ``stale`` JobEvent posted.
+#
+# Setup that isolates the STALE phase from the lease / orphan / deadline
+# phases (so a pass unambiguously proves the stale phase reaped the row):
+#   - commission_submit_only submits generate_report with NO total_deadline
+#     (so ExpireDeadlinedJobs can't touch it — its filter requires a non-null
+#     total_deadline) and a LARGE max_duration=60 (so the LEASE does not
+#     expire first — else ReclaimExpiredLeaseJobs / C1 would catch it).
+#   - the job runs ~20s (10 sections * ~2s) — well past the 3s stale cutoff —
+#     so it is still ``working`` when the stale sweep fires.
+#   - the provider is kept HEALTHY (never killed): a dead owner would let
+#     ResetOrphanedJobs stamp ``orphaned:`` instead of ``stale:``.
+#
+# Asserts:
+#   - status == failed
+#   - error CONTAINS "stale:"  (the stale phase reaped it)
+#   - error does NOT contain "deadline_exceeded" and NOT "orphaned"
+#     (proves it was NOT the explicit-deadline or orphan path)
+#   - owner_instance_id null/absent AND lease_expires_at null (slot freed)
+#   - the events log CONTAINS a {type: "stale"} entry whose payload mentions
+#     reason/stale
+
+name: "MeshJob: stale-job sweep reaps a long job with no total_deadline"
+description: "Job with no total_deadline + large max_duration runs past MCP_MESH_JOB_STALE_TIMEOUT=3s; stale sweep marks it failed with 'stale:' and posts a synthetic stale event"
+tags:
+  - meshjob
+  - python
+  - issue-1229
+  - stale
+  - deadline
+  - slow
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  # Isolated registry with the stale-reaping phase ENABLED
+  # (MCP_MESH_JOB_STALE_TIMEOUT=3s, sweep tick 2s). Used ONLY by this tc —
+  # a suite-wide stale timeout would reap other tcs' working jobs.
+  - routine: start_registry_with_stale_reaping
+
+  - name: "Start provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Start consumer (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only: wait for both agents to REGISTER. Dependency resolution is
+  # covered by the settle window — no fixed dep-resolution sleep needed.
+  - name: "Wait for both agents to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for both agents to register..."
+      for i in $(seq 1 60); do
+        AGENTS=$(meshctl list 2>/dev/null || true)
+        if echo "$AGENTS" | grep -q "long-task-provider" && echo "$AGENTS" | grep -q "long-task-consumer"; then
+          echo "Both agents registered after ~${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: agents did not register within 60s"
+      meshctl list 2>/dev/null || true
+      exit 1
+    capture: wait_registration
+    timeout: 90
+
+  # NO total_deadline (commission_submit_only never sets one) + a large
+  # max_duration so the lease can't lapse first. 10 sections * ~2s ≈ 20s of
+  # work — well past the 3s stale ceiling, so the job is still working when
+  # the stale sweep fires.
+  - name: "Submit generate_report with NO total_deadline, max_duration=60"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g","h","i","j"],"max_retries":0,"max_duration":60}'
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Capture job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1 | xargs -I{} echo "JOB_ID={}"
+    capture: job_id_extract
+
+  # stale_timeout=3s + a couple 2s sweep ticks + headroom. The provider is
+  # kept HEALTHY throughout (never killed) so the row is reaped by the stale
+  # phase, not the orphan phase.
+  - name: "Wait for the stale sweep to fire"
+    handler: wait
+    seconds: 12
+
+  - name: "Final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,error,total_deadline,owner_instance_id,lease_expires_at}'
+    capture: final_status
+
+  - name: "Read job events for the synthetic stale event"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}/events" | jq '.events | map({seq, type, payload})'
+    capture: stale_events
+
+assertions:
+  - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
+    message: "stale job must be marked failed"
+  - expr: "${captured.final_status} contains 'stale:'"
+    message: "error must carry the canonical 'stale:' reason — proves the stale-ceiling sweep reaped it"
+  - expr: "${captured.final_status} not contains 'deadline_exceeded'"
+    message: "the stale path must NOT be confused with the explicit-deadline path (no total_deadline was set)"
+  - expr: "${captured.final_status} not contains 'orphaned'"
+    message: "the provider was kept healthy — error must NOT mention 'orphaned' (that would be the orphan-reset path)"
+  - expr: "${captured.final_status} contains '\"owner_instance_id\": null'"
+    message: "stale reap must clear owner_instance_id (slot freed)"
+  - expr: "${captured.final_status} contains '\"lease_expires_at\": null'"
+    message: "stale reap must clear lease_expires_at (slot freed)"
+  - expr: "${captured.stale_events} contains '\"type\": \"stale\"'"
+    message: "the stale sweep must post a synthetic 'stale' JobEvent"
+  - expr: "${captured.stale_events} contains 'stale'"
+    message: "the synthetic stale event payload must mention the stale reason"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc21_meshjob/tc29_input_required_reclaimed/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc29_input_required_reclaimed/test.yaml
@@ -130,13 +130,6 @@ test:
           echo "REACHED_INPUT_REQUIRED=1"
           exit 0
         fi
-        # If it already went terminal failed (sweep won the race against our
-        # poll), that's still consistent with the reclaim — surface it and
-        # let the terminal assertions below decide.
-        if [ "$ST" = "failed" ]; then
-          echo "ALREADY_FAILED_BEFORE_POLL_SAW_INPUT_REQUIRED=1"
-          exit 0
-        fi
         sleep 1
       done
       echo "ERROR: job never reached input_required within 30s"

--- a/tests/integration/suites/uc21_meshjob/tc29_input_required_reclaimed/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc29_input_required_reclaimed/test.yaml
@@ -1,0 +1,178 @@
+# tc29_input_required_reclaimed — an input_required job whose lease expires
+# is reclaimed by the (now input_required-scoped) lease-recovery sweep
+# (#1229, C1).
+#
+# Before this fix, ReclaimExpiredLeaseJobs / ResetOrphanedJobs only matched
+# ``status=working`` rows, so a job parked in ``input_required`` whose
+# producer stopped heartbeating was stranded forever. The fix widens the
+# filter to ``StatusIn(working, input_required)``. With max_retries=0 the
+# reclaim is terminal on the first lapse: status=failed,
+# error="lease expired: no completion within lease window".
+#
+# Flow:
+#   - The producer's ``awaits_input_forever`` task transitions the row to
+#     ``input_required`` (via the ``request_input`` SDK primitive on the
+#     injected controller) then parks on recv_event for an "answer" that never
+#     arrives, posting NO progress (a progress delta would extend the lease).
+#   - The consumer's ``commission_awaits_input`` submits with a small
+#     max_duration=2 (short lease window) and max_retries=0, and never posts
+#     the answer.
+#   - The lease lapses ~2s after claim; the next sweep tick (fast-sweep
+#     routine, ~10s) runs ReclaimExpiredLeaseJobs which now sees the
+#     input_required row, and — budget exhausted (max_retries=0) — marks it
+#     failed with "lease expired: ...".
+#
+# Uses the EXISTING start_registry_with_fast_sweep routine (NO stale timeout)
+# so the failure is unambiguously lease-reclaim, not the stale phase.
+#
+# Asserts:
+#   - the job first reaches status=input_required (proves it parked there)
+#   - terminal status == failed
+#   - error CONTAINS "lease expired"
+#   - error does NOT contain "stale:"  (distinguishes C1 from C2)
+#   - owner_instance_id null (slot freed by the reclaim)
+
+name: "MeshJob: input_required job with expired lease is reclaimed (failed on exhausted budget)"
+description: "Producer parks a job in input_required without heartbeating; lease-recovery sweep (now input_required-scoped) marks it failed 'lease expired' with max_retries=0"
+tags:
+  - meshjob
+  - python
+  - issue-1229
+  - input-required
+  - retry
+  - slow
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  # Fast sweep, NO stale timeout — the failure must be lease-reclaim only.
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Start consumer (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only: wait for both agents to REGISTER. Dependency resolution is
+  # covered by the settle window — no fixed dep-resolution sleep needed.
+  - name: "Wait for both agents to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for both agents to register..."
+      for i in $(seq 1 60); do
+        AGENTS=$(meshctl list 2>/dev/null || true)
+        if echo "$AGENTS" | grep -q "long-task-provider" && echo "$AGENTS" | grep -q "long-task-consumer"; then
+          echo "Both agents registered after ~${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: agents did not register within 60s"
+      meshctl list 2>/dev/null || true
+      exit 1
+    capture: wait_registration
+    timeout: 90
+
+  # Small max_duration=2 sizes the lease window; max_retries=0 makes the
+  # reclaim terminal on the first lapse. The answer event is never posted.
+  - name: "Submit awaits_input_forever (max_duration=2, max_retries=0)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_awaits_input '{"user_id":"alice","max_duration":2}'
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Capture job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1 | xargs -I{} echo "JOB_ID={}"
+    capture: job_id_extract
+
+  # Poll until the row reaches input_required — proves the producer claimed
+  # the job and transitioned it (the precondition the C1 fix is about). The
+  # row stays input_required only briefly before the lease lapses, so poll
+  # fast and capture the first hit.
+  - name: "Poll until the job is input_required"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      for i in $(seq 1 30); do
+        ST=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.status')
+        echo "poll ${i}: status=${ST}"
+        if [ "$ST" = "input_required" ]; then
+          echo "REACHED_INPUT_REQUIRED=1"
+          exit 0
+        fi
+        # If it already went terminal failed (sweep won the race against our
+        # poll), that's still consistent with the reclaim — surface it and
+        # let the terminal assertions below decide.
+        if [ "$ST" = "failed" ]; then
+          echo "ALREADY_FAILED_BEFORE_POLL_SAW_INPUT_REQUIRED=1"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: job never reached input_required within 30s"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,error,owner_instance_id,lease_expires_at}'
+      exit 1
+    capture: input_required_poll
+    timeout: 45
+
+  # Lease window (max_duration=2) + a couple fast-sweep ticks (~10s) +
+  # headroom. The provider is kept healthy so this is the lease-reclaim path,
+  # not the orphan path.
+  - name: "Wait for the lease-recovery sweep to fire"
+    handler: wait
+    seconds: 12
+
+  - name: "Final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,error,owner_instance_id,lease_expires_at,attempt_count}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.input_required_poll} contains 'REACHED_INPUT_REQUIRED=1'"
+    message: "the job must reach input_required before the lease lapses — proves the producer parked there"
+  - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
+    message: "input_required job whose lease lapsed with no retry budget must be marked failed"
+  - expr: "${captured.final_status} contains 'lease expired'"
+    message: "error must be the canonical 'lease expired' reason from the lease-recovery sweep"
+  - expr: "${captured.final_status} not contains 'stale:'"
+    message: "this is the lease-reclaim path (C1), NOT the stale-ceiling path (C2) — no stale timeout is set here"
+  - expr: "${captured.final_status} contains '\"owner_instance_id\": null'"
+    message: "lease reclaim must clear owner_instance_id (slot freed)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/src/index.ts
@@ -612,6 +612,45 @@ agent.addTool({
   },
 });
 
+// ---------------------------------------------------------------------------
+// input_required lease-reclaim submitter (tc28 / C1, #1229)
+// ---------------------------------------------------------------------------
+//
+// TS port of uc21_meshjob/fixtures/long-task-consumer/main.py
+// (commission_awaits_input). Submits awaits_input_forever with a SMALL
+// max_duration (sizes the lease window so it lapses quickly once the producer
+// parks in input_required without heartbeating) and max_retries=0 (makes the
+// lease lapse terminal on the first reclaim pass: status=failed,
+// error="lease expired: ...", avoiding a reset→reclaim race a non-zero retry
+// budget would introduce). We deliberately NEVER post the "answer" event the
+// producer is parked on.
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "commission_awaits_input",
+  capability: "commission_awaits_input",
+  dependencies: [{ capability: "awaits_input_forever" }],
+  meshJobDepIndex: 0,
+  description:
+    "Submit awaits_input_forever with a small max_duration and max_retries=0; never posts the answer.",
+  parameters: z.object({
+    user_id: z.string().default("alice"),
+    max_duration: z.number().int().default(2),
+  }),
+  execute: async (
+    { user_id, max_duration },
+    awaitsInputForever: MeshJob | null = null,
+  ) => {
+    if (!awaitsInputForever?.submit) {
+      return { error: "awaits_input_forever submitter not injected" };
+    }
+    const proxy = await awaitsInputForever.submit(
+      { user_id },
+      { maxDuration: max_duration, maxRetries: 0 },
+    );
+    return { job_id: (proxy as { jobId?: string }).jobId ?? null };
+  },
+});
+
 console.log(
   `long-task-consumer-ts uc22 fixture defined on port ${HTTP_PORT}. Waiting for auto-start...`,
 );

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/src/index.ts
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/src/index.ts
@@ -479,6 +479,63 @@ agent.addTool({
   },
 });
 
+// ---------------------------------------------------------------------------
+// input_required lease-reclaim producer (tc28 / C1, #1229)
+// ---------------------------------------------------------------------------
+//
+// TS port of uc21_meshjob/fixtures/long-task-provider/main.py
+// (awaits_input_forever). The injected JobController exposes
+// `requestInput(prompt?)` — the SDK primitive (napi binding to the shared
+// Rust core) that transitions the owned job to `input_required` (status-only,
+// non-terminal, flushed immediately). It uses the controller's own job
+// context + lease ownership, so no registry-URL / instance-id plumbing.
+//
+// After signalling input_required the handler parks on recvEvent for an
+// "answer" event that never arrives, posting NO progress. Because progress
+// deltas are what extend the lease, the silent park lets the lease lapse so
+// the registry's ReclaimExpiredLeaseJobs phase (now input_required-scoped)
+// can reap it — the whole point of the C1 test.
+// ---------------------------------------------------------------------------
+agent.addTool({
+  name: "awaits_input_forever",
+  capability: "awaits_input_forever",
+  task: true,
+  meshJobParamIndex: 1,
+  description:
+    "Transitions the job to input_required via requestInput(), then parks on recvEvent for an answer that never arrives — never posts progress, never completes.",
+  parameters: z.object({ user_id: z.string() }),
+  execute: async ({ user_id }, job: MeshJob | null = null) => {
+    if (!job?.requestInput) {
+      return { status: "no_job_ctx" };
+    }
+    // Transition the row to input_required via the SDK primitive (the injected
+    // controller is the lease owner, so no manual owner-check plumbing needed).
+    await job.requestInput(`waiting on input for ${user_id}`);
+    // Park waiting for an "answer" event the consumer never posts.
+    // CRITICAL: do NOT call updateProgress here — a progress delta would
+    // extend the lease and defeat the lease-reclaim test. recvEvent is a
+    // pure long-poll read; it does not heartbeat the lease. We loop on the
+    // long-poll so the handler stays parked well past the lease window; the
+    // registry reaps the row out from under us via ReclaimExpiredLeaseJobs.
+    if (!job.recvEvent) {
+      return { status: "no_recv_event" };
+    }
+    for (let i = 0; i < 60; i++) {
+      const event = await job.recvEvent(["answer"], 15);
+      if (event !== null) {
+        // An answer arrived (not expected in the C1 test) — complete so the
+        // fixture is still well-behaved if ever exercised that way.
+        const payload = { status: "got_answer", payload: event.payload };
+        if (job.complete) {
+          await job.complete(payload);
+        }
+        return payload;
+      }
+    }
+    return { status: "never_answered" };
+  },
+});
+
 console.log(
   `long-task-provider-ts uc22 fixture defined on port ${HTTP_PORT}. Waiting for auto-start...`,
 );

--- a/tests/integration/suites/uc22_meshjob_ts/tc28_input_required_reclaimed_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc28_input_required_reclaimed_ts/test.yaml
@@ -135,13 +135,6 @@ test:
           echo "REACHED_INPUT_REQUIRED=1"
           exit 0
         fi
-        # If it already went terminal failed (sweep won the race against our
-        # poll), that's still consistent with the reclaim — surface it and
-        # let the terminal assertions below decide.
-        if [ "$ST" = "failed" ]; then
-          echo "ALREADY_FAILED_BEFORE_POLL_SAW_INPUT_REQUIRED=1"
-          exit 0
-        fi
         sleep 1
       done
       echo "ERROR: job never reached input_required within 30s"

--- a/tests/integration/suites/uc22_meshjob_ts/tc28_input_required_reclaimed_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc28_input_required_reclaimed_ts/test.yaml
@@ -1,0 +1,183 @@
+# tc28_input_required_reclaimed_ts — TS port of uc21/tc29 (#1229, C1).
+#
+# Proves the new TypeScript `requestInput()` MeshJob primitive (napi binding
+# to the shared Rust core) works end-to-end: it transitions a job to
+# `input_required`, and a job parked there whose lease lapses is reclaimed by
+# the (now input_required-scoped) lease-recovery sweep.
+#
+# Before this fix, ReclaimExpiredLeaseJobs / ResetOrphanedJobs only matched
+# ``status=working`` rows, so a job parked in ``input_required`` whose
+# producer stopped heartbeating was stranded forever. The fix widens the
+# filter to ``StatusIn(working, input_required)``. With max_retries=0 the
+# reclaim is terminal on the first lapse: status=failed,
+# error="lease expired: no completion within lease window".
+#
+# Flow:
+#   - The producer's ``awaits_input_forever`` task calls
+#     ``await job.requestInput("waiting for input")`` to transition the row to
+#     ``input_required`` (proving the TS primitive works), then parks on
+#     recvEvent for an "answer" that never arrives, posting NO progress (a
+#     progress delta would extend the lease).
+#   - The consumer's ``commission_awaits_input`` submits with a small
+#     max_duration=2 (short lease window) and max_retries=0, and never posts
+#     the answer.
+#   - The lease lapses ~2s after claim; the next sweep tick (fast-sweep
+#     routine, ~10s) runs ReclaimExpiredLeaseJobs which now sees the
+#     input_required row, and — budget exhausted (max_retries=0) — marks it
+#     failed with "lease expired: ...".
+#
+# Uses the EXISTING start_registry_with_fast_sweep routine (NO stale timeout)
+# so the failure is unambiguously lease-reclaim, not the stale phase.
+#
+# Asserts:
+#   - the job first reaches status=input_required (proves requestInput worked)
+#   - terminal status == failed
+#   - error CONTAINS "lease expired"
+#   - error does NOT contain "stale:"  (distinguishes C1 from C2)
+#   - owner_instance_id null (slot freed by the reclaim)
+
+name: "MeshJob TS: requestInput() enters input_required; expired-lease job is reclaimed (failed on exhausted budget)"
+description: "TS — producer calls requestInput() to park in input_required without heartbeating; lease-recovery sweep (now input_required-scoped) marks it failed 'lease expired' with max_retries=0"
+tags:
+  - meshjob
+  - typescript
+  - issue-1229
+  - input-required
+  - retry
+  - slow
+timeout: 180
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-ts /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-ts /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/long-task-provider-ts
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/long-task-consumer-ts
+
+  # Fast sweep, NO stale timeout — the failure must be lease-reclaim only.
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9110 -d
+
+  - name: "Start consumer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9111 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only: wait for both agents to REGISTER. Dependency resolution is
+  # covered by the settle window — no fixed dep-resolution sleep needed.
+  - name: "Wait for both agents to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for both agents to register..."
+      for i in $(seq 1 60); do
+        AGENTS=$(meshctl list 2>/dev/null || true)
+        if echo "$AGENTS" | grep -q "long-task-provider-ts" && echo "$AGENTS" | grep -q "long-task-consumer-ts"; then
+          echo "Both agents registered after ~${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: agents did not register within 60s"
+      meshctl list 2>/dev/null || true
+      exit 1
+    capture: wait_registration
+    timeout: 90
+
+  # Small max_duration=2 sizes the lease window; max_retries=0 makes the
+  # reclaim terminal on the first lapse. The answer event is never posted.
+  - name: "Submit awaits_input_forever (max_duration=2, max_retries=0)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_awaits_input '{"user_id":"alice","max_duration":2}' --raw
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Capture job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=${JOB_ID}"
+    capture: job_id_extract
+
+  # Poll until the row reaches input_required — proves requestInput() ran and
+  # the producer transitioned the job (the precondition the C1 fix is about).
+  # The row stays input_required only briefly before the lease lapses, so poll
+  # fast and capture the first hit.
+  - name: "Poll until the job is input_required"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      for i in $(seq 1 30); do
+        ST=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.status')
+        echo "poll ${i}: status=${ST}"
+        if [ "$ST" = "input_required" ]; then
+          echo "REACHED_INPUT_REQUIRED=1"
+          exit 0
+        fi
+        # If it already went terminal failed (sweep won the race against our
+        # poll), that's still consistent with the reclaim — surface it and
+        # let the terminal assertions below decide.
+        if [ "$ST" = "failed" ]; then
+          echo "ALREADY_FAILED_BEFORE_POLL_SAW_INPUT_REQUIRED=1"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: job never reached input_required within 30s"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,error,owner_instance_id,lease_expires_at}'
+      exit 1
+    capture: input_required_poll
+    timeout: 45
+
+  # Lease window (max_duration=2) + a couple fast-sweep ticks (~10s) +
+  # headroom. The provider is kept healthy so this is the lease-reclaim path,
+  # not the orphan path.
+  - name: "Wait for the lease-recovery sweep to fire"
+    handler: wait
+    seconds: 12
+
+  - name: "Final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,error,owner_instance_id,lease_expires_at,attempt_count}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.input_required_poll} contains 'REACHED_INPUT_REQUIRED=1'"
+    message: "the job must reach input_required before the lease lapses — proves requestInput() parked it there"
+  - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
+    message: "input_required job whose lease lapsed with no retry budget must be marked failed"
+  - expr: "${captured.final_status} contains 'lease expired'"
+    message: "error must be the canonical 'lease expired' reason from the lease-recovery sweep"
+  - expr: "${captured.final_status} not contains 'stale:'"
+    message: "this is the lease-reclaim path (C1), NOT the stale-ceiling path (C2) — no stale timeout is set here"
+  - expr: "${captured.final_status} contains '\"owner_instance_id\": null'"
+    message: "lease reclaim must clear owner_instance_id (slot freed)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/src/main/java/com/example/longtaskconsumer/LongTaskConsumerApplication.java
@@ -788,4 +788,51 @@ public class LongTaskConsumerApplication {
             return response;
         }
     }
+
+    // -------------------------------------------------------------------
+    // input_required lease-reclaim submitter (tc29 / C1, #1229)
+    // -------------------------------------------------------------------
+    //
+    // Java port of uc21's commission_awaits_input
+    // (uc21_meshjob/fixtures/long-task-consumer/main.py). Submits the
+    // awaits_input_forever producer with a SMALL max_duration (sizes the
+    // lease window) and max_retries=0 (makes the lease lapse terminal on
+    // the first reclaim pass: status=failed, error="lease expired: ...").
+    // Returns the job_id immediately and NEVER posts the "answer" event
+    // the producer is parked on, so the row sits in input_required until
+    // the registry's lease-recovery sweep reaps it.
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "commission_awaits_input",
+        description = "Submit awaits_input_forever with a small max_duration and max_retries=0; never posts the answer.",
+        dependencies = @Selector(capability = "awaits_input_forever")
+    )
+    public Map<String, Object> commissionAwaitsInput(
+            @Param(value = "user_id", required = false) String userId,
+            @Param(value = "max_duration", required = false) Integer maxDuration,
+            MeshJob awaitsInputForever) throws Exception {
+        if (!(awaitsInputForever instanceof MeshJobSubmitter submitter)) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "awaits_input_forever submitter not injected");
+            return err;
+        }
+        String user = userId == null ? "alice" : userId;
+        // Small max_duration sizes the LEASE window so it lapses quickly
+        // once the producer parks in input_required without heartbeating.
+        // max_retries=0 makes the lease lapse terminal on the first reclaim
+        // pass, avoiding a reset->reclaim race a non-zero retry budget would
+        // introduce. We deliberately NEVER post the "answer" event the
+        // producer is parked on.
+        int duration = maxDuration == null ? 2 : maxDuration;
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("user_id", user);
+        MeshJobSubmitter.SubmitOptions opts = new MeshJobSubmitter.SubmitOptions(
+            payload, null, duration, 0, null);
+        try (JobProxy proxy = submitter.submit(opts).get()) {
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("job_id", proxy.jobId());
+            return response;
+        }
+    }
 }

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/src/main/java/com/example/longtaskprovider/LongTaskProviderApplication.java
@@ -572,4 +572,65 @@ public class LongTaskProviderApplication {
         exhausted.put("events_seen", eventsSeen);
         return exhausted;
     }
+
+    // -------------------------------------------------------------------
+    // input_required parking — exercises C1 lease-reclaim of
+    // input_required jobs (#1229). Java port of uc21's awaits_input_forever
+    // producer (uc21_meshjob/fixtures/long-task-provider/main.py).
+    //
+    // The injected JobController exposes requestInput(prompt) — the SDK
+    // primitive (added in this branch: JNA -> C-FFI -> shared Rust core)
+    // that transitions the owned job to input_required (status-only,
+    // non-terminal, flushed immediately). It uses the controller's own job
+    // context and lease ownership, so no registry-URL / instance-id
+    // plumbing is needed.
+    //
+    // After signalling input_required the handler parks on recvEvent for
+    // an "answer" event that never arrives, posting NO progress. Because
+    // progress deltas are what extend the lease, the silent park lets the
+    // lease lapse so the registry's ReclaimExpiredLeaseJobs phase (now
+    // input_required-scoped) can reap it — the whole point of the C1 test.
+    // -------------------------------------------------------------------
+    @MeshTool(
+        capability = "awaits_input_forever",
+        task = true,
+        description = "Transitions the job to input_required, then parks on recvEvent for an answer that never arrives — never posts progress, never completes."
+    )
+    public Map<String, Object> awaitsInputForever(
+            @Param("user_id") String userId,
+            MeshJob job) {
+        JobController controller = job instanceof JobController c ? c : null;
+        if (controller == null) {
+            Map<String, Object> noJob = new LinkedHashMap<>();
+            noJob.put("status", "no_job_ctx");
+            return noJob;
+        }
+        // Transition the row to input_required via the SDK primitive (the
+        // injected controller is the lease owner, so no manual owner-check
+        // plumbing needed).
+        controller.requestInput("waiting on input for " + userId);
+        // Park waiting for an "answer" event that the consumer never posts.
+        // CRITICAL: do NOT call updateProgress here — a progress delta
+        // would extend the lease and defeat the lease-reclaim test.
+        // recvEvent is a pure long-poll read; it does not heartbeat the
+        // lease. We loop on the long-poll so the handler stays parked well
+        // past the lease window; the registry reaps the row out from under
+        // us via ReclaimExpiredLeaseJobs.
+        for (int i = 0; i < 60; i++) {
+            Map<String, Object> event = controller.recvEvent(
+                List.of("answer"), Duration.ofSeconds(15));
+            if (event != null) {
+                // An answer arrived (not expected in the C1 test) — complete
+                // so the fixture stays well-behaved if ever exercised that way.
+                Map<String, Object> payload = new LinkedHashMap<>();
+                payload.put("status", "got_answer");
+                payload.put("payload", event.get("payload"));
+                controller.complete(payload);
+                return payload;
+            }
+        }
+        Map<String, Object> neverAnswered = new LinkedHashMap<>();
+        neverAnswered.put("status", "never_answered");
+        return neverAnswered;
+    }
 }

--- a/tests/integration/suites/uc23_meshjob_java/tc29_input_required_reclaimed_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc29_input_required_reclaimed_java/test.yaml
@@ -1,0 +1,208 @@
+# tc29_input_required_reclaimed_java — Java port of
+# uc21_meshjob/tc29_input_required_reclaimed (#1229, C1).
+#
+# Proves the new Java requestInput() MeshJob primitive (JNA -> C-FFI ->
+# shared Rust core, added in this branch) works end-to-end: it transitions
+# a job to input_required, then — because the producer parks silently
+# without heartbeating and the consumer never answers — the lease lapses
+# and the (now input_required-scoped) lease-recovery sweep reclaims it.
+#
+# Before this fix, ReclaimExpiredLeaseJobs / ResetOrphanedJobs only matched
+# status=working rows, so a job parked in input_required whose producer
+# stopped heartbeating was stranded forever. The fix widens the filter to
+# StatusIn(working, input_required). With max_retries=0 the reclaim is
+# terminal on the first lapse: status=failed,
+# error="lease expired: no completion within lease window".
+#
+# Flow:
+#   - The producer's awaitsInputForever task transitions the row to
+#     input_required (via controller.requestInput(...) on the injected
+#     JobController) then parks on recvEvent for an "answer" that never
+#     arrives, posting NO progress (a progress delta would extend the lease).
+#   - The consumer's commissionAwaitsInput submits with a small
+#     max_duration=2 (short lease window) and max_retries=0, and never
+#     posts the answer.
+#   - The lease lapses ~2s after claim; the next sweep tick (fast-sweep
+#     routine, ~10s) runs ReclaimExpiredLeaseJobs which now sees the
+#     input_required row, and — budget exhausted (max_retries=0) — marks it
+#     failed with "lease expired: ...".
+#
+# Uses the EXISTING start_registry_with_fast_sweep routine (NO stale
+# timeout) so the failure is unambiguously lease-reclaim, not the stale
+# phase.
+#
+# Asserts:
+#   - the job first reaches status=input_required (proves requestInput worked)
+#   - terminal status == failed
+#   - error CONTAINS "lease expired"
+#   - error does NOT contain "stale:"  (distinguishes C1 from C2)
+#   - owner_instance_id null (slot freed by the reclaim)
+
+name: "MeshJob Java: input_required job with expired lease is reclaimed (failed on exhausted budget)"
+description: "Java producer parks a job in input_required via requestInput() without heartbeating; lease-recovery sweep (now input_required-scoped) marks it failed 'lease expired' with max_retries=0"
+tags:
+  - meshjob
+  - java
+  - issue-1229
+  - input-required
+  - retry
+  - slow
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider-java /workspace/
+      cp -rL /uc-artifacts/long-task-consumer-java /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/long-task-provider-java
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/long-task-consumer-java
+    timeout: 600
+
+  # Fast sweep, NO stale timeout — the failure must be lease-reclaim only.
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start provider (port 9120)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider-java --env MCP_MESH_HTTP_PORT=9120 -d
+
+  - name: "Wait for Java provider healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        S=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] && exit 0; sleep 2
+      done
+      echo "ERROR: provider not healthy"
+      meshctl logs long-task-provider-java 2>&1 | tail -50 || true
+      exit 1
+    timeout: 150
+
+  - name: "Start consumer (port 9121)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer-java --env MCP_MESH_HTTP_PORT=9121 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only: wait until both named agents are registered AND healthy
+  # (Java startup is slow and can flap). DI resolution is covered by the
+  # settle window (MCP_MESH_SETTLE_TIMEOUT=60 on the consumer).
+  - name: "Wait for provider + consumer healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        AGENTS=$(curl -s http://localhost:8000/agents)
+        OK=1
+        S=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-provider-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] || OK=0
+        S=$(echo "$AGENTS" | jq -r '.agents[] | select(.name=="long-task-consumer-java") | .status' 2>/dev/null)
+        [ "$S" = "healthy" ] || OK=0
+        if [ "$OK" = "1" ]; then
+          echo "all agents healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: agents not healthy within 120s"
+      meshctl logs long-task-provider-java 2>&1 | tail -50 || true
+      meshctl logs long-task-consumer-java 2>&1 | tail -50 || true
+      curl -s http://localhost:8000/agents | jq '.agents[] | {name, status, last_seen}'
+      exit 1
+    timeout: 150
+
+  # Small max_duration=2 sizes the lease window; max_retries=0 (hard-coded
+  # in the consumer tool) makes the reclaim terminal on the first lapse.
+  # The answer event is never posted.
+  - name: "Submit awaits_input_forever (max_duration=2, max_retries=0)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_awaits_input '{"user_id":"alice","max_duration":2}'
+    capture: submit_resp
+    timeout: 60
+
+  - name: "Extract job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP='${captured.submit_resp}'
+      JOB_ID=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .job_id')
+      echo "JOB_ID=$JOB_ID"
+    capture: job_id_extract
+
+  # Poll until the row reaches input_required — proves the producer claimed
+  # the job and transitioned it via requestInput() (the precondition the C1
+  # fix is about). The row stays input_required only briefly before the
+  # lease lapses, so poll fast and capture the first hit.
+  - name: "Poll until the job is input_required"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      for i in $(seq 1 30); do
+        ST=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.status')
+        echo "poll ${i}: status=${ST}"
+        if [ "$ST" = "input_required" ]; then
+          echo "REACHED_INPUT_REQUIRED=1"
+          exit 0
+        fi
+        # If it already went terminal failed (sweep won the race against our
+        # poll), that's still consistent with the reclaim — surface it and
+        # let the terminal assertions below decide.
+        if [ "$ST" = "failed" ]; then
+          echo "ALREADY_FAILED_BEFORE_POLL_SAW_INPUT_REQUIRED=1"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: job never reached input_required within 30s"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,error,owner_instance_id,lease_expires_at}'
+      exit 1
+    capture: input_required_poll
+    timeout: 45
+
+  # Lease window (max_duration=2) + a couple fast-sweep ticks (~10s) +
+  # headroom. The provider is kept healthy so this is the lease-reclaim
+  # path, not the orphan path.
+  - name: "Wait for the lease-recovery sweep to fire"
+    handler: wait
+    seconds: 12
+
+  - name: "Final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,error,owner_instance_id,lease_expires_at,attempt_count}'
+    capture: final_status
+
+assertions:
+  - expr: "${captured.input_required_poll} contains 'REACHED_INPUT_REQUIRED=1'"
+    message: "the job must reach input_required before the lease lapses — proves requestInput() transitioned the row"
+  - expr: "${captured.final_status} contains '\"status\": \"failed\"'"
+    message: "input_required job whose lease lapsed with no retry budget must be marked failed"
+  - expr: "${captured.final_status} contains 'lease expired'"
+    message: "error must be the canonical 'lease expired' reason from the lease-recovery sweep"
+  - expr: "${captured.final_status} not contains 'stale:'"
+    message: "this is the lease-reclaim path (C1), NOT the stale-ceiling path (C2) — no stale timeout is set here"
+  - expr: "${captured.final_status} contains '\"owner_instance_id\": null'"
+    message: "lease reclaim must clear owner_instance_id (slot freed)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc23_meshjob_java/tc29_input_required_reclaimed_java/test.yaml
+++ b/tests/integration/suites/uc23_meshjob_java/tc29_input_required_reclaimed_java/test.yaml
@@ -160,13 +160,6 @@ test:
           echo "REACHED_INPUT_REQUIRED=1"
           exit 0
         fi
-        # If it already went terminal failed (sweep won the race against our
-        # poll), that's still consistent with the reclaim — surface it and
-        # let the terminal assertions below decide.
-        if [ "$ST" = "failed" ]; then
-          echo "ALREADY_FAILED_BEFORE_POLL_SAW_INPUT_REQUIRED=1"
-          exit 0
-        fi
         sleep 1
       done
       echo "ERROR: job never reached input_required within 30s"


### PR DESCRIPTION
## Summary

Completes #1229. MeshJob recovered owned work (lease reclaim #1168) but never reaped **abandoned** work — orphaned/parked jobs accumulated and saturated constrained producers. Three parts: a registry bug fix, an opt-in reaping feature, and the SDK primitive needed to actually use (and test) the lifecycle state involved.

## Registry reaping (Go)
- **C1 (bug fix):** `ReclaimExpiredLeaseJobs`/`ResetOrphanedJobs` filtered `status == working` only, but the lease path already treats `input_required` as live. So a parked `input_required` job whose lease lapsed was reclaimed by neither phase (and skipped by `ExpireDeadlinedJobs` when `total_deadline` was NULL) — orphaned forever. Widened the filters/guards to include `input_required`; the reset branches now `SetStatus(working)` so a reclaimed row is genuinely re-claimable.
- **C2 (feature):** new `ExpireStaleJobs` sweep phase gated on **`MCP_MESH_JOB_STALE_TIMEOUT`** (default off) — a fallback `total_deadline` from `submitted_at` for jobs that didn't set their own. Reaps to `failed` + `error="stale: …"`, clears lease/owner; guarded/idempotent; runs after Reclaim/Deadlined.
- **`on_stale` hook:** each reaped row posts a synthetic `stale` JobEvent via the existing `PostJobEvent(allowTerminal=true)` — observable cross-runtime via `recv_event(types=["stale"])`. No new terminal state.

## `request_input()` SDK primitive (all runtimes)
`input_required` was registry-supported but **SDK-unreachable** — no runtime could produce it. Added `await job.request_input(prompt=None)`: a status-only primitive that posts the `input_required` transition (prompt rides `progress_message`, no schema change), flushes immediately (evicting any pending coalesced progress under the lock so a stale progress can't land after the transition), non-terminal. Built on the shared Rust core (`JobDelta::input_required` + `JobController::request_input`) and exposed via pyo3 (Python), napi (TS `requestInput`), and C-FFI (Java `JobController.requestInput`). The handler then composes the existing `recv_event`/`post_event`; `complete()`/`fail()` exit `input_required` (a mid-flight `resume_working()` is a documented follow-up).

## Tests
- Rust core: 439 + 3 new (`request_input` immediate-flush + non-terminal + `JobDelta::input_required`).
- Go registry: C1 reclaim (input_required, retryable + exhausted, lease + orphan phases), C2 reap (stale event, deadline-set untouched, disabled-by-zero, idempotency), env-knob parsing.
- **Integration (uc21):** `tc28_stale_job_reaped` (C2 — stale reap + `stale` event + slot freed, per-tc-isolated stale-timeout routine) and `tc29_input_required_reclaimed` (C1 — `request_input()` enters `input_required`, lease lapses, reclaimed; asserts `lease expired`, not `stale:`). tc29 uses the real `request_input` primitive (no raw-HTTP workaround).

## Docs
`jobs.md` (+ `_typescript`/`_java`): reaping section, `MCP_MESH_JOB_STALE_TIMEOUT`, the synthetic `stale` event, and `request_input` + its `recv_event`/`post_event` flow. `environment.md`: the new knob.

> Validated: Rust/Go/CLI builds + unit tests green locally. The uc21 integration cases are being validated against a freshly-built image (`src-tests` → image with the reaping registry + `request_input` SDK → run uc21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `MCP_MESH_JOB_STALE_TIMEOUT` (disabled by default) to enforce a default total-runtime ceiling for jobs without an explicit `total_deadline`.
  * When enabled, stale jobs are marked failed and reaping emits a synthetic `stale` event visible to handlers.
  * Introduced `requestInput(prompt)` / `request_input(prompt)` to transition jobs to `input_required` with immediate flushing (non-terminal).
* **Bug Fixes**
  * Improved registry sweep handling for `input_required` jobs during orphan reset and lease recovery.
* **Documentation**
  * Updated CLI and SDK docs for the new environment variable, `stale` event semantics, and request-input lifecycle.
* **Tests**
  * Added sweep and integration coverage for stale reaping and input-required reclamation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->