### PR TITLE
feat(ui): time-range filter (1h/1d/all) on the Traffic page

### DIFF
--- a/cmd/mcp-mesh-ui/dist/index.html
+++ b/cmd/mcp-mesh-ui/dist/index.html
@@ -10,8 +10,8 @@
       window.__MESH_BASE_PATH__ = window.__MESH_BASE_PATH__ || "";
       window.__MESH_REGISTRY_URL__ = window.__MESH_REGISTRY_URL__ || "";
     </script>
-    <script type="module" crossorigin src="./assets/index-CtqnXpYX.js"></script>
-    <link rel="stylesheet" crossorigin href="./assets/index-9ua4LBk0.css">
+    <script type="module" crossorigin src="./assets/index-Cr7d7Rvk.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-CmRhQHvZ.css">
   </head>
   <body class="antialiased">
     <div id="root"></div>

--- a/cmd/mcp-mesh-ui/dist/index.html
+++ b/cmd/mcp-mesh-ui/dist/index.html
@@ -10,8 +10,8 @@
       window.__MESH_BASE_PATH__ = window.__MESH_BASE_PATH__ || "";
       window.__MESH_REGISTRY_URL__ = window.__MESH_REGISTRY_URL__ || "";
     </script>
-    <script type="module" crossorigin src="./assets/index-DoMdrFm5.js"></script>
-    <link rel="stylesheet" crossorigin href="./assets/index-XTUpip9I.css">
+    <script type="module" crossorigin src="./assets/index-CtqnXpYX.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-9ua4LBk0.css">
   </head>
   <body class="antialiased">
     <div id="root"></div>

