### PR TITLE
feat(di): required=true parity (Java/TS) + reliable dep-update delivery

### DIFF
--- a/docs/concepts/dddi.md
+++ b/docs/concepts/dddi.md
@@ -226,6 +226,14 @@ Unlike traditional DI where injection happens once at startup, DDDI continuously
 
 When a dependency is unavailable, DDDI injects `None` (Python), `null` (TypeScript/Java) instead of throwing an exception. Agents are designed to check availability and provide fallback behavior.
 
+Strictness is opt-in, per edge. Mark a dependency **required** — `{"capability": "x", "required": True}` (Python), `{ capability: "x", required: true }` (TypeScript), `@Selector(required = true)` / `@MeshDependency(required = true)` (Java) — and the registry folds that edge into a transitive availability predicate:
+
+> a capability is **available** ⇔ its owning agent is healthy **AND** every one of its `required` dependencies resolves to an available provider
+
+An unavailable capability is excluded from resolution exactly like an unhealthy provider, and that exclusion propagates to its own consumers through the existing dependency-update channel — so downstream proxies flip with no code changes. Optional edges never propagate (soft-fail stays the default everywhere you do not opt in). For HTTP routes, the framework's own wrapper returns `503 {"error":"dependency_unavailable","capability":...}` when a required dependency is unavailable at request time. Cycles among required edges can never converge, so the registry rejects the registration that would close one, naming the loop (`required dependency cycle: a → b → a`); cycles through an optional edge stay legal for bootstrapping.
+
+See the language dependency-injection pages for declaration syntax and the full model.
+
 ### Protocol-Agnostic Proxies
 
 Injected proxies abstract away the communication protocol. Today they use MCP over HTTP; tomorrow they could use gRPC or WebSockets without any changes to agent code.

--- a/docs/java/dependency-injection.md
+++ b/docs/java/dependency-injection.md
@@ -282,6 +282,40 @@ public TimeResponse getTime(McpMeshTool<String> dateService) {
 }
 ```
 
+## Required Dependencies
+
+Graceful degradation is the default — an unresolved dependency injects a `null`/unavailable proxy and your agent keeps serving. When a capability is useless without a particular dependency, mark that edge `required` instead of checking `isAvailable()` everywhere. Use `required = true` on `@Selector` (tools) or `@MeshDependency` (routes / `@MeshDependsOn`):
+
+```java
+@MeshTool(capability = "report",
+          description = "Generate a report from mesh data",
+          dependencies = @Selector(capability = "data_service", required = true))
+public Report generateReport(McpMeshTool<Data> dataService) {
+    // dataService is guaranteed live — no isAvailable() check needed
+    return new Report(dataService.call());
+}
+```
+
+`required` defaults to `false` and combines with the other selector fields (`tags`, `version`, `expectedType`).
+
+**What it changes.** The registry now computes a capability as **available** only when its owning agent is healthy *and* every one of its `required` dependencies resolves to an available provider. This is transitive — in a chain `A → B → C`, if `C` goes down then `B` becomes unavailable and `A` becomes unavailable in turn. An unavailable capability drops out of resolution exactly like an unhealthy provider, so any consumer's proxy for it flips to unavailable automatically, with no code change. Optional edges never propagate, so soft-fail stays the default everywhere you don't opt in.
+
+**HTTP routes get an automatic 503.** External callers to a `@MeshRoute` don't go through proxies, so when a route declares a required dependency that is unavailable at request time, the framework returns `503` before your handler runs (after the settle window):
+
+```java
+@GetMapping("/report")
+@MeshRoute(dependencies = @MeshDependency(capability = "data_service", required = true))
+public ResponseEntity<Report> report(McpMeshTool<Data> dataService) {
+    return ResponseEntity.ok(new Report(dataService.call()));
+}
+```
+
+The response body is `{"error":"dependency_unavailable","capability":"data_service"}`. This required check takes precedence over the coarser `failOnMissingDependency` flag — a required-dep 503 fires regardless of that flag, and only non-required missing deps fall through to it.
+
+**Cycles are rejected.** A cycle of required edges could never converge (both ends stay unavailable forever), so the registry rejects the registration that closes one and logs, on the rejected agent, a `required dependency cycle: analyst → enricher → analyst` registration failure. Cycles that route through an optional edge remain legal — that's the bootstrapping path.
+
+**Inspecting availability.** Each capability in the agents/capabilities API carries `available` (boolean) and, when false, `unavailable_reason` naming the first broken edge — e.g. `required dep 'data_service' unavailable (provider agent-7 unhealthy)` or `required dep 'weather-api' unresolved (no provider matches tags=[+prod])`. The capability stays visible in the registry, UI, and `meshctl`; availability is distinct from presence.
+
 ## Auto-Rewiring
 
 When topology changes (agents join/leave), the mesh:

--- a/docs/python/dependency-injection.md
+++ b/docs/python/dependency-injection.md
@@ -135,6 +135,45 @@ async def get_time(date_service: mesh.McpMeshTool = None):
     return datetime.now().isoformat()  # Fallback
 ```
 
+## Required Dependencies
+
+Graceful degradation is the default — an unresolved dependency injects `None` and your agent keeps serving. When a capability is useless without a particular dependency, mark that edge `required` instead of null-checking it everywhere:
+
+```python
+@app.tool()
+@mesh.tool(
+    capability="report",
+    dependencies=[
+        {"capability": "data_service", "required": True},
+        {"capability": "formatter"},  # optional (default)
+    ],
+)
+async def generate_report(
+    data_svc: mesh.McpMeshTool = None,
+    formatter: mesh.McpMeshTool = None,
+) -> str:
+    data = await data_svc(query="sales")  # data_svc is guaranteed live
+    if formatter:
+        return await formatter(data=data)
+    return str(data)
+```
+
+`required` defaults to `False` and combines with the other selector fields (`tags`, `version`, `expected_type`).
+
+**What it changes.** The registry now computes a capability as **available** only when its owning agent is healthy *and* every one of its `required` dependencies resolves to an available provider. This is transitive — in a chain `A → B → C`, if `C` goes down then `B` becomes unavailable and `A` becomes unavailable in turn. An unavailable capability drops out of resolution exactly like an unhealthy provider, so any consumer's proxy for it flips to `None` automatically, with no code change. Optional edges never propagate, so soft-fail stays the default everywhere you don't opt in.
+
+**HTTP routes get an automatic 503.** External callers to a `@mesh.route` don't go through proxies, so when a route declares a required dependency that is unavailable at request time, the framework returns `503` before your handler runs (after the settle window):
+
+```json
+{ "error": "dependency_unavailable", "capability": "data_service" }
+```
+
+Streaming routes can't carry a pre-body 503, so they bypass the perimeter and keep soft-fail semantics — check `None` there.
+
+**Cycles are rejected.** A cycle of required edges could never converge (both ends stay unavailable forever), so the registry rejects the registration that closes one and logs, on the rejected agent, `Agent registration failed: required dependency cycle: analyst → enricher → analyst`. Cycles that route through an optional edge remain legal — that's the bootstrapping path.
+
+**Inspecting availability.** Each capability in the agents/capabilities API carries `available` (boolean) and, when false, `unavailable_reason` naming the first broken edge — e.g. `required dep 'data_service' unavailable (provider agent-7 unhealthy)` or `required dep 'weather-api' unresolved (no provider matches tags=[+prod])`. The capability stays visible in the registry, UI, and `meshctl`; availability is distinct from presence.
+
 ## Proxy Configuration
 
 Configure proxy behavior via `dependency_kwargs`:

