### PR TITLE
feat(jobs): local required-dep claim gating + calling-job identity

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version tag (e.g., v2.7.0)"
+        description: "Version tag (e.g., v2.8.0)"
         required: true
-        default: "v2.7.0"
+        default: "v2.8.0"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version (e.g., v2.7.0)"
+        description: "Version (e.g., v2.8.0)"
         required: true
-        default: "v2.7.0"
+        default: "v2.8.0"
       environment:
         description: "Environment"
         type: choice

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,59 @@
 # MCP Mesh Release Notes
 
-[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.7.0...HEAD)
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.8.0...HEAD)
+
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.7.0...v2.8.0)
+
+## v2.8.0 (2026-07-03)
+
+An availability-aware dependency graph via `required=true`, MeshJob execution integrity under multi-replica consumers, and exact data fidelity for empty returns and LLM replies.
+
+v2.7 made the LLM-provider layer correct and gave MeshJob a proactive reaper; v2.8 turns the mesh's dependency graph from resolution-aware into *availability*-aware. A dependency edge can now declare `required=true`, and the registry computes capability availability **transitively** — an agent's capability is available only when the agent is healthy and every required edge resolves under full tag/version/schema matching — propagating the result through the existing dependency-update channel so consumer proxies and route perimeters gate on it with no SDK changes. Alongside it, MeshJob gains execution integrity for multi-replica consumers (claim-epoch fencing, poll-liveness, per-filter event cursors), and two data-fidelity contracts are made exact across every runtime: empty tool returns now round-trip byte-for-byte, and the `@mesh.llm` reply envelope always carries its answer as a string.
+
+### 🔗 `required=true` — availability-aware dependencies (#1255, #1257, #1258)
+
+A dependency edge may now opt into `required=true`. The registry computes each capability's availability **transitively** — the owning agent is healthy AND every required edge resolves under the existing resolver's full tag/version/schema matching — and propagates it through the dependency-update channel that already drives resolution, so consumers gate mesh-internal calls with **zero SDK changes**. Availability is memoized (O(nodes)), fail-closed, and the check-persist window is serialized; reason strings name the first broken edge with its constraint detail.
+
+- **Route perimeter, all three runtimes** — a route declaring a required dependency auto-returns `503 {"error":"dependency_unavailable","capability":...}` before user code runs. Python gates in the route wrapper; Java via `MeshRouteHandlerInterceptor` (taking precedence over `failOnMissingDependency`); TypeScript via a capability-keyed perimeter judging exactly the state the handler receives.
+- **Declaration syntax** — Python `required: true` on the dependency edge; Java `@Selector(required = true)` for tools and `@MeshDependency(required = true)` for routes / `@MeshDependsOn` / A2A; TypeScript `{ capability, required: true }`. Defaults `false` everywhere — existing specs serialize byte-identically and optional edges never propagate.
+- **Cycle rejection** — required-edge cycles are rejected loudly at registration **and** on heartbeat metadata refresh, closing a path that bypassed the check.
+- **Job claim-gating** (#1258) — `ClaimNextJob` skips a job whose target capability is unavailable under the required-deps predicate: the job stays queued with `attempt_count` / epoch / lease untouched, so a topology outage no longer burns `max_retries`. Evaluated lazily only when a candidate job exists (idle polls are byte-identical to before), fail-open with a warning on query errors, and self-healing within the claim worker's ≤5s poll ceiling.
+- **Availability observability** (#1258) — `meshctl list` annotates a healthy agent that owns an unavailable capability (`(N capabilities unavailable)`), with per-tool reasons in `--verbose`, the `--tools` table, the single-tool detail view, and additive JSON fields; the mesh UI adds an availability badge with a reason tooltip on agent rows, cards, and topology nodes, plus per-capability state in the detail and topology sidebars. Registries without the fields are treated as fully available — no spurious markers.
+- **Reliable dependency-update delivery** (#1256, via #1257) — dependency-update events could be silently lost at the Rust→Python bridge (a cancel-unsafe wait around an already-dequeued receive) and were never retried because the diff gate advanced on enqueue. The pull timeout now lives inside a cancel-safe future, and a throttled 10s reconcile re-emits any edge whose event didn't apply. This bug predates `required=true` and likely explains a class of historical registration-timing flakes.
+
+Soft-fail posture is unchanged: `required` defaults false, optional edges never propagate, and a mesh with zero required edges pays effectively nothing on the hot path.
+
+### 🔒 MeshJob execution integrity under multi-replica consumers (#1253, #1254)
+
+MeshJob execution is made correct when the same job may be claimed and reclaimed across multiple consumer replicas or after a mid-execution reclaim.
+
+- **Claim-epoch fencing** (#1253) — every successful claim/re-claim mints a monotonic `claim_epoch` in the same guarded update that assigns the owner. `/jobs/batch` deltas carry it; any epoch-bearing delta whose `(owner, epoch)` doesn't match the live row — cross-instance, reclaimed `owner=NULL`, or same-instance re-claim — rejects as `claim_superseded`. Epoch-less deltas keep legacy `not_owner` semantics.
+- **Frame-exact supersession** (#1253) — the core translates `claim_superseded` into firing *that execution's own* cancel frame, keyed by epoch rather than top-of-stack, so a superseded zombie aborts while a healthy same-process re-claim keeps running.
+- **Poll-liveness** (#1253) — an epoch-valid executor `recvEvent` poll extends the lease (capped by `total_deadline` and the `max_duration`-derived stale ceiling, preserving #1244 semantics). A handler legitimately blocked in an event gate is no longer reclaimed as wedged, so artificial `progress()` keepalives are unnecessary. The long-poll races the cancellation token, so user cancels and supersession interrupt a blocked gate promptly.
+- **Per-filter event cursors** (#1254) — `recvEvent` tracks an independent cursor per canonical type-filter (exactly-once within a stream, documented at-least-once across streams), so interleaved gates with different filters can no longer permanently skip each other's events; per-filter locks replace the global receive lock, so a long-poll on one type doesn't block another.
+- **Surfaces** — `claimEpoch` is exposed read-only on `JobContext` in Python, TypeScript, and Java, threaded claim→controller through the shared Rust core. A new `uc33_meshjob_replicas` integration suite proves poll-liveness (a quietly-gating handler polling through 2× its lease window keeps a single claim) and fencing (a wedged handler is re-claimed with the stale owner fenced, exactly one surviving owner). Jobs man pages (base + TS/Java), `environment.md`, and `docs/concepts/jobs.md` now document lease derivation, what renews a lease, epoch fencing, per-filter cursor semantics, and the reap-ceiling-vs-lease-window distinction.
+
+### 🔁 Empty tool returns round-trip exactly (#1251)
+
+An empty collection return (`[]` / `{}` / `""` / `null` / non-empty values) now round-trips byte-for-byte across every Python-provider × {Python, TypeScript, Java}-consumer pairing. The root cause was Python-side: FastMCP serialized an empty list/tuple to an MCP content array byte-identical to `None`, so consumers received `null` / `""` / exceptions instead of `[]`. Mesh now patches tool components at a registration chokepoint (covering dynamic/post-startup registrations, drift-hardened with pass-through and warn-once fallbacks) so empty collections emit a real `"[]"` text block while `None` is untouched. Consumers recover from `structuredContent` when content is empty, else resolve to `null` — never a misparsed envelope. A new `uc32_empty_return_values` suite pins the exact received values.
+
+- **Java: untyped tool calls parse generically** — `McpMeshTool<Object>` and undeclared targets parse JSON results via one shared `deserializeDynamic` (objects → `Map`, arrays → `List`, scalars boxed, empty → `""`); typed targets keep strict deserialization and still fail loudly on shape mismatch.
+- **Java: proxy cache keys on declared return type** — each declared type gets its own cached proxy (`null` and `Object` share the dynamic key), fixing a race where two consumers with different type params could resolve run-to-run differently under load.
+- **Java spring-ai: the tool executor serializes non-string results as JSON** instead of `toString()`, which had mangled arrays/objects fed back to the LLM.
+
+### 🧾 LLM reply envelope always carries the answer as a string (#1248)
+
+The `@mesh.llm` `{role, content}` reply envelope now always carries the answer as a JSON string. On the Python structured-output path the answer is recovered from `message.parsed` / `provider_specific_fields` when the text-block join is empty (upstream client libraries move structured output between text blocks, tool-call arguments, and parsed fields across versions), and a warning naming model, mode, and a truncated raw message fires when nothing is recoverable instead of silently emitting empty content. The OpenAI native adapter recovers a `parsed`-only response only when the message has no tool calls, so content is never fabricated on an ordinary tool-call turn and replayed assistant history is byte-for-byte unchanged. As defense in depth, consumers across all three runtimes serialize dict/Map-shaped content and recover a bare envelope-less map as the answer (excluding maps carrying a truthy `error`, `tool_calls`, or `_mesh_usage`, which stay on the diagnostic path), with empty-content parse failures now including a truncated snippet of the raw provider payload.
+
+### ⚠️ Breaking / behavior changes
+
+- **Java: untyped tool calls parse JSON results generically** (#1251). `McpMeshTool<Object>` and undeclared targets now parse objects → `Map`, arrays → `List`, and JSON scalars → boxed values; non-JSON text is returned as-is and an empty result round-trips to `""`. Previously only JSON objects were parsed and arrays/scalars came back as raw JSON strings. Typed targets (`List` / `Map` / POJO) are unaffected.
+- **TypeScript: `callMcpTool` / `extractContent` now return `unknown`** (#1251), was `string | MultiContentResult`, and an empty tool-result content array resolves to `null` instead of `""`. Consumers that assumed a string return must narrow the type.
+- **Interactive MeshJobs: `recvEvent` polling now renews the lease** (#1253). A handler blocked in an event gate keeps its claim as long as it keeps polling, so artificial `progress()` keepalives added only to hold a lease can be removed. Declaring `max_duration` remains recommended for lease sizing.
+
+### ⚠️ Upgrade notes
+
+- **Mixed-version meshes degrade gracefully.** The `required` flag is ignored by registries that predate #1255 (capabilities read as available, exactly as before), and old SDKs are unaffected by a new registry — `claimEpoch` / availability fields are additive, and epoch-less deltas keep legacy ownership semantics. No coordinated upgrade is required; adopt `required=true` once both ends are on v2.8.0.
 
 [Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v2.6.0...v2.7.0)
 

--- a/cmd/meshctl/templates/java/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge (Java/Spring Boot)
-FROM mcpmesh/java-runtime:2.7.0
+FROM mcpmesh/java-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/a2a-consumer/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/a2a-consumer/pom.xml.tmpl
@@ -26,7 +26,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway (Java/Spring Boot)
-FROM mcpmesh/java-runtime:2.7.0
+FROM mcpmesh/java-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/api/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/api/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:2.7.0
+FROM mcpmesh/java-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/basic/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/basic/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:2.7.0
+FROM mcpmesh/java-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:2.7.0
+FROM mcpmesh/java-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/python/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/a2a-consumer/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/a2a-consumer/package.json.tmpl
@@ -13,7 +13,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/cmd/meshctl/templates/typescript/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/api/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/api/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/basic/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/docs/00-why-mcp-mesh/index.md
+++ b/docs/00-why-mcp-mesh/index.md
@@ -111,7 +111,7 @@ meshctl scaffold --compose --observability
 
 # Or deploy to Kubernetes (OCI registry)
 helm install my-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 -n mcp-mesh --create-namespace
+  --version 2.8.0 -n mcp-mesh --create-namespace
 ```
 
 ### 5. Built-in Observability

--- a/docs/02-local-development.md
+++ b/docs/02-local-development.md
@@ -97,7 +97,7 @@ graph LR
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0</version>
     </dependency>
     ```
 

--- a/docs/03-docker-deployment.md
+++ b/docs/03-docker-deployment.md
@@ -24,10 +24,10 @@ MCP Mesh publishes official images to Docker Hub:
 
 | Image                            | Purpose                                          |
 | -------------------------------- | ------------------------------------------------ |
-| `mcpmesh/registry:2.7.0`           | Go-based registry service                        |
-| `mcpmesh/python-runtime:2.7.0`     | Python agent runtime (includes mcp-mesh SDK)     |
-| `mcpmesh/java-runtime:2.7.0`       | Java agent runtime (includes mcp-mesh SDK)       |
-| `mcpmesh/typescript-runtime:2.7.0` | TypeScript agent runtime (includes @mcpmesh/sdk) |
+| `mcpmesh/registry:2.8.0`           | Go-based registry service                        |
+| `mcpmesh/python-runtime:2.8.0`     | Python agent runtime (includes mcp-mesh SDK)     |
+| `mcpmesh/java-runtime:2.8.0`       | Java agent runtime (includes mcp-mesh SDK)       |
+| `mcpmesh/typescript-runtime:2.8.0` | TypeScript agent runtime (includes @mcpmesh/sdk) |
 
 ## Using Scaffold to Generate Compose Files
 
@@ -53,7 +53,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:2.7.0
+        image: mcpmesh/registry:2.8.0
         ports:
           - "8000:8000"
         healthcheck:
@@ -63,7 +63,7 @@ meshctl scaffold --compose --dry-run -d ./agents
           retries: 3
 
       my-agent:
-        image: mcpmesh/python-runtime:2.7.0
+        image: mcpmesh/python-runtime:2.8.0
         ports:
           - "8080:8080"
         volumes:
@@ -88,7 +88,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:2.7.0
+        image: mcpmesh/registry:2.8.0
         ports:
           - "8000:8000"
         healthcheck:
@@ -122,7 +122,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:2.7.0
+        image: mcpmesh/registry:2.8.0
         ports:
           - "8000:8000"
         healthcheck:
@@ -132,7 +132,7 @@ meshctl scaffold --compose --dry-run -d ./agents
           retries: 3
 
       my-agent:
-        image: mcpmesh/typescript-runtime:2.7.0
+        image: mcpmesh/typescript-runtime:2.8.0
         ports:
           - "8080:8080"
         volumes:
@@ -161,12 +161,12 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:2.7.0
+        image: mcpmesh/registry:2.8.0
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/python-runtime:2.7.0
+        image: mcpmesh/python-runtime:2.8.0
         volumes:
           - ./agent.py:/app/agent.py:ro
         command: ["python", "/app/agent.py"]
@@ -185,7 +185,7 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:2.7.0
+        image: mcpmesh/registry:2.8.0
         ports:
           - "8000:8000"
 
@@ -206,12 +206,12 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:2.7.0
+        image: mcpmesh/registry:2.8.0
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/typescript-runtime:2.7.0
+        image: mcpmesh/typescript-runtime:2.8.0
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]
@@ -232,7 +232,7 @@ If you didn't use scaffold, here's a sample Dockerfile:
 === "Python"
 
     ```dockerfile
-    FROM mcpmesh/python-runtime:2.7.0
+    FROM mcpmesh/python-runtime:2.8.0
 
     COPY ./my-agent /app/agent
 
@@ -257,7 +257,7 @@ If you didn't use scaffold, here's a sample Dockerfile:
 === "TypeScript"
 
     ```dockerfile
-    FROM mcpmesh/typescript-runtime:2.7.0
+    FROM mcpmesh/typescript-runtime:2.8.0
 
     WORKDIR /app/agent
     COPY ./my-agent/package*.json ./
@@ -284,12 +284,12 @@ version: "3.8"
 
 services:
   registry:
-    image: mcpmesh/registry:2.7.0
+    image: mcpmesh/registry:2.8.0
     ports:
       - "8000:8000"
 
   auth-agent:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     volumes:
       - ./agents/auth:/app/agent:ro
     command: ["python", "/app/agent/main.py"]
@@ -298,7 +298,7 @@ services:
       - MCP_MESH_HTTP_PORT=8080
 
   data-agent:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     volumes:
       - ./agents/data:/app/agent:ro
     command: ["python", "/app/agent/main.py"]
@@ -307,7 +307,7 @@ services:
       - MCP_MESH_HTTP_PORT=8080
 
   api-agent:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     volumes:
       - ./agents/api:/app/agent:ro
     command: ["python", "/app/agent/main.py"]

--- a/docs/03-docker-deployment/04-networking.md
+++ b/docs/03-docker-deployment/04-networking.md
@@ -31,12 +31,12 @@ graph TD
     # docker-compose.yml
     services:
       registry:
-        image: mcpmesh/registry:2.7.0
+        image: mcpmesh/registry:2.8.0
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/python-runtime:2.7.0
+        image: mcpmesh/python-runtime:2.8.0
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["python", "/app/agent/main.py"]
@@ -44,7 +44,7 @@ graph TD
           - MCP_MESH_REGISTRY_URL=http://registry:8000
 
       another-agent:
-        image: mcpmesh/python-runtime:2.7.0
+        image: mcpmesh/python-runtime:2.8.0
         volumes:
           - ./another-agent:/app/agent:ro
         command: ["python", "/app/agent/main.py"]
@@ -62,12 +62,12 @@ graph TD
     # docker-compose.yml
     services:
       registry:
-        image: mcpmesh/registry:2.7.0
+        image: mcpmesh/registry:2.8.0
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/typescript-runtime:2.7.0
+        image: mcpmesh/typescript-runtime:2.8.0
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]
@@ -75,7 +75,7 @@ graph TD
           - MCP_MESH_REGISTRY_URL=http://registry:8000
 
       another-agent:
-        image: mcpmesh/typescript-runtime:2.7.0
+        image: mcpmesh/typescript-runtime:2.8.0
         volumes:
           - ./another-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]

--- a/docs/04-kubernetes-basics.md
+++ b/docs/04-kubernetes-basics.md
@@ -21,7 +21,7 @@ kubectl create namespace mcp-mesh
 
 # Deploy core (OCI registry - no "helm repo add" needed)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   --namespace mcp-mesh
 
 # Wait for registry
@@ -65,7 +65,7 @@ Build the image:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=my-agent \
@@ -76,7 +76,7 @@ For cloud deployments, use your full registry path:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
@@ -138,7 +138,7 @@ resources:
 ```bash
 # Core without Grafana/Tempo (lighter footprint)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   --namespace mcp-mesh \
   --set grafana.enabled=false \
   --set tempo.enabled=false
@@ -149,7 +149,7 @@ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
 ```bash
 # Just the registry, no database or observability
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 2.7.0 \
+  --version 2.8.0 \
   --namespace mcp-mesh
 ```
 
@@ -161,13 +161,13 @@ just match `-n` with `--set global.namespace`:
 ```bash
 # Deploy core to a custom namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n my-namespace --create-namespace \
   --set global.namespace=my-namespace
 
 # Deploy agent to the same namespace
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n my-namespace \
   -f helm-values.yaml
 ```
@@ -180,12 +180,12 @@ For **multi-tenant** clusters (separate core per team), deploy each core to its 
 ```bash
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n team-a --create-namespace --set global.namespace=team-a
 
 # Team B — same values, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n team-b --create-namespace --set global.namespace=team-b
 ```
 
@@ -193,7 +193,7 @@ For **cross-namespace** access (agent in one namespace, core in another), use FQ
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 -n other-ns \
+  --version 2.8.0 -n other-ns \
   --set mesh.registryUrl=http://mcp-core-mcp-mesh-registry.team-a.svc.cluster.local:8000
 ```
 
@@ -205,13 +205,13 @@ helm list -n mcp-mesh
 
 # Upgrade an agent
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   --namespace mcp-mesh \
   --set image.tag=v2
 
 # Scale replicas
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   --namespace mcp-mesh \
   --reuse-values \
   --set replicaCount=3

--- a/docs/04-kubernetes-basics/05-troubleshooting.md
+++ b/docs/04-kubernetes-basics/05-troubleshooting.md
@@ -373,7 +373,7 @@ kubectl exec <pod-name> -n mcp-mesh -- df -h
 **Symptoms:**
 
 ```
-Failed to pull image "mcpmesh/python-runtime:2.7.0": rpc error: code = Unknown desc = Error response from daemon: pull access denied
+Failed to pull image "mcpmesh/python-runtime:2.8.0": rpc error: code = Unknown desc = Error response from daemon: pull access denied
 ```
 
 **Solutions:**

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -19,7 +19,7 @@ The data flows: **Agents → Redis → Registry → Tempo → Grafana**
 ```bash
 # Deploy core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   --namespace mcp-mesh \
   --set redis.enabled=true \
   --set tempo.enabled=true \

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -216,7 +216,7 @@ Designed for containers and Kubernetes.
 
 ## Multimodal Pipeline
 
-MCP Mesh v2.7.0 adds a media pipeline that lets tools produce and LLMs consume binary content:
+MCP Mesh v2.8.0 adds a media pipeline that lets tools produce and LLMs consume binary content:
 
 ```
 Tool produces media

--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -257,6 +257,17 @@ re-runs only the latter on a peer replica.
 `max_retries=3` means up to 4 total attempts. The default is conservative
 — check your runtime's per-tool default and set explicitly when in doubt.
 
+!!! danger "`max_retries` does not soften a real failure"
+
+    A handler exception **not** matched by `retry_on` — and any explicit
+    `fail()` — is **terminal immediately**, regardless of how much of the
+    `max_retries` budget is unspent. That budget covers only crash-style
+    recoveries the runtime retries for you: lease expiry, orphan reclaim,
+    `max_duration` timeout, plus `retry_on`-matched releases. A job that
+    shows `attempt_count: 1` with `max_retries: 3` after a non-transient
+    error has **zero** retries left — not two — it already reached its
+    terminal `failed` state on that first attempt.
+
 !!! warning "Retries restart from scratch"
 
     There are no idempotency keys in v2.x. Every retry runs the handler
@@ -522,6 +533,30 @@ TypeScript, `JobContext.current().claimEpoch` in Java) can be stamped onto
 external side effects so downstream can dedupe a fenced re-execution's
 duplicate write.
 
+**Calling-job identity (provider-side dual).** The stamp above lets a
+handler fence *its own* side effects. When the dedupe target is itself a
+mesh provider — a state-authority agent that must reject writes from a
+*stale executor* it doesn't control — the caller need not thread `job_id` /
+`claim_epoch` through the payload. The mesh seeds them automatically: any
+outbound mesh→mesh tool call made from within a job handler carries the
+calling job's identity on two dedicated propagated headers,
+`x-mesh-calling-job-id` and (when known) `x-mesh-calling-claim-epoch`,
+forwarded by default across every mesh→mesh hop (including the registry's
+proxy hop). The provider reads the pair with `mesh.calling_job()` in Python
+(→ `CallingJob(job_id, claim_epoch)` or `None`), `callingJob()` in TypeScript
+(→ `{ jobId, claimEpoch }` or `null`, exported from the package root), and
+`MeshCallContext.callingJob()` in Java (→ `CallingJob(jobId, claimEpoch)`,
+package `io.mcpmesh.spring`). Each reports the identity of the job that
+**called this tool**, not the job the handler is itself running as — so each
+is the provider-side dual of the job-context accessor: `current_job()` /
+`currentJob()` / `JobContext.current()` answer "what job am I executing
+*as*", while the calling-job accessor answers "what job *invoked* me". All
+three return the empty/`null` identity for a regular (non-job) `tools/call`,
+a caller on an older SDK, and — critically — inside a handler that was
+**claimed directly** (its own identity lives on the job-context accessor,
+not here); the epoch is `null` for a push-mode inbound job. Reading them is
+purely additive and read-only.
+
 The **agent runtime** is a thin client. On the producer side, it
 maintains a claim queue per `task=true` capability (`UPDATE jobs SET
 owner_instance_id = $self WHERE capability = $cap AND status =
@@ -559,6 +594,19 @@ actually exists — so an idle queue pays nothing. Claiming resumes
 automatically within one claim-poll cycle (≤5s backoff ceiling) of the
 required chain recovering, so no retry budget is spent while the capability
 is down.
+
+The gate is **belt-and-suspenders — enforced at both layers.** The
+registry-side transitive predicate (above) keeps the job out of any claim
+response whose `required` chain is down. Consumer-side, the claim worker
+independently **skips claiming** while a `required` dependency slot is still
+unresolved *locally* — the claim gate and the handler's injection read one
+clock, so a dep flapping DOWN→UP cannot slip a job past the registry gate
+into a handler that would see `null`. As a last resort, a **pre-invoke
+guard** that finds a required slot still unresolved at invoke time
+**releases the claim back to the queue** (a lease release, mirroring the
+`retry_on` path — never a terminal `fail()`) rather than running the handler
+with a missing dependency. Net effect: a handler never observes `null` for a
+`required` dependency, including during dependency recovery.
 
 ## What it does NOT do (v2 limitations)
 

--- a/docs/concepts/stateful-agents.md
+++ b/docs/concepts/stateful-agents.md
@@ -48,7 +48,7 @@ mcp-mesh runs your agent across two event loops:
 
 The two-loop split means a long-running tool body (LLM call, slow registry hop, multi-minute MeshJob) holds the user loop, but never the framework loop — your K8s liveness/readiness probes stay responsive.
 
-**What this fixes**: loop-bound resources work as expected when created in `lifespan` startup. `asyncpg.Pool`, `redis.asyncio.Redis`, and `aiohttp.ClientSession` are all loop-affine — they bind to the asyncio loop that created them and fail if reused from a different one. Because v2.7.0 runs your `lifespan` AND your tools on the same user loop, the canonical FastMCP idiom is straightforward:
+**What this fixes**: loop-bound resources work as expected when created in `lifespan` startup. `asyncpg.Pool`, `redis.asyncio.Redis`, and `aiohttp.ClientSession` are all loop-affine — they bind to the asyncio loop that created them and fail if reused from a different one. Because v2.8.0 runs your `lifespan` AND your tools on the same user loop, the canonical FastMCP idiom is straightforward:
 
 ```python
 # Module-level — FastMCP's `lifespan` parameter receives a FastMCP server
@@ -104,7 +104,7 @@ long-running work. From mesh's perspective it's an ordinary CRUD
 agent — every tool call is short, idempotent where possible, and
 returns. The pool lives inside the agent process — created in
 `lifespan` startup, stored in a module-level global, and closed in
-`lifespan` exit. Since v2.7.0, `lifespan` and all tool bodies share
+`lifespan` exit. Since v2.8.0, `lifespan` and all tool bodies share
 the single user loop, so a module-level pool created in `lifespan`
 startup is the supported pattern. (FastMCP's `lifespan` receives a
 FastMCP server instance — there is no `.state` namespace as there is

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,7 @@ docker-compose up
 ```bash
 # Quick start (OCI registry - no helm repo add needed)
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 2.7.0 -n mcp-mesh --create-namespace
+  --version 2.8.0 -n mcp-mesh --create-namespace
 ```
 
 [:material-arrow-right: Kubernetes Guide](04-kubernetes-basics.md){ .md-button .md-button--primary }
@@ -117,7 +117,7 @@ For Kubernetes, configure TLS via Helm values:
 
 ```bash
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 2.7.0 -n mcp-mesh --create-namespace \
+  --version 2.8.0 -n mcp-mesh --create-namespace \
   --set registry.security.tls.mode=strict \
   --set registry.security.trust.backend=k8s-secrets
 ```

--- a/docs/dev-to-production.md
+++ b/docs/dev-to-production.md
@@ -85,10 +85,10 @@ The [TSuite](https://github.com/dhyansraj/mcp-mesh-test-suite) integration testi
 
     ```bash
     helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-      --version 2.7.0 -n mcp-mesh --create-namespace
+      --version 2.8.0 -n mcp-mesh --create-namespace
 
     helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 2.7.0 -n mcp-mesh -f helm-values.yaml
+      --version 2.8.0 -n mcp-mesh -f helm-values.yaml
     ```
 
 Same agent code runs locally, in Docker, and in Kubernetes — no changes needed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,7 @@ Build multi-agent systems that are production-ready from day one. Mesh handles t
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0</version>
     </dependency>
     ```
 
@@ -364,7 +364,7 @@ A `kubectl`-style command-line tool that follows you from first agent to product
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0</version>
     </dependency>
     ```
 
@@ -383,10 +383,10 @@ A `kubectl`-style command-line tool that follows you from first agent to product
 === "Docker Images"
 
     ```bash
-    docker pull mcpmesh/registry:2.7.0
-    docker pull mcpmesh/python-runtime:2.7.0
-    docker pull mcpmesh/java-runtime:2.7.0
-    docker pull mcpmesh/typescript-runtime:2.7.0
+    docker pull mcpmesh/registry:2.8.0
+    docker pull mcpmesh/python-runtime:2.8.0
+    docker pull mcpmesh/java-runtime:2.8.0
+    docker pull mcpmesh/typescript-runtime:2.8.0
     ```
 
     Official container images for production deployments.
@@ -412,7 +412,7 @@ A `kubectl`-style command-line tool that follows you from first agent to product
 
 ## :star: Project Status
 
-- **Latest Release**: v2.7.0 (March 2026)
+- **Latest Release**: v2.8.0 (March 2026)
 - **License**: MIT
 - **Languages**: Python 3.11+, TypeScript/Node.js 18+, and Java 17+ (runtime), Go 1.23+ (registry)
 - **Status**: Production-ready, actively developed

--- a/docs/java/examples.md
+++ b/docs/java/examples.md
@@ -132,7 +132,7 @@ class AssistantAgentTest {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:2.7.0
+    image: mcpmesh/registry:2.8.0
     ports:
       - "8000:8000"
     healthcheck:

--- a/docs/java/getting-started/index.md
+++ b/docs/java/getting-started/index.md
@@ -83,13 +83,13 @@ Create `pom.xml`:
 
     <groupId>com.example</groupId>
     <artifactId>greeter-agent</artifactId>
-    <version>2.7.0</version>
+    <version>2.8.0</version>
 
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/docs/java/getting-started/prerequisites.md
+++ b/docs/java/getting-started/prerequisites.md
@@ -60,7 +60,7 @@ Add the Spring Boot starter to your `pom.xml`:
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -108,10 +108,10 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:2.7.0`           | Registry service            |
-| `mcpmesh/python-runtime:2.7.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:2.7.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:2.7.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:2.8.0`           | Registry service            |
+| `mcpmesh/python-runtime:2.8.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:2.8.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:2.8.0` | TypeScript runtime with SDK |
 
 Java agents use standard Maven-based Docker builds (see Docker Deployment guide).
 

--- a/docs/java/local-development/01-getting-started.md
+++ b/docs/java/local-development/01-getting-started.md
@@ -45,7 +45,7 @@ The recommended way is to use `meshctl scaffold` (see next page). If you prefer 
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/docs/java/local-development/troubleshooting.md
+++ b/docs/java/local-development/troubleshooting.md
@@ -38,7 +38,7 @@ Ensure the dependency version matches an available release:
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>2.7.0</version>
+    <version>2.8.0</version>
 </dependency>
 ```
 

--- a/docs/java/spring-boot-integration.md
+++ b/docs/java/spring-boot-integration.md
@@ -23,7 +23,7 @@ MCP Mesh provides `@MeshRoute` and `@MeshInject` annotations for Spring Boot RES
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/docs/python/dependency-injection.md
+++ b/docs/python/dependency-injection.md
@@ -236,7 +236,7 @@ loop — K8s liveness/readiness probes stay responsive.
 
 ### Default `MCP_MESH_TOOL_WORKERS=1`
 
-Since v2.7.0, default tool dispatch runs on a single-user loop (was
+Since v2.8.0, default tool dispatch runs on a single-user loop (was
 `min(8, max(2, cpu_count()))`). The canonical pattern for loop-bound
 resources works as expected — `lifespan` startup creates the resource
 on the user loop; every tool body uses it on the same loop; `lifespan`

--- a/docs/python/getting-started/prerequisites.md
+++ b/docs/python/getting-started/prerequisites.md
@@ -97,17 +97,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:2.7.0`           | Registry service            |
-| `mcpmesh/python-runtime:2.7.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:2.7.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:2.7.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:2.8.0`           | Registry service            |
+| `mcpmesh/python-runtime:2.8.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:2.8.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:2.8.0` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:2.7.0
-docker pull mcpmesh/python-runtime:2.7.0
-docker pull mcpmesh/java-runtime:2.7.0
-docker pull mcpmesh/typescript-runtime:2.7.0
+docker pull mcpmesh/registry:2.8.0
+docker pull mcpmesh/python-runtime:2.8.0
+docker pull mcpmesh/java-runtime:2.8.0
+docker pull mcpmesh/typescript-runtime:2.8.0
 ```
 
 ### Generate Docker Compose
@@ -145,12 +145,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/docs/tutorial/day-08-docker-compose.md
+++ b/docs/tutorial/day-08-docker-compose.md
@@ -379,7 +379,7 @@ $ docker compose down -v
 ## Troubleshooting
 
 **Docker build fails with missing requirements.** The compose file uses
-`mcpmesh/python-runtime:2.7.0` images with a dev-mode entrypoint that
+`mcpmesh/python-runtime:2.8.0` images with a dev-mode entrypoint that
 installs `requirements.txt` on startup. If an agent has dependencies not
 in the base image, check that `requirements.txt` exists in the agent
 directory and lists all dependencies.

--- a/docs/tutorial/day-09-kubernetes.md
+++ b/docs/tutorial/day-09-kubernetes.md
@@ -212,7 +212,7 @@ and Grafana as a single Helm release:
 
 ```shell
 $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-    --version 2.7.0 \
+    --version 2.8.0 \
     -n trip-planner \
     -f helm/values-core.yaml \
     --wait --timeout 5m
@@ -246,7 +246,7 @@ $ for agent in "${AGENTS[@]}"; do
     echo "Installing $agent..."
     helm install "$agent" \
       oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 2.7.0 \
+      --version 2.8.0 \
       -n trip-planner \
       -f "helm/values-${agent}.yaml"
   done

--- a/docs/typescript/examples.md
+++ b/docs/typescript/examples.md
@@ -128,7 +128,7 @@ describe("Agent Integration", () => {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:2.7.0
+    image: mcpmesh/registry:2.8.0
     ports:
       - "8000:8000"
     healthcheck:

--- a/docs/typescript/getting-started/prerequisites.md
+++ b/docs/typescript/getting-started/prerequisites.md
@@ -85,17 +85,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:2.7.0`           | Registry service            |
-| `mcpmesh/python-runtime:2.7.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:2.7.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:2.7.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:2.8.0`           | Registry service            |
+| `mcpmesh/python-runtime:2.8.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:2.8.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:2.8.0` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:2.7.0
-docker pull mcpmesh/python-runtime:2.7.0
-docker pull mcpmesh/java-runtime:2.7.0
-docker pull mcpmesh/typescript-runtime:2.7.0
+docker pull mcpmesh/registry:2.8.0
+docker pull mcpmesh/python-runtime:2.8.0
+docker pull mcpmesh/java-runtime:2.8.0
+docker pull mcpmesh/typescript-runtime:2.8.0
 ```
 
 ### Generate Docker Compose

--- a/examples/docker-examples/agents/claude-provider/Dockerfile
+++ b/examples/docker-examples/agents/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/docker-examples/agents/claude-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/claude-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying claude-provider with mcp-mesh-agent chart
 # Usage: helm install claude-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 2.7.0 -f helm-values.yaml
+#        --version 2.8.0 -f helm-values.yaml
 
 image:
   repository: your-registry/claude-provider

--- a/examples/docker-examples/agents/claude-provider/requirements.txt
+++ b/examples/docker-examples/agents/claude-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=2.7.0
+mcp-mesh>=2.8.0
 
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0

--- a/examples/docker-examples/agents/openai-provider/Dockerfile
+++ b/examples/docker-examples/agents/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/docker-examples/agents/openai-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/openai-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying openai-provider with mcp-mesh-agent chart
 # Usage: helm install openai-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 2.7.0 -f helm-values.yaml
+#        --version 2.8.0 -f helm-values.yaml
 
 image:
   repository: your-registry/openai-provider

--- a/examples/docker-examples/agents/openai-provider/requirements.txt
+++ b/examples/docker-examples/agents/openai-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=2.7.0
+mcp-mesh>=2.8.0
 
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0

--- a/examples/java/basic-tool-agent/pom.xml
+++ b/examples/java/basic-tool-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/consumer-date-agent/pom.xml
+++ b/examples/java/consumer-date-agent/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/consumer-report-agent-sse/pom.xml
+++ b/examples/java/consumer-report-agent-sse/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/consumer-report-agent/pom.xml
+++ b/examples/java/consumer-report-agent/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/dependency-agent/pom.xml
+++ b/examples/java/dependency-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/direct-openai-agent/pom.xml
+++ b/examples/java/direct-openai-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/java/employee-service/pom.xml
+++ b/examples/java/employee-service/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/gemini-provider-agent/pom.xml
+++ b/examples/java/gemini-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/java/gpt-provider-agent/pom.xml
+++ b/examples/java/gpt-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/java/header-api/pom.xml
+++ b/examples/java/header-api/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/health-block-test-agent/pom.xml
+++ b/examples/java/health-block-test-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-accurate-provider/pom.xml
+++ b/examples/java/java-accurate-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-alpha-provider/pom.xml
+++ b/examples/java/java-alpha-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-beta-provider/pom.xml
+++ b/examples/java/java-beta-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-booking-consumer/pom.xml
+++ b/examples/java/java-booking-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-calculator/pom.xml
+++ b/examples/java/java-calculator/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-deprecated-provider/pom.xml
+++ b/examples/java/java-deprecated-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-dual-consumer/pom.xml
+++ b/examples/java/java-dual-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-fast-provider/pom.xml
+++ b/examples/java/java-fast-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-math-agent/pom.xml
+++ b/examples/java/java-math-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-schedule-agent/pom.xml
+++ b/examples/java/java-schedule-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-tag-consumer/pom.xml
+++ b/examples/java/java-tag-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-weather-agent/pom.xml
+++ b/examples/java/java-weather-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/llm-mesh-agent/pom.xml
+++ b/examples/java/llm-mesh-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/llm-provider-agent/pom.xml
+++ b/examples/java/llm-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/java/media-consumer-agent/pom.xml
+++ b/examples/java/media-consumer-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/media-producer-agent/pom.xml
+++ b/examples/java/media-producer-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/multijar-api-gateway/pom.xml
+++ b/examples/java/multijar-api-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/multijar-payment-service/pom.xml
+++ b/examples/java/multijar-payment-service/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/producer-date-agent/pom.xml
+++ b/examples/java/producer-date-agent/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/producer-report-agent/pom.xml
+++ b/examples/java/producer-report-agent/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/rest-api-consumer/pom.xml
+++ b/examples/java/rest-api-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/parallel-tools/consumer-gemini-java/pom.xml
+++ b/examples/parallel-tools/consumer-gemini-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-gemini-ts/package.json
+++ b/examples/parallel-tools/consumer-gemini-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/consumer-openai-java/pom.xml
+++ b/examples/parallel-tools/consumer-openai-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-openai-ts/package.json
+++ b/examples/parallel-tools/consumer-openai-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/parallel-consumer-java/pom.xml
+++ b/examples/parallel-tools/parallel-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/parallel-consumer-ts/package.json
+++ b/examples/parallel-tools/parallel-consumer-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/slow-tool-java/pom.xml
+++ b/examples/parallel-tools/slow-tool-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/slow-tool-ts/package.json
+++ b/examples/parallel-tools/slow-tool-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/schema-corpus/java/pom.xml
+++ b/examples/schema-corpus/java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/consumer/pom.xml
+++ b/examples/schema/java/consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/producer-bad/pom.xml
+++ b/examples/schema/java/producer-bad/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/producer-good/pom.xml
+++ b/examples/schema/java/producer-good/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/streaming/chatbot-demo/chatbot-agent/Dockerfile
+++ b/examples/streaming/chatbot-demo/chatbot-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chatbot-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/streaming/chatbot-demo/gateway/Dockerfile
+++ b/examples/streaming/chatbot-demo/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/streaming/chatbot-demo/weather-tool/Dockerfile
+++ b/examples/streaming/chatbot-demo/weather-tool/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/chatbot-agent/Dockerfile
+++ b/examples/streaming/fixtures/chatbot-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chatbot-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/gateway-agent/Dockerfile
+++ b/examples/streaming/fixtures/gateway-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway-agent MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/passthrough-agent/Dockerfile
+++ b/examples/streaming/fixtures/passthrough-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for passthrough-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-java/pom.xml
+++ b/examples/toolcalls/analyst-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/toolcalls/analyst-py/Dockerfile
+++ b/examples/toolcalls/analyst-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for analyst-py MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-ts/Dockerfile
+++ b/examples/toolcalls/analyst-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for analyst-ts MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-ts/package.json
+++ b/examples/toolcalls/analyst-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/claude-provider-java/pom.xml
+++ b/examples/toolcalls/claude-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/claude-provider-py/Dockerfile
+++ b/examples/toolcalls/claude-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/claude-provider-ts/Dockerfile
+++ b/examples/toolcalls/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/claude-provider-ts/package.json
+++ b/examples/toolcalls/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/gemini-provider-java/pom.xml
+++ b/examples/toolcalls/gemini-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/gemini-provider-py/Dockerfile
+++ b/examples/toolcalls/gemini-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/gemini-provider-ts/Dockerfile
+++ b/examples/toolcalls/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/gemini-provider-ts/package.json
+++ b/examples/toolcalls/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/openai-provider-java/pom.xml
+++ b/examples/toolcalls/openai-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/openai-provider-py/Dockerfile
+++ b/examples/toolcalls/openai-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/openai-provider-ts/Dockerfile
+++ b/examples/toolcalls/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/openai-provider-ts/package.json
+++ b/examples/toolcalls/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/weather-tool-java/pom.xml
+++ b/examples/toolcalls/weather-tool-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/toolcalls/weather-tool-py/Dockerfile
+++ b/examples/toolcalls/weather-tool-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool-py MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/weather-tool-ts/Dockerfile
+++ b/examples/toolcalls/weather-tool-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool-ts MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/weather-tool-ts/package.json
+++ b/examples/toolcalls/weather-tool-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/tutorial/trip-planner/day-01/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-01/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh streaming API gateway
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh streaming LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/typescript/context-self-dep-ts-mesh/Dockerfile
+++ b/examples/typescript/context-self-dep-ts-mesh/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for context-self-dep-ts-mesh MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/examples/typescript/header-api/package.json
+++ b/examples/typescript/header-api/package.json
@@ -11,7 +11,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/examples/typescript/llm-consumer/package.json
+++ b/examples/typescript/llm-consumer/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/examples/typescript/llm-provider/package.json
+++ b/examples/typescript/llm-provider/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/helm/mcp-mesh-agent/Chart.yaml
+++ b/helm/mcp-mesh-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-agent
 description: MCP Mesh Agent - Python runtime for MCP agents with mesh capabilities
 type: application
-version: 2.7.0
-appVersion: "2.7.0"
+version: 2.8.0
+appVersion: "2.8.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-agent/README.md
+++ b/helm/mcp-mesh-agent/README.md
@@ -232,7 +232,7 @@ existingSecret: my-secret
 ### Python
 
 ```dockerfile
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 COPY . /app/
 CMD ["-m", "myagent"]
@@ -241,7 +241,7 @@ CMD ["-m", "myagent"]
 ### TypeScript
 
 ```dockerfile
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 COPY . /app/
 CMD ["src/index.ts"]
@@ -250,7 +250,7 @@ CMD ["src/index.ts"]
 ### Java
 
 ```dockerfile
-FROM mcpmesh/java-runtime:2.7.0
+FROM mcpmesh/java-runtime:2.8.0
 
 COPY target/myagent.jar /app/
 CMD ["/app/myagent.jar"]

--- a/helm/mcp-mesh-core/Chart.lock
+++ b/helm/mcp-mesh-core/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: mcp-mesh-postgres
   repository: file://../mcp-mesh-postgres
-  version: 2.7.0
+  version: 2.8.0
 - name: mcp-mesh-redis
   repository: file://../mcp-mesh-redis
-  version: 2.7.0
+  version: 2.8.0
 - name: mcp-mesh-registry
   repository: file://../mcp-mesh-registry
-  version: 2.7.0
+  version: 2.8.0
 - name: mcp-mesh-grafana
   repository: file://../mcp-mesh-grafana
-  version: 2.7.0
+  version: 2.8.0
 - name: mcp-mesh-tempo
   repository: file://../mcp-mesh-tempo
-  version: 2.7.0
+  version: 2.8.0
 - name: mcp-mesh-ui
   repository: file://../mcp-mesh-ui
-  version: 2.7.0
-digest: sha256:76473791fa0569115c2829da6a051c6789f501cff30d7da6ec3add2b60a27a81
-generated: "2026-07-01T08:30:42.216418-04:00"
+  version: 2.8.0
+digest: sha256:9d37b24fbd5d81ab1ed6a5eea55a1919945c7d84fc5bd1032ffcdec99fd055b1
+generated: "2026-07-03T19:03:06.684772-04:00"

--- a/helm/mcp-mesh-core/Chart.yaml
+++ b/helm/mcp-mesh-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-core
 description: MCP Mesh Core Infrastructure - Registry, PostgreSQL, Redis, and Observability
 type: application
-version: 2.7.0
-appVersion: "2.7.0"
+version: 2.8.0
+appVersion: "2.8.0"
 keywords:
   - mcp
   - mesh
@@ -28,26 +28,26 @@ annotations:
   "artifacthub.io/containsSecurityUpdates": "false"
 dependencies:
   - name: mcp-mesh-postgres
-    version: "2.7.0"
+    version: "2.8.0"
     repository: "file://../mcp-mesh-postgres"
     condition: postgres.enabled
   - name: mcp-mesh-redis
-    version: "2.7.0"
+    version: "2.8.0"
     repository: "file://../mcp-mesh-redis"
     condition: redis.enabled
   - name: mcp-mesh-registry
-    version: "2.7.0"
+    version: "2.8.0"
     repository: "file://../mcp-mesh-registry"
     condition: registry.enabled
   - name: mcp-mesh-grafana
-    version: "2.7.0"
+    version: "2.8.0"
     repository: "file://../mcp-mesh-grafana"
     condition: grafana.enabled
   - name: mcp-mesh-tempo
-    version: "2.7.0"
+    version: "2.8.0"
     repository: "file://../mcp-mesh-tempo"
     condition: tempo.enabled
   - name: mcp-mesh-ui
-    version: "2.7.0"
+    version: "2.8.0"
     repository: "file://../mcp-mesh-ui"
     condition: ui.enabled

--- a/helm/mcp-mesh-grafana/Chart.yaml
+++ b/helm/mcp-mesh-grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-grafana
 description: Grafana observability component for MCP Mesh
 type: application
-version: 2.7.0
+version: 2.8.0
 appVersion: "12.3.1"
 keywords:
   - grafana

--- a/helm/mcp-mesh-ingress/Chart.yaml
+++ b/helm/mcp-mesh-ingress/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ingress
 description: Ingress configuration for MCP Mesh services with flexible DNS routing
 type: application
-version: 2.7.0
-appVersion: "2.7.0"
+version: 2.8.0
+appVersion: "2.8.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-postgres/Chart.yaml
+++ b/helm/mcp-mesh-postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-postgres
 description: PostgreSQL database for MCP Mesh Registry
 type: application
-version: 2.7.0
+version: 2.8.0
 appVersion: "15"
 keywords:
   - mcp

--- a/helm/mcp-mesh-redis/Chart.yaml
+++ b/helm/mcp-mesh-redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-redis
 description: Redis cache for MCP Mesh session storage
 type: application
-version: 2.7.0
+version: 2.8.0
 appVersion: "7"
 keywords:
   - mcp

--- a/helm/mcp-mesh-registry/Chart.yaml
+++ b/helm/mcp-mesh-registry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-registry
 description: MCP Mesh Registry Service - Central service registry for MCP agents
 type: application
-version: 2.7.0
-appVersion: "2.7.0"
+version: 2.8.0
+appVersion: "2.8.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-tempo/Chart.yaml
+++ b/helm/mcp-mesh-tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-tempo
 description: Tempo distributed tracing component for MCP Mesh
 type: application
-version: 2.7.0
+version: 2.8.0
 appVersion: "2.9.0"
 keywords:
   - tempo

--- a/helm/mcp-mesh-ui/Chart.yaml
+++ b/helm/mcp-mesh-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ui
 description: MCP Mesh Dashboard UI Server - Web dashboard for monitoring MCP agents
 type: application
-version: 2.7.0
-appVersion: "2.7.0"
+version: 2.8.0
+appVersion: "2.8.0"
 keywords:
   - mcp
   - mesh

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/cli",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "CLI for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration",
   "license": "MIT",
   "repository": {
@@ -23,10 +23,10 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@mcpmesh/cli-linux-x64": "2.7.0",
-    "@mcpmesh/cli-linux-arm64": "2.7.0",
-    "@mcpmesh/cli-darwin-x64": "2.7.0",
-    "@mcpmesh/cli-darwin-arm64": "2.7.0"
+    "@mcpmesh/cli-linux-x64": "2.8.0",
+    "@mcpmesh/cli-linux-arm64": "2.8.0",
+    "@mcpmesh/cli-darwin-x64": "2.8.0",
+    "@mcpmesh/cli-darwin-arm64": "2.8.0"
   },
   "keywords": [
     "mcp",

--- a/packaging/homebrew/mcp-mesh.rb
+++ b/packaging/homebrew/mcp-mesh.rb
@@ -2,7 +2,7 @@
 class McpMesh < Formula
   desc "Kubernetes-native platform for distributed MCP applications"
   homepage "https://github.com/dhyansraj/mcp-mesh"
-  version "2.7.0"  # Will be updated by release automation
+  version "2.8.0"  # Will be updated by release automation
 
   if OS.mac?
     if Hardware::CPU.arm?

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "2.7.0"
+version = "2.8.0"
 description = "Python SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration"
 readme = "README.md"
 license = { text = "MIT" }
@@ -58,7 +58,7 @@ requires-python = ">=3.11"
 # LiteLLM.
 dependencies = [
     # Rust core runtime (required - no Python fallback)
-    "mcp-mesh-core>=2.7.0",
+    "mcp-mesh-core>=2.8.0",
     "fastapi>=0.104.0,<1.0.0",
     "uvicorn>=0.24.0,<1.0.0",
     "httpx>=0.25.0,<1.0.0",

--- a/packaging/scoop/mcp-mesh.json
+++ b/packaging/scoop/mcp-mesh.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Kubernetes-native platform for distributed MCP applications",
   "homepage": "https://github.com/dhyansraj/mcp-mesh",
   "license": "MIT",

--- a/src/core/cli/handlers/java_handler.go
+++ b/src/core/cli/handlers/java_handler.go
@@ -304,7 +304,7 @@ const javaPomTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.0</version>
         </dependency>
     </dependencies>
 

--- a/src/core/cli/handlers/language_test.go
+++ b/src/core/cli/handlers/language_test.go
@@ -202,7 +202,7 @@ func TestDetectLanguage_PythonDirectoryRequirements(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Create requirements.txt
-	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==2.7.0"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==2.8.0"), 0644); err != nil {
 		t.Fatalf("Failed to create requirements.txt: %v", err)
 	}
 

--- a/src/core/cli/handlers/python_handler.go
+++ b/src/core/cli/handlers/python_handler.go
@@ -248,5 +248,5 @@ const pythonInitTemplate = `# {{.Name}} MCP Mesh Agent
 const pythonMainModuleTemplate = `from .main import *
 `
 
-const pythonRequirementsTemplate = `mcp-mesh>=2.7.0
+const pythonRequirementsTemplate = `mcp-mesh>=2.8.0
 `

--- a/src/core/cli/handlers/typescript_handler.go
+++ b/src/core/cli/handlers/typescript_handler.go
@@ -269,7 +269,7 @@ const typescriptPackageTemplate = `{
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "fastmcp": "^3.26.0",
     "zod": "^3.23.0"
   },

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -10,12 +10,12 @@ MCP Mesh supports multiple deployment patterns from local development to product
 
 | Image                              | Description                                        |
 | ---------------------------------- | -------------------------------------------------- |
-| `mcpmesh/registry:2.7.0`             | Registry service for agent discovery               |
-| `mcpmesh/python-runtime:2.7.0`       | Python runtime with mcp-mesh SDK pre-installed     |
-| `mcpmesh/typescript-runtime:2.7.0`   | TypeScript runtime with @mcpmesh/sdk pre-installed |
-| `mcpmesh/java-runtime:2.7.0`         | Java runtime with mcp-mesh Spring Boot starter     |
-| `mcpmesh/ui:2.7.0`                   | Dashboard UI server (basePath: /ops/dashboard)     |
-| `mcpmesh/cli:2.7.0`                  | meshctl CLI for management                         |
+| `mcpmesh/registry:2.8.0`             | Registry service for agent discovery               |
+| `mcpmesh/python-runtime:2.8.0`       | Python runtime with mcp-mesh SDK pre-installed     |
+| `mcpmesh/typescript-runtime:2.8.0`   | TypeScript runtime with @mcpmesh/sdk pre-installed |
+| `mcpmesh/java-runtime:2.8.0`         | Java runtime with mcp-mesh Spring Boot starter     |
+| `mcpmesh/ui:2.8.0`                   | Dashboard UI server (basePath: /ops/dashboard)     |
+| `mcpmesh/cli:2.8.0`                  | meshctl CLI for management                         |
 
 ## Local Development
 
@@ -104,7 +104,7 @@ meshctl scaffold basic --name my-agent
 The generated Dockerfile uses the official runtime:
 
 ```dockerfile
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
@@ -132,7 +132,7 @@ meshctl scaffold --compose --observability
 Generated docker-compose.yml includes:
 
 - PostgreSQL database for registry
-- Registry service (`mcpmesh/registry:2.7.0`)
+- Registry service (`mcpmesh/registry:2.8.0`)
 - All detected agents with proper networking
 - Health checks and dependency ordering
 - Optional: Redis, Tempo, Grafana (with `--observability`)
@@ -155,12 +155,12 @@ For production Kubernetes deployment, use the official Helm charts from the MCP 
 # Install core infrastructure (registry + database + observability)
 # No "helm repo add" needed - uses OCI registry directly
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy agent using scaffold-generated helm-values.yaml
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -171,12 +171,12 @@ Deploy into any namespace — just match `-n` with `--set global.namespace`:
 
 ```bash
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n my-namespace --create-namespace \
   --set global.namespace=my-namespace
 
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n my-namespace \
   -f helm-values.yaml
 ```
@@ -195,19 +195,19 @@ its own namespace. Short service names resolve independently within each namespa
 ```bash
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n team-a --create-namespace --set global.namespace=team-a
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 -n team-a -f greeter/helm-values.yaml
+  --version 2.8.0 -n team-a -f greeter/helm-values.yaml
 
 # Team B — same helm-values.yaml, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n team-b --create-namespace --set global.namespace=team-b
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 -n team-b -f greeter/helm-values.yaml
+  --version 2.8.0 -n team-b -f greeter/helm-values.yaml
 ```
 
 ### Available Helm Charts
@@ -256,16 +256,16 @@ meshctl scaffold basic --name my-agent
 
 # 2. Build and push Docker image (works on all platforms)
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v2.7.0 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v2.8.0 --push .
 
 # 3. Update helm-values.yaml with your image repository
 # 4. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v2.7.0
+  --set image.tag=v2.8.0
 ```
 
 ### Disable Optional Components
@@ -273,14 +273,14 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 ```bash
 # Core without observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh --create-namespace \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 
 # Core without PostgreSQL (in-memory registry)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh --create-namespace \
   --set postgres.enabled=false
 ```
@@ -429,7 +429,7 @@ Or use the `mcp-mesh-ingress` chart which handles routing automatically.
 
 ```bash
 # Docker
-docker run -e MCP_MESH_UI_BASE_PATH=/my/custom/path mcpmesh/ui:2.7.0
+docker run -e MCP_MESH_UI_BASE_PATH=/my/custom/path mcpmesh/ui:2.8.0
 
 # Helm
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -16,7 +16,7 @@ MCP Mesh supports multiple deployment patterns for Java/Spring Boot agents. The 
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>2.7.0</version>
+    <version>2.8.0</version>
 </dependency>
 ```
 
@@ -152,7 +152,7 @@ services:
       retries: 5
 
   registry:
-    image: mcpmesh/registry:2.7.0
+    image: mcpmesh/registry:2.8.0
     ports:
       - "8000:8000"
     environment:
@@ -204,12 +204,12 @@ For production Kubernetes deployment:
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy Java agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -242,15 +242,15 @@ resources:
 ```bash
 # 1. Build and push Docker image
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v2.7.0 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v2.8.0 --push .
 
 # 2. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v2.7.0
+  --set image.tag=v2.8.0
 ```
 
 ## Port Strategy

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -10,8 +10,8 @@ MCP Mesh supports multiple deployment patterns for TypeScript agents. Use `meshc
 
 | Image                            | Description                                        |
 | -------------------------------- | -------------------------------------------------- |
-| `mcpmesh/registry:2.7.0`           | Registry service for agent discovery               |
-| `mcpmesh/typescript-runtime:2.7.0` | TypeScript runtime with @mcpmesh/sdk pre-installed |
+| `mcpmesh/registry:2.8.0`           | Registry service for agent discovery               |
+| `mcpmesh/typescript-runtime:2.8.0` | TypeScript runtime with @mcpmesh/sdk pre-installed |
 
 ## Local Development
 
@@ -75,7 +75,7 @@ meshctl stop               # Stop all
 
 ```dockerfile
 # Dockerfile for my-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 
@@ -123,8 +123,8 @@ meshctl scaffold --compose --observability
 Generated `docker-compose.yml` includes:
 
 - PostgreSQL database for registry
-- Registry service (`mcpmesh/registry:2.7.0`)
-- TypeScript agents with `mcpmesh/typescript-runtime:2.7.0`
+- Registry service (`mcpmesh/registry:2.8.0`)
+- TypeScript agents with `mcpmesh/typescript-runtime:2.8.0`
 - Health checks and dependency ordering
 - Optional: Redis, Tempo, Grafana (with `--observability`)
 
@@ -145,12 +145,12 @@ For production Kubernetes deployment:
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy TypeScript agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -192,15 +192,15 @@ meshctl scaffold basic --name my-agent --lang typescript
 
 # 2. Build and push Docker image
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v2.7.0 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v2.8.0 --push .
 
 # 3. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v2.7.0
+  --set image.tag=v2.8.0
 ```
 
 ## Port Strategy

--- a/src/core/cli/man/content/jobs.md
+++ b/src/core/cli/man/content/jobs.md
@@ -194,6 +194,16 @@ proxy = await generate_report.submit(
 )
 ```
 
+**`max_retries` does NOT soften a real failure.** A handler exception
+that is **not** matched by `retry_on` — and any explicit `fail()` — is
+**terminal immediately**, no matter how much of the `max_retries` budget
+is unspent. That budget covers only crash-style recoveries the runtime
+retries on your behalf: lease expiry, orphan reclaim, `max_duration`
+timeout, plus `retry_on`-matched releases. So a job that shows
+`attempt_count: 1` with `max_retries: 3` after a non-transient error has
+**zero** retries left — not two — it already reached its terminal
+`failed` state on that first attempt.
+
 Retries restart the handler from scratch — there are no idempotency
 keys in v2.x. If the handler has external side effects, design for
 at-least-once: deterministic ids the downstream can dedupe on, or a
@@ -481,6 +491,19 @@ queue pays nothing. Claiming resumes automatically within one claim-poll
 cycle (≤5s backoff ceiling) of the required chain recovering, so no retry
 budget is spent while the capability is down.
 
+**Enforced at both layers.** The gate is belt-and-suspenders. Registry-side,
+the transitive availability predicate keeps the job out of any claim response
+whose `required` chain is down (the description above). Consumer-side, the
+claim worker independently **skips claiming** while a `required` dependency
+slot is still unresolved *locally* — the claim gate and the handler's
+injection read one clock, so a dep flapping DOWN→UP cannot slip a job past
+the registry gate into a handler that would see `None`. As a last resort, a
+**pre-invoke guard** that finds a required slot still unresolved at invoke
+time **releases the claim back to the queue** (a lease release, mirroring the
+`retry_on` path — never a terminal `fail()`) rather than running the handler
+with a missing dependency. Net effect: a handler never observes `None` for a
+`required=true` dependency, including during dependency recovery.
+
 ## Multi-replica execution and fencing
 
 Several replicas may declare the same `task=True` capability. Each job is
@@ -513,6 +536,56 @@ async def charge_card(order_id: str, amount: float, job: mesh.MeshJob = None) ->
     await ledger.upsert(key=order_id, claim_epoch=job.claim_epoch, amount=amount)
     ...
 ```
+
+When the dedupe sink is **itself a mesh provider** (rather than a raw
+DB/client as above), don't plumb the epoch as a tool argument — the provider
+reads the caller's identity straight off the propagated headers via
+`mesh.calling_job()`. See **Calling-job identity** below.
+
+## Calling-job identity
+
+The epoch stamp above lets a handler fence *its own* side effects. The dual
+problem is a **downstream provider** fencing writes from a *stale executor*
+it doesn't control — e.g. a state-authority agent that must reject a write
+issued under a superseded claim. Rather than make every caller thread
+`job_id` / `claim_epoch` through the tool payload, the mesh seeds them
+automatically: any outbound mesh→mesh tool call made from within a job
+handler carries the calling job's identity on two dedicated propagated
+headers — `x-mesh-calling-job-id` and (when known)
+`x-mesh-calling-claim-epoch`. The mesh forwards this pair by default across
+every mesh→mesh hop, including the registry's proxy hop, so no per-agent
+`MCP_MESH_PROPAGATE_HEADERS` configuration is needed.
+
+The provider reads that identity with `mesh.calling_job()`:
+
+```python
+import mesh
+
+@app.tool()
+@mesh.tool(capability="record_charge")
+async def record_charge(order_id: str, amount: float) -> dict:
+    caller = mesh.calling_job()          # CallingJob(job_id, claim_epoch) | None
+    if caller is not None:
+        # Fence: stamp the caller's claim epoch so a superseded
+        # re-execution's duplicate write is distinguishable / rejectable.
+        await ledger.upsert(
+            key=order_id,
+            claim_epoch=caller.claim_epoch,
+            amount=amount,
+        )
+    return {"order_id": order_id}
+```
+
+`calling_job()` returns the identity of the job that **called this tool** —
+not the job this handler is itself running as. It returns `None` for a
+regular (non-job) `tools/call`, for a caller on an older SDK that did not
+seed the headers, and — critically — inside a handler that was **claimed
+directly** (a `task=True` handler pulled off its own claim queue): that
+handler's *own* identity lives on `current_job()`, not here. The returned
+`CallingJob.claim_epoch` is `None` for a push-mode inbound job. It is purely
+additive and read-only — reading it has no effect on the call. This is the
+provider-side dual of `current_job()`: `current_job()` answers "what job am I
+executing *as*", `calling_job()` answers "what job *invoked* me".
 
 ## Out-of-band inspection
 

--- a/src/core/cli/man/content/jobs_java.md
+++ b/src/core/cli/man/content/jobs_java.md
@@ -290,6 +290,16 @@ public Map<String, Object> reportWithTransientFailures(
   compile time via the bound).
 - Misuse surfaces at startup, not at retry time.
 
+**`maxRetries` does NOT soften a real failure.** A handler exception that
+is **not** matched by `retryOn` — and any explicit `fail()` — is
+**terminal immediately**, no matter how much of the `maxRetries` budget is
+unspent. That budget covers only crash-style recoveries the runtime
+retries on your behalf: lease expiry, orphan reclaim, `maxDuration`
+timeout, plus `retryOn`-matched releases. So a job that shows
+`attempt_count: 1` with `maxRetries: 3` after a non-transient error has
+**zero** retries left — not two — it already reached its terminal
+`failed` state on that first attempt.
+
 Retries restart the handler from scratch — there are no idempotency
 keys in v2.x. If the handler has external side effects, design for
 at-least-once: deterministic ids the downstream can dedupe on, or a
@@ -667,6 +677,19 @@ queue pays nothing. Claiming resumes automatically within one claim-poll
 cycle (≤5s backoff ceiling) of the required chain recovering, so no retry
 budget is spent while the capability is down.
 
+**Enforced at both layers.** The gate is belt-and-suspenders. Registry-side,
+the transitive availability predicate keeps the job out of any claim response
+whose `required` chain is down (the description above). Consumer-side, the
+claim worker independently **skips claiming** while a `required` dependency
+slot is still unresolved *locally* — the claim gate and the handler's
+injection read one clock, so a dep flapping DOWN→UP cannot slip a job past
+the registry gate into a handler that would see `null`. As a last resort, a
+**pre-invoke guard** that finds a required slot still unresolved at invoke
+time **releases the claim back to the queue** (`releaseLease`, mirroring the
+`retryOn` path — never a terminal `fail()`) rather than running the handler
+with a missing dependency. Net effect: a handler never observes `null` for a
+`required = true` dependency, including during dependency recovery.
+
 ## Multi-replica execution and fencing
 
 Several replicas may declare the same `task = true` capability. Each job is
@@ -699,6 +722,59 @@ import io.mcpmesh.JobContext;
 Long claimEpoch = JobContext.current().claimEpoch;
 ledger.upsert(orderId, claimEpoch, amount);
 ```
+
+When the dedupe sink is **itself a mesh provider** (rather than a raw
+DB/client as above), don't plumb the epoch as a tool argument — the provider
+reads the caller's identity straight off the propagated headers via
+`MeshCallContext.callingJob()`. See **Calling-job identity** below.
+
+## Calling-job identity
+
+The epoch stamp above lets a handler fence *its own* side effects. The dual
+problem is a **downstream provider** fencing writes from a *stale executor*
+it doesn't control — e.g. a state-authority agent that must reject a write
+issued under a superseded claim. Rather than make every caller thread
+`job_id` / `claim_epoch` through the tool payload, the mesh seeds them
+automatically: any outbound mesh→mesh tool call made from within a job
+handler carries the calling job's identity on two dedicated propagated
+headers — `x-mesh-calling-job-id` and (when known)
+`x-mesh-calling-claim-epoch`. The mesh forwards this pair by default across
+every mesh→mesh hop, including the registry's proxy hop, so no per-agent
+`MCP_MESH_PROPAGATE_HEADERS` configuration is needed.
+
+The provider reads that identity with `MeshCallContext.callingJob()`
+(package `io.mcpmesh.spring`), which returns a
+`CallingJob(String jobId, Long claimEpoch)` record:
+
+```java
+import io.mcpmesh.spring.MeshCallContext;
+import io.mcpmesh.spring.MeshCallContext.CallingJob;
+
+@MeshTool(capability = "record_charge")
+public Map<String, Object> recordCharge(
+    @Param("order_id") String orderId,
+    @Param("amount") double amount) {
+  CallingJob caller = MeshCallContext.callingJob();   // never null; fields nullable
+  if (caller.isPresent()) {
+    // Fence: stamp the caller's claim epoch so a superseded re-execution's
+    // duplicate write is distinguishable / rejectable.
+    ledger.upsert(orderId, caller.claimEpoch(), amount);
+  }
+  return Map.of("order_id", orderId);
+}
+```
+
+`callingJob()` reports the identity of the job that **called this tool** —
+not the job this handler is itself running as. It is never null, but its
+fields are: `jobId()` is null for a regular (non-job) `tools/call` (use
+`isPresent()`), for a caller on an older SDK that did not seed the header,
+and — critically — inside a handler that was **claimed directly** (a
+`task = true` handler pulled off its own claim queue): that handler's *own*
+identity lives on `JobContext.current()`, not here. `claimEpoch()` is null
+for a push-mode inbound job. It is purely additive and read-only — reading
+it has no effect on the call. This is the provider-side dual of
+`JobContext.current()`: `JobContext.current()` answers "what job am I
+executing *as*", `callingJob()` answers "what job *invoked* me".
 
 ## Out-of-band inspection
 

--- a/src/core/cli/man/content/jobs_typescript.md
+++ b/src/core/cli/man/content/jobs_typescript.md
@@ -228,6 +228,16 @@ agent.addTool({
   instances, plain objects, etc).
 - Misuse surfaces at startup, not at retry time.
 
+**`maxRetries` does NOT soften a real failure.** A handler exception that
+is **not** matched by `retryOn` — and any explicit `fail()` — is
+**terminal immediately**, no matter how much of the `maxRetries` budget is
+unspent. That budget covers only crash-style recoveries the runtime
+retries on your behalf: lease expiry, orphan reclaim, `maxDuration`
+timeout, plus `retryOn`-matched releases. So a job that shows
+`attempt_count: 1` with `maxRetries: 3` after a non-transient error has
+**zero** retries left — not two — it already reached its terminal
+`failed` state on that first attempt.
+
 Retries restart the handler from scratch — there are no idempotency
 keys in v2.x. If the handler has external side effects, design for
 at-least-once: deterministic ids the downstream can dedupe on, or a
@@ -528,6 +538,19 @@ queue pays nothing. Claiming resumes automatically within one claim-poll
 cycle (≤5s backoff ceiling) of the required chain recovering, so no retry
 budget is spent while the capability is down.
 
+**Enforced at both layers.** The gate is belt-and-suspenders. Registry-side,
+the transitive availability predicate keeps the job out of any claim response
+whose `required` chain is down (the description above). Consumer-side, the
+claim worker independently **skips claiming** while a `required` dependency
+slot is still unresolved *locally* — the claim gate and the handler's
+injection read one clock, so a dep flapping DOWN→UP cannot slip a job past
+the registry gate into a handler that would see `null`. As a last resort, a
+**pre-invoke guard** that finds a required slot still unresolved at invoke
+time **releases the claim back to the queue** (`releaseLease`, mirroring the
+`retryOn` path — never a terminal `fail()`) rather than running the handler
+with a missing dependency. Net effect: a handler never observes `null` for a
+`required: true` dependency, including during dependency recovery.
+
 ## Multi-replica execution and fencing
 
 Several replicas may declare the same `task: true` capability. Each job is
@@ -560,6 +583,58 @@ import { currentJob } from "@mcpmesh/sdk";
 const claimEpoch = currentJob()?.claimEpoch ?? null;
 await ledger.upsert({ key: orderId, claimEpoch, amount });
 ```
+
+When the dedupe sink is **itself a mesh provider** (rather than a raw
+DB/client as above), don't plumb the epoch as a tool argument — the provider
+reads the caller's identity straight off the propagated headers via
+`callingJob()`. See **Calling-job identity** below.
+
+## Calling-job identity
+
+The epoch stamp above lets a handler fence *its own* side effects. The dual
+problem is a **downstream provider** fencing writes from a *stale executor*
+it doesn't control — e.g. a state-authority agent that must reject a write
+issued under a superseded claim. Rather than make every caller thread
+`jobId` / `claimEpoch` through the tool payload, the mesh seeds them
+automatically: any outbound mesh→mesh tool call made from within a job
+handler carries the calling job's identity on two dedicated propagated
+headers — `x-mesh-calling-job-id` and (when known)
+`x-mesh-calling-claim-epoch`. The mesh forwards this pair by default across
+every mesh→mesh hop, including the registry's proxy hop, so no per-agent
+`MCP_MESH_PROPAGATE_HEADERS` configuration is needed.
+
+The provider reads that identity with `callingJob()` (exported from the
+package root), which returns `{ jobId, claimEpoch }` or `null`:
+
+```typescript
+import { callingJob } from "@mcpmesh/sdk";
+
+agent.addTool({
+  name: "record_charge",
+  capability: "record_charge",
+  parameters: z.object({ order_id: z.string(), amount: z.number() }),
+  execute: async ({ order_id, amount }) => {
+    const caller = callingJob();          // { jobId, claimEpoch } | null
+    if (caller) {
+      // Fence: stamp the caller's claim epoch so a superseded
+      // re-execution's duplicate write is distinguishable / rejectable.
+      await ledger.upsert({ key: order_id, claimEpoch: caller.claimEpoch, amount });
+    }
+    return { order_id };
+  },
+});
+```
+
+`callingJob()` returns the identity of the job that **called this tool** —
+not the job this handler is itself running as. It returns `null` for a
+regular (non-job) `tools/call`, for a caller on an older SDK that did not
+seed the headers, and — critically — inside a handler that was **claimed
+directly** (a `task: true` handler pulled off its own claim queue): that
+handler's *own* identity lives on `currentJob()`, not here. The returned
+`claimEpoch` is `null` for a push-mode inbound job. It is purely additive
+and read-only — reading it has no effect on the call. This is the
+provider-side dual of `currentJob()`: `currentJob()` answers "what job am I
+executing *as*", `callingJob()` answers "what job *invoked* me".
 
 ## Out-of-band inspection
 

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -65,12 +65,12 @@ docker compose up -d
 ```bash
 # Install core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh --create-namespace
 
 # Or disable observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh --create-namespace \
   --set tempo.enabled=false \
   --set grafana.enabled=false

--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -89,17 +89,17 @@ docker compose version
 
 | Image                              | Description                 |
 | ---------------------------------- | --------------------------- |
-| `mcpmesh/registry:2.7.0`           | Registry service            |
-| `mcpmesh/python-runtime:2.7.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:2.7.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:2.7.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:2.8.0`           | Registry service            |
+| `mcpmesh/python-runtime:2.8.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:2.8.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:2.8.0` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:2.7.0
-docker pull mcpmesh/python-runtime:2.7.0
-docker pull mcpmesh/java-runtime:2.7.0
-docker pull mcpmesh/typescript-runtime:2.7.0
+docker pull mcpmesh/registry:2.8.0
+docker pull mcpmesh/python-runtime:2.8.0
+docker pull mcpmesh/java-runtime:2.8.0
+docker pull mcpmesh/typescript-runtime:2.8.0
 ```
 
 ### Generate Docker Compose
@@ -137,12 +137,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/src/core/cli/man/content/prerequisites_java.md
+++ b/src/core/cli/man/content/prerequisites_java.md
@@ -52,7 +52,7 @@ Add the Spring Boot starter to your `pom.xml`:
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -100,10 +100,10 @@ docker compose version
 
 | Image                              | Description                 |
 | ---------------------------------- | --------------------------- |
-| `mcpmesh/registry:2.7.0`           | Registry service            |
-| `mcpmesh/python-runtime:2.7.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:2.7.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:2.7.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:2.8.0`           | Registry service            |
+| `mcpmesh/python-runtime:2.8.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:2.8.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:2.8.0` | TypeScript runtime with SDK |
 
 Java agents use standard Maven-based Docker builds (see Docker Deployment guide).
 

--- a/src/core/cli/man/content/prerequisites_typescript.md
+++ b/src/core/cli/man/content/prerequisites_typescript.md
@@ -77,17 +77,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:2.7.0`           | Registry service            |
-| `mcpmesh/python-runtime:2.7.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:2.7.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:2.7.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:2.8.0`           | Registry service            |
+| `mcpmesh/python-runtime:2.8.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:2.8.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:2.8.0` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:2.7.0
-docker pull mcpmesh/python-runtime:2.7.0
-docker pull mcpmesh/java-runtime:2.7.0
-docker pull mcpmesh/typescript-runtime:2.7.0
+docker pull mcpmesh/registry:2.8.0
+docker pull mcpmesh/python-runtime:2.8.0
+docker pull mcpmesh/java-runtime:2.8.0
+docker pull mcpmesh/typescript-runtime:2.8.0
 ```
 
 ### Generate Docker Compose

--- a/src/core/cli/man/content/quickstart_java.md
+++ b/src/core/cli/man/content/quickstart_java.md
@@ -75,13 +75,13 @@ Create `pom.xml`:
 
     <groupId>com.example</groupId>
     <artifactId>greeter-agent</artifactId>
-    <version>2.7.0</version>
+    <version>2.8.0</version>
 
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/core/cli/man/content/registry.md
+++ b/src/core/cli/man/content/registry.md
@@ -170,7 +170,7 @@ The registry supports multiple replicas for high availability. All replicas shar
 ```bash
 # Scale registry replicas
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 2.7.0 \
+  --version 2.8.0 \
   -n mcp-mesh --create-namespace \
   --set registry.replicas=3
 ```

--- a/src/core/cli/man/content/security.md
+++ b/src/core/cli/man/content/security.md
@@ -208,7 +208,7 @@ Admin endpoints (`/admin/rotate`, `/admin/entities`) are served only on the admi
 ```yaml
 services:
   registry:
-    image: mcpmesh/registry:2.7.0
+    image: mcpmesh/registry:2.8.0
     command: ["--tls-auto"]
     ports: ["8000:8000"]
     volumes:

--- a/src/core/cli/man/content/testing_java.md
+++ b/src/core/cli/man/content/testing_java.md
@@ -124,7 +124,7 @@ class AssistantAgentTest {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:2.7.0
+    image: mcpmesh/registry:2.8.0
     ports:
       - "8000:8000"
     healthcheck:

--- a/src/core/cli/man/content/testing_typescript.md
+++ b/src/core/cli/man/content/testing_typescript.md
@@ -120,7 +120,7 @@ describe("Agent Integration", () => {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:2.7.0
+    image: mcpmesh/registry:2.8.0
     ports:
       - "8000:8000"
     healthcheck:

--- a/src/core/cli/man/content/tutorial.md
+++ b/src/core/cli/man/content/tutorial.md
@@ -1683,7 +1683,7 @@ $ kubectl -n trip-planner create secret generic llm-keys \
 
 ```shell
 $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-    --version 2.7.0 \
+    --version 2.8.0 \
     -n trip-planner \
     -f helm/values-core.yaml \
     --wait --timeout 5m
@@ -1702,7 +1702,7 @@ $ for agent in "${AGENTS[@]}"; do
     echo "Installing $agent..."
     helm install "$agent" \
       oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 2.7.0 \
+      --version 2.8.0 \
       -n trip-planner \
       -f "helm/values-${agent}.yaml"
   done

--- a/src/core/registry/ent_handlers.go
+++ b/src/core/registry/ent_handlers.go
@@ -35,7 +35,8 @@ func init() {
 	// (e.g., "x-trace-*"). Matching is performed in proxyRequest below.
 	//
 	// Baked-in defaults (always forwarded, regardless of this env var):
-	//   X-Trace-ID, X-Parent-Span, X-Mesh-Timeout, X-Mesh-Job-Id
+	//   X-Trace-ID, X-Parent-Span, X-Mesh-Timeout, X-Mesh-Job-Id,
+	//   X-Mesh-Calling-Job-Id, X-Mesh-Calling-Claim-Epoch
 	// MCP_MESH_PROPAGATE_HEADERS is purely *additive* on top of the defaults.
 	// TODO(test): extract this parser into a pure helper so it can be unit-tested
 	// without env-var mutation. Coverage today is via integration tests.
@@ -71,23 +72,23 @@ func init() {
 // Lifecycle/shutdown coordination
 // -------------------------------
 // Some handlers spawn best-effort background goroutines (notably
-// ``forwardCancelToOwner`` in ``ent_handlers_jobs.go``) that outlive the
+// “forwardCancelToOwner“ in “ent_handlers_jobs.go“) that outlive the
 // inbound request. Those goroutines pull their context from
-// ``shutdownCtx`` and register their lifetime on ``shutdownWG`` so the
-// registry's graceful-shutdown path (``Server.Stop``) can:
+// “shutdownCtx“ and register their lifetime on “shutdownWG“ so the
+// registry's graceful-shutdown path (“Server.Stop“) can:
 //
-//  1. Cancel ``shutdownCtx`` — in-flight HTTP forwards observe the
-//     cancellation on their ``http.Request`` context and return promptly
+//  1. Cancel “shutdownCtx“ — in-flight HTTP forwards observe the
+//     cancellation on their “http.Request“ context and return promptly
 //     instead of running to their per-call timeout.
-//  2. Wait on ``shutdownWG`` — the shutdown sequence either drains the
+//  2. Wait on “shutdownWG“ — the shutdown sequence either drains the
 //     forwards or surfaces the wait-timeout in the log (so an operator
 //     sees that some forwards were abandoned), rather than letting them
 //     run on a background goroutine after the process is supposedly
 //     stopped.
 //
-// When the handlers are constructed via ``NewEntBusinessLogicHandlers``
+// When the handlers are constructed via “NewEntBusinessLogicHandlers“
 // (no shutdown context provided — used by tests and older callers), the
-// background goroutines fall back to ``context.Background()`` and a
+// background goroutines fall back to “context.Background()“ and a
 // no-op WaitGroup so the existing best-effort behaviour is preserved.
 type EntBusinessLogicHandlers struct {
 	entService *EntService
@@ -110,11 +111,11 @@ type EntBusinessLogicHandlers struct {
 // NewEntBusinessLogicHandlers creates a new handler instance using EntService
 //
 // Background goroutines spawned by handlers fall back to a detached
-// ``context.Background()`` and a private WaitGroup — i.e. NO shutdown
+// “context.Background()“ and a private WaitGroup — i.e. NO shutdown
 // coordination. Production code paths should prefer
 // :func:`NewEntBusinessLogicHandlersWithShutdown` which wires the
 // registry's graceful-shutdown context in. This constructor is kept for
-// the test suite (where the registry never calls ``Stop``) and to
+// the test suite (where the registry never calls “Stop“) and to
 // preserve the legacy zero-arg surface.
 func NewEntBusinessLogicHandlers(entService *EntService) *EntBusinessLogicHandlers {
 	return &EntBusinessLogicHandlers{
@@ -126,15 +127,15 @@ func NewEntBusinessLogicHandlers(entService *EntService) *EntBusinessLogicHandle
 
 // NewEntBusinessLogicHandlersWithShutdown is the production constructor
 // that wires the registry's graceful-shutdown context and WaitGroup
-// into the handlers. Background goroutines (``forwardCancelToOwner``)
-// derive their HTTP-request context from ``shutdownCtx`` so a server
+// into the handlers. Background goroutines (“forwardCancelToOwner“)
+// derive their HTTP-request context from “shutdownCtx“ so a server
 // shutdown cancels in-flight forwards cleanly, and they register on
-// ``shutdownWG`` so the shutdown sequence can wait for them to drain.
+// “shutdownWG“ so the shutdown sequence can wait for them to drain.
 //
-// ``shutdownCtx`` MUST be the context produced by the caller's shutdown
-// machinery (typically ``context.WithCancel`` whose ``cancel`` is
-// invoked from ``Server.Stop``). ``shutdownWG`` MUST be the same
-// WaitGroup the shutdown sequence calls ``Wait`` on.
+// “shutdownCtx“ MUST be the context produced by the caller's shutdown
+// machinery (typically “context.WithCancel“ whose “cancel“ is
+// invoked from “Server.Stop“). “shutdownWG“ MUST be the same
+// WaitGroup the shutdown sequence calls “Wait“ on.
 func NewEntBusinessLogicHandlersWithShutdown(
 	entService *EntService,
 	shutdownCtx context.Context,
@@ -449,102 +450,102 @@ func ConvertMeshAgentRegistrationToMap(reg generated.MeshAgentRegistration) map[
 	if reg.Tools != nil {
 		toolsData = make([]interface{}, len(reg.Tools))
 		for i, tool := range reg.Tools {
-		toolData := map[string]interface{}{
-			"function_name": tool.FunctionName,
-			"capability":    tool.Capability,
-		}
-		if tool.Description != nil {
-			toolData["description"] = *tool.Description
-		}
-		if tool.Version != nil {
-			toolData["version"] = *tool.Version
-		}
-		if tool.Tags != nil {
-			toolData["tags"] = *tool.Tags
-		}
-		if tool.InputSchema != nil {
-			toolData["inputSchema"] = *tool.InputSchema
-		}
-		// Schema-aware filtering inputs (issue #547). Forwarded to ent_service
-		// upsertSchemaEntry; absence preserves legacy behavior (no canonical stored).
-		if tool.OutputSchema != nil {
-			toolData["outputSchema"] = *tool.OutputSchema
-		}
-		if tool.InputSchemaCanonical != nil {
-			toolData["inputSchemaCanonical"] = *tool.InputSchemaCanonical
-		}
-		if tool.InputSchemaHash != nil {
-			toolData["inputSchemaHash"] = *tool.InputSchemaHash
-		}
-		if tool.OutputSchemaCanonical != nil {
-			toolData["outputSchemaCanonical"] = *tool.OutputSchemaCanonical
-		}
-		if tool.OutputSchemaHash != nil {
-			toolData["outputSchemaHash"] = *tool.OutputSchemaHash
-		}
-		if tool.SchemaWarnings != nil {
-			toolData["schemaWarnings"] = *tool.SchemaWarnings
-		}
-		if tool.LlmFilter != nil {
-			toolData["llm_filter"] = *tool.LlmFilter
-		}
-		if tool.LlmProvider != nil {
-			toolData["llm_provider"] = *tool.LlmProvider
-		}
-		if tool.Dependencies != nil {
-			deps := make([]map[string]interface{}, len(*tool.Dependencies))
-			for j, dep := range *tool.Dependencies {
-				depData := map[string]interface{}{
-					"capability": dep.Capability,
-				}
-				// Required flag (issue #1249). Only forwarded when the wire
-				// payload carried it; absence keeps the default (false) in the
-				// stored JSON and downstream parseDependencySpec.
-				if dep.Required != nil {
-					depData["required"] = *dep.Required
-				}
-				if dep.Namespace != nil {
-					depData["namespace"] = *dep.Namespace
-				}
-				if dep.Tags != nil {
-					// Convert union type items to actual values (string or []string for OR alternatives)
-					tags := make([]interface{}, len(*dep.Tags))
-					for k, tagItem := range *dep.Tags {
-						// Try to extract as string first
-						if str, err := tagItem.AsMeshToolDependencyRegistrationTags0(); err == nil {
-							tags[k] = str
-						} else if arr, err := tagItem.AsMeshToolDependencyRegistrationTags1(); err == nil {
-							// OR alternative: convert []string to []interface{} for parseDependencySpec
-							arrInterface := make([]interface{}, len(arr))
-							for m, s := range arr {
-								arrInterface[m] = s
-							}
-							tags[k] = arrInterface
-						}
-					}
-					depData["tags"] = tags
-				}
-				if dep.Version != nil {
-					depData["version"] = *dep.Version
-				}
-				// Schema-aware filtering inputs (issue #547). Forwarded to the
-				// resolver's schema stage; absence keeps the stage a pass-through.
-				if dep.MatchMode != nil {
-					depData["match_mode"] = string(*dep.MatchMode)
-				}
-				if dep.ExpectedSchemaHash != nil {
-					depData["expected_schema_hash"] = *dep.ExpectedSchemaHash
-				}
-				if dep.ExpectedSchemaCanonical != nil {
-					depData["expected_schema_canonical"] = *dep.ExpectedSchemaCanonical
-				}
-				deps[j] = depData
+			toolData := map[string]interface{}{
+				"function_name": tool.FunctionName,
+				"capability":    tool.Capability,
 			}
-			toolData["dependencies"] = deps
-		}
-		if tool.Kwargs != nil {
-			toolData["kwargs"] = *tool.Kwargs
-		}
+			if tool.Description != nil {
+				toolData["description"] = *tool.Description
+			}
+			if tool.Version != nil {
+				toolData["version"] = *tool.Version
+			}
+			if tool.Tags != nil {
+				toolData["tags"] = *tool.Tags
+			}
+			if tool.InputSchema != nil {
+				toolData["inputSchema"] = *tool.InputSchema
+			}
+			// Schema-aware filtering inputs (issue #547). Forwarded to ent_service
+			// upsertSchemaEntry; absence preserves legacy behavior (no canonical stored).
+			if tool.OutputSchema != nil {
+				toolData["outputSchema"] = *tool.OutputSchema
+			}
+			if tool.InputSchemaCanonical != nil {
+				toolData["inputSchemaCanonical"] = *tool.InputSchemaCanonical
+			}
+			if tool.InputSchemaHash != nil {
+				toolData["inputSchemaHash"] = *tool.InputSchemaHash
+			}
+			if tool.OutputSchemaCanonical != nil {
+				toolData["outputSchemaCanonical"] = *tool.OutputSchemaCanonical
+			}
+			if tool.OutputSchemaHash != nil {
+				toolData["outputSchemaHash"] = *tool.OutputSchemaHash
+			}
+			if tool.SchemaWarnings != nil {
+				toolData["schemaWarnings"] = *tool.SchemaWarnings
+			}
+			if tool.LlmFilter != nil {
+				toolData["llm_filter"] = *tool.LlmFilter
+			}
+			if tool.LlmProvider != nil {
+				toolData["llm_provider"] = *tool.LlmProvider
+			}
+			if tool.Dependencies != nil {
+				deps := make([]map[string]interface{}, len(*tool.Dependencies))
+				for j, dep := range *tool.Dependencies {
+					depData := map[string]interface{}{
+						"capability": dep.Capability,
+					}
+					// Required flag (issue #1249). Only forwarded when the wire
+					// payload carried it; absence keeps the default (false) in the
+					// stored JSON and downstream parseDependencySpec.
+					if dep.Required != nil {
+						depData["required"] = *dep.Required
+					}
+					if dep.Namespace != nil {
+						depData["namespace"] = *dep.Namespace
+					}
+					if dep.Tags != nil {
+						// Convert union type items to actual values (string or []string for OR alternatives)
+						tags := make([]interface{}, len(*dep.Tags))
+						for k, tagItem := range *dep.Tags {
+							// Try to extract as string first
+							if str, err := tagItem.AsMeshToolDependencyRegistrationTags0(); err == nil {
+								tags[k] = str
+							} else if arr, err := tagItem.AsMeshToolDependencyRegistrationTags1(); err == nil {
+								// OR alternative: convert []string to []interface{} for parseDependencySpec
+								arrInterface := make([]interface{}, len(arr))
+								for m, s := range arr {
+									arrInterface[m] = s
+								}
+								tags[k] = arrInterface
+							}
+						}
+						depData["tags"] = tags
+					}
+					if dep.Version != nil {
+						depData["version"] = *dep.Version
+					}
+					// Schema-aware filtering inputs (issue #547). Forwarded to the
+					// resolver's schema stage; absence keeps the stage a pass-through.
+					if dep.MatchMode != nil {
+						depData["match_mode"] = string(*dep.MatchMode)
+					}
+					if dep.ExpectedSchemaHash != nil {
+						depData["expected_schema_hash"] = *dep.ExpectedSchemaHash
+					}
+					if dep.ExpectedSchemaCanonical != nil {
+						depData["expected_schema_canonical"] = *dep.ExpectedSchemaCanonical
+					}
+					deps[j] = depData
+				}
+				toolData["dependencies"] = deps
+			}
+			if tool.Kwargs != nil {
+				toolData["kwargs"] = *tool.Kwargs
+			}
 			toolsData[i] = toolData
 		}
 	}
@@ -832,16 +833,30 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 		proxyReq.Header.Set("X-Mesh-Job-Id", meshJobID)
 	}
 
+	// Forward the calling-job identity pair so the downstream producer can
+	// attribute the call to the originating MeshJob (#1263). Baked-in defaults
+	// like X-Mesh-Job-Id above so registry-proxied topologies keep the identity
+	// feature without setting MCP_MESH_PROPAGATE_HEADERS. Forwarded atomically:
+	// each header is only forwarded if it actually arrived — never synthesized.
+	if callingJobID := c.Request.Header.Get("X-Mesh-Calling-Job-Id"); callingJobID != "" {
+		proxyReq.Header.Set("X-Mesh-Calling-Job-Id", callingJobID)
+	}
+	if callingClaimEpoch := c.Request.Header.Get("X-Mesh-Calling-Claim-Epoch"); callingClaimEpoch != "" {
+		proxyReq.Header.Set("X-Mesh-Calling-Claim-Epoch", callingClaimEpoch)
+	}
+
 	// Names already set explicitly above — don't duplicate via propagation.
 	// MCP_MESH_PROPAGATE_HEADERS is additive on top of these baked-in defaults;
 	// the env var does not need to (and should not) re-list them.
 	explicitlySet := map[string]bool{
-		"content-type":   true,
-		"accept":         true,
-		"x-trace-id":     true,
-		"x-parent-span":  true,
-		"x-mesh-timeout": true,
-		"x-mesh-job-id":  true,
+		"content-type":               true,
+		"accept":                     true,
+		"x-trace-id":                 true,
+		"x-parent-span":              true,
+		"x-mesh-timeout":             true,
+		"x-mesh-job-id":              true,
+		"x-mesh-calling-job-id":      true,
+		"x-mesh-calling-claim-epoch": true,
 	}
 
 	// Forward headers matching MCP_MESH_PROPAGATE_HEADERS allowlist (#769, #790).

--- a/src/core/registry/proxy_headers_test.go
+++ b/src/core/registry/proxy_headers_test.go
@@ -1,0 +1,151 @@
+package registry
+
+// Tests for proxyRequest's baked-in default header forwarding at the
+// registry agent-proxy hop. These headers are forwarded WITHOUT the operator
+// opting in via MCP_MESH_PROPAGATE_HEADERS so registry-proxied topologies keep
+// the calling-job identity feature (#1263) working out of the box. The pair is
+// forwarded atomically: each header is forwarded only if it actually arrived —
+// never synthesized.
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// registerProxyTargetAgent registers an agent whose HTTP endpoint points at the
+// given host:port (typically a downstream httptest server) so proxyRequest's
+// isRegisteredAgentEndpoint validation passes and the call is forwarded.
+func registerProxyTargetAgent(t *testing.T, s *EntService, agentID, host string, port int) {
+	t.Helper()
+	req := &AgentRegistrationRequest{
+		AgentID: agentID,
+		Metadata: map[string]interface{}{
+			"agent_type": "mcp_agent",
+			"name":       agentID,
+			"http_host":  host,
+			"http_port":  port,
+			"namespace":  "default",
+			"tools": []interface{}{
+				map[string]interface{}{
+					"function_name": "echo_fn",
+					"capability":    "echo",
+					"version":       "1.0.0",
+				},
+			},
+		},
+		Timestamp: time.Now().Format(time.RFC3339),
+	}
+	if _, err := s.RegisterAgent(req); err != nil {
+		t.Fatalf("RegisterAgent(%s): %v", agentID, err)
+	}
+}
+
+// newProxyDownstream starts a downstream server that records the headers it
+// received and returns (server, *received). host/port are the dial coordinates
+// to register as the proxy target.
+func newProxyDownstream(t *testing.T, received *http.Header) (*httptest.Server, string, int) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*received = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	host, portStr, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	if err != nil {
+		srv.Close()
+		t.Fatalf("SplitHostPort(%s): %v", srv.URL, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("Atoi(%s): %v", portStr, err)
+	}
+	return srv, host, port
+}
+
+func proxyPost(t *testing.T, h *EntBusinessLogicHandlers, target string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest("POST", "/mcp/v1/tools/call", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	c.Request = req
+	h.proxyRequest(c, target, "POST")
+	return w
+}
+
+// TestProxyRequest_ForwardsCallingJobIdentityPair asserts the calling-job
+// identity pair (and the existing X-Mesh-Job-Id default) are forwarded at the
+// proxy hop with no MCP_MESH_PROPAGATE_HEADERS opt-in.
+func TestProxyRequest_ForwardsCallingJobIdentityPair(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := setupTestService(t)
+
+	var received http.Header
+	srv, host, port := newProxyDownstream(t, &received)
+	defer srv.Close()
+
+	registerProxyTargetAgent(t, s, "echo-agent", host, port)
+	h := &EntBusinessLogicHandlers{entService: s}
+
+	target := host + ":" + strconv.Itoa(port) + "/mcp/v1/tools/call"
+	w := proxyPost(t, h, target, map[string]string{
+		"X-Mesh-Job-Id":              "job-123",
+		"X-Mesh-Calling-Job-Id":      "caller-777",
+		"X-Mesh-Calling-Claim-Epoch": "5",
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("proxy returned %d, body=%s", w.Code, w.Body.String())
+	}
+	if got := received.Get("X-Mesh-Job-Id"); got != "job-123" {
+		t.Errorf("X-Mesh-Job-Id not forwarded: got %q", got)
+	}
+	if got := received.Get("X-Mesh-Calling-Job-Id"); got != "caller-777" {
+		t.Errorf("X-Mesh-Calling-Job-Id not forwarded: got %q", got)
+	}
+	if got := received.Get("X-Mesh-Calling-Claim-Epoch"); got != "5" {
+		t.Errorf("X-Mesh-Calling-Claim-Epoch not forwarded: got %q", got)
+	}
+}
+
+// TestProxyRequest_ForwardsPartialCallingIdentity asserts the pair is forwarded
+// atomically as "forward what arrived": when only X-Mesh-Calling-Job-Id is
+// present, the epoch header is NOT synthesized.
+func TestProxyRequest_ForwardsPartialCallingIdentity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := setupTestService(t)
+
+	var received http.Header
+	srv, host, port := newProxyDownstream(t, &received)
+	defer srv.Close()
+
+	registerProxyTargetAgent(t, s, "echo-agent", host, port)
+	h := &EntBusinessLogicHandlers{entService: s}
+
+	target := host + ":" + strconv.Itoa(port) + "/mcp/v1/tools/call"
+	w := proxyPost(t, h, target, map[string]string{
+		"X-Mesh-Calling-Job-Id": "caller-777",
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("proxy returned %d, body=%s", w.Code, w.Body.String())
+	}
+	if got := received.Get("X-Mesh-Calling-Job-Id"); got != "caller-777" {
+		t.Errorf("X-Mesh-Calling-Job-Id not forwarded: got %q", got)
+	}
+	if got := received.Get("X-Mesh-Calling-Claim-Epoch"); got != "" {
+		t.Errorf("X-Mesh-Calling-Claim-Epoch synthesized when absent: got %q", got)
+	}
+}

--- a/src/runtime/core/Cargo.lock
+++ b/src/runtime/core/Cargo.lock
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-mesh-core"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1093,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd366ba6a12e4bdbc360e1ad4e1f01da40c4395eef1f9e872d88f8b135e8048"
+checksum = "c0c00e5dfe26391abeed44a9c41ae583c3045694d6ae865e2019826869dd5aa0"
 dependencies = [
  "bitflags",
  "ctor",
@@ -1117,9 +1117,9 @@ checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.8"
+version = "3.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6730ee4e7b335eac6d7cf10fc2525d92743bd4713a13cb2e6667f0e97322d7c3"
+checksum = "d4ba572deef53e2c386759a8c2014175a62679d74ff83adc205c8bc0e0285727"
 dependencies = [
  "convert_case",
  "ctor",
@@ -1131,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "5.1.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5ccc18b1b16d1049dcbd3e1a21fdfbf3ce720b8944979c5e1a76d4e30d9f9f"
+checksum = "ddd961eb2aa8965e3f29722d754f3a86907eb1984e2fbcbe3fe87b9a02d6bfba"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -1178,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1683,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rusticata-macros"

--- a/src/runtime/core/Cargo.toml
+++ b/src/runtime/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-mesh-core"
-version = "2.7.0"
+version = "2.8.0"
 edition = "2021"
 # MSRV. CI builds with moving stable (dtolnay/rust-toolchain@stable);
 # this floor documents the newest stdlib API the crate relies on

--- a/src/runtime/core/pyproject.toml
+++ b/src/runtime/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mcp-mesh-core"
-version = "2.7.0"
+version = "2.8.0"
 description = "Rust core runtime for MCP Mesh agents"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/core/typescript/package.json
+++ b/src/runtime/core/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/core",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "MCP Mesh Rust core bindings for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/runtime/java/mcp-mesh-bom/pom.xml
+++ b/src/runtime/java/mcp-mesh-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-bom</artifactId>
-    <version>2.7.0</version>
+    <version>2.8.0</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh BOM</name>

--- a/src/runtime/java/mcp-mesh-core/pom.xml
+++ b/src/runtime/java/mcp-mesh-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>mcp-mesh-core</artifactId>

--- a/src/runtime/java/mcp-mesh-native/pom.xml
+++ b/src/runtime/java/mcp-mesh-native/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>mcp-mesh-native</artifactId>

--- a/src/runtime/java/mcp-mesh-sdk/pom.xml
+++ b/src/runtime/java/mcp-mesh-sdk/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>mcp-mesh-sdk</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-ai/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-ai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-ai</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>2.7.0</version>
+        <version>2.8.0</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
@@ -107,6 +107,23 @@ public final class ClaimDispatcher implements AutoCloseable {
      */
     private final Class<? extends Throwable>[] retryOn;
 
+    /**
+     * Issue #1268 pre-claim gate: returns the capability of a currently
+     * unresolved {@code required} dependency (naming the reason a claim is
+     * skipped), or {@code null} when the tool is clear to claim. Consulted
+     * before every {@code /jobs/claim} attempt so a job for a capability whose
+     * required dep is momentarily unresolved stays queued registry-side (no
+     * owner, no attempt burn) and self-heals on a later poll — exactly the
+     * #1258 claim-gating posture. Never null (defaults to "always ready").
+     */
+    private final java.util.function.Supplier<String> claimBlockedReason;
+
+    /**
+     * Tracks the gate's last observed state so the skip is logged once per
+     * DOWN→UP / UP→DOWN transition (info) rather than every poll (issue #1268).
+     */
+    private final AtomicBoolean claimGated = new AtomicBoolean(false);
+
     private final Semaphore permits = new Semaphore(MAX_CONCURRENT_DISPATCHES);
     private final AtomicBoolean stopped = new AtomicBoolean(false);
     private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
@@ -132,20 +149,27 @@ public final class ClaimDispatcher implements AutoCloseable {
         this(capability, instanceId, registryUrl, handler, EMPTY_RETRY_ON);
     }
 
-    /**
-     * Construct a dispatcher with an explicit {@code retryOn} whitelist
-     * (issue #895). When the handler raises a Throwable matching one of
-     * the entries, the dispatcher calls
-     * {@link JobController#releaseLease(String)} instead of
-     * {@link JobController#fail(String)} so a peer replica can re-claim
-     * the job within ~5s.
-     *
-     * @param retryOn Per-tool retry-eligible exception classes from
-     *                {@link io.mcpmesh.MeshTool#retryOn()}. May be null
-     *                or empty for "no retry-eligible exceptions".
-     */
     public ClaimDispatcher(String capability, String instanceId, String registryUrl,
                            ClaimHandler handler, Class<? extends Throwable>[] retryOn) {
+        this(capability, instanceId, registryUrl, handler, retryOn, null);
+    }
+
+    /**
+     * Construct a dispatcher with an explicit {@code retryOn} whitelist AND a
+     * pre-claim gate (issue #1268). Before each {@code /jobs/claim} poll the
+     * loop consults {@code claimBlockedReason}; a non-null result names an
+     * unresolved {@code required} dependency and the poll is skipped (the job
+     * stays queued registry-side with no attempt burn) until the dep resolves.
+     *
+     * @param retryOn            Per-tool retry-eligible exception classes (may
+     *                           be null/empty for "no retry-eligible exceptions").
+     * @param claimBlockedReason Supplier returning the capability of an
+     *                           unresolved required dependency, or {@code null}
+     *                           when clear to claim. Null ⇒ "always ready".
+     */
+    public ClaimDispatcher(String capability, String instanceId, String registryUrl,
+                           ClaimHandler handler, Class<? extends Throwable>[] retryOn,
+                           java.util.function.Supplier<String> claimBlockedReason) {
         if (capability == null || capability.isEmpty()) {
             throw new IllegalArgumentException("capability is required");
         }
@@ -163,6 +187,7 @@ public final class ClaimDispatcher implements AutoCloseable {
         this.registryUrl = stripTrailingSlash(registryUrl);
         this.handler = handler;
         this.retryOn = retryOn != null ? retryOn : EMPTY_RETRY_ON;
+        this.claimBlockedReason = claimBlockedReason != null ? claimBlockedReason : () -> null;
         this.loopExecutor = Executors.newSingleThreadExecutor(named("mesh-claim-loop-" + capability));
         this.dispatchExecutor = Executors.newFixedThreadPool(MAX_CONCURRENT_DISPATCHES,
             named("mesh-claim-dispatch-" + capability));
@@ -279,6 +304,36 @@ public final class ClaimDispatcher implements AutoCloseable {
                 if (stopped.get()) {
                     permits.release();
                     return;
+                }
+
+                // Pre-claim local skip (issue #1268): do not POST /jobs/claim
+                // while any REQUIRED dependency slot is locally unresolved. The
+                // job stays queued registry-side with no owner and no attempt
+                // increment — the #1258 posture — and self-heals on a later
+                // poll once the dep lands. Logged once per DOWN→UP transition.
+                String blockedCap = claimBlockedReason.get();
+                if (blockedCap != null) {
+                    permits.release();
+                    if (claimGated.compareAndSet(false, true)) {
+                        log.info("[mesh-claim] capability={} instance={}: skipping claim — "
+                            + "required dependency '{}' unavailable; job stays queued (no attempt burn)",
+                            capability, instanceId, blockedCap);
+                    } else {
+                        log.debug("[mesh-claim] capability={} instance={}: still gated on "
+                            + "required dependency '{}'", capability, instanceId, blockedCap);
+                    }
+                    // Fixed base cadence while gated (matches Python/TS ~0.5s) —
+                    // do NOT ride the exponential no-work backoff, so claims
+                    // resume within ~one poll of the required dep landing.
+                    sleep(POLL_BASE_MS);
+                    continue;
+                }
+                if (claimGated.compareAndSet(true, false)) {
+                    // Gate just opened — reset any inherited no-work backoff so
+                    // the resumed claim cadence isn't delayed by a stale window.
+                    backoffMs = POLL_BASE_MS;
+                    log.info("[mesh-claim] capability={} instance={}: required dependencies resolved — "
+                        + "resuming claims", capability, instanceId);
                 }
 
                 Map<String, Object> claimed;

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
@@ -171,13 +171,21 @@ public final class JobsRuntimeManager implements SmartLifecycle {
             // the claim-path matches the inbound-HTTP-path's release-and-retry
             // semantics. invokeForClaim unwraps InvocationTargetException to the
             // user exception so the dispatcher's retryOn matching still applies.
+            // Issue #1268: gate the claim loop on the wrapper's required
+            // dependency slots. firstUnresolvedRequiredDependency() names the
+            // capability of an unresolved required dep (or null when clear),
+            // so a job whose required dep is momentarily unresolved stays
+            // queued registry-side with no attempt burn and self-heals on a
+            // later poll — the pre-invoke guard in invokeForClaim is the
+            // safety net for the narrow window the two clocks leave open.
             ClaimDispatcher dispatcher = new ClaimDispatcher(
                 meta.capability(),
                 instanceId,
                 registryUrl,
                 (payload, controller) -> wrapper.invokeForClaim(
                     payload, controller, deadlineFromJobContext()),
-                meta.retryOn()
+                meta.retryOn(),
+                wrapper::firstUnresolvedRequiredDependency
             );
             dispatcher.start();
             dispatchers.put(meta.capability(), dispatcher);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
@@ -449,9 +449,20 @@ public class McpHttpClient {
             // Get current trace context for propagation
             TraceInfo traceInfo = TraceContext.get();
 
-            // Build merged headers: session propagated + per-call (per-call wins, filtered by allowlist)
+            // Build merged headers: session propagated + calling-job identity +
+            // per-call (per-call wins, filtered by allowlist)
             Map<String, String> propagatedHeaders = TraceContext.getPropagatedHeaders();
             Map<String, String> mergedHeaders = new LinkedHashMap<>(propagatedHeaders);
+            // Issue #1263: when this call originates from within a job execution
+            // context, seed the calling job's identity on the DEDICATED carrier
+            // (x-mesh-calling-job-id + x-mesh-calling-claim-epoch) so a
+            // downstream provider can fence out-of-epoch writes. Never seeds the
+            // push-dispatch protocol pair (x-mesh-job-id / x-mesh-claim-epoch) —
+            // that would self-dispatch a nested same-instance task call as the
+            // caller's job. Replaces any inherited calling-* pair atomically;
+            // no-op outside a job context. Applied before extraHeaders so an
+            // explicit per-call header still wins.
+            TraceContext.applyCallingJobIdentity(mergedHeaders);
             if (extraHeaders != null) {
                 for (Map.Entry<String, String> entry : extraHeaders.entrySet()) {
                     if (TraceContext.matchesPropagateHeader(entry.getKey())) {
@@ -973,9 +984,14 @@ public class McpHttpClient {
 
             TraceInfo traceInfo = TraceContext.get();
 
-            // Build merged headers: session propagated + per-call (per-call wins)
+            // Build merged headers: session propagated + calling-job identity +
+            // per-call (per-call wins)
             Map<String, String> propagatedHeaders = TraceContext.getPropagatedHeaders();
             Map<String, String> mergedHeaders = new LinkedHashMap<>(propagatedHeaders);
+            // Issue #1263: seed the calling job's dedicated identity carrier on
+            // outbound tool calls made from within a job context (see callTool
+            // for the rationale — never the push-dispatch protocol pair).
+            TraceContext.applyCallingJobIdentity(mergedHeaders);
             if (extraHeaders != null) {
                 for (Map.Entry<String, String> entry : extraHeaders.entrySet()) {
                     if (TraceContext.matchesPropagateHeader(entry.getKey())) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshCallContext.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshCallContext.java
@@ -1,0 +1,69 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.spring.tracing.TraceContext;
+
+import java.util.Map;
+
+/**
+ * Provider-side accessor for the identity of the job that originated the
+ * current inbound tool call (issue #1263).
+ *
+ * <p>When a job handler makes an outbound {@code McpMeshTool} call, the mesh
+ * seeds the calling job's identity onto a DEDICATED carrier —
+ * {@code x-mesh-calling-job-id} and (when known) {@code x-mesh-calling-claim-epoch}
+ * (see {@link TraceContext#applyCallingJobIdentity(Map)}). A provider tool being
+ * called can read that identity here — without the caller threading
+ * {@code job_id} / {@code claim_epoch} through the tool payload — to fence
+ * out-of-epoch writes (defense-in-depth on top of the cancellation-based fencing
+ * exposed via {@code JobContext.claimEpoch}).
+ *
+ * <p>The carrier is deliberately separate from the push-dispatch protocol pair
+ * ({@code x-mesh-job-id} / {@code x-mesh-claim-epoch}): reusing those would make
+ * a nested same-instance {@code task=true} call self-dispatch as the caller's
+ * job and auto-complete it with the wrong result.
+ *
+ * <p>Purely additive: returns nulls when the current call did not originate
+ * from a job execution context, or when the caller is an older SDK that does
+ * not seed the headers.
+ *
+ * <p>Cross-runtime consistent: reads exactly {@code x-mesh-calling-job-id} /
+ * {@code x-mesh-calling-claim-epoch}, the same header names Python and
+ * TypeScript seed.
+ */
+public final class MeshCallContext {
+
+    private MeshCallContext() {}
+
+    /**
+     * Identity of the job that originated the current inbound call.
+     *
+     * @param jobId      the calling job's id, or {@code null} when the call did
+     *                   not originate from a job (or the header was absent)
+     * @param claimEpoch the calling job's claim generation, or {@code null}
+     *                   when absent / a push-mode caller / an old SDK
+     */
+    public record CallingJob(String jobId, Long claimEpoch) {
+        /** Whether an originating job id is present. */
+        public boolean isPresent() {
+            return jobId != null && !jobId.isEmpty();
+        }
+    }
+
+    /**
+     * Read the calling job's identity from the current thread's propagated
+     * headers. Never null; its fields are null when the corresponding header is
+     * absent.
+     *
+     * @return the calling job identity (fields nullable)
+     */
+    public static CallingJob callingJob() {
+        Map<String, String> headers = TraceContext.getPropagatedHeaders();
+        String jobId = headers != null ? headers.get(TraceContext.CALLING_JOB_ID_HEADER) : null;
+        if (jobId != null && jobId.isEmpty()) {
+            jobId = null;
+        }
+        Long claimEpoch = MeshToolWrapper.parseClaimEpochHeader(
+            headers != null ? headers.get(TraceContext.CALLING_CLAIM_EPOCH_HEADER) : null);
+        return new CallingJob(jobId, claimEpoch);
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
@@ -299,6 +299,12 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
             annotation.retryOn()
         );
 
+        // Issue #1268: thread the per-declared-dependency required flags so
+        // the claim gate (pre-claim skip + pre-invoke guard) knows which
+        // dependency slots must be resolved before a job may run. Aligned to
+        // the same filtered declaration order as dependencyNames.
+        wrapper.setDependencyRequired(extractDependencyRequired(annotation));
+
         // Issue #923: when @A2AConsumer wired this method, hand the
         // wrapper the cached A2AClient + slot index so dispatch
         // populates the parameter at invoke time.
@@ -331,5 +337,24 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
             }
         }
         return names;
+    }
+
+    /**
+     * Extract the per-declared-dependency {@code required} flags (issue #1268)
+     * in the SAME filtered order as {@link #extractDependencyNames} — only
+     * selectors with a non-empty capability contribute — so the two lists are
+     * positionally aligned.
+     *
+     * @param annotation The @MeshTool annotation
+     * @return required flags in declaration order (parallel to dependency names)
+     */
+    private List<Boolean> extractDependencyRequired(MeshTool annotation) {
+        List<Boolean> required = new ArrayList<>();
+        for (Selector selector : annotation.dependencies()) {
+            if (!selector.capability().isEmpty()) {
+                required.add(selector.required());
+            }
+        }
+        return required;
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -111,6 +111,15 @@ public class MeshToolWrapper implements McpToolHandler {
     // Dependency names for error messages
     private final List<String> dependencyNames;
 
+    // Per declared-dependency-index required flags (issue #1268), parallel to
+    // {@link #dependencyNames}. Threaded by {@link MeshToolBeanPostProcessor}
+    // from {@code @MeshTool(dependencies=...)} {@code Selector.required()}.
+    // All-false (optional) until set, so the claim gate is a no-op for tools
+    // with no required deps and for the many test constructors that never set
+    // it. Consulted by {@link #requiredDepsResolved()} (pre-claim gate) and
+    // {@link #invokeForClaim} (pre-invoke safety net).
+    private volatile boolean[] dependencyRequired;
+
     // Positional pairing between the DECLARED dependency list and this
     // method's injectable slots (issue #1193 fix round). Declared
     // dependencies pair positionally with injectable parameters
@@ -234,6 +243,9 @@ public class MeshToolWrapper implements McpToolHandler {
         this.task = task;
         this.retryOn = retryOn != null ? retryOn : EMPTY_RETRY_ON;
         this.dependencyNames = dependencyNames != null ? dependencyNames : List.of();
+        // Default all-optional (#1268) until MeshToolBeanPostProcessor threads
+        // the per-dep required flags via setDependencyRequired.
+        this.dependencyRequired = new boolean[this.dependencyNames.size()];
         this.objectMapper = objectMapper;
 
         // Make method accessible (for private methods)
@@ -432,6 +444,66 @@ public class MeshToolWrapper implements McpToolHandler {
             MeshSettleState.getInstance().markResolved(
                 MeshToolWrapperRegistry.buildDependencyKey(funcId, depIndex));
         }
+    }
+
+    /**
+     * Thread the per-declared-dependency {@code required} flags (issue #1268)
+     * from {@code @MeshTool(dependencies=...)} {@code Selector.required()}.
+     * The list is positional to the DECLARED dependency list (the same order
+     * as {@code dependencyNames}); shorter/longer lists are tolerated (missing
+     * entries default optional). Called once at wrapper registration by
+     * {@link MeshToolBeanPostProcessor}.
+     *
+     * @param required per-declared-dependency required flags, or null (no-op)
+     */
+    public void setDependencyRequired(List<Boolean> required) {
+        if (required == null) {
+            return;
+        }
+        boolean[] flags = new boolean[dependencyNames.size()];
+        for (int i = 0; i < flags.length && i < required.size(); i++) {
+            flags[i] = Boolean.TRUE.equals(required.get(i));
+        }
+        this.dependencyRequired = flags;
+    }
+
+    /**
+     * Issue #1268 pre-claim / pre-invoke gate: whether every {@code required}
+     * McpMeshTool dependency slot is locally resolved — non-null AND
+     * {@link McpMeshTool#isAvailable()} (the same notion the route interceptor
+     * enforces at {@code MeshRouteHandlerInterceptor}). Optional slots never
+     * gate. Consulted by the {@link ClaimDispatcher} before each
+     * {@code /jobs/claim} attempt so a job whose required dep is momentarily
+     * unresolved stays queued (no owner, no attempt burn) and self-heals on a
+     * later poll.
+     *
+     * @return true when all required deps are resolved (safe to claim/invoke)
+     */
+    public boolean requiredDepsResolved() {
+        return firstUnresolvedRequiredDependency() == null;
+    }
+
+    /**
+     * The capability name of the first {@code required} McpMeshTool dependency
+     * that is currently unresolved (null slot OR present-but-{@code !isAvailable()}),
+     * or {@code null} when every required dep is resolved (issue #1268).
+     * Package-private: method-referenced by {@link JobsRuntimeManager} to gate
+     * the claim loop with a named reason, and asserted directly in unit tests.
+     */
+    @SuppressWarnings("rawtypes")
+    String firstUnresolvedRequiredDependency() {
+        boolean[] req = this.dependencyRequired;
+        for (int slot = 0; slot < meshToolPositions.size(); slot++) {
+            int depIdx = slotToDepIndex[slot];
+            if (depIdx < 0 || depIdx >= req.length || !req[depIdx]) {
+                continue;
+            }
+            McpMeshTool proxy = injectedDeps.get(slot);
+            if (proxy == null || !proxy.isAvailable()) {
+                return dependencyNames.get(depIdx);
+            }
+        }
+        return null;
     }
 
     /**
@@ -734,7 +806,9 @@ public class MeshToolWrapper implements McpToolHandler {
             // claim dispatcher (which re-enters its wrapper and seeds the
             // header) forwarding into a Java tool. Absent ⇒ null ⇒ legacy
             // owner-only fencing; never fabricate a 0. Parse kept regardless
-            // (harmless, future-proof).
+            // (harmless, future-proof). NOTE (#1263): the calling-job identity
+            // carrier (x-mesh-calling-*) is intentionally SEPARATE from this
+            // protocol pair and never feeds this dispatch gate.
             Long claimEpoch = parseClaimEpochHeader(
                 propagated != null ? propagated.get("x-mesh-claim-epoch") : null);
             return dispatchAsJob(cleanArgs, jobIdHeader, deadlineSecs, claimEpoch);
@@ -918,6 +992,42 @@ public class MeshToolWrapper implements McpToolHandler {
      */
     Object invokeForClaim(Map<String, Object> payload, JobController controller, Long deadlineSecs)
             throws Exception {
+        return invokeForClaim(payload, controller, deadlineSecs,
+            reason -> {
+                if (controller != null) {
+                    controller.releaseLease(reason);
+                }
+            });
+    }
+
+    /**
+     * Claim-path entry point with an injectable lease-release action
+     * (issue #1268). The {@code leaseReleaser} seam lets unit tests assert the
+     * pre-invoke guard's release path without an FFI-backed
+     * {@link JobController}; the production overload above supplies
+     * {@link JobController#releaseLease(String)}.
+     *
+     * <p><b>Pre-invoke required-dependency guard (safety net):</b> the claim
+     * gate ({@link #requiredDepsResolved()}) and the consumer's local proxy
+     * injection run on two independent clocks, so a required dep flapping
+     * DOWN→UP can grant a claim whose slot is still null at invocation time. If
+     * a required slot is null/unavailable here, do NOT invoke the handler (it
+     * would observe a null required proxy and NPE) and do NOT {@code fail()}
+     * (terminal by design — that would reproduce the very bug this guards). The
+     * lease is released so the job returns to the queue (retryable while budget
+     * remains) and self-heals once the proxy lands.
+     */
+    Object invokeForClaim(Map<String, Object> payload, JobController controller, Long deadlineSecs,
+                          java.util.function.Consumer<String> leaseReleaser)
+            throws Exception {
+        String missing = firstUnresolvedRequiredDependency();
+        if (missing != null) {
+            log.warn("Claim-invoke guard for {}: required dependency '{}' unavailable at "
+                + "invocation time — releasing lease so the job re-queues (NOT failing; "
+                + "a handler exception would be terminal by design)", funcId, missing);
+            leaseReleaser.accept("required dependency unavailable: " + missing);
+            return null;
+        }
         Object[] fullArgs = buildFullArgs(payload != null ? payload : Map.of());
         if (meshJobParamIndex != null) {
             fullArgs[meshJobParamIndex] = controller;

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TraceContext.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TraceContext.java
@@ -1,9 +1,11 @@
 package io.mcpmesh.spring.tracing;
 
+import io.mcpmesh.JobContext;
 import io.mcpmesh.core.MeshCoreBridge;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -63,6 +65,22 @@ public class TraceContext {
         // Python / TypeScript propagation behavior.
         if (!names.contains("x-mesh-job-id")) {
             names.add("x-mesh-job-id");
+        }
+        // Issue #1263: the calling job's identity rides a DEDICATED carrier —
+        // x-mesh-calling-job-id + x-mesh-calling-claim-epoch — kept strictly
+        // separate from the push-dispatch protocol pair (x-mesh-job-id /
+        // x-mesh-claim-epoch). Seeding the protocol pair on an outbound call
+        // would make a nested same-instance task=true call self-dispatch as
+        // the CALLER's job (owner + epoch match) and auto-complete it with the
+        // wrong result — see MeshToolWrapper.invokeInternal's dispatch gate.
+        // Both the inbound capture (TracingFilter) and outbound extra-header
+        // filtering key off this allowlist, so the carrier pair must be present
+        // for the provider-side MeshCallContext accessor to observe it.
+        if (!names.contains("x-mesh-calling-job-id")) {
+            names.add("x-mesh-calling-job-id");
+        }
+        if (!names.contains("x-mesh-calling-claim-epoch")) {
+            names.add("x-mesh-calling-claim-epoch");
         }
         PROPAGATE_HEADERS = Collections.unmodifiableList(names);
         PROPAGATE_HEADERS_CSV = String.join(",", PROPAGATE_HEADERS);
@@ -159,6 +177,60 @@ public class TraceContext {
 
     public static void clearPropagatedHeaders() {
         PROPAGATED_HEADERS.set(Collections.emptyMap());
+    }
+
+    /** Issue #1263: dedicated calling-job identity carrier header names. */
+    public static final String CALLING_JOB_ID_HEADER = "x-mesh-calling-job-id";
+    public static final String CALLING_CLAIM_EPOCH_HEADER = "x-mesh-calling-claim-epoch";
+
+    /**
+     * Issue #1263: the calling job's identity headers, derived from the active
+     * {@link JobContext} on this thread. Returns {@code x-mesh-calling-job-id}
+     * (when a job is in scope with a non-empty id) plus
+     * {@code x-mesh-calling-claim-epoch} (only when the snapshot carries a
+     * non-null claim generation — a null epoch seeds just the id). Empty when no
+     * job is active.
+     *
+     * <p>Deliberately a DEDICATED carrier, NOT the push-dispatch protocol pair
+     * ({@code x-mesh-job-id} / {@code x-mesh-claim-epoch}): seeding the protocol
+     * pair on an outbound call would make a nested same-instance
+     * {@code task=true} call self-dispatch as the caller's job and auto-complete
+     * it — see {@code MeshToolWrapper.invokeInternal}'s dispatch gate.
+     */
+    public static Map<String, String> callingJobHeaders() {
+        JobContext.Snapshot snap = JobContext.current();
+        if (snap == null || snap.jobId == null || snap.jobId.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put(CALLING_JOB_ID_HEADER, snap.jobId);
+        if (snap.claimEpoch != null) {
+            headers.put(CALLING_CLAIM_EPOCH_HEADER, String.valueOf(snap.claimEpoch));
+        }
+        return headers;
+    }
+
+    /**
+     * Issue #1263: overlay the active job's calling-identity onto an outbound
+     * header map. When a job is in scope, the pair is REPLACED atomically — any
+     * inherited calling-* pair is removed first so a stale foreign epoch can
+     * never ride along with a fresh id (both or none, from ONE snapshot). When
+     * no job is active this is a no-op, so an inherited calling-* pair
+     * propagates transitively through non-job intermediaries unchanged.
+     *
+     * <p>Called by {@code McpHttpClient} on every downstream tool call so a
+     * provider can fence out-of-epoch writes via
+     * {@code MeshCallContext.callingJob()} without the caller threading identity
+     * through the payload.
+     */
+    public static void applyCallingJobIdentity(Map<String, String> headers) {
+        Map<String, String> identity = callingJobHeaders();
+        if (identity.isEmpty()) {
+            return;
+        }
+        headers.remove(CALLING_JOB_ID_HEADER);
+        headers.remove(CALLING_CLAIM_EPOCH_HEADER);
+        headers.putAll(identity);
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/ClaimDispatcherTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/ClaimDispatcherTest.java
@@ -160,6 +160,57 @@ class ClaimDispatcherTest {
             "legacy snapshot must carry null claim epoch; got: " + noEpoch);
     }
 
+    // ---- Issue #1268: pre-claim required-dependency gate --------------------
+
+    @Test
+    void claimGate_blocksClaim_whileRequiredDepUnresolved() throws Exception {
+        // Registry would grant a claim, but the gate reports an unresolved
+        // required dep — the dispatcher must NOT POST /jobs/claim at all.
+        server.enqueue(new MockResponse().setResponseCode(204));
+        java.util.concurrent.atomic.AtomicReference<String> blocked =
+            new java.util.concurrent.atomic.AtomicReference<>("lookup");
+        AtomicInteger handlerCalls = new AtomicInteger(0);
+        ClaimDispatcher d = new ClaimDispatcher(
+            "test_cap",
+            "instance-1",
+            server.url("/").toString(),
+            (payload, controller) -> { handlerCalls.incrementAndGet(); return null; },
+            null,
+            blocked::get);
+        d.start();
+        Thread.sleep(800);
+        d.stop(0);
+        assertEquals(0, server.getRequestCount(),
+            "dispatcher must not POST /jobs/claim while a required dep is unresolved");
+        assertEquals(0, handlerCalls.get(), "handler must not run while gated");
+    }
+
+    @Test
+    void claimGate_resumesClaim_onceRequiredDepResolves() throws Exception {
+        // Gate starts closed, then opens; once open the loop polls /jobs/claim.
+        for (int i = 0; i < 5; i++) {
+            server.enqueue(new MockResponse().setResponseCode(204));
+        }
+        java.util.concurrent.atomic.AtomicReference<String> blocked =
+            new java.util.concurrent.atomic.AtomicReference<>("lookup");
+        ClaimDispatcher d = new ClaimDispatcher(
+            "test_cap",
+            "instance-1",
+            server.url("/").toString(),
+            (payload, controller) -> null,
+            null,
+            blocked::get);
+        d.start();
+        Thread.sleep(400);
+        assertEquals(0, server.getRequestCount(), "no polls while gated");
+        // Required dep resolves → gate opens.
+        blocked.set(null);
+        RecordedRequest req = server.takeRequest(2, TimeUnit.SECONDS);
+        d.stop(0);
+        assertNotNull(req, "dispatcher must poll /jobs/claim once the gate opens");
+        assertEquals("/jobs/claim", req.getPath());
+    }
+
     @Test
     void constructor_validatesRequiredArgs() {
         // capability

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshCallingJobPropagationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshCallingJobPropagationTest.java
@@ -1,0 +1,234 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.JobContext;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.spring.tracing.TraceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1263 — calling-job identity propagation.
+ *
+ * <p>The calling job's identity rides a DEDICATED carrier
+ * ({@code x-mesh-calling-job-id} / {@code x-mesh-calling-claim-epoch}), kept
+ * strictly separate from the push-dispatch protocol pair
+ * ({@code x-mesh-job-id} / {@code x-mesh-claim-epoch}).
+ *
+ * <p>Seams covered below the FFI boundary:
+ * <ul>
+ *   <li><b>Outbound</b>: {@link TraceContext#callingJobHeaders()} /
+ *       {@link TraceContext#applyCallingJobIdentity(Map)} derive + overlay the
+ *       carrier pair from the active {@link JobContext} — what
+ *       {@code McpHttpClient} applies to every downstream tool call.</li>
+ *   <li><b>Provider-side</b>: {@link MeshCallContext#callingJob()} reads the
+ *       carrier pair back off inbound propagated headers.</li>
+ *   <li><b>BLOCKER regression</b>: the carrier pair must NEVER trigger
+ *       push-mode job dispatch (that gate keys on {@code x-mesh-job-id}).</li>
+ * </ul>
+ */
+class MeshCallingJobPropagationTest {
+
+    @AfterEach
+    void clearContext() {
+        TraceContext.clearPropagatedHeaders();
+    }
+
+    // ---- Outbound seam: callingJobHeaders ----------------------------------
+
+    @Test
+    void callingJobHeaders_empty_whenNoJobContext() {
+        assertTrue(TraceContext.callingJobHeaders().isEmpty(),
+            "no active job → no identity headers (purely additive outside a job)");
+    }
+
+    @Test
+    void callingJobHeaders_seedsBoth_whenEpochPresent() throws Exception {
+        Map<String, String> seen = JobContext.withJob(
+            new JobContext.Snapshot("job-42", 30L, 7L),
+            TraceContext::callingJobHeaders);
+        assertEquals("job-42", seen.get("x-mesh-calling-job-id"));
+        assertEquals("7", seen.get("x-mesh-calling-claim-epoch"),
+            "claim epoch must serialize as the plain generation number");
+        // Must NOT seed the push-dispatch protocol pair.
+        assertFalse(seen.containsKey("x-mesh-job-id"),
+            "outbound seeding must never write the push-dispatch discriminator");
+        assertFalse(seen.containsKey("x-mesh-claim-epoch"));
+    }
+
+    @Test
+    void callingJobHeaders_seedsOnlyJobId_whenEpochNull() throws Exception {
+        Map<String, String> seen = JobContext.withJob(
+            new JobContext.Snapshot("job-99", 30L, null),
+            TraceContext::callingJobHeaders);
+        assertEquals("job-99", seen.get("x-mesh-calling-job-id"));
+        assertFalse(seen.containsKey("x-mesh-calling-claim-epoch"),
+            "null claim epoch → seed only x-mesh-calling-job-id");
+    }
+
+    // ---- Outbound overlay: applyCallingJobIdentity (replace-pair) -----------
+
+    @Test
+    void applyCallingJobIdentity_noOp_whenNoJobContext() {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("x-mesh-calling-job-id", "inherited");
+        headers.put("x-mesh-calling-claim-epoch", "1");
+        TraceContext.applyCallingJobIdentity(headers);
+        // Outside a job context, an inherited calling-* pair propagates
+        // transitively unchanged.
+        assertEquals("inherited", headers.get("x-mesh-calling-job-id"));
+        assertEquals("1", headers.get("x-mesh-calling-claim-epoch"));
+    }
+
+    @Test
+    void applyCallingJobIdentity_replacesInheritedPairEntirely() throws Exception {
+        // A stale foreign epoch must NOT ride along with the fresh id — the
+        // active job's identity replaces the pair atomically (both or none).
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("x-mesh-calling-job-id", "stale-job");
+        headers.put("x-mesh-calling-claim-epoch", "999");
+        JobContext.withJob(new JobContext.Snapshot("fresh-job", 30L, null), () -> {
+            TraceContext.applyCallingJobIdentity(headers);
+            return null;
+        });
+        assertEquals("fresh-job", headers.get("x-mesh-calling-job-id"));
+        assertFalse(headers.containsKey("x-mesh-calling-claim-epoch"),
+            "a null fresh epoch must evict the stale inherited epoch, not keep it");
+    }
+
+    // ---- Provider-side seam: MeshCallContext.callingJob ---------------------
+
+    @Test
+    void callingJob_returnsNulls_whenNoHeaders() {
+        MeshCallContext.CallingJob cj = MeshCallContext.callingJob();
+        assertNull(cj.jobId());
+        assertNull(cj.claimEpoch());
+        assertFalse(cj.isPresent());
+    }
+
+    @Test
+    void callingJob_readsBothHeaders() {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("x-mesh-calling-job-id", "job-7");
+        headers.put("x-mesh-calling-claim-epoch", "3");
+        TraceContext.setPropagatedHeaders(headers);
+
+        MeshCallContext.CallingJob cj = MeshCallContext.callingJob();
+        assertEquals("job-7", cj.jobId());
+        assertEquals(3L, cj.claimEpoch());
+        assertTrue(cj.isPresent());
+    }
+
+    @Test
+    void callingJob_ignoresPushProtocolPair() {
+        // A push-mode inbound call carries x-mesh-job-id / x-mesh-claim-epoch
+        // for its OWN dispatch — those must not be misread as a calling job.
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("x-mesh-job-id", "dispatch-job");
+        headers.put("x-mesh-claim-epoch", "5");
+        TraceContext.setPropagatedHeaders(headers);
+
+        MeshCallContext.CallingJob cj = MeshCallContext.callingJob();
+        assertNull(cj.jobId(), "the push-dispatch pair must not surface as calling-job identity");
+        assertNull(cj.claimEpoch());
+    }
+
+    @Test
+    void callingJob_jobIdWithoutEpoch_yieldsNullEpoch() {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("x-mesh-calling-job-id", "job-8");
+        TraceContext.setPropagatedHeaders(headers);
+
+        MeshCallContext.CallingJob cj = MeshCallContext.callingJob();
+        assertEquals("job-8", cj.jobId());
+        assertNull(cj.claimEpoch(), "absent epoch header → null (old SDK / push-mode caller)");
+        assertTrue(cj.isPresent());
+    }
+
+    @Test
+    void callingJob_malformedEpoch_yieldsNullEpoch() {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("x-mesh-calling-job-id", "job-9");
+        headers.put("x-mesh-calling-claim-epoch", "not-a-number");
+        TraceContext.setPropagatedHeaders(headers);
+
+        MeshCallContext.CallingJob cj = MeshCallContext.callingJob();
+        assertEquals("job-9", cj.jobId());
+        assertNull(cj.claimEpoch(), "malformed epoch header must not throw — degrade to null");
+    }
+
+    // ---- Round-trip: outbound seed → inbound capture ------------------------
+
+    @Test
+    void roundTrip_outboundSeed_readBackByProvider() throws Exception {
+        Map<String, String> outbound = JobContext.withJob(
+            new JobContext.Snapshot("job-rt", 30L, 11L),
+            TraceContext::callingJobHeaders);
+        TraceContext.setPropagatedHeaders(outbound);
+
+        MeshCallContext.CallingJob cj = MeshCallContext.callingJob();
+        assertEquals("job-rt", cj.jobId());
+        assertEquals(11L, cj.claimEpoch());
+    }
+
+    // ---- BLOCKER regression: carrier must not trigger push-mode dispatch ----
+
+    /** task=true tool that records whether it ran inside a job dispatch scope. */
+    @SuppressWarnings("unused")
+    public static class TaskProbe {
+        final AtomicReference<JobContext.Snapshot> jobScope = new AtomicReference<>();
+        final AtomicReference<MeshCallContext.CallingJob> seenCaller = new AtomicReference<>();
+
+        @MeshTool(capability = "probe", task = true)
+        public String probe(@Param("input") String input) {
+            // Non-null only when invokeInternal wrapped this call in
+            // dispatchAsJob (JobContext.withJob). A plain (non-dispatch) call
+            // leaves the job scope unset.
+            jobScope.set(JobContext.current());
+            seenCaller.set(MeshCallContext.callingJob());
+            return "ok:" + input;
+        }
+    }
+
+    private static MeshToolWrapper taskProbeWrapper(TaskProbe bean) throws Exception {
+        Method m = TaskProbe.class.getMethod("probe", String.class);
+        return new MeshToolWrapper(
+            "TaskProbe.probe", "probe", "test", bean, m,
+            List.of(), JsonMapper.builder().build(), true);
+    }
+
+    @Test
+    void callingHeaders_doNotTriggerPushDispatch_forSameInstanceTaskTool() throws Exception {
+        // Simulate a job handler calling a same-instance task=true tool: the
+        // outbound call carries ONLY the calling-* carrier (no x-mesh-job-id).
+        // The dispatch gate keys on x-mesh-job-id, so the callee MUST run as a
+        // plain invocation — NOT dispatched as (and completing) the caller's job.
+        TaskProbe bean = new TaskProbe();
+        MeshToolWrapper wrapper = taskProbeWrapper(bean);
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("x-mesh-calling-job-id", "caller-job");
+        headers.put("x-mesh-calling-claim-epoch", "4");
+        TraceContext.setPropagatedHeaders(headers);
+
+        Object result = wrapper.invoke(Map.of("input", "x"));
+
+        assertEquals("ok:x", result);
+        assertNull(bean.jobScope.get(),
+            "calling-* carrier must NOT trigger dispatchAsJob — the callee ran as a plain call, "
+                + "so the caller's job is never auto-completed by this nested invocation");
+        // The provider can still READ the caller's identity for write-fencing.
+        assertNotNull(bean.seenCaller.get());
+        assertEquals("caller-job", bean.seenCaller.get().jobId());
+        assertEquals(4L, bean.seenCaller.get().claimEpoch());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRequiredDepGuardTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRequiredDepGuardTest.java
@@ -1,0 +1,187 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1268 — claim-gating for {@code required=true} dependencies.
+ *
+ * <p>Covers the pure, below-FFI halves of the fix:
+ * <ul>
+ *   <li>{@link MeshToolWrapper#setDependencyRequired} threads per-position
+ *       required flags; {@link MeshToolWrapper#requiredDepsResolved} /
+ *       {@link MeshToolWrapper#firstUnresolvedRequiredDependency} reflect
+ *       them against the heartbeat-resolved proxy slots.</li>
+ *   <li>The pre-invoke guard in {@link MeshToolWrapper#invokeForClaim}: a
+ *       null/unavailable REQUIRED slot at invocation time releases the lease
+ *       and does NOT invoke the handler (and never {@code fail()}s).</li>
+ *   <li>Optional deps are unaffected — a null optional slot still passes
+ *       through to the handler (regression guard).</li>
+ * </ul>
+ *
+ * <p>The lease-release action is injected via the package-private
+ * {@code invokeForClaim} overload so the release path can be asserted without
+ * an FFI-backed {@link io.mcpmesh.JobController} — the same "stay below the FFI
+ * boundary" posture as {@link ClaimDispatcherTest}.
+ */
+class MeshToolWrapperRequiredDepGuardTest {
+
+    /** Producer with ONE required McpMeshTool dependency ("lookup"). */
+    public static class RequiredDepBean {
+        final AtomicBoolean handlerRan = new AtomicBoolean(false);
+        final AtomicReference<McpMeshTool<?>> receivedDep = new AtomicReference<>();
+
+        @MeshTool(capability = "summarize", task = true,
+            dependencies = @io.mcpmesh.Selector(capability = "lookup", required = true))
+        public Object summarize(
+                @Param("user_id") String userId,
+                McpMeshTool<String> lookup,
+                MeshJob job) {
+            handlerRan.set(true);
+            receivedDep.set(lookup);
+            java.util.Map<String, Object> out = new java.util.HashMap<>();
+            out.put("user_id", userId);
+            return out;
+        }
+    }
+
+    /** Available stub proxy returning a sentinel. */
+    static class StubProxy implements McpMeshTool<String> {
+        static final String SENTINEL = "resolved";
+        private final boolean available;
+        StubProxy(boolean available) { this.available = available; }
+        @Override public String call() { return SENTINEL; }
+        @Override public String call(Map<String, Object> params) { return SENTINEL; }
+        @Override public String call(Object... args) { return SENTINEL; }
+        @Override public CompletableFuture<String> callAsync() { return CompletableFuture.completedFuture(SENTINEL); }
+        @Override public CompletableFuture<String> callAsync(Map<String, Object> params) { return CompletableFuture.completedFuture(SENTINEL); }
+        @Override public CompletableFuture<String> callAsync(Object... keyValuePairs) { return CompletableFuture.completedFuture(SENTINEL); }
+        @Override public String getCapability() { return "lookup"; }
+        @Override public String getEndpoint() { return "http://stub"; }
+        @Override public String getFunctionName() { return "lookup"; }
+        @Override public boolean isAvailable() { return available; }
+    }
+
+    private static Method summarizeMethod() throws Exception {
+        return RequiredDepBean.class.getMethod("summarize",
+            String.class, McpMeshTool.class, MeshJob.class);
+    }
+
+    private static MeshToolWrapper wrapperFor(RequiredDepBean bean, boolean required) throws Exception {
+        MeshToolWrapper w = new MeshToolWrapper(
+            "RequiredDepBean.summarize",
+            "summarize",
+            "test",
+            bean,
+            summarizeMethod(),
+            List.of("lookup"),
+            JsonMapper.builder().build(),
+            true);
+        w.setDependencyRequired(List.of(required));
+        return w;
+    }
+
+    // ---- required flags threaded per position -------------------------------
+
+    @Test
+    void setDependencyRequired_threadsFlagPerPosition() throws Exception {
+        RequiredDepBean bean = new RequiredDepBean();
+        MeshToolWrapper wrapper = wrapperFor(bean, true);
+
+        // Required dep unresolved (no proxy pushed) → gate closed, names the cap.
+        assertFalse(wrapper.requiredDepsResolved(),
+            "a required dep with no resolved proxy must gate claiming");
+        assertEquals("lookup", wrapper.firstUnresolvedRequiredDependency(),
+            "the gate must name the unresolved required capability");
+    }
+
+    @Test
+    void requiredDep_null_thenResolved_flipsGate() throws Exception {
+        RequiredDepBean bean = new RequiredDepBean();
+        MeshToolWrapper wrapper = wrapperFor(bean, true);
+
+        // null slot → gate closed.
+        assertFalse(wrapper.requiredDepsResolved());
+
+        // present-but-unavailable proxy still counts as unresolved (#1268).
+        wrapper.updateDependency(0, new StubProxy(false));
+        assertFalse(wrapper.requiredDepsResolved(),
+            "an unavailable proxy must NOT satisfy a required slot");
+
+        // available proxy → gate opens.
+        wrapper.updateDependency(0, new StubProxy(true));
+        assertTrue(wrapper.requiredDepsResolved(),
+            "an available required proxy must open the gate");
+        assertNull(wrapper.firstUnresolvedRequiredDependency());
+    }
+
+    @Test
+    void optionalDep_neverGates() throws Exception {
+        RequiredDepBean bean = new RequiredDepBean();
+        // Same signature, but the dep is declared optional.
+        MeshToolWrapper wrapper = wrapperFor(bean, false);
+
+        assertTrue(wrapper.requiredDepsResolved(),
+            "an optional dep must never gate claiming even when unresolved");
+        assertNull(wrapper.firstUnresolvedRequiredDependency());
+    }
+
+    // ---- pre-invoke guard ---------------------------------------------------
+
+    @Test
+    void invokeForClaim_requiredSlotNull_releasesAndDoesNotInvoke() throws Exception {
+        RequiredDepBean bean = new RequiredDepBean();
+        MeshToolWrapper wrapper = wrapperFor(bean, true);
+
+        AtomicReference<String> releasedReason = new AtomicReference<>();
+
+        // Controller is null; the injected releaser records the release call
+        // so we assert the release path WITHOUT an FFI-backed controller.
+        Object result = wrapper.invokeForClaim(
+            Map.of("user_id", "alice"),
+            null,
+            null,
+            releasedReason::set);
+
+        assertNull(result, "guard must return null (job re-queues), not a handler result");
+        assertFalse(bean.handlerRan.get(),
+            "handler MUST NOT run when a required dependency is unresolved");
+        assertNotNull(releasedReason.get(),
+            "the lease MUST be released (not failed) so the job re-queues");
+        assertTrue(releasedReason.get().contains("lookup"),
+            "release reason must name the missing capability; got: " + releasedReason.get());
+    }
+
+    @Test
+    void invokeForClaim_requiredSlotResolved_invokesHandler() throws Exception {
+        RequiredDepBean bean = new RequiredDepBean();
+        MeshToolWrapper wrapper = wrapperFor(bean, true);
+
+        wrapper.updateDependency(0, new StubProxy(true));
+
+        AtomicBoolean released = new AtomicBoolean(false);
+        Object result = wrapper.invokeForClaim(
+            Map.of("user_id", "bob"),
+            null,
+            null,
+            reason -> released.set(true));
+
+        assertNotNull(result, "handler must run and return a result once the required dep resolves");
+        assertTrue(bean.handlerRan.get(), "handler must run when required deps are resolved");
+        assertNotNull(bean.receivedDep.get(), "resolved required proxy must be injected");
+        assertFalse(released.get(), "lease must NOT be released when required deps are resolved");
+    }
+}

--- a/src/runtime/java/pom.xml
+++ b/src/runtime/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.8.0</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh Java SDK</name>

--- a/src/runtime/python/_mcp_mesh/__init__.py
+++ b/src/runtime/python/_mcp_mesh/__init__.py
@@ -31,7 +31,7 @@ from .engine.decorator_registry import (
     get_decorator_stats,
 )
 
-__version__ = "2.7.0"
+__version__ = "2.8.0"
 
 # Store reference to runtime processor if initialized
 _runtime_processor = None

--- a/src/runtime/python/_mcp_mesh/engine/claim_dispatcher.py
+++ b/src/runtime/python/_mcp_mesh/engine/claim_dispatcher.py
@@ -117,6 +117,8 @@ class PythonClaimDispatcher:
         instance_id: str,
         registry_url: str,
         handler: Any,
+        func_id: Optional[str] = None,
+        required_deps: Optional[list[tuple[int, str]]] = None,
     ) -> None:
         self.capability = capability
         self.instance_id = instance_id
@@ -126,6 +128,23 @@ class PythonClaimDispatcher:
         # job-context dispatch via maybe_dispatch_as_job. We just pass
         # the claimed payload as kwargs.
         self.handler = handler
+        # Claim-gating on required deps (issue #1268). ``func_id`` is the
+        # DI injector's composite-key prefix ("<module>.<qualname>") and
+        # ``required_deps`` is the list of ``(dep_index, capability)`` pairs
+        # this tool declared ``required=True``. The dispatcher consults the
+        # injector's resolved-proxy cache (keyed ``<func_id>:dep_<index>``)
+        # so the claim gate and the handler's injection read ONE clock: a
+        # required slot that is still ``None`` locally must never let a claim
+        # proceed (pre-claim skip) nor invoke the handler (pre-invoke guard).
+        # Empty ⇒ no required deps ⇒ predicate is a no-op (optional deps keep
+        # their None-passthrough semantics).
+        self._func_id = func_id
+        self._required_deps: list[tuple[int, str]] = list(required_deps or [])
+        # Transition-edge state for the required-dep gate (issue #1268): the
+        # capability we're currently gated on, or ``None`` when the gate is
+        # open. Logged only on the edges (close/open) so a long-gated worker
+        # doesn't spam one line per poll.
+        self._gate_missing_cap: Optional[str] = None
         self._task: Optional[asyncio.Task] = None
         self._stop = asyncio.Event()
         # One httpx.AsyncClient per dispatcher instead of per poll —
@@ -145,6 +164,38 @@ class PythonClaimDispatcher:
         # set also lets stop() drain in-flight dispatches so their
         # best-effort terminal fail() reports aren't killed with the loop.
         self._dispatch_tasks: set[asyncio.Task] = set()
+
+    def _first_unresolved_required(self) -> Optional[str]:
+        """Return the capability of the first ``required=True`` dependency slot
+        that is NOT locally resolved (its injected proxy is ``None``/absent),
+        or ``None`` when every required dep has a live proxy (issue #1268).
+
+        Consults the SAME resolved-proxy cache the DI wrapper injects from —
+        the global :class:`DependencyInjector` keyed by
+        ``<func_id>:dep_<index>`` — so the claim gate and the handler's
+        injection observe one clock. A required dep flapping DOWN→UP therefore
+        gates the claim locally instead of racing the registry-side gate.
+
+        No-op (returns ``None``) when this tool declared no required deps, so
+        optional deps keep their documented None-passthrough behaviour.
+        """
+        if not self._required_deps or not self._func_id:
+            return None
+        try:
+            from .dependency_injector import get_global_injector
+
+            injector = get_global_injector()
+        except Exception as e:  # noqa: BLE001 — best-effort gate
+            logger.debug(
+                "claim_dispatcher: could not read injector for required-dep "
+                "gate (%s); allowing claim",
+                e,
+            )
+            return None
+        for dep_index, cap in self._required_deps:
+            if injector.get_dependency(f"{self._func_id}:dep_{dep_index}") is None:
+                return cap
+        return None
 
     async def _claim_once(self) -> list[dict]:
         """Single ``POST /jobs/claim`` call. Returns the list of claimed
@@ -272,6 +323,26 @@ class PythonClaimDispatcher:
 
         claim_epoch = _valid_claim_epoch(claimed.get("claim_epoch"))
 
+        # Pre-invoke guard (issue #1268, safety net for the gate/injection
+        # race). If a required dep is still unresolved at claim-invoke time,
+        # do NOT run the handler with a null proxy — release the lease so the
+        # job returns to the queue and can be re-claimed once the dep lands.
+        # This mirrors the retry_on release path (release_lease, NOT fail):
+        # a terminal fail() here would reproduce the very bug the guard
+        # prevents (a topological race permanently failing the job).
+        missing_cap = self._first_unresolved_required()
+        if missing_cap is not None:
+            logger.warning(
+                "claim_dispatcher: releasing job=%s for capability=%s — "
+                "required dependency '%s' is unresolved at invoke time; "
+                "releasing lease for retry (not failing)",
+                job_id,
+                self.capability,
+                missing_cap,
+            )
+            await self._release_lease(job_id, missing_cap, claim_epoch)
+            return
+
         try:
             await self.handler(**payload)
         except Exception as e:
@@ -305,6 +376,36 @@ class PythonClaimDispatcher:
         except Exception as inner:
             logger.debug(
                 "claim_dispatcher: terminal-fail report failed: %s", inner
+            )
+
+    async def _release_lease(
+        self, job_id: str, capability: str, claim_epoch: Optional[int] = None
+    ) -> None:
+        """Best-effort: release the claim's lease so the job returns to the
+        queue (retryable) instead of staying "working" until lease expiry.
+
+        Used by the pre-invoke required-dep guard (issue #1268). Mirrors
+        :meth:`_report_terminal_fail`'s construction seam but calls
+        ``release_lease`` — the SAME mechanism the retry_on-matched exception
+        path uses in ``job_dispatch`` — so the guard never burns a terminal
+        fail(). Failures here are logged and swallowed; the registry's
+        lease sweep is the ultimate backstop.
+        """
+        try:
+            from mcp_mesh_core import JobController as _JobController
+
+            ctrl = _JobController(
+                job_id, self.instance_id, self.registry_url, claim_epoch
+            )
+            await ctrl.release_lease(
+                reason=(
+                    f"required dependency '{capability}' unavailable at "
+                    f"claim-invoke (issue #1268)"
+                )
+            )
+        except Exception as inner:
+            logger.debug(
+                "claim_dispatcher: release-lease report failed: %s", inner
             )
 
     async def _run_loop(self) -> None:
@@ -372,6 +473,50 @@ class PythonClaimDispatcher:
             try:
                 if self._stop.is_set():
                     break
+
+                # Pre-claim local skip (issue #1268, primary defense). Do NOT
+                # POST /jobs/claim while a required dep slot is unresolved
+                # locally — the job stays queued with no owner and no attempt
+                # increment (the #1258 posture), self-healing on a later poll.
+                missing_cap = self._first_unresolved_required()
+                if missing_cap is not None:
+                    # Transition-edge log only (issue #1268 review): emit once
+                    # when the gate closes (or the missing capability changes),
+                    # then stay silent every poll until it opens — a cheap local
+                    # probe running every base interval must not spam.
+                    if missing_cap != self._gate_missing_cap:
+                        logger.info(
+                            "claim_dispatcher: gate CLOSED for capability=%s — "
+                            "required dependency '%s' not yet resolved locally; "
+                            "holding claims (job stays queued, no attempt "
+                            "burned) until it resolves",
+                            self.capability,
+                            missing_cap,
+                        )
+                        self._gate_missing_cap = missing_cap
+                    # Release the permit (we won't claim) and re-check at the
+                    # BASE cadence — this is a cheap local probe (no network),
+                    # so we poll promptly rather than growing the backoff, and
+                    # claim within one base interval of the dep landing. The
+                    # real-work backoff below is left untouched.
+                    self._dispatch_sem.release()
+                    permit_held = False
+                    try:
+                        await asyncio.wait_for(
+                            self._stop.wait(), timeout=_POLL_BASE_SECS
+                        )
+                    except asyncio.TimeoutError:
+                        pass
+                    continue
+
+                # Gate just opened (was gated, now all required deps resolved).
+                if self._gate_missing_cap is not None:
+                    logger.info(
+                        "claim_dispatcher: gate OPEN for capability=%s — "
+                        "required dependencies resolved; resuming claims",
+                        self.capability,
+                    )
+                    self._gate_missing_cap = None
 
                 claimed = await self._claim_once()
                 if claimed:
@@ -632,12 +777,74 @@ def discover_task_handlers(
                 tool_name,
             )
             continue
+
+        # Claim-gating on required deps (issue #1268). Compute the DI
+        # injector's composite-key prefix and the required-dep slots so the
+        # dispatcher can consult the resolved-proxy cache. ``func_id`` mirrors
+        # ``DependencyInjector.create_injection_wrapper``'s
+        # "<module>.<qualname>"; functools.wraps copies these onto the wrapper,
+        # and the dep_index aligns with ``metadata["dependencies"]`` order (the
+        # same list the injector enumerates into ``:dep_<N>`` keys).
+        func_id: Optional[str] = None
+        orig = handler
+        try:
+            orig = getattr(handler, "_mesh_original_func", handler)
+            func_id = f"{orig.__module__}.{orig.__qualname__}"
+        except Exception as e:  # noqa: BLE001 — gate degrades to allow-claim
+            logger.debug(
+                "claim_dispatcher: could not derive func_id for tool %s (%s); "
+                "required-dep gate disabled for this handler",
+                tool_name,
+                e,
+            )
+
+        # A MeshJob-paired dep slot is a locally-constructed MeshJobSubmitter,
+        # never a resolved proxy in the injector — gating on it would deadlock
+        # the claim loop forever (issue #1268 review; matches TS's
+        # meshJobDepIndex exclusion and Java's structural exclusion). Its
+        # dep_index is the rank of the MeshJob parameter position among the
+        # sorted eligible (McpMeshTool ∪ MeshJob) positions — mirrors the
+        # injection loop in ``dependency_injector._prepare_injection_kwargs``.
+        mesh_job_dep_index: Optional[int] = None
+        try:
+            from .signature_analyzer import (
+                analyze_mesh_job_signature,
+                get_mesh_agent_positions,
+            )
+
+            _mj = analyze_mesh_job_signature(orig)
+            if _mj.mesh_job_param_index is not None:
+                _eligible = sorted(
+                    set(get_mesh_agent_positions(orig))
+                    | {_mj.mesh_job_param_index}
+                )
+                mesh_job_dep_index = _eligible.index(_mj.mesh_job_param_index)
+        except Exception as e:  # noqa: BLE001 — best-effort; err on allow-claim
+            logger.debug(
+                "claim_dispatcher: MeshJob dep-index analysis failed for tool "
+                "%s (%s); not excluding any slot from the required gate",
+                tool_name,
+                e,
+            )
+
+        required_deps: list[tuple[int, str]] = []
+        for dep_index, dep in enumerate(meta.get("dependencies") or []):
+            if dep_index == mesh_job_dep_index:
+                # MeshJob submitter slot — always locally available; skip.
+                continue
+            if isinstance(dep, dict) and dep.get("required"):
+                cap = dep.get("capability")
+                if cap:
+                    required_deps.append((dep_index, cap))
+
         dispatchers.append(
             PythonClaimDispatcher(
                 capability=capability,
                 instance_id=instance_id,
                 registry_url=registry_url,
                 handler=handler,
+                func_id=func_id,
+                required_deps=required_deps,
             )
         )
     return dispatchers

--- a/src/runtime/python/_mcp_mesh/engine/job_context.py
+++ b/src/runtime/python/_mcp_mesh/engine/job_context.py
@@ -32,7 +32,19 @@ __all__ = [
     "CURRENT_JOB",
     "current_job",
     "remaining_seconds",
+    "CallingJob",
+    "calling_job",
 ]
+
+# Propagated-header names carrying the CALLING job's identity (issue #1263).
+# A dedicated pair — distinct from the push-mode dispatch protocol's
+# x-mesh-job-id / x-mesh-claim-epoch (x-mesh-job-id doubles as the dispatch
+# discriminator, so it cannot also carry calling identity). Seeded on outbound
+# mesh→mesh calls made from within a job execution context (see
+# ``unified_mcp_proxy``'s calling-identity overlay) and read back here on the
+# provider side.
+_HDR_CALLING_JOB_ID = "x-mesh-calling-job-id"
+_HDR_CALLING_CLAIM_EPOCH = "x-mesh-calling-claim-epoch"
 
 
 @dataclass(frozen=True)
@@ -86,6 +98,66 @@ def current_job() -> Optional[JobContextSnapshot]:
     use ``mcp_mesh_core.current_job()`` (returns the same view as a dict).
     """
     return CURRENT_JOB.get()
+
+
+@dataclass(frozen=True)
+class CallingJob:
+    """Identity of the job whose handler made the CURRENT inbound call
+    (issue #1263).
+
+    This is the provider-side dual of :class:`JobContextSnapshot`:
+    ``current_job()`` answers "what job am I executing as", while
+    ``calling_job()`` answers "what job invoked me". A provider (e.g. a
+    state-authority agent) reads it to fence stale-executor writes without
+    the caller threading identity through every tool-call payload.
+
+    Attributes:
+        job_id: Server-assigned job UUID of the calling job (from the
+            incoming ``x-mesh-calling-job-id`` propagated header).
+        claim_epoch: Claim generation the caller executes under (from the
+            incoming ``x-mesh-calling-claim-epoch`` propagated header), or
+            ``None`` for a push-mode inbound job / an old SDK that did not
+            seed it.
+    """
+
+    job_id: str
+    claim_epoch: Optional[int] = None
+
+
+def calling_job() -> Optional[CallingJob]:
+    """Return the identity of the job that made the current inbound call,
+    or ``None`` when the call did not originate from a job handler
+    (issue #1263).
+
+    Reads the ``x-mesh-calling-job-id`` / ``x-mesh-calling-claim-epoch``
+    propagated headers the mesh seeds on outbound calls made from within a job
+    execution context. This is the "the job that CALLED me" view — it is
+    ``None`` inside a directly-claimed job handler (that handler's OWN identity
+    lives on :func:`current_job`). Safe to call from any tool body — never
+    raises; returns ``None`` for regular (non-job) ``tools/call`` invocations
+    and for calls from an old SDK that did not propagate the identity.
+
+    Purely additive: reading it has no effect on the call.
+    """
+    try:
+        from ..tracing.context import TraceContext
+
+        headers = TraceContext.get_propagated_headers() or {}
+    except Exception:
+        return None
+    job_id = headers.get(_HDR_CALLING_JOB_ID)
+    if not job_id:
+        return None
+    claim_epoch: Optional[int] = None
+    raw_epoch = headers.get(_HDR_CALLING_CLAIM_EPOCH)
+    if raw_epoch is not None:
+        try:
+            parsed = int(raw_epoch)
+            if parsed >= 0:
+                claim_epoch = parsed
+        except (TypeError, ValueError):
+            claim_epoch = None
+    return CallingJob(job_id=job_id, claim_epoch=claim_epoch)
 
 
 def remaining_seconds() -> Optional[float]:

--- a/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
+++ b/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
@@ -692,6 +692,29 @@ class UnifiedMCPProxy:
                 if matches_propagate_header(k):
                     merged_headers[k.lower()] = v
 
+        # Issue #1263: overlay the CALLING job's identity so a nested outbound
+        # call made from within a job execution context carries who invoked the
+        # downstream (x-mesh-calling-job-id + x-mesh-calling-claim-epoch),
+        # letting the provider fence out-of-epoch writes via calling_job().
+        # Distinct from the push-dispatch x-mesh-job-id (attached later in
+        # _http_call). Seeded atomically from ONE snapshot and REPLACING any
+        # inherited calling-* pair entirely (both-or-none): set the id and
+        # set-or-clear the epoch together, so a stale inherited epoch can never
+        # ride along with this job's id. When there is no active job the
+        # inherited pair passes through unchanged (transitive identity).
+        try:
+            from .job_context import current_job as _calling_snap
+
+            _snap = _calling_snap()
+        except Exception:
+            _snap = None
+        if _snap is not None and getattr(_snap, "job_id", None):
+            merged_headers["x-mesh-calling-job-id"] = _snap.job_id
+            if _snap.claim_epoch is not None:
+                merged_headers["x-mesh-calling-claim-epoch"] = str(_snap.claim_epoch)
+            else:
+                merged_headers.pop("x-mesh-calling-claim-epoch", None)
+
         if current_trace:
             try:
                 import mcp_mesh_core

--- a/src/runtime/python/_mcp_mesh/tracing/context.py
+++ b/src/runtime/python/_mcp_mesh/tracing/context.py
@@ -17,6 +17,17 @@ PROPAGATE_HEADERS: list[str] = [h.strip().lower() for h in _raw.split(",") if h.
 # Always propagate mesh infrastructure headers
 if "x-mesh-timeout" not in PROPAGATE_HEADERS:
     PROPAGATE_HEADERS.append("x-mesh-timeout")
+# Issue #1263: the CALLING job's identity travels as a dedicated infra header
+# pair so a downstream provider can fence out-of-epoch writes
+# (mesh.calling_job()) without every app hand-threading job_id/claim_epoch
+# through payloads. This is a distinct pair from x-mesh-job-id /
+# x-mesh-claim-epoch — those are the push-mode dispatch protocol (x-mesh-job-id
+# doubles as the dispatch discriminator, so it CANNOT also carry calling
+# identity). Always allowlisted so they survive the downstream capture filter
+# (same treatment as x-mesh-timeout).
+for _infra in ("x-mesh-calling-job-id", "x-mesh-calling-claim-epoch"):
+    if _infra not in PROPAGATE_HEADERS:
+        PROPAGATE_HEADERS.append(_infra)
 PROPAGATE_HEADERS_CSV: str = ",".join(PROPAGATE_HEADERS)
 
 

--- a/src/runtime/python/mesh/__init__.py
+++ b/src/runtime/python/mesh/__init__.py
@@ -34,7 +34,7 @@ from .types import (
 # Note: helpers.llm_provider is imported lazily in __getattr__ to avoid
 # initialization timing issues with @mesh.agent auto_run in tests
 
-__version__ = "2.7.0"
+__version__ = "2.8.0"
 
 
 # Helper function to create FastMCP server with proper naming

--- a/src/runtime/python/mesh/__init__.py
+++ b/src/runtime/python/mesh/__init__.py
@@ -210,6 +210,15 @@ def __getattr__(name):
         from _mcp_mesh.tracing.context import TraceContext
 
         return TraceContext
+    elif name == "calling_job":
+        # Issue #1263: provider-side accessor for the calling job's identity.
+        from _mcp_mesh.engine.job_context import calling_job
+
+        return calling_job
+    elif name == "CallingJob":
+        from _mcp_mesh.engine.job_context import CallingJob
+
+        return CallingJob
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "2.7.0"
+version = "2.8.0"
 description = "Python SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/python/tests/unit/test_calling_job_identity.py
+++ b/src/runtime/python/tests/unit/test_calling_job_identity.py
@@ -1,0 +1,191 @@
+"""Issue #1263: propagate the CALLING job's identity on outbound tool calls
+via a dedicated header pair, and expose a provider-side accessor.
+
+Carrier: ``x-mesh-calling-job-id`` / ``x-mesh-calling-claim-epoch`` — distinct
+from the push-mode dispatch protocol's ``x-mesh-job-id`` / ``x-mesh-claim-epoch``
+(x-mesh-job-id doubles as the dispatch discriminator and cannot carry calling
+identity).
+
+Covers:
+- ``mesh.calling_job()`` reads the calling-* pair; ``None`` outside a job.
+- The calling-* pair is always allowlisted; the dispatch pair is NOT (reverted).
+- Outbound proxy overlay seeds the calling-* pair from the active job snapshot,
+  REPLACING any inherited pair entirely (both-or-none).
+- Inside a directly-claimed handler, ``calling_job()`` is ``None`` (the
+  handler's own identity lives on ``current_job``).
+"""
+
+import pytest
+
+import mesh
+from _mcp_mesh.engine.claim_dispatcher import PythonClaimDispatcher
+from _mcp_mesh.engine.job_context import CallingJob, calling_job
+from _mcp_mesh.tracing.context import matches_propagate_header
+from _mcp_mesh.tracing.context import TraceContext
+
+
+class TestAllowlist:
+    def test_calling_pair_is_always_propagated(self):
+        assert matches_propagate_header("x-mesh-calling-job-id") is True
+        assert matches_propagate_header("x-mesh-calling-claim-epoch") is True
+
+    def test_dispatch_pair_is_not_allowlisted(self):
+        # The push-dispatch protocol headers must NOT be in the propagate
+        # allowlist (reverted): x-mesh-job-id is the dispatch discriminator.
+        assert matches_propagate_header("x-mesh-job-id") is False
+        assert matches_propagate_header("x-mesh-claim-epoch") is False
+
+    def test_case_insensitive(self):
+        assert matches_propagate_header("X-Mesh-Calling-Job-Id") is True
+        assert matches_propagate_header("X-Mesh-Calling-Claim-Epoch") is True
+
+
+class TestCallingJobAccessor:
+    def teardown_method(self):
+        TraceContext.set_propagated_headers({})
+
+    def test_none_outside_job(self):
+        TraceContext.set_propagated_headers({})
+        assert calling_job() is None
+
+    def test_none_when_no_calling_job_id(self):
+        TraceContext.set_propagated_headers({"x-mesh-calling-claim-epoch": "7"})
+        assert calling_job() is None
+
+    def test_does_not_read_dispatch_pair(self):
+        # The dispatch pair (job context) must NOT be surfaced as a calling job.
+        TraceContext.set_propagated_headers(
+            {"x-mesh-job-id": "job-self", "x-mesh-claim-epoch": "3"}
+        )
+        assert calling_job() is None
+
+    def test_returns_calling_job_id_and_epoch(self):
+        TraceContext.set_propagated_headers(
+            {"x-mesh-calling-job-id": "job-abc", "x-mesh-calling-claim-epoch": "5"}
+        )
+        cj = calling_job()
+        assert isinstance(cj, CallingJob)
+        assert cj.job_id == "job-abc"
+        assert cj.claim_epoch == 5
+
+    def test_job_id_only_epoch_none(self):
+        TraceContext.set_propagated_headers({"x-mesh-calling-job-id": "job-xyz"})
+        cj = calling_job()
+        assert cj is not None
+        assert cj.job_id == "job-xyz"
+        assert cj.claim_epoch is None
+
+    def test_malformed_epoch_degrades_to_none(self):
+        TraceContext.set_propagated_headers(
+            {"x-mesh-calling-job-id": "job-1", "x-mesh-calling-claim-epoch": "nope"}
+        )
+        assert calling_job().claim_epoch is None
+
+    def test_negative_epoch_rejected(self):
+        TraceContext.set_propagated_headers(
+            {"x-mesh-calling-job-id": "job-1", "x-mesh-calling-claim-epoch": "-3"}
+        )
+        assert calling_job().claim_epoch is None
+
+    def test_exposed_via_mesh_package(self):
+        assert mesh.calling_job is calling_job
+
+
+class TestOutboundOverlay:
+    """The outbound proxy seeds the calling-* pair from the active job
+    snapshot, replacing any inherited pair entirely (both-or-none)."""
+
+    def teardown_method(self):
+        from _mcp_mesh.engine.job_context import CURRENT_JOB
+
+        CURRENT_JOB.set(None)
+        TraceContext.set_propagated_headers({})
+
+    def _merged(self, arguments=None):
+        from _mcp_mesh.engine.unified_mcp_proxy import UnifiedMCPProxy
+
+        proxy = UnifiedMCPProxy("http://downstream:8000", "some_tool")
+        _args, merged = proxy._inject_trace_into_args(arguments or {}, None)
+        return merged
+
+    def _set_job(self, job_id, claim_epoch):
+        from _mcp_mesh.engine.job_context import CURRENT_JOB, JobContextSnapshot
+
+        CURRENT_JOB.set(
+            JobContextSnapshot(
+                job_id=job_id, deadline_secs_remaining=None, claim_epoch=claim_epoch
+            )
+        )
+
+    def test_no_active_job_leaves_headers_untouched(self):
+        merged = self._merged()
+        assert "x-mesh-calling-job-id" not in merged
+
+    def test_seeds_both_from_snapshot(self):
+        self._set_job("job-A", 4)
+        merged = self._merged()
+        assert merged["x-mesh-calling-job-id"] == "job-A"
+        assert merged["x-mesh-calling-claim-epoch"] == "4"
+
+    def test_seeds_id_only_when_no_epoch(self):
+        self._set_job("job-A", None)
+        merged = self._merged()
+        assert merged["x-mesh-calling-job-id"] == "job-A"
+        assert "x-mesh-calling-claim-epoch" not in merged
+
+    def test_replaces_inherited_pair_no_stale_epoch(self):
+        # Inherited calling-* pair from an upstream call, plus THIS handler's
+        # own job with NO epoch → the stale inherited epoch must be dropped
+        # (both-or-none), not ride along with the new job id.
+        TraceContext.set_propagated_headers(
+            {
+                "x-mesh-calling-job-id": "job-OLD",
+                "x-mesh-calling-claim-epoch": "99",
+            }
+        )
+        self._set_job("job-NEW", None)
+        merged = self._merged()
+        assert merged["x-mesh-calling-job-id"] == "job-NEW"
+        assert "x-mesh-calling-claim-epoch" not in merged
+
+    def test_inherited_pair_passes_through_without_active_job(self):
+        # No active job → transitive identity: inherited pair flows onward.
+        TraceContext.set_propagated_headers(
+            {
+                "x-mesh-calling-job-id": "job-UP",
+                "x-mesh-calling-claim-epoch": "2",
+            }
+        )
+        merged = self._merged()
+        assert merged["x-mesh-calling-job-id"] == "job-UP"
+        assert merged["x-mesh-calling-claim-epoch"] == "2"
+
+
+class TestClaimHandlerSeesNoCallingJob:
+    """Inside a directly-claimed handler, calling_job() is None — the claim
+    dispatcher seeds only the dispatch pair (job context), not calling-*."""
+
+    def teardown_method(self):
+        TraceContext.set_propagated_headers({})
+
+    @pytest.mark.asyncio
+    async def test_calling_job_none_inside_claim_handler(self):
+        seen: dict = {}
+
+        async def handler(**kwargs):
+            seen["calling"] = calling_job()
+            seen["headers"] = dict(TraceContext.get_propagated_headers())
+
+        d = PythonClaimDispatcher(
+            capability="cap",
+            instance_id="inst",
+            registry_url="http://r:8000",
+            handler=handler,
+        )
+        await d._dispatch(
+            {"id": "job-self", "submitted_payload": {}, "claim_epoch": 4}
+        )
+        # The claim dispatcher seeds the dispatch pair (job context)…
+        assert seen["headers"].get("x-mesh-job-id") == "job-self"
+        # …but calling_job() reads the calling-* pair → None here.
+        assert seen["calling"] is None

--- a/src/runtime/python/tests/unit/test_claim_dispatcher_required_gate.py
+++ b/src/runtime/python/tests/unit/test_claim_dispatcher_required_gate.py
@@ -1,0 +1,271 @@
+"""Issue #1268: claim dispatch must gate on locally-resolved required deps.
+
+Two defenses, both exercised here:
+
+1. Pre-claim local skip — the dispatcher must NOT POST /jobs/claim while a
+   ``required=True`` dependency slot is unresolved locally (its injected proxy
+   is ``None``/absent). The job stays queued with no attempt burned.
+2. Pre-invoke guard — if a required slot is still unresolved at claim-invoke
+   time, the handler must NOT run; the lease is released (retryable), never a
+   terminal fail().
+
+Optional deps (no required flag) keep their None-passthrough behaviour — the
+handler still runs.
+"""
+
+import asyncio
+
+import pytest
+from _mcp_mesh.engine import dependency_injector as di_module
+from _mcp_mesh.engine.claim_dispatcher import PythonClaimDispatcher
+
+_FUNC_ID = "some.module.my_task"
+
+
+def _make_dispatcher(
+    handler, required_deps=None, func_id=_FUNC_ID
+) -> PythonClaimDispatcher:
+    return PythonClaimDispatcher(
+        capability="test_cap",
+        instance_id="test-instance",
+        registry_url="http://registry:8000",
+        handler=handler,
+        func_id=func_id,
+        required_deps=required_deps,
+    )
+
+
+@pytest.fixture
+def clean_injector():
+    """Reset the global injector's resolved-proxy cache around each test."""
+    injector = di_module.get_global_injector()
+    saved = dict(injector._dependencies)
+    injector._dependencies.clear()
+    try:
+        yield injector
+    finally:
+        injector._dependencies.clear()
+        injector._dependencies.update(saved)
+
+
+class TestRequiredDepPredicate:
+    def test_no_required_deps_is_noop(self, clean_injector):
+        d = _make_dispatcher(handler=None, required_deps=[])
+        assert d._first_unresolved_required() is None
+
+    def test_unresolved_required_returns_capability(self, clean_injector):
+        d = _make_dispatcher(handler=None, required_deps=[(0, "cap_a")])
+        # Nothing registered for f"{func_id}:dep_0" → unresolved.
+        assert d._first_unresolved_required() == "cap_a"
+
+    def test_resolved_required_returns_none(self, clean_injector):
+        clean_injector._dependencies[f"{_FUNC_ID}:dep_0"] = object()
+        d = _make_dispatcher(handler=None, required_deps=[(0, "cap_a")])
+        assert d._first_unresolved_required() is None
+
+    def test_first_of_many_unresolved_wins(self, clean_injector):
+        clean_injector._dependencies[f"{_FUNC_ID}:dep_0"] = object()
+        # dep_1 (cap_b) is the first unresolved.
+        d = _make_dispatcher(
+            handler=None, required_deps=[(0, "cap_a"), (1, "cap_b")]
+        )
+        assert d._first_unresolved_required() == "cap_b"
+
+
+class TestPreInvokeGuard:
+    @pytest.mark.asyncio
+    async def test_unresolved_required_releases_lease_not_fail(
+        self, clean_injector
+    ):
+        called: list = []
+
+        async def handler(**kwargs):
+            called.append(kwargs)
+
+        d = _make_dispatcher(handler=handler, required_deps=[(0, "cap_a")])
+
+        released: list = []
+        failed: list = []
+
+        async def fake_release(job_id, capability, claim_epoch=None):
+            released.append((job_id, capability))
+
+        async def fake_fail(job_id, error, claim_epoch=None):
+            failed.append((job_id, error))
+
+        d._release_lease = fake_release
+        d._report_terminal_fail = fake_fail
+
+        await d._dispatch({"id": "job-1", "submitted_payload": {}})
+
+        assert called == [], "handler must NOT run with an unresolved required dep"
+        assert released == [("job-1", "cap_a")], "lease must be released"
+        assert failed == [], "guard must NEVER terminal-fail the job"
+
+    @pytest.mark.asyncio
+    async def test_resolved_required_invokes_handler(self, clean_injector):
+        clean_injector._dependencies[f"{_FUNC_ID}:dep_0"] = object()
+        called: list = []
+
+        async def handler(**kwargs):
+            called.append(kwargs)
+
+        d = _make_dispatcher(handler=handler, required_deps=[(0, "cap_a")])
+
+        released: list = []
+        d._release_lease = lambda *a, **k: released.append(a)
+
+        await d._dispatch({"id": "job-1", "submitted_payload": {"x": 1}})
+
+        assert called == [{"x": 1}], "handler must run when required dep resolved"
+        assert released == []
+
+    @pytest.mark.asyncio
+    async def test_optional_dep_none_invokes_handler(self, clean_injector):
+        """Regression: a tool with NO required deps runs even with null slots."""
+        called: list = []
+
+        async def handler(**kwargs):
+            called.append(kwargs)
+
+        # No required deps declared → optional None-passthrough preserved.
+        d = _make_dispatcher(handler=handler, required_deps=[])
+
+        released: list = []
+        d._release_lease = lambda *a, **k: released.append(a)
+
+        await d._dispatch({"id": "job-2", "submitted_payload": {}})
+
+        assert called == [{}], "optional-dep handler must still be invoked"
+        assert released == []
+
+
+class TestMeshJobDepExcludedFromGate:
+    """A required dep paired with the MeshJob slot is a locally-constructed
+    MeshJobSubmitter — never a resolved proxy — so the gate must ignore it,
+    else the claim loop deadlocks forever (issue #1268 review; matches TS's
+    meshJobDepIndex / Java's structural exclusion)."""
+
+    def test_discover_excludes_meshjob_paired_required_dep(self):
+        from mesh.types import MeshJob
+        from _mcp_mesh.engine.claim_dispatcher import discover_task_handlers
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+        saved = DecoratorRegistry.get_mesh_tools()
+        try:
+            # MeshJob param at position 1 → eligible {1} → dep_index 0 is the
+            # MeshJob submitter slot. Its dependency is declared required.
+            async def task_with_submitter(x: int, submit: MeshJob = None):
+                return x
+
+            DecoratorRegistry.register_mesh_tool(
+                task_with_submitter,
+                {
+                    "task": True,
+                    "capability": "gate_meshjob_cap",
+                    "dependencies": [
+                        {"capability": "downstream", "required": True},
+                    ],
+                },
+            )
+
+            dispatchers = discover_task_handlers("inst", "http://r:8000")
+            match = [
+                d for d in dispatchers if d.capability == "gate_meshjob_cap"
+            ]
+            assert len(match) == 1
+            # The MeshJob-paired required dep (dep_index 0) is excluded, so the
+            # gate has nothing to hold on and the predicate is a no-op.
+            assert match[0]._required_deps == []
+            assert match[0]._first_unresolved_required() is None
+        finally:
+            DecoratorRegistry._mesh_tools.clear()
+            DecoratorRegistry._mesh_tools.update(saved)
+
+    def test_discover_keeps_non_meshjob_required_dep(self):
+        from mesh.types import McpMeshTool, MeshJob
+        from _mcp_mesh.engine.claim_dispatcher import discover_task_handlers
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+        saved = DecoratorRegistry.get_mesh_tools()
+        try:
+            # dep_0 → McpMeshTool proxy (pos 1, required); dep_1 → MeshJob
+            # submitter (pos 2). Only dep_0 must be gated.
+            async def task_mixed(
+                x: int, proxy: McpMeshTool = None, submit: MeshJob = None
+            ):
+                return x
+
+            DecoratorRegistry.register_mesh_tool(
+                task_mixed,
+                {
+                    "task": True,
+                    "capability": "gate_mixed_cap",
+                    "dependencies": [
+                        {"capability": "real_proxy", "required": True},
+                        {"capability": "downstream", "required": True},
+                    ],
+                },
+            )
+
+            dispatchers = discover_task_handlers("inst", "http://r:8000")
+            match = [d for d in dispatchers if d.capability == "gate_mixed_cap"]
+            assert len(match) == 1
+            # Only the McpMeshTool required dep (index 0) is gated; the MeshJob
+            # submitter (index 1) is excluded.
+            assert match[0]._required_deps == [(0, "real_proxy")]
+        finally:
+            DecoratorRegistry._mesh_tools.clear()
+            DecoratorRegistry._mesh_tools.update(saved)
+
+
+class TestPreClaimSkip:
+    @pytest.mark.asyncio
+    async def test_run_loop_skips_claim_while_required_unresolved(
+        self, clean_injector
+    ):
+        claim_calls: list = []
+
+        async def fake_claim_once():
+            claim_calls.append(True)
+            return []
+
+        async def handler(**kwargs):
+            pass
+
+        d = _make_dispatcher(handler=handler, required_deps=[(0, "cap_a")])
+        d._claim_once = fake_claim_once
+
+        d.start()
+        # Give the loop several poll cadences to run; it must skip every time
+        # because f"{func_id}:dep_0" is unresolved.
+        await asyncio.sleep(0.2)
+        await d.stop(drain_timeout=0)
+
+        assert claim_calls == [], (
+            "dispatcher must not POST /jobs/claim while a required dep is "
+            "unresolved locally"
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_loop_claims_when_required_resolved(self, clean_injector):
+        clean_injector._dependencies[f"{_FUNC_ID}:dep_0"] = object()
+        claim_calls: list = []
+
+        async def fake_claim_once():
+            claim_calls.append(True)
+            return []
+
+        async def handler(**kwargs):
+            pass
+
+        d = _make_dispatcher(handler=handler, required_deps=[(0, "cap_a")])
+        d._claim_once = fake_claim_once
+
+        d.start()
+        await asyncio.sleep(0.2)
+        await d.stop(drain_timeout=0)
+
+        assert len(claim_calls) >= 1, (
+            "dispatcher must claim once required deps are resolved"
+        )

--- a/src/runtime/typescript/package.json
+++ b/src/runtime/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/sdk",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "TypeScript SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/runtime/typescript/src/__tests__/calling-job.test.ts
+++ b/src/runtime/typescript/src/__tests__/calling-job.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Issue #1263: propagate the CALLING job's identity on outbound tool calls via
+ * a dedicated header pair, and expose a provider-side accessor.
+ *
+ * Carrier: `x-mesh-calling-job-id` / `x-mesh-calling-claim-epoch` — distinct
+ * from the push-mode dispatch protocol's `x-mesh-job-id` / `x-mesh-claim-epoch`
+ * (x-mesh-job-id doubles as the dispatch discriminator and cannot carry calling
+ * identity).
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// Keep the REAL core (real matchesPropagateHeader / injectTraceContext); only
+// silence the span publisher and the never-resolving cancel await.
+vi.mock("@mcpmesh/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mcpmesh/core")>();
+  return {
+    ...actual,
+    publishSpan: vi.fn(async () => false),
+    awaitJobCancel: vi.fn(() => new Promise<void>(() => {})),
+  };
+});
+vi.mock("../http-pool.js", () => ({ getDispatcher: () => undefined }));
+
+import {
+  callingJob,
+  callMcpTool,
+  DEFAULT_CALL_OPTIONS,
+  runWithPropagatedHeaders,
+} from "../proxy.js";
+import { matchesPropagateHeader } from "../tracing.js";
+import { CURRENT_JOB, type JobContextSnapshot } from "../job-context.js";
+
+describe("allowlist (issue #1263)", () => {
+  it("always propagates the calling-* pair", () => {
+    expect(matchesPropagateHeader("x-mesh-calling-job-id")).toBe(true);
+    expect(matchesPropagateHeader("x-mesh-calling-claim-epoch")).toBe(true);
+  });
+  it("does NOT allowlist the dispatch pair (reverted)", () => {
+    expect(matchesPropagateHeader("x-mesh-job-id")).toBe(false);
+    expect(matchesPropagateHeader("x-mesh-claim-epoch")).toBe(false);
+  });
+  it("is case-insensitive", () => {
+    expect(matchesPropagateHeader("X-Mesh-Calling-Job-Id")).toBe(true);
+  });
+});
+
+describe("callingJob() accessor (issue #1263)", () => {
+  it("returns null outside a job", () => {
+    expect(callingJob()).toBeNull();
+  });
+  it("returns null when no calling job id", () => {
+    runWithPropagatedHeaders({ "x-mesh-calling-claim-epoch": "7" }, () => {
+      expect(callingJob()).toBeNull();
+    });
+  });
+  it("does NOT read the dispatch pair", () => {
+    runWithPropagatedHeaders(
+      { "x-mesh-job-id": "job-self", "x-mesh-claim-epoch": "3" },
+      () => {
+        expect(callingJob()).toBeNull();
+      },
+    );
+  });
+  it("returns jobId + claimEpoch from the calling-* pair", () => {
+    runWithPropagatedHeaders(
+      {
+        "x-mesh-calling-job-id": "job-abc",
+        "x-mesh-calling-claim-epoch": "5",
+      },
+      () => {
+        expect(callingJob()).toEqual({ jobId: "job-abc", claimEpoch: 5 });
+      },
+    );
+  });
+  it("claimEpoch is null when only calling job id present", () => {
+    runWithPropagatedHeaders({ "x-mesh-calling-job-id": "job-xyz" }, () => {
+      expect(callingJob()).toEqual({ jobId: "job-xyz", claimEpoch: null });
+    });
+  });
+  it("malformed epoch degrades to null", () => {
+    runWithPropagatedHeaders(
+      { "x-mesh-calling-job-id": "job-1", "x-mesh-calling-claim-epoch": "5.5" },
+      () => {
+        expect(callingJob()?.claimEpoch).toBeNull();
+      },
+    );
+  });
+});
+
+describe("outbound overlay (issue #1263)", () => {
+  let captured: RequestInit | undefined;
+
+  function mockFetch(): void {
+    captured = undefined;
+    globalThis.fetch = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      captured = init;
+      const body = JSON.stringify({
+        jsonrpc: "2.0",
+        id: "x",
+        result: { content: [{ type: "text", text: "{}" }] },
+      });
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: async () => body,
+        headers: {
+          get: (n: string) =>
+            n.toLowerCase() === "content-type" ? "application/json" : null,
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+  }
+
+  function capturedHeaders(): Record<string, string> {
+    return (captured?.headers ?? {}) as Record<string, string>;
+  }
+  function capturedMeshHeaders(): Record<string, string> {
+    const body = JSON.parse((captured?.body as string) ?? "{}");
+    return (body?.params?.arguments?._mesh_headers ?? {}) as Record<
+      string,
+      string
+    >;
+  }
+
+  function snap(jobId: string, claimEpoch: number | null): JobContextSnapshot {
+    return { jobId, deadlineSecsRemaining: null, claimEpoch };
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("no active job → no calling-* seeded", async () => {
+    mockFetch();
+    await callMcpTool("http://d:9000", "t", { a: 1 }, DEFAULT_CALL_OPTIONS, "cap");
+    expect(capturedHeaders()["x-mesh-calling-job-id"]).toBeUndefined();
+  });
+
+  it("seeds both from the active job snapshot", async () => {
+    mockFetch();
+    await CURRENT_JOB.run(snap("job-A", 4), async () => {
+      await callMcpTool("http://d:9000", "t", {}, DEFAULT_CALL_OPTIONS, "cap");
+    });
+    expect(capturedHeaders()["x-mesh-calling-job-id"]).toBe("job-A");
+    expect(capturedHeaders()["x-mesh-calling-claim-epoch"]).toBe("4");
+    // Also carried in the _mesh_headers args (FastMCP-visible path).
+    expect(capturedMeshHeaders()["x-mesh-calling-job-id"]).toBe("job-A");
+  });
+
+  it("seeds id only when the snapshot has no epoch", async () => {
+    mockFetch();
+    await CURRENT_JOB.run(snap("job-A", null), async () => {
+      await callMcpTool("http://d:9000", "t", {}, DEFAULT_CALL_OPTIONS, "cap");
+    });
+    expect(capturedHeaders()["x-mesh-calling-job-id"]).toBe("job-A");
+    expect(capturedHeaders()["x-mesh-calling-claim-epoch"]).toBeUndefined();
+  });
+
+  it("replaces an inherited pair entirely — no stale epoch rides along", async () => {
+    mockFetch();
+    await runWithPropagatedHeaders(
+      {
+        "x-mesh-calling-job-id": "job-OLD",
+        "x-mesh-calling-claim-epoch": "99",
+      },
+      async () => {
+        await CURRENT_JOB.run(snap("job-NEW", null), async () => {
+          await callMcpTool("http://d:9000", "t", {}, DEFAULT_CALL_OPTIONS, "cap");
+        });
+      },
+    );
+    expect(capturedHeaders()["x-mesh-calling-job-id"]).toBe("job-NEW");
+    expect(capturedHeaders()["x-mesh-calling-claim-epoch"]).toBeUndefined();
+  });
+
+  it("passes an inherited pair through when there is no active job", async () => {
+    mockFetch();
+    await runWithPropagatedHeaders(
+      {
+        "x-mesh-calling-job-id": "job-UP",
+        "x-mesh-calling-claim-epoch": "2",
+      },
+      async () => {
+        await callMcpTool("http://d:9000", "t", {}, DEFAULT_CALL_OPTIONS, "cap");
+      },
+    );
+    expect(capturedHeaders()["x-mesh-calling-job-id"]).toBe("job-UP");
+    expect(capturedHeaders()["x-mesh-calling-claim-epoch"]).toBe("2");
+  });
+});

--- a/src/runtime/typescript/src/__tests__/claim-dispatcher-required-gate.test.ts
+++ b/src/runtime/typescript/src/__tests__/claim-dispatcher-required-gate.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Issue #1268: claim dispatch must gate on locally-resolved required deps.
+ *
+ * - Pre-claim skip: the dispatcher must NOT POST /jobs/claim while a required
+ *   dependency slot is unresolved locally.
+ * - Pre-invoke guard: a still-unresolved required slot at invoke time must
+ *   release the lease (retryable), never terminal-fail, and must NOT run the
+ *   handler.
+ * - Optional deps (no probe) run as before.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Fake JobController captured per-test so assertions can inspect it.
+let lastController: {
+  releaseLease: ReturnType<typeof vi.fn>;
+  fail: ReturnType<typeof vi.fn>;
+} | null = null;
+
+vi.mock("../inbound-job-dispatch.js", () => ({
+  makeJobController: vi.fn(() => {
+    lastController = {
+      releaseLease: vi.fn(async () => {}),
+      fail: vi.fn(async () => {}),
+    };
+    return lastController;
+  }),
+  // Pass-through: invoke the thunk so the handler runs when the guard allows.
+  runWithJobContext: vi.fn(
+    async (
+      _jobId: string | null,
+      _dl: number | null,
+      _controller: unknown,
+      invoke: () => Promise<unknown>,
+    ) => invoke(),
+  ),
+}));
+
+vi.mock("../proxy.js", () => ({
+  runWithPropagatedHeaders: (_headers: unknown, fn: () => unknown) => fn(),
+}));
+
+import { ClaimDispatcher } from "../claim-dispatcher.js";
+
+function makeDispatcher(
+  handler: (payload: Record<string, unknown>, controller: unknown) => Promise<unknown>,
+  requiredProbe?: () => string | null,
+): ClaimDispatcher {
+  return new ClaimDispatcher(
+    "test_cap",
+    "test-instance",
+    "http://registry:8000",
+    handler as never,
+    undefined,
+    requiredProbe,
+  );
+}
+
+beforeEach(() => {
+  lastController = null;
+  vi.clearAllMocks();
+});
+
+describe("pre-invoke guard (issue #1268)", () => {
+  it("unresolved required dep → releaseLease, no handler, no fail", async () => {
+    const handlerCalls: unknown[] = [];
+    const handler = async (payload: Record<string, unknown>) => {
+      handlerCalls.push(payload);
+    };
+    const d = makeDispatcher(handler, () => "cap_a");
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (d as any)._dispatch({ id: "job-1", submitted_payload: {} });
+
+    expect(handlerCalls).toEqual([]);
+    expect(lastController).not.toBeNull();
+    expect(lastController!.releaseLease).toHaveBeenCalledTimes(1);
+    expect(lastController!.fail).not.toHaveBeenCalled();
+  });
+
+  it("resolved required dep → handler runs, no release", async () => {
+    const handlerCalls: unknown[] = [];
+    const handler = async (payload: Record<string, unknown>) => {
+      handlerCalls.push(payload);
+    };
+    const d = makeDispatcher(handler, () => null);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (d as any)._dispatch({ id: "job-2", submitted_payload: { x: 1 } });
+
+    expect(handlerCalls).toEqual([{ x: 1 }]);
+    expect(lastController!.releaseLease).not.toHaveBeenCalled();
+    expect(lastController!.fail).not.toHaveBeenCalled();
+  });
+
+  it("optional deps (no probe) → handler runs (regression)", async () => {
+    const handlerCalls: unknown[] = [];
+    const handler = async (payload: Record<string, unknown>) => {
+      handlerCalls.push(payload);
+    };
+    const d = makeDispatcher(handler); // no requiredProbe
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (d as any)._dispatch({ id: "job-3", submitted_payload: {} });
+
+    expect(handlerCalls).toEqual([{}]);
+    expect(lastController!.releaseLease).not.toHaveBeenCalled();
+  });
+});
+
+describe("pre-claim skip (issue #1268)", () => {
+  it("does not claim while a required dep is unresolved", async () => {
+    const d = makeDispatcher(async () => {}, () => "cap_a");
+    const claimSpy = vi.fn(async () => []);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (d as any)._claimOnce = claimSpy;
+
+    d.start();
+    await new Promise((r) => setTimeout(r, 60));
+    await d.stop(0);
+
+    expect(claimSpy).not.toHaveBeenCalled();
+  });
+
+  it("claims once the required dep is resolved", async () => {
+    let resolved = false;
+    const d = makeDispatcher(async () => {}, () => (resolved ? null : "cap_a"));
+    const claimSpy = vi.fn(async () => []);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (d as any)._claimOnce = claimSpy;
+
+    d.start();
+    await new Promise((r) => setTimeout(r, 50));
+    resolved = true;
+    // Wait past one base poll interval (500ms) so the loop wakes, re-probes
+    // (now resolved), and issues a claim.
+    await new Promise((r) => setTimeout(r, 650));
+    await d.stop(0);
+
+    expect(claimSpy).toHaveBeenCalled();
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -265,12 +265,20 @@ export class MeshAgent {
    * Issue #894: also carries the per-tool retryOn whitelist so the
    * dispatcher can pass it into `runWithJobContext` for the
    * release-lease-on-retry-eligible-throw path.
+   *
+   * Issue #1268: also carries a `requiredProbe` closure that reports the
+   * first `required=true` dependency slot that is still unresolved locally
+   * (its proxy is null/absent in `resolvedDeps`), or null when all required
+   * deps are live. The dispatcher consults it BEFORE claiming (pre-claim
+   * skip) and BEFORE invoking (pre-invoke guard) so the claim gate and the
+   * handler's injection read one clock.
    */
   private _taskHandlers: Map<
     string,
     {
       handler: ClaimHandler;
       retryOn?: ReadonlyArray<new (...args: unknown[]) => Error>;
+      requiredProbe?: () => string | null;
     }
   > = new Map();
   /**
@@ -968,7 +976,32 @@ export class MeshAgent {
         }
         return await (execute as (...a: unknown[]) => unknown)(...callArgs);
       };
-      this._taskHandlers.set(capability, { handler, retryOn });
+      // Issue #1268: required-dep claim gate. Collect the `required=true`
+      // proxy slots (the MeshJob submitter slot is excluded — it is built
+      // locally, never resolved by an event) and expose a probe that reports
+      // the first one still unresolved in `resolvedDeps`. `?? null`-equality
+      // covers both an absent key and an explicit null slot.
+      const requiredSlots: Array<[number, string]> = [];
+      normalizedDeps.forEach((dep, depIndex) => {
+        if (dep.required && depIndex !== meshJobDepIndex) {
+          requiredSlots.push([depIndex, dep.capability]);
+        }
+      });
+      const requiredProbe: (() => string | null) | undefined =
+        requiredSlots.length > 0
+          ? () => {
+              for (const [depIndex, cap] of requiredSlots) {
+                if (
+                  (this.resolvedDeps.get(`${toolName}:dep_${depIndex}`) ??
+                    null) === null
+                ) {
+                  return cap;
+                }
+              }
+              return null;
+            }
+          : undefined;
+      this._taskHandlers.set(capability, { handler, retryOn, requiredProbe });
     }
 
     // Store mesh metadata with JSON Schema for LLM tool resolution
@@ -1412,6 +1445,7 @@ export class MeshAgent {
         this.config.registryUrl,
         entry.handler,
         entry.retryOn,
+        entry.requiredProbe,
       );
       dispatcher.start();
       this._claimDispatchers.push(dispatcher);

--- a/src/runtime/typescript/src/claim-dispatcher.ts
+++ b/src/runtime/typescript/src/claim-dispatcher.ts
@@ -88,6 +88,23 @@ export class ClaimDispatcher {
    * fail-on-throw behaviour).
    */
   private readonly retryOn?: ReadonlyArray<new (...args: unknown[]) => Error>;
+  /**
+   * Issue #1268: required-dependency claim gate. Returns the capability of
+   * the first `required=true` dependency slot that is still unresolved
+   * locally (its proxy is null/absent in the agent's resolved-deps map), or
+   * `null` when every required dep is live. Consulted BEFORE `/jobs/claim`
+   * (pre-claim skip — the job stays queued, no attempt burned) and BEFORE
+   * invoking the handler (pre-invoke guard — release the lease, never fail).
+   * `undefined` (no required deps) disables the gate entirely.
+   */
+  private readonly requiredProbe?: () => string | null;
+  /**
+   * Transition-edge state for the required-dep gate (issue #1268): the
+   * capability we're currently gated on, or `null` when the gate is open.
+   * Logged only on the edges (close/open) so a long-gated worker doesn't spam
+   * one line per poll (console.debug == console.log in Node).
+   */
+  private _gateMissingCap: string | null = null;
 
   private _stopped = false;
   private _loopPromise: Promise<void> | null = null;
@@ -134,12 +151,14 @@ export class ClaimDispatcher {
     registryUrl: string,
     handler: ClaimHandler,
     retryOn?: ReadonlyArray<new (...args: unknown[]) => Error>,
+    requiredProbe?: () => string | null,
   ) {
     this.capability = capability;
     this.instanceId = instanceId;
     this.registryUrl = registryUrl;
     this.handler = handler;
     this.retryOn = retryOn;
+    this.requiredProbe = requiredProbe;
   }
 
   /** Spawn the polling loop. Idempotent. */
@@ -435,6 +454,33 @@ export class ClaimDispatcher {
       return;
     }
 
+    // Pre-invoke guard (issue #1268, safety net for the gate/injection
+    // race). If a required dep is still unresolved at claim-invoke time, do
+    // NOT run the handler with a null proxy — release the lease so the job
+    // returns to the queue and can be re-claimed once the dep lands. This
+    // mirrors the retryOn release path (releaseLease, NOT fail): a terminal
+    // fail() here would reproduce the very bug the guard prevents (a
+    // topological race permanently failing the job).
+    const missingCap = this.requiredProbe?.() ?? null;
+    if (missingCap !== null) {
+      console.warn(
+        `[mesh-claim] releasing job=${jobId} for capability=${this.capability} — ` +
+          `required dependency '${missingCap}' is unresolved at invoke time; ` +
+          `releasing lease for retry (not failing)`,
+      );
+      try {
+        await controller.releaseLease(
+          `required dependency '${missingCap}' unavailable at claim-invoke (issue #1268)`,
+        );
+      } catch (err) {
+        console.debug(
+          `[mesh-claim] release-lease for job=${jobId} raised:`,
+          err,
+        );
+      }
+      return;
+    }
+
     // Seed the propagated-headers ALS so outbound calls made by the
     // handler continue the submitter's trace tree and carry the job
     // context onward. Mirrors Python's
@@ -495,6 +541,41 @@ export class ClaimDispatcher {
       }
       let permitTransferred = false;
       try {
+        // Pre-claim local skip (issue #1268, primary defense). Do NOT POST
+        // /jobs/claim while a required dep is unresolved locally — the job
+        // stays queued with no owner and no attempt increment (the #1258
+        // posture), self-healing on a later poll.
+        const missingCap = this.requiredProbe?.() ?? null;
+        if (missingCap !== null) {
+          // Transition-edge log only (issue #1268 review): emit once when the
+          // gate closes (or the missing capability changes), then stay silent
+          // every poll until it opens — a cheap local probe running every base
+          // interval must not spam ~7200 lines/hour.
+          if (missingCap !== this._gateMissingCap) {
+            console.warn(
+              `[mesh-claim] capability=${this.capability} instance=${this.instanceId}: ` +
+                `gate CLOSED — required dependency '${missingCap}' not yet ` +
+                `resolved locally; holding claims (job stays queued, no attempt ` +
+                `burned) until it resolves`,
+            );
+            this._gateMissingCap = missingCap;
+          }
+          this._release();
+          permitTransferred = true; // already released; finally must skip
+          // Cheap local probe (no network) — re-check at the BASE cadence so
+          // we claim within one base interval of the dep landing, rather than
+          // growing the backoff. The real-work backoff is left untouched.
+          await this._sleep(_POLL_BASE_MS);
+          continue;
+        }
+        // Gate just opened (was gated, now all required deps resolved).
+        if (this._gateMissingCap !== null) {
+          console.log(
+            `[mesh-claim] capability=${this.capability} instance=${this.instanceId}: ` +
+              `gate OPEN — required dependencies resolved; resuming claims`,
+          );
+          this._gateMissingCap = null;
+        }
         const claimed = await this._claimOnce();
         if (claimed.length > 1) {
           // Defensive warn (W3): the Phase 1 wire is single-claim by

--- a/src/runtime/typescript/src/index.ts
+++ b/src/runtime/typescript/src/index.ts
@@ -192,7 +192,7 @@ export {
 } from "./route.js";
 
 // Proxy utilities (for advanced use)
-export { createProxy, normalizeDependency, getCurrentPropagatedHeaders, extractContent, streamMcpTool, type MultiContentResult } from "./proxy.js";
+export { createProxy, normalizeDependency, getCurrentPropagatedHeaders, callingJob, type CallingJob, extractContent, streamMcpTool, type MultiContentResult } from "./proxy.js";
 
 // Tracing utilities (for advanced use)
 export {

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -85,6 +85,63 @@ export function getCurrentPropagatedHeaders(): Record<string, string> {
 }
 
 /**
+ * Propagated-header names carrying the CALLING job's identity (issue #1263).
+ * A dedicated pair — distinct from the push-mode dispatch protocol's
+ * x-mesh-job-id / x-mesh-claim-epoch (x-mesh-job-id doubles as the dispatch
+ * discriminator, so it cannot also carry calling identity).
+ */
+const HDR_CALLING_JOB_ID = "x-mesh-calling-job-id";
+const HDR_CALLING_CLAIM_EPOCH = "x-mesh-calling-claim-epoch";
+
+/**
+ * Identity of the job whose handler made the CURRENT inbound call
+ * (issue #1263). Returned by {@link callingJob}.
+ */
+export interface CallingJob {
+  /** Server-assigned job UUID of the calling job. */
+  jobId: string;
+  /**
+   * Claim generation the caller executes under, or `null` for a push-mode
+   * inbound job / an old SDK that did not seed it.
+   */
+  claimEpoch: number | null;
+}
+
+/**
+ * Return the identity of the job that made the current inbound call, or
+ * `null` when the call did not originate from a job handler (issue #1263).
+ *
+ * Provider-side dual of `currentJob()`: `currentJob()` answers "what job am I
+ * executing as", while `callingJob()` answers "what job invoked me". Reads the
+ * `x-mesh-calling-job-id` / `x-mesh-calling-claim-epoch` propagated headers the
+ * mesh seeds on outbound calls made from within a job execution context, so a
+ * provider can fence stale-executor writes without the caller threading
+ * identity through every payload. It is `null` inside a directly-claimed job
+ * handler (that handler's OWN identity lives on `currentJob()`).
+ *
+ * Safe to call from any tool body — never throws; returns `null` for regular
+ * (non-job) `tools/call` invocations and for calls from an old SDK that did
+ * not propagate the identity. Purely additive.
+ */
+export function callingJob(): CallingJob | null {
+  const headers = getCurrentPropagatedHeaders();
+  const jobId = headers[HDR_CALLING_JOB_ID];
+  if (!jobId) return null;
+  let claimEpoch: number | null = null;
+  const raw = headers[HDR_CALLING_CLAIM_EPOCH];
+  // Strict: only a clean, wholly-numeric, non-negative integer string is a
+  // real epoch (mirrors readJobHeaders / the claim dispatcher). Never
+  // fabricate a `0` the registry didn't mint.
+  if (raw !== undefined && /^\d+$/.test(raw)) {
+    const parsed = Number(raw);
+    if (Number.isInteger(parsed) && parsed >= 0) {
+      claimEpoch = parsed;
+    }
+  }
+  return { jobId, claimEpoch };
+}
+
+/**
  * Run a function with trace context.
  * The context is automatically propagated to all async operations within the callback.
  * This is the preferred way to set trace context for tool execution.
@@ -294,6 +351,25 @@ function buildMcpRequest(
       if (matchesPropagateHeader(key)) {
         mergedHeaders[key.toLowerCase()] = value;
       }
+    }
+  }
+
+  // Issue #1263: overlay the CALLING job's identity so a nested outbound call
+  // made from within a job execution context carries who invoked the
+  // downstream (x-mesh-calling-job-id + x-mesh-calling-claim-epoch), letting
+  // the provider fence out-of-epoch writes via callingJob(). Distinct from the
+  // push-dispatch x-mesh-job-id. Seeded atomically from ONE snapshot and
+  // REPLACING any inherited calling-* pair entirely (both-or-none): set the id
+  // and set-or-clear the epoch together, so a stale inherited epoch can never
+  // ride along with this job's id. When there is no active job the inherited
+  // pair passes through unchanged (transitive identity).
+  const outboundJob = currentJob();
+  if (outboundJob?.jobId) {
+    mergedHeaders[HDR_CALLING_JOB_ID] = outboundJob.jobId;
+    if (outboundJob.claimEpoch !== null) {
+      mergedHeaders[HDR_CALLING_CLAIM_EPOCH] = String(outboundJob.claimEpoch);
+    } else {
+      delete mergedHeaders[HDR_CALLING_CLAIM_EPOCH];
     }
   }
 

--- a/src/runtime/typescript/src/tracing.ts
+++ b/src/runtime/typescript/src/tracing.ts
@@ -30,6 +30,19 @@ function parsePropagateHeaders(): string[] {
   if (!headers.includes("x-mesh-timeout")) {
     headers.push("x-mesh-timeout");
   }
+  // Issue #1263: the CALLING job's identity travels as a dedicated infra header
+  // pair so a downstream provider can fence out-of-epoch writes (callingJob())
+  // without every app hand-threading job_id/claim_epoch through payloads. This
+  // is a distinct pair from x-mesh-job-id / x-mesh-claim-epoch — those are the
+  // push-mode dispatch protocol (x-mesh-job-id doubles as the dispatch
+  // discriminator, so it CANNOT also carry calling identity). Always
+  // allowlisted so they survive the downstream capture filter (same treatment
+  // as x-mesh-timeout).
+  for (const infra of ["x-mesh-calling-job-id", "x-mesh-calling-claim-epoch"]) {
+    if (!headers.includes(infra)) {
+      headers.push(infra);
+    }
+  }
   return headers;
 }
 

--- a/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-calculator-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-optional-dep-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-report-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-calculator-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-calculator-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-calculator-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-alpha-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-alpha-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-beta-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-beta-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-dual-consumer/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-dual-consumer/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-caller/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-caller/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-provider/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-provider/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-caller/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-caller/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-provider/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/java-slow-agent/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/java-slow-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/ts-slow-agent/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/ts-slow-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc07_llm_agent_py/artifacts/llm-agent/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc07_llm_agent_py/artifacts/llm-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for llm-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc23_structured_output_ts_consumer_py_provider/artifacts/structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc23_structured_output_ts_consumer_py_provider/artifacts/structured-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc28_structured_output_ts_consumer_java_provider/artifacts/structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc28_structured_output_ts_consumer_java_provider/artifacts/structured-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc32_structured_output_ts_consumer_py_openai_provider/artifacts/structured-consumer-openai-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc32_structured_output_ts_consumer_py_openai_provider/artifacts/structured-consumer-openai-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc43_output_mode_hint_override_openai_ts/artifacts/hint-override-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc43_output_mode_hint_override_openai_ts/artifacts/hint-override-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc44_output_mode_hint_override_openai_java/artifacts/hint-override-java/pom.xml
+++ b/tests/integration/suites/uc04_llm_integration/tc44_output_mode_hint_override_openai_java/artifacts/hint-override-java/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <java.version>17</java.version>
         <!-- maven-install handler aligns this from the container's ~/.m2 repo -->
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
+++ b/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/Dockerfile
+++ b/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-auto-port-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc05_meshctl/tc33_ts_api_port_isolation/artifacts/ts-api-app/package.json
+++ b/tests/integration/suites/uc05_meshctl/tc33_ts_api_port_isolation/artifacts/ts-api-app/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "2.7.0",
+    "@mcpmesh/sdk": "2.8.0",
     "express": "^4.21.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc06_observability/artifacts/express-api/package.json
+++ b/tests/integration/suites/uc06_observability/artifacts/express-api/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc06_observability/artifacts/py-calculator/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/py-calculator/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for py-calculator MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/py-math-agent/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/py-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for py-math-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-echo-ts/package.json
+++ b/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-echo-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-relay-ts/package.json
+++ b/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-relay-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc12_registration_trust/artifacts/java-greeter/pom.xml
+++ b/tests/integration/suites/uc12_registration_trust/artifacts/java-greeter/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc14_multimedia/tc30_download_media_typescript/artifacts/ts-download-agent/package.json
+++ b/tests/integration/suites/uc14_multimedia/tc30_download_media_typescript/artifacts/ts-download-agent/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
+++ b/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/Dockerfile
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/Dockerfile
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
+++ b/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc16_schema_filtering/artifacts/ts-schema-agent/package.json
+++ b/tests/integration/suites/uc16_schema_filtering/artifacts/ts-schema-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc17_ui_server/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc17_ui_server/artifacts/ts-math-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/pom.xml
+++ b/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java-sse/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java-sse/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-auth-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-auth-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-report-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-report-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0",
+    "@mcpmesh/sdk": "^2.8.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/pom.xml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/pom.xml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/pom.xml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/pom.xml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-consumer/pom.xml
+++ b/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-provider/pom.xml
+++ b/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc32_empty_return_values/artifacts/ts-empty-consumer/package.json
+++ b/tests/integration/suites/uc32_empty_return_values/artifacts/ts-empty-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/pom.xml
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.7.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/package.json
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.7.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc35_meshjob_claim_gating/artifacts/flap-provider
+++ b/tests/integration/suites/uc35_meshjob_claim_gating/artifacts/flap-provider
@@ -1,0 +1,1 @@
+../fixtures/flap-provider

--- a/tests/integration/suites/uc35_meshjob_claim_gating/artifacts/flap-worker
+++ b/tests/integration/suites/uc35_meshjob_claim_gating/artifacts/flap-worker
@@ -1,0 +1,1 @@
+../fixtures/flap-worker

--- a/tests/integration/suites/uc35_meshjob_claim_gating/fixtures/flap-provider/main.py
+++ b/tests/integration/suites/uc35_meshjob_claim_gating/fixtures/flap-provider/main.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""uc35 flap-provider — the required dependency that flaps DOWN→UP (issue #1268).
+
+Provides ``flap_data``, the capability flap-worker's ``checked_task`` declares
+``required=True``. The test stops and restarts THIS agent to open the
+gate/injection race window #1268 closes: the registry-side claim gate flips
+available the moment this provider re-registers, while the worker's injected
+proxy slot refills only on the worker's next heartbeat. Pre-fix, a claim
+granted inside that window invoked the handler with a null required proxy.
+
+The tool returns a fixed marker so the test can prove — from the completed
+job's ``result`` — that the handler really called THIS provider (a null
+injection would instead die loudly on the unguarded call).
+"""
+
+import os
+from typing import Any
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Flap Provider (uc35)")
+
+
+@app.tool()
+@mesh.tool(
+    capability="flap_data",
+    description="Returns a fixed liveness marker; the required dep that flaps DOWN->UP.",
+)
+def get_flap_data() -> dict[str, Any]:
+    return {"marker": "flap-provider-live"}
+
+
+@mesh.agent(
+    name="flap-provider",
+    version="1.0.0",
+    description="uc35 required-dep provider that the test flaps DOWN->UP (issue #1268)",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9101")),
+    enable_http=True,
+    auto_run=True,
+)
+class FlapProvider:
+    pass

--- a/tests/integration/suites/uc35_meshjob_claim_gating/fixtures/flap-worker/main.py
+++ b/tests/integration/suites/uc35_meshjob_claim_gating/fixtures/flap-worker/main.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""uc35 flap-worker — task=True consumer with a REQUIRED dep (issue #1268).
+
+``checked_task`` is the capability under test: ``task=True`` (claimed from the
+shared job queue) with a ``required=True`` dependency on flap-provider's
+``flap_data``. Two claim-path guarantees from #1268 land here:
+
+1. Pre-claim local skip (primary): while the ``flap_data`` proxy slot is
+   locally unresolved, this agent's claim worker never POSTs /jobs/claim —
+   the job stays queued with no owner and NO attempt increment.
+2. Pre-invoke guard (safety net): a claim that slips through the race window
+   (registry gate open, local slot still null) releases its lease instead of
+   invoking the handler with a null proxy.
+
+The handler calls the required dep DELIBERATELY UNGUARDED: if either guard
+regressed and the handler ran with a null injection, ``await flap_data()``
+raises ``TypeError: 'NoneType' object is not callable`` — the pre-fix
+symptom — which the dispatcher's exception path posts as a terminal fail().
+The test asserts both the absence of that log signature and the row-level
+observables (attempt_count == 1, exactly one stamped execution).
+"""
+
+import os
+from typing import Any
+
+import mesh
+from fastmcp import FastMCP
+from mesh import MeshJob
+
+app = FastMCP("Flap Worker (uc35)")
+
+
+@app.tool()
+@mesh.tool(
+    capability="checked_task",
+    task=True,
+    dependencies=[{"capability": "flap_data", "required": True}],
+    description="Job handler that calls its required flap_data dep unguarded.",
+)
+async def checked_task(
+    label: str = "unlabeled",
+    flap_data: mesh.McpMeshTool = None,
+    job: MeshJob = None,
+) -> dict[str, Any]:
+    # UNGUARDED on purpose (see module docstring): a null required proxy here
+    # must be impossible — the claim gate/pre-invoke guard keep the job queued
+    # instead. Guarding would silently mask the regression under test.
+    dep_result = await flap_data()
+
+    if job is not None:
+        # Stamp every actual execution so the test can assert EXACTLY-ONCE
+        # from the event log (uc33 pattern), attributed to a claim epoch.
+        await mesh.jobs.post_event(
+            job_id=job.job_id,
+            event_type="transition",
+            payload={"marker": "executed", "label": label, "epoch": job.claim_epoch},
+        )
+
+    payload = {
+        "status": "done",
+        "label": label,
+        "dep_marker": str(dep_result),
+    }
+    if job is not None:
+        await job.complete(payload)
+    return payload
+
+
+@mesh.agent(
+    name="flap-worker",
+    version="1.0.0",
+    description="uc35 task=true consumer with required dep on flap_data (issue #1268)",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9102")),
+    enable_http=True,
+    auto_run=True,
+)
+class FlapWorker:
+    pass

--- a/tests/integration/suites/uc35_meshjob_claim_gating/routines.yaml
+++ b/tests/integration/suites/uc35_meshjob_claim_gating/routines.yaml
@@ -1,0 +1,58 @@
+# UC-level routines for uc35_meshjob_claim_gating (issue #1268).
+#
+# Clone of uc33's fast-sweep registry routine. The knobs that matter here:
+#
+#   - MCP_MESH_SWEEP_INTERVAL=10s + HEALTH knobs — a DOWN provider is
+#     detected fast, so the availability flip the flap scenario polls for
+#     lands in seconds, not minutes (see uc21/routines.yaml for the full
+#     knob-chain documentation).
+#   - MCP_MESH_RETENTION=60s (NOT 10s) — the tc reads the job's event log
+#     AFTER the job goes terminal to assert exactly-once execution; at 10s
+#     the terminal-event GC could wipe the log before the final captures
+#     (same rationale as uc33).
+#   - MCP_MESH_JOB_STALE_TIMEOUT deliberately NOT set — the whole point of
+#     the flap window is a job that sits QUEUED (owner NULL, attempt 0) for
+#     tens of seconds while its capability's required dep is down. A stale
+#     ceiling would reap exactly that job and mask the claim-gating
+#     behaviour under test.
+
+routines:
+  start_registry_with_fast_sweep:
+    description: "Start the mesh registry with sweep/health knobs cranked for fast down-detection"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: |
+          MCP_MESH_SWEEP_INTERVAL=10s \
+          MCP_MESH_RETENTION=60s \
+          MCP_MESH_HEALTH_CHECK_INTERVAL=5 \
+          DEFAULT_TIMEOUT_THRESHOLD=15 \
+            meshctl start --registry-only -d
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+              echo "registry ready after ${i}s"
+              # Verify the sweep override actually stamped its log line.
+              # If MCP_MESH_SWEEP_INTERVAL didn't take effect the suite
+              # must fail loudly here, not via slow per-test timeouts.
+              tail -n 200 ~/.mcp-mesh/logs/registry.log \
+                | grep -qE '\[sweep\] using MCP_MESH_SWEEP_INTERVAL' \
+                || { echo "FAIL: MCP_MESH_SWEEP_INTERVAL override did not take effect"; exit 1; }
+              echo "[setup] confirmed sweep override active"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ERROR: registry did not become ready in 20s"
+          tail -50 ~/.mcp-mesh/logs/registry.log 2>/dev/null || true
+          exit 1
+        capture: registry_start
+        timeout: 30
+
+  # Stop everything started by this test (agents + registry).
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: meshctl stop 2>/dev/null || true
+        ignore_errors: true

--- a/tests/integration/suites/uc35_meshjob_claim_gating/tc01_required_dep_flap_claim_gating/test.yaml
+++ b/tests/integration/suites/uc35_meshjob_claim_gating/tc01_required_dep_flap_claim_gating/test.yaml
@@ -1,0 +1,348 @@
+# tc01_required_dep_flap_claim_gating — a required dep flapping DOWN→UP must
+# NOT let a claim invoke the handler with a null proxy (issue #1268).
+#
+# Contract under test (man jobs, #1258 + #1268): "A claim worker never pulls
+# a job for a capability whose required dependencies are currently
+# unavailable." Pre-fix, the registry-side claim gate and the consumer's
+# local injection ran on two independent clocks: the gate flipped available
+# the moment the provider re-registered, while the consumer's injected proxy
+# slot refilled only on its next heartbeat. A claim granted inside that
+# window ran the handler with a NULL required proxy → TypeError →
+# terminal fail() at attempt_count 1 — a purely topological race
+# permanently failing the job.
+#
+# Topology: flap-provider (flap_data) + flap-worker (checked_task,
+# task=True, required=True dep on flap_data; the handler calls the dep
+# UNGUARDED so a null injection dies loudly). Jobs are submitted directly
+# via POST /jobs (tc07/uc21 precedent) so submission never depends on any
+# agent's own dep availability.
+#
+# Flow:
+#   1. BASELINE — both agents up: submit, job completes normally,
+#      attempt_count == 1.
+#   2. DOWN — stop flap-provider; poll until checked_task flips
+#      available=false (reason names flap_data). Submit a second job and
+#      WATCH it for 24s of claim polls (worker polls every ≤5s): it must
+#      stay queued — owner NULL, attempt_count == 0, no attempt burned.
+#   3. UP — restart flap-provider: the job self-heals — claimed and
+#      completed EXACTLY ONCE (final attempt_count == 1, one stamped
+#      "executed" event), result carries the provider's marker (the handler
+#      really called the required dep), and the worker log has no
+#      NoneType/not-callable signature (the pre-fix symptom).
+#
+# Registration waits are liveness-only (issue #1193); dependency resolution
+# is covered by the settle window + the claim gate itself (a queued baseline
+# job is claimed only once the required slot resolves) — no dep-resolution
+# waits. Availability-transition polls are the scenario itself, with
+# deadlines, never fixed sleeps.
+
+name: "MeshJob claim gating: required dep DOWN->UP flap never burns an attempt or invokes with a null proxy"
+description: "Baseline completes; with the required dep down a submitted job stays queued (owner NULL, attempt_count 0) across 24s of claim polls; after provider restart the job completes exactly once at attempt_count 1 with no null-injection error"
+tags:
+  - integration
+  - meshjob
+  - python
+  - required-deps
+  - claim-gating
+  - issue-1268
+  - slow
+timeout: 420
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/flap-provider /workspace/
+      cp -rL /uc-artifacts/flap-worker /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/flap-provider
+
+  - name: "Install worker deps"
+    handler: pip-install
+    path: /workspace/flap-worker
+
+  - routine: start_registry_with_fast_sweep
+
+  - name: "Start flap-provider (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start flap-provider/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Start flap-worker (port 9102)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start flap-worker/main.py --env MCP_MESH_HTTP_PORT=9102 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193) — no dep-resolution wait: the baseline job
+  # below queues until the worker's required slot resolves and the claim
+  # gate opens, which IS the mechanism under test.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "flap-provider flap-worker"
+
+  # ---- Phase 1: baseline (provider UP) --------------------------------
+
+  - name: "Submit baseline job via POST /jobs"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:8000/jobs \
+        -H 'Content-Type: application/json' \
+        -d '{"capability":"checked_task","submitted_payload":{"label":"baseline"},"submitted_by":"tc01-baseline","max_retries":3,"max_duration":30}'
+    capture: baseline_submit
+    timeout: 15
+
+  - name: "Wait for baseline completion"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.baseline_submit}' | jq -r '.id')
+      echo "BASELINE_JOB_ID=${JOB_ID}"
+      for i in $(seq 1 45); do
+        ST=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.status')
+        if [ "$ST" = "completed" ]; then
+          echo "BASELINE_COMPLETED=1 after ~$((i*2))s"
+          exit 0
+        fi
+        if [ "$ST" = "failed" ] || [ "$ST" = "cancelled" ]; then
+          echo "ERROR: baseline job went terminal ${ST}"
+          curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '.'
+          exit 1
+        fi
+        sleep 2
+      done
+      echo "ERROR: baseline job did not complete within 90s (last=${ST})"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '.'
+      meshctl logs flap-worker 2>/dev/null | tail -30 || true
+      exit 1
+    capture: baseline_wait
+    timeout: 110
+
+  - name: "Capture baseline job row"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.baseline_submit}' | jq -r '.id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}"
+    capture: baseline_job
+
+  # ---- Phase 2: required dep DOWN --------------------------------------
+
+  - name: "Stop flap-provider (graceful — unregister is immediate)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop flap-provider
+    capture: stop_provider
+
+  # The registry re-derives checked_task's availability once the provider's
+  # death lands (graceful unregister is immediate; a hard death takes the
+  # cranked health debounce). Poll with a deadline that covers both paths.
+  - name: "Wait for checked_task to flip unavailable"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        AVAIL=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name == "flap-worker") | .capabilities[] | select(.name == "checked_task") | .available' 2>/dev/null || echo "")
+        if [ "$AVAIL" = "false" ]; then
+          echo "CHECKED_TASK_UNAVAILABLE=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: checked_task never flipped to available=false within 120s (last=$AVAIL)"
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name == "flap-worker")' 2>/dev/null || true
+      exit 1
+    capture: wait_unavailable
+    timeout: 140
+
+  - name: "Capture /agents snapshot during outage"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_during_outage
+
+  - name: "Submit flap-window job via POST /jobs"
+    handler: shell
+    workdir: /workspace
+    command: |
+      curl -s -X POST http://localhost:8000/jobs \
+        -H 'Content-Type: application/json' \
+        -d '{"capability":"checked_task","submitted_payload":{"label":"flap"},"submitted_by":"tc01-flap","max_retries":3,"max_duration":30}'
+    capture: flap_submit
+    timeout: 15
+
+  # THE WINDOW: 24s = ~5+ worker claim polls (base 0.5s, backoff cap 5s).
+  # Every poll must leave the row untouched: no owner, attempt_count 0.
+  # This is the #1258/#1268 posture — the job stays queued with NO attempt
+  # burned while the capability's required dep is down. This is the scenario
+  # watch itself, NOT a registration/dep wait.
+  - name: "Watch the down window — job must stay queued, zero attempts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.flap_submit}' | jq -r '.id')
+      echo "FLAP_JOB_ID=${JOB_ID}"
+      for i in $(seq 1 12); do
+        ROW=$(curl -s "http://localhost:8000/jobs/${JOB_ID}")
+        OWNER=$(echo "$ROW" | jq -r '.owner_instance_id // empty')
+        ATTEMPTS=$(echo "$ROW" | jq -r '.attempt_count')
+        ST=$(echo "$ROW" | jq -r '.status')
+        echo "poll ${i}: status=${ST} owner=${OWNER:-null} attempts=${ATTEMPTS}"
+        if [ -n "$OWNER" ]; then
+          echo "FAIL: job was claimed (owner=${OWNER}) while its required dep was DOWN"
+          echo "$ROW" | jq '.'
+          exit 1
+        fi
+        if [ "$ATTEMPTS" != "0" ]; then
+          echo "FAIL: attempt_count=${ATTEMPTS} burned while the required dep was DOWN"
+          echo "$ROW" | jq '.'
+          exit 1
+        fi
+        sleep 2
+      done
+      echo "WINDOW_CLEAN=1"
+    capture: window_watch
+    timeout: 60
+
+  - name: "Capture still-queued flap job row"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.flap_submit}' | jq -r '.id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}"
+    capture: queued_job
+
+  # ---- Phase 3: required dep back UP ------------------------------------
+
+  - name: "Restart flap-provider"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start flap-provider/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  # Self-heal: provider re-registers -> registry re-derives availability ->
+  # the worker's next heartbeat refills the proxy slot -> the local claim
+  # gate opens within one base poll interval. Post-fix BOTH orderings of
+  # (registry gate open, local slot refilled) are safe — pre-fix the
+  # registry-gate-first ordering invoked the handler on a null proxy.
+  - name: "Wait for flap job completion after recovery"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.flap_submit}' | jq -r '.id')
+      for i in $(seq 1 60); do
+        ST=$(curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq -r '.status')
+        if [ "$ST" = "completed" ]; then
+          echo "FLAP_COMPLETED=1 after ~$((i*2))s"
+          exit 0
+        fi
+        if [ "$ST" = "failed" ] || [ "$ST" = "cancelled" ]; then
+          echo "ERROR: flap job went terminal ${ST} — pre-fix symptom is a terminal fail() on the null-proxy TypeError"
+          curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '.'
+          meshctl logs flap-worker 2>/dev/null | tail -40 || true
+          exit 1
+        fi
+        sleep 2
+      done
+      echo "ERROR: flap job did not complete within 120s of provider restart (last=${ST})"
+      curl -s "http://localhost:8000/jobs/${JOB_ID}" | jq '.'
+      meshctl logs flap-worker 2>/dev/null | tail -40 || true
+      exit 1
+    capture: recovery_wait
+    timeout: 140
+
+  - name: "Capture final flap job row"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.flap_submit}' | jq -r '.id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}"
+    capture: final_job
+
+  - name: "Capture flap job event log"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.flap_submit}' | jq -r '.id')
+      curl -s "http://localhost:8000/jobs/${JOB_ID}/events?after=0&limit=100"
+    capture: final_events
+
+  # The pre-fix symptom in the worker log: the handler invoked with a null
+  # required proxy raises TypeError: 'NoneType' object is not callable
+  # (Java sibling: NullPointerException). Scan for all of them explicitly
+  # and emit a positive marker so the assertion reads unambiguously.
+  - name: "Scan worker log for null-injection error signatures"
+    handler: shell
+    workdir: /workspace
+    command: |
+      LOG=$( (meshctl logs flap-worker 2>/dev/null; cat ~/.mcp-mesh/logs/flap-worker*.log 2>/dev/null) || true )
+      HITS=$(echo "$LOG" | grep -Ei "NoneType|not callable|NullPointerException" || true)
+      if [ -n "$HITS" ]; then
+        echo "NULL_CALL_ERROR_FOUND=1"
+        echo "$HITS" | head -10
+        exit 1
+      fi
+      echo "NO_NULL_CALL_ERRORS=1"
+    capture: log_scan
+    timeout: 30
+
+assertions:
+  # IDIOM: equality lives INSIDE the jq filter so the interpolation yields a
+  # bare true/false (tsuite Go-formats extracted values, and the interpolation
+  # body cannot contain '}' — hence no object construction in filters).
+
+  # Scenario gates surfaced by the poll steps
+  - expr: "${captured.baseline_wait} contains 'BASELINE_COMPLETED=1'"
+    message: "baseline: with the required dep UP the job must complete normally"
+  - expr: "${captured.wait_unavailable} contains 'CHECKED_TASK_UNAVAILABLE=1'"
+    message: "stopping the provider must flip checked_task to available=false"
+  - expr: "${captured.window_watch} contains 'WINDOW_CLEAN=1'"
+    message: "with the required dep DOWN the job must survive 24s of claim polls unclaimed with zero attempts"
+  - expr: "${captured.recovery_wait} contains 'FLAP_COMPLETED=1'"
+    message: "restarting the provider must self-heal the queued job to completion"
+  - expr: "${captured.log_scan} contains 'NO_NULL_CALL_ERRORS=1'"
+    message: "the worker log must contain no NoneType/not-callable signature — the handler must never run with a null required proxy"
+
+  # Baseline row: completed on its first and only claim, and the handler
+  # really called the required dep (result carries the provider's marker).
+  - expr: "${jq:captured.baseline_job:(.status == \"completed\") and (.attempt_count == 1)} == 'true'"
+    message: "baseline job must complete at attempt_count == 1"
+  - expr: "${jq:captured.baseline_job:(.result.dep_marker // \"\") | contains(\"flap-provider-live\")} == 'true'"
+    message: "baseline result must carry the provider marker — the handler called the required dep"
+
+  # Outage observability (#1258): checked_task unavailable, reason names the
+  # broken required edge, WHILE flap-worker itself stays registered+healthy.
+  - expr: "${jq:captured.agents_during_outage:(.agents[] | select(.name == \"flap-worker\") | .capabilities[] | select(.name == \"checked_task\") | .available == false)} == 'true'"
+    message: "checked_task must be available=false while its required flap_data edge is broken"
+  - expr: "${jq:captured.agents_during_outage:(.agents[] | select(.name == \"flap-worker\") | .capabilities[] | select(.name == \"checked_task\") | .unavailable_reason // \"\" | contains(\"flap_data\"))} == 'true'"
+    message: "checked_task's unavailable_reason must name the broken required edge (flap_data)"
+  - expr: "${jq:captured.agents_during_outage:(.agents[] | select(.name == \"flap-worker\") | .status == \"healthy\")} == 'true'"
+    message: "flap-worker must stay HEALTHY — unavailability is capability-level derived state"
+
+  # The window row: queued shape — status working, NO owner, ZERO attempts.
+  - expr: "${jq:captured.queued_job:(.status == \"working\") and (.owner_instance_id == null) and (.attempt_count == 0)} == 'true'"
+    message: "after the watch window the job row must still be the unclaimed shape: working, owner NULL, attempt_count 0"
+
+  # Recovery: completed EXACTLY ONCE — attempt_count 1 means no attempt was
+  # burned by a claim granted inside the race window (a pre-invoke-guard
+  # release would show attempt_count > 1; a pre-fix terminal fail would show
+  # status failed).
+  - expr: "${jq:captured.final_job:(.status == \"completed\") and (.attempt_count == 1)} == 'true'"
+    message: "flap job must complete on its FIRST claim after recovery (attempt_count == 1 — no attempts burned in the race window)"
+  - expr: "${jq:captured.final_job:(.result.label == \"flap\") and ((.result.dep_marker // \"\") | contains(\"flap-provider-live\"))} == 'true'"
+    message: "flap result must carry the provider marker — the handler called the restarted required dep for real"
+
+  # Exactly-once from the event log: ONE stamped execution, claim epoch 1.
+  - expr: "${jq:captured.final_events:([.events[] | select(.type == \"transition\") | select(.payload.marker == \"executed\") | select(.payload.label == \"flap\")] | length) == 1} == 'true'"
+    message: "exactly ONE stamped 'executed' event — the handler must have run exactly once"
+  - expr: "${jq:captured.final_events:([.events[] | select(.type == \"transition\") | select(.payload.label == \"flap\")] | all(.payload.epoch == 1))} == 'true'"
+    message: "the single execution must carry claim epoch 1 — no earlier claim ever ran"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary
First of three 2.8.1 PRs. Fixes the field-reported claim-gate/injection race and adds the calling-job identity feature.

- **#1268 — required-dep claim gating, both layers (all runtimes)**: the registry-side transitive gate is now paired with a consumer-side gate — claim workers skip claiming while any `required=true` dependency slot is locally unresolved (job stays queued, zero attempt burn, transition-edge logging), and a last-resort pre-invoke guard releases the lease (never `fail()`) instead of invoking with a missing dep. Handlers never observe null for required deps, including during dependency recovery. Required flags are threaded positionally into the wrappers/dispatchers; Python excludes the MeshJob-paired dep from the gate (matching TS/Java structural behavior).
- **#1263 — calling-job identity**: tool calls made from within a job handler automatically carry the caller's identity on a **dedicated** propagated pair `x-mesh-calling-job-id` / `x-mesh-calling-claim-epoch` — deliberately separate from the push-dispatch protocol headers (a review-caught BLOCKER: reusing `x-mesh-job-id` would have made nested same-instance task calls auto-complete the caller's job). Seeded atomically as a pair from one job-context snapshot, replaced as a pair (no mixed identities), forwarded by default across the registry proxy hop, and readable via `MeshCallContext.callingJob()` (Java), `mesh.calling_job()` (Python), `callingJob()` (TS) — null when a handler was claimed directly.
- **Docs**: terminal-fail retry semantics stated plainly (a non-`retryOn` handler exception is terminal regardless of `max_retries` — field misreading killed), two-layer claim-gating description, calling-job identity + accessors documented in all jobs man pages + docs mirror.
- **New integration UC `uc35_meshjob_claim_gating`**: DOWN→UP flap of a required dep — `attempt_count == 0` asserted on every poll through the outage window, exactly-once execution at epoch 1 after recovery, no null-injection errors.

## Review Notes
Zero-context review applied: 1 BLOCKER (identity-carrier collision with the push-dispatch discriminator — fixed via the dedicated header pair with a regression test), 5 warnings (mixed identity pairs, Python MeshJob-gate divergence, TS log spam, registry-hop epoch drop, accessor self-identity inconsistency) — all fixed. The pre-invoke guard burns the claim's attempt increment by design (documented); the pre-claim skip is the zero-burn layer, proven by uc35.

## Test plan
- [x] Java 548, Python 1289, TS 1035 + tsc clean, registry Go suite green
- [x] src-tests 12/12
- [x] Jobs suites scoped: uc35 + uc21 + uc33 — 27/0
- [x] Full integration: 525 passed / 3 Java cold-start flakes, all green on sequential re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)