### PR TITLE
feat(di): availability observability + job claim-gating (closes #1249)

### DIFF
--- a/cmd/mcp-mesh-ui/dist/index.html
+++ b/cmd/mcp-mesh-ui/dist/index.html
@@ -10,7 +10,7 @@
       window.__MESH_BASE_PATH__ = window.__MESH_BASE_PATH__ || "";
       window.__MESH_REGISTRY_URL__ = window.__MESH_REGISTRY_URL__ || "";
     </script>
-    <script type="module" crossorigin src="./assets/index-Cr7d7Rvk.js"></script>
+    <script type="module" crossorigin src="./assets/index-DB82OHvj.js"></script>
     <link rel="stylesheet" crossorigin href="./assets/index-CmRhQHvZ.css">
   </head>
   <body class="antialiased">

--- a/src/core/cli/list.go
+++ b/src/core/cli/list.go
@@ -209,6 +209,11 @@ type ToolInfo struct {
 	Dependencies []string       `json:"dependencies,omitempty"`
 	LLMFilter    *LLMToolFilter `json:"llm_filter,omitempty"`
 	LLMProvider  *LLMProvider   `json:"llm_provider,omitempty"`
+	// Derived availability (issue #1249): Available is nil when the registry
+	// doesn't report it (older versions) — treated as available. When false,
+	// UnavailableReason names the first broken required dependency edge.
+	Available         *bool  `json:"available,omitempty"`
+	UnavailableReason string `json:"unavailable_reason,omitempty"`
 }
 
 // Dependency represents a resolved dependency
@@ -424,6 +429,11 @@ type AgentInfoAPI struct {
 		Tags         []string       `json:"tags,omitempty"`
 		LlmFilter    *LLMToolFilter `json:"llm_filter,omitempty"`
 		LlmProvider  *LLMProvider   `json:"llm_provider,omitempty"`
+		// Derived availability + reason (issue #1249). Available is nil on
+		// older registries that don't compute the predicate; nil is treated as
+		// available (unknown) throughout the CLI.
+		Available         *bool   `json:"available,omitempty"`
+		UnavailableReason *string `json:"unavailable_reason,omitempty"`
 	} `json:"capabilities"`
 	DependencyResolutions []struct {
 		FunctionName    string   `json:"function_name"`
@@ -541,6 +551,13 @@ func getDetailedAgents(registryURL string) ([]map[string]interface{}, error) {
 			}
 			if cap.LlmProvider != nil {
 				capMap["llm_provider"] = cap.LlmProvider
+			}
+			// Derived availability + reason (issue #1249).
+			if cap.Available != nil {
+				capMap["available"] = *cap.Available
+			}
+			if cap.UnavailableReason != nil {
+				capMap["unavailable_reason"] = *cap.UnavailableReason
 			}
 			capabilities[j] = capMap
 		}
@@ -725,6 +742,11 @@ func processAgentData(data map[string]interface{}) EnhancedAgent {
 				} else if llmProviderMap, ok := capMap["llm_provider"].(map[string]interface{}); ok {
 					tool.LLMProvider = parseLLMProvider(llmProviderMap)
 				}
+				// Parse derived availability + reason (issue #1249).
+				if avail, ok := capMap["available"].(bool); ok {
+					tool.Available = &avail
+				}
+				tool.UnavailableReason = getString(capMap, "unavailable_reason")
 				agent.Tools = append(agent.Tools, tool)
 			}
 		}
@@ -1161,6 +1183,52 @@ func formatSupersededAnnotation(count int) string {
 	return fmt.Sprintf(" %s(+%d superseded)%s", colorGray, count, colorReset)
 }
 
+// countUnavailableCapabilities returns the number of the agent's capabilities
+// the registry has marked unavailable (issue #1249). A nil Available pointer
+// means the registry didn't report availability (older versions) and is
+// treated as available, so it never contributes to the count.
+func countUnavailableCapabilities(agent EnhancedAgent) int {
+	n := 0
+	for _, tool := range agent.Tools {
+		if tool.Available != nil && !*tool.Available {
+			n++
+		}
+	}
+	return n
+}
+
+// formatUnavailableAnnotation renders the red per-row marker flagging a healthy
+// agent that nonetheless owns one or more unavailable capabilities (issue
+// #1249) — e.g. " (1 capability unavailable)". This is the compact signal that
+// some capability's required dependency chain is broken; the per-capability
+// reason is shown by `meshctl list --verbose` and `--tools=<name>`. Empty when
+// the agent has no unavailable capabilities.
+//
+// Suppressed for a non-live agent: the registry marks EVERY capability of an
+// unhealthy agent available:false with reason "agent unhealthy", which is fully
+// redundant with the row's own red status. The capability-level signal is only
+// interesting on a live agent, where it reveals a broken required-dependency
+// chain the agent status alone wouldn't explain.
+func formatUnavailableAnnotation(agent EnhancedAgent) string {
+	if !isLiveStatus(agent.Status) {
+		return ""
+	}
+	n := countUnavailableCapabilities(agent)
+	if n <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(" %s(%d capabilit%s unavailable)%s",
+		colorRed, n, pluralY(n), colorReset)
+}
+
+// pluralY returns the correct suffix for "capabilit(y|ies)".
+func pluralY(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}
+
 // formatListFooter renders the summary line printed after the default table,
 // e.g. "3 agents (3 healthy) - 1 inactive instance hidden (use --all) - 2 superseded hidden".
 // displayed and healthy count distinct declared agent names among the rendered