--- a/docs/typescript/dependency-injection.md
+++ b/docs/typescript/dependency-injection.md
@@ -38,7 +38,7 @@ agent.addTool({
   parameters: z.object({
     name: z.string(),
   }),
-  execute: async ({ name }, { date_service }) => {
+  execute: async ({ name }, date_service: McpMeshTool | null = null) => {
     if (date_service) {
       const today = await date_service({});
       return `Hello ${name}! Today is ${today}`;
@@ -48,7 +48,7 @@ agent.addTool({
 });
 ```
 
-**Important**: Dependencies are injected as the second parameter to `execute`, keyed by capability name. They may be `null` if unavailable.
+**Important**: Dependencies are injected **positionally** as parameters after the first `args` parameter, in declaration order (`dependencies[0]`, `dependencies[1]`, ...). They may be `null` if unavailable.
 
 ### Dependencies with Filters
 
@@ -63,7 +63,11 @@ agent.addTool({
     { capability: "formatter", tags: ["-deprecated"] },
   ],
   parameters: z.object({}),
-  execute: async ({}, { data_service, formatter }) => {
+  execute: async (
+    {},
+    data_service: McpMeshTool | null = null, // dependencies[0]
+    formatter: McpMeshTool | null = null,    // dependencies[1]
+  ) => {
     if (!data_service || !formatter) {
       return "Required services unavailable";
     }
@@ -89,7 +93,7 @@ agent.addTool({
     a: z.number(),
     b: z.number(),
   }),
-  execute: async ({ a, b }, { math }) => {
+  execute: async ({ a, b }, math: McpMeshTool | null = null) => {
     if (!math) return "Math service unavailable";
     const result = await math({ a, b });
     return result;
@@ -113,7 +117,8 @@ and want to prefer one but fallback to another if unavailable.
 Callable proxy for tool invocations:
 
 ```typescript
-execute: async ({}, { helper }) => {
+// dependencies: ["helper"] → helper is dependencies[0]
+execute: async ({}, helper: McpMeshTool | null = null) => {
   if (helper) {
     // Direct call (calls default tool)
     const result = await helper({ arg1: "value" });
@@ -153,7 +158,7 @@ agent.addTool({
   capability: "my_capability",
   dependencies: ["helper"],
   parameters: z.object({}),
-  execute: async ({}, { helper }) => {
+  execute: async ({}, helper: McpMeshTool | null = null) => {
     if (helper === null) {
       return "Service temporarily unavailable";
     }
@@ -170,7 +175,7 @@ agent.addTool({
   capability: "time_service",
   dependencies: ["date_service"],
   parameters: z.object({}),
-  execute: async ({}, { date_service }) => {
+  execute: async ({}, date_service: McpMeshTool | null = null) => {
     if (date_service) {
       return await date_service({});
     }
@@ -179,25 +184,66 @@ agent.addTool({
 });
 ```
 
+## Required Dependencies
+
+Graceful degradation is the default — an unresolved dependency injects `null` and your agent keeps serving. When a capability is useless without a particular dependency, mark that edge `required` instead of null-checking it everywhere:
+
+```typescript
+agent.addTool({
+  name: "generate_report",
+  capability: "report",
+  dependencies: [
+    { capability: "data_service", required: true },
+    { capability: "formatter" }, // optional (default)
+  ],
+  parameters: z.object({}),
+  // Tool deps inject POSITIONALLY as McpMeshTool params after args
+  // (dependencies[0], dependencies[1], ...).
+  execute: async (
+    {},
+    data_service: McpMeshTool | null = null, // dependencies[0] — required, guaranteed live
+    formatter: McpMeshTool | null = null,    // dependencies[1] — optional
+  ) => {
+    const data = await data_service!({ query: "sales" }); // guaranteed live
+    return formatter ? await formatter({ data }) : JSON.stringify(data);
+  },
+});
+```
+
+`required` defaults to `false` and combines with the other selector fields (`tags`, `version`, `expectedSchema`).
+
+**What it changes.** The registry now computes a capability as **available** only when its owning agent is healthy _and_ every one of its `required` dependencies resolves to an available provider. This is transitive — in a chain `A → B → C`, if `C` goes down then `B` becomes unavailable and `A` becomes unavailable in turn. An unavailable capability drops out of resolution exactly like an unhealthy provider, so any consumer's proxy for it flips to `null` automatically, with no code change. Optional edges never propagate, so soft-fail stays the default everywhere you don't opt in.
+
+**HTTP routes get an automatic 503.** External callers to a `mesh.route()` handler don't go through proxies, so when a route declares a required dependency that is unavailable at request time, the framework returns `503` before your handler runs (after the settle window):
+
+```json
+{ "error": "dependency_unavailable", "capability": "data_service" }
+```
+
+**Cycles are rejected.** A cycle of required edges could never converge (both ends stay unavailable forever), so the registry rejects the registration that closes one and logs, on the rejected agent, a `required dependency cycle: analyst → enricher → analyst` registration failure. Cycles that route through an optional edge remain legal — that's the bootstrapping path.
+
+**Inspecting availability.** Each capability in the agents/capabilities API carries `available` (boolean) and, when false, `unavailable_reason` naming the first broken edge — e.g. `required dep 'data_service' unavailable (provider agent-7 unhealthy)` or `required dep 'weather-api' unresolved (no provider matches tags=[+prod])`. The capability stays visible in the registry, UI, and `meshctl`; availability is distinct from presence.
+
 ## Proxy Configuration
 
-Configure proxy behavior via `dependencyConfig`:
+Configure proxy behavior via `dependencyKwargs` — an array indexed by dependency position (aligned with `dependencies`):
 
 ```typescript
 agent.addTool({
   name: "my_tool",
   capability: "my_capability",
   dependencies: ["slow_service"],
-  dependencyConfig: {
-    slow_service: {
-      timeout: 60000, // Request timeout (milliseconds)
-      retryCount: 3, // Retry attempts
-      streaming: true, // Enable streaming
+  dependencyKwargs: [
+    {
+      // Config for dependencies[0] (slow_service)
+      timeout: 60, // Request timeout in seconds (default 30)
+      maxAttempts: 3, // Total attempts incl. the first try (default 1)
+      streaming: true, // Enable streaming (uses streamTimeout)
       sessionRequired: true, // Require session affinity
     },
-  },
+  ],
   parameters: z.object({ data: z.string() }),
-  execute: async ({ data }, { slow_service }) => {
+  execute: async ({ data }, slow_service: McpMeshTool | null = null) => {
     if (slow_service) {
       return await slow_service({ data });
     }
@@ -237,10 +283,14 @@ No code changes needed - happens transparently.
 Dependencies are typed based on the capability name:
 
 ```typescript
-// Dependencies are McpMeshTool | null
-execute: async (params, deps: Record<string, McpMeshTool | null>) => {
-  const { date_service, weather_service } = deps;
-
+// dependencies: ["date_service", "weather_service"]
+// Each dependency is McpMeshTool | null, injected positionally in
+// declaration order after the first args parameter.
+execute: async (
+  params,
+  date_service: McpMeshTool | null = null,    // dependencies[0]
+  weather_service: McpMeshTool | null = null, // dependencies[1]
+) => {
   if (date_service) {
     // TypeScript knows this is McpMeshTool
     const result = await date_service({});
@@ -274,7 +324,9 @@ agent.addTool({
   }),
   execute: async (
     { quarter, year },
-    { data_service, formatter, audit_log },
+    data_service: McpMeshTool | null = null, // dependencies[0]
+    formatter: McpMeshTool | null = null,    // dependencies[1]
+    audit_log: McpMeshTool | null = null,    // dependencies[2] (string form)
   ) => {
     // Graceful degradation for each dependency
     if (!data_service) {

--- a/src/core/cli/man/content/api.md
+++ b/src/core/cli/man/content/api.md
@@ -136,6 +136,19 @@ async def greet(request: Request, greeting: McpMeshTool = None):
     return {"message": result.get("text")}
 ```
 
+## Required Dependencies
+
+To skip the hand-written `None`-check above, mark the dependency `required`. When a required dependency is unavailable at request time, the framework's own wrapper returns **503** with body `{"error":"dependency_unavailable","capability":"<cap>"}` before your handler runs (after the settle window):
+
+```python
+@mesh.route(dependencies=[{"capability": "greeting", "required": True}])
+async def greet(request: Request, greeting: McpMeshTool = None):
+    result = await greeting(name="World")  # framework guarantees greeting is live
+    return {"message": result.get("text")}
+```
+
+Streaming routes bypass the 503 perimeter by design and keep soft-fail semantics — check `None` there. See `meshctl man dependency-injection` for the full availability model, transitive propagation, and cycle rules.
+
 ## See Also
 
 - `meshctl man decorators` - All mesh decorators

--- a/src/core/cli/man/content/api_java.md
+++ b/src/core/cli/man/content/api_java.md
@@ -176,6 +176,22 @@ public ResponseEntity<?> greetWithFallback(
 
 Without this flag, a missing dependency returns `503 Service Unavailable` automatically.
 
+## Required Dependencies
+
+`failOnMissingDependency` is a coarse per-route switch. To mark a single edge strict, set `required = true` on its `@MeshDependency`. When that dependency is unavailable at request time, the framework's interceptor returns **503** with body `{"error":"dependency_unavailable","capability":"<cap>"}` before your handler runs (after the settle window):
+
+```java
+@GetMapping("/greet")
+@MeshRoute(dependencies = @MeshDependency(capability = "greeting", required = true))
+public ResponseEntity<?> greet(@RequestParam(defaultValue = "World") String name,
+                               McpMeshTool<Map<String, Object>> greeting) {
+    // framework guarantees greeting is live
+    return ResponseEntity.ok(greeting.call(Map.of("name", name)));
+}
+```
+
+The required check takes precedence over `failOnMissingDependency`: a required-dep 503 fires regardless of that flag, and only non-required missing deps fall through to the coarse backstop. See `meshctl man dependency-injection --java` for the full availability model, transitive propagation, and cycle rules.
+
 ## How It Works
 
 1. Spring Boot starts and detects `@MeshRoute` annotations (no `@MeshAgent` needed)

--- a/src/core/cli/man/content/api_typescript.md
+++ b/src/core/cli/man/content/api_typescript.md
@@ -173,6 +173,26 @@ app.post(
 );
 ```
 
+## Required Dependencies
+
+To skip the hand-written `null`-check above, mark the dependency `required`. When a required dependency is unavailable at request time, the framework's own middleware returns **503** with body `{"error":"dependency_unavailable","capability":"<cap>"}` before your handler runs (after the settle window):
+
+```typescript
+app.post(
+  "/greet",
+  mesh.route(
+    [{ capability: "greeting", required: true }],
+    async (req, res, { greeting }) => {
+      // framework guarantees greeting is live
+      const result = await greeting({ name: req.body.name });
+      res.json({ message: result.text });
+    },
+  ),
+);
+```
+
+See `meshctl man dependency-injection --typescript` for the full availability model, transitive propagation, and cycle rules.
+
 ## See Also
 
 - `meshctl man decorators` - All mesh decorators and functions

--- a/src/core/cli/man/content/dependency-injection.md
+++ b/src/core/cli/man/content/dependency-injection.md
@@ -195,6 +195,68 @@ async def get_time(date_service: mesh.McpMeshTool = None):
     return datetime.now().isoformat()  # Fallback
 ```
 
+## Required Dependencies
+
+By default a dependency is optional: an unresolved dependency injects `None`, and the agent still starts, registers, and serves (soft-fail). Mark an edge `required` to opt that single edge into strictness:
+
+```python
+@app.tool()
+@mesh.tool(
+    capability="report",
+    dependencies=[
+        {"capability": "data_service", "required": True},
+        {"capability": "formatter"},  # optional (default)
+    ],
+)
+async def generate_report(
+    data_svc: mesh.McpMeshTool = None,
+    formatter: mesh.McpMeshTool = None,
+) -> str: ...
+```
+
+`required` defaults to `False` and combines with the other selector fields (`tags`, `version`, `expected_type`). It is carried on the wire only when `True`.
+
+### Availability Semantics
+
+The registry computes a capability-availability predicate:
+
+> a capability is **available** ⇔ its owning agent is healthy **AND** every one of its `required` dependencies resolves to an available provider (full tag / version / schema matching)
+
+The predicate is **transitive**: in a required chain `A → B → C`, if `C` goes down then `B` becomes unavailable and `A` becomes unavailable in turn. Optional edges never propagate — strictness flows only along edges you mark `required`, so the soft-fail default is preserved everywhere else.
+
+An unavailable capability is excluded from resolution exactly like an unhealthy provider — it drops out at the resolver's `health` stage. Consumers holding a proxy to it see the proxy flip to `None` through the same background dependency-update channel that already delivers topology changes — no code changes, no SDK upgrade required.
+
+### Route Perimeter (503)
+
+Mesh-internal calls go through proxies; external HTTP callers to a `@mesh.route` do not. When a route declares a required dependency that is unavailable at call time, the framework's own wrapper returns **503** — before your handler runs, after the settle window — with the body:
+
+```json
+{ "error": "dependency_unavailable", "capability": "data_service" }
+```
+
+503 rather than 404 so monitoring alarms on 5xx, load-balancer health checks eject the instance, and clients see a retryable "unavailable" instead of a permanent "missing". A caller that supplies its own value for the slot (a test override) is honored and skips the check.
+
+**Streaming routes** (`is_stream=True`) bypass the 503 perimeter by design — an in-flight stream cannot carry a pre-body 503 — so a streaming route's required deps stay soft-fail (`None` injected). The framework logs a warning at registration so the author knows enforcement is off for that route.
+
+### Cycle Rule
+
+A cycle among `required` edges can never converge (both ends stay unavailable forever), so the registry rejects the registration/heartbeat that would close one, loudly naming the loop:
+
+```
+required dependency cycle: analyst → enricher → analyst
+```
+
+The rejected agent logs `Agent registration failed: required dependency cycle: …` and keeps retrying on each heartbeat until the loop is broken. Cycles routed through an **optional** edge remain legal — that is the bootstrapping path.
+
+### Observing Availability
+
+The agents/capabilities API carries two derived fields per capability:
+
+- `available` — the predicate above (boolean)
+- `unavailable_reason` — set when `available` is false; names the first broken edge with its constraint detail, e.g. `required dep 'weather-api' unresolved (no provider matches tags=[+prod])`, `required dep 'data_service' unavailable (provider agent-7 unhealthy)`, or `agent unhealthy` when the owning agent is itself down.
+
+The capability stays visible in the registry, UI, and `meshctl` (availability is distinct from presence), so the reason chain is a diagnostic upgrade, not a disappearance.
+
 ## Proxy Configuration
 
 Per-dependency proxy options (timeout, retry, streaming, session affinity, auth, custom headers, etc.) are configured via `dependency_kwargs`. See `meshctl man proxies` for the full options table.

--- a/src/core/cli/man/content/dependency-injection_java.md
+++ b/src/core/cli/man/content/dependency-injection_java.md
@@ -329,6 +329,63 @@ public TimeResponse getTime(McpMeshTool<String> dateService) {
 }
 ```
 
+## Required Dependencies
+
+By default a dependency is optional: an unresolved dependency injects a `null`/unavailable proxy, and the agent still starts, registers, and serves (soft-fail). Mark an edge `required` to opt that single edge into strictness — `@Selector(required = true)` on a `@MeshTool`, `@MeshDependency(required = true)` on a `@MeshRoute` or `@MeshDependsOn`:
+
+```java
+@MeshTool(capability = "report",
+          dependencies = @Selector(capability = "data_service", required = true))
+public Report generateReport(McpMeshTool<Data> dataService) { ... }
+
+@MeshRoute(dependencies = {
+    @MeshDependency(capability = "data_service", required = true)
+})
+@PostMapping("/report")
+public ResponseEntity<Report> report(McpMeshTool<Data> dataService) { ... }
+```
+
+`required` defaults to `false` and combines with the other selector fields (`tags`, `version`, `expectedType`). It is carried on the wire only when `true`.
+
+### Availability Semantics
+
+The registry computes a capability-availability predicate:
+
+> a capability is **available** ⇔ its owning agent is healthy **AND** every one of its `required` dependencies resolves to an available provider (full tag / version / schema matching)
+
+The predicate is **transitive**: in a required chain `A → B → C`, if `C` goes down then `B` becomes unavailable and `A` becomes unavailable in turn. Optional edges never propagate — strictness flows only along edges you mark `required`, so the soft-fail default is preserved everywhere else.
+
+An unavailable capability is excluded from resolution exactly like an unhealthy provider — it drops out at the resolver's `health` stage. Consumers holding a proxy to it see it flip to unavailable through the same background dependency-update channel that already delivers topology changes — no code changes, no SDK upgrade required.
+
+### Route Perimeter (503)
+
+Mesh-internal calls go through proxies; external HTTP callers to a `@MeshRoute` do not. When a route declares a required dependency that is unavailable at call time, the framework's own interceptor returns **503** — before your handler runs, after the settle window — with the body:
+
+```json
+{ "error": "dependency_unavailable", "capability": "data_service" }
+```
+
+503 rather than 404 so monitoring alarms on 5xx, load-balancer health checks eject the instance, and clients see a retryable "unavailable" instead of a permanent "missing". The required check takes precedence over the coarser `failOnMissingDependency` backstop: a required-dep 503 fires regardless of that flag, and only non-required missing deps fall through to `failOnMissingDependency`.
+
+### Cycle Rule
+
+A cycle among `required` edges can never converge (both ends stay unavailable forever), so the registry rejects the registration/heartbeat that would close one, loudly naming the loop:
+
+```
+required dependency cycle: analyst → enricher → analyst
+```
+
+The rejected agent logs the registration failure and keeps retrying on each heartbeat until the loop is broken. Cycles routed through an **optional** edge remain legal — that is the bootstrapping path.
+
+### Observing Availability
+
+The agents/capabilities API carries two derived fields per capability:
+
+- `available` — the predicate above (boolean)
+- `unavailable_reason` — set when `available` is false; names the first broken edge with its constraint detail, e.g. `required dep 'weather-api' unresolved (no provider matches tags=[+prod])`, `required dep 'data_service' unavailable (provider agent-7 unhealthy)`, or `agent unhealthy` when the owning agent is itself down.
+
+The capability stays visible in the registry, UI, and `meshctl` (availability is distinct from presence), so the reason chain is a diagnostic upgrade, not a disappearance.
+
 ## Auto-Rewiring
 
 When topology changes (agents join/leave), the mesh:

--- a/src/core/cli/man/content/dependency-injection_typescript.md
+++ b/src/core/cli/man/content/dependency-injection_typescript.md
@@ -47,7 +47,7 @@ agent.addTool({
   parameters: z.object({
     name: z.string(),
   }),
-  execute: async ({ name }, { date_service }) => {
+  execute: async ({ name }, date_service: McpMeshTool | null = null) => {
     if (date_service) {
       const today = await date_service({});
       return `Hello ${name}! Today is ${today}`;
@@ -57,7 +57,7 @@ agent.addTool({
 });
 ```
 
-**Important**: Dependencies are injected as the second parameter to `execute`, keyed by capability name. They may be `null` if unavailable.
+**Important**: Dependencies are injected **positionally** as parameters after the first `args` parameter, in declaration order (`dependencies[0]`, `dependencies[1]`, ...). They may be `null` if unavailable.
 
 ### Dependencies with Filters
 
@@ -72,7 +72,11 @@ agent.addTool({
     { capability: "formatter", tags: ["-deprecated"] },
   ],
   parameters: z.object({}),
-  execute: async ({}, { data_service, formatter }) => {
+  execute: async (
+    {},
+    data_service: McpMeshTool | null = null, // dependencies[0]
+    formatter: McpMeshTool | null = null,    // dependencies[1]
+  ) => {
     if (!data_service || !formatter) {
       return "Required services unavailable";
     }
@@ -106,7 +110,7 @@ agent.addTool({
     },
   ],
   parameters: z.object({}),
-  execute: async ({}, { lookup_employee }) => { /* ... */ },
+  execute: async ({}, lookup_employee: McpMeshTool | null = null) => { /* ... */ },
 });
 ```
 
@@ -128,7 +132,7 @@ agent.addTool({
     a: z.number(),
     b: z.number(),
   }),
-  execute: async ({ a, b }, { math }) => {
+  execute: async ({ a, b }, math: McpMeshTool | null = null) => {
     if (!math) return "Math service unavailable";
     const result = await math({ a, b });
     return result;
@@ -152,7 +156,8 @@ and want to prefer one but fallback to another if unavailable.
 Callable proxy for tool invocations:
 
 ```typescript
-execute: async ({}, { helper }) => {
+// dependencies: ["helper"] → helper is dependencies[0]
+execute: async ({}, helper: McpMeshTool | null = null) => {
   if (helper) {
     // Direct call (calls default tool)
     const result = await helper({ arg1: "value" });
@@ -192,7 +197,7 @@ agent.addTool({
   capability: "my_capability",
   dependencies: ["helper"],
   parameters: z.object({}),
-  execute: async ({}, { helper }) => {
+  execute: async ({}, helper: McpMeshTool | null = null) => {
     if (helper === null) {
       return "Service temporarily unavailable";
     }
@@ -209,7 +214,7 @@ agent.addTool({
   capability: "time_service",
   dependencies: ["date_service"],
   parameters: z.object({}),
-  execute: async ({}, { date_service }) => {
+  execute: async ({}, date_service: McpMeshTool | null = null) => {
     if (date_service) {
       return await date_service({});
     }
@@ -218,25 +223,90 @@ agent.addTool({
 });
 ```
 
+## Required Dependencies
+
+By default a dependency is optional: an unresolved dependency injects `null`, and the agent still starts, registers, and serves (soft-fail). Mark an edge `required` to opt that single edge into strictness:
+
+```typescript
+agent.addTool({
+  name: "generate_report",
+  capability: "report",
+  dependencies: [
+    { capability: "data_service", required: true },
+    { capability: "formatter" }, // optional (default)
+  ],
+  parameters: z.object({}),
+  // Tool deps inject POSITIONALLY as McpMeshTool params after args
+  // (dependencies[0], dependencies[1], ...).
+  execute: async (
+    {},
+    data_service: McpMeshTool | null = null, // dependencies[0] — required
+    formatter: McpMeshTool | null = null,    // dependencies[1] — optional
+  ) => { /* ... */ },
+});
+```
+
+`required` defaults to `false` and combines with the other selector fields (`tags`, `version`, `expectedSchema`). It is carried on the wire only when `true`.
+
+### Availability Semantics
+
+The registry computes a capability-availability predicate:
+
+> a capability is **available** ⇔ its owning agent is healthy **AND** every one of its `required` dependencies resolves to an available provider (full tag / version / schema matching)
+
+The predicate is **transitive**: in a required chain `A → B → C`, if `C` goes down then `B` becomes unavailable and `A` becomes unavailable in turn. Optional edges never propagate — strictness flows only along edges you mark `required`, so the soft-fail default is preserved everywhere else.
+
+An unavailable capability is excluded from resolution exactly like an unhealthy provider — it drops out at the resolver's `health` stage. Consumers holding a proxy to it see the proxy flip to `null` through the same background dependency-update channel that already delivers topology changes — no code changes, no SDK upgrade required.
+
+### Route Perimeter (503)
+
+Mesh-internal calls go through proxies; external HTTP callers to a `mesh.route()` handler do not. When a route declares a required dependency that is unavailable at call time, the framework's own middleware returns **503** — before your handler runs, after the settle window — with the body:
+
+```json
+{ "error": "dependency_unavailable", "capability": "data_service" }
+```
+
+503 rather than 404 so monitoring alarms on 5xx, load-balancer health checks eject the instance, and clients see a retryable "unavailable" instead of a permanent "missing".
+
+### Cycle Rule
+
+A cycle among `required` edges can never converge (both ends stay unavailable forever), so the registry rejects the registration/heartbeat that would close one, loudly naming the loop:
+
+```
+required dependency cycle: analyst → enricher → analyst
+```
+
+The rejected agent logs the registration failure and keeps retrying on each heartbeat until the loop is broken. Cycles routed through an **optional** edge remain legal — that is the bootstrapping path.
+
+### Observing Availability
+
+The agents/capabilities API carries two derived fields per capability:
+
+- `available` — the predicate above (boolean)
+- `unavailable_reason` — set when `available` is false; names the first broken edge with its constraint detail, e.g. `required dep 'weather-api' unresolved (no provider matches tags=[+prod])`, `required dep 'data_service' unavailable (provider agent-7 unhealthy)`, or `agent unhealthy` when the owning agent is itself down.
+
+The capability stays visible in the registry, UI, and `meshctl` (availability is distinct from presence), so the reason chain is a diagnostic upgrade, not a disappearance.
+
 ## Proxy Configuration
 
-Configure proxy behavior via `dependencyConfig`:
+Configure proxy behavior via `dependencyKwargs` — an array indexed by dependency position (aligned with `dependencies`):
 
 ```typescript
 agent.addTool({
   name: "my_tool",
   capability: "my_capability",
   dependencies: ["slow_service"],
-  dependencyConfig: {
-    slow_service: {
-      timeout: 60000, // Request timeout (milliseconds)
-      retryCount: 3, // Retry attempts
-      streaming: true, // Enable streaming
+  dependencyKwargs: [
+    {
+      // Config for dependencies[0] (slow_service)
+      timeout: 60, // Request timeout in seconds (default 30)
+      maxAttempts: 3, // Total attempts incl. the first try (default 1)
+      streaming: true, // Enable streaming (uses streamTimeout)
       sessionRequired: true, // Require session affinity
     },
-  },
+  ],
   parameters: z.object({ data: z.string() }),
-  execute: async ({ data }, { slow_service }) => {
+  execute: async ({ data }, slow_service: McpMeshTool | null = null) => {
     if (slow_service) {
       return await slow_service({ data });
     }
@@ -276,10 +346,14 @@ No code changes needed - happens transparently.
 Dependencies are typed based on the capability name:
 
 ```typescript
-// Dependencies are McpMeshTool | null
-execute: async (params, deps: Record<string, McpMeshTool | null>) => {
-  const { date_service, weather_service } = deps;
-
+// dependencies: ["date_service", "weather_service"]
+// Each dependency is McpMeshTool | null, injected positionally in
+// declaration order after the first args parameter.
+execute: async (
+  params,
+  date_service: McpMeshTool | null = null,    // dependencies[0]
+  weather_service: McpMeshTool | null = null, // dependencies[1]
+) => {
   if (date_service) {
     // TypeScript knows this is McpMeshTool
     const result = await date_service({});
@@ -313,7 +387,9 @@ agent.addTool({
   }),
   execute: async (
     { quarter, year },
-    { data_service, formatter, audit_log },
+    data_service: McpMeshTool | null = null, // dependencies[0]
+    formatter: McpMeshTool | null = null,    // dependencies[1]
+    audit_log: McpMeshTool | null = null,    // dependencies[2] (string form)
   ) => {
     // Graceful degradation for each dependency
     if (!data_service) {

--- a/src/runtime/core/src/handle.rs
+++ b/src/runtime/core/src/handle.rs
@@ -9,6 +9,7 @@
 use pyo3::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{mpsc, Mutex, RwLock};
 
 use crate::events::{HealthStatus, MeshEvent};
@@ -85,6 +86,42 @@ impl AgentHandle {
     pub fn event_rx(&self) -> Arc<Mutex<mpsc::Receiver<MeshEvent>>> {
         self.event_rx.clone()
     }
+
+    /// Cancel-safe pull of the next mesh event, with an internal liveness
+    /// timeout.
+    ///
+    /// Returns:
+    /// - `Some(event)` when an event is available;
+    /// - `Some(MeshEvent::shutdown())` when the runtime channel has closed;
+    /// - `None` when `timeout` elapsed with no event (a loop-liveness tick so
+    ///   callers can re-check their own shutdown flag).
+    ///
+    /// # Cancel-safety invariant
+    /// This function never removes a message from the channel that it does not
+    /// return. `mpsc::Receiver::recv` is cancel-safe, and `tokio::time::timeout`
+    /// only drops the `recv` future when the timer wins the race — at which
+    /// point `recv` has not yet dequeued anything. This is the whole point of
+    /// pushing the timeout *inside* the future (issue #1256): the previous
+    /// design wrapped `next_event()` in an external `asyncio.wait_for(...)`,
+    /// whose cancellation could fire in the window *after* `recv` dequeued a
+    /// message but *before* it crossed the pyo3→asyncio boundary, silently
+    /// dropping that event and permanently stalling a dependency edge. With
+    /// the timeout internal, callers loop on plain `.await`s and no event is
+    /// ever cancelled mid-delivery.
+    pub async fn pull_next_event(
+        event_rx: Arc<Mutex<mpsc::Receiver<MeshEvent>>>,
+        timeout: Duration,
+    ) -> Option<MeshEvent> {
+        let mut rx = event_rx.lock().await;
+        match tokio::time::timeout(timeout, rx.recv()).await {
+            Ok(Some(event)) => Some(event),
+            // Channel closed — surface the shutdown sentinel so the caller
+            // can break its loop, matching the pre-existing contract.
+            Ok(None) => Some(MeshEvent::shutdown()),
+            // Timer won the race; recv did not dequeue anything (cancel-safe).
+            Err(_) => None,
+        }
+    }
 }
 
 /// Python-specific methods for AgentHandle
@@ -93,12 +130,24 @@ impl AgentHandle {
 impl AgentHandle {
     /// Wait for and return the next mesh event.
     ///
-    /// This is an async method that blocks until an event is available.
-    /// Returns None when the runtime has shut down.
+    /// This is an async method that resolves either with the next event or,
+    /// after a short internal liveness timeout, with `None`. `None` means "no
+    /// event yet" — the caller should loop and re-check its own shutdown flag,
+    /// then call `next_event()` again. A `shutdown` event is returned when the
+    /// runtime channel closes.
+    ///
+    /// # Cancel-safety (issue #1256)
+    /// The timeout lives *inside* this future (see [`Self::pull_next_event`]),
+    /// so callers MUST NOT wrap this in an external `asyncio.wait_for(...)`
+    /// cancellation: doing so can drop a dequeued event in the window between
+    /// the mpsc pop and delivery to Python, permanently stalling a dependency
+    /// edge. Loop on plain `await handle.next_event()` and branch on `None`.
     ///
     /// # Example (Python)
     /// ```python
     /// event = await handle.next_event()
+    /// if event is None:
+    ///     continue  # liveness tick; re-check shutdown and loop
     /// if event.event_type == "dependency_available":
     ///     print(f"Dependency {event.capability} at {event.endpoint}")
     /// ```
@@ -106,14 +155,7 @@ impl AgentHandle {
         let event_rx = self.event_rx.clone();
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let mut rx = event_rx.lock().await;
-            match rx.recv().await {
-                Some(event) => Ok(event),
-                None => {
-                    // Channel closed, return shutdown event
-                    Ok(MeshEvent::shutdown())
-                }
-            }
+            Ok(AgentHandle::pull_next_event(event_rx, Duration::from_secs(1)).await)
         })
     }
 
@@ -404,6 +446,85 @@ mod tests {
 
         handle.shutdown_async().await;
         assert!(handle.is_shutdown_requested_async().await);
+    }
+
+    /// Issue #1256: the event pull must be cancel-safe across its internal
+    /// liveness timeout. A slow consumer that lets many timeout ticks elapse
+    /// between events must still observe EVERY event — none may be dropped in
+    /// the recv→deliver window. Uses a 1ms timeout so the consumer takes many
+    /// `None` ticks between the producer's events.
+    #[tokio::test]
+    async fn test_next_event_pull_is_cancel_safe_across_timeout_ticks() {
+        use crate::events::EventType;
+
+        let (event_tx, event_rx) = mpsc::channel(100);
+        let event_rx = Arc::new(Mutex::new(event_rx));
+
+        let n = 25u32;
+        let producer = tokio::spawn(async move {
+            for i in 0..n {
+                // Delay straddles the pull timeout so the consumer sees many
+                // `None` ticks between deliveries.
+                tokio::time::sleep(Duration::from_millis(3)).await;
+                event_tx
+                    .send(MeshEvent::dependency_available(
+                        format!("cap-{i}"),
+                        "http://endpoint".to_string(),
+                        "func".to_string(),
+                        "agent".to_string(),
+                        "requesting_fn".to_string(),
+                        0,
+                        None,
+                    ))
+                    .await
+                    .unwrap();
+            }
+            // Dropping the sender closes the channel; recv drains buffered
+            // messages first, then yields the shutdown sentinel.
+        });
+
+        let mut got = 0u32;
+        loop {
+            match AgentHandle::pull_next_event(event_rx.clone(), Duration::from_millis(1)).await {
+                Some(ev) if ev.event_type == EventType::Shutdown => break,
+                Some(_) => got += 1,
+                None => {} // liveness tick — keep looping
+            }
+        }
+
+        producer.await.unwrap();
+        assert_eq!(
+            got, n,
+            "no event may be lost across internal timeout ticks (cancel-safety)"
+        );
+    }
+
+    /// A pull against an idle channel must resolve to `None` (a liveness tick)
+    /// once the internal timeout elapses — not block forever.
+    #[tokio::test]
+    async fn test_next_event_pull_times_out_to_none_when_idle() {
+        let (_event_tx, event_rx) = mpsc::channel::<MeshEvent>(4);
+        let event_rx = Arc::new(Mutex::new(event_rx));
+
+        let result = AgentHandle::pull_next_event(event_rx, Duration::from_millis(20)).await;
+        assert!(result.is_none(), "idle channel must yield a None liveness tick");
+    }
+
+    /// When the channel closes, the pull must surface the shutdown sentinel
+    /// (not `None`) so the caller breaks its loop.
+    #[tokio::test]
+    async fn test_next_event_pull_returns_shutdown_on_close() {
+        use crate::events::EventType;
+
+        let (event_tx, event_rx) = mpsc::channel::<MeshEvent>(4);
+        let event_rx = Arc::new(Mutex::new(event_rx));
+        drop(event_tx);
+
+        let result = AgentHandle::pull_next_event(event_rx, Duration::from_secs(5)).await;
+        match result {
+            Some(ev) => assert_eq!(ev.event_type, EventType::Shutdown),
+            None => panic!("closed channel must yield a shutdown event, not a timeout tick"),
+        }
     }
 
     #[test]

--- a/src/runtime/core/src/napi.rs
+++ b/src/runtime/core/src/napi.rs
@@ -34,6 +34,12 @@ pub struct JsDependencySpec {
     pub expected_schema_hash: Option<String>,
     /// Issue #547: schema match mode ("subset" or "strict")
     pub match_mode: Option<String>,
+    /// Issue #1249: opt-in strictness for this dependency edge. When true, the
+    /// registry factors this edge into transitive capability availability and
+    /// routes declaring it return 503 when the proxy is unavailable at call
+    /// time. Optional/absent → false, keeping existing heartbeats byte-identical
+    /// (the field is omitted from the wire when false).
+    pub required: Option<bool>,
 }
 
 impl From<JsDependencySpec> for RustDependencySpec {
@@ -45,9 +51,9 @@ impl From<JsDependencySpec> for RustDependencySpec {
             js.expected_schema_canonical,
             js.expected_schema_hash,
             js.match_mode,
-            // Issue #1249: TS SDK does not surface `required` yet — default
-            // false keeps existing TypeScript heartbeats byte-identical.
-            false,
+            // Issue #1249: absent → false so zero-required meshes stay
+            // byte-identical on the wire (DependencySpec omits false).
+            js.required.unwrap_or(false),
         )
     }
 }
@@ -1124,6 +1130,35 @@ mod tests {
         let rust_spec: RustAgentSpec = js_spec.into();
         assert_eq!(rust_spec.agent_type, AgentType::Api);
         assert_eq!(rust_spec.http_port, 0);
+    }
+
+    #[test]
+    fn test_js_dependency_required_passthrough() {
+        // Issue #1249: required=Some(true) reaches the Rust DependencySpec.
+        let js_required = JsDependencySpec {
+            capability: "weather-api".to_string(),
+            tags: "[]".to_string(),
+            version: None,
+            expected_schema_canonical: None,
+            expected_schema_hash: None,
+            match_mode: None,
+            required: Some(true),
+        };
+        let rust_dep: RustDependencySpec = js_required.into();
+        assert!(rust_dep.required);
+
+        // Absent (None) → false, keeping existing TS heartbeats byte-identical.
+        let js_absent = JsDependencySpec {
+            capability: "weather-api".to_string(),
+            tags: "[]".to_string(),
+            version: None,
+            expected_schema_canonical: None,
+            expected_schema_hash: None,
+            match_mode: None,
+            required: None,
+        };
+        let rust_dep_absent: RustDependencySpec = js_absent.into();
+        assert!(!rust_dep_absent.required);
     }
 
     #[test]

--- a/src/runtime/core/src/runtime.rs
+++ b/src/runtime/core/src/runtime.rs
@@ -6,9 +6,9 @@
 //! - Sends events to the Python SDK via channels
 //! - Tracks topology changes and emits dependency events
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, watch, RwLock};
 use tokio::time::sleep;
 use tracing::{info, trace, warn};
@@ -137,6 +137,21 @@ pub struct AgentRuntime {
     /// `watch::Receiver` and wakes when this transitions to `Some(n>0)`.
     /// Initialized to `None` (no pending work known).
     pending_jobs_tx: watch::Sender<Option<u32>>,
+    /// Minimum interval between dependency reconcile re-emissions (issue
+    /// #1256). On a full heartbeat the pure edge-diff only emits an event
+    /// when an endpoint actually changes and records the edge as delivered
+    /// on `send()` — i.e. on *enqueue*, not on *apply*. If that event is
+    /// ever dropped downstream of the channel (e.g. a cancelled pull at the
+    /// pyo3 boundary before #1256's fix), the diff gate would suppress it
+    /// forever. The reconcile pass re-emits the FULL set of currently
+    /// resolved dependencies so any lost edge self-heals. It is throttled by
+    /// this interval so bursts of full heartbeats (topology churn) don't
+    /// produce a re-emit storm; re-applying an unchanged endpoint is
+    /// idempotent on the SDK side.
+    reconcile_interval: Duration,
+    /// Timestamp of the last dependency reconcile re-emission (`None` until
+    /// the first). See [`Self::reconcile_interval`].
+    last_dep_reconcile: Option<Instant>,
 }
 
 impl AgentRuntime {
@@ -176,6 +191,8 @@ impl AgentRuntime {
             command_rx,
             force_full_heartbeat: false,
             pending_jobs_tx,
+            reconcile_interval: Duration::from_secs(10),
+            last_dep_reconcile: None,
         })
     }
 
@@ -655,6 +672,9 @@ impl AgentRuntime {
             self.topology.dependencies.remove(&key);
         }
 
+        // Track the keys emitted by the edge-diff this cycle so the reconcile
+        // pass below doesn't double-emit them.
+        let mut just_emitted: HashSet<DepKey> = HashSet::new();
         for (key, value, is_new) in added_or_changed {
             let event = if is_new {
                 MeshEvent::dependency_available(
@@ -686,7 +706,53 @@ impl AgentRuntime {
                 continue;
             }
 
+            just_emitted.insert(key.clone());
             self.topology.dependencies.insert(key, value);
+        }
+
+        // Reconcile pass (issue #1256): the edge-diff above records an edge as
+        // delivered when `send()` succeeds — i.e. on enqueue, not on apply. If
+        // a dependency event is ever dropped downstream of the channel, the
+        // diff gate would suppress it forever and the consumer's proxy stays
+        // unbound. To self-heal, periodically re-emit the FULL set of
+        // currently resolved dependencies (idempotent on the SDK side).
+        //
+        // Throttled by `reconcile_interval` so bursts of full heartbeats
+        // (topology churn) don't produce a re-emit storm. Only re-emits edges
+        // that are already recorded in `topology` (i.e. believed-delivered);
+        // brand-new edges are left to the diff gate's own next-heartbeat retry
+        // so a genuinely-failed `send` isn't masked. Skips edges just emitted
+        // above to avoid a double-emit within the same heartbeat.
+        let reconcile_due = self
+            .last_dep_reconcile
+            .map(|t| t.elapsed() >= self.reconcile_interval)
+            .unwrap_or(true);
+        if reconcile_due {
+            self.last_dep_reconcile = Some(Instant::now());
+            for (key, value) in &new_deps {
+                if just_emitted.contains(key) {
+                    continue;
+                }
+                if !self.topology.dependencies.contains_key(key) {
+                    continue;
+                }
+                let event = MeshEvent::dependency_available(
+                    value.capability.clone(),
+                    value.endpoint.clone(),
+                    value.function_name.clone(),
+                    value.agent_id.clone(),
+                    key.requesting_function.clone(),
+                    key.dep_index,
+                    value.kwargs.clone(),
+                );
+                if let Err(e) = self.event_tx.send(event).await {
+                    warn!(
+                        "Reconcile: failed to re-emit dependency '{}' at {}:{}: {}; \
+                         will retry on next reconcile",
+                        value.capability, key.requesting_function, key.dep_index, e
+                    );
+                }
+            }
         }
     }
 
@@ -1159,5 +1225,155 @@ mod tests {
             "no heartbeat may be sent after shutdown arrived during backoff"
         );
         unregister.assert_async().await;
+    }
+
+    // ---- Issue #1256: diff-gate reconcile self-heal ----
+
+    fn reconcile_spec() -> crate::spec::AgentSpec {
+        crate::spec::AgentSpec::new(
+            "reconcile-agent".to_string(),
+            "http://127.0.0.1:1".to_string(),
+            "1.0.0".to_string(),
+            "".to_string(),
+            8080,
+            "localhost".to_string(),
+            "default".to_string(),
+            None,
+            None,
+            None,
+            None,
+            5,
+            None,
+        )
+    }
+
+    fn resolved_single(
+        capability: &str,
+        endpoint: &str,
+    ) -> HashMap<String, Vec<crate::registry::ResolvedDependency>> {
+        let mut m = HashMap::new();
+        m.insert(
+            "consumer_fn".to_string(),
+            vec![crate::registry::ResolvedDependency {
+                agent_id: "provider-agent".to_string(),
+                endpoint: endpoint.to_string(),
+                function_name: "provider_fn".to_string(),
+                capability: capability.to_string(),
+                status: "available".to_string(),
+                ttl: 0,
+                kwargs: None,
+            }],
+        );
+        m
+    }
+
+    async fn new_reconcile_runtime(
+        event_tx: mpsc::Sender<MeshEvent>,
+    ) -> AgentRuntime {
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let (_command_tx, command_rx) = mpsc::channel(10);
+        let shared_state = Arc::new(RwLock::new(HandleState::default()));
+        AgentRuntime::new(
+            reconcile_spec(),
+            RuntimeConfig::default(),
+            event_tx,
+            shared_state,
+            shutdown_rx,
+            command_rx,
+        )
+        .await
+        .expect("runtime construction should succeed")
+    }
+
+    fn drain_available(rx: &mut mpsc::Receiver<MeshEvent>) -> usize {
+        use crate::events::EventType;
+        let mut count = 0;
+        while let Ok(ev) = rx.try_recv() {
+            if ev.event_type == EventType::DependencyAvailable
+                || ev.event_type == EventType::DependencyChanged
+            {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// Issue #1256: once the reconcile interval has elapsed, a full heartbeat
+    /// whose edge-diff sees NO change must still re-emit the currently-resolved
+    /// dependency — this is what makes a silently-dropped event self-heal.
+    #[tokio::test]
+    async fn dependency_reconcile_reemits_after_interval() {
+        let (event_tx, mut event_rx) = mpsc::channel(100);
+        let mut runtime = new_reconcile_runtime(event_tx).await;
+
+        let resolved = resolved_single("weather", "http://provider:9000");
+
+        // First heartbeat: the diff gate emits the new edge exactly once.
+        runtime.process_dependency_changes(&resolved).await;
+        assert_eq!(drain_available(&mut event_rx), 1, "new edge emits once");
+
+        // Simulate the reconcile interval having elapsed.
+        runtime.last_dep_reconcile =
+            Some(Instant::now() - runtime.reconcile_interval - Duration::from_secs(1));
+
+        // Same resolved set: the diff gate sees no change, but the reconcile
+        // pass re-emits the resolved dependency (self-heal of a lost event).
+        runtime.process_dependency_changes(&resolved).await;
+        assert_eq!(
+            drain_available(&mut event_rx),
+            1,
+            "reconcile must re-emit the resolved dependency after the interval"
+        );
+    }
+
+    /// Issue #1256: within the throttle window a full heartbeat whose edge-diff
+    /// sees no change must emit NOTHING — no re-emit storm, idempotent.
+    #[tokio::test]
+    async fn dependency_reconcile_throttled_no_storm() {
+        let (event_tx, mut event_rx) = mpsc::channel(100);
+        let mut runtime = new_reconcile_runtime(event_tx).await;
+
+        let resolved = resolved_single("weather", "http://provider:9000");
+
+        // First heartbeat: emits once and stamps last_dep_reconcile = now.
+        runtime.process_dependency_changes(&resolved).await;
+        assert_eq!(drain_available(&mut event_rx), 1);
+
+        // Immediately re-process the SAME set without advancing the clock:
+        // diff gate suppresses (no change) and reconcile is throttled.
+        runtime.process_dependency_changes(&resolved).await;
+        assert_eq!(
+            drain_available(&mut event_rx),
+            0,
+            "no re-emit within the reconcile throttle window (idempotence)"
+        );
+    }
+
+    /// A genuine endpoint change is still emitted by the edge-diff regardless
+    /// of the reconcile throttle, and is not double-emitted by reconcile in
+    /// the same cycle.
+    #[tokio::test]
+    async fn dependency_change_emits_once_even_when_reconcile_due() {
+        let (event_tx, mut event_rx) = mpsc::channel(100);
+        let mut runtime = new_reconcile_runtime(event_tx).await;
+
+        runtime
+            .process_dependency_changes(&resolved_single("weather", "http://provider:9000"))
+            .await;
+        assert_eq!(drain_available(&mut event_rx), 1);
+
+        // Force reconcile to be due, then change the endpoint.
+        runtime.last_dep_reconcile =
+            Some(Instant::now() - runtime.reconcile_interval - Duration::from_secs(1));
+        runtime
+            .process_dependency_changes(&resolved_single("weather", "http://provider:9999"))
+            .await;
+        // Exactly one event: the diff emits the change; reconcile skips the
+        // just-emitted key.
+        assert_eq!(
+            drain_available(&mut event_rx),
+            1,
+            "a changed edge emits exactly once even when reconcile is due"
+        );
     }
 }

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/AgentSpec.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/AgentSpec.java
@@ -596,6 +596,21 @@ public class AgentSpec {
         @JsonProperty("match_mode")
         private String matchMode;
 
+        /**
+         * Issue #1249: opt-in strictness for this dependency edge. When
+         * {@code true}, the registry factors this edge into transitive
+         * capability availability (own agent healthy AND every required dep
+         * available). Default {@code false} (soft-fail). Serialized only when
+         * {@code true} — {@link JsonInclude.Include#NON_DEFAULT} drops the
+         * default {@code false} so existing payloads are byte-identical and
+         * the Rust core's {@code skip_serializing_if} wire style is mirrored
+         * (the core deserializes the omitted field back to {@code false} via
+         * {@code #[serde(default)]}).
+         */
+        @JsonProperty("required")
+        @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+        private boolean required = false;
+
         public DependencySpec() {
         }
 
@@ -637,6 +652,11 @@ public class AgentSpec {
 
         public DependencySpec matchMode(String matchMode) {
             this.matchMode = matchMode;
+            return this;
+        }
+
+        public DependencySpec required(boolean required) {
+            this.required = required;
             return this;
         }
 
@@ -688,6 +708,14 @@ public class AgentSpec {
 
         public void setMatchMode(String matchMode) {
             this.matchMode = matchMode;
+        }
+
+        public boolean isRequired() {
+            return required;
+        }
+
+        public void setRequired(boolean required) {
+            this.required = required;
         }
     }
 

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/Selector.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/Selector.java
@@ -91,6 +91,29 @@ public @interface Selector {
     String version() default "";
 
     /**
+     * Whether this dependency edge is <b>required</b> (issue #1249).
+     *
+     * <p>Opt-in strictness, default {@code false} (soft-fail: an unresolved
+     * dependency injects a {@code null}/unavailable proxy and the agent still
+     * starts and registers). When {@code true}, the registry factors this edge
+     * into transitive capability availability — the depending capability is
+     * marked unavailable (and that unavailability propagates to <i>its</i>
+     * consumers through the existing dependency-update channel) whenever this
+     * required dependency's capability is unavailable.
+     *
+     * <p>Only carried on the wire when {@code true}; {@code false} is omitted
+     * from the registration payload to match the optional-field style of
+     * {@link #version()}.
+     *
+     * <p><b>Scope:</b> meaningful only where a {@code Selector} declares a
+     * dependency edge (e.g. {@link MeshTool#dependencies()}). It is IGNORED on
+     * {@code @MeshLlm} {@code providerSelector} / {@code filter} selectors —
+     * those pick an LLM provider / tool-filter set, not a mesh dependency
+     * edge, so there is no availability predicate to feed.
+     */
+    boolean required() default false;
+
+    /**
      * Optional expected response type for schema-aware capability matching (issue #547).
      *
      * <p>Pair with {@link #schemaMode()}. The Java consumer's expected type is

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -1059,6 +1059,14 @@ public class MeshAutoConfiguration {
                 if (dep.version() != null && !dep.version().isEmpty()) {
                     agentDep.setVersion(dep.version());
                 }
+                // Issue #1249: carry the @MeshDependency required flag through
+                // to the spec JSON (omitted when false via NON_DEFAULT on the
+                // AgentSpec dep). @MeshDependsOn edges participate in the same
+                // transitive availability predicate as @MeshRoute / @MeshTool
+                // dependencies. The value() array is a user-authored ordered
+                // list, so no required-wins merge is needed here (unlike the
+                // route/A2A registries' nondeterministic map iteration).
+                agentDep.setRequired(dep.required());
                 // Issue #547: honour expectedType / schemaMode the same way
                 // @MeshRoute does. Default-sentinel (Void.class) means "not
                 // set" — same convention as MeshRouteRegistry.DependencySpec

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
@@ -309,6 +309,9 @@ public class MeshToolRegistry {
                     depSpec.setTags("[]");
                 }
                 depSpec.setVersion(dep.version());
+                // Issue #1249: carry the required flag through to the spec JSON
+                // (omitted when false via NON_DEFAULT on AgentSpec.DependencySpec).
+                depSpec.setRequired(dep.required());
                 applySchemaMatching(depSpec, dep, clusterStrict);
                 spec.getDependencies().add(depSpec);
             }
@@ -426,6 +429,7 @@ public class MeshToolRegistry {
                     spec.setTags("[]");
                 }
                 spec.setVersion(dep.version());
+                spec.setRequired(dep.required());
                 applySchemaMatching(spec, dep, clusterStrict);
                 deps.add(spec);
             }
@@ -447,7 +451,8 @@ public class MeshToolRegistry {
                     Arrays.asList(sel.tags()),
                     sel.version(),
                     expectedType,
-                    sel.schemaMode()
+                    sel.schemaMode(),
+                    sel.required()
                 ));
             }
         }
@@ -597,10 +602,16 @@ public class MeshToolRegistry {
         List<String> tags,
         String version,
         Class<?> expectedType,
-        SchemaMode schemaMode
+        SchemaMode schemaMode,
+        boolean required
     ) {
         public DependencyInfo(String capability, List<String> tags, String version) {
-            this(capability, tags, version, null, SchemaMode.NONE);
+            this(capability, tags, version, null, SchemaMode.NONE, false);
+        }
+
+        public DependencyInfo(String capability, List<String> tags, String version,
+                              Class<?> expectedType, SchemaMode schemaMode) {
+            this(capability, tags, version, expectedType, schemaMode, false);
         }
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ARegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ARegistry.java
@@ -10,11 +10,9 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -141,37 +139,54 @@ public class MeshA2ARegistry {
      * schema-compatibility stage (issue #1089).
      */
     public List<AgentSpec.DependencySpec> getUniqueDependencySpecs() {
-        Set<String> seenCapabilities = new HashSet<>();
-        List<AgentSpec.DependencySpec> specs = new ArrayList<>();
+        // Keyed by capability, insertion-ordered. Issue #1249: required WINS on
+        // merge — see the conflict branch below.
+        Map<String, AgentSpec.DependencySpec> byCapability = new LinkedHashMap<>();
         var jsonMapper = JsonMapper.builder().build();
         // Issue #547 Phase 4: cluster-wide strict knob promotes WARN→BLOCK.
         boolean clusterStrict = MeshSchemaSupport.clusterStrictEnabled();
         for (SurfaceMetadata surface : getAllSurfaces()) {
             for (MeshRouteRegistry.DependencySpec dep : surface.dependencies()) {
-                if (seenCapabilities.add(dep.getCapability())) {
-                    AgentSpec.DependencySpec agentDep = new AgentSpec.DependencySpec();
-                    agentDep.setCapability(dep.getCapability());
-                    if (dep.hasTags()) {
-                        // Issue #1158: tags is contractually a JSON-array string
-                        // (the Rust core JSON-parses it; a comma-joined string
-                        // silently degrades to "no tag constraint").
-                        try {
-                            agentDep.setTags(jsonMapper.writeValueAsString(dep.getTags()));
-                        } catch (Exception e) {
-                            log.warn("Failed to serialize tags for dependency '{}' — registering with no tag constraint: {}",
-                                dep.getCapability(), e.getMessage());
-                            agentDep.setTags("[]");
-                        }
+                AgentSpec.DependencySpec existing = byCapability.get(dep.getCapability());
+                if (existing != null) {
+                    // Issue #1249: dedupe is otherwise first-wins, but surface
+                    // iteration order is nondeterministic — a required=true
+                    // declaration must never be dropped because a non-required
+                    // declaration of the same capability was visited first.
+                    if (dep.isRequired() && !existing.isRequired()) {
+                        log.warn("Capability '{}' is declared by multiple @MeshA2A dependencies "
+                                + "with conflicting required flags — upgrading the deduped dependency "
+                                + "to required=true (required wins on merge)",
+                            dep.getCapability());
+                        existing.setRequired(true);
                     }
-                    if (dep.hasVersion()) {
-                        agentDep.setVersion(dep.getVersion());
-                    }
-                    MeshRouteRegistry.applySchemaMatching(agentDep, dep, clusterStrict);
-                    specs.add(agentDep);
+                    continue;
                 }
+                AgentSpec.DependencySpec agentDep = new AgentSpec.DependencySpec();
+                agentDep.setCapability(dep.getCapability());
+                if (dep.hasTags()) {
+                    // Issue #1158: tags is contractually a JSON-array string
+                    // (the Rust core JSON-parses it; a comma-joined string
+                    // silently degrades to "no tag constraint").
+                    try {
+                        agentDep.setTags(jsonMapper.writeValueAsString(dep.getTags()));
+                    } catch (Exception e) {
+                        log.warn("Failed to serialize tags for dependency '{}' — registering with no tag constraint: {}",
+                            dep.getCapability(), e.getMessage());
+                        agentDep.setTags("[]");
+                    }
+                }
+                if (dep.hasVersion()) {
+                    agentDep.setVersion(dep.getVersion());
+                }
+                // Issue #1249: carry required through to the spec JSON
+                // (omitted when false via NON_DEFAULT on the AgentSpec dep).
+                agentDep.setRequired(dep.isRequired());
+                MeshRouteRegistry.applySchemaMatching(agentDep, dep, clusterStrict);
+                byCapability.put(dep.getCapability(), agentDep);
             }
         }
-        return specs;
+        return new ArrayList<>(byCapability.values());
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshDependency.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshDependency.java
@@ -75,6 +75,27 @@ public @interface MeshDependency {
     String name() default "";
 
     /**
+     * Whether this route dependency is <b>required</b> (issue #1249).
+     *
+     * <p>Opt-in strictness, default {@code false} (soft-fail). When
+     * {@code true}, the framework's own route wrapper returns HTTP
+     * <b>503</b> with body
+     * {@code {"error":"dependency_unavailable","capability":"<cap>"}} — before
+     * user code runs — whenever this dependency's proxy is unavailable at
+     * call time (after the settling window). This is the perimeter backstop:
+     * external HTTP callers don't go through mesh proxies, so the required
+     * predicate is evaluated at the route boundary from the proxy state the
+     * agent already holds locally.
+     *
+     * <p>Only carried on the wire when {@code true}; {@code false} is omitted
+     * from the registration payload.
+     *
+     * @return true to mark this dependency required (perimeter 503 when
+     *         unavailable)
+     */
+    boolean required() default false;
+
+    /**
      * Optional expected response type for schema-aware capability matching (issue #547).
      *
      * <p>When set together with {@link #schemaMode()}, the resolver filters out

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteHandlerInterceptor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteHandlerInterceptor.java
@@ -1,5 +1,6 @@
 package io.mcpmesh.spring.web;
 
+import io.mcpmesh.core.MeshObjectMappers;
 import io.mcpmesh.spring.MeshDependencyInjector;
 import io.mcpmesh.spring.tracing.ExecutionTracer;
 import io.mcpmesh.spring.tracing.SpanScope;
@@ -12,6 +13,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
+import tools.jackson.databind.ObjectMapper;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -37,6 +39,10 @@ import java.util.concurrent.atomic.AtomicReference;
 public class MeshRouteHandlerInterceptor implements HandlerInterceptor {
 
     private static final Logger log = LoggerFactory.getLogger(MeshRouteHandlerInterceptor.class);
+
+    /** Serializes the issue #1249 perimeter 503 body as real JSON (safe for
+     * any characters a capability name might carry). */
+    private static final ObjectMapper JSON = MeshObjectMappers.create();
 
     /**
      * Request attribute key for resolved dependencies map.
@@ -115,6 +121,13 @@ public class MeshRouteHandlerInterceptor implements HandlerInterceptor {
         // Resolve dependencies
         Map<String, McpMeshTool> resolvedDeps = new LinkedHashMap<>();
         boolean allResolved = true;
+        // Issue #1249 perimeter: capability of the first UNAVAILABLE dependency
+        // declared required=true. When non-null after resolution, the route
+        // returns 503 (naming the capability) before user code — regardless of
+        // failOnMissingDependency. External HTTP callers don't traverse mesh
+        // proxies, so the required predicate is evaluated here at the boundary
+        // from the proxy state the agent already holds locally.
+        String firstUnavailableRequiredCap = null;
 
         io.mcpmesh.spring.MeshSettleState settleState =
             io.mcpmesh.spring.MeshSettleState.getInstance();
@@ -147,16 +160,50 @@ public class MeshRouteHandlerInterceptor implements HandlerInterceptor {
                     log.warn("Dependency '{}' not available for route {}",
                         dep.getCapability(), handlerMethodId);
                     allResolved = false;
+                    if (dep.isRequired() && firstUnavailableRequiredCap == null) {
+                        firstUnavailableRequiredCap = dep.getCapability();
+                    }
                 }
             } catch (Exception e) {
                 log.error("Failed to resolve dependency '{}': {}",
                     dep.getCapability(), e.getMessage());
                 allResolved = false;
+                // Fail-closed: a resolution exception on a required dep counts
+                // as unavailable and intentionally trips the perimeter 503 —
+                // never let a required edge fall through on error.
+                if (dep.isRequired() && firstUnavailableRequiredCap == null) {
+                    firstUnavailableRequiredCap = dep.getCapability();
+                }
             }
         }
 
         // Store resolved dependencies in request
         request.setAttribute(MESH_DEPENDENCIES_ATTR, resolvedDeps);
+
+        // Issue #1249 perimeter 503: a dependency declared required=true is
+        // unavailable at call time — return 503 with the capability reason
+        // BEFORE user code runs. Mirrors the Python route wrapper's
+        // {"error":"dependency_unavailable","capability":...} contract and takes
+        // precedence over the coarse failOnMissingDependency backstop below.
+        if (firstUnavailableRequiredCap != null) {
+            log.warn("Route '{}': required dependency '{}' unavailable — returning 503",
+                handlerMethodId, firstUnavailableRequiredCap);
+            spanScope.withError(new RuntimeException(
+                "Required dependency unavailable: " + firstUnavailableRequiredCap));
+            spanScope.close();
+            request.removeAttribute(MESH_SPAN_SCOPE_ATTR);
+            response.setStatus(HttpStatus.SERVICE_UNAVAILABLE.value());
+            response.setContentType("application/json");
+            // Build the body through Jackson (insertion-ordered map) so a
+            // capability name containing e.g. a quote can't corrupt the JSON.
+            // Shape is identical to the Python contract:
+            //   {"error":"dependency_unavailable","capability":"<cap>"}
+            Map<String, String> errorBody = new LinkedHashMap<>();
+            errorBody.put("error", "dependency_unavailable");
+            errorBody.put("capability", firstUnavailableRequiredCap);
+            response.getWriter().write(JSON.writeValueAsString(errorBody));
+            return false;
+        }
 
         // Handle missing dependencies
         if (!allResolved && metadata.isFailOnMissingDependency()) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
@@ -13,11 +13,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -126,39 +124,58 @@ public class MeshRouteRegistry {
      * @return list of unique AgentSpec.DependencySpec for route dependencies
      */
     public List<AgentSpec.DependencySpec> getUniqueDependencySpecs() {
-        Set<String> seenCapabilities = new HashSet<>();
-        List<AgentSpec.DependencySpec> specs = new ArrayList<>();
+        // Keyed by capability, insertion-ordered. Issue #1249: required WINS on
+        // merge — see the conflict branch below.
+        Map<String, AgentSpec.DependencySpec> byCapability = new LinkedHashMap<>();
         var jsonMapper = JsonMapper.builder().build();
         // Issue #547 Phase 4: cluster-wide strict knob promotes WARN→BLOCK.
         boolean clusterStrict = MeshSchemaSupport.clusterStrictEnabled();
 
         for (RouteMetadata route : routesByPath.values()) {
             for (DependencySpec dep : route.getDependencies()) {
-                if (seenCapabilities.add(dep.getCapability())) {
-                    AgentSpec.DependencySpec agentDep = new AgentSpec.DependencySpec();
-                    agentDep.setCapability(dep.getCapability());
-                    if (dep.hasTags()) {
-                        // Issue #1158: tags is contractually a JSON-array string
-                        // (the Rust core JSON-parses it; a comma-joined string
-                        // silently degrades to "no tag constraint").
-                        try {
-                            agentDep.setTags(jsonMapper.writeValueAsString(dep.getTags()));
-                        } catch (Exception e) {
-                            log.warn("Failed to serialize tags for dependency '{}' — registering with no tag constraint: {}",
-                                dep.getCapability(), e.getMessage());
-                            agentDep.setTags("[]");
-                        }
+                AgentSpec.DependencySpec existing = byCapability.get(dep.getCapability());
+                if (existing != null) {
+                    // Issue #1249: dedupe on capability is otherwise first-wins,
+                    // but iteration order over the route map is nondeterministic
+                    // (ConcurrentHashMap). A required=true declaration must never
+                    // be silently dropped just because a non-required declaration
+                    // of the same capability happened to be visited first —
+                    // required WINS on merge.
+                    if (dep.isRequired() && !existing.isRequired()) {
+                        log.warn("Capability '{}' is declared by multiple @MeshRoute dependencies "
+                                + "with conflicting required flags — upgrading the deduped dependency "
+                                + "to required=true (required wins on merge)",
+                            dep.getCapability());
+                        existing.setRequired(true);
                     }
-                    if (dep.hasVersion()) {
-                        agentDep.setVersion(dep.getVersion());
-                    }
-                    applySchemaMatching(agentDep, dep, clusterStrict);
-                    specs.add(agentDep);
+                    continue;
                 }
+                AgentSpec.DependencySpec agentDep = new AgentSpec.DependencySpec();
+                agentDep.setCapability(dep.getCapability());
+                if (dep.hasTags()) {
+                    // Issue #1158: tags is contractually a JSON-array string
+                    // (the Rust core JSON-parses it; a comma-joined string
+                    // silently degrades to "no tag constraint").
+                    try {
+                        agentDep.setTags(jsonMapper.writeValueAsString(dep.getTags()));
+                    } catch (Exception e) {
+                        log.warn("Failed to serialize tags for dependency '{}' — registering with no tag constraint: {}",
+                            dep.getCapability(), e.getMessage());
+                        agentDep.setTags("[]");
+                    }
+                }
+                if (dep.hasVersion()) {
+                    agentDep.setVersion(dep.getVersion());
+                }
+                // Issue #1249: carry required through to the spec JSON
+                // (omitted when false via NON_DEFAULT on the AgentSpec dep).
+                agentDep.setRequired(dep.isRequired());
+                applySchemaMatching(agentDep, dep, clusterStrict);
+                byCapability.put(dep.getCapability(), agentDep);
             }
         }
 
-        return specs;
+        return new ArrayList<>(byCapability.values());
     }
 
     /**
@@ -365,20 +382,27 @@ public class MeshRouteRegistry {
         private final String parameterName;
         private final Class<?> expectedType;
         private final SchemaMode schemaMode;
+        private final boolean required;
         private Type returnType;  // Set by BeanPostProcessor after construction
 
         public DependencySpec(String capability, String[] tags, String version, String parameterName) {
-            this(capability, tags, version, parameterName, null, SchemaMode.NONE);
+            this(capability, tags, version, parameterName, null, SchemaMode.NONE, false);
         }
 
         public DependencySpec(String capability, String[] tags, String version, String parameterName,
                               Class<?> expectedType, SchemaMode schemaMode) {
+            this(capability, tags, version, parameterName, expectedType, schemaMode, false);
+        }
+
+        public DependencySpec(String capability, String[] tags, String version, String parameterName,
+                              Class<?> expectedType, SchemaMode schemaMode, boolean required) {
             this.capability = capability;
             this.tags = tags != null ? tags : new String[0];
             this.version = version;
             this.parameterName = parameterName;
             this.expectedType = expectedType;
             this.schemaMode = schemaMode != null ? schemaMode : SchemaMode.NONE;
+            this.required = required;
         }
 
         /**
@@ -400,7 +424,8 @@ public class MeshRouteRegistry {
                 annotation.version(),
                 paramName,
                 expectedType,
-                annotation.schemaMode()
+                annotation.schemaMode(),
+                annotation.required()
             );
         }
 
@@ -447,6 +472,17 @@ public class MeshRouteRegistry {
          */
         public SchemaMode getSchemaMode() {
             return schemaMode;
+        }
+
+        /**
+         * Whether this route dependency is required (issue #1249). When true,
+         * the route perimeter returns 503 before user code if the dependency's
+         * proxy is unavailable at call time.
+         *
+         * @return true if the source {@link MeshDependency#required()} was set
+         */
+        public boolean isRequired() {
+            return required;
         }
 
         public Type getReturnType() { return returnType; }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependencyRequiredSerializationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependencyRequiredSerializationTest.java
@@ -1,0 +1,243 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.core.MeshObjectMappers;
+import io.mcpmesh.SchemaMode;
+import io.mcpmesh.spring.web.MeshA2ARegistry;
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshRoute;
+import io.mcpmesh.spring.web.MeshRouteRegistry;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1249: verifies the per-dependency {@code required} flag flows from the
+ * declaration annotations ({@link Selector} on {@code @MeshTool},
+ * {@link MeshDependency} on {@code @MeshRoute}) into the registry metadata AND
+ * into the {@link AgentSpec.DependencySpec} spec JSON handed to the Rust core.
+ *
+ * <p>Mirrors Python's serialization contract: {@code "required": true} is
+ * present in the dependency entry when opted in, and OMITTED entirely (not
+ * {@code false}) when default — byte-identical to pre-#1249 payloads so
+ * existing agents are unaffected. The Rust core's
+ * {@code #[serde(default, skip_serializing_if = ...)]} on {@code required}
+ * accepts both shapes.
+ */
+class MeshDependencyRequiredSerializationTest {
+
+    // The same mapper MeshHandle uses to serialize the AgentSpec for the FFI.
+    private static final ObjectMapper MAPPER = MeshObjectMappers.create();
+
+    // ---- @MeshTool / @Selector producer path ----------------------------------
+
+    static class ToolBean {
+        @MeshTool(capability = "needs_deps", dependencies = {
+            @Selector(capability = "req_cap", required = true),
+            @Selector(capability = "opt_cap")
+        })
+        public String withDeps(
+            @Param("x") String x,
+            io.mcpmesh.types.McpMeshTool reqCap,
+            io.mcpmesh.types.McpMeshTool optCap) {
+            return x;
+        }
+    }
+
+    private static Method method(Class<?> c, String name) {
+        for (Method m : c.getDeclaredMethods()) {
+            if (m.getName().equals(name)) return m;
+        }
+        throw new AssertionError(name);
+    }
+
+    @Test
+    void tool_requiredFlagFlowsIntoDependencyInfo() {
+        MeshToolRegistry reg = new MeshToolRegistry();
+        Method m = method(ToolBean.class, "withDeps");
+        reg.registerTool(new ToolBean(), m, m.getAnnotation(MeshTool.class));
+
+        MeshToolRegistry.ToolMetadata meta = reg.getTool("needs_deps");
+        assertNotNull(meta);
+        MeshToolRegistry.DependencyInfo req = meta.dependencies().stream()
+            .filter(d -> d.capability().equals("req_cap")).findFirst().orElseThrow();
+        MeshToolRegistry.DependencyInfo opt = meta.dependencies().stream()
+            .filter(d -> d.capability().equals("opt_cap")).findFirst().orElseThrow();
+        assertTrue(req.required(), "req_cap must carry required=true from @Selector");
+        assertFalse(opt.required(), "opt_cap defaults to required=false");
+    }
+
+    @Test
+    void tool_specJson_emitsRequiredTrueOnlyForRequiredDep() throws Exception {
+        MeshToolRegistry reg = new MeshToolRegistry();
+        Method m = method(ToolBean.class, "withDeps");
+        reg.registerTool(new ToolBean(), m, m.getAnnotation(MeshTool.class));
+
+        AgentSpec.ToolSpec toolSpec = reg.getToolSpecs().stream()
+            .filter(s -> "needs_deps".equals(s.getCapability())).findFirst().orElseThrow();
+
+        AgentSpec.DependencySpec reqDep = toolSpec.getDependencies().stream()
+            .filter(d -> "req_cap".equals(d.getCapability())).findFirst().orElseThrow();
+        AgentSpec.DependencySpec optDep = toolSpec.getDependencies().stream()
+            .filter(d -> "opt_cap".equals(d.getCapability())).findFirst().orElseThrow();
+
+        assertTrue(reqDep.isRequired());
+        assertFalse(optDep.isRequired());
+
+        // Serialize each dependency entry through the FFI mapper.
+        String reqJson = MAPPER.writeValueAsString(reqDep);
+        String optJson = MAPPER.writeValueAsString(optDep);
+
+        assertTrue(reqJson.contains("\"required\":true"),
+            "required dep JSON must contain \"required\":true, got: " + reqJson);
+        assertFalse(optJson.contains("required"),
+            "optional dep JSON must OMIT the required field entirely, got: " + optJson);
+    }
+
+    // ---- @MeshRoute / @MeshDependency perimeter path --------------------------
+
+    static class RouteBean {
+        @MeshRoute(dependencies = {
+            @MeshDependency(capability = "route_req", required = true),
+            @MeshDependency(capability = "route_opt")
+        })
+        public String handler() {
+            return "ok";
+        }
+    }
+
+    @Test
+    void route_requiredFlagFlowsIntoDependencySpec() {
+        Method m = method(RouteBean.class, "handler");
+        List<MeshRouteRegistry.DependencySpec> specs =
+            MeshRouteRegistry.DependencySpec.fromAnnotation(m.getAnnotation(MeshRoute.class));
+
+        MeshRouteRegistry.DependencySpec req = specs.stream()
+            .filter(d -> d.getCapability().equals("route_req")).findFirst().orElseThrow();
+        MeshRouteRegistry.DependencySpec opt = specs.stream()
+            .filter(d -> d.getCapability().equals("route_opt")).findFirst().orElseThrow();
+        assertTrue(req.isRequired(), "route_req must carry required=true from @MeshDependency");
+        assertFalse(opt.isRequired(), "route_opt defaults to required=false");
+    }
+
+    @Test
+    void route_uniqueSpecJson_emitsRequiredTrueOnlyForRequiredDep() throws Exception {
+        Method m = method(RouteBean.class, "handler");
+        MeshRouteRegistry registry = new MeshRouteRegistry();
+        MeshRouteRegistry.RouteMetadata metadata = new MeshRouteRegistry.RouteMetadata(
+            RouteBean.class.getName() + ".handler",
+            MeshRouteRegistry.DependencySpec.fromAnnotation(m.getAnnotation(MeshRoute.class)),
+            "test route",
+            true);
+        registry.register("POST", "/test", metadata);
+
+        List<AgentSpec.DependencySpec> specs = registry.getUniqueDependencySpecs();
+        AgentSpec.DependencySpec reqDep = specs.stream()
+            .filter(d -> "route_req".equals(d.getCapability())).findFirst().orElseThrow();
+        AgentSpec.DependencySpec optDep = specs.stream()
+            .filter(d -> "route_opt".equals(d.getCapability())).findFirst().orElseThrow();
+
+        assertTrue(reqDep.isRequired());
+        assertFalse(optDep.isRequired());
+
+        assertTrue(MAPPER.writeValueAsString(reqDep).contains("\"required\":true"),
+            "required route dep JSON must contain \"required\":true");
+        assertFalse(MAPPER.writeValueAsString(optDep).contains("required"),
+            "optional route dep JSON must OMIT the required field entirely");
+    }
+
+    // ---- required-wins on dedupe merge (route + A2A registries) ---------------
+
+    private static MeshRouteRegistry.DependencySpec routeDep(String cap, boolean required) {
+        return new MeshRouteRegistry.DependencySpec(
+            cap, new String[0], "", cap, null, SchemaMode.NONE, required);
+    }
+
+    private void assertRouteMergeYieldsRequired(
+            List<MeshRouteRegistry.DependencySpec> deps) {
+        MeshRouteRegistry registry = new MeshRouteRegistry();
+        registry.register("POST", "/merge",
+            new MeshRouteRegistry.RouteMetadata(
+                RouteBean.class.getName() + ".handler", deps, "merge", true));
+
+        List<AgentSpec.DependencySpec> specs = registry.getUniqueDependencySpecs();
+        List<AgentSpec.DependencySpec> shared = specs.stream()
+            .filter(d -> "shared_cap".equals(d.getCapability())).toList();
+        assertEquals(1, shared.size(), "capability must be deduped to a single spec");
+        assertTrue(shared.get(0).isRequired(),
+            "required must WIN on merge regardless of declaration order");
+    }
+
+    @Test
+    void route_requiredWinsMerge_requiredDeclaredFirst() {
+        // Deterministic order via a single route's ordered dependency list.
+        assertRouteMergeYieldsRequired(List.of(
+            routeDep("shared_cap", true), routeDep("shared_cap", false)));
+    }
+
+    @Test
+    void route_requiredWinsMerge_optionalDeclaredFirst() {
+        assertRouteMergeYieldsRequired(List.of(
+            routeDep("shared_cap", false), routeDep("shared_cap", true)));
+    }
+
+    private void assertA2aMergeYieldsRequired(
+            List<MeshRouteRegistry.DependencySpec> deps) {
+        MeshA2ARegistry registry = new MeshA2ARegistry();
+        registry.register(new MeshA2ARegistry.SurfaceMetadata(
+            "/a2a", "skill", "Skill", "", List.of(), deps, "", "Bean.m", new Object(), null));
+
+        List<AgentSpec.DependencySpec> specs = registry.getUniqueDependencySpecs();
+        List<AgentSpec.DependencySpec> shared = specs.stream()
+            .filter(d -> "shared_cap".equals(d.getCapability())).toList();
+        assertEquals(1, shared.size(), "capability must be deduped to a single spec");
+        assertTrue(shared.get(0).isRequired(),
+            "required must WIN on merge regardless of declaration order");
+    }
+
+    @Test
+    void a2a_requiredFlowsAndWinsMerge_requiredFirst() {
+        assertA2aMergeYieldsRequired(List.of(
+            routeDep("shared_cap", true), routeDep("shared_cap", false)));
+    }
+
+    @Test
+    void a2a_requiredFlowsAndWinsMerge_optionalFirst() {
+        assertA2aMergeYieldsRequired(List.of(
+            routeDep("shared_cap", false), routeDep("shared_cap", true)));
+    }
+
+    @Test
+    void a2a_singleRequiredDep_emitsRequiredTrueInJson() throws Exception {
+        MeshA2ARegistry registry = new MeshA2ARegistry();
+        registry.register(new MeshA2ARegistry.SurfaceMetadata(
+            "/a2a", "skill", "Skill", "", List.of(),
+            List.of(routeDep("a2a_req", true), routeDep("a2a_opt", false)),
+            "", "Bean.m", new Object(), null));
+
+        List<AgentSpec.DependencySpec> specs = registry.getUniqueDependencySpecs();
+        AgentSpec.DependencySpec req = specs.stream()
+            .filter(d -> "a2a_req".equals(d.getCapability())).findFirst().orElseThrow();
+        AgentSpec.DependencySpec opt = specs.stream()
+            .filter(d -> "a2a_opt".equals(d.getCapability())).findFirst().orElseThrow();
+        assertTrue(MAPPER.writeValueAsString(req).contains("\"required\":true"));
+        assertFalse(MAPPER.writeValueAsString(opt).contains("required"));
+    }
+
+    @Test
+    void dependencySpec_defaultsToRequiredFalse_andOmitsFromJson() throws Exception {
+        // Guards the byte-identical-payload invariant for all existing callers
+        // that never touch `required`.
+        AgentSpec.DependencySpec dep = new AgentSpec.DependencySpec("plain_cap");
+        assertFalse(dep.isRequired());
+        assertFalse(MAPPER.writeValueAsString(dep).contains("required"),
+            "a default DependencySpec must serialize without the required field");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependsOnIntegrationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependsOnIntegrationTest.java
@@ -233,6 +233,22 @@ class MeshDependsOnIntegrationTest {
         @Bean public TypedCapDeclarer typedCapDeclarer() { return new TypedCapDeclarer(); }
     }
 
+    // Issue #1249: a @MeshDependsOn edge marked required=true must carry the
+    // flag into the synthetic __mesh_depends_on_deps tool spec; a sibling
+    // default edge stays required=false (omitted on the wire).
+    @Component
+    @MeshDependsOn({
+        @MeshDependency(capability = "req_dep_cap", required = true),
+        @MeshDependency(capability = "opt_dep_cap")
+    })
+    static class RequiredCapDeclarer {}
+
+    @Configuration
+    @MeshAgent(name = "required-cap-agent")
+    static class RequiredCapAgentConfig {
+        @Bean public RequiredCapDeclarer requiredCapDeclarer() { return new RequiredCapDeclarer(); }
+    }
+
     // Heartbeat-driven availability
     @Component
     @MeshDependsOn(@MeshDependency(capability = "avail_cap"))
@@ -660,6 +676,38 @@ class MeshDependsOnIntegrationTest {
                 assertThat(dep.getVersion())
                     .as("version constraint must propagate verbatim")
                     .isEqualTo(">=1.0");
+            });
+    }
+
+    @Test
+    @DisplayName("#1249: required flag propagates to DependencySpec for @MeshDependsOn")
+    void requiredFlagPropagatesForMeshDependsOn() {
+        baseRunner
+            .withUserConfiguration(RequiredCapAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+                AgentSpec.DependencySpec req = spec.getTools().stream()
+                    .filter(t -> "__mesh_depends_on_deps".equals(t.getCapability()))
+                    .flatMap(t -> t.getDependencies().stream())
+                    .filter(d -> "req_dep_cap".equals(d.getCapability()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                        "req_dep_cap dependency missing from __mesh_depends_on_deps tool"));
+                AgentSpec.DependencySpec opt = spec.getTools().stream()
+                    .filter(t -> "__mesh_depends_on_deps".equals(t.getCapability()))
+                    .flatMap(t -> t.getDependencies().stream())
+                    .filter(d -> "opt_dep_cap".equals(d.getCapability()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                        "opt_dep_cap dependency missing from __mesh_depends_on_deps tool"));
+
+                assertThat(req.isRequired())
+                    .as("required=true @MeshDependsOn edge must carry required into the spec")
+                    .isTrue();
+                assertThat(opt.isRequired())
+                    .as("default @MeshDependsOn edge must stay required=false")
+                    .isFalse();
             });
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyStreamTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyStreamTest.java
@@ -310,6 +310,7 @@ class MeshLlmAgentProxyStreamTest {
             @Override public String capability() { return "llm"; }
             @Override public String[] tags() { return new String[]{"+claude", "ai.mcpmesh.stream"}; }
             @Override public String version() { return ""; }
+            @Override public boolean required() { return false; }
             @Override public Class<?> expectedType() { return Void.class; }
             @Override public io.mcpmesh.SchemaMode schemaMode() { return io.mcpmesh.SchemaMode.NONE; }
         };

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshRouteRequiredPerimeterTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshRouteRequiredPerimeterTest.java
@@ -1,0 +1,172 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.spring.web.MeshRouteHandlerInterceptor;
+import io.mcpmesh.spring.web.MeshRouteRegistry;
+import io.mcpmesh.types.McpMeshTool;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.web.method.HandlerMethod;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Issue #1249 perimeter: the {@code @MeshRoute} interceptor returns 503 with
+ * {@code {"error":"dependency_unavailable","capability":"<cap>"}} — BEFORE the
+ * controller runs — when a dependency declared {@code required=true} has no
+ * available proxy at call time. Optional (default) deps keep soft-fail
+ * semantics: with {@code failOnMissingDependency=false} the handler still runs
+ * with a {@code null} dependency.
+ *
+ * <p>Mirrors the Python route wrapper contract. Placed in
+ * {@code io.mcpmesh.spring} so the package-private {@code MeshSettleState}
+ * reset hooks are visible (settled=true short-circuits the settling-window
+ * wait so unavailable deps are judged immediately).
+ */
+class MeshRouteRequiredPerimeterTest {
+
+    // Sample controller whose method IDs back the registered route metadata.
+    static class SampleController {
+        public String requiredRoute() { return "ok"; }
+        public String optionalRoute() { return "ok"; }
+    }
+
+    private MeshRouteRegistry registry;
+    private MeshDependencyInjector injector;
+    private MeshRouteHandlerInterceptor interceptor;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        // timeout 0.0 → isSettled() returns true immediately, so the
+        // interceptor does not block on the per-capability settle latch.
+        MeshSettleState.resetForTests(0.0);
+
+        registry = new MeshRouteRegistry();
+        injector = mock(MeshDependencyInjector.class);
+        ObjectProvider<MeshDependencyInjector> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(injector);
+        interceptor = new MeshRouteHandlerInterceptor(registry, provider);
+    }
+
+    private static Method method(String name) {
+        for (Method m : SampleController.class.getDeclaredMethods()) {
+            if (m.getName().equals(name)) return m;
+        }
+        throw new AssertionError(name);
+    }
+
+    private static String handlerId(String methodName) {
+        return SampleController.class.getName() + "." + methodName;
+    }
+
+    private void registerRoute(String httpMethod, String path, String methodName,
+                               List<MeshRouteRegistry.DependencySpec> deps,
+                               boolean failOnMissing) {
+        MeshRouteRegistry.RouteMetadata metadata = new MeshRouteRegistry.RouteMetadata(
+            handlerId(methodName), deps, "test", failOnMissing);
+        registry.register(httpMethod, path, metadata);
+    }
+
+    private HandlerMethod handler(String methodName) {
+        return new HandlerMethod(new SampleController(), method(methodName));
+    }
+
+    @Test
+    void requiredDependencyUnavailable_returns503_handlerNotInvoked() throws Exception {
+        registerRoute("POST", "/req", "requiredRoute", List.of(
+            new MeshRouteRegistry.DependencySpec("req_cap", new String[0], "", "reqCap",
+                null, io.mcpmesh.SchemaMode.NONE, true)), true);
+
+        // Required cap has no live proxy → unavailable.
+        when(injector.getToolProxy("req_cap")).thenReturn(null);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getRequestURI()).thenReturn("/req");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        StringWriter body = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+        boolean proceed = interceptor.preHandle(request, response, handler("requiredRoute"));
+
+        assertFalse(proceed, "preHandle must return false so the controller is NOT invoked");
+        verify(response).setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        assertEquals(
+            "{\"error\":\"dependency_unavailable\",\"capability\":\"req_cap\"}",
+            body.toString());
+    }
+
+    @Test
+    void requiredDependencyAvailable_proceeds() throws Exception {
+        registerRoute("POST", "/req2", "requiredRoute", List.of(
+            new MeshRouteRegistry.DependencySpec("req_cap", new String[0], "", "reqCap",
+                null, io.mcpmesh.SchemaMode.NONE, true)), true);
+
+        McpMeshTool live = mock(McpMeshTool.class);
+        when(live.isAvailable()).thenReturn(true);
+        when(injector.getToolProxy("req_cap")).thenReturn(live);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getRequestURI()).thenReturn("/req2");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        boolean proceed = interceptor.preHandle(request, response, handler("requiredRoute"));
+
+        assertTrue(proceed, "available required dep must let the controller run");
+        verify(response, never()).setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    void optionalDependencyUnavailable_softFail_handlerRuns() throws Exception {
+        // Optional (default required=false) dep + failOnMissingDependency=false
+        // → soft-fail: the handler runs with a null dependency, no 503.
+        registerRoute("GET", "/opt", "optionalRoute", List.of(
+            new MeshRouteRegistry.DependencySpec("opt_cap", new String[0], "", "optCap")), false);
+
+        when(injector.getToolProxy("opt_cap")).thenReturn(null);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getRequestURI()).thenReturn("/opt");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        boolean proceed = interceptor.preHandle(request, response, handler("optionalRoute"));
+
+        assertTrue(proceed, "unavailable OPTIONAL dep must not trip the perimeter 503");
+        verify(response, never()).setStatus(anyInt());
+    }
+
+    @Test
+    void requiredWins_evenWhenFailOnMissingIsFalse() throws Exception {
+        // A required dep must 503 with the dependency_unavailable body even
+        // when the route opted out of the coarse failOnMissingDependency check.
+        registerRoute("POST", "/mix", "requiredRoute", List.of(
+            new MeshRouteRegistry.DependencySpec("req_cap", new String[0], "", "reqCap",
+                null, io.mcpmesh.SchemaMode.NONE, true)), false);
+
+        when(injector.getToolProxy("req_cap")).thenReturn(null);
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getRequestURI()).thenReturn("/mix");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        StringWriter body = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+        boolean proceed = interceptor.preHandle(request, response, handler("requiredRoute"));
+
+        assertFalse(proceed);
+        verify(response).setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+        assertTrue(body.toString().contains("\"capability\":\"req_cap\""));
+    }
+}

--- a/src/runtime/python/_mcp_mesh/pipeline/a2a_heartbeat/rust_a2a_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/a2a_heartbeat/rust_a2a_heartbeat.py
@@ -469,9 +469,15 @@ async def rust_a2a_heartbeat_task(heartbeat_config: dict[str, Any]) -> None:
                 pass
 
             try:
-                try:
-                    event = await asyncio.wait_for(handle.next_event(), timeout=1.0)
-                except TimeoutError:
+                # Pull the next event. The 1s liveness timeout lives INSIDE the
+                # Rust future (issue #1256): a `None` return is a timeout tick
+                # that lets us re-check the shutdown signal. We must NOT wrap
+                # this in asyncio.wait_for — an external cancellation could drop
+                # a dequeued event in the recv→deliver window, permanently
+                # stalling a dependency edge.
+                event = await handle.next_event()
+                if event is None:
+                    # Liveness tick, no event; loop back to check shutdown.
                     continue
 
                 if event.event_type == "shutdown":

--- a/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/rust_api_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/rust_api_heartbeat.py
@@ -466,12 +466,15 @@ async def rust_api_heartbeat_task(heartbeat_config: dict[str, Any]) -> None:
                 pass
 
             try:
-                # Wait for next event from Rust core with timeout
-                # Timeout allows periodic shutdown checks
-                try:
-                    event = await asyncio.wait_for(handle.next_event(), timeout=1.0)
-                except TimeoutError:
-                    # No event in 1 second, loop back to check shutdown signal
+                # Pull the next event. The 1s liveness timeout lives INSIDE the
+                # Rust future (issue #1256): a `None` return is a timeout tick
+                # that lets us re-check the shutdown signal. We must NOT wrap
+                # this in asyncio.wait_for — an external cancellation could drop
+                # a dequeued event in the recv→deliver window, permanently
+                # stalling a dependency edge.
+                event = await handle.next_event()
+                if event is None:
+                    # Liveness tick, no event; loop back to check shutdown.
                     continue
 
                 if event.event_type == "shutdown":

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
@@ -1161,12 +1161,15 @@ async def rust_heartbeat_task(heartbeat_config: dict[str, Any]) -> None:
                 pass
 
             try:
-                # Wait for next event from Rust core with timeout
-                # Timeout allows periodic shutdown checks
-                try:
-                    event = await asyncio.wait_for(handle.next_event(), timeout=1.0)
-                except TimeoutError:
-                    # No event in 1 second, loop back to check shutdown signal
+                # Pull the next event. The 1s liveness timeout lives INSIDE the
+                # Rust future (issue #1256): a `None` return is a timeout tick
+                # that lets us re-check the shutdown signal. We must NOT wrap
+                # this in asyncio.wait_for — an external cancellation could drop
+                # a dequeued event in the recv→deliver window, permanently
+                # stalling a dependency edge.
+                event = await handle.next_event()
+                if event is None:
+                    # Liveness tick, no event; loop back to check shutdown.
                     continue
 
                 if event.event_type == "shutdown":

--- a/src/runtime/python/tests/unit/test_1256_rust_event_pull.py
+++ b/src/runtime/python/tests/unit/test_1256_rust_event_pull.py
@@ -1,0 +1,149 @@
+"""Issue #1256: Rust event-pull loop must be cancel-safe and self-healing.
+
+These tests cover the Python side of the fix:
+
+1. The consumer loop uses the plain-await pull pattern: ``next_event()``
+   returns ``None`` as a liveness tick (internal Rust timeout) instead of the
+   old ``asyncio.wait_for(..., timeout=1.0)`` wrapper, whose cancellation could
+   drop a dequeued event. A ``None`` must be skipped, real events dispatched,
+   and a ``shutdown`` event must break the loop.
+
+2. Shutdown still terminates promptly (what the old 1s timeout protected).
+
+3. Re-applying the same dependency endpoint is idempotent — the reconcile
+   re-emit (Rust side) relies on the Python apply being a no-op storm-free
+   overwrite.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import _mcp_mesh.pipeline.mcp_heartbeat.rust_heartbeat as rh
+
+
+class _FakeEvent:
+    def __init__(self, event_type: str):
+        self.event_type = event_type
+
+
+class _FakeHandle:
+    """Fake AgentHandle whose ``next_event`` replays a scripted sequence.
+
+    After the script is exhausted it yields ``None`` (liveness ticks), matching
+    the real Rust handle's internal-timeout contract.
+    """
+
+    def __init__(self, script):
+        self._script = list(script)
+        self.shutdown_called = 0
+
+    async def next_event(self):
+        await asyncio.sleep(0)  # yield control like the real awaitable
+        if self._script:
+            return self._script.pop(0)
+        return None
+
+    def shutdown(self):
+        self.shutdown_called += 1
+
+
+@pytest.mark.asyncio
+async def test_pull_skips_none_dispatches_events_and_breaks_on_shutdown():
+    """None ticks are skipped, real events dispatched, shutdown breaks."""
+    handle = _FakeHandle(
+        [
+            None,  # liveness tick — must be skipped
+            _FakeEvent("dependency_available"),  # dispatched
+            None,  # another tick
+            _FakeEvent("shutdown"),  # breaks the loop
+        ]
+    )
+    core = MagicMock()
+    core.start_agent.return_value = handle
+    handle_event = AsyncMock()
+
+    with (
+        patch.object(rh, "_get_rust_core", return_value=core),
+        patch.object(rh, "_build_agent_spec", return_value=MagicMock()),
+        patch.object(
+            rh, "_start_claim_dispatchers_on_heartbeat_loop", return_value=[]
+        ),
+        patch.object(rh, "_handle_mesh_event", handle_event),
+        patch(
+            "_mcp_mesh.shared.simple_shutdown.should_stop_heartbeat",
+            return_value=False,
+        ),
+        patch("_mcp_mesh.shared.simple_shutdown.register_rust_agent_handle"),
+        patch("_mcp_mesh.shared.simple_shutdown.unregister_rust_agent_handle"),
+    ):
+        await asyncio.wait_for(
+            rh.rust_heartbeat_task(
+                {"agent_id": "a", "context": {}, "standalone_mode": False}
+            ),
+            timeout=5.0,
+        )
+
+    # Exactly one real event dispatched (the None ticks were skipped).
+    assert handle_event.await_count == 1
+    dispatched = handle_event.await_args.args[0]
+    assert dispatched.event_type == "dependency_available"
+    # Graceful shutdown of the Rust core in the finally block.
+    assert handle.shutdown_called >= 1
+
+
+@pytest.mark.asyncio
+async def test_shutdown_signal_terminates_loop_promptly():
+    """A Python shutdown signal breaks the loop before any event is handled."""
+    handle = _FakeHandle([_FakeEvent("dependency_available")])
+    core = MagicMock()
+    core.start_agent.return_value = handle
+    handle_event = AsyncMock()
+
+    with (
+        patch.object(rh, "_get_rust_core", return_value=core),
+        patch.object(rh, "_build_agent_spec", return_value=MagicMock()),
+        patch.object(
+            rh, "_start_claim_dispatchers_on_heartbeat_loop", return_value=[]
+        ),
+        patch.object(rh, "_handle_mesh_event", handle_event),
+        patch(
+            "_mcp_mesh.shared.simple_shutdown.should_stop_heartbeat",
+            return_value=True,
+        ),
+        patch("_mcp_mesh.shared.simple_shutdown.register_rust_agent_handle"),
+        patch("_mcp_mesh.shared.simple_shutdown.unregister_rust_agent_handle"),
+    ):
+        # Must return well within the timeout — promptness is the property the
+        # old 1s wait_for was protecting.
+        await asyncio.wait_for(
+            rh.rust_heartbeat_task(
+                {"agent_id": "a", "context": {}, "standalone_mode": False}
+            ),
+            timeout=3.0,
+        )
+
+    assert handle_event.await_count == 0
+    assert handle.shutdown_called >= 1
+
+
+@pytest.mark.asyncio
+async def test_dependency_apply_is_idempotent():
+    """Re-registering the same dep key/endpoint is a storm-free overwrite.
+
+    The Rust reconcile pass (#1256) re-emits already-applied edges; the Python
+    apply must tolerate that without accumulating state or raising.
+    """
+    from _mcp_mesh.engine.dependency_injector import DependencyInjector
+
+    injector = DependencyInjector()
+    proxy_a = MagicMock(name="proxy-endpoint-9000")
+    proxy_b = MagicMock(name="proxy-endpoint-9000-again")
+
+    dep_key = "pkg.mod.consumer:dep_0"
+    await injector.register_dependency(dep_key, proxy_a)
+    await injector.register_dependency(dep_key, proxy_b)
+
+    # Single entry, latest instance wins — no accumulation, no error.
+    assert injector.get_dependency(dep_key) is proxy_b

--- a/src/runtime/typescript/src/__tests__/route-required.spec.ts
+++ b/src/runtime/typescript/src/__tests__/route-required.spec.ts
@@ -1,0 +1,206 @@
+/**
+ * Issue #1249: per-dependency `required` flag + route perimeter 503.
+ *
+ * Uses the REAL `normalizeDependency` (proxy.js) and the REAL route
+ * middleware — no proxy mock — so the declaration → normalized-dep → wire
+ * mapping and the perimeter check are genuinely exercised.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import type { Request, Response, NextFunction } from "express";
+import { normalizeDependency } from "../proxy.js";
+import { route, RouteRegistry } from "../route.js";
+import { resetSettleStateForTests } from "../settle.js";
+import type { McpMeshTool } from "../types.js";
+
+// Disable the settling-window grace (#1193) so the perimeter is judged
+// immediately (MCP_MESH_SETTLE_TIMEOUT=0 tuning case). The perimeter runs
+// AFTER the settle wait, so with the grace on a still-settling dep would get
+// its full window before being called unavailable — covered elsewhere.
+const savedSettleTimeout = process.env.MCP_MESH_SETTLE_TIMEOUT;
+beforeEach(() => {
+  process.env.MCP_MESH_SETTLE_TIMEOUT = "0";
+  resetSettleStateForTests();
+  RouteRegistry.reset();
+});
+afterAll(() => {
+  if (savedSettleTimeout === undefined) {
+    delete process.env.MCP_MESH_SETTLE_TIMEOUT;
+  } else {
+    process.env.MCP_MESH_SETTLE_TIMEOUT = savedSettleTimeout;
+  }
+  resetSettleStateForTests();
+});
+
+function mockRes(): Response {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+describe("normalizeDependency required flag (#1249)", () => {
+  it("carries required:true through to the normalized dep (napi wire seam)", () => {
+    const norm = normalizeDependency({ capability: "weather-api", required: true });
+    expect(norm.capability).toBe("weather-api");
+    expect(norm.required).toBe(true);
+    // The three JsDependencySpec builders map `dep.required ? true : undefined`,
+    // so a true here becomes required:true on the napi DependencySpec.
+    expect(norm.required ? true : undefined).toBe(true);
+  });
+
+  it("omits required when declared false (byte-identical soft-fail default)", () => {
+    const norm = normalizeDependency({ capability: "weather-api", required: false });
+    expect(norm.required).toBeUndefined();
+    expect(norm.required ? true : undefined).toBeUndefined();
+  });
+
+  it("omits required when absent (default optional)", () => {
+    const norm = normalizeDependency({ capability: "weather-api" });
+    expect(norm.required).toBeUndefined();
+  });
+
+  it("string-form deps are always optional", () => {
+    const norm = normalizeDependency("weather-api");
+    expect(norm.required).toBeUndefined();
+  });
+});
+
+describe("RouteRegistry stores required in route metadata (#1249)", () => {
+  it("persists required:true on the declared route dep", () => {
+    const registry = RouteRegistry.getInstance();
+    const routeId = registry.registerRoute("GET", "/x", [
+      { capability: "weather-api", required: true },
+      { capability: "logger" },
+    ]);
+    const meta = registry.getRoute(routeId);
+    expect(meta?.dependencies[0].required).toBe(true);
+    expect(meta?.dependencies[1].required).toBeUndefined();
+  });
+});
+
+describe("route perimeter 503 (#1249)", () => {
+  it("returns 503 before user code when a required dep is unavailable", async () => {
+    const handler = vi.fn();
+    const middleware = route([{ capability: "calculator", required: true }], handler);
+
+    const req = { method: "POST", path: "/compute", headers: {} } as unknown as Request;
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "dependency_unavailable",
+      capability: "calculator",
+    });
+    // User code must NOT run.
+    expect(handler).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("runs the handler (no 503) when the required dep IS available", async () => {
+    const registry = RouteRegistry.getInstance();
+    const handler = vi.fn();
+    const middleware = route(
+      [{ capability: "calculator", required: true }],
+      handler
+    ) as ReturnType<typeof route> & { _meshRouteId: string };
+
+    const mockCalc = (async () => "result") as unknown as McpMeshTool;
+    registry.setDependency(middleware._meshRouteId, 0, mockCalc);
+
+    const req = { method: "POST", path: "/compute", headers: {} } as unknown as Request;
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledWith(
+      req,
+      res,
+      expect.objectContaining({ calculator: mockCalc })
+    );
+  });
+
+  it("does NOT 503 for an unavailable OPTIONAL dep (soft-fail preserved)", async () => {
+    const handler = vi.fn();
+    const middleware = route([{ capability: "calculator" }], handler);
+
+    const req = { method: "POST", path: "/compute", headers: {} } as unknown as Request;
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(res.status).not.toHaveBeenCalled();
+    // Handler runs with a null proxy — the existing degraded behavior.
+    expect(handler).toHaveBeenCalledWith(
+      req,
+      res,
+      expect.objectContaining({ calculator: null })
+    );
+  });
+
+  it("does NOT 503 when a duplicate capability is live in the winning slot", async () => {
+    // A capability declared twice collapses to one capability-keyed `deps`
+    // slot (last resolution wins). The perimeter must judge the same slot the
+    // handler sees — not a dead sibling index — so a live proxy means run.
+    const registry = RouteRegistry.getInstance();
+    const handler = vi.fn();
+    const middleware = route(
+      [
+        { capability: "calculator", required: true }, // required, its index unresolved
+        { capability: "calculator" }, // optional, this index is live → wins deps[cap]
+      ],
+      handler
+    ) as ReturnType<typeof route> & { _meshRouteId: string };
+
+    const mockCalc = (async () => "result") as unknown as McpMeshTool;
+    registry.setDependency(middleware._meshRouteId, 1, mockCalc);
+
+    const req = { method: "POST", path: "/compute", headers: {} } as unknown as Request;
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledWith(
+      req,
+      res,
+      expect.objectContaining({ calculator: mockCalc })
+    );
+  });
+
+  it("503s on the first unavailable required dep among a mix", async () => {
+    const registry = RouteRegistry.getInstance();
+    const handler = vi.fn();
+    const middleware = route(
+      [
+        { capability: "logger" }, // optional, unresolved
+        { capability: "calculator", required: true }, // required, resolved
+        { capability: "weather-api", required: true }, // required, unresolved
+      ],
+      handler
+    ) as ReturnType<typeof route> & { _meshRouteId: string };
+
+    const mockCalc = (async () => "result") as unknown as McpMeshTool;
+    registry.setDependency(middleware._meshRouteId, 1, mockCalc);
+
+    const req = { method: "POST", path: "/compute", headers: {} } as unknown as Request;
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "dependency_unavailable",
+      capability: "weather-api",
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -1638,6 +1638,9 @@ export class MeshAgent {
                 expectedSchemaCanonical: expectedCanonical,
                 expectedSchemaHash: expectedHash,
                 matchMode: dep.matchMode,
+                // Issue #1249: only carry `required` when opted in (absent →
+                // false) so existing heartbeats stay byte-identical.
+                required: dep.required ? true : undefined,
               };
             }
           ),

--- a/src/runtime/typescript/src/api-runtime.ts
+++ b/src/runtime/typescript/src/api-runtime.ts
@@ -71,6 +71,9 @@ function buildToolSpecs(routes: RouteMetadata[]): JsToolSpec[] {
           capability: dep.capability,
           tags: JSON.stringify(dep.tags ?? []),
           version: dep.version,
+          // Issue #1249: carry the required flag so the registry factors this
+          // route edge into transitive availability. Only when true.
+          required: dep.required ? true : undefined,
         })
       ),
       inputSchema: undefined,

--- a/src/runtime/typescript/src/express.ts
+++ b/src/runtime/typescript/src/express.ts
@@ -110,6 +110,9 @@ function buildToolSpecs(routes: RouteMetadata[]): JsToolSpec[] {
             expectedSchemaCanonical: expectedCanonical,
             expectedSchemaHash: expectedHash,
             matchMode: dep.matchMode,
+            // Issue #1249: carry the required flag so the registry factors
+            // this route edge into transitive availability. Only when true.
+            required: dep.required ? true : undefined,
           };
         }
       ),

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -1203,6 +1203,10 @@ export function normalizeDependency(dep: DependencySpec): NormalizedDependency {
     capability: dep.capability,
     tags: dep.tags ?? [],
     version: dep.version,
+    // Issue #1249: carry the opt-in required flag through to the heartbeat
+    // pipeline and (for routes) the perimeter check. Only set when true so
+    // the default soft-fail path stays untouched.
+    ...(dep.required ? { required: true } : {}),
   };
 
   if (dep.expectedSchema !== undefined) {

--- a/src/runtime/typescript/src/route.ts
+++ b/src/runtime/typescript/src/route.ts
@@ -107,6 +107,9 @@ export interface RouteMetadata {
     expectedSchemaRaw?: object;
     /** Issue #547: schema match mode. */
     matchMode?: "subset" | "strict";
+    /** Issue #1249: opt-in required edge (default false). A required route dep
+     * whose proxy is unavailable at call time trips the perimeter 503. */
+    required?: boolean;
   }>;
   /** Per-dependency kwargs */
   dependencyKwargs?: DependencyKwargs[];
@@ -388,6 +391,16 @@ export function route(
   // Store normalized deps for the handler
   const normalizedDeps = dependencies.map(normalizeDependency);
 
+  // Issue #1249: does this route declare any required dep? Precomputed once so
+  // the perimeter check below is a no-op for the common (all-optional) route.
+  // Every declared dep always has a slot in the `deps` object keyed by
+  // capability, so — unlike Python's positional injection — there is no
+  // "required perimeter INACTIVE (no injectable slot)" case to warn about.
+  // TS `mesh.route` has no declared streaming/SSE variant either, and the 503
+  // is emitted before the handler runs (nothing written to `res` yet), so
+  // there is no stream to break and no creation-time bypass warning to emit.
+  const hasRequiredDep = normalizedDeps.some((dep) => dep.required === true);
+
   // Return Express middleware
   const middleware: RequestHandler = async (
     req: Request,
@@ -432,6 +445,40 @@ export function route(
       for (const dep of normalizedDeps) {
         if (deps[dep.capability] === undefined) {
           deps[dep.capability] = null;
+        }
+      }
+
+      // Issue #1249 perimeter: a route dep declared `required: true` whose
+      // proxy is unavailable AT CALL TIME (after the settle wait above) makes
+      // the capability unavailable — return 503 before user code, naming the
+      // capability, so monitoring alarms on 5xx and clients see a retryable
+      // "unavailable" rather than a hand-written null check.
+      //
+      // Evaluate required-ness PER UNIQUE CAPABILITY against the same
+      // capability-keyed `deps` object the handler receives — NOT per index.
+      // Injection is capability-keyed (a capability declared twice collapses to
+      // one `deps[cap]` slot, last resolution winning), so an index-based check
+      // could 503 on a dead sibling slot while `deps[cap]` is actually live.
+      // Deduping with "required wins" (a capability required in any slot is
+      // required) keeps the perimeter and the handler seeing identical state.
+      if (hasRequiredDep) {
+        const checkedCaps = new Set<string>();
+        for (const dep of normalizedDeps) {
+          if (dep.required !== true) continue;
+          if (checkedCaps.has(dep.capability)) continue;
+          checkedCaps.add(dep.capability);
+          // `== null` catches both the resolved-null and never-set cases.
+          if (deps[dep.capability] == null) {
+            console.warn(
+              `🚫 Route '${req.method} ${req.path}': required dependency ` +
+                `'${dep.capability}' unavailable — returning 503`
+            );
+            res.status(503).json({
+              error: "dependency_unavailable",
+              capability: dep.capability,
+            });
+            return;
+          }
         }
       }
 

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -210,6 +210,15 @@ export type DependencySpec =
        * {@link expectedSchema}. Defaults to "subset" when expectedSchema is set.
        */
       matchMode?: "subset" | "strict";
+      /** Issue #1249: opt-in strictness for this dependency edge. When `true`,
+       * the registry factors this edge into transitive capability availability
+       * (own agent healthy AND every required dep available) and — for
+       * `mesh.route` deps — the framework returns HTTP 503
+       * (`{ error: "dependency_unavailable", capability }`) before user code
+       * when the proxy is unavailable at call time. Default `false` (soft-fail:
+       * an unresolved dep injects a null proxy that the handler null-checks).
+       */
+      required?: boolean;
     };
 
 /**
@@ -226,6 +235,8 @@ export interface NormalizedDependency {
   expectedSchemaRaw?: object;
   /** Issue #547: schema match mode ("subset" or "strict"). */
   matchMode?: "subset" | "strict";
+  /** Issue #1249: opt-in strictness for this dependency edge (default false). */
+  required?: boolean;
 }
 
 /**

--- a/tests/integration/suites/uc34_required_dependencies/artifacts/agent-a
+++ b/tests/integration/suites/uc34_required_dependencies/artifacts/agent-a
@@ -1,0 +1,1 @@
+../fixtures/agent-a

--- a/tests/integration/suites/uc34_required_dependencies/artifacts/agent-b
+++ b/tests/integration/suites/uc34_required_dependencies/artifacts/agent-b
@@ -1,0 +1,1 @@
+../fixtures/agent-b

--- a/tests/integration/suites/uc34_required_dependencies/artifacts/agent-b2
+++ b/tests/integration/suites/uc34_required_dependencies/artifacts/agent-b2
@@ -1,0 +1,1 @@
+../fixtures/agent-b2

--- a/tests/integration/suites/uc34_required_dependencies/artifacts/agent-c
+++ b/tests/integration/suites/uc34_required_dependencies/artifacts/agent-c
@@ -1,0 +1,1 @@
+../fixtures/agent-c

--- a/tests/integration/suites/uc34_required_dependencies/artifacts/agent-c2
+++ b/tests/integration/suites/uc34_required_dependencies/artifacts/agent-c2
@@ -1,0 +1,1 @@
+../fixtures/agent-c2

--- a/tests/integration/suites/uc34_required_dependencies/artifacts/agent-x
+++ b/tests/integration/suites/uc34_required_dependencies/artifacts/agent-x
@@ -1,0 +1,1 @@
+../fixtures/agent-x

--- a/tests/integration/suites/uc34_required_dependencies/artifacts/agent-y
+++ b/tests/integration/suites/uc34_required_dependencies/artifacts/agent-y
@@ -1,0 +1,1 @@
+../fixtures/agent-y

--- a/tests/integration/suites/uc34_required_dependencies/artifacts/base-provider
+++ b/tests/integration/suites/uc34_required_dependencies/artifacts/base-provider
@@ -1,0 +1,1 @@
+../fixtures/base-provider

--- a/tests/integration/suites/uc34_required_dependencies/artifacts/gateway-z
+++ b/tests/integration/suites/uc34_required_dependencies/artifacts/gateway-z
@@ -1,0 +1,1 @@
+../fixtures/gateway-z

--- a/tests/integration/suites/uc34_required_dependencies/artifacts/java-route-consumer
+++ b/tests/integration/suites/uc34_required_dependencies/artifacts/java-route-consumer
@@ -1,0 +1,1 @@
+../fixtures/java-route-consumer

--- a/tests/integration/suites/uc34_required_dependencies/artifacts/ts-required-consumer
+++ b/tests/integration/suites/uc34_required_dependencies/artifacts/ts-required-consumer
@@ -1,0 +1,1 @@
+../fixtures/ts-required-consumer

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/agent-a/main.py
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/agent-a/main.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""uc34 agent-a — provides a-cap with an OPTIONAL dep on b-cap (issue #1249).
+
+The top of the tc01 chain. The A -> B edge is deliberately OPTIONAL: when
+b-cap goes unavailable (because B's required c-cap edge broke), a-cap must
+STAY available==true — optional edges never propagate unavailability. tc01
+asserts exactly that contrast against the required B -> C edge.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("AgentA Service")
+
+
+@app.tool()
+@mesh.tool(
+    capability="a-cap",
+    description="A reports whether the b proxy is present",
+    dependencies=["b-cap"],
+)
+async def a_tool(b_dep: mesh.McpMeshTool = None) -> str:
+    if b_dep is None:
+        return "a: b proxy is None"
+    result = await b_dep()
+    return f"a: b proxy present, b said: {result}"
+
+
+@mesh.agent(
+    name="agent-a",
+    version="1.0.0",
+    description="uc34 provider of a-cap (optional dep on b-cap)",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9103")),
+    enable_http=True,
+    auto_run=True,
+)
+class AgentA:
+    pass

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/agent-b/main.py
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/agent-b/main.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""uc34 agent-b — provides b-cap with a REQUIRED dep on c-cap (issue #1249).
+
+The middle of the tc01 chain: because the c-cap edge is required, the
+registry marks b-cap available==false (unavailable_reason naming c-cap)
+whenever no available c-cap provider resolves — while THIS agent stays
+registered and healthy. That derived-state split (agent healthy, capability
+unavailable) is the core #1249 guarantee tc01 asserts.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("AgentB Service")
+
+
+@app.tool()
+@mesh.tool(
+    capability="b-cap",
+    description="B calls C",
+    dependencies=[{"capability": "c-cap", "required": True}],
+)
+async def b_tool(c_dep: mesh.McpMeshTool = None) -> str:
+    if c_dep is None:
+        return "b: c-cap NOT available"
+    result = await c_dep()
+    return f"b got: {result}"
+
+
+@mesh.agent(
+    name="agent-b",
+    version="1.0.0",
+    description="uc34 provider of b-cap (required dep on c-cap)",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9102")),
+    enable_http=True,
+    auto_run=True,
+)
+class AgentB:
+    pass

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/agent-b2/main.py
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/agent-b2/main.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""uc34 agent-b2 — b2-cap REQUIRES c-cap narrowed by tag (issue #1249).
+
+Constraint-mismatch fixture for tc02: the required edge demands c-cap WITH
+tags=["needs-this-tag"]. A healthy but UNTAGGED c-cap provider must NOT
+satisfy it — availability evaluation applies the same tag/version matching
+as ordinary consumer resolution, and the unavailable_reason must name the
+missing tag ("no provider matches tags=[needs-this-tag]") rather than blame
+provider health.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("AgentB2 Service")
+
+
+@app.tool()
+@mesh.tool(
+    capability="b2-cap",
+    description="B2 calls tag-narrowed C",
+    dependencies=[{"capability": "c-cap", "required": True, "tags": ["needs-this-tag"]}],
+)
+async def b2_tool(c_dep: mesh.McpMeshTool = None) -> str:
+    if c_dep is None:
+        return "b2: tagged c-cap NOT available"
+    result = await c_dep()
+    return f"b2 got: {result}"
+
+
+@mesh.agent(
+    name="agent-b2",
+    version="1.0.0",
+    description="uc34 provider of b2-cap (required tag-narrowed dep on c-cap)",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9107")),
+    enable_http=True,
+    auto_run=True,
+)
+class AgentB2:
+    pass

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/agent-c/main.py
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/agent-c/main.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""uc34 agent-c — leaf provider of c-cap (issue #1249).
+
+The bottom of the tc01 chain (A -> B -> C) and the UNTAGGED c-cap provider
+in tc02. It declares no dependencies of its own, so its availability is
+purely its agent health: killing this process is what makes b-cap's
+required edge break upstream.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("AgentC Service")
+
+
+@app.tool()
+@mesh.tool(capability="c-cap", description="Constant from C")
+async def c_tool() -> str:
+    return "hello-from-c"
+
+
+@mesh.agent(
+    name="agent-c",
+    version="1.0.0",
+    description="uc34 leaf provider of c-cap",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9101")),
+    enable_http=True,
+    auto_run=True,
+)
+class AgentC:
+    pass

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/agent-c2/main.py
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/agent-c2/main.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""uc34 agent-c2 — provides c-cap WITH the tag needs-this-tag (issue #1249).
+
+The tc02 resolution flip: once this tagged provider registers, agent-b2's
+tag-narrowed required edge finally matches and b2-cap must flip to
+available==true — proving availability is re-derived live as matching
+providers arrive, not frozen at registration.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("AgentC2 Service")
+
+
+@app.tool()
+@mesh.tool(
+    capability="c-cap",
+    description="Tagged constant from C2",
+    tags=["needs-this-tag"],
+)
+async def c2_tool() -> str:
+    return "hello-from-c2-tagged"
+
+
+@mesh.agent(
+    name="agent-c2",
+    version="1.0.0",
+    description="uc34 provider of tagged c-cap",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9108")),
+    enable_http=True,
+    auto_run=True,
+)
+class AgentC2:
+    pass

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/agent-x/main.py
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/agent-x/main.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""uc34 agent-x — x-cap REQUIRES y-cap (one half of the tc03 cycle).
+
+Started FIRST in tc03: with no y-cap edges registered yet, x's required edge
+is merely unresolved, so x registers fine — its x-cap simply sits at
+available==false ("required dep 'y-cap' unresolved"). agent-y then arrives
+declaring y-cap -> x-cap and closes the loop; y is the one the registry
+rejects.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("AgentX Service")
+
+
+@app.tool()
+@mesh.tool(
+    capability="x-cap",
+    description="X requires Y",
+    dependencies=[{"capability": "y-cap", "required": True}],
+)
+async def x_tool(y_dep: mesh.McpMeshTool = None) -> str:
+    return "x" if y_dep is None else "x with y"
+
+
+@mesh.agent(
+    name="agent-x",
+    version="1.0.0",
+    description="uc34 provider of x-cap (required dep on y-cap)",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9105")),
+    enable_http=True,
+    auto_run=True,
+)
+class AgentX:
+    pass

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/agent-y/main.py
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/agent-y/main.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""uc34 agent-y — y-cap REQUIRES x-cap (the cycle-closing half of tc03).
+
+With agent-x already registered (x-cap -> y-cap required), this agent's
+registration would close a required-edge cycle. The registry rejects it
+semantically (HTTP 200 + status:"error"), the Rust core surfaces the message
+loudly ("Registry rejected agent ...: required dependency cycle: ...") and
+keeps retrying with bounded backoff — so agent-y NEVER appears in /agents
+while the loop stands. tc03 asserts the absence + the log line.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("AgentY Service")
+
+
+@app.tool()
+@mesh.tool(
+    capability="y-cap",
+    description="Y requires X",
+    dependencies=[{"capability": "x-cap", "required": True}],
+)
+async def y_tool(x_dep: mesh.McpMeshTool = None) -> str:
+    return "y" if x_dep is None else "y with x"
+
+
+@mesh.agent(
+    name="agent-y",
+    version="1.0.0",
+    description="uc34 provider of y-cap (required dep on x-cap — closes the cycle)",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9106")),
+    enable_http=True,
+    auto_run=True,
+)
+class AgentY:
+    pass

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/base-provider/main.py
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/base-provider/main.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""uc34 base-provider — plain provider of base-cap (issue #1249).
+
+Shared Python provider for the cross-language TCs: the Java route consumer
+(tc04) and the TypeScript required-declaration consumer (tc05) both declare
+required=true edges on base-cap. Killing/restarting THIS process drives
+their unavailable -> recovered transitions. Returns a dict so the Java
+McpMeshTool<Map<String, Object>> proxy deserializes naturally.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Base Provider (uc34)")
+
+
+@app.tool()
+@mesh.tool(capability="base-cap", description="Constant payload from the base provider")
+async def base_tool() -> dict:
+    return {"msg": "hello-from-base"}
+
+
+@mesh.agent(
+    name="base-provider",
+    version="1.0.0",
+    description="uc34 provider of base-cap for the Java/TS required-dep TCs",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9101")),
+    enable_http=True,
+    auto_run=True,
+)
+class BaseProvider:
+    pass

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/gateway-z/main.py
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/gateway-z/main.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""uc34 gateway-z — FastAPI perimeter gateway; /z has a REQUIRED dep on b-cap.
+
+Issue #1249 route perimeter (Python): external HTTP callers never traverse a
+mesh proxy, so the required predicate is enforced at the route boundary by
+the framework's own @mesh.route wrapper — when the b-cap proxy is unavailable
+at call time (after the settle window), /z answers 503 with
+{"error":"dependency_unavailable","capability":"b-cap"} BEFORE user code runs.
+The handler body therefore calls b_dep unguarded: reaching it with a None
+proxy would crash with a 500, so a clean 503 is proof the perimeter fired.
+"""
+
+import mesh
+from fastapi import FastAPI, Request
+from mesh.types import McpMeshTool
+
+app = FastAPI(title="GatewayZ", description="uc34 gateway for /z", version="1.0.0")
+
+
+@app.get("/health")
+async def health():
+    return {"status": "healthy", "service": "gateway-z"}
+
+
+@app.get("/z")
+@mesh.route(dependencies=[{"capability": "b-cap", "required": True}])
+async def z_endpoint(request: Request, b_dep: McpMeshTool = None):
+    result = await b_dep()
+    return {"status": "ok", "b_said": result}
+
+
+if __name__ == "__main__":
+    import os
+
+    import uvicorn
+
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9104")),
+        log_level="info",
+    )

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/pom.xml
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.routereq</groupId>
+    <artifactId>java-route-consumer</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>JavaRouteConsumer Agent</name>
+    <description>uc34 consumer proving the #1249 @MeshDependency(required=true) route perimeter</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.2</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web (for the HTTP route perimeter under test) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.routereq.JavaRouteConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/src/main/java/com/example/routereq/JavaRouteConsumerApplication.java
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/src/main/java/com/example/routereq/JavaRouteConsumerApplication.java
@@ -1,0 +1,86 @@
+package com.example.routereq;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshRoute;
+import io.mcpmesh.types.McpMeshTool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * uc34 fixture — Java route perimeter for issue #1249.
+ *
+ * <p>The {@code /check} route declares {@code @MeshDependency(capability =
+ * "base-cap", required = true)}. Contract under test (mirrors the Python
+ * {@code @mesh.route} wrapper):
+ *
+ * <ul>
+ *   <li>Provider up: the framework injects the {@code McpMeshTool} proxy and
+ *       the handler answers 200 with the provider payload.</li>
+ *   <li>Provider down: {@code MeshRouteHandlerInterceptor} answers HTTP 503
+ *       with body {@code {"error":"dependency_unavailable","capability":"base-cap"}}
+ *       BEFORE user code runs. The handler body calls the proxy unguarded on
+ *       purpose — reaching it with a null proxy would blow up as a 500, so a
+ *       clean 503 is proof the perimeter fired, not a handler fallback.</li>
+ * </ul>
+ */
+@MeshAgent(
+    name = "java-route-consumer",
+    version = "1.0.0",
+    description = "uc34 consumer proving the #1249 required-route perimeter (503 before user code)",
+    port = 9201
+)
+@SpringBootApplication
+public class JavaRouteConsumerApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(JavaRouteConsumerApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting java-route-consumer (uc34 #1249 route perimeter)...");
+        SpringApplication.run(JavaRouteConsumerApplication.class, args);
+    }
+
+    /**
+     * The route under test. Parameter name {@code baseCap} matches the
+     * capability {@code base-cap} via the default hyphen-to-camelCase mapping.
+     */
+    @RestController
+    static class CheckController {
+
+        @GetMapping("/check")
+        @MeshRoute(dependencies = @MeshDependency(capability = "base-cap", required = true))
+        public ResponseEntity<Map<String, Object>> check(McpMeshTool<Map<String, Object>> baseCap) {
+            // Deliberately unguarded: the #1249 perimeter must 503 before we
+            // ever get here with an unavailable proxy.
+            Map<String, Object> result = baseCap.call(Map.of());
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("status", "ok");
+            out.put("base", result);
+            return ResponseEntity.ok(out);
+        }
+    }
+
+    /**
+     * Liveness anchor: a trivial tool capability so the agent registers on the
+     * ordinary tool-agent path and shows up in {@code meshctl list} under its
+     * declared name for the registration wait. Not asserted on.
+     */
+    @Service
+    static class PingService {
+
+        @MeshTool(capability = "java-route-ping", description = "uc34 liveness ping")
+        public Map<String, Object> ping() {
+            return Map.of("ok", true);
+        }
+    }
+}

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/src/main/resources/application.yml
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+# uc34 java-route-consumer configuration (issue #1249 route perimeter)
+
+spring:
+  application:
+    name: java-route-consumer
+  main:
+    banner-mode: "off"
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9201}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:java-route-consumer}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    root: INFO
+    io.mcpmesh: DEBUG
+    com.example: DEBUG

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/package.json
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ts-required-consumer",
+  "version": "1.0.0",
+  "description": "uc34 TypeScript consumer declaring a required=true dependency (issue #1249)",
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^2.7.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/src/index.ts
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/src/index.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env npx tsx
+/**
+ * ts-required-consumer - MCP Mesh Agent (uc34, issue #1249)
+ *
+ * Declares ts-req-cap with a REQUIRED dependency on the Python base-cap via
+ * the object DependencySpec form { capability, required: true }.
+ *
+ * Contract under test: the TS SDK must carry required=true on the wire so the
+ * registry factors the edge into transitive availability — when base-cap's
+ * provider dies, /agents must show ts-req-cap available==false with an
+ * unavailable_reason naming base-cap, and flip back once the provider
+ * returns. The tool body itself is a trivial probe; tc05's assertions are
+ * entirely registry-API driven.
+ */
+
+import { FastMCP, mesh, McpMeshTool } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+// FastMCP server instance
+const server = new FastMCP({
+  name: "TsRequiredConsumer Service",
+  version: "1.0.0",
+});
+
+// Wrap with MCP Mesh
+const agent = mesh(server, {
+  name: "ts-required-consumer",
+  httpPort: 9051,
+});
+
+agent.addTool({
+  name: "ts_required_probe",
+  capability: "ts-req-cap",
+  description: "Call the required base-cap dependency and report what it said",
+  tags: ["required", "probe"],
+  dependencies: [{ capability: "base-cap", required: true }],
+  parameters: z.object({}),
+  execute: async (
+    _args,
+    baseCap: McpMeshTool | null = null // Positional: dependencies[0]
+  ) => {
+    if (!baseCap) {
+      return JSON.stringify({ error: "base-cap not injected" });
+    }
+    const result = await baseCap({});
+    return JSON.stringify({ status: "ok", base: result });
+  },
+});
+
+console.log("ts-required-consumer agent defined. Waiting for auto-start...");

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/tsconfig.json
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc34_required_dependencies/routines.yaml
+++ b/tests/integration/suites/uc34_required_dependencies/routines.yaml
@@ -1,0 +1,17 @@
+# UC-level routines for uc34_required_dependencies (issue #1249).
+#
+# All availability transitions in this UC ride the registry's DEFAULT health
+# debounce (~3 missed heartbeats, ~15-25s) — no knob-cranked registry routine
+# on purpose: #1249's derived availability must hold under stock timing, and
+# every TC polls with a deadline instead of sleeping fixed. The registry is
+# auto-started by the first `meshctl start`.
+
+routines:
+  # Stop everything started by this test (agents + registry).
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: meshctl stop 2>/dev/null || true
+        ignore_errors: true

--- a/tests/integration/suites/uc34_required_dependencies/tc01_chain_propagation_python/test.yaml
+++ b/tests/integration/suites/uc34_required_dependencies/tc01_chain_propagation_python/test.yaml
@@ -1,0 +1,265 @@
+# tc01_chain_propagation_python — transitive required-dependency availability
+# propagates up a chain and out to the route perimeter (issue #1249, Python).
+#
+# Topology: A --optional--> B --REQUIRED--> C, plus gateway-z whose /z route
+# has a REQUIRED dep on b-cap.
+#
+# Design guarantees under test:
+#   1. Kill C -> b-cap flips available==false with unavailable_reason naming
+#      the broken required edge (c-cap) — WHILE agent-b itself stays
+#      registered and status=healthy. Availability is derived per-CAPABILITY
+#      state; the agent's own health is untouched.
+#   2. a-cap stays available==true — the A->B edge is OPTIONAL, and optional
+#      edges never propagate unavailability (soft-fail default preserved).
+#   3. /z answers 503 {"error":"dependency_unavailable","capability":"b-cap"}
+#      BEFORE user code runs: the gateway's required perimeter sees b-cap
+#      exactly as it would see a dead provider, two hops from the actual
+#      failure. The handler calls the proxy unguarded, so a clean 503 (not a
+#      500) proves the framework wrapper fired.
+#   4. Restart C -> the whole chain heals organically: /z returns 200 again
+#      with no restarts of B, A or the gateway.
+#
+# Timing: availability transitions ride the registry's default health
+# debounce (~3 missed heartbeats, ~15-25s) plus one consumer heartbeat to
+# propagate proxy state — every transition is POLLED with a deadline, never
+# a fixed sleep. Registration waits are liveness-only (issue #1193); the
+# settle window covers dependency resolution.
+
+name: "Required deps: chain propagation A->B->C with route perimeter (Python)"
+description: "Kill C: b-cap unavailable (reason names c-cap) while agent-b stays healthy, a-cap stays available (optional edge), /z answers 503 dependency_unavailable; restart C: /z recovers 200"
+tags:
+  - integration
+  - python
+  - registry
+  - required-deps
+  - availability
+  - issue-1249
+  - slow
+timeout: 600
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/agent-a /workspace/
+      cp -rL /uc-artifacts/agent-b /workspace/
+      cp -rL /uc-artifacts/agent-c /workspace/
+      cp -rL /uc-artifacts/gateway-z /workspace/
+
+  - name: "Install agent-a deps"
+    handler: pip-install
+    path: /workspace/agent-a
+
+  - name: "Install agent-b deps"
+    handler: pip-install
+    path: /workspace/agent-b
+
+  - name: "Install agent-c deps"
+    handler: pip-install
+    path: /workspace/agent-c
+
+  - name: "Install gateway-z deps"
+    handler: pip-install
+    path: /workspace/gateway-z
+
+  - name: "Start agent-c (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start agent-c/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Start agent-b (port 9102)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start agent-b/main.py --env MCP_MESH_HTTP_PORT=9102 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  - name: "Start agent-a (port 9103)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start agent-a/main.py --env MCP_MESH_HTTP_PORT=9103 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  - name: "Start gateway-z (port 9104)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start gateway-z/main.py --env MCP_MESH_HTTP_PORT=9104 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193): the three tool agents must APPEAR in
+  # meshctl list. The gateway is API-type; its readiness is proven by the /z
+  # baseline poll below. No dep-resolution wait — the settle window covers it.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "agent-a agent-b agent-c"
+
+  # Baseline: the FULL chain works end-to-end (gateway -> b-cap -> c-cap).
+  # This is also the gateway's liveness + settle gate.
+  - name: "Wait for /z baseline 200"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        CODE=$(curl -s -o /tmp/z_baseline.json -w "%{http_code}" http://localhost:9104/z 2>/dev/null || echo 000)
+        if [ "$CODE" = "200" ]; then
+          echo "Z_BASELINE_200=1 after ~$((i*2))s"
+          cat /tmp/z_baseline.json
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: /z never answered 200 within 120s (last code=$CODE)"
+      cat /tmp/z_baseline.json 2>/dev/null || true
+      meshctl logs gateway-z 2>/dev/null | tail -30 || true
+      exit 1
+    capture: z_baseline
+    timeout: 140
+
+  - name: "Capture baseline /agents snapshot"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_baseline
+
+  - name: "Kill agent-c"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop agent-c
+    capture: kill_c
+
+  # The registry re-derives b-cap's availability once C's death lands
+  # (graceful unregister is immediate; a hard death takes the ~15-25s health
+  # debounce). Poll with a deadline that covers both paths.
+  - name: "Wait for b-cap to flip unavailable"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        AVAIL=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name == "agent-b") | .capabilities[] | select(.name == "b-cap") | .available' 2>/dev/null || echo "")
+        if [ "$AVAIL" = "false" ]; then
+          echo "BCAP_UNAVAILABLE=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: b-cap never flipped to available=false within 120s (last=$AVAIL)"
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name == "agent-b")' 2>/dev/null || true
+      exit 1
+    capture: wait_bcap_down
+    timeout: 140
+
+  # Perimeter: the gateway learns via its own heartbeat's resolution diff,
+  # then its required route wrapper 503s before user code.
+  - name: "Wait for /z to answer 503"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9104/z 2>/dev/null || echo 000)
+        if [ "$CODE" = "503" ]; then
+          echo "Z_503=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: /z never answered 503 within 120s (last code=$CODE)"
+      curl -s http://localhost:9104/z 2>/dev/null || true
+      meshctl logs gateway-z 2>/dev/null | tail -30 || true
+      exit 1
+    capture: wait_z_503
+    timeout: 140
+
+  # Pure-JSON captures for jq assertions (state is stable while C is down).
+  - name: "Capture /z outage body"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:9104/z
+    capture: z_outage_body
+
+  - name: "Capture /z outage status code"
+    handler: shell
+    workdir: /workspace
+    command: curl -s -o /dev/null -w "%{http_code}" http://localhost:9104/z
+    capture: z_outage_code
+
+  # Snapshot taken WHILE /z is 503 — this is the snapshot that proves
+  # agent-b is still registered/healthy during the perimeter outage.
+  - name: "Capture /agents snapshot during outage"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_during_outage
+
+  - name: "Restart agent-c"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start agent-c/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  # Recovery: C re-registers, b-cap re-derives available, the gateway's next
+  # heartbeat restores the proxy — nothing else is restarted.
+  - name: "Wait for /z recovery 200"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 75); do
+        CODE=$(curl -s -o /tmp/z_recovery.json -w "%{http_code}" http://localhost:9104/z 2>/dev/null || echo 000)
+        if [ "$CODE" = "200" ]; then
+          echo "Z_RECOVERED=1 after ~$((i*2))s"
+          cat /tmp/z_recovery.json
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: /z never recovered to 200 within 150s (last code=$CODE)"
+      cat /tmp/z_recovery.json 2>/dev/null || true
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name == "agent-b")' 2>/dev/null || true
+      meshctl logs gateway-z 2>/dev/null | tail -30 || true
+      exit 1
+    capture: z_recovery
+    timeout: 170
+
+assertions:
+  # IDIOM: equality lives INSIDE the jq filter so the interpolation yields a
+  # bare true/false (tsuite Go-formats extracted values, and the interpolation
+  # body cannot contain '}' — hence no object construction in filters).
+
+  # Scenario gates surfaced by the poll steps
+  - expr: "${captured.z_baseline} contains 'Z_BASELINE_200=1'"
+    message: "the full A->B->C chain plus gateway must work before the kill"
+  - expr: "${captured.wait_bcap_down} contains 'BCAP_UNAVAILABLE=1'"
+    message: "killing C must flip b-cap to available=false within the health-debounce deadline"
+  - expr: "${captured.wait_z_503} contains 'Z_503=1'"
+    message: "/z must transition to 503 once b-cap is unavailable"
+  - expr: "${captured.z_recovery} contains 'Z_RECOVERED=1'"
+    message: "restarting C must heal the chain: /z back to 200 with no other restarts"
+
+  # Baseline: with C up, b-cap is available and carries no reason
+  - expr: "${jq:captured.agents_baseline:(.agents[] | select(.name == \"agent-b\") | .capabilities[] | select(.name == \"b-cap\") | .available == true and .unavailable_reason == null)} == 'true'"
+    message: "baseline: b-cap must be available with no unavailable_reason while C is up"
+
+  # Guarantee 1: b-cap unavailable, reason names the broken c-cap edge...
+  - expr: "${jq:captured.agents_during_outage:(.agents[] | select(.name == \"agent-b\") | .capabilities[] | select(.name == \"b-cap\") | .available == false)} == 'true'"
+    message: "b-cap must be available=false while its required c-cap edge is broken"
+  - expr: "${jq:captured.agents_during_outage:(.agents[] | select(.name == \"agent-b\") | .capabilities[] | select(.name == \"b-cap\") | .unavailable_reason // \"\" | contains(\"c-cap\"))} == 'true'"
+    message: "b-cap's unavailable_reason must name the broken required edge (c-cap)"
+
+  # ...WHILE agent-b itself is still registered and healthy (derived
+  # capability state, not agent health)
+  - expr: "${jq:captured.agents_during_outage:([.agents[] | select(.name == \"agent-b\")] | length == 1)} == 'true'"
+    message: "agent-b must still be REGISTERED while its capability is unavailable"
+  - expr: "${jq:captured.agents_during_outage:(.agents[] | select(.name == \"agent-b\") | .status == \"healthy\")} == 'true'"
+    message: "agent-b must still be HEALTHY — unavailability is capability-level derived state"
+
+  # Guarantee 2: the optional A->B edge does NOT propagate unavailability
+  - expr: "${jq:captured.agents_during_outage:(.agents[] | select(.name == \"agent-a\") | .capabilities[] | select(.name == \"a-cap\") | .available == true)} == 'true'"
+    message: "a-cap must STAY available — optional edges never propagate unavailability"
+
+  # Guarantee 3: the perimeter 503 carries the structured contract body
+  - expr: "${captured.z_outage_code} == '503'"
+    message: "/z must answer HTTP 503 while b-cap is unavailable"
+  - expr: "${jq:captured.z_outage_body:(.error == \"dependency_unavailable\" and .capability == \"b-cap\")} == 'true'"
+    message: "the 503 body must be the structured contract: error=dependency_unavailable, capability=b-cap (a 500/handler crash would mean user code ran with a dead proxy)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc34_required_dependencies/tc02_constraint_mismatch_tags/test.yaml
+++ b/tests/integration/suites/uc34_required_dependencies/tc02_constraint_mismatch_tags/test.yaml
@@ -1,0 +1,163 @@
+# tc02_constraint_mismatch_tags — required-edge availability applies FULL
+# constraint matching, not just capability-name existence (issue #1249).
+#
+# Topology: agent-b2's b2-cap REQUIRES c-cap WITH tags=["needs-this-tag"].
+# agent-c provides c-cap UNTAGGED and perfectly healthy.
+#
+# Design guarantees under test:
+#   1. A healthy provider that fails the edge's tag constraint does NOT
+#      satisfy a required edge: b2-cap is available==false even though a
+#      c-cap provider is up. The unavailable_reason must name the missing
+#      tag ("no provider matches tags=[needs-this-tag]") — NOT blame the
+#      healthy provider's health (the describeUnresolvedRequiredEdge
+#      live-validation fix: constraint-failing providers are irrelevant to
+#      why the edge is broken).
+#   2. Availability is re-derived live: starting agent-c2 (c-cap tagged
+#      needs-this-tag) flips b2-cap to available==true with no restart of
+#      agent-b2.
+#
+# Timing: verdicts are computed at /agents read time from registered state,
+# so both transitions land as soon as registration does — still polled with
+# deadlines, never fixed sleeps.
+
+name: "Required deps: tag-constrained edge ignores a healthy non-matching provider (Python)"
+description: "b2-cap requires c-cap+needs-this-tag; untagged healthy C leaves b2-cap unavailable with the tag named in the reason; starting tagged C2 flips it available"
+tags:
+  - integration
+  - python
+  - registry
+  - required-deps
+  - availability
+  - tags
+  - issue-1249
+timeout: 420
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/agent-b2 /workspace/
+      cp -rL /uc-artifacts/agent-c /workspace/
+      cp -rL /uc-artifacts/agent-c2 /workspace/
+
+  - name: "Install agent-b2 deps"
+    handler: pip-install
+    path: /workspace/agent-b2
+
+  - name: "Install agent-c deps"
+    handler: pip-install
+    path: /workspace/agent-c
+
+  - name: "Install agent-c2 deps"
+    handler: pip-install
+    path: /workspace/agent-c2
+
+  - name: "Start untagged agent-c (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start agent-c/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Start agent-b2 (port 9107)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start agent-b2/main.py --env MCP_MESH_HTTP_PORT=9107 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193). "agent-c" is a substring of "agent-c2" too,
+  # but c2 is not started yet — this wait can only be satisfied by agent-c.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "agent-b2 agent-c"
+
+  # The mismatch verdict: b2-cap must surface as unavailable as soon as it is
+  # listed. Polling until 'false' (rather than until listed) means a bugged
+  # 'true' verdict fails HERE with a loud named error, not in a later step.
+  - name: "Wait for b2-cap mismatch verdict (available=false)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 45); do
+        AVAIL=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name == "agent-b2") | .capabilities[] | select(.name == "b2-cap") | .available' 2>/dev/null || echo "")
+        if [ "$AVAIL" = "false" ]; then
+          echo "B2CAP_UNAVAILABLE=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: b2-cap never surfaced as available=false within 90s (last=$AVAIL) — a healthy UNTAGGED provider must not satisfy a tag-constrained required edge"
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name == "agent-b2")' 2>/dev/null || true
+      exit 1
+    capture: wait_b2_mismatch
+    timeout: 110
+
+  - name: "Capture /agents snapshot with only the untagged provider"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_mismatch
+
+  - name: "Start tagged agent-c2 (port 9108)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start agent-c2/main.py --env MCP_MESH_HTTP_PORT=9108 -d
+
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "agent-c2"
+
+  - name: "Wait for b2-cap to flip available (tagged provider matched)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        AVAIL=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name == "agent-b2") | .capabilities[] | select(.name == "b2-cap") | .available' 2>/dev/null || echo "")
+        if [ "$AVAIL" = "true" ]; then
+          echo "B2CAP_AVAILABLE=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: b2-cap never flipped to available=true within 120s of the tagged provider registering (last=$AVAIL)"
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name == "agent-b2")' 2>/dev/null || true
+      exit 1
+    capture: wait_b2_available
+    timeout: 140
+
+  - name: "Capture /agents snapshot with the tagged provider"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_tagged
+
+assertions:
+  # IDIOM: equality INSIDE the jq filter, '== true' outside; no '}' in
+  # interpolation bodies.
+
+  - expr: "${captured.wait_b2_mismatch} contains 'B2CAP_UNAVAILABLE=1'"
+    message: "b2-cap must surface available=false while only the untagged provider exists"
+  - expr: "${captured.wait_b2_available} contains 'B2CAP_AVAILABLE=1'"
+    message: "b2-cap must flip available=true once the tagged provider registers"
+
+  # Guarantee 1: constraint mismatch, with the TAG named in the reason
+  - expr: "${jq:captured.agents_mismatch:(.agents[] | select(.name == \"agent-b2\") | .capabilities[] | select(.name == \"b2-cap\") | .available == false)} == 'true'"
+    message: "a healthy non-matching provider must NOT satisfy a tag-constrained required edge"
+  - expr: "${jq:captured.agents_mismatch:(.agents[] | select(.name == \"agent-b2\") | .capabilities[] | select(.name == \"b2-cap\") | .unavailable_reason // \"\" | contains(\"needs-this-tag\"))} == 'true'"
+    message: "the unavailable_reason must name the unmatched tag constraint (needs-this-tag), not provider health"
+
+  # The untagged provider itself is healthy and its own c-cap is available —
+  # proving the mismatch verdict above is constraint-driven, not health-driven
+  - expr: "${jq:captured.agents_mismatch:(.agents[] | select(.name == \"agent-c\") | .status == \"healthy\")} == 'true'"
+    message: "the untagged c-cap provider must be healthy — otherwise this test degenerates into tc01"
+  - expr: "${jq:captured.agents_mismatch:(.agents[] | select(.name == \"agent-c\") | .capabilities[] | select(.name == \"c-cap\") | .available == true)} == 'true'"
+    message: "the untagged provider's own c-cap must be available (it has no required deps)"
+
+  # Guarantee 2: the tagged provider flips the verdict, reason cleared
+  - expr: "${jq:captured.agents_tagged:(.agents[] | select(.name == \"agent-b2\") | .capabilities[] | select(.name == \"b2-cap\") | .available == true and .unavailable_reason == null)} == 'true'"
+    message: "b2-cap must be available with no unavailable_reason once a tag-matching provider exists"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc34_required_dependencies/tc03_cycle_rejection/test.yaml
+++ b/tests/integration/suites/uc34_required_dependencies/tc03_cycle_rejection/test.yaml
@@ -1,0 +1,130 @@
+# tc03_cycle_rejection — a registration that would close a required-edge
+# cycle is REJECTED loudly at the registry (issue #1249, Python).
+#
+# Topology: agent-x declares x-cap --REQUIRED--> y-cap; agent-y declares
+# y-cap --REQUIRED--> x-cap. Started SEQUENTIALLY so the rejected party is
+# deterministic: x registers first (its edge is merely unresolved — legal),
+# then y's registration closes the loop and is the one rejected.
+#
+# Design guarantees under test:
+#   1. Cycle rejection is registration-time and semantic: the registry
+#      answers HTTP 200 + status:"error" with a message naming the loop;
+#      the Rust core surfaces it as a loud per-attempt log ("Registry
+#      rejected agent ...: required dependency cycle: ...") and keeps
+#      retrying with bounded backoff (soft-fail: fix the config, agent heals
+#      without restart). A required cycle can never converge, so a loud
+#      deterministic rejection beats a silent permanent deadlock.
+#   2. The rejected agent NEVER appears in /agents while the loop stands.
+#   3. The half-cycle that DID register is legal but simply unavailable:
+#      agent-x stays registered with x-cap available==false, reason naming
+#      the unresolved y-cap edge. (Optional edges remain the sanctioned
+#      bootstrapping path for mutually-dependent agents.)
+
+name: "Required deps: cycle-closing registration is rejected, half-cycle stays unavailable (Python)"
+description: "x requires y-cap then y requires x-cap: y is rejected ('required dependency cycle' in its logs, absent from /agents); x stays registered with x-cap available=false naming y-cap"
+tags:
+  - integration
+  - python
+  - registry
+  - required-deps
+  - availability
+  - cycle
+  - issue-1249
+timeout: 420
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/agent-x /workspace/
+      cp -rL /uc-artifacts/agent-y /workspace/
+
+  - name: "Install agent-x deps"
+    handler: pip-install
+    path: /workspace/agent-x
+
+  - name: "Install agent-y deps"
+    handler: pip-install
+    path: /workspace/agent-y
+
+  # Sequential start makes the rejection deterministic: x's lone required
+  # edge (x-cap -> y-cap) cannot close a cycle against an empty graph.
+  - name: "Start agent-x (port 9105)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start agent-x/main.py --env MCP_MESH_HTTP_PORT=9105 -d
+
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "agent-x"
+
+  - name: "Start cycle-closing agent-y (port 9106)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start agent-y/main.py --env MCP_MESH_HTTP_PORT=9106 -d
+
+  # The Rust core logs the semantic rejection on every heartbeat attempt.
+  # meshctl logs resolves the DECLARED agent name; fall back to the raw log
+  # dir in case the process tracker keys differently for a never-registered
+  # agent.
+  - name: "Wait for the cycle rejection in agent-y's logs"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 45); do
+        if (meshctl logs agent-y 2>/dev/null; cat ~/.mcp-mesh/logs/agent-y*.log 2>/dev/null) | grep -q "required dependency cycle"; then
+          echo "CYCLE_REJECTED=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: 'required dependency cycle' never appeared in agent-y's logs within 90s"
+      meshctl logs agent-y 2>/dev/null | tail -50 || true
+      ls ~/.mcp-mesh/logs/ 2>/dev/null || true
+      exit 1
+    capture: wait_cycle_rejected
+    timeout: 110
+
+  - name: "Capture agent-y rejection log lines"
+    handler: shell
+    workdir: /workspace
+    command: |
+      (meshctl logs agent-y 2>/dev/null || true; cat ~/.mcp-mesh/logs/agent-y*.log 2>/dev/null || true) | grep "required dependency cycle" | head -5
+    capture: y_rejection_log
+
+  - name: "Capture /agents snapshot"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_snapshot
+
+assertions:
+  # IDIOM: equality INSIDE the jq filter, '== true' outside; no '}' in
+  # interpolation bodies.
+
+  - expr: "${captured.wait_cycle_rejected} contains 'CYCLE_REJECTED=1'"
+    message: "agent-y's registration must be rejected with the cycle named in its logs"
+
+  # Guarantee 1: the rejection is loud and names the failure class
+  - expr: "${captured.y_rejection_log} contains 'required dependency cycle'"
+    message: "the rejected agent's log must carry the registry's 'required dependency cycle' message (loud soft-fail, not a silent drop)"
+
+  # Guarantee 2: the cycle-closer never registers
+  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"agent-y\")] | length == 0)} == 'true'"
+    message: "agent-y must be ABSENT from /agents — a cycle-closing registration is never written"
+
+  # Guarantee 3: the legal half-cycle is registered but unavailable
+  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"agent-x\")] | length == 1)} == 'true'"
+    message: "agent-x must stay registered — an unresolved required edge is legal, only the cycle is not"
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"agent-x\") | .capabilities[] | select(.name == \"x-cap\") | .available == false)} == 'true'"
+    message: "x-cap must be available=false while its required y-cap edge is unresolved"
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"agent-x\") | .capabilities[] | select(.name == \"x-cap\") | .unavailable_reason // \"\" | contains(\"y-cap\"))} == 'true'"
+    message: "x-cap's unavailable_reason must name the unresolved y-cap edge"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc34_required_dependencies/tc04_java_route_perimeter/test.yaml
+++ b/tests/integration/suites/uc34_required_dependencies/tc04_java_route_perimeter/test.yaml
@@ -1,0 +1,201 @@
+# tc04_java_route_perimeter — Java parity for the issue #1249 required-route
+# perimeter: @MeshDependency(required = true) on a @MeshRoute.
+#
+# Topology: Python base-provider (base-cap) + Java java-route-consumer whose
+# /check route declares the required edge and calls the proxy UNGUARDED.
+#
+# Design guarantees under test (mirrors the Python contract exactly):
+#   1. Provider up: /check answers 200 through the injected proxy.
+#   2. Provider down: MeshRouteHandlerInterceptor answers HTTP 503 with the
+#      structured body {"error":"dependency_unavailable","capability":"base-cap"}
+#      BEFORE user code runs — external HTTP callers never traverse a mesh
+#      proxy, so the perimeter is the enforcement point. A 500 here would
+#      mean user code ran with a dead proxy (perimeter did NOT fire).
+#   3. Provider restarted: /check heals to 200 with no consumer restart.
+#
+# Timing: the unavailable transition rides the default health debounce
+# (~3 missed heartbeats, ~15-25s) plus one consumer heartbeat — polled with
+# deadlines. Registration waits are liveness-only with the global routine's
+# 240s deadline (cold-JVM mvn spring-boot:run starts routinely exceed 90s).
+
+name: "Required deps: Java @MeshDependency(required=true) route perimeter answers 503/recovers"
+description: "Java /check route with a required base-cap edge: 200 with the Python provider up, 503 dependency_unavailable (before user code) when it dies, 200 again after restart"
+tags:
+  - integration
+  - java
+  - python
+  - registry
+  - required-deps
+  - availability
+  - issue-1249
+  - slow
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/base-provider /workspace/
+      cp -rL /uc-artifacts/java-route-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/base-provider
+
+  - name: "Install Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-route-consumer
+    timeout: 600
+
+  - name: "Start base-provider (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start base-provider/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Start java-route-consumer (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-route-consumer --env MCP_MESH_HTTP_PORT=9201 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193): 240s deadline covers the cold JVM start.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "base-provider java-route-consumer"
+
+  # Baseline 200 through the injected proxy. Long deadline: Spring context
+  # refresh + first heartbeat resolution on a cold JVM.
+  - name: "Wait for /check baseline 200"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 90); do
+        CODE=$(curl -s -o /tmp/check_baseline.json -w "%{http_code}" http://localhost:9201/check 2>/dev/null || echo 000)
+        if [ "$CODE" = "200" ]; then
+          echo "CHECK_BASELINE_200=1 after ~$((i*2))s"
+          cat /tmp/check_baseline.json
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: /check never answered 200 within 180s (last code=$CODE)"
+      cat /tmp/check_baseline.json 2>/dev/null || true
+      meshctl logs java-route-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: check_baseline
+    timeout: 200
+
+  # Pure-JSON capture for the jq payload assertion: the wait step above mixes
+  # its progress marker with the body in one capture, which jq can't parse.
+  - name: "Capture /check baseline body"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:9201/check
+    capture: check_baseline_body
+
+  - name: "Kill base-provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop base-provider
+    capture: kill_provider
+
+  - name: "Wait for /check to answer 503"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9201/check 2>/dev/null || echo 000)
+        if [ "$CODE" = "503" ]; then
+          echo "CHECK_503=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: /check never answered 503 within 120s (last code=$CODE)"
+      curl -s http://localhost:9201/check 2>/dev/null || true
+      meshctl logs java-route-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: wait_check_503
+    timeout: 140
+
+  # Pure-JSON captures for jq assertions (state stable while provider is down).
+  - name: "Capture /check outage body"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:9201/check
+    capture: check_outage_body
+
+  - name: "Capture /check outage status code"
+    handler: shell
+    workdir: /workspace
+    command: curl -s -o /dev/null -w "%{http_code}" http://localhost:9201/check
+    capture: check_outage_code
+
+  - name: "Restart base-provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start base-provider/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Wait for /check recovery 200"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 75); do
+        CODE=$(curl -s -o /tmp/check_recovery.json -w "%{http_code}" http://localhost:9201/check 2>/dev/null || echo 000)
+        if [ "$CODE" = "200" ]; then
+          echo "CHECK_RECOVERED=1 after ~$((i*2))s"
+          cat /tmp/check_recovery.json
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: /check never recovered to 200 within 150s (last code=$CODE)"
+      cat /tmp/check_recovery.json 2>/dev/null || true
+      meshctl logs java-route-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: check_recovery
+    timeout: 170
+
+  # Pure-JSON capture for the jq payload assertion (same reason as baseline).
+  - name: "Capture /check recovery body"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:9201/check
+    capture: check_recovery_body
+
+assertions:
+  # IDIOM: equality INSIDE the jq filter, '== true' outside; no '}' in
+  # interpolation bodies.
+
+  - expr: "${captured.check_baseline} contains 'CHECK_BASELINE_200=1'"
+    message: "/check must answer 200 through the injected proxy while the provider is up"
+  - expr: "${jq:captured.check_baseline_body:(.base.msg == \"hello-from-base\")} == 'true'"
+    message: "the baseline 200 must carry the provider payload — proving the proxy path, not a static handler"
+
+  # Guarantee 2: the perimeter 503 with the structured contract body
+  - expr: "${captured.wait_check_503} contains 'CHECK_503=1'"
+    message: "/check must transition to 503 once the required base-cap provider dies"
+  - expr: "${captured.check_outage_code} == '503'"
+    message: "/check must answer HTTP 503 during the outage"
+  - expr: "${jq:captured.check_outage_body:(.error == \"dependency_unavailable\" and .capability == \"base-cap\")} == 'true'"
+    message: "the 503 body must be the structured contract (error=dependency_unavailable, capability=base-cap) — a 500 or other body means user code ran with a dead proxy"
+
+  # Guarantee 3: organic recovery, no consumer restart
+  - expr: "${captured.check_recovery} contains 'CHECK_RECOVERED=1'"
+    message: "/check must heal to 200 after the provider restarts, with no consumer restart"
+  - expr: "${jq:captured.check_recovery_body:(.base.msg == \"hello-from-base\")} == 'true'"
+    message: "the recovered 200 must again carry the provider payload"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop 2>/dev/null || true
+      pkill -f "spring-boot:run" 2>/dev/null || true
+      pkill -f "java.*route" 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc34_required_dependencies/tc05_ts_required_declaration/test.yaml
+++ b/tests/integration/suites/uc34_required_dependencies/tc05_ts_required_declaration/test.yaml
@@ -1,0 +1,191 @@
+# tc05_ts_required_declaration — TypeScript parity for the issue #1249
+# required-dependency declaration chain.
+#
+# Topology: Python base-provider (base-cap) + TS ts-required-consumer whose
+# ts-req-cap tool declares { capability: "base-cap", required: true } via the
+# object DependencySpec form.
+#
+# Design guarantees under test:
+#   1. The TS SDK carries required=true over the wire (decorator ->
+#      NormalizedDependency -> heartbeat payload) and the registration is
+#      accepted: ts-req-cap resolves and reads available==true while the
+#      provider is up. (If the flag were dropped, step 3 could never flip.)
+#   2. Kill the provider -> the registry's derived availability marks
+#      ts-req-cap available==false with an unavailable_reason naming the
+#      broken base-cap edge — driven purely by the REGISTRY predicate; the
+#      TS agent itself stays registered and healthy.
+#   3. Restart the provider -> ts-req-cap re-derives available==true with no
+#      consumer restart.
+#
+# Timing: default health debounce (~3 missed heartbeats, ~15-25s) — every
+# transition polled with a deadline, never a fixed sleep. Registration waits
+# are liveness-only (issue #1193); no dep-resolution waits.
+
+name: "Required deps: TS {capability, required: true} declaration drives registry availability"
+description: "TS consumer requires base-cap: ts-req-cap available=true baseline, flips false (reason names base-cap) when the Python provider dies while the TS agent stays healthy, recovers on restart"
+tags:
+  - integration
+  - typescript
+  - python
+  - registry
+  - required-deps
+  - availability
+  - issue-1249
+  - slow
+timeout: 600
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/base-provider /workspace/
+      cp -rL /uc-artifacts/ts-required-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/base-provider
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/ts-required-consumer
+
+  - name: "Start base-provider (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start base-provider/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Start ts-required-consumer (port 9051)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start ts-required-consumer/src/index.ts --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193).
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "base-provider ts-required-consumer"
+
+  # Baseline: the required edge RESOLVES — proving the TS registration with
+  # required=true was accepted and matched (guarantee 1).
+  - name: "Wait for ts-req-cap baseline (available=true)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        AVAIL=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name == "ts-required-consumer") | .capabilities[] | select(.name == "ts-req-cap") | .available' 2>/dev/null || echo "")
+        if [ "$AVAIL" = "true" ]; then
+          echo "TSCAP_AVAILABLE=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: ts-req-cap never became available=true within 120s (last=$AVAIL)"
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name == "ts-required-consumer")' 2>/dev/null || true
+      meshctl logs ts-required-consumer 2>/dev/null | tail -30 || true
+      exit 1
+    capture: wait_ts_baseline
+    timeout: 140
+
+  - name: "Capture baseline /agents snapshot"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_baseline
+
+  - name: "Kill base-provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop base-provider
+    capture: kill_provider
+
+  # Guarantee 2: the registry-derived verdict flips — the discriminator that
+  # required=true actually crossed the wire from the TS SDK (an optional edge
+  # would leave ts-req-cap available=true forever and time out HERE).
+  - name: "Wait for ts-req-cap to flip unavailable"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        AVAIL=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name == "ts-required-consumer") | .capabilities[] | select(.name == "ts-req-cap") | .available' 2>/dev/null || echo "")
+        if [ "$AVAIL" = "false" ]; then
+          echo "TSCAP_UNAVAILABLE=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: ts-req-cap never flipped to available=false within 120s (last=$AVAIL) — did the TS SDK drop required=true on the wire?"
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name == "ts-required-consumer")' 2>/dev/null || true
+      exit 1
+    capture: wait_ts_unavailable
+    timeout: 140
+
+  - name: "Capture outage /agents snapshot"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_outage
+
+  - name: "Restart base-provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start base-provider/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  # Guarantee 3: organic recovery, no consumer restart.
+  - name: "Wait for ts-req-cap recovery (available=true)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 75); do
+        AVAIL=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name == "ts-required-consumer") | .capabilities[] | select(.name == "ts-req-cap") | .available' 2>/dev/null || echo "")
+        if [ "$AVAIL" = "true" ]; then
+          echo "TSCAP_RECOVERED=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: ts-req-cap never recovered to available=true within 150s (last=$AVAIL)"
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name == "ts-required-consumer")' 2>/dev/null || true
+      exit 1
+    capture: wait_ts_recovery
+    timeout: 170
+
+  - name: "Capture recovery /agents snapshot"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_recovery
+
+assertions:
+  # IDIOM: equality INSIDE the jq filter, '== true' outside; no '}' in
+  # interpolation bodies.
+
+  - expr: "${captured.wait_ts_baseline} contains 'TSCAP_AVAILABLE=1'"
+    message: "ts-req-cap must resolve to available=true with the provider up — the required declaration must not break TS registration"
+  - expr: "${captured.wait_ts_unavailable} contains 'TSCAP_UNAVAILABLE=1'"
+    message: "killing the provider must flip ts-req-cap to available=false — proves required=true crossed the wire from the TS SDK"
+  - expr: "${captured.wait_ts_recovery} contains 'TSCAP_RECOVERED=1'"
+    message: "restarting the provider must flip ts-req-cap back to available=true with no consumer restart"
+
+  # Baseline: available, no reason
+  - expr: "${jq:captured.agents_baseline:(.agents[] | select(.name == \"ts-required-consumer\") | .capabilities[] | select(.name == \"ts-req-cap\") | .available == true and .unavailable_reason == null)} == 'true'"
+    message: "baseline: ts-req-cap must be available with no unavailable_reason"
+
+  # Outage: unavailable with the broken edge named, agent itself untouched
+  - expr: "${jq:captured.agents_outage:(.agents[] | select(.name == \"ts-required-consumer\") | .capabilities[] | select(.name == \"ts-req-cap\") | .available == false)} == 'true'"
+    message: "ts-req-cap must be available=false while its required base-cap edge is broken"
+  - expr: "${jq:captured.agents_outage:(.agents[] | select(.name == \"ts-required-consumer\") | .capabilities[] | select(.name == \"ts-req-cap\") | .unavailable_reason // \"\" | contains(\"base-cap\"))} == 'true'"
+    message: "ts-req-cap's unavailable_reason must name the broken required edge (base-cap)"
+  - expr: "${jq:captured.agents_outage:(.agents[] | select(.name == \"ts-required-consumer\") | .status == \"healthy\")} == 'true'"
+    message: "the TS consumer agent must stay HEALTHY — unavailability is capability-level derived state, not agent health"
+
+  # Recovery: available again, reason cleared
+  - expr: "${jq:captured.agents_recovery:(.agents[] | select(.name == \"ts-required-consumer\") | .capabilities[] | select(.name == \"ts-req-cap\") | .available == true and .unavailable_reason == null)} == 'true'"
+    message: "recovery: ts-req-cap must be available again with the reason cleared"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary
Second slice of #1249, plus a latent runtime bug it surfaced:

- **Java parity**: `@Selector(required = true)` (tools) and `@MeshDependency(required = true)` (routes / `@MeshDependsOn` / A2A) flow into the spec JSON (Jackson omit-when-false — byte-identical for existing code); route perimeter 503 via `MeshRouteHandlerInterceptor` (Jackson-serialized body, precedence over `failOnMissingDependency`); **required-wins** dedupe across the route and A2A registries with a warn on conflicting declarations.
- **TypeScript parity**: `{ capability, required: true }` through the napi boundary (was hardcoded false); capability-keyed route perimeter that judges exactly the state the handler receives.
- **Reliable dependency-update delivery (closes #1256)**: dep-update events could be silently lost at the Rust→Python bridge (cancel-unsafe `wait_for` around an already-dequeued recv) and never retried (diff gate advanced on enqueue). Fixed both: the pull timeout moved inside the future (`pull_next_event`, recv stays cancel-safe; Python loops use plain awaits with a `None` liveness tick), and a throttled 10s reconcile re-emits any edge whose event didn't apply. Validated 10/10 kill/restart cycles (pre-fix stuck at ~5); this bug predates #1249 (blamed to 2026-01) and likely explains a class of historical registration-timing flakes.
- **uc34_required_dependencies**: five integration cases — chain propagation + route perimeter (Python), tag-constrained required edges, cycle rejection, Java perimeter (payload-verified proxy path), TS wire parity.
- **Docs**: required-deps documented across six man pages + four guides (all claims code-verified); systemic corrections to the TS DI docs (object-destructuring → the real positional injection in ~20 examples; `dependencyConfig` → `dependencyKwargs` with correct keys/units).

## Review Notes
Zero-context review applied; all findings fixed incl. a BLOCKER (`@MeshDependsOn` silently dropping the flag — a third construction site). Deferred, noted: cross-source dedupe doesn't yet apply required-wins between surfaces (pre-existing policy); `napi.rs::next_event` should adopt `pull_next_event` for the same cancel-safety (TS consumers; commented on #1256); Java's route-level `failOnMissingDependency=true` default divergence from Python soft-fail (pre-existing, parity discussion).

Part of #1249 (remaining: meshctl/UI reason-chain, jobs claim-gating)
Closes #1256

## Test plan
- [x] Java 529+98+15; TS 1016 + tsc clean; Rust 482; Python 1261
- [x] Live repro: 10/10 kill/restart recovery cycles (pre-fix: permanent stall)
- [x] src-tests 12/12; uc34 5/5; **full integration 527 passed, 0 failed** — first zero-failure full run on record

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in required dependencies across supported languages, with transitive availability tracking and clearer availability status details.
  * HTTP routes now return a structured **503** response when a required dependency is unavailable.
  * TypeScript dependency injection now uses positional parameters and updated proxy configuration options.

* **Bug Fixes**
  * Improved event handling to avoid losing in-flight events during short waits or cancellation.
  * Added reconciliation logic so dependency availability can self-heal after transient misses.

* **Tests**
  * Expanded cross-language integration coverage for required dependencies, cycles, tag matching, and route perimeter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->