### PR TITLE
fix(llm): guarantee reply envelope carries the answer as a string

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -1430,13 +1430,32 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
         if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
             try {
                 Map<String, Object> parsed = objectMapper.readValue(trimmed, Map.class);
-                // If it has a "content" field, extract it (this is the LLM's actual response)
-                if (parsed.containsKey("content")) {
+                // Provider envelope wrapper? (carries a content/role marker.) Mirror
+                // the top-level extractContent recovery so a nested envelope — the
+                // MCP content[0].text carrying the serialized {role, content} object
+                // — is handled symmetrically instead of returning the wrapper JSON.
+                if (parsed.containsKey("content") || parsed.containsKey("role")) {
                     Object innerContent = parsed.get("content");
                     if (innerContent instanceof String s) {
                         log.debug("Extracted inner content from LLM provider wrapper");
                         return s;
                     }
+                    if (innerContent instanceof Map<?, ?> innerMap) {
+                        return serializeContent(innerMap,
+                            "structured (Map) content nested in a provider wrapper");
+                    }
+                    // No usable string/map content (null, empty, tool-call turn, or a
+                    // truthy nested error) — return "" so empty-content diagnostics
+                    // fire instead of feeding the wrapper JSON to the schema parser.
+                    return "";
+                }
+                // Not an envelope. A bare payload carrying reserved wire keys or a
+                // truthy "error" is NOT an answer either — surface it via empty-
+                // content diagnostics rather than returning the error/tool JSON.
+                if (parsed.containsKey("tool_calls")
+                        || parsed.containsKey("_mesh_usage")
+                        || isTruthy(parsed.get("error"))) {
+                    return "";
                 }
             } catch (JacksonException e) {
                 // Not valid JSON, return as-is

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -424,6 +424,12 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
         private long accumulatedOutputTokens = 0;
         private String effectiveModel = null;
 
+        // Raw provider envelope of the final (no-tool-calls) response, captured so
+        // generate(Class) can surface it when content resolves to empty and the
+        // structured parse fails — the honest signal is "empty content", not
+        // "failed to parse as <Model>".
+        private Map<String, Object> lastRawResponse = null;
+
         // --- Messages ---
 
         @Override
@@ -572,6 +578,15 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
 
             String response = generate();
 
+            // Empty content is not a parse problem — the provider reply carried no
+            // answer (lost upstream). Blame that honestly and include the raw
+            // envelope so the failure is diagnosable, rather than a misleading
+            // "Failed to parse LLM response as <Model>".
+            if (response == null || response.isBlank()) {
+                throw new RuntimeException("Failed to parse LLM response as " + responseType.getSimpleName()
+                    + ": provider reply had empty content. Raw response payload: " + rawResponseSnippet());
+            }
+
             try {
                 return responseModelMapper.readValue(response, responseType);
             } catch (JacksonException e) {
@@ -583,8 +598,27 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                         log.warn("Failed to parse extracted JSON: {}", e2.getMessage());
                     }
                 }
-                throw new RuntimeException("Failed to parse LLM response as " + responseType.getSimpleName(), e);
+                throw new RuntimeException("Failed to parse LLM response as " + responseType.getSimpleName()
+                    + ". Raw response payload: " + rawResponseSnippet(), e);
             }
+        }
+
+        /**
+         * Truncated JSON repr (~500 chars) of the raw provider envelope from the
+         * final response, for parse-failure diagnostics. Falls back to a marker
+         * when no envelope was captured (e.g. max-iterations exit).
+         */
+        private String rawResponseSnippet() {
+            if (lastRawResponse == null) {
+                return "<none>";
+            }
+            String json;
+            try {
+                json = objectMapper.writeValueAsString(lastRawResponse);
+            } catch (JacksonException e) {
+                json = String.valueOf(lastRawResponse);
+            }
+            return json.length() > 500 ? json.substring(0, 500) + "..." : json;
         }
 
         @Override
@@ -795,6 +829,7 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
             accumulatedInputTokens = 0;
             accumulatedOutputTokens = 0;
             effectiveModel = null;
+            lastRawResponse = null;
             try {
             int iteration = 0;
             while (iteration < maxIterations) {
@@ -845,6 +880,7 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                 List<Map<String, Object>> toolCalls = extractToolCalls(response);
 
                 if (toolCalls.isEmpty()) {
+                    lastRawResponse = response;
                     return extractContent(response);
                 }
 
@@ -1259,7 +1295,64 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                 }
             }
         }
+        // Recovery: the structured answer leaked unserialized as a Map instead of
+        // a JSON string. Serialize it verbatim (no parseNestedContent — this Map
+        // IS the answer, not a provider wrapper to unwrap).
+        if (content instanceof Map<?, ?> map) {
+            return serializeContent(map, "structured (Map) content");
+        }
+        // Bare structured answer returned without the {role, content} envelope:
+        // no "content" key and no "role" key — treat the whole map as the answer.
+        // Guard: maps carrying reserved wire keys (tool_calls / _mesh_usage) or a
+        // TRUTHY "error" are NOT answers. Fall through to "" so the empty-content
+        // diagnostic surfaces the real payload (e.g. a vendor error) instead of a
+        // misleading schema-validation failure, and so a tool-call turn's replayed
+        // assistant content never carries the whole map (incl. tool_calls). An
+        // "error": null value is a plain model field, so a falsy error is allowed.
+        if (!response.containsKey("content")
+                && !response.containsKey("role")
+                && !response.containsKey("tool_calls")
+                && !response.containsKey("_mesh_usage")
+                && !isTruthy(response.get("error"))) {
+            return serializeContent(response, "a bare structured answer without an envelope");
+        }
         return "";
