### PR TITLE
fix(java): OpenAI handler uses max_completion_tokens (closes #1238)

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
@@ -162,7 +162,7 @@ public class OpenAiHandler implements LlmProviderHandler {
     private void applyModelParams(OpenAiChatOptions.Builder builder, Map<String, Object> options) {
         Integer maxTokens = LlmProviderHandler.maxTokensOption(options);
         if (maxTokens != null) {
-            builder.maxTokens(maxTokens);
+            builder.maxCompletionTokens(maxTokens);
         }
         Double temperature = LlmProviderHandler.temperatureOption(options);
         if (temperature != null) {

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderModelParamsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderModelParamsTest.java
@@ -85,7 +85,7 @@ class ProviderModelParamsTest {
 
             ChatOptions opts = captor.getValue().getOptions();
             assertInstanceOf(OpenAiChatOptions.class, opts);
-            assertEquals(1234, opts.getMaxTokens());
+            assertEquals(1234, ((OpenAiChatOptions) opts).getMaxCompletionTokens());
             assertEquals(0.42, opts.getTemperature(), 1e-9);
             assertEquals(0.9, opts.getTopP(), 1e-9);
         }
@@ -127,7 +127,8 @@ class ProviderModelParamsTest {
             handler.generateWithTools(model, userMessages(), List.of(), null, null, Map.of());
 
             ChatOptions opts = captor.getValue().getOptions();
-            assertNull(opts.getMaxTokens(), "absent max_tokens must not be force-set");
+            assertNull(((OpenAiChatOptions) opts).getMaxCompletionTokens(),
+                "absent max_tokens must not be force-set");
             assertNull(opts.getTemperature(), "absent temperature must not be force-set");
             assertNull(opts.getTopP(), "absent top_p must not be force-set");
             assertNull(opts.getModel(), "absent model must not be force-set");


### PR DESCRIPTION
## Summary

Closes #1238. The Java OpenAI handler applied `model_params.max_tokens` via the deprecated `OpenAiChatOptions.maxTokens` builder (wire field `max_tokens`), which gpt-4o and the o-series reject with HTTP 400 (`unsupported_parameter`, "use max_completion_tokens instead"). Every Java OpenAI generation carrying `model_params.max_tokens` on those models failed at the vendor.

`OpenAiHandler.applyModelParams` now calls `builder.maxCompletionTokens(...)` — the forward-compatible chat-completions parameter accepted across current OpenAI models. Spring AI's `OpenAiChatOptions.Builder` already exposes it (no version change). It's the only OpenAI site setting the token limit (verified). Gemini (`maxOutputTokens`) / Anthropic (`maxTokens`) map to their own vendor fields and are untouched.

## Validation

- Reactor BUILD SUCCESS · 160 unit tests pass (OpenAI `model_params` test updated to assert `maxCompletionTokens`).
- Rebuilt the image and ran a cross-section of OpenAI+Java tcs: **7 pass** (provider, structured output ×3, tool-call, parallel-tools, prompt-template) — no regression. Only `model_params.max_tokens`-bearing calls change behavior (guarded by `if (maxTokens != null)`).
- **The original `max_tokens` 400 is gone**, confirmed by `tc44`'s error now being a *different* parameter restriction (`temperature: 0.7` unsupported by this deployment's gpt-4o) rather than `max_tokens` — visible thanks to the #1236 error propagation. That temperature restriction is a separate finding, tracked as its own follow-up; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)