### PR TITLE
fix(python): translate max_tokens to max_completion_tokens for OpenAI restricted models

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/native_clients/_native_client_helpers.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/_native_client_helpers.py
@@ -86,6 +86,39 @@ def restricts_sampling_params(model: str | None) -> bool:
     return False
 
 
+def translate_max_tokens_for_restricted(
+    params: dict[str, Any], model: str | None, logger: logging.Logger
+) -> None:
+    """For OpenAI restricted models (o-series / gpt-5 non-chat), move a
+    supplied ``max_tokens`` into ``max_completion_tokens`` (unless one is
+    already present, which wins) and drop the raw ``max_tokens`` so it never
+    reaches the wire — those models return HTTP 400 for raw ``max_tokens``.
+    Operates in place on ``params``. No-op for unrestricted / non-OpenAI
+    models and when ``max_tokens`` is absent. Soft-fail WARN, mesh philosophy.
+    Shared by the native OpenAI adapter and the LiteLLM path so their behavior
+    cannot drift.
+    """
+    if not restricts_sampling_params(model):
+        return
+    if params.get("max_tokens") is None:
+        return
+    value = params.pop("max_tokens")
+    if params.get("max_completion_tokens") is None:
+        params["max_completion_tokens"] = value
+        logger.warning(
+            "OpenAI model %s rejects max_tokens; using "
+            "max_completion_tokens instead",
+            model,
+        )
+    else:
+        logger.warning(
+            "OpenAI model %s rejects max_tokens; dropping max_tokens=%s "
+            "in favor of the supplied max_completion_tokens",
+            model,
+            value,
+        )
+
+
 def resolve_request_timeout(
     request_params: dict[str, Any],
     *,

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -506,6 +506,26 @@ def _build_create_kwargs(
                 value,
             )
             continue
+        # Restricted models reject the raw ``max_tokens`` (HTTP 400) — they
+        # require ``max_completion_tokens``. Translate the caller-supplied
+        # value into ``max_completion_tokens`` (unless one is already present,
+        # which wins) and never emit ``max_tokens`` on the wire.
+        if restricted and key == "max_tokens":
+            if request_params.get("max_completion_tokens") is None:
+                create_kwargs["max_completion_tokens"] = value
+                logger.warning(
+                    "OpenAI model %s rejects max_tokens; using "
+                    "max_completion_tokens instead",
+                    model,
+                )
+            else:
+                logger.warning(
+                    "OpenAI model %s rejects max_tokens; dropping max_tokens=%s "
+                    "in favor of the supplied max_completion_tokens",
+                    model,
+                    value,
+                )
+            continue
         create_kwargs[key] = value
 
     # WARN once when ``n>1`` is observed. OpenAI's SDK accepts ``n=k>1`` and

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -46,6 +46,7 @@ from ._native_client_helpers import (
     reset_unsupported_kwargs_dedupe,
     resolve_request_timeout,
     restricts_sampling_params,
+    translate_max_tokens_for_restricted,
     warn_unsupported_kwarg_once,
 )
 
@@ -506,27 +507,14 @@ def _build_create_kwargs(
                 value,
             )
             continue
-        # Restricted models reject the raw ``max_tokens`` (HTTP 400) — they
-        # require ``max_completion_tokens``. Translate the caller-supplied
-        # value into ``max_completion_tokens`` (unless one is already present,
-        # which wins) and never emit ``max_tokens`` on the wire.
-        if restricted and key == "max_tokens":
-            if request_params.get("max_completion_tokens") is None:
-                create_kwargs["max_completion_tokens"] = value
-                logger.warning(
-                    "OpenAI model %s rejects max_tokens; using "
-                    "max_completion_tokens instead",
-                    model,
-                )
-            else:
-                logger.warning(
-                    "OpenAI model %s rejects max_tokens; dropping max_tokens=%s "
-                    "in favor of the supplied max_completion_tokens",
-                    model,
-                    value,
-                )
-            continue
         create_kwargs[key] = value
+
+    # Restricted models reject the raw ``max_tokens`` (HTTP 400) — they require
+    # ``max_completion_tokens``. Translate any forwarded ``max_tokens`` into
+    # ``max_completion_tokens`` (unless one is already present, which wins) and
+    # never emit ``max_tokens`` on the wire. Shared with the LiteLLM path so
+    # the two cannot drift.
+    translate_max_tokens_for_restricted(create_kwargs, model, logger)
 
     # WARN once when ``n>1`` is observed. OpenAI's SDK accepts ``n=k>1`` and
     # returns k candidates in ``choices[0..k-1]``, but ``_adapt_response``

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_sampling_param_gating.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_sampling_param_gating.py
@@ -16,6 +16,7 @@ import pytest
 
 from _mcp_mesh.engine.native_clients._native_client_helpers import (
     restricts_sampling_params,
+    translate_max_tokens_for_restricted,
 )
 
 
@@ -165,3 +166,42 @@ class TestNativeMaxTokensTranslation:
             self._build("openai/o3-mini", max_tokens=256)
         warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
         assert any("max_tokens" in m and "max_completion_tokens" in m for m in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Shared helper: translate_max_tokens_for_restricted (direct, in place)
+# ---------------------------------------------------------------------------
+
+
+class TestTranslateMaxTokensForRestricted:
+    def _log(self):
+        import logging
+
+        return logging.getLogger("test_translate_max_tokens")
+
+    def test_restricted_moves_max_tokens(self):
+        params = {"max_tokens": 256}
+        translate_max_tokens_for_restricted(params, "openai/o3-mini", self._log())
+        assert params == {"max_completion_tokens": 256}
+
+    def test_restricted_both_supplied_keeps_max_completion_tokens(self):
+        params = {"max_tokens": 256, "max_completion_tokens": 512}
+        translate_max_tokens_for_restricted(params, "openai/o3-mini", self._log())
+        assert params == {"max_completion_tokens": 512}
+
+    def test_unrestricted_is_noop(self):
+        params = {"max_tokens": 256}
+        translate_max_tokens_for_restricted(params, "openai/gpt-4o", self._log())
+        assert params == {"max_tokens": 256}
+
+    def test_gemini_is_noop(self):
+        params = {"max_tokens": 256}
+        translate_max_tokens_for_restricted(
+            params, "gemini/gemini-2.5-flash", self._log()
+        )
+        assert params == {"max_tokens": 256}
+
+    def test_absent_max_tokens_is_noop(self):
+        params = {"max_completion_tokens": 512}
+        translate_max_tokens_for_restricted(params, "openai/o3-mini", self._log())
+        assert params == {"max_completion_tokens": 512}

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_sampling_param_gating.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_sampling_param_gating.py
@@ -114,3 +114,54 @@ class TestNativeBuildCreateKwargsGating:
         warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
         assert any("temperature" in m for m in warnings)
         assert any("top_p" in m for m in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Native-SDK path: max_tokens → max_completion_tokens translation
+# ---------------------------------------------------------------------------
+
+
+class TestNativeMaxTokensTranslation:
+    def _build(self, model: str, **params):
+        from _mcp_mesh.engine.native_clients import openai_native
+
+        request_params = {
+            "messages": [{"role": "user", "content": "Hi."}],
+            **params,
+        }
+        return openai_native._build_create_kwargs(request_params, model=model)
+
+    def test_restricted_model_moves_max_tokens(self):
+        kwargs = self._build("openai/o3-mini", max_tokens=256)
+        assert "max_tokens" not in kwargs
+        assert kwargs["max_completion_tokens"] == 256
+
+    def test_restricted_gpt5_moves_max_tokens(self):
+        kwargs = self._build("openai/gpt-5-mini", max_tokens=256)
+        assert "max_tokens" not in kwargs
+        assert kwargs["max_completion_tokens"] == 256
+
+    def test_restricted_model_both_supplied_keeps_max_completion_tokens(self):
+        kwargs = self._build(
+            "openai/o3-mini", max_tokens=256, max_completion_tokens=512
+        )
+        assert "max_tokens" not in kwargs
+        assert kwargs["max_completion_tokens"] == 512
+
+    def test_unrestricted_model_keeps_max_tokens(self):
+        kwargs = self._build("openai/gpt-4o", max_tokens=256)
+        assert kwargs["max_tokens"] == 256
+        assert "max_completion_tokens" not in kwargs
+
+    def test_gpt5_chat_keeps_max_tokens(self):
+        kwargs = self._build("openai/gpt-5-chat-latest", max_tokens=256)
+        assert kwargs["max_tokens"] == 256
+        assert "max_completion_tokens" not in kwargs
+
+    def test_restricted_model_warns_on_translation(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._build("openai/o3-mini", max_tokens=256)
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("max_tokens" in m and "max_completion_tokens" in m for m in warnings)

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -2332,6 +2332,7 @@ def _sanitize_sampling_params(
     """
     from _mcp_mesh.engine.native_clients._native_client_helpers import (
         restricts_sampling_params,
+        translate_max_tokens_for_restricted,
     )
 
     if not restricts_sampling_params(effective_model):
@@ -2348,26 +2349,10 @@ def _sanitize_sampling_params(
                 value,
             )
     # Restricted models reject the raw ``max_tokens`` (HTTP 400) — they require
-    # ``max_completion_tokens``. Move a caller-supplied ``max_tokens`` into
-    # ``max_completion_tokens`` (unless one is already present, which wins) and
-    # pop the raw ``max_tokens`` so it never reaches the wire. LiteLLM auto-maps
-    # this today, but mesh translates explicitly to stay self-contained.
-    if completion_args.get("max_tokens") is not None:
-        value = completion_args.pop("max_tokens")
-        if completion_args.get("max_completion_tokens") is None:
-            completion_args["max_completion_tokens"] = value
-            logger.warning(
-                "OpenAI model %s rejects max_tokens; using "
-                "max_completion_tokens instead",
-                effective_model,
-            )
-        else:
-            logger.warning(
-                "OpenAI model %s rejects max_tokens; dropping max_tokens=%s "
-                "in favor of the supplied max_completion_tokens",
-                effective_model,
-                value,
-            )
+    # ``max_completion_tokens``. Shared with the native OpenAI adapter so the
+    # two paths cannot drift. LiteLLM auto-maps this today, but mesh translates
+    # explicitly to stay self-contained.
+    translate_max_tokens_for_restricted(completion_args, effective_model, logger)
 
 
 def llm_provider(

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -2312,17 +2312,23 @@ def _infer_big3_vendor_from_bare_name(model: str) -> str | None:
 def _sanitize_sampling_params(
     completion_args: dict[str, Any], effective_model: str
 ) -> None:
-    """Drop ``temperature``/``top_p`` from ``completion_args`` in place when the
-    effective OpenAI model rejects them (o-series / gpt-5 non-chat).
+    """Rewrite restricted-model sampling params in ``completion_args`` in place
+    when the effective OpenAI model rejects them (o-series / gpt-5 non-chat).
 
     OpenAI reasoning models and the gpt-5 family (except gpt-5-chat) return
-    HTTP 400 for any explicit ``temperature``/``top_p``. Pop them with a WARN
-    (soft-fail, mesh philosophy) so the LiteLLM call never forwards them. The
-    classifier strips the vendor prefix and matches only OpenAI restricted
-    names, so this is a safe no-op for gemini/anthropic and for unrestricted
-    OpenAI models (gpt-4o, gpt-4.1, gpt-5-chat-latest). Only present params are
-    touched — mesh sends no default temperature, so an unset value is left
-    unset.
+    HTTP 400 for any explicit ``temperature``/``top_p`` and for the raw
+    ``max_tokens`` param. For those models this:
+
+      * pops ``temperature``/``top_p`` (only the default is accepted), and
+      * translates ``max_tokens`` → ``max_completion_tokens`` (unless a
+        ``max_completion_tokens`` is already present, which wins), popping the
+        raw ``max_tokens`` so it never reaches the wire.
+
+    Each rewrite emits a WARN (soft-fail, mesh philosophy). The classifier
+    strips the vendor prefix and matches only OpenAI restricted names, so this
+    is a safe no-op for gemini/anthropic and for unrestricted OpenAI models
+    (gpt-4o, gpt-4.1, gpt-5-chat-latest). Only present params are touched —
+    mesh sends no defaults, so an unset value is left unset.
     """
     from _mcp_mesh.engine.native_clients._native_client_helpers import (
         restricts_sampling_params,
@@ -2339,6 +2345,27 @@ def _sanitize_sampling_params(
                 effective_model,
                 key,
                 key,
+                value,
+            )
+    # Restricted models reject the raw ``max_tokens`` (HTTP 400) — they require
+    # ``max_completion_tokens``. Move a caller-supplied ``max_tokens`` into
+    # ``max_completion_tokens`` (unless one is already present, which wins) and
+    # pop the raw ``max_tokens`` so it never reaches the wire. LiteLLM auto-maps
+    # this today, but mesh translates explicitly to stay self-contained.
+    if completion_args.get("max_tokens") is not None:
+        value = completion_args.pop("max_tokens")
+        if completion_args.get("max_completion_tokens") is None:
+            completion_args["max_completion_tokens"] = value
+            logger.warning(
+                "OpenAI model %s rejects max_tokens; using "
+                "max_completion_tokens instead",
+                effective_model,
+            )
+        else:
+            logger.warning(
+                "OpenAI model %s rejects max_tokens; dropping max_tokens=%s "
+                "in favor of the supplied max_completion_tokens",
+                effective_model,
                 value,
             )
 

--- a/src/runtime/python/tests/unit/test_llm_sampling_param_gating.py
+++ b/src/runtime/python/tests/unit/test_llm_sampling_param_gating.py
@@ -65,6 +65,49 @@ class TestSanitizeSamplingParams:
         assert any("temperature" in m for m in warnings)
         assert any("top_p" in m for m in warnings)
 
+    def test_restricted_model_moves_max_tokens(self):
+        args = {"model": "o3-mini", "max_tokens": 256}
+        _sanitize_sampling_params(args, "o3-mini")
+        assert "max_tokens" not in args
+        assert args["max_completion_tokens"] == 256
+
+    def test_restricted_prefixed_model_moves_max_tokens(self):
+        args = {"max_tokens": 128}
+        _sanitize_sampling_params(args, "openai/gpt-5-mini")
+        assert "max_tokens" not in args
+        assert args["max_completion_tokens"] == 128
+
+    def test_restricted_model_both_supplied_keeps_max_completion_tokens(self):
+        args = {"max_tokens": 256, "max_completion_tokens": 512}
+        _sanitize_sampling_params(args, "o3-mini")
+        assert "max_tokens" not in args
+        assert args["max_completion_tokens"] == 512
+
+    def test_unrestricted_model_keeps_max_tokens(self):
+        args = {"max_tokens": 256}
+        _sanitize_sampling_params(args, "gpt-4o")
+        assert args["max_tokens"] == 256
+        assert "max_completion_tokens" not in args
+
+    def test_gemini_model_max_tokens_noop(self):
+        args = {"max_tokens": 256}
+        _sanitize_sampling_params(args, "gemini/gemini-2.5-flash")
+        assert args["max_tokens"] == 256
+        assert "max_completion_tokens" not in args
+
+    def test_restricted_model_no_max_tokens_is_noop(self):
+        args = {"model": "o3-mini"}
+        _sanitize_sampling_params(args, "o3-mini")
+        assert "max_tokens" not in args
+        assert "max_completion_tokens" not in args
+
+    def test_restricted_model_warns_on_max_tokens(self, caplog):
+        args = {"max_tokens": 256}
+        with caplog.at_level(logging.WARNING):
+            _sanitize_sampling_params(args, "o3-mini")
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("max_tokens" in m and "max_completion_tokens" in m for m in warnings)
+
 
 # ---------------------------------------------------------------------------
 # _build_iteration_completion_args integration


### PR DESCRIPTION
## Summary

OpenAI o-series (o1/o3/o4) and gpt-5 (except gpt-5-chat) reject the raw `max_tokens` parameter with HTTP 400 and require `max_completion_tokens`. The Python provider forwarded a caller-supplied `max_tokens` **raw** on both the native-SDK path and the LiteLLM path, so a provider on such a model with `max_tokens` set failed every call.

Verified against the live OpenAI API: `max_tokens` accepted by gpt-4o/gpt-4.1, **rejected** by gpt-5-mini/o3-mini/o4-mini (`unsupported_parameter`, "use max_completion_tokens").

## Fix

Extends the #1241 gating (reuses the same `restricts_sampling_params` classifier). For **restricted models only**, a supplied `max_tokens` is moved to `max_completion_tokens` (unless one is already present, which wins) and the raw `max_tokens` is dropped, with a warn — on both paths:
- **Native** (`openai_native._build_create_kwargs`) — inside the passthrough loop, next to the existing temperature/top_p omission.
- **LiteLLM** (`helpers._sanitize_sampling_params`) — gated by its early-return on non-restricted models, so it's inherently a no-op for gpt-4o/gemini/anthropic.

Non-restricted models (gpt-4o, gpt-4.1, gpt-5-chat-latest) and other vendors are unchanged; only acts when `max_tokens` is present. LiteLLM auto-maps this today, but mesh is now self-contained on both paths.

## Validation
- 49 gating unit tests pass (new native `TestNativeMaxTokensTranslation` + LiteLLM `_sanitize_sampling_params` cases: restricted move, both-supplied precedence, gpt-4o keeps, gpt-5-chat keeps, gemini no-op, absent no-op, warns).
- Full Python unit suite green — no regressions.

## Related
- Cross-runtime parity: Java already always emits `max_completion_tokens` (#1238); TypeScript is safe via `@ai-sdk/openai` (sets `max_output_tokens` on the Responses API / remaps on Chat). This closes the Python native-path gap.
- Sampling-param (temperature/top_p) gating parity: #1241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of token limit settings for certain OpenAI models, avoiding request errors by automatically using the compatible parameter.
  * Preserved the explicit token completion limit when both settings are provided, with a warning when one setting is ignored.

* **Tests**
  * Added coverage for restricted and unrestricted model behavior to confirm the correct request parameters are sent.
  * Added checks for warning messages and non-OpenAI model pass-through behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->