+    }
+
+    /** Loose truthiness mirroring the other runtimes: null / blank string / empty
+     * collection / false / zero are falsy; everything else is truthy. */
+    private static boolean isTruthy(Object value) {
+        if (value == null) {
+            return false;
+        }
+        if (value instanceof String s) {
+            return !s.isBlank();
+        }
+        if (value instanceof Boolean b) {
+            return b;
+        }
+        if (value instanceof Number n) {
+            return n.doubleValue() != 0.0;
+        }
+        if (value instanceof Map<?, ?> m) {
+            return !m.isEmpty();
+        }
+        if (value instanceof Collection<?> c) {
+            return !c.isEmpty();
+        }
+        return true;
+    }
+
+    /** Serialize recovered non-string content to a JSON string; "" if serialization fails. */
+    private String serializeContent(Object value, String description) {
+        try {
+            String json = objectMapper.writeValueAsString(value);
+            log.warn("Mesh provider sent {}; normalized to a JSON string", description);
+            return json;
+        } catch (JacksonException e) {
+            log.warn("Failed to serialize {} from mesh provider: {}", description, e.getMessage());
+            return "";
+        }
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyContentRecoveryTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyContentRecoveryTest.java
@@ -1,0 +1,268 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.MeshObjectMappers;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Consumer-side recovery + honest diagnostics for the {@code {role, content}}
+ * reply envelope in {@link MeshLlmAgentProxy}.
+ *
+ * <p>Providers should send the answer as a string. Two malformed-but-recoverable
+ * shapes occur in the field:
+ * <ul>
+ *   <li>{@code content} is a raw Map — the structured answer leaked unserialized.
+ *       {@link MeshLlmAgentProxy#extractContent} serializes it to a JSON string.</li>
+ *   <li>the map carries neither {@code content} nor {@code role} — a bare
+ *       structured answer without the envelope. The whole map is serialized.</li>
+ * </ul>
+ *
+ * <p>When content resolves to empty, {@code generate(Class)} must blame the empty
+ * reply and surface the raw payload — not a misleading "Failed to parse as &lt;Model&gt;".
+ *
+ * <p>{@code extractContent} is reflected out (private instance method) so the exact
+ * proxy logic is exercised; the empty-content diagnostic runs end-to-end through a
+ * {@link MockWebServer} mirroring {@code MeshLlmAgentProxyTokenTelemetryTest}.
+ */
+@DisplayName("MeshLlmAgentProxy — content recovery + empty-content diagnostics")
+class MeshLlmAgentProxyContentRecoveryTest {
+
+    private MockWebServer server;
+    private McpHttpClient client;
+    private ObjectMapper mapper;
+    private MeshLlmAgentProxy proxy;
+
+    record Reply(String answer) {}
+
+    @BeforeAll
+    static void initTlsConfig() throws Exception {
+        Constructor<MeshTlsConfig> ctor = MeshTlsConfig.class.getDeclaredConstructor(
+            boolean.class, String.class, String.class, String.class, String.class);
+        ctor.setAccessible(true);
+        MeshTlsConfig disabled = ctor.newInstance(false, "off", null, null, null);
+
+        Field cachedField = MeshTlsConfig.class.getDeclaredField("cached");
+        cachedField.setAccessible(true);
+        cachedField.set(null, disabled);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        mapper = MeshObjectMappers.create();
+        client = new McpHttpClient(mapper);
+
+        proxy = new MeshLlmAgentProxy("test.recovery");
+        proxy.configure(client, null, null, null, "", "ctx", 1, false);
+        proxy.updateProvider(
+            server.url("/").toString().replaceAll("/$", ""),
+            "process_chat",
+            "anthropic"
+        );
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (client != null) client.close();
+        server.shutdown();
+    }
+
+    // -------------------------------------------------------------------------
+    // extractContent (reflected private instance method)
+    // -------------------------------------------------------------------------
+
+    private String invokeExtractContent(Map<String, Object> response) throws Exception {
+        Method m = MeshLlmAgentProxy.class.getDeclaredMethod("extractContent", Map.class);
+        m.setAccessible(true);
+        return (String) m.invoke(proxy, response);
+    }
+
+    @Test
+    @DisplayName("string content passes through unchanged (regression)")
+    void stringContentUnchanged() throws Exception {
+        assertEquals("hello", invokeExtractContent(Map.of("role", "assistant", "content", "hello")));
+    }
+
+    @Test
+    @DisplayName("list-of-blocks content reads the first block's text (regression)")
+    void listOfBlocksUnchanged() throws Exception {
+        Map<String, Object> response = Map.of(
+            "role", "assistant",
+            "content", List.of(Map.of("type", "text", "text", "hi from block"))
+        );
+        assertEquals("hi from block", invokeExtractContent(response));
+    }
+
+    @Test
+    @DisplayName("Map content is serialized to a JSON string")
+    void mapContentSerialized() throws Exception {
+        Map<String, Object> answer = new LinkedHashMap<>();
+        answer.put("answer", "42");
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("role", "assistant");
+        response.put("content", answer);
+
+        String result = invokeExtractContent(response);
+
+        // Round-trips into the response model rather than degrading to "".
+        Reply parsed = mapper.readValue(result, Reply.class);
+        assertEquals("42", parsed.answer());
+    }
+
+    @Test
+    @DisplayName("bare map without content/role keys is serialized whole")
+    void bareMapSerializedWhole() throws Exception {
+        Map<String, Object> bare = new LinkedHashMap<>();
+        bare.put("answer", "bare");
+
+        String result = invokeExtractContent(bare);
+
+        Reply parsed = mapper.readValue(result, Reply.class);
+        assertEquals("bare", parsed.answer());
+    }
+
+    @Test
+    @DisplayName("error map (truthy) is NOT treated as a bare answer (degrades to empty)")
+    void errorMapNotBareAnswer() throws Exception {
+        assertEquals("", invokeExtractContent(Map.of("error", "rate limited by vendor")));
+    }
+
+    @Test
+    @DisplayName("bare answer with a null error field is still recovered")
+    void bareAnswerWithNullErrorFieldRecovered() throws Exception {
+        // LinkedHashMap tolerates the null value that Map.of() rejects.
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("answer", "ok");
+        payload.put("error", null);
+
+        String result = invokeExtractContent(payload);
+
+        assertFalse(result.isEmpty(),
+            "bare answer with a falsy error field must be recovered, not degraded to empty");
+        Map<?, ?> back = mapper.readValue(result, Map.class);
+        assertEquals("ok", back.get("answer"));
+        assertTrue(back.containsKey("error"), "the whole map (incl. error:null) is serialized");
+    }
+
+    @Test
+    @DisplayName("tool_calls-only map is NOT treated as a bare answer (degrades to empty)")
+    void toolCallsMapNotBareAnswer() throws Exception {
+        Map<String, Object> response = Map.of(
+            "tool_calls", List.of(Map.of(
+                "id", "call_1",
+                "type", "function",
+                "function", Map.of("name", "f", "arguments", "{}")
+            ))
+        );
+        assertEquals("", invokeExtractContent(response));
+    }
+
+    @Test
+    @DisplayName("_mesh_usage-only map is NOT treated as a bare answer (degrades to empty)")
+    void meshUsageMapNotBareAnswer() throws Exception {
+        assertEquals("", invokeExtractContent(
+            Map.of("_mesh_usage", Map.of("prompt_tokens", 1, "completion_tokens", 2))));
+    }
+
+    @Test
+    @DisplayName("envelope with empty content still degrades to empty string")
+    void emptyEnvelopeStillEmpty() throws Exception {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("role", "assistant");
+        response.put("content", "");
+        assertEquals("", invokeExtractContent(response));
+    }
+
+    // -------------------------------------------------------------------------
+    // generate(Class) empty-content diagnostic (end-to-end via MockWebServer)
+    // -------------------------------------------------------------------------
+
+    /** Build the MCP JSON-RPC envelope wrapping a JSON-encoded inner provider payload. */
+    private MockResponse envelope(Map<String, Object> innerPayload) {
+        try {
+            String innerJson = mapper.writeValueAsString(innerPayload);
+            Map<String, Object> envelope = Map.of(
+                "jsonrpc", "2.0",
+                "id", System.currentTimeMillis(),
+                "result", Map.of(
+                    "content", List.of(Map.of("type", "text", "text", innerJson))
+                )
+            );
+            return new MockResponse()
+                .setBody(mapper.writeValueAsString(envelope))
+                .setHeader("Content-Type", "application/json");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    @DisplayName("empty content under a response model → error blames empty content + shows raw payload")
+    void emptyContentDiagnostic() {
+        Map<String, Object> inner = new LinkedHashMap<>();
+        inner.put("role", "assistant");
+        inner.put("content", "");
+        server.enqueue(envelope(inner));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> proxy.request().user("hi").generate(Reply.class));
+
+        assertTrue(ex.getMessage().contains("empty content"),
+            "error must blame the empty reply, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("Raw response payload:"),
+            "error must include the raw payload, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("assistant"),
+            "raw payload snippet must carry the envelope, got: " + ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("Map content under a response model → deserializes instead of failing")
+    void mapContentDeserializesEndToEnd() {
+        Map<String, Object> inner = new LinkedHashMap<>();
+        inner.put("role", "assistant");
+        inner.put("content", Map.of("answer", "structured"));
+        server.enqueue(envelope(inner));
+
+        Reply result = proxy.request().user("hi").generate(Reply.class);
+        assertEquals("structured", result.answer());
+    }
+
+    @Test
+    @DisplayName("error map under a response model → diagnostic surfaces the error, not a schema failure")
+    void errorMapSurfacedInDiagnostic() {
+        server.enqueue(envelope(Map.of("error", "rate limited by vendor")));
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+            () -> proxy.request().user("hi").generate(Reply.class));
+
+        assertTrue(ex.getMessage().contains("empty content"),
+            "error must blame the empty reply, got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("rate limited by vendor"),
+            "raw payload snippet must surface the error, got: " + ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("genuine bare answer under a response model → recovered (not an error)")
+    void genuineBareAnswerEndToEnd() {
+        server.enqueue(envelope(Map.of("answer", "bare")));
+
+        Reply result = proxy.request().user("hi").generate(Reply.class);
+        assertEquals("bare", result.answer());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyContentRecoveryTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyContentRecoveryTest.java
@@ -190,6 +190,56 @@ class MeshLlmAgentProxyContentRecoveryTest {
     }
 
     // -------------------------------------------------------------------------
+    // Nested provider-wrapper recovery: a String / content[0].text carrying a
+    // serialized {role, content} envelope (parseNestedContent path) mirrors the
+    // top-level guards instead of returning the wrapper JSON verbatim.
+    // -------------------------------------------------------------------------
+
+    /** Wraps a serialized envelope as the (string) content of an outer response. */
+    private String extractFromNestedWrapper(Object innerEnvelope) throws Exception {
+        String wrapper = mapper.writeValueAsString(innerEnvelope);
+        return invokeExtractContent(Map.of("role", "assistant", "content", wrapper));
+    }
+
+    @Test
+    @DisplayName("nested wrapper with string content → inner string returned (regression)")
+    void nestedWrapperStringContentUnchanged() throws Exception {
+        assertEquals("hello world", extractFromNestedWrapper(
+            Map.of("role", "assistant", "content", "hello world")));
+    }
+
+    @Test
+    @DisplayName("nested wrapper with dict content → inner map serialized")
+    void nestedWrapperMapContentSerialized() throws Exception {
+        String result = extractFromNestedWrapper(
+            Map.of("role", "assistant", "content", Map.of("answer", "42")));
+        Reply parsed = mapper.readValue(result, Reply.class);
+        assertEquals("42", parsed.answer());
+    }
+
+    @Test
+    @DisplayName("nested bare error payload → empty (diagnostics), not the wrapper JSON")
+    void nestedTruthyErrorDegradesToEmpty() throws Exception {
+        assertEquals("", extractFromNestedWrapper(
+            Map.of("error", "rate limited by vendor")));
+    }
+
+    @Test
+    @DisplayName("nested envelope with role but no usable content → empty (diagnostics)")
+    void nestedEnvelopeNoContentDegradesToEmpty() throws Exception {
+        assertEquals("", extractFromNestedWrapper(
+            Map.of("role", "assistant", "error", "rate limited")));
+    }
+
+    @Test
+    @DisplayName("genuine nested JSON answer (no wrapper markers) passes through unchanged")
+    void nestedGenuineJsonAnswerUnchanged() throws Exception {
+        String result = extractFromNestedWrapper(Map.of("answer", "42"));
+        Reply parsed = mapper.readValue(result, Reply.class);
+        assertEquals("42", parsed.answer());
+    }
+
+    // -------------------------------------------------------------------------
     // generate(Class) empty-content diagnostic (end-to-end via MockWebServer)
     // -------------------------------------------------------------------------
 

--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
@@ -43,6 +43,19 @@ logger = logging.getLogger(__name__)
 _CONTEXT_NOT_PROVIDED = object()
 
 
+def _dumps_safe(value: Any) -> str:
+    """JSON-serialize a recovered content value, hardened like the provider's
+    ``_coerce_content_to_str``: ``default=str`` coerces stray non-serializable
+    leaves (datetimes, Pydantic models, …) so a single bad leaf can't abort
+    recovery; a final fallback emits the repr AS a JSON string for the circular-
+    ref case so ``content`` still parses.
+    """
+    try:
+        return json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        return json.dumps(str(value))
+
+
 # ---------------------------------------------------------------------------
 # Mock LiteLLM response types for mesh-delegated provider responses
 # ---------------------------------------------------------------------------
@@ -79,14 +92,66 @@ class _MockToolCall:
 class _MockMessage:
     """Mock message matching LiteLLM ModelResponse.choices[].message."""
 
-    __slots__ = ("content", "role", "tool_calls")
+    __slots__ = ("content", "role", "tool_calls", "_raw")
 
     def __init__(self, message_dict: dict):
-        self.content = message_dict.get("content")
+        # Retain the original wire dict for empty-content diagnostics — model_dump()
+        # only echoes {role, content, tool_calls} and would drop non-answer keys
+        # (e.g. "error") that the diagnostic must surface.
+        self._raw = message_dict
+        content = message_dict.get("content")
+        # Providers should send the answer as a string. Two malformed-but-
+        # recoverable shapes occur in the field:
+        #   1. content is a raw dict — the structured answer leaked
+        #      unserialized. Serialize it so downstream parsing sees JSON.
+        #   2. the map has neither "content" nor "role" — a bare structured
+        #      answer returned without the envelope; treat the whole map as
+        #      the answer. Guard: maps carrying reserved wire keys (tool_calls /
+        #      _mesh_usage) or a TRUTHY "error" are NOT answers — leave content
+        #      empty so the honest empty-content diagnostic surfaces the real
+        #      payload (e.g. a vendor error) instead of a misleading schema-
+        #      validation failure. ("error": null is a plain model field, so a
+        #      falsy error does not disqualify a bare answer.)
+        if isinstance(content, dict):
+            logger.debug(
+                "Provider sent structured (dict) content; "
+                "normalizing to a JSON string"
+            )
+            content = _dumps_safe(content)
+        elif (
+            content is None
+            and "content" not in message_dict
+            and "role" not in message_dict
+            and not (message_dict.keys() & {"tool_calls", "_mesh_usage"})
+            and not message_dict.get("error")
+        ):
+            logger.debug(
+                "Provider returned a bare structured answer without an "
+                "envelope; treating the whole map as content"
+            )
+            content = _dumps_safe(message_dict)
+        self.content = content
         self.role = message_dict.get("role", "assistant")
         self.tool_calls = None
-        if "tool_calls" in message_dict and message_dict["tool_calls"]:
-            self.tool_calls = [_MockToolCall(tc) for tc in message_dict["tool_calls"]]
+        raw_tool_calls = message_dict.get("tool_calls")
+        if raw_tool_calls:
+            # Only construct tool calls from entries that look real (carry an
+            # "id" and a "function"); ignore malformed entries with a debug log
+            # rather than crashing the whole call on a KeyError.
+            self.tool_calls = [
+                _MockToolCall(tc)
+                for tc in raw_tool_calls
+                if isinstance(tc, dict) and "id" in tc and "function" in tc
+            ]
+            skipped = len(raw_tool_calls) - len(self.tool_calls)
+            if skipped:
+                logger.debug(
+                    "Ignored %d malformed tool_calls entry(ies) "
+                    "missing 'id'/'function'",
+                    skipped,
+                )
+            if not self.tool_calls:
+                self.tool_calls = None
 
     def model_dump(self) -> dict:
         dump: dict[str, Any] = {"role": self.role, "content": self.content}
@@ -605,9 +670,12 @@ class MeshLlmAgent:
                         "content": message_dict,
                     }
 
+            # content may be a non-string (dict) on the malformed-but-recoverable
+            # path — str() keeps this preview slice safe (normalization happens in
+            # _MockMessage).
             logger.debug(
                 f"📥 Received response from mesh provider: "
-                f"content={(message_dict.get('content') or '')[:200]}..., "
+                f"content={str(message_dict.get('content') or '')[:200]}..., "
                 f"tool_calls={len(message_dict.get('tool_calls') or [])}"
             )
 
@@ -1046,7 +1114,9 @@ class MeshLlmAgent:
                 )
 
                 # Parse the response
-                result = self._parse_response(assistant_message.content)
+                result = self._parse_response(
+                    assistant_message.content, raw_response=assistant_message
+                )
 
                 # Issue #311: Calculate latency and attach _mesh_meta
                 latency_ms = (time.perf_counter() - start_time) * 1000
@@ -1207,7 +1277,9 @@ class MeshLlmAgent:
 
         return resolved
 
-    def _parse_response(self, content: Optional[str]) -> Any:
+    def _parse_response(
+        self, content: Optional[str], raw_response: Optional[Any] = None
+    ) -> Any:
         """
         Parse LLM response into output type.
 
@@ -1217,6 +1289,9 @@ class MeshLlmAgent:
         Args:
             content: Response content from LLM (may be None — a legal
                 OpenAI-shape final message, e.g. on max-token cutoffs)
+            raw_response: Optional raw provider message (LiteLLM ModelResponse
+                message or _MockMessage) used to enrich the empty-content
+                diagnostic with the raw payload.
 
         Returns:
             Raw string (if output_type is str) or parsed Pydantic model instance
@@ -1224,19 +1299,23 @@ class MeshLlmAgent:
         Raises:
             ResponseParseError: If response doesn't match output_type schema or invalid JSON
         """
-        # content=None is a legal final-message shape (e.g. max-token
+        # content None/"" is a legal final-message shape (e.g. max-token
         # cutoffs). For str output, normalize to "". For structured output,
         # raise a proper parse error instead of letting None propagate into
-        # the parser as a TypeError (issue #1162).
-        if content is None:
+        # the parser as a TypeError (issue #1162). Surface the raw payload so
+        # the failure blames the empty reply, not the response schema.
+        if content is None or content == "":
             if self.output_type is str:
                 return ""
             raise ResponseParseError(
-                raw_content="",
+                raw_content=self._raw_response_snippet(raw_response),
                 expected_schema=getattr(
                     self.output_type, "__name__", str(self.output_type)
                 ),
-                validation_errors="model returned empty content (content=None)",
+                validation_errors=(
+                    "provider reply had empty content "
+                    "(the LLM answer was lost upstream)"
+                ),
             )
 
         # For str return type, return content directly without parsing
@@ -1244,6 +1323,24 @@ class MeshLlmAgent:
             return content
 
         return ResponseParser.parse(content, self.output_type)
+
+    @staticmethod
+    def _raw_response_snippet(raw_response: Optional[Any]) -> str:
+        """Truncated repr (~500 chars) of the raw provider message for diagnostics.
+
+        Prefers the original wire dict (``_MockMessage._raw``) so non-answer keys
+        like ``error`` show up; falls back to ``model_dump()`` for real LiteLLM
+        messages on the direct path.
+        """
+        if raw_response is None:
+            return ""
+        raw = getattr(raw_response, "_raw", None)
+        try:
+            if raw is not None:
+                return json.dumps(raw)[:500]
+            return json.dumps(raw_response.model_dump())[:500]
+        except Exception:
+            return str(raw_response)[:500]
 
     @staticmethod
     def _merge_streamed_tool_calls(buffered: list[Any]) -> list[dict]:

--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
@@ -1335,11 +1335,14 @@ class MeshLlmAgent:
         if raw_response is None:
             return ""
         raw = getattr(raw_response, "_raw", None)
+        if raw is not None:
+            # _dumps_safe never raises: default=str coerces stray leaves and a
+            # final fallback handles circular refs, so the preview is always useful.
+            return _dumps_safe(raw)[:500]
         try:
-            if raw is not None:
-                return json.dumps(raw)[:500]
-            return json.dumps(raw_response.model_dump())[:500]
+            return _dumps_safe(raw_response.model_dump())[:500]
         except Exception:
+            # model_dump() itself blew up (not a serialization issue) — last resort.
             return str(raw_response)[:500]
 
     @staticmethod

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -549,6 +549,30 @@ def _build_create_kwargs(
 # ---------------------------------------------------------------------------
 
 
+def _parsed_to_json_str(parsed: Any) -> str | None:
+    """Serialize an OpenAI Structured-Outputs ``message.parsed`` payload to a
+    JSON string.
+
+    ``parsed`` may be a Pydantic model (``model_dump_json``), a plain dict, or
+    already a string. Returns ``None`` when there is nothing to recover or the
+    payload can't be serialized.
+    """
+    if parsed is None:
+        return None
+    if isinstance(parsed, str):
+        return parsed
+    dump = getattr(parsed, "model_dump_json", None)
+    if callable(dump):
+        try:
+            return dump()
+        except Exception:  # noqa: BLE001 - defensive; fall through to json
+            pass
+    try:
+        return json.dumps(parsed)
+    except (TypeError, ValueError):
+        return None
+
+
 def _adapt_response(raw: Any) -> _Response:
     """Translate openai.ChatCompletion → litellm-shape ``_Response``.
 
@@ -615,6 +639,18 @@ def _adapt_response(raw: Any) -> _Response:
                 tool_calls.append(
                     _ToolCall(id=tc_id, name=tc_name or "", arguments=tc_args or "")
                 )
+
+            # Structured output can arrive in a non-text carrier: OpenAI's
+            # Structured Outputs (``.parse``) surfaces the answer on
+            # ``message.parsed`` with ``content=None`` and no tool_calls. A
+            # non-refusal ``content=None`` collapses to ``""`` downstream and
+            # degrades into an opaque "failed to parse" error, so recover it as
+            # a string here (refusals were already raised above). Gated on the
+            # absence of tool_calls: on an ordinary tool-call turn ``content``
+            # is legitimately ``None`` and MUST stay ``None`` so it isn't
+            # replayed as a synthetic text block on the next iteration.
+            if text is None and not tool_calls:
+                text = _parsed_to_json_str(getattr(msg, "parsed", None))
         finish_reason = getattr(first_choice, "finish_reason", None) or "stop"
 
     message = _Message(

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -568,7 +568,10 @@ def _parsed_to_json_str(parsed: Any) -> str | None:
         except Exception:  # noqa: BLE001 - defensive; fall through to json
             pass
     try:
-        return json.dumps(parsed)
+        # ``default=str`` coerces stray non-serializable leaves (datetimes,
+        # nested Pydantic models, etc.) so a plain-dict payload still recovers
+        # instead of collapsing to ``None``.
+        return json.dumps(parsed, default=str)
     except (TypeError, ValueError):
         return None
 

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native.py
@@ -460,6 +460,59 @@ class TestCompleteResponseShape:
         assert response.usage.prompt_tokens == 20
         assert response.usage.completion_tokens == 8
 
+    @pytest.mark.asyncio
+    async def test_tool_use_only_leaves_content_none(self):
+        """A tool_use-only turn (no TextBlock) MUST leave ``content=None``.
+
+        The tool_use arguments are the tool invocation, not the answer:
+        fabricating ``content`` from them would leak a synthetic JSON text
+        block into the replayed assistant history on the next agentic
+        iteration (token inflation, model drift, broken turn shape). The
+        legitimate structured-final case is handled by the loop's synthetic
+        path / non-text-carrier recovery, not here.
+        """
+        api_resp = _make_anthropic_message(
+            text=None,
+            tool_uses=[
+                {
+                    "id": "toolu_fmt",
+                    "name": "get_weather",
+                    "input": {"city": "NYC"},
+                }
+            ],
+        )
+        cls_mock, _, _ = _patched_async_anthropic(api_resp)
+        with patch("anthropic.AsyncAnthropic", cls_mock):
+            response = await anthropic_native.complete(
+                {"messages": [{"role": "user", "content": "Q?"}]},
+                model="anthropic/claude-sonnet-4-5",
+                api_key="sk-test",
+            )
+
+        msg = response.choices[0].message
+        # content stays None; the tool_call carries the invocation.
+        assert msg.content is None
+        assert msg.tool_calls[0].function.name == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_text_and_tool_use_keeps_text_content(self):
+        """When a TextBlock is present alongside a tool_use, ``content`` is
+        the text (unchanged happy path)."""
+        api_resp = _make_anthropic_message(
+            text="Here you go:",
+            tool_uses=[
+                {"id": "toolu_1", "name": "get_weather", "input": {"city": "NYC"}}
+            ],
+        )
+        cls_mock, _, _ = _patched_async_anthropic(api_resp)
+        with patch("anthropic.AsyncAnthropic", cls_mock):
+            response = await anthropic_native.complete(
+                {"messages": [{"role": "user", "content": "Q?"}]},
+                model="anthropic/claude-sonnet-4-5",
+                api_key="sk-test",
+            )
+        assert response.choices[0].message.content == "Here you go:"
+
 
 # ---------------------------------------------------------------------------
 # Backend selection

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
@@ -1537,6 +1537,21 @@ class TestAdaptResponse:
         assert out.choices[0].message.content == "Calling weather..."
         assert len(out.choices[0].message.tool_calls) == 1
 
+    def test_function_call_only_leaves_content_none(self):
+        """A functionCall-only response (no text Part) MUST leave
+        ``content=None``. The call args are the tool invocation, not the
+        answer: fabricating ``content`` from them would leak a synthetic JSON
+        text block into the replayed assistant history on the next agentic
+        iteration."""
+        raw = _make_gemini_response(
+            function_calls=[{"name": "get_weather", "args": {"city": "NYC"}}],
+            finish_reason="STOP",
+        )
+        out = gemini_native._adapt_response(raw, model="gemini-2.5-flash")
+        msg = out.choices[0].message
+        assert msg.content is None
+        assert msg.tool_calls[0].function.name == "get_weather"
+
     def test_usage_metadata_field_name_mapping(self):
         raw = _make_gemini_response(
             text="hi",

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
@@ -684,6 +684,18 @@ class TestParsedToJsonStr:
 
         assert openai_native._parsed_to_json_str(_Model()) == '{"a": 1}'
 
+    def test_dict_with_non_serializable_leaf_recovers_via_default_str(self):
+        """A plain dict carrying a non-JSON-serializable leaf (e.g. datetime)
+        must still recover as valid JSON (``default=str``), not collapse to
+        ``None``."""
+        import datetime as _dt
+
+        result = openai_native._parsed_to_json_str(
+            {"when": _dt.datetime(2026, 1, 2, 3, 4, 5)}
+        )
+        assert result is not None
+        assert json.loads(result) == {"when": "2026-01-02 03:04:05"}
+
 
 # ---------------------------------------------------------------------------
 # Backend selection / per-call client construction

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
@@ -541,6 +541,101 @@ class TestCompleteResponseShape:
         assert response.choices[0].finish_reason == "tool_calls"
 
     @pytest.mark.asyncio
+    async def test_content_none_recovers_from_parsed_when_no_tool_calls(self):
+        """OpenAI Structured Outputs (``.parse``) surfaces the answer on
+        ``message.parsed`` with ``content=None`` and no tool_calls — recover
+        it as a JSON string."""
+        message = SimpleNamespace(
+            role="assistant",
+            content=None,
+            tool_calls=None,
+            parsed={"answer": "42"},
+        )
+        choice = SimpleNamespace(index=0, message=message, finish_reason="stop")
+        usage = SimpleNamespace(
+            prompt_tokens=1, completion_tokens=1, total_tokens=2
+        )
+        api_resp = SimpleNamespace(
+            choices=[choice], usage=usage, model="gpt-4o-mini"
+        )
+        cls_mock, _, _ = _patched_async_openai(api_resp)
+        with patch("openai.AsyncOpenAI", cls_mock):
+            response = await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Q?"}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        assert json.loads(response.choices[0].message.content) == {"answer": "42"}
+
+    @pytest.mark.asyncio
+    async def test_parsed_ignored_when_tool_calls_present(self):
+        """On a tool-call turn ``content`` MUST stay ``None`` even if a
+        ``parsed`` field is also present. The parsed recovery is gated on the
+        absence of tool_calls so an ordinary tool-call turn's content is not
+        fabricated (which would pollute the replayed assistant history)."""
+        message = SimpleNamespace(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1",
+                    type="function",
+                    function=SimpleNamespace(
+                        name="get_weather", arguments='{"city": "NYC"}'
+                    ),
+                )
+            ],
+            parsed={"answer": "42"},
+        )
+        choice = SimpleNamespace(
+            index=0, message=message, finish_reason="tool_calls"
+        )
+        usage = SimpleNamespace(
+            prompt_tokens=1, completion_tokens=1, total_tokens=2
+        )
+        api_resp = SimpleNamespace(
+            choices=[choice], usage=usage, model="gpt-4o-mini"
+        )
+        cls_mock, _, _ = _patched_async_openai(api_resp)
+        with patch("openai.AsyncOpenAI", cls_mock):
+            response = await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Q?"}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+
+        out_msg = response.choices[0].message
+        assert out_msg.content is None
+        assert out_msg.tool_calls[0].function.name == "get_weather"
+
+    @pytest.mark.asyncio
+    async def test_text_present_wins_over_parsed_for_content(self):
+        """Happy path: when ``content`` text is present it is used verbatim —
+        the parsed recovery must not override it."""
+        message = SimpleNamespace(
+            role="assistant",
+            content="Here you go:",
+            tool_calls=None,
+            parsed={"answer": "42"},
+        )
+        choice = SimpleNamespace(index=0, message=message, finish_reason="stop")
+        usage = SimpleNamespace(
+            prompt_tokens=1, completion_tokens=1, total_tokens=2
+        )
+        api_resp = SimpleNamespace(
+            choices=[choice], usage=usage, model="gpt-4o-mini"
+        )
+        cls_mock, _, _ = _patched_async_openai(api_resp)
+        with patch("openai.AsyncOpenAI", cls_mock):
+            response = await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Q?"}]},
+                model="openai/gpt-4o-mini",
+                api_key="sk-test",
+            )
+        assert response.choices[0].message.content == "Here you go:"
+
+    @pytest.mark.asyncio
     async def test_response_with_no_usage_does_not_crash(self):
         """Some OpenAI-compatible backends omit usage on certain calls. The
         adapter must tolerate it (usage=None) instead of crashing."""
@@ -567,6 +662,27 @@ class TestCompleteResponseShape:
 
         assert response.choices[0].message.content == "hi"
         assert response.usage is None
+
+
+class TestParsedToJsonStr:
+    """Unit coverage for ``_parsed_to_json_str`` — the OpenAI Structured
+    Outputs ``message.parsed`` serializer used by the content recovery path."""
+
+    def test_none_returns_none(self):
+        assert openai_native._parsed_to_json_str(None) is None
+
+    def test_str_passthrough(self):
+        assert openai_native._parsed_to_json_str('{"a": 1}') == '{"a": 1}'
+
+    def test_dict_serialized(self):
+        assert json.loads(openai_native._parsed_to_json_str({"a": 1})) == {"a": 1}
+
+    def test_pydantic_model_uses_model_dump_json(self):
+        class _Model:
+            def model_dump_json(self):
+                return '{"a": 1}'
+
+        assert openai_native._parsed_to_json_str(_Model()) == '{"a": 1}'
 
 
 # ---------------------------------------------------------------------------

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -997,6 +997,67 @@ def _extract_text_from_message_content(content: Any) -> str:
     return str(content)
 
 
+def _coerce_content_to_str(content: Any) -> str:
+    """Guarantee an MCP tool-result envelope's ``content`` is a string.
+
+    The mesh contract is "content always carries the answer as a string";
+    consumers (Java ``extractContent``, TypeScript, Python) JSON-parse string
+    content and turn a Map/dict into ``""``. Structured-output carriers can
+    surface the answer as a dict, so serialize non-strings defensively before
+    they reach the envelope. ``None`` becomes ``""`` (the historical default).
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    try:
+        # ``default=str`` coerces stray non-serializable leaves (datetimes,
+        # Pydantic models, etc.) so the result stays valid JSON rather than a
+        # Python repr.
+        return json.dumps(content, default=str)
+    except (TypeError, ValueError):
+        # Last resort (e.g. circular refs): emit the repr AS a JSON string so
+        # ``content`` is still valid JSON a consumer can parse.
+        return json.dumps(str(content))
+
+
+def _recover_structured_content_from_message(message: Any) -> str | None:
+    """Recover a structured answer that a provider/litellm transform left out
+    of ``message.content``.
+
+    Some upstream paths — notably newer litellm routing Claude ``output_config``
+    — deliver the structured JSON in a non-text carrier: a ``parsed`` attribute
+    or ``provider_specific_fields``. Returns the answer as a JSON string, or
+    ``None`` when nothing is recoverable (caller then emits ``content: ""`` with
+    a WARN).
+
+    Only called at the no-tool-calls final-answer sites: ``tool_calls`` are NOT
+    consulted here because on an ordinary tool-call turn the arguments are the
+    tool invocation, not the answer — surfacing them as ``content`` would leak
+    fabricated text into the replayed assistant history.
+    """
+    # 1) ``parsed`` (OpenAI Structured Outputs shape, sometimes forwarded).
+    parsed = getattr(message, "parsed", None)
+    if parsed is not None:
+        dump = getattr(parsed, "model_dump_json", None)
+        if callable(dump):
+            try:
+                return dump()
+            except Exception:  # noqa: BLE001 - defensive; fall through
+                pass
+        return _coerce_content_to_str(parsed)
+
+    # 2) ``provider_specific_fields`` (litellm passthrough bag).
+    psf = getattr(message, "provider_specific_fields", None)
+    if isinstance(psf, dict):
+        for key in ("parsed", "structured_output", "output"):
+            val = psf.get(key)
+            if val is not None:
+                return _coerce_content_to_str(val)
+
+    return None
+
+
 # Vendors that do NOT support images in tool/function result messages.
 # OpenAI strictly rejects images in role:tool messages.
 # For these vendors, images are accumulated and sent as one user message
@@ -1561,7 +1622,10 @@ async def _provider_agentic_loop(
 
                 message_dict: dict[str, Any] = {
                     "role": getattr(message, "role", "assistant"),
-                    "content": synthetic_args,
+                    # Enforce the string-content contract: a synthetic-tool
+                    # answer surfaced as a dict would be dropped to "" by
+                    # dict-unaware consumers (e.g. Java ``extractContent``).
+                    "content": _coerce_content_to_str(synthetic_args),
                 }
                 if hasattr(response, "usage") and response.usage:
                     message_dict["_mesh_usage"] = _build_mesh_usage(
@@ -1666,6 +1730,37 @@ async def _provider_agentic_loop(
                             "output_config.format normally enforces this) — "
                             "surfacing the raw text to the caller without retry",
                             output_config_output_type_name,
+                        )
+
+                # Non-text-carrier recovery: newer litellm output_config
+                # transforms can leave ``message.content`` empty while the
+                # structured JSON rides in ``parsed`` /
+                # ``provider_specific_fields``. Recover it so ``content`` still
+                # carries the answer; otherwise WARN loudly (naming the model
+                # and mode) so this never silently degrades into a downstream
+                # "failed to parse as <Model>" mystery.
+                if not final_content:
+                    recovered = _recover_structured_content_from_message(message)
+                    if recovered:
+                        final_content = recovered
+                        if loop_logger:
+                            loop_logger.info(
+                                "Native output_config mode for '%s': recovered "
+                                "structured content from a non-text carrier "
+                                "(model=%s)",
+                                output_config_output_type_name,
+                                effective_model,
+                            )
+                    else:
+                        (loop_logger or logger).warning(
+                            "Native output_config mode for '%s' (model=%s): "
+                            "empty content and no recoverable structured carrier "
+                            "(parsed/provider_specific) — emitting "
+                            "content='' ; downstream will fail to parse. "
+                            "Raw message: %.500r",
+                            output_config_output_type_name,
+                            effective_model,
+                            message,
                         )
 
                 message_dict: dict[str, Any] = {
@@ -2829,7 +2924,9 @@ def llm_provider(
                         )
                     message_dict = {
                         "role": getattr(message, "role", "assistant"),
-                        "content": synthetic_args,
+                        # Enforce the string-content contract (see the buffered
+                        # provider loop's synthetic path for rationale).
+                        "content": _coerce_content_to_str(synthetic_args),
                     }
                     if hasattr(response, "usage") and response.usage:
                         message_dict["_mesh_usage"] = _build_mesh_usage(
@@ -2874,6 +2971,36 @@ def llm_provider(
                                 "the caller without retry",
                                 output_config_output_type_name,
                             )
+                        # Non-text-carrier recovery (mirrors the agentic loop):
+                        # recover the structured answer from a non-text carrier
+                        # when ``message.content`` is empty, else WARN loudly so
+                        # it never silently degrades into a downstream parse
+                        # failure.
+                        if not final_content:
+                            recovered = _recover_structured_content_from_message(
+                                message
+                            )
+                            if recovered:
+                                final_content = recovered
+                                logger.info(
+                                    "Native output_config mode for '%s': "
+                                    "recovered structured content from a "
+                                    "non-text carrier (model=%s)",
+                                    output_config_output_type_name,
+                                    effective_model,
+                                )
+                            else:
+                                logger.warning(
+                                    "Native output_config mode for '%s' "
+                                    "(model=%s): empty content and no "
+                                    "recoverable structured carrier "
+                                    "(parsed/provider_specific) — "
+                                    "emitting content='' ; downstream will fail "
+                                    "to parse. Raw message: %.500r",
+                                    output_config_output_type_name,
+                                    effective_model,
+                                    message,
+                                )
                         # Fall through to the message_dict construction below
                         # (skip both HINT and synthetic fallbacks).
                     else:

--- a/src/runtime/python/tests/unit/test_mesh_llm_content_none_and_parse_error.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_content_none_and_parse_error.py
@@ -211,6 +211,22 @@ class TestEmptyContentRawPayloadDiagnostic:
         agent = _make_agent(_none_content_provider, str)
         assert agent._parse_response("") == ""
 
+    def test_raw_payload_non_serializable_still_useful(self):
+        # A non-JSON leaf in the raw payload must not collapse the snippet to an
+        # object repr — _dumps_safe coerces it (default=str) so the diagnostic
+        # still summarizes the payload.
+        from datetime import datetime
+
+        agent = _make_agent(_none_content_provider, StrictModel)
+        raw = _MockMessage(
+            {"role": "assistant", "content": None, "when": datetime(2026, 7, 2)}
+        )
+        with pytest.raises(llm_errors.ResponseParseError) as exc_info:
+            agent._parse_response(None, raw_response=raw)
+        err = exc_info.value
+        assert "2026" in err.raw_content
+        assert "object at 0x" not in err.raw_content
+
 
 class TestResponseParseErrorUnification:
     def test_single_class_aliased_for_back_compat(self):

--- a/src/runtime/python/tests/unit/test_mesh_llm_content_none_and_parse_error.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_content_none_and_parse_error.py
@@ -16,10 +16,12 @@ real parse failures. Now there is exactly one class: the parser raises the
 rich one and ``response_parser.ResponseParseError`` is a back-compat alias.
 """
 
+import json
+
 import pytest
 from _mcp_mesh.engine import llm_errors, response_parser
 from _mcp_mesh.engine.llm_config import LLMConfig
-from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent, _MockMessage, _dumps_safe
 from _mcp_mesh.engine.response_parser import ResponseParser
 from pydantic import BaseModel
 
@@ -48,6 +50,18 @@ async def _none_content_provider(request):
     return {"role": "assistant", "content": None}
 
 
+async def _dict_content_provider(request):
+    return {"role": "assistant", "content": {"count": 7, "name": "ok"}}
+
+
+async def _error_map_provider(request):
+    return {"error": "rate limited by vendor"}
+
+
+async def _bare_answer_provider(request):
+    return {"verdict": "BLOCK", "reason": "policy violation", "count": 1, "name": "x"}
+
+
 class TestContentNoneFinalResponse:
     @pytest.mark.asyncio
     async def test_str_output_returns_empty_string(self):
@@ -72,6 +86,130 @@ class TestContentNoneFinalResponse:
         agent = _make_agent(_none_content_provider, StrictModel)
         with pytest.raises(llm_errors.ResponseParseError):
             agent._parse_response(None)
+
+
+class TestMockMessageContentRecovery:
+    """Consumer-side recovery of malformed-but-recoverable content shapes."""
+
+    def test_string_content_unchanged(self):
+        msg = _MockMessage({"role": "assistant", "content": "hello"})
+        assert msg.content == "hello"
+
+    def test_dict_content_serialized_to_json_string(self):
+        msg = _MockMessage(
+            {"role": "assistant", "content": {"count": 5, "name": "x"}}
+        )
+        assert msg.content == json.dumps({"count": 5, "name": "x"})
+
+    def test_bare_map_without_content_or_role_serialized_whole(self):
+        msg = _MockMessage({"count": 5, "name": "x"})
+        assert msg.content == json.dumps({"count": 5, "name": "x"})
+
+    def test_envelope_with_none_content_stays_none(self):
+        # A real envelope (has "role") with null content is legal — left as-is.
+        msg = _MockMessage({"role": "assistant", "content": None})
+        assert msg.content is None
+
+    def test_error_map_not_treated_as_bare_answer(self):
+        # {"error": <truthy>} is a non-answer payload — must NOT be serialized as
+        # content (would produce a misleading schema failure). Left empty so the
+        # empty-content diagnostic surfaces the error.
+        msg = _MockMessage({"error": "rate limited by vendor"})
+        assert msg.content is None
+
+    def test_bare_answer_with_null_error_field_recovered(self):
+        # "error": null is a plain model field, not a failure payload — the map
+        # is still a genuine bare answer and must be recovered.
+        payload = {"data": "ok", "error": None, "count": 1, "name": "x"}
+        msg = _MockMessage(payload)
+        assert msg.content == _dumps_safe(payload)
+
+    def test_non_serializable_leaf_does_not_abort(self):
+        # A stray non-JSON leaf must be coerced (default=str), not raise.
+        from datetime import datetime
+
+        payload = {"when": datetime(2026, 7, 2), "count": 1, "name": "x"}
+        msg = _MockMessage(payload)
+        assert isinstance(msg.content, str)
+        assert "2026" in msg.content
+
+    def test_mesh_usage_only_map_not_treated_as_bare_answer(self):
+        msg = _MockMessage({"_mesh_usage": {"prompt_tokens": 1}})
+        assert msg.content is None
+
+    def test_tool_calls_only_map_not_treated_as_bare_answer_no_crash(self):
+        # A tool-call turn without role/content must not be dumped as the answer,
+        # and its tool_calls must still parse.
+        msg = _MockMessage(
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ]
+            }
+        )
+        assert msg.content is None
+        assert msg.tool_calls is not None
+        assert len(msg.tool_calls) == 1
+
+    def test_malformed_tool_calls_entry_ignored_not_crash(self):
+        # An entry missing "id"/"function" is skipped rather than raising KeyError.
+        msg = _MockMessage(
+            {"role": "assistant", "content": "hi", "tool_calls": [{"name": "f"}]}
+        )
+        assert msg.content == "hi"
+        assert msg.tool_calls is None
+
+
+class TestDictContentEndToEnd:
+    @pytest.mark.asyncio
+    async def test_dict_content_parses_into_model(self):
+        agent = _make_agent(_dict_content_provider, StrictModel)
+        result = await agent("hello")
+        assert result.count == 7
+        assert result.name == "ok"
+
+    @pytest.mark.asyncio
+    async def test_genuine_bare_answer_recovered(self):
+        # A genuinely bare answer map (no envelope-adjacent keys) is recovered.
+        agent = _make_agent(_bare_answer_provider, StrictModel)
+        result = await agent("hello")
+        assert result.count == 1
+        assert result.name == "x"
+
+    @pytest.mark.asyncio
+    async def test_error_map_surfaces_error_in_diagnostic_not_schema_failure(self):
+        agent = _make_agent(_error_map_provider, StrictModel)
+        with pytest.raises(llm_errors.ResponseParseError) as exc_info:
+            await agent("hello")
+        err = exc_info.value
+        assert "empty content" in (err.validation_errors or "")
+        # The real error payload is visible in the raw-payload snippet.
+        assert "rate limited by vendor" in err.raw_content
+
+
+class TestEmptyContentRawPayloadDiagnostic:
+    def test_parse_response_includes_raw_payload(self):
+        agent = _make_agent(_none_content_provider, StrictModel)
+        raw = _MockMessage({"role": "assistant", "content": None})
+        with pytest.raises(llm_errors.ResponseParseError) as exc_info:
+            agent._parse_response(None, raw_response=raw)
+        err = exc_info.value
+        assert "assistant" in err.raw_content
+        assert "empty content" in (err.validation_errors or "")
+
+    def test_empty_string_content_pydantic_raises(self):
+        agent = _make_agent(_none_content_provider, StrictModel)
+        with pytest.raises(llm_errors.ResponseParseError) as exc_info:
+            agent._parse_response("")
+        assert "empty content" in (exc_info.value.validation_errors or "")
+
+    def test_empty_string_content_str_output_returns_empty(self):
+        agent = _make_agent(_none_content_provider, str)
+        assert agent._parse_response("") == ""
 
 
 class TestResponseParseErrorUnification:

--- a/src/runtime/python/tests/unit/test_provider_agentic_loop_output_config.py
+++ b/src/runtime/python/tests/unit/test_provider_agentic_loop_output_config.py
@@ -364,7 +364,12 @@ class TestOutputConfigShortCircuitContentFallback:
         from mesh.helpers import _provider_agentic_loop
 
         # The model returned no parsable text — extractor will yield None.
+        # Null out every non-text carrier so the recovery step also finds
+        # nothing (MagicMock auto-vivifies attributes otherwise), exercising
+        # the genuine "nothing recoverable → emit ''" path.
         msg = _message(content=None, tool_calls=None)
+        msg.parsed = None
+        msg.provider_specific_fields = None
 
         with patch(
             "asyncio.to_thread", new=AsyncMock(return_value=_response(msg))
@@ -395,3 +400,255 @@ class TestOutputConfigShortCircuitContentFallback:
         # The critical assertion: never ``None``, always ``""``.
         assert result["content"] == ""
         assert result["content"] is not None
+
+
+class TestOutputConfigNonTextCarrierRecovery:
+    """Newer litellm output_config transforms can leave ``message.content``
+    empty while the structured JSON rides in a non-text carrier (``parsed`` /
+    ``provider_specific_fields`` / ``tool_calls``). The loop must recover it
+    before building the envelope; when nothing is recoverable it must WARN
+    (naming the model + mode) and still return ``content: ""``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_recovers_from_parsed_when_content_empty(self):
+        from mesh.helpers import _provider_agentic_loop
+
+        msg = _message(content=None, tool_calls=None)
+        msg.parsed = {"destination": "Paris", "days": 5}
+        msg.provider_specific_fields = None
+
+        with patch(
+            "asyncio.to_thread", new=AsyncMock(return_value=_response(msg))
+        ), patch(
+            "mesh.helpers._maybe_run_synthetic_fallback", new=AsyncMock()
+        ), patch(
+            "mesh.helpers._maybe_run_hint_fallback", new=AsyncMock()
+        ):
+            result = await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-6",
+                messages=[{"role": "user", "content": "Plan a Paris trip."}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_output_config_mode": True,
+                    "_mesh_output_config_schema": _trip_schema(),
+                    "_mesh_output_config_output_type_name": "Trip",
+                },
+                litellm_kwargs={},
+                vendor="anthropic",
+            )
+
+        assert json.loads(result["content"]) == {"destination": "Paris", "days": 5}
+
+    @pytest.mark.asyncio
+    async def test_recovers_from_provider_specific_fields(self):
+        from mesh.helpers import _provider_agentic_loop
+
+        msg = _message(content=None, tool_calls=None)
+        msg.parsed = None
+        msg.provider_specific_fields = {
+            "parsed": {"destination": "Tokyo", "days": 3}
+        }
+
+        with patch(
+            "asyncio.to_thread", new=AsyncMock(return_value=_response(msg))
+        ), patch(
+            "mesh.helpers._maybe_run_synthetic_fallback", new=AsyncMock()
+        ), patch(
+            "mesh.helpers._maybe_run_hint_fallback", new=AsyncMock()
+        ):
+            result = await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-6",
+                messages=[{"role": "user", "content": "Plan a Tokyo trip."}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_output_config_mode": True,
+                    "_mesh_output_config_schema": _trip_schema(),
+                    "_mesh_output_config_output_type_name": "Trip",
+                },
+                litellm_kwargs={},
+                vendor="anthropic",
+            )
+
+        assert json.loads(result["content"]) == {"destination": "Tokyo", "days": 3}
+
+    @pytest.mark.asyncio
+    async def test_warns_and_returns_empty_when_nothing_recoverable(self, caplog):
+        from mesh.helpers import _provider_agentic_loop
+
+        msg = _message(content=None, tool_calls=None)
+        msg.parsed = None
+        msg.provider_specific_fields = None
+
+        with patch(
+            "asyncio.to_thread", new=AsyncMock(return_value=_response(msg))
+        ), patch(
+            "mesh.helpers._maybe_run_synthetic_fallback", new=AsyncMock()
+        ), patch(
+            "mesh.helpers._maybe_run_hint_fallback", new=AsyncMock()
+        ):
+            with caplog.at_level("WARNING", logger="mesh.helpers"):
+                result = await _provider_agentic_loop(
+                    effective_model="anthropic/claude-sonnet-4-6",
+                    messages=[{"role": "user", "content": "Q?"}],
+                    tools=[],
+                    tool_endpoints={},
+                    model_params={
+                        "_mesh_output_config_mode": True,
+                        "_mesh_output_config_schema": _trip_schema(),
+                        "_mesh_output_config_output_type_name": "Trip",
+                    },
+                    litellm_kwargs={},
+                    vendor="anthropic",
+                )
+
+        # Still returns an envelope with content "".
+        assert result["content"] == ""
+        # WARN names the output type, the model, and the empty-carrier reason.
+        warn_msgs = [
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+        ]
+        assert any(
+            "Trip" in m
+            and "claude-sonnet-4-6" in m
+            and "no recoverable structured carrier" in m
+            for m in warn_msgs
+        ), f"Expected empty-carrier WARN; got: {warn_msgs}"
+
+
+class TestRecoverStructuredContentHelper:
+    """Direct unit coverage for ``_recover_structured_content_from_message``."""
+
+    def test_recovers_from_parsed(self):
+        from mesh.helpers import _recover_structured_content_from_message
+
+        msg = _message(content=None, tool_calls=None)
+        msg.parsed = {"answer": "42"}
+        msg.provider_specific_fields = None
+        assert json.loads(_recover_structured_content_from_message(msg)) == {
+            "answer": "42"
+        }
+
+    def test_recovers_empty_dict_from_provider_specific_fields(self):
+        """A legitimately falsy structured payload (empty dict) MUST still be
+        recovered as ``"{}"`` — the carrier check is presence-based
+        (``is not None``), not truthiness."""
+        from mesh.helpers import _recover_structured_content_from_message
+
+        msg = _message(content=None, tool_calls=None)
+        msg.parsed = None
+        msg.provider_specific_fields = {"parsed": {}}
+        assert _recover_structured_content_from_message(msg) == "{}"
+
+    def test_parsed_takes_priority_over_provider_specific_fields(self):
+        """When BOTH ``parsed`` and ``provider_specific_fields`` are present,
+        ``parsed`` wins (it is the first-class Structured Outputs carrier)."""
+        from mesh.helpers import _recover_structured_content_from_message
+
+        msg = _message(content=None, tool_calls=None)
+        msg.parsed = {"answer": "from_parsed"}
+        msg.provider_specific_fields = {"parsed": {"answer": "from_psf"}}
+        assert json.loads(_recover_structured_content_from_message(msg)) == {
+            "answer": "from_parsed"
+        }
+
+    def test_ignores_tool_calls_carrier(self):
+        """``tool_calls`` are NOT a recovery carrier — on a tool-call turn the
+        arguments are the invocation, not the answer. With only tool_calls and
+        no parsed/psf, recovery returns ``None``."""
+        from mesh.helpers import _recover_structured_content_from_message
+
+        msg = _message(
+            content=None,
+            tool_calls=[
+                _tool_call("c1", "get_weather", '{"city": "NYC"}')
+            ],
+        )
+        msg.parsed = None
+        msg.provider_specific_fields = None
+        assert _recover_structured_content_from_message(msg) is None
+
+    def test_returns_none_when_nothing_recoverable(self):
+        from mesh.helpers import _recover_structured_content_from_message
+
+        msg = _message(content=None, tool_calls=None)
+        msg.parsed = None
+        msg.provider_specific_fields = None
+        assert _recover_structured_content_from_message(msg) is None
+
+
+class TestIntermediateToolCallReplayUnchanged:
+    """item-1 protected surface: an intermediate tool-call turn whose adapter
+    ``content`` is ``None`` (the common real-tool-call-with-no-preamble case)
+    MUST be replayed to the model with ``content: ""`` — never with fabricated
+    JSON tool args. Guards against the reverted adapter tool-arg fallback
+    re-appearing and polluting the assistant history.
+    """
+
+    @pytest.mark.asyncio
+    async def test_tool_call_turn_replayed_with_empty_content(self):
+        from mesh.helpers import _provider_agentic_loop
+
+        # Iter 1: real tool call, no text preamble (content=None).
+        # Iter 2: final text answer terminates the loop.
+        tool_call_msg = _message(
+            content=None,
+            tool_calls=[_tool_call("call_1", "get_weather", '{"city": "NYC"}')],
+        )
+        final_msg = _message(content="It's sunny.", tool_calls=None)
+
+        async def _passthrough(*, final_content, message, response, **kwargs):
+            return final_content, message, response
+
+        completion = AsyncMock(
+            side_effect=[_response(tool_call_msg), _response(final_msg)]
+        )
+        with patch("asyncio.to_thread", new=completion), patch(
+            "mesh.helpers._execute_tool_calls_for_iteration",
+            new=AsyncMock(
+                return_value=(
+                    [
+                        {
+                            "role": "tool",
+                            "tool_call_id": "call_1",
+                            "content": "sunny",
+                        }
+                    ],
+                    [],
+                )
+            ),
+        ), patch(
+            "mesh.helpers._maybe_run_synthetic_fallback",
+            new=AsyncMock(side_effect=_passthrough),
+        ), patch(
+            "mesh.helpers._maybe_run_hint_fallback",
+            new=AsyncMock(side_effect=_passthrough),
+        ):
+            await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-6",
+                messages=[{"role": "user", "content": "Weather in NYC?"}],
+                tools=[
+                    {"type": "function", "function": {"name": "get_weather"}}
+                ],
+                tool_endpoints={"get_weather": "http://weather"},
+                model_params={},
+                litellm_kwargs={},
+                max_iterations=5,
+                vendor="anthropic",
+            )
+
+        # Inspect the conversation replayed on iteration 2.
+        second_call_messages = completion.await_args_list[1].kwargs["messages"]
+        assistant_tool_turns = [
+            m
+            for m in second_call_messages
+            if m.get("role") == "assistant" and m.get("tool_calls")
+        ]
+        assert assistant_tool_turns, (
+            "expected the intermediate tool-call assistant turn in the replay"
+        )
+        # The critical assertion: content is the empty string, NOT fabricated
+        # JSON tool args.
+        assert assistant_tool_turns[0]["content"] == ""

--- a/src/runtime/python/tests/unit/test_provider_agentic_loop_synthetic_format.py
+++ b/src/runtime/python/tests/unit/test_provider_agentic_loop_synthetic_format.py
@@ -729,3 +729,69 @@ class TestStreamingLoopSyntheticRecognition:
         # Mesh internal flags MUST NOT reach the wire.
         assert "_mesh_synthetic_format_tool" not in sent
         assert "_mesh_synthetic_format_tool_name" not in sent
+
+
+# ---------------------------------------------------------------------------
+# String-content contract: the synthetic path's envelope ``content`` must
+# always be a string. Consumers (Java ``extractContent``, TS, Python)
+# JSON-parse string content and drop a Map/dict to "". ``synthetic_args`` is
+# a JSON string today, but ``_coerce_content_to_str`` is the guard that keeps
+# a future dict from silently leaking into the envelope.
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceContentToStr:
+    def test_str_passthrough(self):
+        from mesh.helpers import _coerce_content_to_str
+
+        assert _coerce_content_to_str('{"a": 1}') == '{"a": 1}'
+
+    def test_none_becomes_empty_string(self):
+        from mesh.helpers import _coerce_content_to_str
+
+        assert _coerce_content_to_str(None) == ""
+
+    def test_dict_is_json_serialized(self):
+        from mesh.helpers import _coerce_content_to_str
+
+        assert json.loads(_coerce_content_to_str({"a": 1})) == {"a": 1}
+
+
+class TestSyntheticEnvelopeContentIsString:
+    @pytest.mark.asyncio
+    async def test_dict_synthetic_args_serialized_to_string(self, monkeypatch):
+        """Regression guard: even if the synthetic-args extractor were to
+        return a raw dict, the envelope's ``content`` must be a string."""
+        from mesh.helpers import _provider_agentic_loop
+
+        # Disable the schema-validation retry so this test isolates the
+        # envelope-coercion behavior (the retry path is exercised elsewhere).
+        monkeypatch.setenv("MCP_MESH_LLM_SYNTHETIC_RETRY_MAX", "0")
+
+        msg = _message(
+            content=None,
+            tool_calls=[_tool_call("toolu_1", SYNTHETIC_TOOL_NAME, "{}")],
+        )
+
+        with patch(
+            "asyncio.to_thread", new=AsyncMock(return_value=_response(msg))
+        ), patch(
+            # Force the (hypothetical) dict shape to exercise the coercion.
+            "mesh.helpers._extract_synthetic_format_arguments",
+            return_value=({"answer": "42"}, "toolu_1"),
+        ):
+            result = await _provider_agentic_loop(
+                effective_model="anthropic/claude-sonnet-4-5",
+                messages=[{"role": "user", "content": "Q?"}],
+                tools=[],
+                tool_endpoints={},
+                model_params={
+                    "_mesh_synthetic_format_tool_name": SYNTHETIC_TOOL_NAME,
+                    "_mesh_synthetic_format_tool": _synthetic_tool(),
+                },
+                litellm_kwargs={},
+                vendor="anthropic",
+            )
+
+        assert isinstance(result["content"], str)
+        assert json.loads(result["content"]) == {"answer": "42"}

--- a/src/runtime/typescript/src/__tests__/llm-agent-content-recovery.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-agent-content-recovery.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Consumer-side recovery + honest diagnostics for the mesh provider's
+ * ``{ role, content }`` reply envelope (llm-agent.ts).
+ *
+ * Providers should send the answer as a string. Two malformed-but-recoverable
+ * shapes occur in the field:
+ *   1. ``content`` is a raw object — the structured answer leaked unserialized.
+ *      ``complete()`` serializes it so downstream schema parsing sees JSON.
+ *   2. the map carries neither ``content`` nor ``role`` — a bare structured
+ *      answer without the envelope; the whole map is treated as the answer.
+ *
+ * When content resolves to empty under a response schema, ``run()`` blames the
+ * empty reply and surfaces the raw payload — not an opaque "could not extract
+ * JSON".
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
+
+vi.mock("@mcpmesh/core", () => ({
+  generateTraceId: () => "trace-mock",
+  generateSpanId: () => "span-mock",
+  injectTraceContext: (argsJson: string) => argsJson,
+  publishSpan: vi.fn(async () => false),
+  parseSseResponse: (s: string) => s,
+  parseSseResponseToObject: (s: string) => JSON.parse(s),
+  extractJson: (s: string) => s,
+}));
+
+vi.mock("../http-pool.js", () => ({
+  getDispatcher: () => undefined,
+}));
+
+import { MeshDelegatedProvider, MeshLlmAgent } from "../llm-agent.js";
+import { ResponseParseError } from "../errors.js";
+import type { LlmMessage } from "../types.js";
+
+const ENDPOINT = "http://provider.local:9001";
+const FN_BUFFERED = "process_chat";
+
+function mcpJsonResponse(payload: object): Response {
+  const envelope = {
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      content: [{ type: "text", text: JSON.stringify(payload) }],
+    },
+  };
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+    text: async () => JSON.stringify(envelope),
+    json: async () => envelope,
+  } as unknown as Response;
+}
+
+describe("MeshDelegatedProvider.complete() — content normalization", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  function stub(payload: object) {
+    globalThis.fetch = vi.fn(
+      async () => mcpJsonResponse(payload)
+    ) as unknown as typeof fetch;
+  }
+
+  async function completeWith(payload: object): Promise<string | undefined> {
+    stub(payload);
+    const provider = new MeshDelegatedProvider(ENDPOINT, FN_BUFFERED, false);
+    const messages: LlmMessage[] = [{ role: "user", content: "hi" }];
+    const res = await provider.complete("anthropic/claude-sonnet-4-5", messages);
+    return res.choices[0]?.message.content as string | undefined;
+  }
+
+  it("string content passes through unchanged (regression)", async () => {
+    expect(await completeWith({ role: "assistant", content: "ok" })).toBe("ok");
+  });
+
+  it("object content is serialized to a JSON string", async () => {
+    const answer = { count: 5, name: "x" };
+    expect(await completeWith({ role: "assistant", content: answer })).toBe(
+      JSON.stringify(answer)
+    );
+  });
+
+  it("bare map without content/role keys is serialized whole", async () => {
+    const bare = { verdict: "BLOCK", reason: "policy" };
+    expect(await completeWith(bare)).toBe(JSON.stringify(bare));
+  });
+
+  it("error map is NOT treated as a bare answer (stays empty)", async () => {
+    expect(await completeWith({ error: "rate limited by vendor" })).toBe("");
+  });
+
+  it("bare answer with a null error field is still recovered", async () => {
+    const payload = { data: "ok", error: null, verdict: "PASS" };
+    expect(await completeWith(payload)).toBe(JSON.stringify(payload));
+  });
+
+  it("tool_calls-only map is NOT treated as a bare answer (stays empty)", async () => {
+    const payload = {
+      tool_calls: [
+        { id: "call_1", type: "function", function: { name: "f", arguments: "{}" } },
+      ],
+    };
+    expect(await completeWith(payload)).toBe("");
+  });
+
+  it("_mesh_usage-only map is NOT treated as a bare answer (stays empty)", async () => {
+    expect(
+      await completeWith({ _mesh_usage: { prompt_tokens: 1, completion_tokens: 2 } })
+    ).toBe("");
+  });
+
+  it("empty-string content in a real envelope stays empty", async () => {
+    expect(await completeWith({ role: "assistant", content: "" })).toBe("");
+  });
+
+  it("null content in a real envelope stays empty (legal, e.g. tool calls)", async () => {
+    expect(
+      await completeWith({ role: "assistant", content: null })
+    ).toBe("");
+  });
+});
+
+describe("MeshLlmAgent.run() — empty-content diagnostic", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  const schema = z.object({ answer: z.string() });
+
+  function makeAgent() {
+    return new MeshLlmAgent({
+      functionId: "test.recovery",
+      provider: { capability: "llm" },
+      maxIterations: 5,
+      returnSchema: schema,
+    });
+  }
+
+  function stub(payload: object) {
+    globalThis.fetch = vi.fn(
+      async () => mcpJsonResponse(payload)
+    ) as unknown as typeof fetch;
+  }
+
+  it("empty content under a response schema → ResponseParseError with raw payload", async () => {
+    stub({ role: "assistant", content: "" });
+    const agent = makeAgent();
+    await expect(
+      agent.run("hi", {
+        tools: [],
+        meshProvider: { endpoint: ENDPOINT, functionName: FN_BUFFERED },
+      })
+    ).rejects.toMatchObject({
+      name: "ResponseParseError",
+    });
+
+    stub({ role: "assistant", content: "" });
+    const agent2 = makeAgent();
+    const err = await agent2
+      .run("hi", {
+        tools: [],
+        meshProvider: { endpoint: ENDPOINT, functionName: FN_BUFFERED },
+      })
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(ResponseParseError);
+    expect(err.message).toContain("empty content");
+    expect(err.message).toContain("Raw response payload:");
+  });
+
+  it("object content under a response schema → parses instead of failing", async () => {
+    stub({ role: "assistant", content: { answer: "structured" } });
+    const agent = makeAgent();
+    const result = await agent.run("hi", {
+      tools: [],
+      meshProvider: { endpoint: ENDPOINT, functionName: FN_BUFFERED },
+    });
+    expect(result).toEqual({ answer: "structured" });
+  });
+
+  it("genuine bare answer under a response schema → recovered (not an error)", async () => {
+    stub({ answer: "bare" });
+    const agent = makeAgent();
+    const result = await agent.run("hi", {
+      tools: [],
+      meshProvider: { endpoint: ENDPOINT, functionName: FN_BUFFERED },
+    });
+    expect(result).toEqual({ answer: "bare" });
+  });
+
+  it("error map → diagnostic surfaces the error payload, not a schema failure", async () => {
+    stub({ error: "rate limited by vendor" });
+    const agent = makeAgent();
+    const err = await agent
+      .run("hi", {
+        tools: [],
+        meshProvider: { endpoint: ENDPOINT, functionName: FN_BUFFERED },
+      })
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(ResponseParseError);
+    expect(err.message).toContain("empty content");
+    expect(err.message).toContain("rate limited by vendor");
+  });
+});

--- a/src/runtime/typescript/src/llm-agent.ts
+++ b/src/runtime/typescript/src/llm-agent.ts
@@ -53,6 +53,7 @@ import {
   MaxIterationsError,
   LLMAPIError,
   ToolExecutionError,
+  ResponseParseError,
 } from "./errors.js";
 import { resolveMediaInputs } from "./media/index.js";
 import {
@@ -149,11 +150,20 @@ export class MeshDelegatedProvider implements LlmProvider {
   private endpoint: string;
   private functionName: string;
   private parallelToolCalls: boolean;
+  // Raw wire payload of the most recent complete() reply, retained so run() can
+  // surface it in the empty-content diagnostic (the normalized assistant message
+  // drops non-answer keys like "error").
+  private _lastRawResponse: string | undefined;
 
   constructor(endpoint: string, functionName: string, parallelToolCalls: boolean = false) {
     this.endpoint = endpoint;
     this.functionName = functionName;
     this.parallelToolCalls = parallelToolCalls;
+  }
+
+  /** Raw wire payload of the last complete() reply (for diagnostics). */
+  get lastRawResponse(): string | undefined {
+    return this._lastRawResponse;
   }
 
   /**
@@ -308,12 +318,14 @@ export class MeshDelegatedProvider implements LlmProvider {
     if (typeof content !== "string") {
       throw new Error("Invalid response from mesh provider");
     }
+    // Retain the raw wire payload for the empty-content diagnostic in run().
+    this._lastRawResponse = content;
 
     // Parse the LLM provider response
     // Format: { role, content, tool_calls?, _mesh_usage? }
     const meshResponse = JSON.parse(content) as {
-      role: string;
-      content: string;
+      role?: string;
+      content?: unknown;
       tool_calls?: Array<{
         id: string;
         type: "function";
@@ -321,6 +333,45 @@ export class MeshDelegatedProvider implements LlmProvider {
       }>;
       _mesh_usage?: { prompt_tokens: number; completion_tokens: number };
     };
+
+    // Normalize the envelope's content to a string. Providers should send the
+    // answer as a string, but two malformed-but-recoverable shapes occur:
+    //   1. content is a raw object — the structured answer leaked unserialized.
+    //      Serialize it so downstream schema parsing sees valid JSON.
+    //   2. the map has neither "content" nor "role" — a bare structured answer
+    //      returned without the envelope; treat the whole map as the answer.
+    //      Guard: maps carrying reserved wire keys (tool_calls / _mesh_usage) or
+    //      a TRUTHY "error" are NOT answers — leave empty so run()'s empty-content
+    //      diagnostic surfaces the real payload (e.g. a vendor error) rather than
+    //      a misleading schema-validation failure. An `error: null` value is a
+    //      plain model field, so a falsy error does not disqualify a bare answer.
+    let normalizedContent: string;
+    const rawContent = meshResponse.content;
+    const meshMap = meshResponse as Record<string, unknown>;
+    const looksBareAnswer =
+      !("content" in meshResponse) &&
+      !("role" in meshResponse) &&
+      !("tool_calls" in meshResponse) &&
+      !("_mesh_usage" in meshResponse) &&
+      !meshMap.error;
+    if (typeof rawContent === "string") {
+      normalizedContent = rawContent;
+    } else if (rawContent !== null && typeof rawContent === "object") {
+      console.warn(
+        "[mesh.llm] Provider sent structured (object) content; normalizing to a JSON string"
+      );
+      normalizedContent = JSON.stringify(rawContent);
+    } else if (looksBareAnswer) {
+      console.warn(
+        "[mesh.llm] Provider returned a bare structured answer without an envelope; treating the whole map as content"
+      );
+      normalizedContent = JSON.stringify(meshResponse);
+    } else {
+      // content is null/undefined inside a real envelope — legal (tool calls,
+      // max-token cutoff). Leave empty; run() surfaces a diagnostic if this
+      // becomes the final answer under a response schema.
+      normalizedContent = "";
+    }
 
     // Validate role - LLM responses should always be "assistant"
     let validatedRole: "assistant" = "assistant";
@@ -341,7 +392,7 @@ export class MeshDelegatedProvider implements LlmProvider {
           index: 0,
           message: {
             role: validatedRole,
-            content: meshResponse.content,
+            content: normalizedContent,
             tool_calls: meshResponse.tool_calls,
           },
           finish_reason: meshResponse.tool_calls ? "tool_calls" : "stop",
@@ -752,6 +803,22 @@ export class MeshLlmAgent<T = string> {
       model,
       provider: this.getProviderName(context),
     };
+
+    // Empty final content under a response schema is not a parse problem — the
+    // provider reply carried no answer (lost upstream). Blame that honestly and
+    // include the raw payload, rather than an opaque "could not extract JSON".
+    if (finalContent === "" && this.config.returnSchema) {
+      // Prefer the raw wire payload (carries non-answer keys like "error");
+      // fall back to the normalized assistant message.
+      const rawPayload =
+        (provider instanceof MeshDelegatedProvider
+          ? provider.lastRawResponse
+          : undefined) ?? JSON.stringify(messages[messages.length - 1] ?? {});
+      throw new ResponseParseError(
+        `Provider reply had empty content; nothing to parse as the response schema. Raw response payload: ${rawPayload.slice(0, 500)}`,
+        rawPayload
+      );
+    }
 
     // Parse and validate response
     return this.responseParser.parse(finalContent);


### PR DESCRIPTION
## Summary
- **Provider (Python, primary fix)**: the `{role, content}` reply envelope now always carries the answer as a string. The `output_config` structured-output path recovers the answer from `message.parsed` / `provider_specific_fields` when the text-block join is empty (upstream client libraries move structured output between text blocks, tool-call arguments, and parsed fields across versions); envelope content is coerced to valid-JSON strings at every construction site; a warning naming model + mode + truncated raw message fires when nothing is recoverable, instead of silently emitting empty content.
- **OpenAI native adapter**: recovers a `parsed`-only response (`content=None`) — gated on the message having no tool calls, so content is never fabricated on an ordinary tool-call turn and replayed assistant history is byte-for-byte unchanged (pinned by tests).
- **Consumers (Python / TypeScript / Java, defense in depth)**: dict/Map-shaped `content` is serialized and parsed normally; a bare envelope-less map is recovered as the answer itself (excluding maps carrying a truthy `error`, `tool_calls`, or `_mesh_usage` — those route to the diagnostic path so real failures stay visible); empty-content parse failures now include a truncated snippet of the raw provider payload instead of a bare "failed to parse as <Model>".

## Review Notes
Two independent zero-context review passes were applied during development:
- Pass 1 found (and the fix removed) an adapter-level fallback that would have leaked tool-call arguments into replayed assistant history on every agentic tool turn; recovery now lives only where the no-tool-calls context is known.
- Pass 2: 0 blockers; both warnings fixed (truthy-`error` bare-map exclusion; hardened `json.dumps` in the Python consumer). Remaining known-minor INFOs, deliberately deferred: TS serializes array-shaped content whole where Java/Python extract the first block's text; TS streaming path's empty-content diagnostic falls back to the last message rather than the raw wire payload; Java uses `isBlank()` where Python/TS check `== ""`.

Closes #1247

## Test plan
- [x] Unit tests across all three runtimes: string-content contract, recovery priorities (`parsed` > `provider_specific_fields`), bare-map recovery + exclusions, empty-content diagnostics, non-serializable-leaf hardening
- [x] Regression pins: happy path (text present) behavior-identical; intermediate tool-call turns replay with unchanged history
- [x] `tsuite run --suite-path tests/src-tests` — 12/12 (all SDKs build, local image rebuilt)
- [x] `tsuite run --suite-path tests/integration --parallel 8` — full suite green (7 transient failures passed on targeted re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for structured outputs returned in unexpected forms (including nested wrappers and bare answer maps), reducing empty-response parsing failures.
  * Tool-call-only and metadata-only payloads are no longer misclassified as final answers.
  * When final content is blank, thrown parsing errors now include a truncated snippet of the original provider payload for easier troubleshooting.
  * Enhanced multi-runtime content normalization so non-text carriers and structured “parsed” fields are handled consistently.
* **Tests**
  * Added extensive coverage for content recovery and “empty content” diagnostics across agent loops and delegated providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->