@@ -1375,6 +1443,13 @@ func printAgentRow(agent EnhancedAgent, nameWidth, runtimeWidth, statusWidth, ty
 		fmt.Printf("%s", annotation)
 	}
 
+	// Unavailable-capability annotation (issue #1249): flags a live agent whose
+	// capability chain is broken. Rendered even for healthy rows, since a
+	// capability can be unavailable while its owning agent is perfectly healthy.
+	if ua := formatUnavailableAnnotation(agent); ua != "" {
+		fmt.Printf("%s", ua)
+	}
+
 	fmt.Println()
 }
 
@@ -1507,7 +1582,16 @@ func printVerboseDetails(agents []EnhancedAgent) {
 		if len(agent.Tools) > 0 {
 			fmt.Printf("  Tools:\n")
 			for _, tool := range agent.Tools {
-				fmt.Printf("    - %s (%s)\n", tool.Name, tool.Capability)
+				if tool.Available != nil && !*tool.Available {
+					reason := tool.UnavailableReason
+					if reason == "" {
+						reason = "required dependency unavailable"
+					}
+					fmt.Printf("    - %s (%s) %s[unavailable: %s]%s\n",
+						tool.Name, tool.Capability, colorRed, reason, colorReset)
+				} else {
+					fmt.Printf("    - %s (%s)\n", tool.Name, tool.Capability)
+				}
 			}
 		}
 
@@ -2254,6 +2338,30 @@ type ToolListItem struct {
 	Version     string `json:"version"`
 	Tags        string `json:"tags"`
 	Endpoint    string `json:"endpoint"`
+	// Derived availability + reason for this capability (issue #1249). Available
+	// is nil when the registry doesn't report it (older versions).
+	Available         *bool  `json:"available,omitempty"`
+	UnavailableReason string `json:"unavailable_reason,omitempty"`
+	// AgentHealthy is the live status of the owning agent, carried so the tools
+	// table can suppress the unavailable marker on unhealthy agents (whose caps
+	// are all available:false with reason "agent unhealthy" — redundant noise).
+	AgentHealthy bool `json:"-"`
+}
+
+// formatToolUnavailableMarker returns the compact red " unavailable" suffix for
+// a tools-table row whose capability the registry has marked unavailable on a
+// LIVE agent (issue #1249). Empty otherwise — including for every capability of
+// an unhealthy agent, where available:false only means "agent unhealthy" and is
+// redundant. The reason stays in the single-tool detail view to keep the table
+// compact.
+func formatToolUnavailableMarker(tool ToolListItem) string {
+	if !tool.AgentHealthy {
+		return ""
+	}
+	if tool.Available != nil && !*tool.Available {
+		return fmt.Sprintf("  %sunavailable%s", colorRed, colorReset)
+	}
+	return ""
 }
 
 // runToolsListCommand handles the --tools flag. When showFramework is false
@@ -2284,12 +2392,15 @@ func runToolsListCommand(registryURL, toolSpec string, jsonOutput, healthyOnly, 
 				continue
 			}
 			toolItem := ToolListItem{
-				ToolName:   funcName,
-				AgentName:  agent.Name,
-				AgentID:    agent.ID,
-				Capability: tool.Capability,
-				Version:    tool.Version,
-				Endpoint:   agent.Endpoint,
+				ToolName:          funcName,
+				AgentName:         agent.Name,
+				AgentID:           agent.ID,
+				Capability:        tool.Capability,
+				Version:           tool.Version,
+				Endpoint:          agent.Endpoint,
+				Available:         tool.Available,
+				UnavailableReason: tool.UnavailableReason,
+				AgentHealthy:      isLiveStatus(agent.Status),
 			}
 			if len(tool.Tags) > 0 {
 				toolItem.Tags = strings.Join(tool.Tags, ",")
@@ -2337,12 +2448,15 @@ func runToolsListCommand(registryURL, toolSpec string, jsonOutput, healthyOnly, 
 			// (e.g. `--tools=__mesh_job_status`), surface it even without
 			// --show-framework. Only the bulk-list path filters by default.
 			toolItem := ToolListItem{
-				ToolName:   funcName,
-				AgentName:  agent.Name,
-				AgentID:    agent.ID,
-				Capability: tool.Capability,
-				Version:    tool.Version,
-				Endpoint:   agent.Endpoint,
+				ToolName:          funcName,
+				AgentName:         agent.Name,
+				AgentID:           agent.ID,
+				Capability:        tool.Capability,
+				Version:           tool.Version,
+				Endpoint:          agent.Endpoint,
+				Available:         tool.Available,
+				UnavailableReason: tool.UnavailableReason,
+				AgentHealthy:      isLiveStatus(agent.Status),
 			}
 			if len(tool.Tags) > 0 {
 				toolItem.Tags = strings.Join(tool.Tags, ",")
@@ -2483,11 +2597,13 @@ func outputToolsList(tools []ToolListItem, jsonOutput bool) error {
 		if tags == "" {
 			tags = "-"
 		}
-		fmt.Printf("%-*s %-*s %-*s %s\n",
+		// Availability marker (issue #1249) is appended after the last column so
+		// it never disturbs the padded columns' alignment.
+		fmt.Printf("%-*s %-*s %-*s %s%s\n",
 			toolWidth, truncateStringForList(tool.ToolName, toolWidth-2),
 			agentWidth, truncateStringForList(tool.AgentID, agentWidth-2),
 			capWidth, truncateStringForList(tool.Capability, capWidth-2),
-			tags)
+			tags, formatToolUnavailableMarker(tool))
 	}
 
 	fmt.Printf("\n%d tool(s) found\n", len(tools))
@@ -2534,6 +2650,12 @@ func outputToolDetails(tool *ToolListItem, agent *EnhancedAgent, registryURL str
 			"version":    tool.Version,
 			"tags":       tool.Tags,
 		}
+		if tool.Available != nil {
+			output["available"] = *tool.Available
+		}
+		if tool.UnavailableReason != "" {
+			output["unavailable_reason"] = tool.UnavailableReason
+		}
 		if mcpTool != nil {
 			output["description"] = mcpTool.Description
 			output["input_schema"] = mcpTool.InputSchema
@@ -2550,6 +2672,20 @@ func outputToolDetails(tool *ToolListItem, agent *EnhancedAgent, registryURL str
 	fmt.Printf("%sTool: %s%s\n", colorBlue, tool.ToolName, colorReset)
 	fmt.Printf("Agent: %s\n", tool.AgentID)
 	fmt.Printf("Capability: %s\n", tool.Capability)
+	// Derived availability + reason (issue #1249). Only printed when the
+	// registry reports it (Available non-nil); the unavailable line names the
+	// broken required-dependency edge so the reason is visible without jq.
+	if tool.Available != nil {
+		if *tool.Available {
+			fmt.Printf("Availability: %savailable%s\n", colorGreen, colorReset)
+		} else {
+			reason := tool.UnavailableReason
+			if reason == "" {
+				reason = "required dependency unavailable"
+			}
+			fmt.Printf("Availability: %sunavailable%s (%s)\n", colorRed, colorReset, reason)
+		}
+	}
 	if mcpTool != nil && mcpTool.Description != "" {
 		fmt.Printf("Description: %s\n", mcpTool.Description)
 	}

--- a/src/core/cli/list_test.go
+++ b/src/core/cli/list_test.go
@@ -480,3 +480,149 @@ func TestFormatSupersededAnnotation(t *testing.T) {
 	assert.Empty(t, formatSupersededAnnotation(-1))
 	assert.Contains(t, formatSupersededAnnotation(2), "(+2 superseded)")
 }
+
+// --- Capability availability rendering (issue #1249) ------------------------
+//
+// The registry marks a capability unavailable (available:false + a reason)
+// when its owning agent is healthy but a required dependency's chain is broken.
+// meshctl must surface that on healthy agents without needing jq on the API.
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestCountUnavailableCapabilities covers the nil/true/false tri-state of the
+// per-capability Available pointer. nil (older registries that don't report
+// availability) must be treated as available and never counted.
+func TestCountUnavailableCapabilities(t *testing.T) {
+	agent := EnhancedAgent{
+		Tools: []ToolInfo{
+			{Name: "greet", Available: boolPtr(true)},
+			{Name: "forecast", Available: boolPtr(false), UnavailableReason: "required dep 'weather-api' unresolved"},
+			{Name: "legacy", Available: nil}, // registry didn't report -> available
+			{Name: "enrich", Available: boolPtr(false)},
+		},
+	}
+	assert.Equal(t, 2, countUnavailableCapabilities(agent),
+		"only capabilities with Available==false count; nil is treated as available")
+
+	assert.Equal(t, 0, countUnavailableCapabilities(EnhancedAgent{
+		Tools: []ToolInfo{{Name: "a", Available: boolPtr(true)}, {Name: "b"}},
+	}), "an agent with no unavailable capabilities counts zero")
+}
+
+// TestFormatUnavailableAnnotation guards the compact per-row marker: empty when
+// nothing is unavailable, singular/plural wording otherwise, and always red so
+// it reads as an alarm even on a healthy (green) row.
+func TestFormatUnavailableAnnotation(t *testing.T) {
+	// All available -> no annotation.
+	assert.Empty(t, formatUnavailableAnnotation(EnhancedAgent{
+		Status: "healthy",
+		Tools:  []ToolInfo{{Name: "a", Available: boolPtr(true)}},
+	}))
+	// nil Available -> treated as available -> no annotation.
+	assert.Empty(t, formatUnavailableAnnotation(EnhancedAgent{
+		Status: "healthy",
+		Tools:  []ToolInfo{{Name: "a"}},
+	}))
+
+	one := formatUnavailableAnnotation(EnhancedAgent{
+		Status: "healthy",
+		Tools:  []ToolInfo{{Name: "a", Available: boolPtr(false)}},
+	})
+	assert.Contains(t, one, "(1 capability unavailable)")
+	assert.Contains(t, one, colorRed, "the marker must render red")
+
+	two := formatUnavailableAnnotation(EnhancedAgent{
+		Status: "healthy",
+		Tools: []ToolInfo{
+			{Name: "a", Available: boolPtr(false)},
+			{Name: "b", Available: boolPtr(false)},
+		},
+	})
+	assert.Contains(t, two, "(2 capabilities unavailable)")
+}
+
+// TestFormatUnavailableAnnotation_SuppressedForUnhealthyAgent guards the
+// double-signal fix: the registry marks EVERY capability of an unhealthy agent
+// available:false (reason "agent unhealthy"), which is redundant with the row's
+// own red status. The annotation must therefore be suppressed on a non-live
+// agent even though its capabilities are technically unavailable.
+func TestFormatUnavailableAnnotation_SuppressedForUnhealthyAgent(t *testing.T) {
+	for _, status := range []string{"unhealthy", "", "unknown"} {
+		agent := EnhancedAgent{
+			Status: status,
+			Tools: []ToolInfo{
+				{Name: "a", Available: boolPtr(false), UnavailableReason: "agent unhealthy"},
+				{Name: "b", Available: boolPtr(false), UnavailableReason: "agent unhealthy"},
+			},
+		}
+		assert.Empty(t, formatUnavailableAnnotation(agent),
+			"unavailable annotation must be suppressed for non-live status %q", status)
+	}
+}
+
+// TestFormatToolUnavailableMarker covers the bulk `--tools` table suffix: shown
+// (red) only for an unavailable capability on a LIVE agent; suppressed for
+// available caps, nil availability, and every capability of an unhealthy agent.
+func TestFormatToolUnavailableMarker(t *testing.T) {
+	// Unavailable on a live agent -> red marker.
+	m := formatToolUnavailableMarker(ToolListItem{AgentHealthy: true, Available: boolPtr(false)})
+	assert.Contains(t, m, "unavailable")
+	assert.Contains(t, m, colorRed)
+
+	// Available on a live agent -> no marker.
+	assert.Empty(t, formatToolUnavailableMarker(ToolListItem{AgentHealthy: true, Available: boolPtr(true)}))
+	// nil availability -> no marker.
+	assert.Empty(t, formatToolUnavailableMarker(ToolListItem{AgentHealthy: true}))
+	// Unavailable but agent unhealthy -> suppressed (redundant "agent unhealthy").
+	assert.Empty(t, formatToolUnavailableMarker(ToolListItem{AgentHealthy: false, Available: boolPtr(false)}))
+}
+
+// TestProcessAgentData_ParsesAvailability verifies the registry's
+// available/unavailable_reason fields survive the map round-trip in
+// processAgentData and land on the right ToolInfo. This is the wiring the
+// rendering above depends on.
+func TestProcessAgentData_ParsesAvailability(t *testing.T) {
+	data := map[string]interface{}{
+		"id":     "analyst-abc123",
+		"name":   "analyst",
+		"status": "healthy",
+		"capabilities": []interface{}{
+			map[string]interface{}{
+				"name":          "summarize",
+				"function_name": "summarize",
+				"version":       "1.0.0",
+				"available":     true,
+			},
+			map[string]interface{}{
+				"name":               "forecast",
+				"function_name":      "forecast",
+				"version":            "1.0.0",
+				"available":          false,
+				"unavailable_reason": "required dep 'weather-api' unresolved (via analyst → enricher)",
+			},
+		},
+	}
+
+	agent := processAgentData(data)
+	require.Len(t, agent.Tools, 2)
+
+	byName := map[string]ToolInfo{}
+	for _, tool := range agent.Tools {
+		byName[tool.Name] = tool
+	}
+
+	summarize := byName["summarize"]
+	require.NotNil(t, summarize.Available)
+	assert.True(t, *summarize.Available)
+	assert.Empty(t, summarize.UnavailableReason)
+
+	forecast := byName["forecast"]
+	require.NotNil(t, forecast.Available)
+	assert.False(t, *forecast.Available)
+	assert.Equal(t,
+		"required dep 'weather-api' unresolved (via analyst → enricher)",
+		forecast.UnavailableReason)
+
+	// And the derived aggregate the row marker uses.
+	assert.Equal(t, 1, countUnavailableCapabilities(agent))
+}

--- a/src/core/registry/ent_handlers_jobs_claimgate_test.go
+++ b/src/core/registry/ent_handlers_jobs_claimgate_test.go
@@ -1,0 +1,197 @@
+package registry
+
+// Coverage for MeshJob claim gating on the transitive required-dependency
+// predicate (issue #1249 follow-up scope). A claim worker must not claim a job
+// for a capability that is currently UNAVAILABLE under the required-deps
+// predicate — otherwise a purely topological outage (a required dep down) burns
+// max_retries as the handler fails on the missing dep. A gated claim leaves the
+// job queued (owner=NULL, attempt_count unchanged, no lease) so it self-heals on
+// a later poll once the dependency recovers.
+//
+// Reuses newJobsEndpointTestEnvWithService + seedJob (ent_handlers_jobs_extended_test.go)
+// and regAgent / setAgentStatus / getCap (availability_test.go).
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"mcp-mesh/src/core/ent/agent"
+	"mcp-mesh/src/core/ent/job"
+)
+
+// ---------- gate: unresolved required dep blocks the claim ----------
+
+func TestClaimNextJob_GatedByUnresolvedRequiredDep(t *testing.T) {
+	_, service, cleanup := newJobsEndpointTestEnvWithService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Producer of "render" declares a REQUIRED dep on "weather", which no agent
+	// provides yet → "render" is unavailable under the predicate.
+	regAgent(t, service, "worker", "render", depSpec("weather", true))
+	seed := seedJob(t, service, "job-gated", "render", nil)
+
+	// Claim is gated: no job returned, and the row is left completely untouched.
+	claimed, err := service.ClaimNextJob(ctx, "render", "worker")
+	require.NoError(t, err)
+	assert.Nil(t, claimed, "claim must be gated while the required dep is unresolved")
+
+	after, err := service.GetJob(ctx, seed.ID)
+	require.NoError(t, err)
+	assert.Equal(t, job.StatusWorking, after.Status, "gated job stays queued (working)")
+	assert.Nil(t, after.OwnerInstanceID, "gated job keeps owner=NULL")
+	assert.Equal(t, 0, after.AttemptCount, "gated claim must NOT burn an attempt")
+	assert.Equal(t, int64(0), after.ClaimEpoch, "gated claim must NOT mint an epoch")
+	assert.Nil(t, after.LeaseExpiresAt, "gated claim must NOT set a lease")
+
+	// The dependency recovers: a provider of "weather" registers. The claim
+	// worker polls again (its next tick) and now claims normally — self-healing
+	// via the existing poll cadence, no operator intervention.
+	regAgent(t, service, "weather-agent", "weather")
+
+	claimed2, err := service.ClaimNextJob(ctx, "render", "worker")
+	require.NoError(t, err)
+	require.NotNil(t, claimed2, "claim must succeed once the required dep resolves")
+	assert.Equal(t, seed.ID, claimed2.ID)
+	assert.Equal(t, 1, claimed2.AttemptCount, "the recovering claim is the FIRST attempt")
+	assert.Equal(t, int64(1), claimed2.ClaimEpoch, "first successful claim mints epoch 1")
+}
+
+// ---------- gate: required dep provider goes unhealthy mid-life ----------
+
+func TestClaimNextJob_GatedWhenRequiredProviderUnhealthy(t *testing.T) {
+	_, service, cleanup := newJobsEndpointTestEnvWithService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	regAgent(t, service, "dep-agent", "weather")
+	regAgent(t, service, "worker", "render", depSpec("weather", true))
+	seed := seedJob(t, service, "job-provider-down", "render", nil)
+
+	// Provider healthy → claim proceeds.
+	claimed := claimVia(t, service, "render", "worker")
+	assert.Equal(t, seed.ID, claimed.ID)
+
+	// Reset the row to pending and take the required provider unhealthy.
+	_, err := service.entDB.Job.UpdateOneID(seed.ID).
+		ClearOwnerInstanceID().
+		SetStatus(job.StatusWorking).
+		SetAttemptCount(0).
+		Save(ctx)
+	require.NoError(t, err)
+	setAgentStatus(t, service, "dep-agent", agent.StatusUnhealthy)
+
+	blocked, err := service.ClaimNextJob(ctx, "render", "worker")
+	require.NoError(t, err)
+	assert.Nil(t, blocked, "claim must be gated while the required provider is unhealthy")
+
+	after, err := service.GetJob(ctx, seed.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, after.AttemptCount, "gated claim leaves attempt_count untouched")
+}
+
+// ---------- byte-identical: capability with no required edges ----------
+
+func TestClaimNextJob_NoRequiredEdges_ClaimsNormally(t *testing.T) {
+	_, service, cleanup := newJobsEndpointTestEnvWithService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// Registered producer of "render" with NO required deps → the gate short-
+	// circuits (no provider resolution) and the claim behaves exactly as before.
+	regAgent(t, service, "worker", "render")
+	seed := seedJob(t, service, "job-plain", "render", nil)
+
+	claimed, err := service.ClaimNextJob(ctx, "render", "worker")
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	assert.Equal(t, seed.ID, claimed.ID)
+	assert.Equal(t, 1, claimed.AttemptCount)
+	assert.Equal(t, int64(1), claimed.ClaimEpoch)
+	require.NotNil(t, claimed.OwnerInstanceID)
+	assert.Equal(t, "worker", *claimed.OwnerInstanceID)
+	assert.NotNil(t, claimed.LeaseExpiresAt)
+}
+
+// ---------- byte-identical: unowned/anonymous claimer is never gated ----------
+
+func TestClaimNextJob_UnownedCapability_NotGated(t *testing.T) {
+	_, service, cleanup := newJobsEndpointTestEnvWithService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	// No agent/capability registered for "render" at all: the claimer owns no
+	// matching capability row, so there are no required edges to evaluate and
+	// the pre-#1249 claim behavior is preserved byte-for-byte.
+	seed := seedJob(t, service, "job-anon", "render", nil)
+
+	claimed, err := service.ClaimNextJob(ctx, "render", "replica-a")
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "an unowned capability must not be gated")
+	assert.Equal(t, seed.ID, claimed.ID)
+	assert.Equal(t, 1, claimed.AttemptCount)
+}
+
+// ---------- fail-open: a gate-query error must not block the claim ----------
+
+func TestCapabilityUnavailableForClaim_QueryError_FailsOpen(t *testing.T) {
+	_, service, cleanup := newJobsEndpointTestEnvWithService(t)
+	defer cleanup()
+
+	// render has an unresolved REQUIRED dep, so it is genuinely gated...
+	regAgent(t, service, "worker", "render", depSpec("weather", true))
+	live := service.capabilityUnavailableForClaim(context.Background(), "worker", "render", newAvailEval())
+	require.NotEmpty(t, live, "precondition: render must be gated while weather is unresolved")
+
+	// ...but a failed gate query (forced here via an already-cancelled context)
+	// must FAIL OPEN — return "" so the live worker degrades to pre-#1249 ungated
+	// behavior rather than being starved by a transient DB error.
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	got := service.capabilityUnavailableForClaim(cancelled, "worker", "render", newAvailEval())
+	assert.Equal(t, "", got, "a gate-query error must fail open (ungated)")
+}
+
+// ---------- memoization across the transitive DAG in one gate eval ----------
+
+// The claimed capability sits atop a diamond of required deps (render→B,
+// render→C, B→D, C→D). One gate evaluation shares a single availEval, so the
+// tail D is evaluated exactly once — the O(paths) → O(nodes) collapse, mirroring
+// TestAvailability_MemoEvaluatesEachNodeOnce for the claim path.
+func TestCapabilityUnavailableForClaim_MemoizesDiamond(t *testing.T) {
+	_, service, cleanup := newJobsEndpointTestEnvWithService(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	regAgent(t, service, "agent-d", "capD")
+	regAgent(t, service, "agent-b", "capB", depSpec("capD", true))
+	regAgent(t, service, "agent-c", "capC", depSpec("capD", true))
+	regAgent(t, service, "worker", "render", depSpec("capB", true), depSpec("capC", true))
+
+	eval := newAvailEval()
+	reason := service.capabilityUnavailableForClaim(ctx, "worker", "render", eval)
+	assert.Equal(t, "", reason, "render should be available while the whole diamond is healthy")
+
+	for _, k := range []string{
+		availKey("worker", "render"),
+		availKey("agent-b", "capB"),
+		availKey("agent-c", "capC"),
+		availKey("agent-d", "capD"),
+	} {
+		_, ok := eval.memo[k]
+		assert.Truef(t, ok, "expected memo entry for %q", k)
+	}
+	assert.Equalf(t, 4, len(eval.memo),
+		"expected exactly 4 memoized nodes (tail capD evaluated once), got %d: %v", len(eval.memo), eval.memo)
+
+	// Break the shared tail: render must now be gated, naming a broken edge.
+	setAgentStatus(t, service, "agent-d", agent.StatusUnhealthy)
+	broken := service.capabilityUnavailableForClaim(ctx, "worker", "render", newAvailEval())
+	require.NotEmpty(t, broken, "render must be gated when the shared tail capD is down")
+	assert.True(t, strings.Contains(broken, "capB") || strings.Contains(broken, "capC"),
+		"gate reason should name a broken required edge, got %q", broken)
+}

--- a/src/core/registry/ent_service_jobs.go
+++ b/src/core/registry/ent_service_jobs.go
@@ -568,6 +568,79 @@ func (s *EntService) ApplyJobDeltas(ctx context.Context, instanceID string, delt
 	return accepted, rejections, nil
 }
 
+// capabilityUnavailableForClaim gates a claim of `capName` by the agent
+// identified by `instanceID` against the transitive required-dependency
+// predicate (issue #1249). It returns the first broken required edge's reason
+// (naming the dep) when the claiming agent's capability is currently
+// UNAVAILABLE, or "" when the claim may proceed.
+//
+// Why gate here: MeshJob claims are pull-based, not proxy-gated — a claim
+// worker would happily pull a job for a capability whose required dependency
+// is down, run the handler, fail on the missing dep, and burn an attempt
+// (max_retries) on a purely topological outage. Skipping the claim leaves the
+// job queued (no owner, no attempt increment, no lease) so it self-heals on a
+// later poll once the dependency recovers — see ClaimNextJob's caller cadence.
+//
+// Scope: this evaluates ONLY the required-dependency half of the predicate
+// (capabilityUnavailableReason), deliberately NOT the claiming agent's own
+// recorded health — the agent is demonstrably alive (it is polling to claim),
+// so a heartbeat-lagged status must not permanently starve it of work.
+// Narrow accepted exception: if the claiming agent ALSO provides one of its own
+// required-dep capabilities and that provider row is itself heartbeat-lagged
+// (registry-unhealthy), the resolver's health stage excludes it and the edge
+// reads as unresolved — so the claim can still be gated indirectly through its
+// own lagged provider row. This is a rare self-referential topology and the
+// gate correctly reflects that the dep is (registry-visibly) unavailable.
+//
+// Fast paths (zero-required-edge capabilities pay ~nothing):
+//   - A claim for a capability this instance does not own as a registered
+//     capability (no matching row — e.g. a legacy/anonymous claimer) is NOT
+//     gated: there are no required edges to evaluate, so pre-#1249 claim
+//     behavior is preserved byte-for-byte.
+//   - A registered capability with no required deps short-circuits inside
+//     capabilityUnavailableReason (its requiredDepEntries loop is empty), so
+//     no provider resolution runs.
+//
+// eval is threaded so the transitive required-dep DAG is memoized (a diamond
+// pays O(nodes+edges), not O(paths)).
+func (s *EntService) capabilityUnavailableForClaim(ctx context.Context, instanceID, capName string, eval *availEval) string {
+	caps, err := s.entDB.Capability.Query().
+		Where(
+			capability.CapabilityEQ(capName),
+			capability.HasAgentWith(agent.IDEQ(instanceID)),
+		).
+		WithAgent().
+		All(ctx)
+	if err != nil {
+		// Fail-open: a gate-query failure must NOT block claims — degrade to the
+		// pre-#1249 ungated behavior rather than starving a live worker on a
+		// transient DB hiccup. Log so the fail-open is observable (distinct from
+		// the silent no-row fallback below, which is normal steady state).
+		s.logger.Warning(
+			"ClaimNextJob gate: capability availability query for %q (instance %q) failed; failing open (claim ungated): %v",
+			capName, instanceID, err,
+		)
+		return ""
+	}
+	if len(caps) == 0 {
+		// Unknown/unowned capability → nothing to gate (no required edges).
+		return ""
+	}
+	// Duplicate same-name capability rows for one agent are pathological, but if
+	// present we gate on ANY broken one: the claim would dispatch to an ambiguous
+	// handler anyway, so the conservative (fail-closed across the set) verdict is
+	// the safe one.
+	for _, cap := range caps {
+		if cap.Edges.Agent == nil {
+			continue
+		}
+		if r := s.capabilityUnavailableReason(ctx, cap.Edges.Agent.ID, cap, eval); r != "" {
+			return r
+		}
+	}
+	return ""
+}
+
 // ClaimNextJob atomically claims a single pending job for the calling
 // instance. Returns (nil, nil) when no work is available — "no work" is
 // not an error (see Resolved Decisions).
@@ -600,6 +673,16 @@ func (s *EntService) ClaimNextJob(ctx context.Context, capability, instanceID st
 
 	now := time.Now().UTC()
 
+	// Claim gating (issue #1249) is evaluated LAZILY — only once a candidate
+	// actually exists to claim (see the gate below). This keeps the idle hot
+	// path (every worker polling per capability every ≤5s, fleet-wide) byte-
+	// identical to pre-#1249: a poll that finds no pending job pays no
+	// availability query and no transitive evaluation. The verdict is invariant
+	// across the retry loop (every candidate shares this capability and claiming
+	// instance), so it is computed at most once per call and reused across race-
+	// loss retries via gateChecked.
+	gateChecked := false
+
 	for attempt := 0; attempt < claimMaxAttempts; attempt++ {
 		candidate, err := s.entDB.Job.Query().
 			Where(
@@ -615,6 +698,24 @@ func (s *EntService) ClaimNextJob(ctx context.Context, capability, instanceID st
 				return nil, nil // No claimable row — caller treats as "no work".
 			}
 			return nil, fmt.Errorf("query candidate: %w", err)
+		}
+
+		// Gate BEFORE the guarded claim UPDATE: don't claim work for a capability
+		// whose required dependencies are currently unavailable — the handler
+		// would only fail on the missing dep and burn an attempt. On skip the job
+		// is left untouched (still queued, owner=NULL, attempt_count unchanged,
+		// no lease) for a later poll once the topology heals. Evaluated once
+		// (gateChecked) with a single availEval so the transitive required-dep DAG
+		// is memoized and race-loss retries re-use the verdict.
+		if !gateChecked {
+			gateChecked = true
+			if reason := s.capabilityUnavailableForClaim(ctx, instanceID, capability, newAvailEval()); reason != "" {
+				s.logger.Debug(
+					"ClaimNextJob: skipping capability %q for instance %q — unavailable: %s",
+					capability, instanceID, reason,
+				)
+				return nil, nil
+			}
 		}
 
 		// Retry-budget guard. We don't push this into the WHERE clause

--- a/src/ui/components/agents/AgentBadges.tsx
+++ b/src/ui/components/agents/AgentBadges.tsx
@@ -19,11 +19,28 @@ function hasMeshJob(agent: Agent): boolean {
   return Boolean(agent.capabilities?.some((c) => c.task === true));
 }
 
+// unavailableBadgeCount returns how many of the agent's capabilities should
+// surface an "unavailable" badge (issue #1249). Two suppressions apply:
+//   - `available === undefined` means the registry didn't report availability
+//     (older versions) and is treated as available.
+//   - a NON-healthy agent contributes zero: the registry marks EVERY capability
+//     of an unhealthy agent available:false with reason "agent unhealthy",
+//     which is redundant with the agent's own red status dot. The
+//     capability-level signal is only interesting on a healthy agent, where it
+//     reveals a broken required-dependency chain the status alone wouldn't show.
+// Exported so list-level views (AgentCard) gate their badge row on the same
+// predicate and never render an empty badge row.
+export function unavailableBadgeCount(agent: Agent): number {
+  if (agent.status !== "healthy") return 0;
+  return agent.capabilities?.filter((c) => c.available === false).length ?? 0;
+}
+
 export function AgentBadges({ agent, dense }: AgentBadgesProps) {
   const sizing = dense ? "px-1 py-0 text-[9px]" : "px-1.5 py-0 text-[10px]";
   const meshJob = hasMeshJob(agent);
+  const unavailable = unavailableBadgeCount(agent);
 
-  if (!agent.a2a_producer && !agent.a2a_consumer && !meshJob) {
+  if (!agent.a2a_producer && !agent.a2a_consumer && !meshJob && unavailable === 0) {
     return null;
   }
 
@@ -51,6 +68,15 @@ export function AgentBadges({ agent, dense }: AgentBadgesProps) {
           className={cn("bg-amber-500/20 text-amber-300 border-amber-500/30", sizing)}
         >
           MeshJob
+        </Badge>
+      )}
+      {unavailable > 0 && (
+        <Badge
+          variant="outline"
+          className={cn("bg-red-500/20 text-red-300 border-red-500/30", sizing)}
+          title={`${unavailable} capabilit${unavailable === 1 ? "y" : "ies"} unavailable — a required dependency chain is broken`}
+        >
+          {unavailable} unavailable
         </Badge>
       )}
     </>

--- a/src/ui/components/agents/AgentCard.tsx
+++ b/src/ui/components/agents/AgentCard.tsx
@@ -9,7 +9,7 @@ import {
   getStatusBgColor,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
-import { AgentBadges } from "./AgentBadges";
+import { AgentBadges, unavailableBadgeCount } from "./AgentBadges";
 
 interface AgentCardProps {
   agent: Agent;
@@ -30,6 +30,9 @@ function getDepsColor(resolved: number, total: number): string {
 // extend this check too.
 function hasAnyAgentBadge(agent: Agent): boolean {
   if (agent.a2a_producer || agent.a2a_consumer) return true;
+  // Unavailable-capability badge fires when a healthy agent's required
+  // dependency chain is broken (issue #1249); suppressed on unhealthy agents.
+  if (unavailableBadgeCount(agent) > 0) return true;
   // MeshJob badge fires only for real task=true producers (see AgentBadges).
   return Boolean(agent.capabilities?.some((c) => c.task === true));
 }

--- a/src/ui/components/agents/AgentDetail.tsx
+++ b/src/ui/components/agents/AgentDetail.tsx
@@ -54,12 +54,24 @@ function renderCapabilityRow(cap: Capability, key: string, framework: boolean) {
             framework
           </Badge>
         )}
+        {cap.available === false && (
+          <Badge
+            variant="outline"
+            className="text-[10px] px-1.5 py-0 bg-red-600/20 text-red-400 border-red-500/30"
+            title={cap.unavailable_reason || "A required dependency chain is broken"}
+          >
+            unavailable
+          </Badge>
+        )}
         {cap.tags?.map((tag) => (
           <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
             {tag}
           </Badge>
         ))}
       </div>
+      {cap.available === false && cap.unavailable_reason && (
+        <p className="mt-1 text-xs text-red-400">{cap.unavailable_reason}</p>
+      )}
       {cap.description && (
         <p className="mt-1 text-xs text-muted-foreground">{cap.description}</p>
       )}

--- a/src/ui/components/topology/TopologySidebar.tsx
+++ b/src/ui/components/topology/TopologySidebar.tsx
@@ -111,6 +111,14 @@ function AgentDetailBlock({ agent }: { agent: Agent }) {
                 <p className="text-[10px] text-muted-foreground mb-1">
                   {cap.name} v{cap.version}
                 </p>
+                {cap.available === false && (
+                  <p
+                    className="text-[10px] text-red-400 mb-1"
+                    title={cap.unavailable_reason || "A required dependency chain is broken"}
+                  >
+                    unavailable{cap.unavailable_reason ? `: ${cap.unavailable_reason}` : ""}
+                  </p>
+                )}
                 {cap.description && (
                   <p className="text-[10px] text-muted-foreground/80 mb-1">{cap.description}</p>
                 )}

--- a/src/ui/lib/types.ts
+++ b/src/ui/lib/types.ts
@@ -48,6 +48,13 @@ export interface Capability {
   // True when this tool was declared task=True — a long-running MeshJob
   // producer. Surfaced by the registry from the stored capability kwargs.
   task?: boolean;
+  // Derived availability (issue #1249): false when the owning agent is healthy
+  // but a required dependency's chain is broken. Undefined on older registries
+  // that don't compute the predicate — treated as available (unknown).
+  available?: boolean;
+  // One-level explanation of why the capability is unavailable, naming the
+  // first broken required-dependency edge. Empty/undefined when available.
+  unavailable_reason?: string;
 }
 
 export interface DependencyResolution {


### PR DESCRIPTION
## Summary
Final slice of #1249:

- **meshctl**: `list` annotates healthy agents owning unavailable capabilities (the "healthy agent, broken required chain" diagnosability case); reasons render in `--verbose`, the bulk `--tools` table (compact marker), the single-tool detail view, and JSON output (additive fields). Old registries without the fields are treated as fully available — no spurious markers.
- **mesh UI**: availability badge with reason tooltip on agent rows/cards/topology nodes; per-capability state + reason in the detail and topology sidebar views. Aggregate markers are suppressed on already-unhealthy agents (the registry stamps every capability "agent unhealthy" there — no information); drill-in surfaces keep true per-capability state.
- **Job claim-gating**: `ClaimNextJob` skips jobs targeting capabilities unavailable under the required-deps predicate — left queued, no `attempt_count`/epoch/lease touched — so topology outages don't burn `max_retries`. Evaluated lazily only when a candidate job exists (idle polls byte-identical to before), once per claim call with the memoized availability evaluation, fail-open with a warning on query errors, byte-identical for legacy/unregistered claimers. Recovery self-heals within the claim worker's ≤5s poll ceiling.

## Review Notes
Zero-context review applied; all findings fixed (lazy gate placement, observable fail-open, `--tools` table coverage, unhealthy-agent noise suppression). Accepted edge cases documented in code: a claimer providing its own required dep can be gated via its heartbeat-lagged row; duplicate same-name capability rows gate conservatively.

Closes #1249

## Test plan
- [x] Registry package + `-race` on claim tests (gated/recovery/fail-open/memoization); CLI suite with the new rendering tests
- [x] `make ui-server-build` clean (go:embed rebuild)
- [x] src-tests 12/12; full integration 526 passed + 1 maven-resolve infra flake green on re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability availability indicators across agent lists, detail views, and topology panels.
  * Show unavailable capabilities with red badges/markers and optional reasons when provided.
  * Tool listings now include availability status and agent health context.

* **Bug Fixes**
  * Prevented claim processing when required capability dependencies are unavailable.
  * Improved badge visibility so unavailable capability counts are shown consistently for healthy agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->