### PR TITLE
chore: bump MCP SDKs (Java 1.1.3, TS fastmcp v4)

### DIFF
--- a/src/runtime/java/pom.xml
+++ b/src/runtime/java/pom.xml
@@ -57,7 +57,7 @@
         <!-- Dependency versions -->
         <spring-boot.version>4.0.5</spring-boot.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
-        <mcp-sdk.version>1.1.0</mcp-sdk.version>
+        <mcp-sdk.version>1.1.3</mcp-sdk.version>
         <jnr-ffi.version>2.2.16</jnr-ffi.version>
         <!-- Jackson 3 (databind uses tools.jackson, annotations stays on com.fasterxml) -->
         <jackson3.version>3.0.1</jackson3.version>

--- a/src/runtime/typescript/package-lock.json
+++ b/src/runtime/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcpmesh/sdk",
-  "version": "2.0.0-beta.1",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcpmesh/sdk",
-      "version": "2.0.0-beta.1",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
@@ -15,7 +15,7 @@
         "@ai-sdk/openai": "^3.0.0",
         "@mcpmesh/core": "file:../core/typescript",
         "ai": "^6.0.0",
-        "fastmcp": "^3.34.0",
+        "fastmcp": "^4.3.2",
         "handlebars": "^4.7.8",
         "mcp-proxy": "6.4.4",
         "undici": "^6.21.0",
@@ -32,7 +32,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
         "express": "^4.18.0 || ^5.0.0"
@@ -45,7 +45,7 @@
     },
     "../core/typescript": {
       "name": "@mcpmesh/core",
-      "version": "2.0.0-beta.1",
+      "version": "2.6.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^3.5.1"
@@ -2839,9 +2839,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastmcp": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.35.0.tgz",
-      "integrity": "sha512-bcyAaVa3Zw5f4xighGg6fNNgEzZoP6tX/O+ZfS2lIhbEULWe/zUWG533JyFEUOjZT7EB+tiZW1ot4eWKmYJ6DA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-4.3.2.tgz",
+      "integrity": "sha512-sbGT0DSTv143JqInYq8Igz7C1NZCNddgGZIT2sR+UFgGaj0gStCu0UVunp0ZujHmG7BymtkdXrp4WoPOai+9sQ==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.3",
@@ -2850,7 +2850,7 @@
         "file-type": "^21.1.1",
         "fuse.js": "^7.1.0",
         "hono": "^4.11.5",
-        "mcp-proxy": "^6.4.0",
+        "mcp-proxy": "^6.4.6",
         "strict-event-emitter-types": "^2.0.0",
         "undici": "^7.16.0",
         "uri-templates": "^0.2.0",
@@ -2869,6 +2869,18 @@
         "jose": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fastmcp/node_modules/mcp-proxy": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.5.2.tgz",
+      "integrity": "sha512-3sE9kedh81dqqpObzO0nUf8aAyGnzLVDVH97GCLL3fXCBOkXDWZBts63u0bM5lT1Q4FKZY0+E91dZ7Chb2ybsA==",
+      "license": "MIT",
+      "dependencies": {
+        "pipenet": "^1.3.0"
+      },
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.mjs"
       }
     },
     "node_modules/fastmcp/node_modules/undici": {

--- a/src/runtime/typescript/package.json
+++ b/src/runtime/typescript/package.json
@@ -37,7 +37,7 @@
     "@ai-sdk/openai": "^3.0.0",
     "@mcpmesh/core": "file:../core/typescript",
     "ai": "^6.0.0",
-    "fastmcp": "^3.34.0",
+    "fastmcp": "^4.3.2",
     "handlebars": "^4.7.8",
     "mcp-proxy": "6.4.4",
     "undici": "^6.21.0",


### PR DESCRIPTION
## Summary

Two low-risk MCP-dependency upgrades, each as its own revertable commit:

- **Java** `io.modelcontextprotocol.sdk:mcp` **1.1.0 → 1.1.3** — latest 1.1.x patch (SSE-client transport endpoint validation + HTTP 405 handling in the streamable-HTTP client). Non-breaking; `dependencyManagement` forces 1.1.3 over Spring AI's transitive 1.1.0 on the direct path.
- **TypeScript** `fastmcp` **^3.34.0 → ^4.3.2** — the fastmcp v4 line. The only v4 breaking change (`OAuthProxy.allowedRedirectUriPatterns` no longer defaulting) does **not** apply — this runtime uses only `FastMCP` the server class + types, never `OAuthProxy`. v4 also brings structured tool output, httpStream CORS, and the no-progressToken progress-skip fix.

**Zero source changes** in either runtime — both compile clean against the new versions.

Python (`mcp` 1.28.1, jlowin `fastmcp` 3.4.2) is already current; the Java SDK 2.0.0 major is deliberately deferred to a scoped evaluation alongside the streaming-producer work (#1223), since its SSE→Streamable-HTTP transport shift intersects that blocker.

## Validation

- Java reactor build SUCCESS · 160 unit tests pass
- TS `tsc` clean · 950 unit tests pass
- src-tests image build 12/12
- Full integration suite (524 tcs): **509 passed, 9 skipped, 6 failed**
  - 4 failures (latency / Spring-Boot-startup race / Gemini schema) passed on re-run — transient
  - 2 persistent (`tc44_output_mode_hint_override_openai_java`, `tc14_java_mesh_openai`) are **pre-existing**: they fail **identically on `main` (SDK 1.1.0)** in a base comparison, so they are unrelated to these bumps. Both are Java-only OpenAI-provider tcs (no TS path); the failure is thrown downstream of the bumped transport, inside Spring AI's OpenAI generation block. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Java runtime’s MCP SDK dependency to a newer version.
  * Updated the TypeScript runtime’s `fastmcp` dependency to a newer version.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->