### PR TITLE
fix(registry): stale-job sweep honors a job's declared max_duration

### DIFF
--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -469,6 +469,26 @@ loop reaps orphaned jobs (owner crashed, lease expired) and enforces
 so any consumer that holds the `job_id` sees the latest state on the
 next poll regardless of which replica owns the job.
 
+### Default stale ceiling (opt-in)
+
+Operators can set `MCP_MESH_JOB_STALE_TIMEOUT` (a Go duration, e.g.
+`2h`) on the registry to apply a *default* total-runtime ceiling —
+measured from submission — to jobs that did **not** set their own
+`total_deadline`. A job that set `total_deadline` is fully exempt; the
+per-job hard bound already governs it. The effective ceiling for a job
+is `max(MCP_MESH_JOB_STALE_TIMEOUT, max_duration)`: the registry never
+reaps a job before its own declared per-attempt `max_duration` has
+elapsed, since a longer `max_duration` expresses intent to run that
+long. Reaped jobs are marked `failed` with a `stale: ...` reason and a
+synthetic `stale` event. Unset (the default) leaves the feature off —
+such jobs run unbounded, subject only to lease recovery.
+
+For a job that runs for hours: set `max_duration` to its real
+per-attempt runtime (this sizes the lease AND floors the stale
+ceiling) and/or emit periodic progress to keep the lease renewed. Set
+`total_deadline` if you want a hard total-runtime bound across all
+attempts, or to opt out of the registry-wide stale ceiling entirely.
+
 The **agent runtime** is a thin client. On the producer side, it
 maintains a claim queue per `task=true` capability (`UPDATE jobs SET
 owner_instance_id = $self WHERE capability = $cap AND status =

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -257,17 +257,36 @@ export DEFAULT_EVICTION_THRESHOLD=60
 # that are no longer referenced by any capability — purged when both
 # orphan and older than this retention window; #842).
 export MCP_MESH_RETENTION=1h
+
+# How often the periodic job/agent sweep runs (reaping, lease recovery,
+# retention purges). Go duration string (e.g. "30s", "5m", "1m30s").
+# Default: 5m. A shorter interval makes reaping and retention purges run
+# more promptly at the cost of extra sweep scans; production deployments
+# typically leave this unset.
+export MCP_MESH_SWEEP_INTERVAL=5m
+
+# MeshJob default total-runtime ceiling. Go duration string (e.g. "2h",
+# "30m"). Applies a DEFAULT total_deadline — measured from a job's
+# submission time — to jobs that did NOT set their own total_deadline; a
+# job that exceeds it is marked failed with a "stale: ..." reason and a
+# synthetic `stale` event. The effective ceiling for a job is
+# max(MCP_MESH_JOB_STALE_TIMEOUT, max_duration) — it never reaps a job
+# before its own declared per-attempt max_duration elapses. Jobs that
+# set their own total_deadline are fully exempt. Default: off (unset /
+# "0") — jobs without an explicit total_deadline run unbounded, subject
+# only to lease recovery.
+export MCP_MESH_JOB_STALE_TIMEOUT=2h
 ```
 
 **Notes:**
 
-- The sweep runs on a hardcoded 5-minute interval, so actual purge can
-  lag retention by up to ~5 minutes.
-- Setting `MCP_MESH_RETENTION` shorter than 5m (e.g. `1m`) will not
-  speed up the purge cadence — it only affects when an agent becomes
-  eligible for purge.
-- Hardcoded internal constants: sweep interval = 5m, event hard cap =
-  100,000 rows.
+- The sweep runs every `MCP_MESH_SWEEP_INTERVAL` (default 5m), so actual
+  purge can lag retention by up to one sweep interval.
+- Setting `MCP_MESH_RETENTION` shorter than the sweep interval (e.g.
+  `1m` with the default 5m sweep) will not speed up the purge cadence —
+  it only affects when an agent becomes eligible for purge. Lower
+  `MCP_MESH_SWEEP_INTERVAL` to tighten the cadence.
+- Internal constant: event hard cap = 100,000 rows.
 
 ### Logging and Debug
 

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -514,13 +514,23 @@ export DEFAULT_EVICTION_THRESHOLD=60  # Evict stale agents (seconds)
 # rows). Event rows are governed by a separate hardcoded 100k row cap.
 export MCP_MESH_RETENTION=1h
 
+# Registry sweep cadence — how often the periodic job/agent sweep runs
+# (reaping, lease recovery, retention purges). Go duration string (e.g.
+# "30s", "5m", "1m30s"). Default: 5m. A shorter interval makes reaping
+# and retention purges run more promptly at the cost of extra sweep
+# scans; production deployments typically leave this unset.
+export MCP_MESH_SWEEP_INTERVAL=5m
+
 # MeshJob default total-runtime ceiling. Go duration string (e.g. "2h",
 # "30m"). Applies a DEFAULT total_deadline — measured from a job's
 # submission time — to jobs that did NOT set their own total_deadline; a
 # job that exceeds it is marked failed with a "stale: ..." reason and a
-# synthetic `stale` event. Jobs that set their own total_deadline are
-# unaffected. Default: off (unset / "0") — jobs without an explicit
-# total_deadline run unbounded, subject only to lease recovery.
+# synthetic `stale` event. The effective ceiling for a job is
+# max(MCP_MESH_JOB_STALE_TIMEOUT, max_duration) — it never reaps a job
+# before its own declared per-attempt max_duration elapses. Jobs that
+# set their own total_deadline are fully exempt. Default: off (unset /
+# "0") — jobs without an explicit total_deadline run unbounded, subject
+# only to lease recovery.
 export MCP_MESH_JOB_STALE_TIMEOUT=2h
 
 # CORS

--- a/src/core/cli/man/content/jobs.md
+++ b/src/core/cli/man/content/jobs.md
@@ -137,7 +137,7 @@ async def commission_report(
 | Keyword            | Type             | Purpose                                                 |
 | ------------------ | ---------------- | ------------------------------------------------------- |
 | `**args`           | per-tool         | Forwarded as the tool's input arguments                 |
-| `max_duration`     | `int` (seconds)  | Per-attempt soft timeout (provider runtime + cron sweep)|
+| `max_duration`     | `int` (seconds)  | Per-attempt soft timeout; also sizes the lease window and floors the stale ceiling |
 | `max_retries`      | `int`            | Retries beyond initial attempt (Sidekiq convention)     |
 | `total_deadline`   | `int` (seconds)  | Hard ceiling across all attempts (registry enforces)    |
 | `owner_instance_id`| `str`            | Pin to a specific replica (rarely needed)               |
@@ -427,14 +427,23 @@ intervention:
 - **Default stale ceiling (opt-in).** Set `MCP_MESH_JOB_STALE_TIMEOUT`
   (a duration, e.g. `2h`) on the registry to apply a *default*
   total-runtime ceiling, measured from submission, to jobs that did
-  **not** set their own `total_deadline`. Such a job is marked `failed`
-  with a `stale: ...` error once it exceeds the ceiling. Unset (the
-  default) leaves the feature off — jobs without an explicit
-  `total_deadline` run unbounded (subject only to lease recovery).
-  Jobs that set their own `total_deadline` are unaffected.
+  **not** set their own `total_deadline`. The effective ceiling for a
+  job is `max(MCP_MESH_JOB_STALE_TIMEOUT, max_duration)` — it never
+  reaps a job before its own declared per-attempt `max_duration` has
+  elapsed. Such a job is marked `failed` with a `stale: ...` error once
+  it exceeds the ceiling. Unset (the default) leaves the feature off —
+  jobs without an explicit `total_deadline` run unbounded (subject only
+  to lease recovery). Jobs that set their own `total_deadline` are fully
+  exempt.
 
 Reaping is observable in-handler via a synthetic `stale` event — see
 **Event injection** below.
+
+**Long-running (hours) jobs.** Set `max_duration` to the job's real
+per-attempt runtime — this sizes the lease window AND floors the stale
+ceiling — and/or emit periodic progress to keep the lease renewed. Set
+`total_deadline` if you want a hard total-runtime bound across all
+attempts, or to opt out of the registry-wide stale ceiling entirely.
 
 ## Out-of-band inspection
 

--- a/src/core/cli/man/content/jobs_java.md
+++ b/src/core/cli/man/content/jobs_java.md
@@ -222,7 +222,7 @@ public class LongTaskConsumerApplication {
 public record SubmitOptions(
     Object args,                  // Map of args forwarded to the tool
     String ownerInstanceId,       // optional: pin to a replica
-    Integer maxDuration,          // per-attempt soft timeout (seconds)
+    Integer maxDuration,          // per-attempt soft timeout (sec); also sizes the lease + floors the stale ceiling
     Integer maxRetries,           // retries beyond initial attempt
     Integer totalDeadline         // hard ceiling across attempts (seconds)
 ) { }
@@ -613,14 +613,23 @@ intervention:
 - **Default stale ceiling (opt-in).** Set `MCP_MESH_JOB_STALE_TIMEOUT`
   (a duration, e.g. `2h`) on the registry to apply a *default*
   total-runtime ceiling, measured from submission, to jobs that did
-  **not** set their own `totalDeadline`. Such a job is marked `failed`
-  with a `stale: ...` error once it exceeds the ceiling. Unset (the
-  default) leaves the feature off — jobs without an explicit
-  `totalDeadline` run unbounded (subject only to lease recovery). Jobs
-  that set their own `totalDeadline` are unaffected.
+  **not** set their own `totalDeadline`. The effective ceiling for a
+  job is `max(MCP_MESH_JOB_STALE_TIMEOUT, maxDuration)` — it never reaps
+  a job before its own declared per-attempt `maxDuration` has elapsed.
+  Such a job is marked `failed` with a `stale: ...` error once it
+  exceeds the ceiling. Unset (the default) leaves the feature off —
+  jobs without an explicit `totalDeadline` run unbounded (subject only
+  to lease recovery). Jobs that set their own `totalDeadline` are fully
+  exempt.
 
 Reaping is observable in-handler via a synthetic `stale` event — see
 **Event injection** above.
+
+**Long-running (hours) jobs.** Set `maxDuration` to the job's real
+per-attempt runtime — this sizes the lease window AND floors the stale
+ceiling — and/or emit periodic progress to keep the lease renewed. Set
+`totalDeadline` if you want a hard total-runtime bound across all
+attempts, or to opt out of the registry-wide stale ceiling entirely.
 
 ## Out-of-band inspection
 

--- a/src/core/cli/man/content/jobs_typescript.md
+++ b/src/core/cli/man/content/jobs_typescript.md
@@ -168,7 +168,7 @@ agent.addTool({
 const proxy = await generateReport.submit(
   { user_id, sections },                    // tool args
   {
-    maxDuration: 60,                        // per-attempt soft timeout (sec)
+    maxDuration: 60,                        // per-attempt soft timeout (sec); also sizes the lease + floors the stale ceiling
     maxRetries: 3,                          // retries beyond initial attempt
     totalDeadline: 300,                     // hard ceiling across attempts (sec)
     ownerInstanceId: undefined,             // optional: pin to a replica
@@ -475,14 +475,23 @@ intervention:
 - **Default stale ceiling (opt-in).** Set `MCP_MESH_JOB_STALE_TIMEOUT`
   (a duration, e.g. `2h`) on the registry to apply a *default*
   total-runtime ceiling, measured from submission, to jobs that did
-  **not** set their own `totalDeadline`. Such a job is marked `failed`
-  with a `stale: ...` error once it exceeds the ceiling. Unset (the
-  default) leaves the feature off — jobs without an explicit
-  `totalDeadline` run unbounded (subject only to lease recovery). Jobs
-  that set their own `totalDeadline` are unaffected.
+  **not** set their own `totalDeadline`. The effective ceiling for a
+  job is `max(MCP_MESH_JOB_STALE_TIMEOUT, maxDuration)` — it never reaps
+  a job before its own declared per-attempt `maxDuration` has elapsed.
+  Such a job is marked `failed` with a `stale: ...` error once it
+  exceeds the ceiling. Unset (the default) leaves the feature off —
+  jobs without an explicit `totalDeadline` run unbounded (subject only
+  to lease recovery). Jobs that set their own `totalDeadline` are fully
+  exempt.
 
 Reaping is observable in-handler via a synthetic `stale` event — see
 **Event injection** above.
+
+**Long-running (hours) jobs.** Set `maxDuration` to the job's real
+per-attempt runtime — this sizes the lease window AND floors the stale
+ceiling — and/or emit periodic progress to keep the lease renewed. Set
+`totalDeadline` if you want a hard total-runtime bound across all
+attempts, or to opt out of the registry-wide stale ceiling entirely.
 
 ## Out-of-band inspection
 

--- a/src/core/registry/ent_service_jobs.go
+++ b/src/core/registry/ent_service_jobs.go
@@ -1403,10 +1403,17 @@ const staleJobError = "stale: no total_deadline set and exceeded MCP_MESH_JOB_ST
 // total_deadline are left to ExpireDeadlinedJobs (the total_deadline IS NULL
 // filter below excludes them).
 //
+// The effective stale ceiling for a job is max(staleTimeout, max_duration):
+// never shorter than the job's own declared per-attempt duration. A job that
+// declared a max_duration longer than the operator-wide default has expressed
+// intent to run that long, so the registry-wide default must not undercut it.
 // For every non-terminal job with a NULL total_deadline whose submitted_at is
-// older than `now - staleTimeout`, the row is marked failed with the
-// `stale:` reason and its lease/owner cleared. No new terminal state is
-// introduced — `failed` + the reason string IS the signal.
+// older than `now - max(staleTimeout, max_duration)`, the row is marked failed
+// with the `stale:` reason and its lease/owner cleared. No new terminal state
+// is introduced — `failed` + the reason string IS the signal. (The query below
+// uses `now - staleTimeout` as its cutoff — the widest net, since
+// max(staleTimeout, max_duration) >= staleTimeout — and the per-candidate loop
+// then skips any row not yet past its own effective ceiling.)
 //
 // Each reap uses the guarded-update discipline (WHERE id=? AND status NOT IN
 // terminal AND total_deadline IS NULL) so a concurrent completion / explicit
@@ -1443,6 +1450,22 @@ func (s *EntService) ExpireStaleJobs(ctx context.Context, staleTimeout time.Dura
 
 	staled := 0
 	for _, j := range candidates {
+		// Honor the job's own declared per-attempt duration: never reap as stale
+		// before submitted_at + max(staleTimeout, max_duration). A job that declared
+		// a max_duration longer than the operator's default ceiling has expressed
+		// intent to run that long — the registry-wide default must not undercut it.
+		// (max_duration also sizes the lease window, so a wedged job is still caught
+		// by lease reclaim; total_deadline remains the way to opt out entirely.)
+		effective := staleTimeout
+		if j.MaxDuration != nil && *j.MaxDuration > 0 {
+			if md := time.Duration(*j.MaxDuration) * time.Second; md > effective {
+				effective = md
+			}
+		}
+		if j.SubmittedAt.After(now.Add(-effective)) {
+			continue // not yet past this job's own effective ceiling
+		}
+
 		// The guarded status flip AND the synthetic `stale` event insert run
 		// in ONE transaction per row: either both commit or neither does.
 		// Unlike cancel — where the cancel HTTP-forward is the primary signal

--- a/src/core/registry/ent_service_jobs.go
+++ b/src/core/registry/ent_service_jobs.go
@@ -1389,11 +1389,19 @@ func (s *EntService) ExpireDeadlinedJobs(ctx context.Context) (int, error) {
 	return expired, nil
 }
 
-// staleJobError is the error string stamped on jobs reaped by
-// ExpireStaleJobs. Mirrors the "deadline_exceeded" / "orphaned: ..."
-// reason-string style so operators can grep all sweep-reap paths the same
-// way.
-const staleJobError = "stale: no total_deadline set and exceeded MCP_MESH_JOB_STALE_TIMEOUT default ceiling"
+// staleReason builds the failure reason for a stale-reaped job, naming the
+// ceiling that actually bound it. effective = max(staleTimeout, max_duration);
+// when max_duration is larger it, not the operator default, is the limit the
+// job exceeded — so the message must reflect that rather than always blaming
+// MCP_MESH_JOB_STALE_TIMEOUT. Both variants keep the leading "stale:" so
+// operators can grep all sweep-reap paths and consumers keying on the prefix
+// still work.
+func staleReason(effective, staleTimeout time.Duration) string {
+	if effective > staleTimeout {
+		return fmt.Sprintf("stale: no total_deadline set and exceeded max_duration (%s)", effective)
+	}
+	return fmt.Sprintf("stale: no total_deadline set and exceeded the MCP_MESH_JOB_STALE_TIMEOUT ceiling (%s)", staleTimeout)
+}
 
 // ExpireStaleJobs enforces a DEFAULT total-runtime ceiling for jobs that did
 // NOT set their own total_deadline. It is the opt-in companion to
@@ -1466,6 +1474,8 @@ func (s *EntService) ExpireStaleJobs(ctx context.Context, staleTimeout time.Dura
 			continue // not yet past this job's own effective ceiling
 		}
 
+		reason := staleReason(effective, staleTimeout)
+
 		// The guarded status flip AND the synthetic `stale` event insert run
 		// in ONE transaction per row: either both commit or neither does.
 		// Unlike cancel — where the cancel HTTP-forward is the primary signal
@@ -1486,7 +1496,7 @@ func (s *EntService) ExpireStaleJobs(ctx context.Context, staleTimeout time.Dura
 					job.TotalDeadlineIsNil(),
 				).
 				SetStatus(job.StatusFailed).
-				SetError(staleJobError).
+				SetError(reason).
 				ClearLeaseExpiresAt().
 				ClearOwnerInstanceID().
 				SetLastHeartbeatAt(now).
@@ -1506,7 +1516,7 @@ func (s *EntService) ExpireStaleJobs(ctx context.Context, staleTimeout time.Dura
 				tx,
 				j.ID,
 				"stale",
-				map[string]interface{}{"reason": "stale", "detail": staleJobError},
+				map[string]interface{}{"reason": "stale", "detail": reason},
 				nil,
 				"",
 			); evErr != nil {

--- a/src/core/registry/sweep.go
+++ b/src/core/registry/sweep.go
@@ -83,9 +83,12 @@ type SweepConfig struct {
 	Retention time.Duration
 
 	// JobStaleTimeout is a DEFAULT total-runtime ceiling applied to jobs that
-	// did NOT set their own total_deadline, measured from submitted_at. 0
-	// (the default) DISABLES the stale-job phase entirely — it is opt-in, so
-	// most deployments scan zero rows. See ExpireStaleJobs.
+	// did NOT set their own total_deadline, measured from submitted_at. The
+	// effective ceiling for any given job is max(JobStaleTimeout, max_duration)
+	// — never shorter than the job's own declared per-attempt duration, so a
+	// registry-wide default can't reap a genuine long job before its declared
+	// duration elapses. 0 (the default) DISABLES the stale-job phase entirely —
+	// it is opt-in, so most deployments scan zero rows. See ExpireStaleJobs.
 	JobStaleTimeout time.Duration
 }
 
@@ -382,7 +385,9 @@ func (s *SweepJob) runOnce(ctx context.Context) (sweepResult, error) {
 
 		// Default total-runtime ceiling (opt-in: MCP_MESH_JOB_STALE_TIMEOUT,
 		// 0 = disabled). Applies a default total_deadline measured from
-		// submitted_at to jobs that did NOT set their own. Runs AFTER the
+		// submitted_at to jobs that did NOT set their own — but the effective
+		// ceiling for each job is max(JobStaleTimeout, max_duration), so a job's
+		// declared per-attempt duration is never undercut. Runs AFTER the
 		// lease-reclaim and explicit-deadline phases so a row those already
 		// retired isn't double-processed (the guarded update would no-op
 		// anyway, but skipping the scan keeps the common disabled case free).

--- a/src/core/registry/sweep_jobs_test.go
+++ b/src/core/registry/sweep_jobs_test.go
@@ -7,6 +7,7 @@ package registry
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -980,8 +981,10 @@ func TestSweep_ExpireStaleJobs_NoDeadlineReaped(t *testing.T) {
 	if got.Status != job.StatusFailed {
 		t.Errorf("expected status=failed, got %s", got.Status)
 	}
-	if got.Error == nil || *got.Error != staleJobError {
-		t.Errorf("expected error %q, got %v", staleJobError, got.Error)
+	if got.Error == nil ||
+		!strings.Contains(*got.Error, "stale:") ||
+		!strings.Contains(*got.Error, "MCP_MESH_JOB_STALE_TIMEOUT") {
+		t.Errorf("expected stale-timeout reason, got %v", got.Error)
 	}
 	if got.LeaseExpiresAt != nil {
 		t.Errorf("expected lease cleared, got %v", got.LeaseExpiresAt)
@@ -1082,8 +1085,10 @@ func TestSweep_ExpireStaleJobs_MaxDurationGreaterThanStale_Elapsed(t *testing.T)
 	if got.Status != job.StatusFailed {
 		t.Errorf("expected status=failed, got %s", got.Status)
 	}
-	if got.Error == nil || *got.Error != staleJobError {
-		t.Errorf("expected error %q, got %v", staleJobError, got.Error)
+	if got.Error == nil ||
+		!strings.Contains(*got.Error, "stale:") ||
+		!strings.Contains(*got.Error, "max_duration") {
+		t.Errorf("expected max_duration reason, got %v", got.Error)
 	}
 	if got.LeaseExpiresAt != nil {
 		t.Errorf("expected lease cleared, got %v", got.LeaseExpiresAt)
@@ -1366,7 +1371,9 @@ func TestSweep_ExpireStaleJobs_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reload job: %v", err)
 	}
-	if got.Error == nil || *got.Error != staleJobError {
-		t.Errorf("expected stale error preserved, got %v", got.Error)
+	if got.Error == nil ||
+		!strings.Contains(*got.Error, "stale:") ||
+		!strings.Contains(*got.Error, "MCP_MESH_JOB_STALE_TIMEOUT") {
+		t.Errorf("expected stale-timeout reason preserved, got %v", got.Error)
 	}
 }

--- a/src/core/registry/sweep_jobs_test.go
+++ b/src/core/registry/sweep_jobs_test.go
@@ -995,6 +995,193 @@ func TestSweep_ExpireStaleJobs_NoDeadlineReaped(t *testing.T) {
 	}
 }
 
+// seedMaxDuration sets max_duration (seconds) on an already-seeded job row.
+func seedMaxDuration(t *testing.T, client *ent.Client, jobID string, seconds int) {
+	t.Helper()
+	if _, err := client.Job.UpdateOneID(jobID).
+		SetMaxDuration(seconds).
+		Save(context.Background()); err != nil {
+		t.Fatalf("seed max_duration on %s: %v", jobID, err)
+	}
+}
+
+// TestSweep_ExpireStaleJobs_MaxDurationGreaterThanStale_NotYetElapsed verifies
+// the effective ceiling is max(staleTimeout, max_duration): a job that declared
+// a max_duration LONGER than the operator's stale timeout, aged PAST the stale
+// timeout but BEFORE its own max_duration, is NOT reaped — it is still within
+// its declared per-attempt duration.
+func TestSweep_ExpireStaleJobs_MaxDurationGreaterThanStale_NotYetElapsed(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 24 * time.Hour, JobStaleTimeout: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "longjob-owner", agent.StatusHealthy, now)
+	owner := "longjob-owner"
+	// staleTimeout=1h, max_duration=3h. submitted_at 2h ago: past the 1h
+	// stale timeout but within the 3h declared duration → effective ceiling
+	// is 3h, so NOT yet reaped.
+	j := seedJobRow(t, client, "job-long-working", "render", &owner, job.StatusWorking, 1, 3, now.Add(-2*time.Hour))
+	seedMaxDuration(t, client, j.ID, int((3 * time.Hour).Seconds()))
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsStaled != 0 {
+		t.Errorf("expected 0 staled (within declared max_duration), got %d", res.jobsStaled)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusWorking {
+		t.Errorf("expected status=working preserved, got %s", got.Status)
+	}
+	if got.OwnerInstanceID == nil || *got.OwnerInstanceID != owner {
+		t.Errorf("expected owner preserved, got %v", got.OwnerInstanceID)
+	}
+	if n := countJobEventsOfType(t, client, j.ID, "stale"); n != 0 {
+		t.Errorf("expected no stale event (still working), got %d", n)
+	}
+}
+
+// TestSweep_ExpireStaleJobs_MaxDurationGreaterThanStale_Elapsed verifies the
+// same long job IS reaped once aged PAST its own max_duration: failed + stale
+// event, lease/owner cleared.
+func TestSweep_ExpireStaleJobs_MaxDurationGreaterThanStale_Elapsed(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 24 * time.Hour, JobStaleTimeout: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "longjob-done-owner", agent.StatusHealthy, now)
+	owner := "longjob-done-owner"
+	// staleTimeout=1h, max_duration=3h. submitted_at 4h ago: past the 3h
+	// effective ceiling → reaped.
+	j := seedJobRow(t, client, "job-long-elapsed", "render", &owner, job.StatusWorking, 1, 3, now.Add(-4*time.Hour))
+	seedMaxDuration(t, client, j.ID, int((3 * time.Hour).Seconds()))
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsStaled != 1 {
+		t.Errorf("expected 1 staled (past declared max_duration), got %d", res.jobsStaled)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusFailed {
+		t.Errorf("expected status=failed, got %s", got.Status)
+	}
+	if got.Error == nil || *got.Error != staleJobError {
+		t.Errorf("expected error %q, got %v", staleJobError, got.Error)
+	}
+	if got.LeaseExpiresAt != nil {
+		t.Errorf("expected lease cleared, got %v", got.LeaseExpiresAt)
+	}
+	if got.OwnerInstanceID != nil {
+		t.Errorf("expected owner cleared, got %v", *got.OwnerInstanceID)
+	}
+	if n := countJobEventsOfType(t, client, j.ID, "stale"); n != 1 {
+		t.Errorf("expected exactly 1 stale event, got %d", n)
+	}
+}
+
+// TestSweep_ExpireStaleJobs_MaxDurationLessThanStale_Reaped verifies existing
+// behavior is preserved when max_duration is SHORTER than the stale timeout:
+// the effective ceiling stays at staleTimeout, so a job aged past staleTimeout
+// is reaped even though its own (shorter) max_duration would also have passed.
+func TestSweep_ExpireStaleJobs_MaxDurationLessThanStale_Reaped(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 24 * time.Hour, JobStaleTimeout: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "shortmd-owner", agent.StatusHealthy, now)
+	owner := "shortmd-owner"
+	// staleTimeout=1h, max_duration=10m (< stale). submitted_at 2h ago: past
+	// staleTimeout → effective ceiling is 1h → reaped (max_duration doesn't
+	// shorten the ceiling).
+	j := seedJobRow(t, client, "job-short-md", "render", &owner, job.StatusWorking, 1, 3, now.Add(-2*time.Hour))
+	seedMaxDuration(t, client, j.ID, int((10 * time.Minute).Seconds()))
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsStaled != 1 {
+		t.Errorf("expected 1 staled (past staleTimeout), got %d", res.jobsStaled)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusFailed {
+		t.Errorf("expected status=failed, got %s", got.Status)
+	}
+	if n := countJobEventsOfType(t, client, j.ID, "stale"); n != 1 {
+		t.Errorf("expected 1 stale event, got %d", n)
+	}
+}
+
+// TestSweep_ExpireStaleJobs_MaxDurationWithTotalDeadlineExempt verifies a job
+// that ALSO set total_deadline remains exempt from the stale phase even with a
+// max_duration set — total_deadline is still the way to opt out entirely.
+func TestSweep_ExpireStaleJobs_MaxDurationWithTotalDeadlineExempt(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 24 * time.Hour, JobStaleTimeout: 1 * time.Hour}
+	client, _, sweep, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	seedAgent(t, client, "md-deadline-owner", agent.StatusHealthy, now)
+	owner := "md-deadline-owner"
+	// max_duration=3h AND a future total_deadline: total_deadline IS NULL
+	// filter excludes it from the stale phase; deadline not yet passed so
+	// ExpireDeadlinedJobs skips it too.
+	j := seedJobRow(t, client, "job-md-deadline", "render", &owner, job.StatusWorking, 1, 3, now.Add(-2*time.Hour))
+	// total_deadline in the FUTURE relative to wall-clock (ExpireDeadlinedJobs
+	// uses time.Now(), not the mock clock) so the deadline phase skips it too.
+	if _, err := client.Job.UpdateOneID(j.ID).
+		SetMaxDuration(int((3 * time.Hour).Seconds())).
+		SetTotalDeadline(time.Now().UTC().Add(1 * time.Hour)).
+		Save(ctx); err != nil {
+		t.Fatalf("seed max_duration+deadline: %v", err)
+	}
+
+	res, err := sweep.runOnce(ctx)
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.jobsStaled != 0 {
+		t.Errorf("expected 0 staled (total_deadline exempts), got %d", res.jobsStaled)
+	}
+
+	got, err := client.Job.Get(ctx, j.ID)
+	if err != nil {
+		t.Fatalf("reload job: %v", err)
+	}
+	if got.Status != job.StatusWorking {
+		t.Errorf("expected status=working preserved, got %s", got.Status)
+	}
+	if n := countJobEventsOfType(t, client, j.ID, "stale"); n != 0 {
+		t.Errorf("expected no stale event, got %d", n)
+	}
+}
+
 // TestSweep_ExpireStaleJobs_InputRequiredReaped verifies the stale ceiling
 // also covers input_required jobs (non-terminal, no total_deadline).
 func TestSweep_ExpireStaleJobs_InputRequiredReaped(t *testing.T) {

--- a/tests/integration/suites/uc21_meshjob/fixtures/long-task-consumer/main.py
+++ b/tests/integration/suites/uc21_meshjob/fixtures/long-task-consumer/main.py
@@ -119,11 +119,19 @@ async def commission_submit_only(
     user_id: str,
     sections: list[str],
     max_retries: int = 1,
-    max_duration: int = 60,
+    max_duration: Optional[int] = None,
     generate_report: MeshJob = None,
 ) -> dict:
     if generate_report is None:
         return {"error": "generate_report submitter not injected"}
+    # max_duration is Optional: when the caller omits it (None), we pass None
+    # to submit() so the registry applies its DEFAULT lease (300s). This is
+    # what the C2 stale-reaping test (tc28) needs — a job with NO explicit
+    # max_duration whose effective stale ceiling is just
+    # MCP_MESH_JOB_STALE_TIMEOUT, while the 300s default lease stays alive so
+    # only the stale sweep (not the lease-reclaim sweep) can reap it. When a
+    # caller DOES pass max_duration (e.g. tc30), it flows through verbatim and
+    # raises the effective ceiling to max(stale_timeout, max_duration).
     proxy = await generate_report.submit(
         user_id=user_id,
         sections=sections,

--- a/tests/integration/suites/uc21_meshjob/tc28_stale_job_reaped/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc28_stale_job_reaped/test.yaml
@@ -9,12 +9,23 @@
 # marked ``failed`` with error ``"stale: ..."``, its lease/owner cleared, and
 # a synthetic ``stale`` JobEvent posted.
 #
+# The stale sweep now HONORS a job's own ``max_duration``: the effective
+# runtime ceiling is ``max(MCP_MESH_JOB_STALE_TIMEOUT, max_duration)``. A job
+# whose ``max_duration`` exceeds the stale timeout is therefore NOT reaped
+# until its ``max_duration`` elapses (this protects genuine long jobs from a
+# registry-wide stale timeout — see tc30 for that shielding proof).
+#
 # Setup that isolates the STALE phase from the lease / orphan / deadline
 # phases (so a pass unambiguously proves the stale phase reaped the row):
 #   - commission_submit_only submits generate_report with NO total_deadline
 #     (so ExpireDeadlinedJobs can't touch it — its filter requires a non-null
-#     total_deadline) and a LARGE max_duration=60 (so the LEASE does not
-#     expire first — else ReclaimExpiredLeaseJobs / C1 would catch it).
+#     total_deadline) and — crucially — with NO ``max_duration``. With no
+#     max_duration the effective stale ceiling is just
+#     ``max(3s, 0) = 3s = MCP_MESH_JOB_STALE_TIMEOUT``, so the running job IS
+#     subject to the 3s ceiling. Omitting max_duration makes the lease fall
+#     back to the registry DEFAULT of 300s, so the LEASE stays alive well past
+#     the ~20s run — ReclaimExpiredLeaseJobs / C1 can't reach it first, and
+#     only the stale sweep reaps the row.
 #   - the job runs ~20s (10 sections * ~2s) — well past the 3s stale cutoff —
 #     so it is still ``working`` when the stale sweep fires.
 #   - the provider is kept HEALTHY (never killed): a dead owner would let
@@ -29,8 +40,8 @@
 #   - the events log CONTAINS a {type: "stale"} entry whose payload mentions
 #     reason/stale
 
-name: "MeshJob: stale-job sweep reaps a long job with no total_deadline"
-description: "Job with no total_deadline + large max_duration runs past MCP_MESH_JOB_STALE_TIMEOUT=3s; stale sweep marks it failed with 'stale:' and posts a synthetic stale event"
+name: "MeshJob: stale-job sweep reaps a long job with no total_deadline and no max_duration"
+description: "Job with no total_deadline and no max_duration runs past MCP_MESH_JOB_STALE_TIMEOUT=3s (effective ceiling max(3s,0)=3s); stale sweep marks it failed with 'stale:' and posts a synthetic stale event"
 tags:
   - meshjob
   - python
@@ -95,16 +106,18 @@ test:
     capture: wait_registration
     timeout: 90
 
-  # NO total_deadline (commission_submit_only never sets one) + a large
-  # max_duration so the lease can't lapse first. 10 sections * ~2s ≈ 20s of
-  # work — well past the 3s stale ceiling, so the job is still working when
-  # the stale sweep fires.
-  - name: "Submit generate_report with NO total_deadline, max_duration=60"
+  # NO total_deadline (commission_submit_only never sets one) and NO
+  # max_duration — so the effective stale ceiling is max(3s, 0) = 3s. Omitting
+  # max_duration makes the lease fall back to the registry default (300s), so
+  # the lease can't lapse during the ~20s run and only the stale sweep can
+  # reap the row. 10 sections * ~2s ≈ 20s of work — well past the 3s stale
+  # ceiling, so the job is still working when the stale sweep fires.
+  - name: "Submit generate_report with NO total_deadline and NO max_duration"
     handler: shell
     workdir: /workspace
     command: |
       meshctl call commission_submit_only \
-        '{"user_id":"alice","sections":["a","b","c","d","e","f","g","h","i","j"],"max_retries":0,"max_duration":60}'
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g","h","i","j"],"max_retries":0}'
     capture: submit_resp
     timeout: 30
 

--- a/tests/integration/suites/uc21_meshjob/tc30_stale_respects_max_duration/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc30_stale_respects_max_duration/test.yaml
@@ -1,0 +1,179 @@
+# tc30_stale_respects_max_duration — a declared ``max_duration`` SHIELDS a
+# genuine long job from the registry-wide stale ceiling (#1229, C2 follow-up).
+#
+# The stale sweep (``MCP_MESH_JOB_STALE_TIMEOUT``, opt-in default total-runtime
+# ceiling for jobs with no ``total_deadline``) now HONORS a job's own
+# ``max_duration``: the effective ceiling is
+# ``max(MCP_MESH_JOB_STALE_TIMEOUT, max_duration)``. So a job whose
+# ``max_duration`` exceeds the stale timeout is NOT reaped until its
+# ``max_duration`` elapses. This protects declared long-running jobs from a
+# registry-wide stale timeout.
+#
+# This tc is the mirror image of tc28:
+#   - tc28: NO max_duration → effective ceiling = max(3s, 0) = 3s → REAPED.
+#   - tc30: max_duration=60 → effective ceiling = max(3s, 60) = 60s → NOT
+#           reaped; the ~20s job runs to completion.
+#
+# Setup:
+#   - Same isolated registry with the stale phase enabled
+#     (``start_registry_with_stale_reaping``, MCP_MESH_JOB_STALE_TIMEOUT=3s,
+#     sweep tick 2s). A suite-wide stale timeout would reap other tcs'
+#     working jobs, so this tc — like tc28 — spins up its own registry.
+#   - commission_submit_only submits generate_report with NO total_deadline,
+#     max_retries=0, and max_duration=60. 10 sections * ~2s ≈ 20s of work —
+#     PAST the 3s stale timeout but WELL WITHIN max_duration=60.
+#   - the provider is kept HEALTHY throughout (never killed).
+#
+# Because max(3s, 60) = 60s, the job survives every stale sweep tick during
+# its ~20s run and completes normally.
+#
+# Asserts:
+#   - status == completed  (the producer calls job.complete(...) on success)
+#   - error is null / does NOT contain "stale:"  (the stale phase left it alone)
+#   - NO synthetic {type: "stale"} JobEvent was posted
+
+name: "MeshJob: max_duration shields a long job from the stale-ceiling sweep"
+description: "Job with no total_deadline, max_duration=60 runs ~20s past MCP_MESH_JOB_STALE_TIMEOUT=3s but within max_duration (effective ceiling max(3s,60)=60s); it is NOT stale-reaped and completes"
+tags:
+  - meshjob
+  - python
+  - issue-1229
+  - stale
+  - deadline
+  - slow
+timeout: 120
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/long-task-provider /workspace/
+      cp -rL /uc-artifacts/long-task-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/long-task-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/long-task-consumer
+
+  # Isolated registry with the stale-reaping phase ENABLED
+  # (MCP_MESH_JOB_STALE_TIMEOUT=3s, sweep tick 2s). Same routine as tc28 —
+  # the difference is purely the submitted max_duration, which raises the
+  # effective ceiling above the stale timeout.
+  - routine: start_registry_with_stale_reaping
+
+  - name: "Start provider (port 9100)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-provider/main.py --env MCP_MESH_HTTP_PORT=9100 -d
+
+  - name: "Start consumer (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start long-task-consumer/main.py --env MCP_MESH_HTTP_PORT=9101 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only: wait for both agents to REGISTER. Dependency resolution is
+  # covered by the settle window — no fixed dep-resolution sleep needed.
+  - name: "Wait for both agents to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for both agents to register..."
+      for i in $(seq 1 60); do
+        AGENTS=$(meshctl list 2>/dev/null || true)
+        if echo "$AGENTS" | grep -q "long-task-provider" && echo "$AGENTS" | grep -q "long-task-consumer"; then
+          echo "Both agents registered after ~${i}s"
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: agents did not register within 60s"
+      meshctl list 2>/dev/null || true
+      exit 1
+    capture: wait_registration
+    timeout: 90
+
+  # NO total_deadline + max_duration=60. Effective stale ceiling =
+  # max(3s, 60) = 60s. 10 sections * ~2s ≈ 20s of work — PAST the 3s stale
+  # timeout but WELL WITHIN the 60s max_duration, so the stale sweep must
+  # leave the job alone and let it run to completion.
+  - name: "Submit generate_report with NO total_deadline, max_duration=60"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call commission_submit_only \
+        '{"user_id":"alice","sections":["a","b","c","d","e","f","g","h","i","j"],"max_retries":0,"max_duration":60}'
+    capture: submit_resp
+    timeout: 30
+
+  - name: "Capture job_id"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1 | xargs -I{} echo "JOB_ID={}"
+    capture: job_id_extract
+
+  # Poll for the job to reach a terminal COMPLETED state. The run is ~20s, so
+  # poll up to ~45s (run + margin). If the (buggy) stale sweep reaped it, the
+  # poll would instead see status=failed early — the assertions below catch
+  # that. We stop polling as soon as the row leaves the non-terminal states.
+  - name: "Poll until the job reaches a terminal status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      for i in $(seq 1 45); do
+        ST=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.status')
+        echo "poll ${i}: status=${ST}"
+        case "$ST" in
+          completed|failed|cancelled)
+            echo "TERMINAL_STATUS=${ST}"
+            exit 0
+            ;;
+        esac
+        sleep 1
+      done
+      echo "ERROR: job never reached a terminal status within 45s"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,error,owner_instance_id,lease_expires_at}'
+      exit 1
+    capture: terminal_poll
+    timeout: 60
+
+  - name: "Final status"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '{status,error,total_deadline,owner_instance_id,lease_expires_at}'
+    capture: final_status
+
+  - name: "Read job events to confirm NO synthetic stale event was posted"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.job_id_extract}' | grep '^JOB_ID=' | cut -d= -f2)
+      echo "JOB_ID=${JOB_ID}"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}/events" | jq '.events | map({seq, type, payload})'
+    capture: job_events
+
+assertions:
+  - expr: "${captured.terminal_poll} contains 'TERMINAL_STATUS=completed'"
+    message: "max_duration=60 must shield the job from the 3s stale ceiling — it should run to completion, not be reaped early"
+  - expr: "${captured.final_status} contains '\"status\": \"completed\"'"
+    message: "the job must end up completed (the producer calls job.complete on success)"
+  - expr: "${captured.final_status} not contains 'stale:'"
+    message: "the stale phase must NOT touch a job whose max_duration exceeds the stale timeout"
+  - expr: "${captured.job_events} not contains '\"type\": \"stale\"'"
+    message: "NO synthetic 'stale' JobEvent must be posted — the stale sweep left this job alone"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

`MCP_MESH_JOB_STALE_TIMEOUT` is a **registry-wide** opt-in default total-runtime ceiling for jobs that set no `total_deadline`. It was a hard wall-clock cutoff from `submitted_at` that **ignored `max_duration`** — so a genuine long-running job sized via `max_duration` alone (the intuitive knob) was reaped at the operator's ceiling even though it had declared its intended runtime, and even while actively making progress. The only escape hatch was `total_deadline`, which isn't discoverable from the job-author side.

`ExpireStaleJobs` now uses an effective per-job ceiling of **`max(staleTimeout, max_duration)`**: a job is never reaped as stale before its own declared per-attempt duration elapses. The query still uses the `staleTimeout` cutoff (widest net); the loop skips candidates not yet past their own ceiling. `total_deadline` remains the full opt-out, and a wedged job is still caught by lease reclaim (`max_duration` also sizes the lease window).

## Docs (both surfaces + all runtime variants)
- Man pages `jobs.md` / `jobs_typescript.md` / `jobs_java.md`: the `max(stale_timeout, max_duration)` rule, an updated `max_duration` description (per-attempt soft timeout **+** lease window **+** floors the stale ceiling), and new long-running-job guidance.
- `environment.md`: updated `MCP_MESH_JOB_STALE_TIMEOUT`; **added `MCP_MESH_SWEEP_INTERVAL`** (was undocumented everywhere).
- Public `docs/concepts/jobs.md` (which never mentioned the stale ceiling) + `docs/environment-variables.md`: added both vars and the interaction.

## Tests
- **4 registry unit tests**: `max_duration` > stale not-yet-elapsed → not reaped; elapsed → reaped; `max_duration` ≤ stale → reaped (unchanged); `total_deadline` → exempt.
- **Integration**: `tc28_stale_job_reaped` updated to submit *without* `max_duration` (so the 3s ceiling applies and it still stale-reaps); **new `tc30_stale_respects_max_duration`** proves a `max_duration=60` job runs past the 3s stale timeout and **completes, not reaped** — the end-to-end guarantee. Fixture `commission_submit_only` default `max_duration: int = 60` → `Optional = None` so omitting it truly omits it (all 8 existing callers pass it explicitly — no behavior change).

## Validation
- `go test ./src/core/registry/...` green.
- src-tests image build 12/12.
- **uc21 24/24** (incl. tc28 reaped + tc30 protected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in registry-wide stale timeout for jobs, with clearer behavior for long-running jobs and per-attempt duration limits.
  * Jobs without their own total deadline now honor a combined runtime ceiling; jobs with an explicit total deadline remain exempt.

* **Documentation**
  * Updated job and environment-variable docs with the new sweep interval setting, stale-timeout behavior, and guidance for configuring long-running jobs.

* **Bug Fixes**
  * Stale reaping now respects a job’s per-attempt duration before marking it failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->