### PR TITLE
docs: post-campaign gaps — claim-gating, list availability, stale anchors

### DIFF
--- a/docs/concepts/in-process-state.md
+++ b/docs/concepts/in-process-state.md
@@ -9,7 +9,7 @@ the overwhelming majority of stateful workloads in mesh:
 - **Externalized state via a state agent + MeshJob orchestrator** —
   durable, horizontally scalable, restart-tolerant.
 - **FastAPI `lifespan` for a loop-bound resource** (see
-  [Loop topology](../python/dependency-injection.md#loop-topology-v221))
+  [Loop topology](../python/dependency-injection.md#loop-topology-v224))
   — create the pool / client in `lifespan` startup; the default single
   user loop hosts both `lifespan` and every tool body.
 
@@ -25,7 +25,7 @@ MeshJob.
 
 Before reaching for the in-process runtime pattern, can you answer **no** to all of these?
 
-1. **Is your work driven by tool calls (request-driven)?** → if yes, put your loop-bound resource in FastAPI `lifespan` startup (see [Loop topology](../python/dependency-injection.md#loop-topology-v221)).
+1. **Is your work driven by tool calls (request-driven)?** → if yes, put your loop-bound resource in FastAPI `lifespan` startup (see [Loop topology](../python/dependency-injection.md#loop-topology-v224)).
 2. **Can your state mutations tolerate ~10ms HTTP round-trip overhead per mutation?** → if yes, use MeshJob with a state agent (see [stateful agents](stateful-agents.md)).
 3. **Is your stateful resource portable across processes (DB pool, Redis connection, message-broker client)?** → if yes, you don't need in-process binding.
 
@@ -290,7 +290,7 @@ immediately after.
 This pattern is an escape hatch, not a recommendation. If you're
 reading it because of a "where do I put my asyncpg pool" question, the
 answer is almost always the standard FastAPI `lifespan` pattern (see
-[Loop topology](../python/dependency-injection.md#loop-topology-v221))
+[Loop topology](../python/dependency-injection.md#loop-topology-v224))
 or the [MeshJob state-agent decomposition](stateful-agents.md) — not
 this page. Use MeshJob unless you can answer the three gate questions
 with "no, no, and no."
@@ -299,7 +299,7 @@ with "no, no, and no."
 
 - [Stateful Agents](stateful-agents.md) — the canonical MeshJob +
   state-agent decomposition that covers the common case
-- [Loop Topology](../python/dependency-injection.md#loop-topology-v221)
+- [Loop Topology](../python/dependency-injection.md#loop-topology-v224)
   — two-loop model, default `MCP_MESH_TOOL_WORKERS=1`, FastAPI
   `lifespan` for loop-bound resources
 - [Long-Running Jobs](jobs.md) — MeshJob substrate: lifecycle,

--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -545,6 +545,21 @@ For the full design rationale and lifecycle diagrams, see
 [`MESHJOB_DESIGN.org`](https://github.com/dhyansraj/mcp-mesh/blob/main/MESHJOB_DESIGN.org)
 and [`MESHJOB_DDDI_CONTRACT.md`](https://github.com/dhyansraj/mcp-mesh/blob/main/MESHJOB_DDDI_CONTRACT.md).
 
+### Claim gating on unavailable capabilities
+
+Claiming is also gated on capability availability. A claim worker will not
+pull a job for a `task=true` capability whose `required` dependencies are
+currently unavailable under the [availability predicate](../python/dependency-injection.md#required-dependencies) —
+claiming it would only run the handler far enough to fail on the missing
+dependency and burn a retry on a purely topological outage. Instead the
+registry leaves the job queued and untouched (no owner, no `attempt_count`
+increment, no `claim_epoch` bump, no lease) and the worker moves on to the
+next candidate. The gate is evaluated lazily — only once a candidate job
+actually exists — so an idle queue pays nothing. Claiming resumes
+automatically within one claim-poll cycle (≤5s backoff ceiling) of the
+required chain recovering, so no retry budget is spent while the capability
+is down.
+
 ## What it does NOT do (v2 limitations)
 
 - **No idempotency keys.** Retries restart the handler from scratch;

--- a/docs/concepts/stateful-agents.md
+++ b/docs/concepts/stateful-agents.md
@@ -494,7 +494,7 @@ A handful of anti-patterns this decomposition exists to prevent:
   bound to worker-0. The supported shape at the default is the
   FastMCP-`lifespan` + module-global pattern (binds to the single-user
   loop, used by all tools on the same loop) — see
-  [Loop topology](#loop-topology-v221) above. If you also need N>1
+  [Loop topology](#loop-topology-v224) above. If you also need N>1
   workers for sync-blocking parallelism, switch to a per-loop dict
   cache (each worker lazily builds its own resource on first access).
 - **Putting orchestration state on the orchestrator process.** The
@@ -510,6 +510,6 @@ A handful of anti-patterns this decomposition exists to prevent:
   responses; pairs with MeshJob for live updates
 - [In-Process State (Escape Hatch)](in-process-state.md) — when even
   MeshJob can't fit your shape, with documented caveats
-- [Loop Topology](../python/dependency-injection.md#loop-topology-v221)
+- [Loop Topology](../python/dependency-injection.md#loop-topology-v224)
   — two-loop model, default `MCP_MESH_TOOL_WORKERS=1`, when to opt into N>1
 - `meshctl man dependency-injection` — DDDI and loop topology

--- a/src/core/cli/man/content/cli.md
+++ b/src/core/cli/man/content/cli.md
@@ -115,6 +115,7 @@ for script compatibility.
 meshctl list                       # Healthy agents (down agents counted in the footer)
 meshctl list --all                 # Every instance, incl. unhealthy (purged after MCP_MESH_RETENTION)
 meshctl list --wide                # Endpoints + tool counts
+meshctl list --verbose             # Per-tool detail incl. unavailable-capability reasons
 meshctl list --filter hello        # Substring match on agent ID
 meshctl list --since 1h            # Active in the last hour
 
@@ -129,6 +130,15 @@ meshctl list --schemas             # Most recent 100 canonical schemas
 meshctl list --schemas --limit 20  # Last 20
 meshctl list --schemas --json      # Raw envelope from GET /schemas
 ```
+
+**Capability availability.** When an agent is healthy but one of its
+capabilities has a broken `required` dependency chain, its row is flagged in
+red with `(N capabilities unavailable)`. `--verbose` expands each affected
+tool with its reason (`[unavailable: required dep '…' unresolved]`); the
+`--tools` table marks the row with a trailing red `unavailable`; and
+`--tools=<name>` prints an `Availability:` line naming the broken edge. The
+markers appear only on healthy agents — an unhealthy agent's capabilities are
+all unavailable by definition, so the row status already says so.
 
 ### `meshctl call`
 

--- a/src/core/cli/man/content/jobs.md
+++ b/src/core/cli/man/content/jobs.md
@@ -467,6 +467,20 @@ periodic `update_progress` to keep the lease renewed. Set
 `total_deadline` if you want a hard total-runtime bound across all
 attempts, or to opt out of the registry-wide stale ceiling entirely.
 
+## Claim gating on unavailable capabilities
+
+A claim worker never pulls a job for a capability whose `required`
+dependencies are currently unavailable (see **Required Dependencies** in
+`meshctl man dependency-injection` for the availability predicate).
+Claiming it would only run the handler far enough to fail on the missing
+dependency and burn a retry on a purely topological outage. Instead the
+registry leaves the job queued and untouched — no owner, no attempt-count
+increment, no epoch bump, no lease — and the worker moves on. The gate is
+evaluated lazily, only once a candidate job actually exists, so an idle
+queue pays nothing. Claiming resumes automatically within one claim-poll
+cycle (≤5s backoff ceiling) of the required chain recovering, so no retry
+budget is spent while the capability is down.
+
 ## Multi-replica execution and fencing
 
 Several replicas may declare the same `task=True` capability. Each job is

--- a/src/core/cli/man/content/jobs_java.md
+++ b/src/core/cli/man/content/jobs_java.md
@@ -653,6 +653,20 @@ periodic `updateProgress` to keep the lease renewed. Set `totalDeadline`
 if you want a hard total-runtime bound across all attempts, or to opt out
 of the registry-wide stale ceiling entirely.
 
+## Claim gating on unavailable capabilities
+
+A claim worker never pulls a job for a capability whose `required`
+dependencies are currently unavailable (see **Required Dependencies** in
+`meshctl man dependency-injection` for the availability predicate).
+Claiming it would only run the handler far enough to fail on the missing
+dependency and burn a retry on a purely topological outage. Instead the
+registry leaves the job queued and untouched — no owner, no attempt-count
+increment, no epoch bump, no lease — and the worker moves on. The gate is
+evaluated lazily, only once a candidate job actually exists, so an idle
+queue pays nothing. Claiming resumes automatically within one claim-poll
+cycle (≤5s backoff ceiling) of the required chain recovering, so no retry
+budget is spent while the capability is down.
+
 ## Multi-replica execution and fencing
 
 Several replicas may declare the same `task = true` capability. Each job is

--- a/src/core/cli/man/content/jobs_typescript.md
+++ b/src/core/cli/man/content/jobs_typescript.md
@@ -514,6 +514,20 @@ periodic `updateProgress` to keep the lease renewed. Set `totalDeadline`
 if you want a hard total-runtime bound across all attempts, or to opt out
 of the registry-wide stale ceiling entirely.
 
+## Claim gating on unavailable capabilities
+
+A claim worker never pulls a job for a capability whose `required`
+dependencies are currently unavailable (see **Required Dependencies** in
+`meshctl man dependency-injection` for the availability predicate).
+Claiming it would only run the handler far enough to fail on the missing
+dependency and burn a retry on a purely topological outage. Instead the
+registry leaves the job queued and untouched — no owner, no attempt-count
+increment, no epoch bump, no lease — and the worker moves on. The gate is
+evaluated lazily, only once a candidate job actually exists, so an idle
+queue pays nothing. Claiming resumes automatically within one claim-poll
+cycle (≤5s backoff ceiling) of the required chain recovering, so no retry
+budget is spent while the capability is down.
+
 ## Multi-replica execution and fencing
 
 Several replicas may declare the same `task: true` capability. Each job is


### PR DESCRIPTION
## Summary
Closes the documentation gaps found in the post-2.8.0-campaign audit (#1259):

- **Claim gating on unavailable capabilities** documented in all three jobs man pages + `docs/concepts/jobs.md` (runtime-neutral prose in the reliability block, cross-referencing the required-dependencies predicate): jobs stay queued with owner/attempt-count/epoch/lease untouched, evaluated lazily, resuming within one claim-poll cycle (≤5s) of chain recovery. Every claim verified against `ent_service_jobs.go`/`claim_worker.rs`.
- **`meshctl list` availability surfaces** added to `cli.md`: the `--verbose` flag, the healthy-row `(N capabilities unavailable)` annotation, per-tool reasons, the `--tools` table marker, the detail-view `Availability:` line, and the healthy-agents-only suppression rule.
- **Six dangling anchors** retargeted (`#loop-topology-v221` → `#loop-topology-v224`) in `in-process-state.md` and `stateful-agents.md` — `mkdocs build --strict` now has zero link/anchor warnings (the one remaining strict abort is the git-revision plugin lacking history in local working copies; environmental, proven by stash test, absent in CI checkouts — worth enabling `--strict` in docs CI after this).

Closes #1259

## Test plan
- [x] `mkdocs build` clean; `--strict` link/anchor-clean
- [x] All documented behaviors verified against source (file:line basis in the work log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)