### PR TITLE
fix(java): propagate the underlying LLM vendor error (closes #1236)

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/MeshLlmProviderProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/MeshLlmProviderProcessor.java
@@ -563,7 +563,8 @@ public class MeshLlmProviderProcessor implements BeanPostProcessor, ApplicationC
             }
         } catch (Exception e) {
             log.error("LLM generation failed: {}", e.getMessage(), e);
-            throw new RuntimeException("LLM generation failed", e);
+            throw new RuntimeException(
+                "LLM generation failed [provider=" + config.provider() + ", model=" + config.modelName() + "]: " + e.getMessage(), e);
         }
 
         response.put("model", config.provider() + "/" + config.modelName());

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -833,7 +833,7 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                     response = mcpClient.callTool(provider.endpoint(), provider.functionName(), params);
                 } catch (Exception e) {
                     log.error("LLM call failed: {}", e.getMessage());
-                    throw new RuntimeException("LLM call failed", e);
+                    throw new RuntimeException("LLM call failed: " + e.getMessage(), e);
                 }
 
                 // Accumulate LLM token usage from this iteration's response


### PR DESCRIPTION
## Summary

Closes #1236. The Java LLM provider discarded the real vendor error (OpenAI/Gemini/Anthropic, carried by the raw Spring AI exception) behind two constant-string exception re-wraps, so a failed generation reached the consumer as the opaque `Error: LLM generation failed` / `Error: LLM call failed` with no vendor detail. In ephemeral/containerized runs the provider container log — the only place the real error was written — is destroyed at teardown, making such failures undiagnosable after the fact.

The vendor message was alive (and even logged) at the swallow point and discarded one line later. This preserves it at both wrap sites, mirroring the Python path which interpolates the underlying error:

- **`MeshLlmProviderProcessor`** — the throw now embeds the vendor message plus provider/model context: `"LLM generation failed [provider=<p>, model=<m>]: <vendor msg>"`.
- **`MeshLlmAgentProxy`** — the consumer relay now interpolates the cause message instead of replacing it with a constant.

The generic MCP tool handler (`"Error: " + e.getMessage()`) and the per-vendor handlers (which correctly let the raw exception propagate) surface the enriched message automatically — no change needed there.

## Validation

- Java reactor BUILD SUCCESS · 160 unit tests pass · no test assertions relaxed (nothing asserted the old exact strings).
- **End-to-end proof**: rebuilt the image and re-ran the two tcs that previously failed with the opaque error. `tc14` passed (the earlier failure was a transient vendor hiccup). `tc44` failed — but now surfaces the real, previously-hidden cause verbatim:

  ```
  Error: LLM generation failed [provider=openai, model=gpt-4o]: HTTP 400 - {
    "error": { "message": "Unsupported parameter: 'max_tokens' is not supported with
    this model. Use 'max_completion_tokens' instead.", "type": "invalid_request_error",
    "param": "max_tokens", "code": "unsupported_parameter" }
  }
  ```

  That is exactly the diagnosability this change exists to deliver. The surfaced cause is a separate, concrete bug in the OpenAI request builder (sends `max_tokens` to a model that requires `max_completion_tokens`), tracked as its own follow-up — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)