--- a/src/core/registry/tracing/accumulator.go
+++ b/src/core/registry/tracing/accumulator.go
@@ -292,12 +292,12 @@ func (at *activeTrace) buildSnapshot(completed bool) *TraceSnapshot {
 		}
 
 		ss := SnapshotSpan{
-			SpanID:    s.SpanID,
-			AgentName: s.AgentName,
-			Operation: s.Operation,
+			SpanID:     s.SpanID,
+			AgentName:  s.AgentName,
+			Operation:  s.Operation,
 			DurationMs: s.DurationMS,
-			Success:   s.Success,
-			Runtime:   s.Runtime,
+			Success:    s.Success,
+			Runtime:    s.Runtime,
 		}
 
 		if s.ParentSpan != nil {
@@ -585,6 +585,56 @@ func (ta *TraceAccumulator) finalizeReadyTraces() {
 	// Publish outside of mu lock
 	for _, evt := range completedEvents {
 		ta.publishLive(evt)
+	}
+}
+
+// FinalizeAllActive force-finalizes every currently-active trace immediately,
+// bypassing the grace period. It runs the same edge-detection + finalizeTrace
+// path as finalizeReadyTraces, so edge stats and total finalized/error counters
+// end up identical to the live consumer's — just without the async wait.
+//
+// This exists for windowed replay over a throwaway accumulator: after feeding a
+// bounded batch of stream events, the caller flushes all in-flight traces so the
+// aggregates (edges, totals) are complete. It is NOT used on the live
+// accumulator, which relies on the grace period to absorb late cross-process
+// spans.
+func (ta *TraceAccumulator) FinalizeAllActive() {
+	ta.mu.Lock()
+	defer ta.mu.Unlock()
+
+	for id, at := range ta.activeTraces {
+		// Detect cross-agent edges from all spans (mirrors finalizeReadyTraces).
+		for _, s := range at.Spans {
+			if s.ParentSpan == nil || s.DurationMS == nil {
+				continue
+			}
+			parentAgent, ok := at.SpanAgent[*s.ParentSpan]
+			if ok && parentAgent != s.AgentName {
+				ta.recordEdge(parentAgent, s.AgentName, *s.DurationMS, s.Success)
+			}
+		}
+
+		// Finalize into ring buffer + totals, preferring the root span.
+		if at.RootSpan != nil {
+			ta.finalizeTrace(at, at.RootSpan)
+		} else {
+			var rootSpan *TraceEvent
+			for _, s := range at.Spans {
+				if s.ParentSpan == nil {
+					rootSpan = s
+					break
+				}
+			}
+			if rootSpan == nil && len(at.Spans) > 0 {
+				rootSpan = at.Spans[0]
+			}
+			if rootSpan != nil {
+				ta.finalizeTrace(at, rootSpan)
+			} else {
+				delete(ta.activeTraces, id)
+			}
+		}
+		delete(ta.dirtyTraces, id)
 	}
 }
 

--- a/src/core/registry/tracing/consumer.go
+++ b/src/core/registry/tracing/consumer.go
@@ -372,16 +372,25 @@ func (sc *StreamConsumer) TrimStream() (int64, error) {
 // the live consumer uses. Stream entry IDs are millisecond timestamps, so a
 // startID of "<unix-millis>-0" yields a time-bounded read that never scans the
 // whole stream. maxEntries caps the total returned defensively so a wide window
-// cannot OOM; reads are paged in batches of batchCount using the exclusive
-// "(id" cursor. Returns (nil, nil) when the consumer is not connected.
-func (sc *StreamConsumer) RangeEvents(startID string, maxEntries, batchCount int) ([]*TraceEvent, error) {
+// cannot OOM.
+//
+// To keep the most RECENT entries under that cap (busy windows with >maxEntries
+// entries must not drop the newest calls), it reads newest-first via XREVRANGE
+// from "+" walking DOWN toward startID, advancing the cursor to the exclusive
+// predecessor of the last-seen (oldest-in-page) ID. If the cap is hit before the
+// range is exhausted, truncated is true. The collected events (newest→oldest)
+// are reversed in place before returning so callers receive them in chronological
+// (oldest→newest) order, matching the live consumer's feed order.
+//
+// Returns (nil, false, nil) when the consumer is not connected.
+func (sc *StreamConsumer) RangeEvents(startID string, maxEntries, batchCount int) ([]*TraceEvent, bool, error) {
 	sc.mu.RLock()
 	client := sc.client
 	state := sc.connectionState
 	sc.mu.RUnlock()
 
 	if client == nil || state != StateConnected {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	if maxEntries <= 0 {
@@ -392,14 +401,15 @@ func (sc *StreamConsumer) RangeEvents(startID string, maxEntries, batchCount int
 	}
 
 	events := make([]*TraceEvent, 0, batchCount)
-	cursor := startID
+	cursor := "+"
+	truncated := false
 
 	for len(events) < maxEntries {
 		ctx, cancel := context.WithTimeout(sc.ctx, 10*time.Second)
-		msgs, err := client.XRangeN(ctx, sc.streamName, cursor, "+", int64(batchCount)).Result()
+		msgs, err := client.XRevRangeN(ctx, sc.streamName, cursor, startID, int64(batchCount)).Result()
 		cancel()
 		if err != nil {
-			return events, fmt.Errorf("failed to XRANGE stream %s: %w", sc.streamName, err)
+			return events, false, fmt.Errorf("failed to XREVRANGE stream %s: %w", sc.streamName, err)
 		}
 		if len(msgs) == 0 {
 			break
@@ -414,19 +424,29 @@ func (sc *StreamConsumer) RangeEvents(startID string, maxEntries, batchCount int
 			}
 			events = append(events, event)
 			if len(events) >= maxEntries {
+				// Capped before reaching startID: the window has more entries
+				// than we returned, so callers should treat totals as partial.
+				truncated = true
 				break
 			}
 		}
 
-		// Fewer than a full batch means we reached the end of the range.
+		// Fewer than a full batch means we reached the end (startID) of the range.
 		if len(msgs) < batchCount {
 			break
 		}
-		// Advance the cursor past the last-seen ID (exclusive) for the next page.
+		// Advance the cursor past the last-seen (oldest-in-page) ID (exclusive)
+		// for the next, older page.
 		cursor = "(" + msgs[len(msgs)-1].ID
 	}
 
-	return events, nil
+	// XREVRANGE collected newest→oldest; reverse in place so callers get
+	// chronological (oldest→newest) order, matching the live processMessage feed.
+	for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {
+		events[i], events[j] = events[j], events[i]
+	}
+
+	return events, truncated, nil
 }
 
 // handleConnectionError records connection failure and updates state

--- a/src/core/registry/tracing/consumer.go
+++ b/src/core/registry/tracing/consumer.go
@@ -367,6 +367,68 @@ func (sc *StreamConsumer) TrimStream() (int64, error) {
 	return removed, nil
 }
 
+// RangeEvents reads trace events from the stream whose entry IDs fall in
+// [startID, "+"], parsing each into a TraceEvent via the same FromRedisMap path
+// the live consumer uses. Stream entry IDs are millisecond timestamps, so a
+// startID of "<unix-millis>-0" yields a time-bounded read that never scans the
+// whole stream. maxEntries caps the total returned defensively so a wide window
+// cannot OOM; reads are paged in batches of batchCount using the exclusive
+// "(id" cursor. Returns (nil, nil) when the consumer is not connected.
+func (sc *StreamConsumer) RangeEvents(startID string, maxEntries, batchCount int) ([]*TraceEvent, error) {
+	sc.mu.RLock()
+	client := sc.client
+	state := sc.connectionState
+	sc.mu.RUnlock()
+
+	if client == nil || state != StateConnected {
+		return nil, nil
+	}
+
+	if maxEntries <= 0 {
+		maxEntries = 50000
+	}
+	if batchCount <= 0 || batchCount > maxEntries {
+		batchCount = maxEntries
+	}
+
+	events := make([]*TraceEvent, 0, batchCount)
+	cursor := startID
+
+	for len(events) < maxEntries {
+		ctx, cancel := context.WithTimeout(sc.ctx, 10*time.Second)
+		msgs, err := client.XRangeN(ctx, sc.streamName, cursor, "+", int64(batchCount)).Result()
+		cancel()
+		if err != nil {
+			return events, fmt.Errorf("failed to XRANGE stream %s: %w", sc.streamName, err)
+		}
+		if len(msgs) == 0 {
+			break
+		}
+
+		for _, m := range msgs {
+			event := &TraceEvent{}
+			if perr := event.FromRedisMap(m.Values); perr != nil {
+				// Skip malformed entries, mirroring the consumer's per-message
+				// error tolerance.
+				continue
+			}
+			events = append(events, event)
+			if len(events) >= maxEntries {
+				break
+			}
+		}
+
+		// Fewer than a full batch means we reached the end of the range.
+		if len(msgs) < batchCount {
+			break
+		}
+		// Advance the cursor past the last-seen ID (exclusive) for the next page.
+		cursor = "(" + msgs[len(msgs)-1].ID
+	}
+
+	return events, nil
+}
+
 // handleConnectionError records connection failure and updates state
 func (sc *StreamConsumer) handleConnectionError(err error) {
 	sc.mu.Lock()

--- a/src/core/registry/tracing/manager.go
+++ b/src/core/registry/tracing/manager.go
@@ -49,24 +49,24 @@ type TracingManager struct {
 
 // TracingConfig holds configuration for distributed tracing
 type TracingConfig struct {
-	Enabled              bool          `json:"enabled"`
-	RedisURL             string        `json:"redis_url"`
-	StreamName           string        `json:"stream_name"`
-	ConsumerGroup        string        `json:"consumer_group"`
-	ConsumerName         string        `json:"consumer_name"`
-	BatchSize            int64         `json:"batch_size"`
-	BlockTimeout         time.Duration `json:"block_timeout"`
-	TraceTimeout         time.Duration `json:"trace_timeout"`
-	TraceRetention       time.Duration `json:"trace_retention"`
-	ExporterType         string        `json:"exporter_type"`
-	PrettyConsoleOutput  bool          `json:"pretty_console_output"`
-	JSONOutputDirectory  string        `json:"json_output_directory,omitempty"`
-	EnableStats          bool          `json:"enable_stats"`
+	Enabled             bool          `json:"enabled"`
+	RedisURL            string        `json:"redis_url"`
+	StreamName          string        `json:"stream_name"`
+	ConsumerGroup       string        `json:"consumer_group"`
+	ConsumerName        string        `json:"consumer_name"`
+	BatchSize           int64         `json:"batch_size"`
+	BlockTimeout        time.Duration `json:"block_timeout"`
+	TraceTimeout        time.Duration `json:"trace_timeout"`
+	TraceRetention      time.Duration `json:"trace_retention"`
+	ExporterType        string        `json:"exporter_type"`
+	PrettyConsoleOutput bool          `json:"pretty_console_output"`
+	JSONOutputDirectory string        `json:"json_output_directory,omitempty"`
+	EnableStats         bool          `json:"enable_stats"`
 	// Generic telemetry endpoints (OTLP compatible)
-	TelemetryEndpoint    string        `json:"telemetry_endpoint,omitempty"`
-	TelemetryProtocol    string        `json:"telemetry_protocol,omitempty"`
+	TelemetryEndpoint string `json:"telemetry_endpoint,omitempty"`
+	TelemetryProtocol string `json:"telemetry_protocol,omitempty"`
 	// Tempo query endpoint for fetching traces (HTTP API)
-	TempoQueryURL        string        `json:"tempo_query_url,omitempty"`
+	TempoQueryURL string `json:"tempo_query_url,omitempty"`
 }
 
 // NewTracingManager creates a new tracing manager with the given configuration
@@ -88,7 +88,7 @@ func NewTracingManager(config *TracingConfig) (*TracingManager, error) {
 
 	// Determine if we should use stream-through mode (for OTLP/telemetry backends)
 	manager.streamThroughMode = strings.ToLower(config.ExporterType) == "otlp" ||
-								strings.ToLower(config.ExporterType) == "telemetry"
+		strings.ToLower(config.ExporterType) == "telemetry"
 
 	mode := "correlation"
 	if manager.streamThroughMode {
@@ -827,6 +827,23 @@ func (tm *TracingManager) GetEdgeStats(limit int) ([]EdgeStats, error) {
 // disabled or not in stream-through mode).
 func (tm *TracingManager) GetAccumulator() *TraceAccumulator {
 	return tm.accumulator
+}
+
+// RangeEventsSince reads trace events from the stream whose entry IDs are at or
+// after (now - window), parsed into TraceEvents. It leverages the stream's
+// millisecond-timestamped entry IDs for a time-bounded XRANGE (no full scan)
+// and caps the total returned via maxEntries. Returns (nil, nil) when tracing
+// is disabled or the consumer is not connected.
+func (tm *TracingManager) RangeEventsSince(window time.Duration, maxEntries, batchCount int) ([]*TraceEvent, error) {
+	if !tm.enabled || tm.consumer == nil {
+		return nil, nil
+	}
+	startMs := time.Now().Add(-window).UnixMilli()
+	if startMs < 0 {
+		startMs = 0
+	}
+	startID := strconv.FormatInt(startMs, 10) + "-0"
+	return tm.consumer.RangeEvents(startID, maxEntries, batchCount)
 }
 
 // GetTotalFinalized returns the total number of finalized traces from the accumulator.

--- a/src/core/registry/tracing/manager.go
+++ b/src/core/registry/tracing/manager.go
@@ -832,11 +832,13 @@ func (tm *TracingManager) GetAccumulator() *TraceAccumulator {
 // RangeEventsSince reads trace events from the stream whose entry IDs are at or
 // after (now - window), parsed into TraceEvents. It leverages the stream's
 // millisecond-timestamped entry IDs for a time-bounded XRANGE (no full scan)
-// and caps the total returned via maxEntries. Returns (nil, nil) when tracing
-// is disabled or the consumer is not connected.
-func (tm *TracingManager) RangeEventsSince(window time.Duration, maxEntries, batchCount int) ([]*TraceEvent, error) {
+// and caps the total returned via maxEntries. The truncated bool reports whether
+// the maxEntries cap was hit before the window was fully read (newest entries are
+// retained). Returns (nil, false, nil) when tracing is disabled or the consumer
+// is not connected.
+func (tm *TracingManager) RangeEventsSince(window time.Duration, maxEntries, batchCount int) ([]*TraceEvent, bool, error) {
 	if !tm.enabled || tm.consumer == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 	startMs := time.Now().Add(-window).UnixMilli()
 	if startMs < 0 {

--- a/src/core/registry/tracing/rangeevents_test.go
+++ b/src/core/registry/tracing/rangeevents_test.go
@@ -1,0 +1,91 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// seedSpan adds a stream entry with a distinguishable span_id so RangeEvents'
+// ordering and truncation behavior can be asserted by span_id sequence.
+func seedSpan(t *testing.T, client *redis.Client, stream string, ts time.Time, span string) {
+	t.Helper()
+	id := fmt.Sprintf("%d-0", ts.UnixMilli())
+	if err := client.XAdd(context.Background(), &redis.XAddArgs{
+		Stream: stream,
+		ID:     id,
+		Values: map[string]interface{}{"trace_id": "t", "span_id": span},
+	}).Err(); err != nil {
+		t.Fatalf("failed to seed span %s: %v", span, err)
+	}
+}
+
+// TestRangeEventsChronologicalOrder verifies RangeEvents returns events oldest→
+// newest even though it reads newest-first via XREVRANGE.
+func TestRangeEventsChronologicalOrder(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	const stream = "mesh:trace"
+	now := time.Now()
+	seedSpan(t, client, stream, now.Add(-3*time.Minute), "s1")
+	seedSpan(t, client, stream, now.Add(-2*time.Minute), "s2")
+	seedSpan(t, client, stream, now.Add(-1*time.Minute), "s3")
+
+	sc := newTestConsumer(client, stream, time.Hour)
+
+	events, truncated, err := sc.RangeEvents("0-0", 50000, 1000)
+	if err != nil {
+		t.Fatalf("RangeEvents failed: %v", err)
+	}
+	if truncated {
+		t.Errorf("expected truncated=false when under cap")
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+	want := []string{"s1", "s2", "s3"}
+	for i, e := range events {
+		if e.SpanID != want[i] {
+			t.Errorf("event[%d]: expected span %s, got %s (order not chronological)", i, want[i], e.SpanID)
+		}
+	}
+}
+
+// TestRangeEventsTruncationKeepsNewest verifies that when the maxEntries cap is
+// hit, the flag is set AND the retained slice is the newest entries (still
+// returned in chronological order).
+func TestRangeEventsTruncationKeepsNewest(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	const stream = "mesh:trace"
+	base := time.Now().Add(-time.Hour)
+	// 5 entries s0..s4, oldest first.
+	for i := 0; i < 5; i++ {
+		seedSpan(t, client, stream, base.Add(time.Duration(i)*time.Second), fmt.Sprintf("s%d", i))
+	}
+
+	sc := newTestConsumer(client, stream, time.Hour)
+
+	// Cap at 2: the two NEWEST (s3, s4) must be retained, in chronological order.
+	events, truncated, err := sc.RangeEvents("0-0", 2, 1)
+	if err != nil {
+		t.Fatalf("RangeEvents failed: %v", err)
+	}
+	if !truncated {
+		t.Errorf("expected truncated=true when cap hit before range exhausted")
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events at cap, got %d", len(events))
+	}
+	if events[0].SpanID != "s3" || events[1].SpanID != "s4" {
+		t.Errorf("expected newest [s3 s4] chronological, got [%s %s]", events[0].SpanID, events[1].SpanID)
+	}
+}

--- a/src/core/ui/server.go
+++ b/src/core/ui/server.go
@@ -95,6 +95,7 @@ func NewServer(config *UIConfig, entService *registry.EntService, tracingManager
 		api.GET("/trace/edge-stats", s.handleEdgeStats)
 		api.GET("/trace/agent-stats", s.handleAgentStats)
 		api.GET("/trace/model-stats", s.handleModelStats)
+		api.GET("/trace/traffic", s.handleTraffic)
 		api.GET("/trace/list", s.handleTraceList)
 		api.GET("/trace/search", s.handleTraceSearch)
 		api.GET("/trace/:trace_id", s.handleTraceGet)

--- a/src/core/ui/server.go
+++ b/src/core/ui/server.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"mcp-mesh/src/core/registry"
@@ -30,6 +31,9 @@ type Server struct {
 	tracePoller         *TracePoller
 	configuredIndexHTML []byte
 	version             string
+
+	trafficCacheMu sync.Mutex
+	trafficCache   map[string]trafficCacheEntry
 }
 
 // NewServer creates a new UI server that serves the embedded SPA and proxies
@@ -65,6 +69,7 @@ func NewServer(config *UIConfig, entService *registry.EntService, tracingManager
 		eventPoller:      eventPoller,
 		tracingManager:   tracingManager,
 		metricsProcessor: metricsProcessor,
+		trafficCache:     make(map[string]trafficCacheEntry),
 	}
 
 	// If tracing is enabled, create a trace poller for dashboard events

--- a/src/core/ui/traffic_handler.go
+++ b/src/core/ui/traffic_handler.go
@@ -1,0 +1,183 @@
+package ui
+
+import (
+	"log"
+	"strconv"
+	"time"
+
+	"mcp-mesh/src/core/registry/tracing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Windowed-replay bounds. maxWindowEntries caps how many stream entries a single
+// windowed request will read+replay so a wide (1d) window can never OOM the UI
+// server; windowReadBatch is the XRANGE page size. At ~2 spans per call these
+// bounds cover a healthy amount of traffic while staying memory-safe.
+const (
+	maxWindowEntries = 50000
+	windowReadBatch  = 1000
+)
+
+// TrafficResponse is the /trace/traffic payload. edge_stats/agent_stats/model_stats
+// carry the exact element shapes produced by TraceAccumulator.GetEdgeStats,
+// MetricsProcessor.GetAgentMetrics and MetricsProcessor.GetModelMetrics, so the
+// frontend consumes the same field casing it already uses for the live endpoints.
+type TrafficResponse struct {
+	Enabled     bool                `json:"enabled"`
+	Window      string              `json:"window"`
+	TotalCalls  int                 `json:"total_calls"`
+	TotalErrors int                 `json:"total_errors"`
+	EdgeStats   []tracing.EdgeStats `json:"edge_stats"`
+	AgentStats  []AgentMetricsData  `json:"agent_stats"`
+	ModelStats  []ModelMetricsData  `json:"model_stats"`
+}
+
+// parseWindow maps a window query value to a duration. The bool result reports
+// whether the window is "all" (live aggregates) vs a bounded re-aggregation.
+// Unknown values are rejected (ok=false).
+func parseWindow(v string) (dur time.Duration, isAll bool, ok bool) {
+	switch v {
+	case "", "all":
+		return 0, true, true
+	case "1h":
+		return time.Hour, false, true
+	case "1d":
+		return 24 * time.Hour, false, true
+	default:
+		return 0, false, false
+	}
+}
+
+// replayWindow re-aggregates a slice of trace events through FRESH throwaway
+// accumulator + metrics-processor instances, feeding each event through the SAME
+// entry points the live consumer uses (accumulator.ProcessTraceEvent +
+// MetricsProcessor.ProcessTraceEvent). After feeding, it force-finalizes all
+// in-flight traces so edge stats and totals are complete. This reuses ALL the
+// existing metrics math; the only windowing logic is the event slice the caller
+// supplies. Factored out (no Redis) so it is unit-testable directly.
+func replayWindow(events []*tracing.TraceEvent, limit int) (edges []tracing.EdgeStats, agents []AgentMetricsData, models []ModelMetricsData, totalCalls, totalErrors int) {
+	acc := tracing.NewTraceAccumulator(0, log.Default())
+	mp := NewMetricsProcessor()
+
+	// Feed each event through the exact live per-event path (minus SSE publish
+	// side effects, which are inert here since there are no subscribers).
+	for _, e := range events {
+		_ = acc.ProcessTraceEvent(e)
+		_ = mp.ProcessTraceEvent(e)
+	}
+
+	// Flush all in-flight traces synchronously so edges + totals are complete.
+	acc.FinalizeAllActive()
+
+	edges = acc.GetEdgeStats()
+	if limit > 0 && limit < len(edges) {
+		edges = edges[:limit]
+	}
+	agents = mp.GetAgentMetrics()
+	models = mp.GetModelMetrics()
+	totalCalls = acc.GetTotalFinalized()
+	totalErrors = acc.GetTotalErrors()
+	return edges, agents, models, totalCalls, totalErrors
+}
+
+// handleTraffic returns windowed traffic aggregates for the Traffic-page time
+// filter. window=all (default) serves the live all-time aggregates unchanged;
+// window=1h/1d re-aggregate over a bounded XRANGE of the Redis trace stream.
+func (s *Server) handleTraffic(c *gin.Context) {
+	limit := 20
+	if l := c.Query("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	windowParam := c.Query("window")
+	window, isAll, ok := parseWindow(windowParam)
+	if !ok {
+		c.JSON(400, gin.H{
+			"error": "invalid window; expected one of: 1h, 1d, all",
+		})
+		return
+	}
+	normalizedWindow := windowParam
+	if normalizedWindow == "" {
+		normalizedWindow = "all"
+	}
+
+	if s.tracingManager == nil {
+		c.JSON(200, TrafficResponse{
+			Enabled:    false,
+			Window:     normalizedWindow,
+			EdgeStats:  []tracing.EdgeStats{},
+			AgentStats: []AgentMetricsData{},
+			ModelStats: []ModelMetricsData{},
+		})
+		return
+	}
+
+	// window=all: serve the LIVE aggregates exactly as the existing handlers do.
+	if isAll {
+		edges, err := s.tracingManager.GetEdgeStats(limit)
+		if err != nil {
+			c.JSON(500, gin.H{"error": err.Error()})
+			return
+		}
+		var agents []AgentMetricsData
+		var models []ModelMetricsData
+		if s.metricsProcessor != nil {
+			agents = s.metricsProcessor.GetAgentMetrics()
+			models = s.metricsProcessor.GetModelMetrics()
+		}
+		if edges == nil {
+			edges = []tracing.EdgeStats{}
+		}
+		if agents == nil {
+			agents = []AgentMetricsData{}
+		}
+		if models == nil {
+			models = []ModelMetricsData{}
+		}
+		c.JSON(200, TrafficResponse{
+			Enabled:     true,
+			Window:      normalizedWindow,
+			TotalCalls:  s.tracingManager.GetTotalFinalized(),
+			TotalErrors: s.tracingManager.GetTotalErrors(),
+			EdgeStats:   edges,
+			AgentStats:  agents,
+			ModelStats:  models,
+		})
+		return
+	}
+
+	// window=1h/1d: bounded XRANGE + replay through fresh throwaway instances.
+	events, err := s.tracingManager.RangeEventsSince(window, maxWindowEntries, windowReadBatch)
+	if err != nil {
+		c.JSON(500, gin.H{"error": err.Error()})
+		return
+	}
+
+	edges, agents, models, totalCalls, totalErrors := replayWindow(events, limit)
+	if edges == nil {
+		edges = []tracing.EdgeStats{}
+	}
+	if agents == nil {
+		agents = []AgentMetricsData{}
+	}
+	if models == nil {
+		models = []ModelMetricsData{}
+	}
+
+	c.JSON(200, TrafficResponse{
+		Enabled:     true,
+		Window:      normalizedWindow,
+		TotalCalls:  totalCalls,
+		TotalErrors: totalErrors,
+		EdgeStats:   edges,
+		AgentStats:  agents,
+		ModelStats:  models,
+	})
+}

--- a/src/core/ui/traffic_handler.go
+++ b/src/core/ui/traffic_handler.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"log"
 	"strconv"
 	"time"
@@ -19,6 +20,20 @@ const (
 	windowReadBatch  = 1000
 )
 
+// trafficCacheTTL bounds how long a windowed (1h/1d) result is reused. It is
+// deliberately SHORTER than the dashboard's 5s poll interval so consecutive
+// polls from a single viewer see fresh data while concurrent viewers (and
+// duplicate in-flight polls) share one XRANGE+replay pass.
+const trafficCacheTTL = 2 * time.Second
+
+// trafficCacheEntry is a cached windowed /trace/traffic result keyed by
+// window+limit. Only the windowed (1h/1d) path is cached; window=all reads are
+// cheap live aggregates and error responses are never cached.
+type trafficCacheEntry struct {
+	response  TrafficResponse
+	expiresAt time.Time
+}
+
 // TrafficResponse is the /trace/traffic payload. edge_stats/agent_stats/model_stats
 // carry the exact element shapes produced by TraceAccumulator.GetEdgeStats,
 // MetricsProcessor.GetAgentMetrics and MetricsProcessor.GetModelMetrics, so the
@@ -31,6 +46,10 @@ type TrafficResponse struct {
 	EdgeStats   []tracing.EdgeStats `json:"edge_stats"`
 	AgentStats  []AgentMetricsData  `json:"agent_stats"`
 	ModelStats  []ModelMetricsData  `json:"model_stats"`
+	// Truncated is set on windowed responses when the maxWindowEntries cap was
+	// hit before the whole window was read; the newest entries are retained, so
+	// totals reflect the most recent slice of a busier window.
+	Truncated bool `json:"truncated,omitempty"`
 }
 
 // parseWindow maps a window query value to a duration. The bool result reports
@@ -154,7 +173,16 @@ func (s *Server) handleTraffic(c *gin.Context) {
 	}
 
 	// window=1h/1d: bounded XRANGE + replay through fresh throwaway instances.
-	events, err := s.tracingManager.RangeEventsSince(window, maxWindowEntries, windowReadBatch)
+	// Short-TTL cache: a windowed result is relatively expensive to rebuild, so
+	// serve a recent one (younger than trafficCacheTTL) to concurrent viewers and
+	// duplicate polls instead of re-running RangeEventsSince + replayWindow.
+	cacheKey := fmt.Sprintf("%s:%d", normalizedWindow, limit)
+	if cached, ok := s.getTrafficCache(cacheKey); ok {
+		c.JSON(200, cached)
+		return
+	}
+
+	events, truncated, err := s.tracingManager.RangeEventsSince(window, maxWindowEntries, windowReadBatch)
 	if err != nil {
 		c.JSON(500, gin.H{"error": err.Error()})
 		return
@@ -171,7 +199,7 @@ func (s *Server) handleTraffic(c *gin.Context) {
 		models = []ModelMetricsData{}
 	}
 
-	c.JSON(200, TrafficResponse{
+	resp := TrafficResponse{
 		Enabled:     true,
 		Window:      normalizedWindow,
 		TotalCalls:  totalCalls,
@@ -179,5 +207,30 @@ func (s *Server) handleTraffic(c *gin.Context) {
 		EdgeStats:   edges,
 		AgentStats:  agents,
 		ModelStats:  models,
-	})
+		Truncated:   truncated,
+	}
+	s.setTrafficCache(cacheKey, resp)
+	c.JSON(200, resp)
+}
+
+// getTrafficCache returns a cached windowed response when present and unexpired.
+func (s *Server) getTrafficCache(key string) (TrafficResponse, bool) {
+	s.trafficCacheMu.Lock()
+	defer s.trafficCacheMu.Unlock()
+	entry, ok := s.trafficCache[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return TrafficResponse{}, false
+	}
+	return entry.response, true
+}
+
+// setTrafficCache stores a windowed response under a trafficCacheTTL window. The
+// Redis read + replay happens outside the lock; only the store is guarded here.
+func (s *Server) setTrafficCache(key string, resp TrafficResponse) {
+	s.trafficCacheMu.Lock()
+	defer s.trafficCacheMu.Unlock()
+	s.trafficCache[key] = trafficCacheEntry{
+		response:  resp,
+		expiresAt: time.Now().Add(trafficCacheTTL),
+	}
 }

--- a/src/core/ui/traffic_handler_test.go
+++ b/src/core/ui/traffic_handler_test.go
@@ -1,0 +1,139 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"mcp-mesh/src/core/registry/tracing"
+)
+
+// ptr helpers for the optional TraceEvent fields.
+func i64(v int64) *int64 { return &v }
+func boolp(v bool) *bool { return &v }
+
+// makeCall builds the two spans of one cross-agent call (source -> target):
+// a root span on `source` (no parent, has duration) and a child span on
+// `target` whose parent is the root span. Both carry `ts` as their timestamp.
+// success controls the child span outcome so we can exercise the error counters.
+func makeCall(traceID, rootSpanID, source, target string, ts time.Time, success bool) []*tracing.TraceEvent {
+	unix := float64(ts.UnixNano()) / 1e9
+	childID := rootSpanID + "-child"
+	return []*tracing.TraceEvent{
+		{
+			TraceID:    traceID,
+			SpanID:     rootSpanID,
+			AgentName:  source,
+			Operation:  "root",
+			EventType:  "span_end",
+			Timestamp:  unix,
+			DurationMS: i64(20),
+			Success:    boolp(true),
+		},
+		{
+			TraceID:    traceID,
+			SpanID:     childID,
+			ParentSpan: &rootSpanID,
+			AgentName:  target,
+			Operation:  "call",
+			EventType:  "span_end",
+			Timestamp:  unix,
+			DurationMS: i64(10),
+			Success:    boolp(success),
+		},
+	}
+}
+
+// TestReplayWindowExcludesOlderEvents feeds a set of trace events spanning >1h
+// and asserts the 1h replay excludes the older call while the all-time replay
+// includes both — proving the windowing narrows edge/agent counts and totals.
+func TestReplayWindowExcludesOlderEvents(t *testing.T) {
+	now := time.Now()
+
+	// Old call (2h ago): agentA -> agentB, failed.
+	old := makeCall("trace-old", "span-old", "agentA", "agentB", now.Add(-2*time.Hour), false)
+	// Recent call (10m ago): agentA -> agentC, succeeded.
+	recent := makeCall("trace-recent", "span-recent", "agentA", "agentC", now.Add(-10*time.Minute), true)
+
+	all := append(append([]*tracing.TraceEvent{}, old...), recent...)
+
+	// Simulate the XRANGE bound: the 1h window would only return entries newer
+	// than (now - 1h), i.e. the recent call. Mirror that by slicing here — the
+	// real handler gets this slice from RangeEventsSince.
+	windowCutoff := now.Add(-time.Hour)
+	var windowed []*tracing.TraceEvent
+	for _, e := range all {
+		if time.Unix(0, int64(e.Timestamp*1e9)).After(windowCutoff) {
+			windowed = append(windowed, e)
+		}
+	}
+
+	// --- all-time replay: both calls present ---
+	edgesAll, agentsAll, _, callsAll, errsAll := replayWindow(all, 20)
+	if callsAll != 2 {
+		t.Fatalf("all-time total_calls = %d, want 2", callsAll)
+	}
+	if errsAll != 1 {
+		t.Fatalf("all-time total_errors = %d, want 1", errsAll)
+	}
+	if len(edgesAll) != 2 {
+		t.Fatalf("all-time edges = %d, want 2 (A->B, A->C)", len(edgesAll))
+	}
+	// agentA, agentB, agentC all appear.
+	if len(agentsAll) != 3 {
+		t.Fatalf("all-time agents = %d, want 3", len(agentsAll))
+	}
+
+	// --- 1h replay: only the recent (successful) call ---
+	edges1h, agents1h, _, calls1h, errs1h := replayWindow(windowed, 20)
+	if calls1h != 1 {
+		t.Fatalf("1h total_calls = %d, want 1", calls1h)
+	}
+	if errs1h != 0 {
+		t.Fatalf("1h total_errors = %d, want 0 (old failed call excluded)", errs1h)
+	}
+	if len(edges1h) != 1 {
+		t.Fatalf("1h edges = %d, want 1 (A->C only)", len(edges1h))
+	}
+	if edges1h[0].Source != "agentA" || edges1h[0].Target != "agentC" {
+		t.Fatalf("1h edge = %s->%s, want agentA->agentC", edges1h[0].Source, edges1h[0].Target)
+	}
+	// agentB (only in the old call) must be excluded from the window.
+	for _, a := range agents1h {
+		if a.AgentName == "agentB" {
+			t.Fatalf("1h agents unexpectedly include agentB (from excluded old call)")
+		}
+	}
+	if len(agents1h) != 2 {
+		t.Fatalf("1h agents = %d, want 2 (agentA, agentC)", len(agents1h))
+	}
+
+	// The window must strictly narrow the aggregates.
+	if calls1h >= callsAll || len(edges1h) >= len(edgesAll) || len(agents1h) >= len(agentsAll) {
+		t.Fatalf("1h aggregate did not narrow vs all-time: calls %d/%d edges %d/%d agents %d/%d",
+			calls1h, callsAll, len(edges1h), len(edgesAll), len(agents1h), len(agentsAll))
+	}
+}
+
+// TestParseWindow covers the accepted values and rejection of unknown windows.
+func TestParseWindow(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantDur time.Duration
+		wantAll bool
+		wantOK  bool
+	}{
+		{"", 0, true, true},
+		{"all", 0, true, true},
+		{"1h", time.Hour, false, true},
+		{"1d", 24 * time.Hour, false, true},
+		{"5m", 0, false, false},
+		{"garbage", 0, false, false},
+	}
+	for _, tc := range cases {
+		dur, isAll, ok := parseWindow(tc.in)
+		if dur != tc.wantDur || isAll != tc.wantAll || ok != tc.wantOK {
+			t.Errorf("parseWindow(%q) = (%v,%v,%v), want (%v,%v,%v)",
+				tc.in, dur, isAll, ok, tc.wantDur, tc.wantAll, tc.wantOK)
+		}
+	}
+}

--- a/src/ui/app/traffic/page.tsx
+++ b/src/ui/app/traffic/page.tsx
@@ -10,8 +10,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { useMesh } from "@/lib/mesh-context";
-import { formatBytes, formatTokenCount } from "@/lib/api";
+import { Segmented } from "@/components/ui/segmented";
+import { formatBytes, formatTokenCount, getTraffic } from "@/lib/api";
+import { AgentStat, EdgeStat, ModelStat, TrafficWindow } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import {
   Activity,
@@ -25,6 +26,13 @@ import {
 } from "lucide-react";
 
 const MAX_HISTORY = 30;
+const POLL_INTERVAL_MS = 5000;
+
+const WINDOW_OPTIONS: { value: TrafficWindow; label: string }[] = [
+  { value: "1h", label: "1h" },
+  { value: "1d", label: "1d" },
+  { value: "all", label: "All" },
+];
 
 function getErrorRateColor(rate: number): string {
   if (rate === 0) return "text-green-400";
@@ -87,28 +95,79 @@ function Sparkline({
 }
 
 export default function TrafficPage() {
-  const { edgeStats, agentStats, modelStats, loading, error, refresh, totalCalls: totalCallsFromContext, totalErrors: totalErrorsFromContext } = useMesh();
+  const [window, setWindow] = useState<TrafficWindow>("all");
+
+  const [edgeStats, setEdgeStats] = useState<EdgeStat[]>([]);
+  const [agentStats, setAgentStats] = useState<AgentStat[]>([]);
+  const [modelStats, setModelStats] = useState<ModelStat[]>([]);
+  const [totalCalls, setTotalCalls] = useState(0);
+  const [totalErrors, setTotalErrors] = useState(0);
+  const [enabled, setEnabled] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [refetching, setRefetching] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
 
   // Sparkline history ring buffer
   const historyRef = useRef<Map<string, number[]>>(new Map());
   const [, setTick] = useState(0);
 
+  // Windowed pull: fetch on mount, on window change, and on a poll interval.
+  // Each fetch captures the window it was issued for and drops its result if
+  // the selected window changed in the meantime (stale-guard).
   useEffect(() => {
-    if (edgeStats.length === 0) return;
-    for (const edge of edgeStats) {
-      const key = `${edge.source}->${edge.target}`;
-      const history = historyRef.current.get(key) || [];
-      history.push(edge.avg_latency_ms);
-      if (history.length > MAX_HISTORY) history.shift();
-      historyRef.current.set(key, history);
-    }
-    setTick((t) => t + 1);
-  }, [edgeStats]);
+    let cancelled = false;
+    const requestedWindow = window;
+
+    // A fresh window must not inherit the previous window's trend or numbers.
+    historyRef.current = new Map();
+    setLoading(true);
+
+    const load = async (isInitial: boolean) => {
+      if (!isInitial) setRefetching(true);
+      try {
+        const data = await getTraffic(requestedWindow);
+        if (cancelled || requestedWindow !== window) return;
+
+        setEnabled(data.enabled);
+        setTotalCalls(data.total_calls);
+        setTotalErrors(data.total_errors);
+        setModelStats(data.model_stats || []);
+        setAgentStats(data.agent_stats || []);
+
+        const edges = data.edge_stats || [];
+        setEdgeStats(edges);
+        for (const edge of edges) {
+          const key = `${edge.source}->${edge.target}`;
+          const history = historyRef.current.get(key) || [];
+          history.push(edge.avg_latency_ms);
+          if (history.length > MAX_HISTORY) history.shift();
+          historyRef.current.set(key, history);
+        }
+        setTick((t) => t + 1);
+        setError(null);
+      } catch (err) {
+        if (cancelled || requestedWindow !== window) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        if (!cancelled && requestedWindow === window) {
+          setLoading(false);
+          setRefetching(false);
+        }
+      }
+    };
+
+    load(true);
+    const interval = setInterval(() => load(false), POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [window, reloadKey]);
 
   // Aggregated stats for overview cards
   const overview = useMemo(() => {
-    const totalCalls = totalCallsFromContext;
-    const totalErrors = totalErrorsFromContext;
     const successRate = totalCalls > 0 ? ((1 - totalErrors / totalCalls) * 100) : 100;
 
     const totalTokens = agentStats.reduce(
@@ -122,7 +181,7 @@ export default function TrafficPage() {
     );
 
     return { totalCalls, successRate, totalTokens, totalData };
-  }, [edgeStats, agentStats, totalCallsFromContext, totalErrorsFromContext]);
+  }, [agentStats, totalCalls, totalErrors]);
 
   // Sorted edges by route name
   const sortedEdges = useMemo(() => {
@@ -143,10 +202,28 @@ export default function TrafficPage() {
     return [...modelStats].sort((a, b) => a.model.localeCompare(b.model));
   }, [modelStats]);
 
+  const headerActions = (
+    <div className="flex items-center gap-3">
+      {refetching && !loading && (
+        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+      )}
+      <Segmented
+        aria-label="Traffic time range"
+        options={WINDOW_OPTIONS}
+        value={window}
+        onChange={setWindow}
+      />
+    </div>
+  );
+
   if (loading) {
     return (
       <div className="flex flex-col h-full">
-        <Header title="Traffic" subtitle="Network traffic and usage metrics" />
+        <Header
+          title="Traffic"
+          subtitle="Network traffic and usage metrics"
+          actions={headerActions}
+        />
         <div className="flex flex-1 items-center justify-center">
           <Loader2 className="h-8 w-8 animate-spin text-primary" />
         </div>
@@ -157,8 +234,15 @@ export default function TrafficPage() {
   if (error) {
     return (
       <div className="flex flex-col h-full">
-        <Header title="Traffic" subtitle="Network traffic and usage metrics" />
-        <ConnectionError error={error} onRetry={refresh} />
+        <Header
+          title="Traffic"
+          subtitle="Network traffic and usage metrics"
+          actions={headerActions}
+        />
+        <ConnectionError
+          error={error}
+          onRetry={() => setReloadKey((k) => k + 1)}
+        />
       </div>
     );
   }
@@ -219,8 +303,21 @@ export default function TrafficPage() {
 
   return (
     <div className="flex flex-col h-full">
-      <Header title="Traffic" subtitle="Network traffic and usage metrics" />
+      <Header
+        title="Traffic"
+        subtitle="Network traffic and usage metrics"
+        actions={headerActions}
+      />
       <div className="flex-1 space-y-6 p-6 overflow-auto">
+        {!enabled && (
+          <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
+            <RadioTower className="h-4 w-4 opacity-60" />
+            <span>
+              Distributed tracing is disabled — no traffic metrics are being
+              recorded.
+            </span>
+          </div>
+        )}
         {/* Section 1: Traffic Overview */}
         <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-4">
           {overviewStats.map((stat) => (

--- a/src/ui/app/traffic/page.tsx
+++ b/src/ui/app/traffic/page.tsx
@@ -95,7 +95,7 @@ function Sparkline({
 }
 
 export default function TrafficPage() {
-  const [window, setWindow] = useState<TrafficWindow>("all");
+  const [timeWindow, setTimeWindow] = useState<TrafficWindow>("all");
 
   const [edgeStats, setEdgeStats] = useState<EdgeStat[]>([]);
   const [agentStats, setAgentStats] = useState<AgentStat[]>([]);
@@ -103,6 +103,7 @@ export default function TrafficPage() {
   const [totalCalls, setTotalCalls] = useState(0);
   const [totalErrors, setTotalErrors] = useState(0);
   const [enabled, setEnabled] = useState(true);
+  const [truncated, setTruncated] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [refetching, setRefetching] = useState(false);
@@ -117,7 +118,7 @@ export default function TrafficPage() {
   // the selected window changed in the meantime (stale-guard).
   useEffect(() => {
     let cancelled = false;
-    const requestedWindow = window;
+    const requestedWindow = timeWindow;
 
     // A fresh window must not inherit the previous window's trend or numbers.
     historyRef.current = new Map();
@@ -127,9 +128,10 @@ export default function TrafficPage() {
       if (!isInitial) setRefetching(true);
       try {
         const data = await getTraffic(requestedWindow);
-        if (cancelled || requestedWindow !== window) return;
+        if (cancelled || requestedWindow !== timeWindow) return;
 
         setEnabled(data.enabled);
+        setTruncated(!!data.truncated);
         setTotalCalls(data.total_calls);
         setTotalErrors(data.total_errors);
         setModelStats(data.model_stats || []);
@@ -147,10 +149,14 @@ export default function TrafficPage() {
         setTick((t) => t + 1);
         setError(null);
       } catch (err) {
-        if (cancelled || requestedWindow !== window) return;
-        setError(err instanceof Error ? err : new Error(String(err)));
+        if (cancelled || requestedWindow !== timeWindow) return;
+        if (isInitial) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+        }
+        // Background poll failure: keep the last good data on screen; do not
+        // trip the full-page error and do not clear any stats state.
       } finally {
-        if (!cancelled && requestedWindow === window) {
+        if (!cancelled && requestedWindow === timeWindow) {
           setLoading(false);
           setRefetching(false);
         }
@@ -164,7 +170,7 @@ export default function TrafficPage() {
       cancelled = true;
       clearInterval(interval);
     };
-  }, [window, reloadKey]);
+  }, [timeWindow, reloadKey]);
 
   // Aggregated stats for overview cards
   const overview = useMemo(() => {
@@ -210,8 +216,8 @@ export default function TrafficPage() {
       <Segmented
         aria-label="Traffic time range"
         options={WINDOW_OPTIONS}
-        value={window}
-        onChange={setWindow}
+        value={timeWindow}
+        onChange={setTimeWindow}
       />
     </div>
   );
@@ -347,7 +353,14 @@ export default function TrafficPage() {
         {/* Section 2: Per-Edge Traffic Table */}
         <Card>
           <CardHeader>
-            <CardTitle className="text-base">Per-Edge Traffic</CardTitle>
+            <div className="flex items-center gap-2">
+              <CardTitle className="text-base">Per-Edge Traffic</CardTitle>
+              {truncated && (
+                <span className="inline-flex items-center rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-500">
+                  Partial — window exceeded the sample cap
+                </span>
+              )}
+            </div>
           </CardHeader>
           <CardContent>
             {sortedEdges.length === 0 ? (

--- a/src/ui/components/layout/Header.tsx
+++ b/src/ui/components/layout/Header.tsx
@@ -1,9 +1,13 @@
+import { ReactNode } from "react";
+
 interface HeaderProps {
   title: string;
   subtitle?: string;
+  /** Optional right-aligned content (e.g. a segmented time-range control). */
+  actions?: ReactNode;
 }
 
-export function Header({ title, subtitle }: HeaderProps) {
+export function Header({ title, subtitle, actions }: HeaderProps) {
   return (
     <header className="flex h-16 items-center justify-between border-b border-border bg-background px-6">
       <div>
@@ -12,6 +16,7 @@ export function Header({ title, subtitle }: HeaderProps) {
           <p className="text-sm text-muted-foreground">{subtitle}</p>
         )}
       </div>
+      {actions && <div className="flex items-center gap-2">{actions}</div>}
     </header>
   );
 }

--- a/src/ui/components/ui/segmented.tsx
+++ b/src/ui/components/ui/segmented.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@/lib/utils";
+
+export interface SegmentedOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface SegmentedProps<T extends string> {
+  options: SegmentedOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  className?: string;
+  "aria-label"?: string;
+}
+
+/**
+ * Compact segmented pill (like a trading-chart "1M/3M/6M" control). The
+ * active segment is highlighted with the app's primary accent; the group
+ * sits inside a muted rounded track. Buttons expose aria-pressed for a11y.
+ */
+export function Segmented<T extends string>({
+  options,
+  value,
+  onChange,
+  className,
+  "aria-label": ariaLabel,
+}: SegmentedProps<T>) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex items-center rounded-lg bg-muted p-[3px] text-muted-foreground",
+        className
+      )}
+    >
+      {options.map((opt) => {
+        const active = opt.value === value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(opt.value)}
+            className={cn(
+              "inline-flex h-7 items-center justify-center rounded-md px-3 text-xs font-medium transition-all outline-none focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+              active
+                ? "bg-primary text-primary-foreground shadow-sm"
+                : "hover:text-foreground"
+            )}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/lib/api.ts
+++ b/src/ui/lib/api.ts
@@ -1,4 +1,4 @@
-import { AgentsResponse, DashboardEvent, EdgeStatsResponse, EventsHistoryResponse, HealthResponse, JobsQuery, JobsResponse, RecentTracesResponse, RegistryEventInfo, SchemasResponse, SchemaUsage, TraceDetail } from "./types";
+import { AgentsResponse, DashboardEvent, EdgeStatsResponse, EventsHistoryResponse, HealthResponse, JobsQuery, JobsResponse, RecentTracesResponse, RegistryEventInfo, SchemasResponse, SchemaUsage, TraceDetail, TrafficResponse, TrafficWindow } from "./types";
 import { getApiBase } from "./config";
 
 const API_BASE = getApiBase();
@@ -208,6 +208,24 @@ export async function getTraceDetail(traceId: string): Promise<TraceDetail> {
 export async function getEdgeStats(limit: number = 20): Promise<EdgeStatsResponse> {
   const res = await fetch(`${API_BASE}/trace/edge-stats?limit=${limit}`, { cache: "no-store" });
   if (!res.ok) throw new Error(`Failed to fetch edge stats: ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Windowed traffic aggregates. `window=all` returns live all-time stats;
+ * "1h"/"1d" return trailing-window aggregates. Element shapes match the
+ * live EdgeStat/AgentStat/ModelStat, so the Traffic page reuses the same
+ * rendering code with a swapped data source.
+ */
+export async function getTraffic(
+  window: TrafficWindow,
+  limit: number = 20
+): Promise<TrafficResponse> {
+  const res = await fetch(
+    `${API_BASE}/trace/traffic?window=${window}&limit=${limit}`,
+    { cache: "no-store" }
+  );
+  if (!res.ok) throw new Error(`Failed to fetch traffic: ${res.status}`);
   return res.json();
 }
 

--- a/src/ui/lib/types.ts
+++ b/src/ui/lib/types.ts
@@ -229,6 +229,25 @@ export interface EdgeStatsResponse {
   edge_count: number;
 }
 
+export type TrafficWindow = "1h" | "1d" | "all";
+
+/**
+ * Windowed traffic aggregates from GET /api/trace/traffic?window=&limit=.
+ * The element shapes are identical to the live EdgeStat/AgentStat/ModelStat
+ * types, so the Traffic page renders them through the same code paths.
+ * `window=all` returns live all-time aggregates; `enabled:false` (with empty
+ * arrays) when distributed tracing is off.
+ */
+export interface TrafficResponse {
+  enabled: boolean;
+  window: TrafficWindow;
+  total_calls: number;
+  total_errors: number;
+  edge_stats: EdgeStat[];
+  agent_stats: AgentStat[];
+  model_stats: ModelStat[];
+}
+
 /**
  * Issue #973: MeshJob observability types. Mirrors the Job + JobsListResponse
  * schemas in api/mcp-mesh-registry.openapi.yaml — time fields are UNIX-epoch

--- a/src/ui/lib/types.ts
+++ b/src/ui/lib/types.ts
@@ -246,6 +246,11 @@ export interface TrafficResponse {
   edge_stats: EdgeStat[];
   agent_stats: AgentStat[];
   model_stats: ModelStat[];
+  /**
+   * True when a busy window exceeded the read cap and the returned aggregates
+   * are partial (sampled). The Traffic page surfaces a muted "partial" note.
+   */
+  truncated?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

The Traffic page only ever showed **all-time** aggregates (pushed over SSE from in-memory counters that discard per-observation timestamps). This adds a **1h / 1d / All** segmented control (top-right of the page header) backed by a new windowed aggregation endpoint, so traffic can be scoped to a recent window.

Scope was chosen as the MVP that the 24h-retained trace stream supports cleanly (1h/1d/all); 1w/1m would need longer retention or persisted rollups and are deliberately out of scope.

## Backend — `GET /api/trace/traffic?window=<1h|1d|all>&limit=<n>`
- `window=all` (default): live all-time aggregates — the existing path, unchanged.
- `window=1h|1d`: a **bounded XRANGE** over the timestamped `mesh:trace` Redis stream (start ID = `now-window` in millis; capped at 50k entries, paged in batches), replayed through **fresh** `TraceAccumulator` + `MetricsProcessor` instances so **all existing metrics math is reused** — no duplicated aggregation.
  - Added `TraceAccumulator.FinalizeAllActive()` to synchronously run the same edge-detection + finalize the live 3s-debounce loop does (edges and `total_calls`/`total_errors` are only produced on finalize — a windowed replay must force it or it would silently miss all edges/totals).
  - Added `manager.RangeEventsSince` / `consumer.RangeEvents` for the bounded time-range read (reusing the consumer's client, stream name, and `FromRedisMap` parse).
- Response returns `edge_stats` / `agent_stats` / `model_stats` (same element shapes as the live endpoints) + `total_calls` / `total_errors` in one payload. Invalid window → HTTP 400; tracing disabled → `enabled:false`.

## Frontend (Traffic page only — shared SSE context untouched)
- New reusable `Segmented` control + `getTraffic()` client + `TrafficResponse` type.
- The page pulls the selected window (default **All**) on mount/change and polls every 5s to stay live, with a stale-response guard. Fetched data feeds the **existing** summary-card memo + the three tables unchanged; the trend sparkline resets per window. Loading / error / tracing-disabled states handled. Dashboard/Live still use the SSE context.

## Validation
- `make ui-server-build` clean; Go unit tests pass (`TestReplayWindowExcludesOlderEvents`, `TestParseWindow`).
- **End-to-end against a local registry + redis**: ran `bin/meshui`, seeded spans at 2h-ago (failed `digest-agent→analyzer`) and 10m-ago (`digest-agent→recommender`):

  | window | calls | errors | edges | agents |
  |---|---|---|---|---|
  | all | 2 | 1 | 2 | 3 |
  | 1d | 2 | 1 | 2 | 3 |
  | 1h | 1 | 0 | 1 (old failed edge excluded) | 2 |
  | `5m` | — | — | 400 | — |

  SPA serves on :3080 and the built bundle contains the control + endpoint call.

## Notes
- Windowed accuracy is bounded by `MCP_MESH_TRACE_RETENTION` (default 24h) — a `1d` window at default retention is at the edge of what the stream holds; that's inherent to sourcing windows from the stream.
- `cmd/mcp-mesh-ui/dist/index.html` is the rebuilt embed pointer (per prior UI-PR convention); `dist/assets/` is gitignored and regenerated by `make ui-server-build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a traffic view time window selector for the tracing dashboard.
  * Traffic data can now be viewed for all time, last 1 hour, or last 1 day.
  * The page now refreshes automatically and shows clearer loading and retry behavior.

* **Bug Fixes**
  * Older events are now excluded correctly when viewing a shorter time window.
  * Disabled tracing is handled gracefully with an empty, informative view.

* **UI Improvements**
  * Added a cleaner segmented control and updated the page header layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->