### PR TITLE
fix(java): apply declared provider model to every LLM request + gate restricted-model sampling params

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/MeshLlmProviderProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/MeshLlmProviderProcessor.java
@@ -349,6 +349,13 @@ public class MeshLlmProviderProcessor implements BeanPostProcessor, ApplicationC
         // or invalid the handler falls back to per-vendor auto-selection (zero
         // regression). Threaded to handlers via the options map.
         Map<String, Object> handlerOptions = new LinkedHashMap<>();
+        // Thread the provider's DECLARED model (vendor-stripped) into EVERY generate
+        // path so handlers set the model on every request. Without this, requests
+        // with no per-call override fall through to Spring AI's vendor default model
+        // (e.g. OpenAI's default gpt-5), which can reject non-default sampling params.
+        if (config.modelName() != null && !config.modelName().isBlank()) {
+            handlerOptions.put(LlmProviderHandler.OPTION_DECLARED_MODEL, config.modelName());
+        }
         if (modelParams != null) {
             Object om = modelParams.get("output_mode");
             if (om != null && !String.valueOf(om).isEmpty()) {

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
@@ -328,23 +328,23 @@ public class AnthropicHandler implements LlmProviderHandler {
         // a vendor-matched per-call override) is set on EVERY request. output_format
         // is added when an outputSchema is present; consumer-supplied model_params are
         // applied too.
-        try {
-            AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder();
-            if (outputSchema != null) {
+        AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder();
+        if (outputSchema != null) {
+            // Isolate ONLY the schema serialization: a schema failure must not
+            // prevent applyModelParams/options(...) from running, otherwise the
+            // declared model is dropped and the request falls back to Spring AI's default.
+            try {
                 Map<String, Object> sanitizedSchema = outputSchema.sanitize();
                 String schemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(sanitizedSchema);
                 optionsBuilder.outputSchema(schemaJson);
-            }
-            applyModelParams(optionsBuilder, options);
-
-            requestSpec.options(optionsBuilder.build());
-            if (outputSchema != null) {
                 log.debug("Applied Anthropic output_format with schema: {}", outputSchema.name());
+            } catch (Exception e) {
+                log.warn("Failed to apply Anthropic output_schema for {}: {}, proceeding without it",
+                    outputSchema.name(), e.getMessage());
             }
-        } catch (Exception e) {
-            log.warn("Failed to apply Anthropic options (schema={}): {}",
-                outputSchema != null ? outputSchema.name() : "none", e.getMessage());
         }
+        applyModelParams(optionsBuilder, options);
+        requestSpec.options(optionsBuilder.build());
 
         // Execute the request — if outputFormat was applied and the API rejects it,
         // retry with HINT-mode instructions instead of native output_format

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
@@ -174,17 +174,13 @@ public class AnthropicHandler implements LlmProviderHandler {
         log.debug("AnthropicHandler: Processing {} messages", messages.size());
 
         List<Message> springMessages = convertMessages(messages);
-        // Plain-text generation: apply consumer-supplied model_params
-        // (max_tokens/temperature/top_p/vendor-matched model) when present so the
-        // no-tools/no-schema path honors them like the tools path does.
-        Prompt prompt;
-        if (LlmProviderHandler.hasAnyModelParam(options)) {
-            AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder();
-            applyModelParams(optionsBuilder, options);
-            prompt = new Prompt(springMessages, optionsBuilder.build());
-        } else {
-            prompt = new Prompt(springMessages);
-        }
+        // Plain-text generation: always build AnthropicChatOptions so the effective
+        // model (declared model, or a vendor-matched per-call override) is set on the
+        // request — without it the request falls through to Spring AI's default
+        // Anthropic model. Consumer-supplied model_params are applied here too.
+        AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder();
+        applyModelParams(optionsBuilder, options);
+        Prompt prompt = new Prompt(springMessages, optionsBuilder.build());
         ChatResponse response = model.call(prompt);
 
         String content = response.getResult() != null && response.getResult().getOutput() != null
@@ -274,10 +270,13 @@ public class AnthropicHandler implements LlmProviderHandler {
         if (topP != null) {
             builder.topP(topP);
         }
-        String modelOverride = LlmProviderHandler.resolveModelOverride(options, getVendor(), getAliases());
-        if (modelOverride != null) {
-            builder.model(modelOverride);
-            log.debug("AnthropicHandler: applied model override '{}'", modelOverride);
+        // Set the effective model on EVERY request: a vendor-matched per-call
+        // override wins, else the provider's declared model. Without this the
+        // request falls through to Spring AI's default Anthropic model.
+        String eff = LlmProviderHandler.effectiveModel(options, getVendor(), getAliases());
+        if (eff != null) {
+            builder.model(eff);
+            log.debug("AnthropicHandler: applied model '{}'", eff);
         }
     }
 
@@ -325,29 +324,26 @@ public class AnthropicHandler implements LlmProviderHandler {
             requestSpec.toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]));
         }
 
-        // Apply native output_format when outputSchema is present, plus any
-        // consumer-supplied model_params (max_tokens/temperature/top_p/model).
-        // Build options whenever EITHER a schema OR model_params are present so
-        // the numeric/model overrides reach the wire even without a schema.
-        boolean hasModelParams = LlmProviderHandler.hasAnyModelParam(options);
-        if (outputSchema != null || hasModelParams) {
-            try {
-                AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder();
-                if (outputSchema != null) {
-                    Map<String, Object> sanitizedSchema = outputSchema.sanitize();
-                    String schemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(sanitizedSchema);
-                    optionsBuilder.outputSchema(schemaJson);
-                }
-                applyModelParams(optionsBuilder, options);
-
-                requestSpec.options(optionsBuilder.build());
-                if (outputSchema != null) {
-                    log.debug("Applied Anthropic output_format with schema: {}", outputSchema.name());
-                }
-            } catch (Exception e) {
-                log.warn("Failed to apply Anthropic options (schema={}): {}",
-                    outputSchema != null ? outputSchema.name() : "none", e.getMessage());
+        // Always build AnthropicChatOptions so the effective model (declared model or
+        // a vendor-matched per-call override) is set on EVERY request. output_format
+        // is added when an outputSchema is present; consumer-supplied model_params are
+        // applied too.
+        try {
+            AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder();
+            if (outputSchema != null) {
+                Map<String, Object> sanitizedSchema = outputSchema.sanitize();
+                String schemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(sanitizedSchema);
+                optionsBuilder.outputSchema(schemaJson);
             }
+            applyModelParams(optionsBuilder, options);
+
+            requestSpec.options(optionsBuilder.build());
+            if (outputSchema != null) {
+                log.debug("Applied Anthropic output_format with schema: {}", outputSchema.name());
+            }
+        } catch (Exception e) {
+            log.warn("Failed to apply Anthropic options (schema={}): {}",
+                outputSchema != null ? outputSchema.name() : "none", e.getMessage());
         }
 
         // Execute the request — if outputFormat was applied and the API rejects it,

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
@@ -113,14 +113,14 @@ public class GeminiHandler implements LlmProviderHandler {
         log.debug("GeminiHandler: Processing {} messages", messages.size());
 
         List<Message> springMessages = convertMessages(messages);
-        // Plain-text generation: apply consumer-supplied model_params
-        // (max_tokens→maxOutputTokens/temperature/top_p/vendor-matched model) when
-        // present. buildModelParamOptions branches Vertex vs GenAI to match the
-        // underlying chat model and returns null when no params are present.
+        // Plain-text generation: always build a vendor-correct Gemini options object
+        // so the effective model (declared model, or a vendor-matched per-call
+        // override) is set on the request — without it the request falls through to
+        // Spring AI's default Gemini model. Consumer-supplied model_params
+        // (max_tokens→maxOutputTokens/temperature/top_p) are applied here too.
+        // buildModelParamOptions branches Vertex vs GenAI to match the chat model.
         ChatOptions paramOptions = buildModelParamOptions(model, options);
-        Prompt prompt = paramOptions != null
-            ? new Prompt(springMessages, paramOptions)
-            : new Prompt(springMessages);
+        Prompt prompt = new Prompt(springMessages, paramOptions);
         ChatResponse response = model.call(prompt);
 
         String content = response.getResult() != null && response.getResult().getOutput() != null
@@ -233,15 +233,12 @@ public class GeminiHandler implements LlmProviderHandler {
         // Don't use applyResponseFormat - Spring AI has issues with Gemini responseSchema
         // Structured output is handled via prompt-based hints in formatSystemPrompt()
 
-        // Apply consumer-supplied model_params (max_tokens/temperature/top_p/model)
-        // onto a vendor-correct Gemini options object when present. The concrete
-        // options class must match the underlying chat model (see buildModelParamOptions).
-        if (LlmProviderHandler.hasAnyModelParam(options)) {
-            ChatOptions paramOptions = buildModelParamOptions(model, options);
-            if (paramOptions != null) {
-                requestSpec.options(paramOptions);
-            }
-        }
+        // Always attach a vendor-correct Gemini options object so the effective
+        // model (declared model or a vendor-matched per-call override) is set on
+        // EVERY request, plus any consumer-supplied model_params (max_tokens/
+        // temperature/top_p). The concrete options class must match the underlying
+        // chat model (see buildModelParamOptions).
+        requestSpec.options(buildModelParamOptions(model, options));
 
         // Execute the request
         ChatResponse chatResponse = requestSpec.call().chatResponse();
@@ -398,17 +395,17 @@ public class GeminiHandler implements LlmProviderHandler {
     }
 
     /**
-     * Build a vendor-correct Gemini options object carrying ONLY the
+     * Build a vendor-correct Gemini options object carrying the effective model
+     * (declared model or a vendor-matched per-call override) and any
      * consumer-supplied {@code model_params} (no tool callbacks) for the
      * auto-execute (ChatClient) path, where tools are attached via the request
      * spec rather than the options object.
      *
-     * @return the options object, or {@code null} if no params are present
+     * <p>Always returns a non-null options object so the effective model is set on
+     * EVERY request — without it the request falls through to Spring AI's default
+     * Gemini model.
      */
     private ChatOptions buildModelParamOptions(ChatModel chatModel, Map<String, Object> options) {
-        if (!LlmProviderHandler.hasAnyModelParam(options)) {
-            return null;
-        }
         if (VERTEX_CHAT_MODEL_CLASS != null && VERTEX_CHAT_MODEL_CLASS.isInstance(chatModel)) {
             VertexAiGeminiChatOptions.Builder builder = VertexAiGeminiChatOptions.builder();
             applyVertexModelParams(builder, options);
@@ -438,10 +435,13 @@ public class GeminiHandler implements LlmProviderHandler {
         if (topP != null) {
             builder.topP(topP);
         }
-        String modelOverride = LlmProviderHandler.resolveModelOverride(options, getVendor(), MODEL_OVERRIDE_ALIASES);
-        if (modelOverride != null) {
-            builder.model(modelOverride);
-            log.debug("GeminiHandler: applied model override '{}'", modelOverride);
+        // Set the effective model on EVERY request: a vendor-matched per-call
+        // override wins, else the provider's declared model. Without this the
+        // request falls through to Spring AI's default Gemini model.
+        String eff = LlmProviderHandler.effectiveModel(options, getVendor(), MODEL_OVERRIDE_ALIASES);
+        if (eff != null) {
+            builder.model(eff);
+            log.debug("GeminiHandler: applied model '{}'", eff);
         }
     }
 
@@ -480,10 +480,11 @@ public class GeminiHandler implements LlmProviderHandler {
         if (topP != null) {
             builder.topP(topP);
         }
-        String modelOverride = LlmProviderHandler.resolveModelOverride(options, getVendor(), MODEL_OVERRIDE_ALIASES);
-        if (modelOverride != null) {
-            builder.model(modelOverride);
-            log.debug("GeminiHandler (vertex): applied model override '{}'", modelOverride);
+        // Set the effective model on EVERY request (see applyGoogleGenAiModelParams).
+        String eff = LlmProviderHandler.effectiveModel(options, getVendor(), MODEL_OVERRIDE_ALIASES);
+        if (eff != null) {
+            builder.model(eff);
+            log.debug("GeminiHandler (vertex): applied model '{}'", eff);
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/LlmProviderHandler.java
@@ -68,6 +68,15 @@ public interface LlmProviderHandler {
     /** Key under which a consumer-supplied per-tool/per-call model override travels (e.g. "anthropic/claude-..."). */
     String OPTION_MODEL = "model";
 
+    /**
+     * Internal options key carrying the provider's DECLARED model (vendor-stripped,
+     * e.g. {@code "gpt-4o"}) from {@code @MeshLlmProvider(model=...)}. Underscore-prefixed
+     * so it cannot collide with a real {@code model_params} key. Threaded by
+     * {@code MeshLlmProviderProcessor} so handlers can set the model on EVERY request —
+     * without it, requests fall through to Spring AI's vendor default model.
+     */
+    String OPTION_DECLARED_MODEL = "__declared_model__";
+
     /** Key under which a consumer-supplied {@code max_tokens} travels in the options map. */
     String OPTION_MAX_TOKENS = "max_tokens";
 
@@ -444,6 +453,37 @@ public interface LlmProviderHandler {
             "Ignoring cross-vendor model override '{}' (declared vendor '{}' does not match provider vendor '{}'); "
             + "falling back to the provider's default model.", value, declaredVendor, expectedVendor);
         return null;
+    }
+
+    /**
+     * Read the provider's declared model from the options map.
+     *
+     * @param options the generation options (may be null)
+     * @return the declared model (vendor-stripped, e.g. "gpt-4o"), or {@code null} if absent
+     */
+    static String declaredModelOption(Map<String, Object> options) {
+        if (options == null) {
+            return null;
+        }
+        Object v = options.get(OPTION_DECLARED_MODEL);
+        return v instanceof String s && !s.isBlank() ? s : null;
+    }
+
+    /**
+     * Resolve the effective model to set on the request: a vendor-matched per-call
+     * {@code model} override wins; otherwise the provider's declared model.
+     *
+     * <p>This is the single resolution point used by handlers to set the model on
+     * EVERY request so requests never fall through to Spring AI's vendor default.
+     *
+     * @param options        the generation options (may be null)
+     * @param expectedVendor this handler's vendor (e.g. "openai")
+     * @param aliases        accepted vendor aliases (e.g. {"gpt"}); may be null
+     * @return the bare model name to apply, or {@code null} if neither is available
+     */
+    static String effectiveModel(Map<String, Object> options, String expectedVendor, String[] aliases) {
+        String override = resolveModelOverride(options, expectedVendor, aliases);
+        return override != null ? override : declaredModelOption(options);
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
@@ -262,9 +262,12 @@ public class OpenAiHandler implements LlmProviderHandler {
         // vendor-matched per-call override) is set on EVERY request. response_format
         // is added when an outputSchema is present (like Python); consumer-supplied
         // model_params are applied with sampling-param gating for restricted models.
-        try {
-            OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder();
-            if (outputSchema != null) {
+        OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder();
+        if (outputSchema != null) {
+            // Isolate ONLY the response_format construction: a schema failure must
+            // not prevent applyModelParams/options(...) from running, otherwise the
+            // declared model is dropped and the request falls back to Spring AI's default.
+            try {
                 // Make schema strict (add additionalProperties: false, all properties required)
                 Map<String, Object> strictSchema = outputSchema.makeStrict(true);
 
@@ -277,17 +280,14 @@ public class OpenAiHandler implements LlmProviderHandler {
                         .build())
                     .build();
                 optionsBuilder.responseFormat(responseFormat);
-            }
-            applyModelParams(optionsBuilder, options);
-
-            requestSpec.options(optionsBuilder.build());
-            if (outputSchema != null) {
                 log.debug("Applied OpenAI response_format with schema: {}", outputSchema.name());
+            } catch (Exception e) {
+                log.warn("Failed to apply OpenAI response_format for {}: {}, proceeding without it",
+                    outputSchema.name(), e.getMessage());
             }
-        } catch (Exception e) {
-            log.warn("Failed to apply OpenAI options (schema={}): {}",
-                outputSchema != null ? outputSchema.name() : "none", e.getMessage());
         }
+        applyModelParams(optionsBuilder, options);
+        requestSpec.options(optionsBuilder.build());
 
         // Execute the request
         ChatResponse chatResponse = requestSpec.call().chatResponse();

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
@@ -79,17 +79,14 @@ public class OpenAiHandler implements LlmProviderHandler {
         log.debug("OpenAiHandler: Processing {} messages", messages.size());
 
         List<Message> springMessages = convertMessages(messages);
-        // Plain-text generation: apply consumer-supplied model_params
-        // (max_tokens/temperature/top_p/vendor-matched model) when present so the
-        // no-tools/no-schema path honors them like the tools path does.
-        Prompt prompt;
-        if (LlmProviderHandler.hasAnyModelParam(options)) {
-            OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder();
-            applyModelParams(optionsBuilder, options);
-            prompt = new Prompt(springMessages, optionsBuilder.build());
-        } else {
-            prompt = new Prompt(springMessages);
-        }
+        // Plain-text generation: always build OpenAiChatOptions so the effective
+        // model (declared model, or a vendor-matched per-call override) is set on
+        // the request — without it the request falls through to Spring AI's default
+        // OpenAI model. Consumer-supplied model_params (max_tokens/temperature/
+        // top_p) are applied here too, with sampling-param gating for restricted models.
+        OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder();
+        applyModelParams(optionsBuilder, options);
+        Prompt prompt = new Prompt(springMessages, optionsBuilder.build());
         ChatResponse response = model.call(prompt);
 
         String content = response.getResult() != null && response.getResult().getOutput() != null
@@ -160,23 +157,62 @@ public class OpenAiHandler implements LlmProviderHandler {
      * provider's default model is kept.
      */
     private void applyModelParams(OpenAiChatOptions.Builder builder, Map<String, Object> options) {
+        // Resolve the effective model ONCE: a vendor-matched per-call override wins,
+        // else the provider's declared model. Set it on EVERY request so requests
+        // never fall through to Spring AI's vendor default model.
+        String eff = LlmProviderHandler.effectiveModel(options, getVendor(), getAliases());
+        if (eff != null) {
+            builder.model(eff);
+            log.debug("OpenAiHandler: applied model '{}'", eff);
+        }
+
         Integer maxTokens = LlmProviderHandler.maxTokensOption(options);
         if (maxTokens != null) {
             builder.maxCompletionTokens(maxTokens);
         }
+
+        // gpt-5 (non-chat) and o-series reasoning models accept ONLY the default
+        // temperature/top_p and reject any explicit value. Gate those params for
+        // the restricted models, using the SAME effective model resolved above.
+        boolean restricted = restrictsSamplingParams(eff);
         Double temperature = LlmProviderHandler.temperatureOption(options);
         if (temperature != null) {
-            builder.temperature(temperature);
+            if (restricted) {
+                log.warn("OpenAiHandler: omitting temperature={} for model '{}' (only the default is supported)", temperature, eff);
+            } else {
+                builder.temperature(temperature);
+            }
         }
         Double topP = LlmProviderHandler.topPOption(options);
         if (topP != null) {
-            builder.topP(topP);
+            if (restricted) {
+                log.warn("OpenAiHandler: omitting top_p={} for model '{}' (only the default is supported)", topP, eff);
+            } else {
+                builder.topP(topP);
+            }
         }
-        String modelOverride = LlmProviderHandler.resolveModelOverride(options, getVendor(), getAliases());
-        if (modelOverride != null) {
-            builder.model(modelOverride);
-            log.debug("OpenAiHandler: applied model override '{}'", modelOverride);
-        }
+    }
+
+    /**
+     * Whether an OpenAI model restricts {@code temperature}/{@code top_p} to their
+     * default value (rejecting any explicit setting). Verified against the live API:
+     * <ul>
+     *   <li>REJECT: gpt-5, gpt-5-mini, gpt-5-nano, o1, o3-mini, o4-mini</li>
+     *   <li>ACCEPT: gpt-4o, gpt-4.1, gpt-5-chat-latest</li>
+     * </ul>
+     * Accepts a bare or {@code vendor/}-qualified model string.
+     */
+    static boolean restrictsSamplingParams(String model) {
+        if (model == null) return false;
+        String m = model.toLowerCase();
+        int slash = m.indexOf('/');
+        if (slash >= 0) m = m.substring(slash + 1);
+        // o-series reasoning models reject temperature/top_p
+        if (m.equals("o1") || m.equals("o3") || m.equals("o4")
+            || m.startsWith("o1-") || m.startsWith("o3-") || m.startsWith("o4-")) return true;
+        // gpt-5 family restricts temperature/top_p to default — except gpt-5-chat*
+        if (m.startsWith("gpt-5") && !m.startsWith("gpt-5-chat")) return true;
+        return false;
     }
 
     /**
@@ -222,38 +258,35 @@ public class OpenAiHandler implements LlmProviderHandler {
             requestSpec.toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]));
         }
 
-        // Apply response_format immediately when outputSchema is present (like Python),
-        // plus any consumer-supplied model_params (max_tokens/temperature/top_p/model).
-        // Build options whenever EITHER a schema OR model_params are present so the
-        // numeric/model overrides reach the wire even without a schema.
-        boolean hasModelParams = LlmProviderHandler.hasAnyModelParam(options);
-        if (outputSchema != null || hasModelParams) {
-            try {
-                OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder();
-                if (outputSchema != null) {
-                    // Make schema strict (add additionalProperties: false, all properties required)
-                    Map<String, Object> strictSchema = outputSchema.makeStrict(true);
+        // Always build OpenAiChatOptions so the effective model (declared model or a
+        // vendor-matched per-call override) is set on EVERY request. response_format
+        // is added when an outputSchema is present (like Python); consumer-supplied
+        // model_params are applied with sampling-param gating for restricted models.
+        try {
+            OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder();
+            if (outputSchema != null) {
+                // Make schema strict (add additionalProperties: false, all properties required)
+                Map<String, Object> strictSchema = outputSchema.makeStrict(true);
 
-                    ResponseFormat responseFormat = ResponseFormat.builder()
-                        .type(Type.JSON_SCHEMA)
-                        .jsonSchema(ResponseFormat.JsonSchema.builder()
-                            .name(outputSchema.name())
-                            .schema(strictSchema)
-                            .strict(true)
-                            .build())
-                        .build();
-                    optionsBuilder.responseFormat(responseFormat);
-                }
-                applyModelParams(optionsBuilder, options);
-
-                requestSpec.options(optionsBuilder.build());
-                if (outputSchema != null) {
-                    log.debug("Applied OpenAI response_format with schema: {}", outputSchema.name());
-                }
-            } catch (Exception e) {
-                log.warn("Failed to apply OpenAI options (schema={}): {}",
-                    outputSchema != null ? outputSchema.name() : "none", e.getMessage());
+                ResponseFormat responseFormat = ResponseFormat.builder()
+                    .type(Type.JSON_SCHEMA)
+                    .jsonSchema(ResponseFormat.JsonSchema.builder()
+                        .name(outputSchema.name())
+                        .schema(strictSchema)
+                        .strict(true)
+                        .build())
+                    .build();
+                optionsBuilder.responseFormat(responseFormat);
             }
+            applyModelParams(optionsBuilder, options);
+
+            requestSpec.options(optionsBuilder.build());
+            if (outputSchema != null) {
+                log.debug("Applied OpenAI response_format with schema: {}", outputSchema.name());
+            }
+        } catch (Exception e) {
+            log.warn("Failed to apply OpenAI options (schema={}): {}",
+                outputSchema != null ? outputSchema.name() : "none", e.getMessage());
         }
 
         // Execute the request

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderDeclaredModelTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderDeclaredModelTest.java
@@ -1,0 +1,316 @@
+package io.mcpmesh.ai.handlers;
+
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+import org.springframework.ai.anthropic.AnthropicChatOptions;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the unified fix:
+ * <ol>
+ *   <li>The provider's DECLARED model (threaded via {@link LlmProviderHandler#OPTION_DECLARED_MODEL})
+ *       is set on every request across all three handlers, even with no per-call
+ *       {@code model} override (PART 1/2).</li>
+ *   <li>A per-call override still wins over the declared model.</li>
+ *   <li>OpenAI sampling-param gating: gpt-5 (non-chat) and o-series reasoning
+ *       models drop {@code temperature}/{@code top_p} but keep {@code maxCompletionTokens};
+ *       gpt-4o / gpt-5-chat-latest keep all (PART 3).</li>
+ * </ol>
+ */
+@DisplayName("declared-model propagation + OpenAI sampling gating")
+class ProviderDeclaredModelTest {
+
+    @BeforeAll
+    static void installNativeStub() {
+        FormatSystemPromptStub.install();
+    }
+
+    @AfterAll
+    static void uninstallNativeStub() {
+        FormatSystemPromptStub.uninstall();
+    }
+
+    private static ChatModel mockModel(ArgumentCaptor<Prompt> captor) {
+        ChatModel model = mock(ChatModel.class);
+        ChatResponse response = new ChatResponse(
+            List.of(new Generation(new AssistantMessage("done"))));
+        when(model.call(captor.capture())).thenReturn(response);
+        return model;
+    }
+
+    private static List<Map<String, Object>> userMessages() {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("role", "user");
+        m.put("content", "hi");
+        return List.of(m);
+    }
+
+    private static Map<String, Object> declared(String model) {
+        Map<String, Object> o = new LinkedHashMap<>();
+        o.put(LlmProviderHandler.OPTION_DECLARED_MODEL, model);
+        return o;
+    }
+
+    // =====================================================================
+    // PART 1/2 — declared-model propagation
+    // =====================================================================
+
+    @Nested
+    @DisplayName("OpenAI propagation")
+    class OpenAiPropagation {
+        private final OpenAiHandler handler = new OpenAiHandler();
+
+        @Test
+        @DisplayName("declared model (no override) is set on the request")
+        void declaredModelSet() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null, declared("gpt-4o"));
+
+            assertEquals("gpt-4o", captor.getValue().getOptions().getModel(),
+                "declared model must be set when no per-call override is present");
+        }
+
+        @Test
+        @DisplayName("declared model is set on the plain-text generateWithMessages path")
+        void declaredModelSetPlainText() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithMessages(model, userMessages(), declared("gpt-4o"));
+
+            assertEquals("gpt-4o", captor.getValue().getOptions().getModel());
+        }
+
+        @Test
+        @DisplayName("per-call override wins over the declared model")
+        void overrideWinsOverDeclared() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            Map<String, Object> options = declared("gpt-4o");
+            options.put(LlmProviderHandler.OPTION_MODEL, "openai/gpt-4.1");
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null, options);
+
+            assertEquals("gpt-4.1", captor.getValue().getOptions().getModel(),
+                "a same-vendor per-call override must win over the declared model");
+        }
+
+        @Test
+        @DisplayName("cross-vendor override falls back to the declared model (not null)")
+        void crossVendorFallsBackToDeclared() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            Map<String, Object> options = declared("gpt-4o");
+            options.put(LlmProviderHandler.OPTION_MODEL, "anthropic/claude-3-5-sonnet-latest");
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null, options);
+
+            assertEquals("gpt-4o", captor.getValue().getOptions().getModel(),
+                "a rejected cross-vendor override falls back to the declared model");
+        }
+    }
+
+    @Nested
+    @DisplayName("Anthropic propagation")
+    class AnthropicPropagation {
+        private final AnthropicHandler handler = new AnthropicHandler();
+
+        @Test
+        @DisplayName("declared model (no override) is set on the request")
+        void declaredModelSet() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null,
+                declared("claude-3-5-sonnet-latest"));
+
+            assertEquals("claude-3-5-sonnet-latest", captor.getValue().getOptions().getModel());
+        }
+
+        @Test
+        @DisplayName("declared model is set on the plain-text generateWithMessages path")
+        void declaredModelSetPlainText() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithMessages(model, userMessages(), declared("claude-3-5-sonnet-latest"));
+
+            ChatOptions opts = captor.getValue().getOptions();
+            assertInstanceOf(AnthropicChatOptions.class, opts);
+            assertEquals("claude-3-5-sonnet-latest", opts.getModel());
+        }
+    }
+
+    @Nested
+    @DisplayName("Gemini propagation")
+    class GeminiPropagation {
+        private final GeminiHandler handler = new GeminiHandler();
+
+        @Test
+        @DisplayName("declared model (no override) is set on the GoogleGenAiChatOptions")
+        void declaredModelSet() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null,
+                declared("gemini-2.0-flash"));
+
+            ChatOptions opts = captor.getValue().getOptions();
+            assertInstanceOf(GoogleGenAiChatOptions.class, opts);
+            assertEquals("gemini-2.0-flash", opts.getModel());
+        }
+
+        @Test
+        @DisplayName("declared model is set on the plain-text generateWithMessages path")
+        void declaredModelSetPlainText() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            handler.generateWithMessages(model, userMessages(), declared("gemini-2.0-flash"));
+
+            assertEquals("gemini-2.0-flash", captor.getValue().getOptions().getModel());
+        }
+    }
+
+    // =====================================================================
+    // PART 3 — OpenAI sampling-param gating
+    // =====================================================================
+
+    @Nested
+    @DisplayName("OpenAI sampling-param gating")
+    class OpenAiGating {
+        private final OpenAiHandler handler = new OpenAiHandler();
+
+        private OpenAiChatOptions callWith(String declaredModel) {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            Map<String, Object> options = declared(declaredModel);
+            options.put(LlmProviderHandler.OPTION_MAX_TOKENS, 1000);
+            options.put(LlmProviderHandler.OPTION_TEMPERATURE, 0.7);
+            options.put(LlmProviderHandler.OPTION_TOP_P, 0.9);
+
+            handler.generateWithTools(model, userMessages(), List.of(), null, null, options);
+            return (OpenAiChatOptions) captor.getValue().getOptions();
+        }
+
+        @Test
+        @DisplayName("gpt-5-mini omits temperature/top_p but keeps maxCompletionTokens")
+        void gpt5MiniRestricted() {
+            OpenAiChatOptions opts = callWith("gpt-5-mini");
+            assertNull(opts.getTemperature(), "temperature must be omitted for gpt-5-mini");
+            assertNull(opts.getTopP(), "top_p must be omitted for gpt-5-mini");
+            assertEquals(1000, opts.getMaxCompletionTokens(), "max_tokens is always applied");
+            assertEquals("gpt-5-mini", opts.getModel());
+        }
+
+        @Test
+        @DisplayName("o3-mini omits temperature/top_p but keeps maxCompletionTokens")
+        void o3MiniRestricted() {
+            OpenAiChatOptions opts = callWith("o3-mini");
+            assertNull(opts.getTemperature());
+            assertNull(opts.getTopP());
+            assertEquals(1000, opts.getMaxCompletionTokens());
+            assertEquals("o3-mini", opts.getModel());
+        }
+
+        @Test
+        @DisplayName("gpt-4o applies temperature/top_p")
+        void gpt4oAllowed() {
+            OpenAiChatOptions opts = callWith("gpt-4o");
+            assertEquals(0.7, opts.getTemperature(), 1e-9);
+            assertEquals(0.9, opts.getTopP(), 1e-9);
+            assertEquals(1000, opts.getMaxCompletionTokens());
+        }
+
+        @Test
+        @DisplayName("gpt-5-chat-latest applies temperature/top_p")
+        void gpt5ChatAllowed() {
+            OpenAiChatOptions opts = callWith("gpt-5-chat-latest");
+            assertEquals(0.7, opts.getTemperature(), 1e-9);
+            assertEquals(0.9, opts.getTopP(), 1e-9);
+        }
+    }
+
+    @Nested
+    @DisplayName("restrictsSamplingParams truth table")
+    class RestrictsTable {
+        @Test
+        @DisplayName("restricted models")
+        void restricted() {
+            assertTrue(OpenAiHandler.restrictsSamplingParams("o1"));
+            assertTrue(OpenAiHandler.restrictsSamplingParams("o3-mini"));
+            assertTrue(OpenAiHandler.restrictsSamplingParams("o4-mini"));
+            assertTrue(OpenAiHandler.restrictsSamplingParams("gpt-5"));
+            assertTrue(OpenAiHandler.restrictsSamplingParams("gpt-5-mini"));
+            assertTrue(OpenAiHandler.restrictsSamplingParams("gpt-5-nano"));
+            assertTrue(OpenAiHandler.restrictsSamplingParams("openai/gpt-5"));
+        }
+
+        @Test
+        @DisplayName("unrestricted models")
+        void unrestricted() {
+            assertFalse(OpenAiHandler.restrictsSamplingParams("gpt-4o"));
+            assertFalse(OpenAiHandler.restrictsSamplingParams("gpt-4.1"));
+            assertFalse(OpenAiHandler.restrictsSamplingParams("gpt-5-chat-latest"));
+            assertFalse(OpenAiHandler.restrictsSamplingParams(null));
+        }
+    }
+
+    // =====================================================================
+    // PART 1 — effectiveModel resolution
+    // =====================================================================
+
+    @Nested
+    @DisplayName("effectiveModel resolution")
+    class EffectiveModel {
+        @Test
+        @DisplayName("override wins over declared")
+        void overrideWins() {
+            Map<String, Object> o = declared("gpt-4o");
+            o.put(LlmProviderHandler.OPTION_MODEL, "openai/gpt-4.1");
+            assertEquals("gpt-4.1",
+                LlmProviderHandler.effectiveModel(o, "openai", new String[]{"gpt"}));
+        }
+
+        @Test
+        @DisplayName("declared used when no override")
+        void declaredUsed() {
+            assertEquals("gpt-4o",
+                LlmProviderHandler.effectiveModel(declared("gpt-4o"), "openai", new String[]{"gpt"}));
+        }
+
+        @Test
+        @DisplayName("cross-vendor override falls back to declared")
+        void crossVendorFallsBack() {
+            Map<String, Object> o = declared("gpt-4o");
+            o.put(LlmProviderHandler.OPTION_MODEL, "anthropic/claude-3-5-sonnet-latest");
+            assertEquals("gpt-4o",
+                LlmProviderHandler.effectiveModel(o, "openai", new String[]{"gpt"}));
+        }
+
+        @Test
+        @DisplayName("null when neither override nor declared present")
+        void noneNull() {
+            assertNull(LlmProviderHandler.effectiveModel(Map.of(), "openai", new String[]{"gpt"}));
+            assertNull(LlmProviderHandler.effectiveModel(null, "openai", new String[]{"gpt"}));
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderDeclaredModelTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderDeclaredModelTest.java
@@ -190,6 +190,59 @@ class ProviderDeclaredModelTest {
     }
 
     // =====================================================================
+    // Regression — schema-construction failure must NOT drop the declared model
+    // on the auto-execute path (toolExecutor != null).
+    // =====================================================================
+
+    @Nested
+    @DisplayName("schema-failure does not drop the declared model (auto-execute)")
+    class SchemaFailureKeepsModel {
+
+        /** A no-op tool executor — non-null so the handler takes the auto-execute path. */
+        private final LlmProviderHandler.ToolExecutorCallback noopExecutor = (name, args) -> "";
+
+        /**
+         * An OutputSchema whose {@code properties} is a String, not a Map. Both
+         * OpenAI's {@code makeStrict()} and Anthropic's {@code sanitize()} cast
+         * {@code properties} to a Map and throw ClassCastException — the exact
+         * schema-construction failure the fix isolates.
+         */
+        private LlmProviderHandler.OutputSchema brokenSchema() {
+            Map<String, Object> schema = new LinkedHashMap<>();
+            schema.put("type", "object");
+            schema.put("properties", "not-a-map");
+            return new LlmProviderHandler.OutputSchema("Broken", schema, false);
+        }
+
+        @Test
+        @DisplayName("OpenAI: declared model survives a response_format build failure")
+        void openAiKeepsModelOnSchemaFailure() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            new OpenAiHandler().generateWithTools(
+                model, userMessages(), List.of(), noopExecutor, brokenSchema(), declared("gpt-4o"));
+
+            assertEquals("gpt-4o", captor.getValue().getOptions().getModel(),
+                "declared model must still be applied when response_format construction fails");
+        }
+
+        @Test
+        @DisplayName("Anthropic: declared model survives an output_schema build failure")
+        void anthropicKeepsModelOnSchemaFailure() {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel model = mockModel(captor);
+
+            new AnthropicHandler().generateWithTools(
+                model, userMessages(), List.of(), noopExecutor, brokenSchema(),
+                declared("claude-3-5-sonnet-latest"));
+
+            assertEquals("claude-3-5-sonnet-latest", captor.getValue().getOptions().getModel(),
+                "declared model must still be applied when output_schema construction fails");
+        }
+    }
+
+    // =====================================================================
     // PART 3 — OpenAI sampling-param gating
     // =====================================================================
 

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderModelParamsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderModelParamsTest.java
@@ -287,15 +287,20 @@ class ProviderModelParamsTest {
         }
 
         @Test
-        @DisplayName("plain-text generateWithMessages with no params builds a no-options prompt")
+        @DisplayName("plain-text generateWithMessages with no params builds an options object with no model set")
         void plainTextPathNoParams() {
             ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
             ChatModel model = mockModel(captor);
 
             handler.generateWithMessages(model, userMessages(), Map.of());
 
-            assertNull(captor.getValue().getOptions(),
-                "no model_params → plain Prompt(messages) with no ChatOptions");
+            // The handler now always builds a vendor-correct options object so the
+            // effective model can be set on every request. With no declared model
+            // and no override, the model stays null (Spring AI default applies).
+            ChatOptions opts = captor.getValue().getOptions();
+            assertInstanceOf(GoogleGenAiChatOptions.class, opts);
+            assertNull(opts.getModel(),
+                "no declared model and no override → model stays null (Spring AI default)");
         }
     }
 


### PR DESCRIPTION
## Summary

Java LLM provider handlers (OpenAI/Gemini/Anthropic) only set the request model when a per-call `model_params.model` **override** was present. With no override, the provider's declared `@MeshLlmProvider(model=...)` was kept in config (for descriptions/errors) but **never applied to the request** — so every call fell through to Spring AI 2.0.0-M4's default OpenAI model (a **gpt-5**). A provider declaring `gpt-4o` actually ran gpt-5, and the error path misreported the configured name. This was a latent correctness bug (and silently broke per-vendor multi-model, since all providers shared the one autoconfigured `ChatModel`'s default). It surfaced now because Spring AI's gpt-5 default landed on top of the `model_params` temperature work: gpt-5 restricts `temperature` to its default, so a non-default temperature failed with HTTP 400 on a provider that thought it was on gpt-4o.

Model/parameter boundary verified against the live OpenAI API:
- temperature 0.7 **accepted**: gpt-4o, gpt-4.1, gpt-5-chat-latest
- temperature 0.7 **rejected**: gpt-5, gpt-5-mini, gpt-5-nano, o1, o3-mini, o4-mini

## Fix

- **Propagation (all 3 handlers):** thread the declared model (`config.modelName()`) into handler options as `OPTION_DECLARED_MODEL` at the single construction point (covers every generate path). Add `LlmProviderHandler.effectiveModel()` = override else declared. All three handlers now build their vendor options on **every** generate path (previously skipped when no `model_params`) and set the effective model — so providers honor their declared model and per-vendor multi-model works.
- **OpenAI sampling-param gating:** `restrictsSamplingParams()` omits `temperature`/`top_p` (warn, soft-fail) for models that reject them — o-series (o1/o3/o4) and the gpt-5 family **except** gpt-5-chat — while keeping `max_completion_tokens`. Gemini/Anthropic get propagation only (no such restriction).

## Validation

- **178** spring-ai unit tests pass (new `ProviderDeclaredModelTest`: propagation across all 3 handlers, override-wins, cross-vendor fallback, OpenAI gating, classifier truth table).
- src-tests image build 12/12.
- **uc04 + uc08 + uc10 (Java LLM suites, all vendors): 106 passed, 0 failed**, 9 pre-existing skips. `tc44_output_mode_hint_override_openai_java` — which previously failed because the declared gpt-4o was never used — is now green, and no regression across any Java OpenAI/Gemini/Anthropic provider now that they all honor their declared models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model settings are now applied more consistently across requests, including plain-text and tool-based generations.
  * Provider-declared models are now honored when no per-request model override is set, while same-vendor overrides still take precedence.
  * OpenAI requests now respect model-specific limits on sampling options, avoiding unsupported settings for certain models.
  * Gemini, Anthropic, and OpenAI requests now consistently include the correct request options, improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->