### PR TITLE
fix(ts): mesh-level sampling-param gating for OpenAI restricted models

### DIFF
--- a/src/runtime/typescript/src/__tests__/llm-provider-sampling-gating.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-provider-sampling-gating.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Mesh-level OpenAI sampling-param gating (cross-runtime parity with Java
+ * `OpenAiHandler.restrictsSamplingParams` and Python `restricts_sampling_params`).
+ *
+ * OpenAI o-series (o1/o3/o4) and gpt-5 (except gpt-5-chat) reject non-default
+ * `temperature`/`top_p` with HTTP 400. This is version-independent HARDENING:
+ * mesh omits temperature/topP for restricted models BEFORE handing off to the
+ * SDK (rather than silently relying on @ai-sdk/openai to strip them) and logs
+ * its own warning. maxOutputTokens is intentionally NOT touched.
+ *
+ * Two layers:
+ *  - the `restrictsSamplingParams` classifier truth table, and
+ *  - behavioral: the options reaching the mocked vendor call (generateText /
+ *    generateObject) carry NO temperature/topP for a restricted model, while a
+ *    non-restricted model (gpt-4o) keeps them.
+ *
+ * The Vercel `ai` module is mocked — no real LLM is invoked.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const generateObjectMock = vi.fn();
+const generateTextMock = vi.fn();
+
+vi.mock("ai", () => ({
+  generateText: (opts: unknown) => generateTextMock(opts),
+  generateObject: (opts: unknown) => generateObjectMock(opts),
+  jsonSchema: (schema: Record<string, unknown>) => schema,
+  tool: (config: unknown) => config,
+  stepCountIs: (n: number) => ({ steps }: { steps: unknown[] }) => steps.length === n,
+}));
+
+// Keep tracing inert/deterministic (publishTraceSpan is best-effort anyway).
+vi.mock("../tracing.js", () => ({
+  generateTraceId: () => "trace-mock",
+  generateSpanId: () => "span-mock",
+  publishTraceSpan: vi.fn(async () => {}),
+  matchesPropagateHeader: () => false,
+}));
+
+import { llmProvider, restrictsSamplingParams } from "../llm-provider.js";
+
+// ----------------------------------------------------------------------------
+// Classifier truth table
+// ----------------------------------------------------------------------------
+
+describe("restrictsSamplingParams truth table", () => {
+  it.each([
+    "o1",
+    "o3-mini",
+    "o4-mini",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5-nano",
+    "openai/o3-mini",
+    "openai/gpt-5",
+    "O3-MINI", // case-insensitive
+  ])("restricts %s", (model) => {
+    expect(restrictsSamplingParams(model)).toBe(true);
+  });
+
+  it.each([
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-5-chat-latest",
+    "openai/gpt-4o",
+    "gemini/gemini-2.0-flash",
+    "anthropic/claude-sonnet-4-5",
+    "o5", // not an o1/o3/o4 series
+    undefined,
+    null,
+    "",
+  ])("does not restrict %s", (model) => {
+    expect(restrictsSamplingParams(model as string | undefined | null)).toBe(false);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Behavioral — the options reaching the vendor SDK call
+// ----------------------------------------------------------------------------
+
+const SCHEMA = {
+  type: "object",
+  properties: { answer: { type: "string" } },
+  required: ["answer"],
+};
+
+function baseRequest(
+  modelParams: Record<string, unknown>,
+  opts: { withSchema?: boolean } = {},
+) {
+  const mp: Record<string, unknown> = { ...modelParams };
+  if (opts.withSchema) {
+    mp.output_schema = SCHEMA;
+    mp.output_type_name = "Answer";
+  }
+  return {
+    request: {
+      messages: [
+        { role: "system", content: "You are helpful." },
+        { role: "user", content: "hi" },
+      ],
+      model_params: mp,
+    },
+  };
+}
+
+describe("OpenAI sampling-param gating — vendor call options", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    generateObjectMock.mockReset();
+    generateTextMock.mockReset();
+    generateObjectMock.mockResolvedValue({
+      object: { answer: "ok" },
+      usage: { inputTokens: 1, outputTokens: 1 },
+      finishReason: "stop",
+    });
+    generateTextMock.mockResolvedValue({
+      text: "ok",
+      toolCalls: [],
+      usage: { inputTokens: 1, outputTokens: 1 },
+      finishReason: "stop",
+    });
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // --- generateText (plain / no schema) path ---
+
+  it("omits temperature/topP for a restricted model (o3-mini) — generateText", async () => {
+    const tool = llmProvider({
+      model: "openai/o3-mini",
+      capability: "llm",
+      temperature: 0.7,
+      topP: 0.9,
+    });
+    await tool.execute(baseRequest({}) as never);
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    const opts = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect("temperature" in opts).toBe(false);
+    expect("topP" in opts).toBe(false);
+    // mesh surfaces its own warning (one per omitted param).
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps temperature/topP for a non-restricted model (gpt-4o) — generateText", async () => {
+    const tool = llmProvider({
+      model: "openai/gpt-4o",
+      capability: "llm",
+      temperature: 0.7,
+      topP: 0.9,
+    });
+    await tool.execute(baseRequest({}) as never);
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    const opts = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.temperature).toBe(0.7);
+    expect(opts.topP).toBe(0.9);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("omits temperature/topP supplied via model_params for a restricted model", async () => {
+    const tool = llmProvider({ model: "openai/gpt-5", capability: "llm" });
+    await tool.execute(
+      baseRequest({ temperature: 0.3, top_p: 0.5 }) as never,
+    );
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    const opts = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect("temperature" in opts).toBe(false);
+    expect("topP" in opts).toBe(false);
+  });
+
+  it("does not touch maxOutputTokens for a restricted model", async () => {
+    const tool = llmProvider({
+      model: "openai/o3-mini",
+      capability: "llm",
+      maxOutputTokens: 4096,
+      temperature: 0.7,
+    });
+    await tool.execute(baseRequest({}) as never);
+
+    const opts = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.maxOutputTokens).toBe(4096);
+    expect("temperature" in opts).toBe(false);
+  });
+
+  // --- generateObject (structured output) path ---
+
+  it("omits temperature/topP for a restricted model (o3-mini) — generateObject", async () => {
+    const tool = llmProvider({
+      model: "openai/o3-mini",
+      capability: "llm",
+      temperature: 0.7,
+      topP: 0.9,
+    });
+    await tool.execute(baseRequest({}, { withSchema: true }) as never);
+
+    expect(generateObjectMock).toHaveBeenCalledTimes(1);
+    const opts = generateObjectMock.mock.calls[0][0] as Record<string, unknown>;
+    expect("temperature" in opts).toBe(false);
+    expect("topP" in opts).toBe(false);
+  });
+
+  it("keeps temperature/topP for a non-restricted model (gpt-4o) — generateObject", async () => {
+    const tool = llmProvider({
+      model: "openai/gpt-4o",
+      capability: "llm",
+      temperature: 0.7,
+      topP: 0.9,
+    });
+    await tool.execute(baseRequest({}, { withSchema: true }) as never);
+
+    expect(generateObjectMock).toHaveBeenCalledTimes(1);
+    const opts = generateObjectMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.temperature).toBe(0.7);
+    expect(opts.topP).toBe(0.9);
+  });
+});

--- a/src/runtime/typescript/src/llm-provider.ts
+++ b/src/runtime/typescript/src/llm-provider.ts
@@ -228,6 +228,70 @@ export function extractModelName(model: string): string {
 }
 
 /**
+ * Whether an OpenAI model restricts ``temperature``/``top_p`` to their default
+ * value (rejecting any explicit setting with HTTP 400).
+ *
+ * OpenAI o-series reasoning models (o1/o3/o4) and the gpt-5 family (except
+ * gpt-5-chat) accept ONLY the default sampling params. Verified against the
+ * live API:
+ *   - REJECT: gpt-5, gpt-5-mini, gpt-5-nano, o1, o3-mini, o4-mini
+ *   - ACCEPT: gpt-4o, gpt-4.1, gpt-5-chat-latest
+ *
+ * Accepts a bare or ``vendor/``-qualified model string (e.g. "openai/o3-mini").
+ * Returns true when ``temperature``/``topP`` should be omitted. Mirrors the
+ * Java ``OpenAiHandler.restrictsSamplingParams`` and Python
+ * ``restricts_sampling_params``.
+ */
+export function restrictsSamplingParams(model: string | undefined | null): boolean {
+  if (!model) return false;
+  let m = model.toLowerCase();
+  const slash = m.indexOf("/");
+  if (slash >= 0) m = m.slice(slash + 1); // strip vendor prefix e.g. "openai/o3-mini"
+  // o-series reasoning models reject temperature/top_p
+  if (
+    m === "o1" || m === "o3" || m === "o4" ||
+    m.startsWith("o1-") || m.startsWith("o3-") || m.startsWith("o4-")
+  ) {
+    return true;
+  }
+  // gpt-5 family restricts temperature/top_p to default — except gpt-5-chat*
+  if (m.startsWith("gpt-5") && !m.startsWith("gpt-5-chat")) return true;
+  return false;
+}
+
+/**
+ * Remove ``temperature``/``topP`` from a fully-assembled request options object
+ * for OpenAI models that reject non-default sampling params (see
+ * {@link restrictsSamplingParams}). No-op for unrestricted models and when the
+ * param is absent (mesh sends no default unless configured).
+ *
+ * This is version-independent hardening: it makes mesh self-contained rather
+ * than silently relying on @ai-sdk/openai to strip these, and surfaces mesh's
+ * OWN warning (the SDK's `warnings` array is not surfaced by mesh). One warning
+ * is logged per omitted param. Does NOT touch maxOutputTokens.
+ */
+export function sanitizeSamplingParams(
+  options: { temperature?: number; topP?: number },
+  model: string | undefined | null,
+): void {
+  if (!restrictsSamplingParams(model)) return;
+  if (options.temperature !== undefined) {
+    console.warn(
+      `OpenAI model ${model} rejects temperature=${options.temperature}; ` +
+        `omitting it (only the default is supported)`
+    );
+    delete options.temperature;
+  }
+  if (options.topP !== undefined) {
+    console.warn(
+      `OpenAI model ${model} rejects top_p=${options.topP}; ` +
+        `omitting it (only the default is supported)`
+    );
+    delete options.topP;
+  }
+}
+
+/**
  * Coerce an arbitrary value to a positive integer iteration cap, or undefined
  * when it is unset/invalid (NaN, non-finite, <= 0, or floors to 0). Floors
  * BEFORE the > 0 check so fractional values in (0,1) are rejected, not zeroed.
@@ -927,6 +991,18 @@ export function llmProvider(config: LlmProviderConfig): {
       requestOptions.topP = modelParams.top_p as number;
     }
 
+    // Version-independent hardening: OpenAI o-series (o1/o3/o4) and gpt-5
+    // (except gpt-5-chat) reject non-default temperature/top_p with HTTP 400.
+    // Strip them from the fully-assembled options BEFORE handing off to the
+    // SDK (rather than relying on @ai-sdk/openai to strip them silently), and
+    // surface mesh's own warning. Sanitizing requestOptions here covers BOTH
+    // generateText call sites (the manual agentic loop and the plain/Gemini
+    // path both consume requestOptions) AND the generateObject structured path,
+    // which reads temperature/topP off requestOptions below. Matches Java
+    // OpenAiHandler / Python restricts_sampling_params. maxOutputTokens is left
+    // untouched (the SDK maps it per-model).
+    sanitizeSamplingParams(requestOptions, effectiveModelName);
+
     // Pass responseFormat from handler's prepareRequest to generateText via providerOptions.
     // This enables native structured output (response_format) alongside tools in generateText(),
     // which generateObject() doesn't support. The handler sets responseFormat when in strict mode.
@@ -997,15 +1073,36 @@ export function llmProvider(config: LlmProviderConfig): {
       // Required for OpenAI/Gemini structured output, and enables future Claude support
       const strictSchema = makeSchemaStrict(cleanSchema as Record<string, unknown>, { addAllRequired: true });
 
-      const objectResult = await generateObject({
+      // temperature/topP inherit from requestOptions, which has already been
+      // run through sanitizeSamplingParams above — so for restricted OpenAI
+      // models these are already stripped (undefined) here. Only include a key
+      // when it is actually set so the vendor call carries NO temperature/topP
+      // for restricted models (mirrors Java/Python omission, not "pass null").
+      const generateObjectOptions: {
+        model: unknown;
+        messages: unknown[];
+        schema: unknown;
+        schemaName?: string;
+        maxOutputTokens?: number;
+        temperature?: number;
+        topP?: number;
+      } = {
         model: aiModel,
         messages: convertedMessages,
         schema: jsonSchema(strictSchema),
         schemaName: outputTypeName,
-        maxOutputTokens: requestOptions.maxOutputTokens,
-        temperature: requestOptions.temperature,
-        topP: requestOptions.topP,
-      });
+      };
+      if (requestOptions.maxOutputTokens !== undefined) {
+        generateObjectOptions.maxOutputTokens = requestOptions.maxOutputTokens;
+      }
+      if (requestOptions.temperature !== undefined) {
+        generateObjectOptions.temperature = requestOptions.temperature;
+      }
+      if (requestOptions.topP !== undefined) {
+        generateObjectOptions.topP = requestOptions.topP;
+      }
+
+      const objectResult = await generateObject(generateObjectOptions);
 
       latencyMs = Date.now() - startTime;
       debug(


### PR DESCRIPTION
## Summary

Cross-runtime parity **hardening** with Java (`OpenAiHandler.restrictsSamplingParams`) and Python (`restricts_sampling_params`). OpenAI o-series (o1/o3/o4) and the gpt-5 family (except gpt-5-chat) reject non-default `temperature`/`top_p`.

This is hardening, **not an active-bug fix**: `@ai-sdk/openai@3.0.11` already strips those params for reasoning models, so there's no 400 today. But mesh silently depended on that SDK behavior (pinned via `^3.0.0`) and never surfaced its own warning. This makes mesh self-contained and gives it parity with the Java/Python runtimes, which gate in-tree.

## Change

- `restrictsSamplingParams(model)` in `llm-provider.ts` — mirrors Java/Python exactly (o1/o3/o4 + `gpt-5*` except `gpt-5-chat*`, vendor-prefix tolerant).
- `sanitizeSamplingParams(options, model)` chokepoint — omits `temperature`/`topP` for restricted models before the vendor call and logs one warning per omitted param. A single call after `requestOptions` is assembled covers both `generateText` paths; the `generateObject` structured path reads the same options and now omits the keys entirely (true omission, not `undefined`) for restricted models.

Non-restricted models (gpt-4o, gpt-4.1, gpt-5-chat-latest, gemini, anthropic) are unchanged. `maxOutputTokens` is untouched — TS uses the SDK abstraction, which the SDK maps to the correct wire field per model (`max_output_tokens` on the Responses API), so there is no TS `max_tokens` gap.

## Validation
- `npm run build` — tsc clean.
- `npm test` — **975 tests pass** (25 new: classifier truth table + behavioral tests asserting no `temperature`/`topP` for restricted models, kept for gpt-4o, `maxOutputTokens` intact, warnings emitted).

## Related (cross-runtime sampling-param parity, now complete)
- Java: #1240 (gating) — in-tree.
- Python: #1241 (temperature/top_p gating) + #1242 (max_tokens → max_completion_tokens).
- TypeScript: this PR (temperature/top_p hardening). max_tokens is SDK-handled (no gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)