### PR TITLE
fix(python): gate sampling params for OpenAI reasoning/gpt-5 models

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/native_clients/_native_client_helpers.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/_native_client_helpers.py
@@ -59,6 +59,33 @@ def reset_unsupported_kwargs_dedupe(dedupe_set: set[str]) -> None:
     dedupe_set.clear()
 
 
+def restricts_sampling_params(model: str | None) -> bool:
+    """Whether an OpenAI model restricts ``temperature``/``top_p`` to their
+    default value (rejecting any explicit setting with HTTP 400).
+
+    OpenAI o-series reasoning models (o1/o3/o4) and the gpt-5 family (except
+    gpt-5-chat) accept ONLY the default sampling params. Verified against the
+    live API:
+
+      * REJECT: gpt-5, gpt-5-mini, gpt-5-nano, o1, o3-mini, o4-mini
+      * ACCEPT: gpt-4o, gpt-4.1, gpt-5-chat-latest
+
+    Accepts a bare or ``vendor/``-qualified model string (e.g.
+    ``openai/o3-mini``). Returns ``True`` when ``temperature``/``top_p`` should
+    be omitted. Mirrors the Java ``OpenAiHandler.restrictsSamplingParams``.
+    """
+    if not model:
+        return False
+    m = model.lower()
+    if "/" in m:
+        m = m.split("/", 1)[1]  # strip vendor prefix e.g. "openai/o3-mini"
+    if m in ("o1", "o3", "o4") or m.startswith(("o1-", "o3-", "o4-")):
+        return True
+    if m.startswith("gpt-5") and not m.startswith("gpt-5-chat"):
+        return True
+    return False
+
+
 def resolve_request_timeout(
     request_params: dict[str, Any],
     *,

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -45,6 +45,7 @@ from ._native_client_helpers import (
     make_is_available,
     reset_unsupported_kwargs_dedupe,
     resolve_request_timeout,
+    restricts_sampling_params,
     warn_unsupported_kwarg_once,
 )
 
@@ -480,6 +481,13 @@ def _build_create_kwargs(
 
     create_kwargs: dict[str, Any] = {"model": _strip_prefix(model)}
 
+    # gpt-5 (non-chat) and o-series reasoning models reject any explicit
+    # ``temperature``/``top_p`` (HTTP 400) — only the default is accepted.
+    # Omit those two params for the restricted models (everything else,
+    # including ``max_completion_tokens``, is forwarded normally). Soft-fail
+    # with a WARN per omitted param rather than letting the request 400.
+    restricted = restricts_sampling_params(model)
+
     for key in _OPENAI_PASSTHROUGH_KWARGS:
         value = request_params.get(key)
         # Drop None values — OpenAI rejects ``max_tokens=None`` etc., and
@@ -487,6 +495,16 @@ def _build_create_kwargs(
         # callers expect. (``request_params.get`` already returns None for
         # missing keys, so the absence check collapses into the value check.)
         if value is None:
+            continue
+        if restricted and key in ("temperature", "top_p"):
+            logger.warning(
+                "OpenAI model %s rejects %s; omitting %s=%s "
+                "(only the default is supported)",
+                model,
+                key,
+                key,
+                value,
+            )
             continue
         create_kwargs[key] = value
 

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_sampling_param_gating.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_sampling_param_gating.py
@@ -1,0 +1,116 @@
+"""Unit tests for OpenAI sampling-param gating (temperature/top_p).
+
+OpenAI o-series reasoning models (o1/o3/o4) and the gpt-5 family (except
+gpt-5-chat) reject non-default ``temperature``/``top_p`` with HTTP 400. These
+tests cover:
+
+  * the shared :func:`restricts_sampling_params` classifier truth table, and
+  * the native-SDK gating in ``openai_native._build_create_kwargs``.
+
+Mirrors the Java ``OpenAiHandler.restrictsSamplingParams`` behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from _mcp_mesh.engine.native_clients._native_client_helpers import (
+    restricts_sampling_params,
+)
+
+
+# ---------------------------------------------------------------------------
+# Classifier truth table
+# ---------------------------------------------------------------------------
+
+
+class TestRestrictsSamplingParams:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "o1",
+            "o3",
+            "o4",
+            "o3-mini",
+            "o4-mini",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5-nano",
+            "openai/gpt-5",
+            "openai/o3-mini",
+            "GPT-5-MINI",  # case-insensitive
+        ],
+    )
+    def test_restricted_models(self, model):
+        assert restricts_sampling_params(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-4o",
+            "gpt-4.1",
+            "gpt-4o-mini",
+            "gpt-5-chat-latest",
+            "gpt-5-chat",
+            "openai/gpt-4o",
+            "gemini/gemini-2.5-flash",
+            "anthropic/claude-sonnet-4-5",
+            "o3xyz",  # not an o-series family member (no trailing dash)
+            None,
+            "",
+        ],
+    )
+    def test_unrestricted_models(self, model):
+        assert restricts_sampling_params(model) is False
+
+
+# ---------------------------------------------------------------------------
+# Native-SDK path: _build_create_kwargs gating
+# ---------------------------------------------------------------------------
+
+
+class TestNativeBuildCreateKwargsGating:
+    def _build(self, model: str, **params):
+        from _mcp_mesh.engine.native_clients import openai_native
+
+        request_params = {
+            "messages": [{"role": "user", "content": "Hi."}],
+            **params,
+        }
+        return openai_native._build_create_kwargs(request_params, model=model)
+
+    def test_restricted_model_omits_temperature_and_top_p(self):
+        kwargs = self._build(
+            "openai/o3-mini",
+            temperature=0.7,
+            top_p=0.9,
+            max_completion_tokens=256,
+        )
+        assert "temperature" not in kwargs
+        assert "top_p" not in kwargs
+        # Everything else is still forwarded.
+        assert kwargs["max_completion_tokens"] == 256
+        assert kwargs["model"] == "o3-mini"
+
+    def test_restricted_gpt5_omits_sampling_params(self):
+        kwargs = self._build("openai/gpt-5-mini", temperature=0.5, top_p=0.8)
+        assert "temperature" not in kwargs
+        assert "top_p" not in kwargs
+
+    def test_unrestricted_model_keeps_temperature(self):
+        kwargs = self._build("openai/gpt-4o", temperature=0.7, top_p=0.9)
+        assert kwargs["temperature"] == 0.7
+        assert kwargs["top_p"] == 0.9
+
+    def test_gpt5_chat_keeps_temperature(self):
+        kwargs = self._build("openai/gpt-5-chat-latest", temperature=0.7)
+        assert kwargs["temperature"] == 0.7
+
+    def test_restricted_model_warns_on_omission(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._build("openai/o3-mini", temperature=0.7, top_p=0.9)
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("temperature" in m for m in warnings)
+        assert any("top_p" in m for m in warnings)

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -1303,6 +1303,11 @@ def _build_iteration_completion_args(
     if model_params:
         completion_args.update(model_params)
 
+    # Restricted OpenAI models (o-series / gpt-5 non-chat) reject explicit
+    # temperature/top_p — strip them here so neither the native adapter nor
+    # the LiteLLM fallback forwards them.
+    _sanitize_sampling_params(completion_args, effective_model)
+
     if stream:
         existing_stream_opts = completion_args.get("stream_options") or {}
         completion_args["stream"] = True
@@ -2304,6 +2309,40 @@ def _infer_big3_vendor_from_bare_name(model: str) -> str | None:
     return None
 
 
+def _sanitize_sampling_params(
+    completion_args: dict[str, Any], effective_model: str
+) -> None:
+    """Drop ``temperature``/``top_p`` from ``completion_args`` in place when the
+    effective OpenAI model rejects them (o-series / gpt-5 non-chat).
+
+    OpenAI reasoning models and the gpt-5 family (except gpt-5-chat) return
+    HTTP 400 for any explicit ``temperature``/``top_p``. Pop them with a WARN
+    (soft-fail, mesh philosophy) so the LiteLLM call never forwards them. The
+    classifier strips the vendor prefix and matches only OpenAI restricted
+    names, so this is a safe no-op for gemini/anthropic and for unrestricted
+    OpenAI models (gpt-4o, gpt-4.1, gpt-5-chat-latest). Only present params are
+    touched — mesh sends no default temperature, so an unset value is left
+    unset.
+    """
+    from _mcp_mesh.engine.native_clients._native_client_helpers import (
+        restricts_sampling_params,
+    )
+
+    if not restricts_sampling_params(effective_model):
+        return
+    for key in ("temperature", "top_p"):
+        if completion_args.get(key) is not None:
+            value = completion_args.pop(key)
+            logger.warning(
+                "OpenAI model %s rejects %s; omitting %s=%s "
+                "(only the default is supported)",
+                effective_model,
+                key,
+                key,
+                value,
+            )
+
+
 def llm_provider(
     model: str,
     capability: str = "llm",
@@ -2684,6 +2723,11 @@ def llm_provider(
             if model_params_copy:
                 completion_args.update(model_params_copy)
 
+            # Restricted OpenAI models (o-series / gpt-5 non-chat) reject
+            # explicit temperature/top_p — strip them before native/LiteLLM
+            # dispatch (and before the fallback args derive from these).
+            _sanitize_sampling_params(completion_args, effective_model)
+
             # Strip internal mesh control flags before they reach LiteLLM.
             # These are set by handlers (e.g., ClaudeHandler HINT mode) and
             # would otherwise cause provider APIs to reject the request with
@@ -2994,6 +3038,11 @@ def llm_provider(
                 completion_args["tools"] = effective_tools
             if model_params_copy:
                 completion_args.update(model_params_copy)
+
+            # Restricted OpenAI models (o-series / gpt-5 non-chat) reject
+            # explicit temperature/top_p — strip them before native/LiteLLM
+            # streaming dispatch.
+            _sanitize_sampling_params(completion_args, effective_model)
 
             # Strip internal mesh control flags before they reach LiteLLM
             # (mirrors the buffered legacy path). Captured values are not

--- a/src/runtime/python/tests/unit/test_llm_sampling_param_gating.py
+++ b/src/runtime/python/tests/unit/test_llm_sampling_param_gating.py
@@ -1,0 +1,102 @@
+"""Unit tests for OpenAI sampling-param gating on the LiteLLM path.
+
+OpenAI o-series reasoning models (o1/o3/o4) and the gpt-5 family (except
+gpt-5-chat) reject non-default ``temperature``/``top_p`` with HTTP 400. The
+provider's LiteLLM dispatch must strip those params from ``completion_args``
+before they reach ``litellm.completion``/``acompletion``.
+
+Covers the shared ``_sanitize_sampling_params`` helper and its application in
+``_build_iteration_completion_args`` (the agentic-loop build site shared by the
+buffered and streaming loops). Mirrors the Java ``OpenAiHandler`` gating.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from mesh.helpers import (
+    _build_iteration_completion_args,
+    _sanitize_sampling_params,
+)
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_sampling_params
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeSamplingParams:
+    def test_restricted_model_pops_temperature_and_top_p(self):
+        args = {"model": "o3-mini", "temperature": 0.7, "top_p": 0.9}
+        _sanitize_sampling_params(args, "o3-mini")
+        assert "temperature" not in args
+        assert "top_p" not in args
+
+    def test_restricted_prefixed_model_pops_params(self):
+        args = {"temperature": 0.5, "top_p": 0.8}
+        _sanitize_sampling_params(args, "openai/gpt-5-mini")
+        assert "temperature" not in args
+        assert "top_p" not in args
+
+    def test_unrestricted_model_keeps_params(self):
+        args = {"temperature": 0.7, "top_p": 0.9}
+        _sanitize_sampling_params(args, "gpt-4o")
+        assert args["temperature"] == 0.7
+        assert args["top_p"] == 0.9
+
+    def test_gemini_model_is_noop(self):
+        args = {"temperature": 0.7}
+        _sanitize_sampling_params(args, "gemini/gemini-2.5-flash")
+        assert args["temperature"] == 0.7
+
+    def test_only_present_params_touched(self):
+        # No temperature supplied → nothing to strip, no crash.
+        args = {"model": "o3-mini"}
+        _sanitize_sampling_params(args, "o3-mini")
+        assert "temperature" not in args
+
+    def test_restricted_model_warns(self, caplog):
+        args = {"temperature": 0.7, "top_p": 0.9}
+        with caplog.at_level(logging.WARNING):
+            _sanitize_sampling_params(args, "o3-mini")
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("temperature" in m for m in warnings)
+        assert any("top_p" in m for m in warnings)
+
+
+# ---------------------------------------------------------------------------
+# _build_iteration_completion_args integration
+# ---------------------------------------------------------------------------
+
+
+class TestBuildIterationCompletionArgsGating:
+    def _build(self, model, model_params):
+        return _build_iteration_completion_args(
+            effective_model=model,
+            current_messages=[{"role": "user", "content": "Hi."}],
+            tools=[],
+            litellm_kwargs={},
+            model_params=model_params,
+        )
+
+    def test_restricted_model_omits_sampling_params(self):
+        args = self._build(
+            "o3-mini",
+            {"temperature": 0.7, "top_p": 0.9, "max_completion_tokens": 256},
+        )
+        assert "temperature" not in args
+        assert "top_p" not in args
+        # max_completion_tokens (and everything else) is preserved.
+        assert args["max_completion_tokens"] == 256
+
+    def test_restricted_gpt5_omits_sampling_params(self):
+        args = self._build("openai/gpt-5", {"temperature": 0.7, "top_p": 0.9})
+        assert "temperature" not in args
+        assert "top_p" not in args
+
+    def test_unrestricted_model_keeps_sampling_params(self):
+        args = self._build("gpt-4o", {"temperature": 0.7, "top_p": 0.9})
+        assert args["temperature"] == 0.7
+        assert args["top_p"] == 0.9


### PR DESCRIPTION
## Summary

Cross-runtime parity with the Java sampling-param gating. OpenAI o-series (o1/o3/o4) and the gpt-5 family (except gpt-5-chat) reject non-default `temperature`/`top_p` with HTTP 400. The Python provider forwarded them **unconditionally** on both the native-SDK path and the LiteLLM path (no `drop_params`), so a provider declaring such a model with an explicit `temperature`/`top_p` failed every call.

Model/parameter boundary verified against the live OpenAI API: temperature 0.7 rejected by gpt-5/gpt-5-mini/gpt-5-nano/o1/o3-mini/o4-mini; accepted by gpt-4o/gpt-4.1/gpt-5-chat-latest.

## Fix

- `restricts_sampling_params(model)` added to the shared native-client helpers (o1/o3/o4 + `gpt-5*` except `gpt-5-chat*`, vendor-prefix tolerant) — mirrors Java's `OpenAiHandler.restrictsSamplingParams`.
- **Native path** (`openai_native._build_create_kwargs`): omit `temperature`/`top_p` for restricted models, keep `max_completion_tokens`, warn per omitted param.
- **LiteLLM path** (`helpers.py`): `_sanitize_sampling_params` pops `temperature`/`top_p` from `completion_args` for a restricted effective model at all three build sites (buffered, agentic-loop iteration, streaming); retry/fallback paths derive from the sanitized dicts.

Non-restricted models (gpt-4o, gpt-4.1, gpt-5-chat-latest, gemini, anthropic) are unchanged. mesh injects no default temperature, so only a caller-supplied value is ever omitted (matches Java's `if temperature is not None`).

## Validation
- 36 new unit tests (classifier truth table + native `_build_create_kwargs` gating + LiteLLM `_sanitize_sampling_params`/`_build_iteration_completion_args`).
- Full Python unit suite passes — no regressions.

## Related
- Java equivalent: #1240. TypeScript is covered by `@ai-sdk/openai` (which strips these params for reasoning models); a defensive mesh-level hardening for TS is a separate follow-up.
- Follow-up noted (not in scope): the native path also forwards a raw `max_tokens`, which o-series/gpt-5 reject (they require `max_completion_tokens`) — a separate gap worth a translate/gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)