### PR TITLE
chore: 2.8.1 hygiene batch — backlog fixes, bump-pipeline hardening

### DIFF
--- a/cmd/meshctl/templates/java/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/a2a-consumer/Dockerfile.tmpl
@@ -8,9 +8,7 @@ USER root
 COPY pom.xml .
 COPY src/ src/
 
-RUN mvn package -DskipTests -q
-
-RUN chown -R mcp-mesh:mcp-mesh /app
+RUN mvn package -DskipTests -q && chown -R mcp-mesh:mcp-mesh /app
 
 USER mcp-mesh
 

--- a/cmd/meshctl/templates/java/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/api/Dockerfile.tmpl
@@ -10,11 +10,8 @@ USER root
 COPY pom.xml .
 COPY src/ src/
 
-# Build the application
-RUN mvn package -DskipTests -q
-
-# Set permissions
-RUN chown -R mcp-mesh:mcp-mesh /app
+# Build the application and set permissions
+RUN mvn package -DskipTests -q && chown -R mcp-mesh:mcp-mesh /app
 
 # Switch back to non-root user
 USER mcp-mesh

--- a/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
@@ -10,11 +10,8 @@ USER root
 COPY pom.xml .
 COPY src/ src/
 
-# Build the application
-RUN mvn package -DskipTests -q
-
-# Set permissions
-RUN chown -R mcp-mesh:mcp-mesh /app
+# Build the application and set permissions
+RUN mvn package -DskipTests -q && chown -R mcp-mesh:mcp-mesh /app
 
 # Switch back to non-root user
 USER mcp-mesh

--- a/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
@@ -10,11 +10,8 @@ USER root
 COPY pom.xml .
 COPY src/ src/
 
-# Build the application
-RUN mvn package -DskipTests -q
-
-# Set permissions
-RUN chown -R mcp-mesh:mcp-mesh /app
+# Build the application and set permissions
+RUN mvn package -DskipTests -q && chown -R mcp-mesh:mcp-mesh /app
 
 # Switch back to non-root user
 USER mcp-mesh

--- a/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
@@ -10,11 +10,8 @@ USER root
 COPY pom.xml .
 COPY src/ src/
 
-# Build the application
-RUN mvn package -DskipTests -q
-
-# Set permissions
-RUN chown -R mcp-mesh:mcp-mesh /app
+# Build the application and set permissions
+RUN mvn package -DskipTests -q && chown -R mcp-mesh:mcp-mesh /app
 
 # Switch back to non-root user
 USER mcp-mesh

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -84,6 +84,27 @@ export MCP_MESH_SESSION_TTL=3600
 export MCP_MESH_TOOL_WORKERS=1
 ```
 
+### Tool Isolation (Python / TypeScript)
+
+```bash
+# Default: true. Runs each async tool body off the main event loop — Python
+# dispatches it to the mesh worker loop, TypeScript runs it on a worker
+# thread — so a blocking or long-running tool call cannot stall the main
+# loop that serves /health, /ready, the FastMCP/HTTP transport, and registry
+# heartbeats.
+#
+# Set to false to revert to legacy inline execution on the main loop.
+#
+# Scope and carve-outs:
+# - Python: only async tools are wrapped (sync tools already run off-loop via
+#   FastMCP); streaming tools are always inline (progress notifications must
+#   run on the main loop).
+# - TypeScript: requires `tsx` in your dependencies. A2A-consumer tools and
+#   MeshJob/task tools force-disable isolation (their injected handles cannot
+#   cross the worker_threads boundary) regardless of this setting.
+export MCP_MESH_TOOL_ISOLATION=true
+```
+
 ### Strict DI Diagnostics (Python)
 
 ```bash

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -99,9 +99,12 @@ export MCP_MESH_TOOL_WORKERS=1
 # - Python: only async tools are wrapped (sync tools already run off-loop via
 #   FastMCP); streaming tools are always inline (progress notifications must
 #   run on the main loop).
-# - TypeScript: requires `tsx` in your dependencies. A2A-consumer tools and
-#   MeshJob/task tools force-disable isolation (their injected handles cannot
-#   cross the worker_threads boundary) regardless of this setting.
+# - TypeScript: when the agent's entrypoint is a TypeScript source file
+#   (.ts/.mts/.cts/.tsx), the worker loads it through `tsx`, which must be in
+#   your dependencies; a precompiled .js entrypoint needs nothing extra.
+#   A2A-consumer tools and MeshJob/task tools force-disable isolation (their
+#   injected handles cannot cross the worker_threads boundary) regardless of
+#   this setting.
 export MCP_MESH_TOOL_ISOLATION=true
 ```
 

--- a/examples/docker-examples/docker-compose.yml
+++ b/examples/docker-examples/docker-compose.yml
@@ -2,12 +2,12 @@
 # Demonstrates Go registry + Python agents architecture using published Docker images
 #
 # Services:
-# - registry: Go-based registry with SQLite storage (mcpmesh/registry:2.7.0)
-# - hello-world-agent: Python agent with greeting capabilities (mcpmesh/python-runtime:2.7.0)
-# - system-agent: Python agent with system monitoring capabilities (mcpmesh/python-runtime:2.7.0)
-# - fastmcp-agent: FastMCP service with mesh integration (mcpmesh/python-runtime:2.7.0)
-# - dependent-agent: Service that depends on fastmcp-agent (mcpmesh/python-runtime:2.7.0)
-# - fastapi-app: FastAPI application with mesh integration (mcpmesh/python-runtime:2.7.0)
+# - registry: Go-based registry with SQLite storage (mcpmesh/registry:2.8.0)
+# - hello-world-agent: Python agent with greeting capabilities (mcpmesh/python-runtime:2.8.0)
+# - system-agent: Python agent with system monitoring capabilities (mcpmesh/python-runtime:2.8.0)
+# - fastmcp-agent: FastMCP service with mesh integration (mcpmesh/python-runtime:2.8.0)
+# - dependent-agent: Service that depends on fastmcp-agent (mcpmesh/python-runtime:2.8.0)
+# - fastapi-app: FastAPI application with mesh integration (mcpmesh/python-runtime:2.8.0)
 #
 # Usage:
 #   docker-compose up

--- a/examples/java/benchmark-chain/svc-a/pom.xml
+++ b/examples/java/benchmark-chain/svc-a/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-b/pom.xml
+++ b/examples/java/benchmark-chain/svc-b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-c/pom.xml
+++ b/examples/java/benchmark-chain/svc-c/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-d/pom.xml
+++ b/examples/java/benchmark-chain/svc-d/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-e/pom.xml
+++ b/examples/java/benchmark-chain/svc-e/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.1.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/jobs-java/event-aware-consumer-java/pom.xml
+++ b/examples/jobs-java/event-aware-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.1.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/event-aware-provider-java/pom.xml
+++ b/examples/jobs-java/event-aware-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>2.1.0</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/long-task-consumer-java/pom.xml
+++ b/examples/jobs-java/long-task-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/long-task-provider-java/pom.xml
+++ b/examples/jobs-java/long-task-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-claude-java/pom.xml
+++ b/examples/parallel-tools/consumer-claude-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>1.4.1</mcp-mesh.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/required-dependency/README.md
+++ b/examples/required-dependency/README.md
@@ -1,0 +1,81 @@
+# Required Dependency Example (Issue #1249)
+
+A minimal, runnable example of a `required=true` dependency edge, mirrored in
+Python and Java. It shows the difference between the default **soft-fail**
+behavior (an unresolved dependency injects `None`/`null`) and an edge marked
+**required**, where the depending capability is only *available* while its
+dependency has a healthy provider.
+
+| Agent             | Capability     | Depends on                       |
+|-------------------|----------------|----------------------------------|
+| `data-provider`   | `data_service` | —                                |
+| `report-consumer` | `report`       | `data_service` (**required**)    |
+
+## What `required=true` does
+
+By default a dependency is optional: if it does not resolve, `None`/`null` is
+injected and the agent still starts, registers, and serves. Marking an edge
+`required` opts that single edge into strictness:
+
+- The registry computes **capability availability** transitively — `report` is
+  *available* only while `data_service` has a healthy provider. When the
+  provider goes down, `report` is excluded from resolution exactly like an
+  unhealthy provider, and any consumer holding a proxy to it sees the proxy
+  flip to `None`/`null` through the normal dependency-update channel (no code
+  change, no SDK upgrade required).
+- For an HTTP `@mesh.route`/`@MeshRoute` perimeter, a required-but-unavailable
+  dependency makes the framework return **503** with
+  `{"error": "dependency_unavailable", "capability": "data_service"}` before
+  your handler runs.
+
+Optional edges never propagate strictness, so the soft-fail default is
+preserved everywhere you do not opt in. See `meshctl man dependency-injection`
+for the full availability, route-perimeter, and cycle-rule semantics.
+
+## Declaration syntax
+
+**Python** (`dict`-form dependency):
+
+```python
+@mesh.tool(
+    capability="report",
+    dependencies=[{"capability": "data_service", "required": True}],
+)
+async def build_report(data_service: mesh.McpMeshTool = None) -> dict: ...
+```
+
+**Java** (`@Selector`):
+
+```java
+@MeshTool(
+    capability = "report",
+    dependencies = @Selector(capability = "data_service", required = true)
+)
+public Map<String, Object> buildReport(McpMeshTool<Map<String, Object>> dataService) { ... }
+```
+
+## Run it (Python)
+
+```bash
+# Terminal 1 — provider
+meshctl start python/data-provider/main.py
+
+# Terminal 2 — consumer
+meshctl start python/report-consumer/main.py
+```
+
+Call `report` once both are healthy — `data_service` is injected and the report
+carries the source data. Now stop `data-provider`: after the missed-heartbeat
+debounce the registry marks `report` unavailable and the consumer's injected
+`data_service` proxy flips to `None`.
+
+## Run it (Java)
+
+```bash
+cd java/data-provider   && mvn spring-boot:run   # port 8090
+cd java/report-consumer && mvn spring-boot:run   # port 8091
+```
+
+Each agent directory also ships the full scaffolded file set (`Dockerfile`,
+`helm-values.yaml`, etc.) for Docker/Kubernetes deployment — see
+`meshctl man deployment`.

--- a/examples/required-dependency/java/data-provider/.dockerignore
+++ b/examples/required-dependency/java/data-provider/.dockerignore
@@ -1,0 +1,21 @@
+# Git
+.git
+.gitignore
+
+# Maven
+target/
+*.jar
+*.war
+
+# IDE
+.idea/
+.vscode/
+*.iml
+*.swp
+*.swo
+
+# OS
+.DS_Store
+
+# Documentation
+*.md

--- a/examples/required-dependency/java/data-provider/Dockerfile
+++ b/examples/required-dependency/java/data-provider/Dockerfile
@@ -1,0 +1,24 @@
+# Dockerfile for data-provider MCP Mesh agent (Java/Spring Boot)
+FROM mcpmesh/java-runtime:2.8.0
+
+WORKDIR /app
+
+# Switch to root to copy files
+USER root
+
+# Copy Maven config and source
+COPY pom.xml .
+COPY src/ src/
+
+# Build the application and set permissions
+RUN mvn package -DskipTests -q && chown -R mcp-mesh:mcp-mesh /app
+
+# Switch back to non-root user
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 8090
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["java", "-jar"], so CMD only needs the jar path
+CMD ["target/data-provider-1.0.0-SNAPSHOT.jar"]

--- a/examples/required-dependency/java/data-provider/README.md
+++ b/examples/required-dependency/java/data-provider/README.md
@@ -1,0 +1,71 @@
+# data-provider
+
+A MCP Mesh agent generated using `meshctl scaffold`.
+
+## Overview
+
+This is a Java/Spring Boot MCP Mesh agent.
+
+## Getting Started
+
+### Prerequisites
+
+- Java 17+
+- Maven 3.9+
+- MCP Mesh SDK
+
+### Running the Agent
+
+```bash
+mvn spring-boot:run
+```
+
+Or with meshctl:
+
+```bash
+meshctl start data-provider
+```
+
+The agent will start on port 8090 by default.
+
+## Project Structure
+
+```
+data-provider/
+├── pom.xml
+├── Dockerfile
+├── helm-values.yaml
+└── src/main/java/com/example/dataprovider/
+    └── DataProviderApplication.java
+```
+
+## Docker
+
+```bash
+# Build the image
+docker build -t data-provider:latest .
+
+# Run the container
+docker run -p 8090:8090 data-provider:latest
+```
+
+## Kubernetes
+
+```bash
+# Deploy using Helm
+helm install data-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
+  -n mcp-mesh \
+  -f helm-values.yaml \
+  --set image.repository=your-registry/data-provider \
+  --set image.tag=v1.0.0
+```
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- [Java SDK Reference](https://github.com/dhyansraj/mcp-mesh/tree/main/src/runtime/java)
+- Run `meshctl man decorators --java` for decorator reference
+
+## License
+
+MIT

--- a/examples/required-dependency/java/data-provider/README.md
+++ b/examples/required-dependency/java/data-provider/README.md
@@ -30,7 +30,7 @@ The agent will start on port 8090 by default.
 
 ## Project Structure
 
-```
+```text
 data-provider/
 ├── pom.xml
 ├── Dockerfile

--- a/examples/required-dependency/java/data-provider/helm-values.yaml
+++ b/examples/required-dependency/java/data-provider/helm-values.yaml
@@ -1,0 +1,41 @@
+# Helm values for deploying data-provider with mcp-mesh-agent chart
+# Usage: helm install data-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/data-provider
+  tag: "v1.0.0"
+  pullPolicy: IfNotPresent
+
+agent:
+  name: data-provider
+  runtime: java
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"
+
+# Optional: Secrets (creates a K8s Secret, injected via envFrom)
+# Uncomment to add — leaving commented avoids overriding base values
+# secrets:
+#   DATABASE_URL: "postgres://user:pass@host:5432/db"
+#   API_KEY: "your-api-key"

--- a/examples/required-dependency/java/data-provider/pom.xml
+++ b/examples/required-dependency/java/data-provider/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.dataprovider</groupId>
+    <artifactId>data-provider</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>DataProvider Agent</name>
+    <description>MCP Mesh agent</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web (for HTTP server) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.dataprovider.DataProviderApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/required-dependency/java/data-provider/src/main/java/com/example/dataprovider/DataProviderApplication.java
+++ b/examples/required-dependency/java/data-provider/src/main/java/com/example/dataprovider/DataProviderApplication.java
@@ -1,0 +1,127 @@
+package com.example.dataprovider;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.types.McpMeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.MediaParam;
+import io.mcpmesh.spring.media.MeshMedia;
+import io.mcpmesh.spring.media.MediaStore;
+import io.modelcontextprotocol.spec.McpSchema.ResourceLink;
+import io.mcpmesh.Selector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * DataProvider - MCP Mesh Agent
+ *
+ * A MCP Mesh agent generated using meshctl scaffold.
+ */
+@MeshAgent(
+    name = "data-provider",
+    version = "1.0.0",
+    description = "MCP Mesh agent",
+    port = 8090
+)
+@SpringBootApplication
+public class DataProviderApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(DataProviderApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting DataProvider Agent...");
+        SpringApplication.run(DataProviderApplication.class, args);
+    }
+
+    /**
+     * Provide source data that the report consumer depends on.
+     *
+     * @return A row of source data.
+     */
+    @MeshTool(
+        capability = "data_service",
+        description = "Returns a row of source data for reports",
+        tags = {"data"}
+    )
+    public java.util.Map<String, Object> dataService() {
+        return java.util.Map.of("revenue", 1250, "currency", "USD", "region", "emea");
+    }
+
+    // ===== MULTI-PARAMETER EXAMPLE (uncomment and adapt) =====
+    //
+    // @MeshTool methods can accept multiple typed parameters.
+    // The mesh SDK generates JSON Schema from the @Param annotations.
+    //
+    // @MeshTool(
+    //     capability = "process",
+    //     description = "Process data with options",
+    //     tags = {"tools"}
+    // )
+    // public String process(
+    //     @Param(value = "text", description = "Text to process") String text,
+    //     @Param(value = "count", description = "Repeat count") int count,
+    //     @Param(value = "threshold", description = "Score threshold") double threshold,
+    //     @Param(value = "verbose", description = "Verbose output", required = false) boolean verbose
+    // ) {
+    //     return "Processed: " + text;
+    // }
+
+    // ===== DEPENDENCY INJECTION EXAMPLE (uncomment and adapt) =====
+    //
+    // Declare dependencies to call tools on other agents in the mesh.
+    // The mesh runtime injects McpMeshTool instances for each dependency.
+    //
+    // @MeshTool(
+    //     capability = "orchestrate",
+    //     description = "Calls another agent's tool",
+    //     tags = {"tools"},
+    //     dependencies = @Selector(capability = "calculator")
+    // )
+    // public String orchestrate(
+    //     @Param(value = "expression", description = "Math expression") String expression,
+    //     McpMeshTool<String> calculator                // injected by mesh
+    // ) {
+    //     if (!calculator.isAvailable()) {
+    //         return "calculator dependency not available";
+    //     }
+    //     String result = calculator.call(java.util.Map.of("expression", expression));
+    //     return "Calculator says: " + result;
+    // }
+
+    // ===== RETURN TYPE EXAMPLES =====
+    //
+    // Tools can return complex types. The SDK serializes them to JSON.
+    //
+    // public record ProcessResult(String output, int tokenCount) {}
+    //
+    // @MeshTool(capability = "analyze", description = "Analyze text", tags = {"tools"})
+    // public ProcessResult analyze(@Param(value = "text", description = "Text") String text) {
+    //     return new ProcessResult("analyzed: " + text, text.length());
+    // }
+
+    // ===== MULTIMODAL EXAMPLE (uncomment and adapt) =====
+    //
+    // Return media (images, PDFs, files) from tools using MeshMedia.
+    // LLMs automatically resolve resource_link objects to native image blocks.
+    //
+    // @MeshTool(capability = "chart_gen", description = "Generate a chart", tags = {"tools"})
+    // public ResourceLink generateChart(
+    //     @Param(value = "query", description = "Chart query") String query,
+    //     MediaStore mediaStore
+    // ) {
+    //     byte[] png = renderChart(query);
+    //     return MeshMedia.mediaResult(png, "chart.png", "image/png", mediaStore);
+    // }
+    //
+    // Accept media URIs with @MediaParam:
+    //
+    // @MeshTool(capability = "image_analyzer", description = "Analyze an image", tags = {"tools"})
+    // public String analyzeImage(
+    //     @Param(value = "question", description = "Question about the image") String question,
+    //     @MediaParam("image/*") @Param(value = "image", description = "Image URI") String imageUri
+    // ) {
+    //     return "Received image: " + imageUri;
+    // }
+}

--- a/examples/required-dependency/java/data-provider/src/main/resources/application.yml
+++ b/examples/required-dependency/java/data-provider/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${MCP_MESH_HTTP_PORT:8090}
+
+spring:
+  main:
+    banner-mode: off
+
+logging:
+  level:
+    root: INFO
+    io.mcpmesh: DEBUG

--- a/examples/required-dependency/java/report-consumer/.dockerignore
+++ b/examples/required-dependency/java/report-consumer/.dockerignore
@@ -1,0 +1,21 @@
+# Git
+.git
+.gitignore
+
+# Maven
+target/
+*.jar
+*.war
+
+# IDE
+.idea/
+.vscode/
+*.iml
+*.swp
+*.swo
+
+# OS
+.DS_Store
+
+# Documentation
+*.md

--- a/examples/required-dependency/java/report-consumer/Dockerfile
+++ b/examples/required-dependency/java/report-consumer/Dockerfile
@@ -1,0 +1,24 @@
+# Dockerfile for report-consumer MCP Mesh agent (Java/Spring Boot)
+FROM mcpmesh/java-runtime:2.8.0
+
+WORKDIR /app
+
+# Switch to root to copy files
+USER root
+
+# Copy Maven config and source
+COPY pom.xml .
+COPY src/ src/
+
+# Build the application and set permissions
+RUN mvn package -DskipTests -q && chown -R mcp-mesh:mcp-mesh /app
+
+# Switch back to non-root user
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 8091
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["java", "-jar"], so CMD only needs the jar path
+CMD ["target/report-consumer-1.0.0-SNAPSHOT.jar"]

--- a/examples/required-dependency/java/report-consumer/README.md
+++ b/examples/required-dependency/java/report-consumer/README.md
@@ -1,0 +1,71 @@
+# report-consumer
+
+A MCP Mesh agent generated using `meshctl scaffold`.
+
+## Overview
+
+This is a Java/Spring Boot MCP Mesh agent.
+
+## Getting Started
+
+### Prerequisites
+
+- Java 17+
+- Maven 3.9+
+- MCP Mesh SDK
+
+### Running the Agent
+
+```bash
+mvn spring-boot:run
+```
+
+Or with meshctl:
+
+```bash
+meshctl start report-consumer
+```
+
+The agent will start on port 8091 by default.
+
+## Project Structure
+
+```
+report-consumer/
+├── pom.xml
+├── Dockerfile
+├── helm-values.yaml
+└── src/main/java/com/example/reportconsumer/
+    └── ReportConsumerApplication.java
+```
+
+## Docker
+
+```bash
+# Build the image
+docker build -t report-consumer:latest .
+
+# Run the container
+docker run -p 8091:8091 report-consumer:latest
+```
+
+## Kubernetes
+
+```bash
+# Deploy using Helm
+helm install report-consumer oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
+  -n mcp-mesh \
+  -f helm-values.yaml \
+  --set image.repository=your-registry/report-consumer \
+  --set image.tag=v1.0.0
+```
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- [Java SDK Reference](https://github.com/dhyansraj/mcp-mesh/tree/main/src/runtime/java)
+- Run `meshctl man decorators --java` for decorator reference
+
+## License
+
+MIT

--- a/examples/required-dependency/java/report-consumer/README.md
+++ b/examples/required-dependency/java/report-consumer/README.md
@@ -30,7 +30,7 @@ The agent will start on port 8091 by default.
 
 ## Project Structure
 
-```
+```text
 report-consumer/
 ├── pom.xml
 ├── Dockerfile

--- a/examples/required-dependency/java/report-consumer/helm-values.yaml
+++ b/examples/required-dependency/java/report-consumer/helm-values.yaml
@@ -1,0 +1,41 @@
+# Helm values for deploying report-consumer with mcp-mesh-agent chart
+# Usage: helm install report-consumer oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/report-consumer
+  tag: "v1.0.0"
+  pullPolicy: IfNotPresent
+
+agent:
+  name: report-consumer
+  runtime: java
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"
+
+# Optional: Secrets (creates a K8s Secret, injected via envFrom)
+# Uncomment to add — leaving commented avoids overriding base values
+# secrets:
+#   DATABASE_URL: "postgres://user:pass@host:5432/db"
+#   API_KEY: "your-api-key"

--- a/examples/required-dependency/java/report-consumer/pom.xml
+++ b/examples/required-dependency/java/report-consumer/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.reportconsumer</groupId>
+    <artifactId>report-consumer</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>ReportConsumer Agent</name>
+    <description>MCP Mesh agent</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.8.0</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web (for HTTP server) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.reportconsumer.ReportConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/required-dependency/java/report-consumer/src/main/java/com/example/reportconsumer/ReportConsumerApplication.java
+++ b/examples/required-dependency/java/report-consumer/src/main/java/com/example/reportconsumer/ReportConsumerApplication.java
@@ -1,0 +1,139 @@
+package com.example.reportconsumer;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.types.McpMeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.MediaParam;
+import io.mcpmesh.spring.media.MeshMedia;
+import io.mcpmesh.spring.media.MediaStore;
+import io.modelcontextprotocol.spec.McpSchema.ResourceLink;
+import io.mcpmesh.Selector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * ReportConsumer - MCP Mesh Agent
+ *
+ * A MCP Mesh agent generated using meshctl scaffold.
+ */
+@MeshAgent(
+    name = "report-consumer",
+    version = "1.0.0",
+    description = "MCP Mesh agent",
+    port = 8091
+)
+@SpringBootApplication
+public class ReportConsumerApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(ReportConsumerApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting ReportConsumer Agent...");
+        SpringApplication.run(ReportConsumerApplication.class, args);
+    }
+
+    /**
+     * Build a report from the required data_service.
+     *
+     * <p>The {@code @Selector(required = true)} edge opts this capability into
+     * transitive availability: the mesh runtime only keeps {@code report}
+     * available while a healthy {@code data_service} provider exists, so
+     * {@code dataService} is expected to be injected here.
+     *
+     * @param dataService injected required dependency
+     * @return the assembled report
+     */
+    @MeshTool(
+        capability = "report",
+        description = "Builds a report from the required data_service",
+        tags = {"reports"},
+        dependencies = @Selector(capability = "data_service", required = true)
+    )
+    public java.util.Map<String, Object> buildReport(
+        McpMeshTool<java.util.Map<String, Object>> dataService
+    ) {
+        Object source = dataService.isAvailable()
+            ? dataService.call(java.util.Map.of())
+            : java.util.Map.of();
+        return java.util.Map.of("report", "revenue-summary", "source", source);
+    }
+
+    // ===== MULTI-PARAMETER EXAMPLE (uncomment and adapt) =====
+    //
+    // @MeshTool methods can accept multiple typed parameters.
+    // The mesh SDK generates JSON Schema from the @Param annotations.
+    //
+    // @MeshTool(
+    //     capability = "process",
+    //     description = "Process data with options",
+    //     tags = {"tools"}
+    // )
+    // public String process(
+    //     @Param(value = "text", description = "Text to process") String text,
+    //     @Param(value = "count", description = "Repeat count") int count,
+    //     @Param(value = "threshold", description = "Score threshold") double threshold,
+    //     @Param(value = "verbose", description = "Verbose output", required = false) boolean verbose
+    // ) {
+    //     return "Processed: " + text;
+    // }
+
+    // ===== DEPENDENCY INJECTION EXAMPLE (uncomment and adapt) =====
+    //
+    // Declare dependencies to call tools on other agents in the mesh.
+    // The mesh runtime injects McpMeshTool instances for each dependency.
+    //
+    // @MeshTool(
+    //     capability = "orchestrate",
+    //     description = "Calls another agent's tool",
+    //     tags = {"tools"},
+    //     dependencies = @Selector(capability = "calculator")
+    // )
+    // public String orchestrate(
+    //     @Param(value = "expression", description = "Math expression") String expression,
+    //     McpMeshTool<String> calculator                // injected by mesh
+    // ) {
+    //     if (!calculator.isAvailable()) {
+    //         return "calculator dependency not available";
+    //     }
+    //     String result = calculator.call(java.util.Map.of("expression", expression));
+    //     return "Calculator says: " + result;
+    // }
+
+    // ===== RETURN TYPE EXAMPLES =====
+    //
+    // Tools can return complex types. The SDK serializes them to JSON.
+    //
+    // public record ProcessResult(String output, int tokenCount) {}
+    //
+    // @MeshTool(capability = "analyze", description = "Analyze text", tags = {"tools"})
+    // public ProcessResult analyze(@Param(value = "text", description = "Text") String text) {
+    //     return new ProcessResult("analyzed: " + text, text.length());
+    // }
+
+    // ===== MULTIMODAL EXAMPLE (uncomment and adapt) =====
+    //
+    // Return media (images, PDFs, files) from tools using MeshMedia.
+    // LLMs automatically resolve resource_link objects to native image blocks.
+    //
+    // @MeshTool(capability = "chart_gen", description = "Generate a chart", tags = {"tools"})
+    // public ResourceLink generateChart(
+    //     @Param(value = "query", description = "Chart query") String query,
+    //     MediaStore mediaStore
+    // ) {
+    //     byte[] png = renderChart(query);
+    //     return MeshMedia.mediaResult(png, "chart.png", "image/png", mediaStore);
+    // }
+    //
+    // Accept media URIs with @MediaParam:
+    //
+    // @MeshTool(capability = "image_analyzer", description = "Analyze an image", tags = {"tools"})
+    // public String analyzeImage(
+    //     @Param(value = "question", description = "Question about the image") String question,
+    //     @MediaParam("image/*") @Param(value = "image", description = "Image URI") String imageUri
+    // ) {
+    //     return "Received image: " + imageUri;
+    // }
+}

--- a/examples/required-dependency/java/report-consumer/src/main/resources/application.yml
+++ b/examples/required-dependency/java/report-consumer/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${MCP_MESH_HTTP_PORT:8091}
+
+spring:
+  main:
+    banner-mode: off
+
+logging:
+  level:
+    root: INFO
+    io.mcpmesh: DEBUG

--- a/examples/required-dependency/python/data-provider/.dockerignore
+++ b/examples/required-dependency/python/data-provider/.dockerignore
@@ -1,0 +1,51 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Documentation
+docs/_build/
+*.md
+
+# Local files
+*.local
+.DS_Store

--- a/examples/required-dependency/python/data-provider/Dockerfile
+++ b/examples/required-dependency/python/data-provider/Dockerfile
@@ -1,0 +1,25 @@
+# Dockerfile for data-provider MCP Mesh agent
+FROM mcpmesh/python-runtime:2.8.0
+
+WORKDIR /app
+
+# Switch to root to copy files (base image runs as non-root mcp-mesh user)
+USER root
+
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy agent source code and set permissions
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
+
+# Switch back to non-root user for security
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 8080
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["python"], so CMD only needs the script name
+CMD ["main.py"]

--- a/examples/required-dependency/python/data-provider/README.md
+++ b/examples/required-dependency/python/data-provider/README.md
@@ -1,0 +1,88 @@
+# data-provider
+
+A MCP Mesh agent generated using `meshctl scaffold`.
+
+## Overview
+
+This is a basic MCP Mesh agent that provides simple tools for demonstration.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.11+
+- MCP Mesh SDK
+- FastMCP
+
+### Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+### Running the Agent
+
+```bash
+meshctl start main.py
+```
+
+Or with debug logging:
+
+```bash
+meshctl start main.py --debug
+```
+
+The agent will start on port 8080 by default.
+
+To override the port, modify the `http_port` parameter in the `@mesh.agent` decorator.
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `data_service` | Returns a row of source data for reports |
+
+## Project Structure
+
+```
+data-provider/
+├── __init__.py        # Package init
+├── __main__.py        # Module entry point
+├── main.py            # Agent implementation
+├── requirements.txt   # Python dependencies
+├── Dockerfile         # Container image definition for local docker compose / k8s
+├── .dockerignore      # Files to exclude from docker build context
+├── helm-values.yaml   # Values for the mcp-mesh-agent Helm chart deployment
+└── README.md          # This file
+```
+
+## Docker
+
+```bash
+# Build the image
+docker build -t data-provider:latest .
+
+# Run the container
+docker run -p 8080:8080 data-provider:latest
+```
+
+## Kubernetes
+
+```bash
+# Deploy using Helm
+helm install data-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
+  -n mcp-mesh \
+  -f helm-values.yaml \
+  --set image.repository=your-registry/data-provider \
+  --set image.tag=v1.0.0
+```
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- [Python SDK Reference](https://github.com/dhyansraj/mcp-mesh/tree/main/src/runtime/python)
+- Run `meshctl man decorators` for decorator reference
+
+## License
+
+MIT

--- a/examples/required-dependency/python/data-provider/README.md
+++ b/examples/required-dependency/python/data-provider/README.md
@@ -4,7 +4,10 @@ A MCP Mesh agent generated using `meshctl scaffold`.
 
 ## Overview
 
-This is a basic MCP Mesh agent that provides simple tools for demonstration.
+Provider half of the `required=true` example: it publishes the `data_service`
+capability that `report-consumer` declares as a required dependency. While this
+agent is healthy the consumer's `report` capability stays available; stop it and
+the consumer's required dependency goes unavailable.
 
 ## Getting Started
 
@@ -44,7 +47,7 @@ To override the port, modify the `http_port` parameter in the `@mesh.agent` deco
 
 ## Project Structure
 
-```
+```text
 data-provider/
 ├── __init__.py        # Package init
 ├── __main__.py        # Module entry point

--- a/examples/required-dependency/python/data-provider/__init__.py
+++ b/examples/required-dependency/python/data-provider/__init__.py
@@ -1,0 +1,1 @@
+"""DataProvider Agent - MCP Mesh agent."""

--- a/examples/required-dependency/python/data-provider/__main__.py
+++ b/examples/required-dependency/python/data-provider/__main__.py
@@ -1,0 +1,3 @@
+"""Entry point for `python -m data_provider`."""
+
+from . import main  # noqa: F401 — importing `main` triggers the @mesh.agent decorator

--- a/examples/required-dependency/python/data-provider/helm-values.yaml
+++ b/examples/required-dependency/python/data-provider/helm-values.yaml
@@ -1,0 +1,44 @@
+# Helm values for deploying data-provider with mcp-mesh-agent chart
+# Usage: helm install data-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/data-provider
+  tag: "v1.0.0"  # Your image version. Override with: --set image.tag=v1.2.3
+  pullPolicy: IfNotPresent
+
+agent:
+  name: data-provider
+  runtime: python
+  # K8s uses port 8080 by default (each pod has its own IP, no conflicts)
+  # http:
+  #   port: 8080
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"
+
+# Optional: Secrets (creates a K8s Secret, injected via envFrom)
+# Uncomment to add — leaving commented avoids overriding base values
+# secrets:
+#   DATABASE_URL: "postgres://user:pass@host:5432/db"
+#   API_KEY: "your-api-key"

--- a/examples/required-dependency/python/data-provider/main.py
+++ b/examples/required-dependency/python/data-provider/main.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+data-provider - MCP Mesh Agent
+
+A MCP Mesh agent generated using meshctl scaffold.
+"""
+
+from typing import Any
+
+import mesh
+from fastmcp import FastMCP
+
+# FastMCP server instance
+app = FastMCP("DataProvider Service")
+
+
+# ===== TOOLS =====
+
+@app.tool()
+@mesh.tool(
+    capability="data_service",
+    description="Returns a row of source data for reports",
+    tags=["data"],
+)
+async def data_service() -> dict:
+    """
+    Provide source data that the report consumer depends on.
+
+    Returns:
+        A dict of sample data.
+    """
+    return {"revenue": 1250, "currency": "USD", "region": "emea"}
+
+
+# ===== TOOL PARAMETER EXAMPLES (uncomment and adapt) =====
+#
+# Tool functions can accept typed parameters. The mesh SDK generates
+# JSON Schema from the type hints automatically.
+#
+# @app.tool()
+# @mesh.tool(capability="process", description="Process data", tags=["tools"])
+# async def process(
+#     text: str,                          # required string
+#     count: int = 1,                     # optional int with default
+#     threshold: float = 0.5,             # optional float with default
+#     verbose: bool = False,              # optional boolean with default
+# ) -> str:
+#     return f"Processed {text} x{count}"
+
+
+# ===== DEPENDENCY INJECTION EXAMPLE (uncomment and adapt) =====
+#
+# Declare dependencies to call tools on other agents in the mesh.
+# The mesh runtime injects McpMeshTool instances by keyword name.
+#
+# @app.tool()
+# @mesh.tool(
+#     capability="orchestrate",
+#     description="Calls another agent's tool",
+#     tags=["tools"],
+#     dependencies=["calculator"],          # declare dependency on "calculator" capability
+# )
+# async def orchestrate(
+#     input_text: str,
+#     calculator: mesh.McpMeshTool = None,  # injected by mesh (matches dependency name)
+# ) -> str:
+#     if calculator is None:
+#         return "calculator dependency not available"
+#     result = await calculator({"expression": "2 + 2"})
+#     return f"Calculator says: {result}"
+
+
+# ===== MULTIMODAL EXAMPLE (uncomment and adapt) =====
+#
+# Return media (images, PDFs, files) from tools using MediaResult.
+# The LLM automatically resolves resource_link objects to native image blocks.
+#
+# @app.tool()
+# @mesh.tool(capability="chart_gen", description="Generate a chart", tags=["tools"])
+# async def generate_chart(query: str) -> ResourceLink:
+#     png_bytes = render_chart(query)
+#     return await mesh.MediaResult(
+#         data=png_bytes, filename="chart.png", mime_type="image/png",
+#         name="Chart", description=query,
+#     )
+#
+# Accept media URIs with MediaParam type hints:
+#
+# @app.tool()
+# @mesh.tool(capability="image_analyzer", description="Analyze an image", tags=["tools"])
+# async def analyze_image(
+#     question: str,
+#     image: mesh.MediaParam("image/*") = None,
+#     llm: mesh.MeshLlmAgent = None,
+# ) -> str:
+#     media = [image] if image else []
+#     return await llm(question, media=media)
+
+
+@mesh.agent(
+    name="data-provider",
+    version="1.0.0",
+    description="MCP Mesh agent for data-provider",
+    http_port=8080,
+    enable_http=True,
+    auto_run=True,
+)
+class DataProviderAgent:
+    """
+    Agent class that configures how mesh should run the FastMCP server.
+
+    The mesh processor will:
+    1. Discover the 'app' FastMCP instance
+    2. Apply dependency injection to decorated functions
+    3. Start the FastMCP HTTP server on the configured port
+    4. Register all capabilities with the mesh registry
+    """
+
+    pass
+
+
+# No main method needed!
+# Mesh processor automatically handles:
+# - FastMCP server discovery and startup
+# - Dependency injection between functions
+# - HTTP server configuration
+# - Service registration with mesh registry

--- a/examples/required-dependency/python/data-provider/requirements.txt
+++ b/examples/required-dependency/python/data-provider/requirements.txt
@@ -1,0 +1,3 @@
+# data-provider dependencies
+# Add your third-party dependencies here
+# Note: mcp-mesh is provided by the runtime environment (local venv or Docker base image)

--- a/examples/required-dependency/python/report-consumer/.dockerignore
+++ b/examples/required-dependency/python/report-consumer/.dockerignore
@@ -1,0 +1,51 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Documentation
+docs/_build/
+*.md
+
+# Local files
+*.local
+.DS_Store

--- a/examples/required-dependency/python/report-consumer/Dockerfile
+++ b/examples/required-dependency/python/report-consumer/Dockerfile
@@ -1,0 +1,25 @@
+# Dockerfile for report-consumer MCP Mesh agent
+FROM mcpmesh/python-runtime:2.8.0
+
+WORKDIR /app
+
+# Switch to root to copy files (base image runs as non-root mcp-mesh user)
+USER root
+
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy agent source code and set permissions
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
+
+# Switch back to non-root user for security
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 8081
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["python"], so CMD only needs the script name
+CMD ["main.py"]

--- a/examples/required-dependency/python/report-consumer/README.md
+++ b/examples/required-dependency/python/report-consumer/README.md
@@ -1,0 +1,88 @@
+# report-consumer
+
+A MCP Mesh agent generated using `meshctl scaffold`.
+
+## Overview
+
+This is a basic MCP Mesh agent that provides simple tools for demonstration.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.11+
+- MCP Mesh SDK
+- FastMCP
+
+### Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+### Running the Agent
+
+```bash
+meshctl start main.py
+```
+
+Or with debug logging:
+
+```bash
+meshctl start main.py --debug
+```
+
+The agent will start on port 8081 by default.
+
+To override the port, modify the `http_port` parameter in the `@mesh.agent` decorator.
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `report` | Builds a report from the required data_service |
+
+## Project Structure
+
+```
+report-consumer/
+├── __init__.py        # Package init
+├── __main__.py        # Module entry point
+├── main.py            # Agent implementation
+├── requirements.txt   # Python dependencies
+├── Dockerfile         # Container image definition for local docker compose / k8s
+├── .dockerignore      # Files to exclude from docker build context
+├── helm-values.yaml   # Values for the mcp-mesh-agent Helm chart deployment
+└── README.md          # This file
+```
+
+## Docker
+
+```bash
+# Build the image
+docker build -t report-consumer:latest .
+
+# Run the container
+docker run -p 8081:8081 report-consumer:latest
+```
+
+## Kubernetes
+
+```bash
+# Deploy using Helm
+helm install report-consumer oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
+  -n mcp-mesh \
+  -f helm-values.yaml \
+  --set image.repository=your-registry/report-consumer \
+  --set image.tag=v1.0.0
+```
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- [Python SDK Reference](https://github.com/dhyansraj/mcp-mesh/tree/main/src/runtime/python)
+- Run `meshctl man decorators` for decorator reference
+
+## License
+
+MIT

--- a/examples/required-dependency/python/report-consumer/README.md
+++ b/examples/required-dependency/python/report-consumer/README.md
@@ -44,7 +44,7 @@ To override the port, modify the `http_port` parameter in the `@mesh.agent` deco
 
 ## Project Structure
 
-```
+```text
 report-consumer/
 ├── __init__.py        # Package init
 ├── __main__.py        # Module entry point

--- a/examples/required-dependency/python/report-consumer/__init__.py
+++ b/examples/required-dependency/python/report-consumer/__init__.py
@@ -1,0 +1,1 @@
+"""ReportConsumer Agent - MCP Mesh agent."""

--- a/examples/required-dependency/python/report-consumer/__main__.py
+++ b/examples/required-dependency/python/report-consumer/__main__.py
@@ -1,0 +1,3 @@
+"""Entry point for `python -m report_consumer`."""
+
+from . import main  # noqa: F401 — importing `main` triggers the @mesh.agent decorator

--- a/examples/required-dependency/python/report-consumer/helm-values.yaml
+++ b/examples/required-dependency/python/report-consumer/helm-values.yaml
@@ -10,9 +10,10 @@ image:
 agent:
   name: report-consumer
   runtime: python
-  # K8s uses port 8080 by default (each pod has its own IP, no conflicts)
-  # http:
-  #   port: 8080
+  # This agent listens on 8081 (see @mesh.agent http_port in main.py and the
+  # Dockerfile EXPOSE) — keep the chart's port in sync so the Service targets it.
+  http:
+    port: 8081
 
 resources:
   limits:

--- a/examples/required-dependency/python/report-consumer/helm-values.yaml
+++ b/examples/required-dependency/python/report-consumer/helm-values.yaml
@@ -1,0 +1,44 @@
+# Helm values for deploying report-consumer with mcp-mesh-agent chart
+# Usage: helm install report-consumer oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/report-consumer
+  tag: "v1.0.0"  # Your image version. Override with: --set image.tag=v1.2.3
+  pullPolicy: IfNotPresent
+
+agent:
+  name: report-consumer
+  runtime: python
+  # K8s uses port 8080 by default (each pod has its own IP, no conflicts)
+  # http:
+  #   port: 8080
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"
+
+# Optional: Secrets (creates a K8s Secret, injected via envFrom)
+# Uncomment to add — leaving commented avoids overriding base values
+# secrets:
+#   DATABASE_URL: "postgres://user:pass@host:5432/db"
+#   API_KEY: "your-api-key"

--- a/examples/required-dependency/python/report-consumer/main.py
+++ b/examples/required-dependency/python/report-consumer/main.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+report-consumer - MCP Mesh Agent
+
+A MCP Mesh agent generated using meshctl scaffold.
+"""
+
+from typing import Any
+
+import mesh
+from fastmcp import FastMCP
+
+# FastMCP server instance
+app = FastMCP("ReportConsumer Service")
+
+
+# ===== TOOLS =====
+
+@app.tool()
+@mesh.tool(
+    capability="report",
+    description="Builds a report from the required data_service",
+    tags=["reports"],
+    dependencies=[
+        # required=True: this capability is UNAVAILABLE whenever data_service
+        # has no healthy provider. The registry excludes it from resolution and
+        # (for @mesh.route) the perimeter returns 503 instead of injecting None.
+        {"capability": "data_service", "required": True},
+    ],
+)
+async def build_report(
+    data_service: mesh.McpMeshTool = None,
+) -> dict:
+    """
+    Build a report using the injected data_service.
+
+    Because the dependency is required, the mesh runtime only keeps this
+    capability available while a data_service provider is healthy, so
+    `data_service` is expected to be injected here.
+
+    Returns:
+        The assembled report.
+    """
+    source = await data_service() if data_service else {}
+    return {"report": "revenue-summary", "source": source}
+
+
+# ===== TOOL PARAMETER EXAMPLES (uncomment and adapt) =====
+#
+# Tool functions can accept typed parameters. The mesh SDK generates
+# JSON Schema from the type hints automatically.
+#
+# @app.tool()
+# @mesh.tool(capability="process", description="Process data", tags=["tools"])
+# async def process(
+#     text: str,                          # required string
+#     count: int = 1,                     # optional int with default
+#     threshold: float = 0.5,             # optional float with default
+#     verbose: bool = False,              # optional boolean with default
+# ) -> str:
+#     return f"Processed {text} x{count}"
+
+
+# ===== DEPENDENCY INJECTION EXAMPLE (uncomment and adapt) =====
+#
+# Declare dependencies to call tools on other agents in the mesh.
+# The mesh runtime injects McpMeshTool instances by keyword name.
+#
+# @app.tool()
+# @mesh.tool(
+#     capability="orchestrate",
+#     description="Calls another agent's tool",
+#     tags=["tools"],
+#     dependencies=["calculator"],          # declare dependency on "calculator" capability
+# )
+# async def orchestrate(
+#     input_text: str,
+#     calculator: mesh.McpMeshTool = None,  # injected by mesh (matches dependency name)
+# ) -> str:
+#     if calculator is None:
+#         return "calculator dependency not available"
+#     result = await calculator({"expression": "2 + 2"})
+#     return f"Calculator says: {result}"
+
+
+# ===== MULTIMODAL EXAMPLE (uncomment and adapt) =====
+#
+# Return media (images, PDFs, files) from tools using MediaResult.
+# The LLM automatically resolves resource_link objects to native image blocks.
+#
+# @app.tool()
+# @mesh.tool(capability="chart_gen", description="Generate a chart", tags=["tools"])
+# async def generate_chart(query: str) -> ResourceLink:
+#     png_bytes = render_chart(query)
+#     return await mesh.MediaResult(
+#         data=png_bytes, filename="chart.png", mime_type="image/png",
+#         name="Chart", description=query,
+#     )
+#
+# Accept media URIs with MediaParam type hints:
+#
+# @app.tool()
+# @mesh.tool(capability="image_analyzer", description="Analyze an image", tags=["tools"])
+# async def analyze_image(
+#     question: str,
+#     image: mesh.MediaParam("image/*") = None,
+#     llm: mesh.MeshLlmAgent = None,
+# ) -> str:
+#     media = [image] if image else []
+#     return await llm(question, media=media)
+
+
+@mesh.agent(
+    name="report-consumer",
+    version="1.0.0",
+    description="MCP Mesh agent for report-consumer",
+    http_port=8081,
+    enable_http=True,
+    auto_run=True,
+)
+class ReportConsumerAgent:
+    """
+    Agent class that configures how mesh should run the FastMCP server.
+
+    The mesh processor will:
+    1. Discover the 'app' FastMCP instance
+    2. Apply dependency injection to decorated functions
+    3. Start the FastMCP HTTP server on the configured port
+    4. Register all capabilities with the mesh registry
+    """
+
+    pass
+
+
+# No main method needed!
+# Mesh processor automatically handles:
+# - FastMCP server discovery and startup
+# - Dependency injection between functions
+# - HTTP server configuration
+# - Service registration with mesh registry

--- a/examples/required-dependency/python/report-consumer/requirements.txt
+++ b/examples/required-dependency/python/report-consumer/requirements.txt
@@ -1,0 +1,3 @@
+# report-consumer dependencies
+# Add your third-party dependencies here
+# Note: mcp-mesh is provided by the runtime environment (local venv or Docker base image)

--- a/examples/tutorial/trip-planner/day-08/python/docker-compose.yml
+++ b/examples/tutorial/trip-planner/day-08/python/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - trip-planner-network
 
   registry:
-    image: mcpmesh/registry:2.7.0
+    image: mcpmesh/registry:2.8.0
     container_name: trip-planner-registry
     hostname: registry
     ports:
@@ -81,7 +81,7 @@ services:
 
   # --8<-- [start:mesh_ui]
   mesh-ui:
-    image: mcpmesh/ui:2.7.0
+    image: mcpmesh/ui:2.8.0
     container_name: trip-planner-mesh-ui
     hostname: mesh-ui
     ports:
@@ -172,7 +172,7 @@ services:
   # --8<-- [start:gateway]
   # FastAPI Gateway: manually added (scaffold detects @mesh.agent, not @mesh.route)
   gateway:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: trip-planner-gateway
     hostname: gateway
     user: root
@@ -213,7 +213,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   adventure-advisor:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: trip-planner-adventure-advisor
     hostname: adventure-advisor
     user: root
@@ -256,7 +256,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   budget-analyst:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: trip-planner-budget-analyst
     hostname: budget-analyst
     user: root
@@ -299,7 +299,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   chat-history-agent:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: trip-planner-chat-history-agent
     hostname: chat-history-agent
     user: root
@@ -342,7 +342,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   claude-provider:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: trip-planner-claude-provider
     hostname: claude-provider
     user: root
@@ -386,7 +386,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   flight-agent:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: trip-planner-flight-agent
     hostname: flight-agent
     user: root
@@ -429,7 +429,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   hotel-agent:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: trip-planner-hotel-agent
     hostname: hotel-agent
     user: root
@@ -472,7 +472,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   logistics-planner:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: trip-planner-logistics-planner
     hostname: logistics-planner
     user: root
@@ -515,7 +515,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   openai-provider:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: trip-planner-openai-provider
     hostname: openai-provider
     user: root
@@ -559,7 +559,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   planner-agent:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: trip-planner-planner-agent
     hostname: planner-agent
     user: root
@@ -602,7 +602,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   poi-agent:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: trip-planner-poi-agent
     hostname: poi-agent
     user: root
@@ -645,7 +645,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   user-prefs-agent:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: trip-planner-user-prefs-agent
     hostname: user-prefs-agent
     user: root
@@ -688,7 +688,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   weather-agent:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: trip-planner-weather-agent
     hostname: weather-agent
     user: root

--- a/examples/typescript/benchmark-chain/svc-a/package.json
+++ b/examples/typescript/benchmark-chain/svc-a/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-b/package.json
+++ b/examples/typescript/benchmark-chain/svc-b/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-c/package.json
+++ b/examples/typescript/benchmark-chain/svc-c/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-d/package.json
+++ b/examples/typescript/benchmark-chain/svc-d/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-e/package.json
+++ b/examples/typescript/benchmark-chain/svc-e/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^1.1.0"
+    "@mcpmesh/sdk": "^2.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -45,7 +45,7 @@ image:
   repository: mcpmesh/python-runtime
   pullPolicy: IfNotPresent
   # Minor version tag tracks latest patch (0.8 → 0.8.x)
-  tag: "2.7"
+  tag: "2.8"
 
 # Pull secrets for this chart's pods, merged with global.imagePullSecrets
 # (deduplicated by name). Standard shape:

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -147,7 +147,7 @@ mcp-mesh-redis:
 mcp-mesh-registry:
   image:
     repository: mcpmesh/registry
-    tag: "2.7" # Minor version tracks latest patch
+    tag: "2.8" # Minor version tracks latest patch
   registry:
     # Database configuration (connects to PostgreSQL). The endpoint and
     # credentials are inherited from global.postgres above; set

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -15,7 +15,7 @@ image:
   repository: mcpmesh/registry
   pullPolicy: IfNotPresent
   # Minor version tag tracks latest patch (0.8 → 0.8.x)
-  tag: "2.7"
+  tag: "2.8"
 
 # Image for the wait-for-db init container (rendered for non-sqlite databases;
 # disable the init container via registry.database.waitForDatabase: false).

--- a/helm/mcp-mesh-ui/values.yaml
+++ b/helm/mcp-mesh-ui/values.yaml
@@ -7,7 +7,7 @@ image:
   registry: ""
   repository: mcpmesh/ui
   pullPolicy: IfNotPresent
-  tag: "2.7"
+  tag: "2.8"
 
 # Pull secrets for this chart's pods, merged with global.imagePullSecrets
 # (deduplicated by name). Standard shape:

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -1,7 +1,7 @@
 # MCP Mesh Python Package Configuration
 
 [build-system]
-requires = ["hatchling>=1.21.0,<1.30"]  # <1.30: hatchling 1.30.0 emits Metadata-Version 2.5 which twine rejects (revert when twine supports 2.5)
+requires = ["hatchling>=1.21.0"]
 build-backend = "hatchling.build"
 
 [project]

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -573,17 +573,19 @@ HANDLERS: list[Handler] = [
         ),
         replacement=r"\g<1>NEW",
     ),
-    # --- NEW: language_test.go uses the MINOR-tag form (e.g., :1.3) ------
-    # Minor tag — (?![\d.\-+]) prevents matching `:1.3` as the prefix of `:1.30` or `:1.3.0`.
+    # --- NEW: language_test.go pins the FULL release tag (e.g., :1.3.0) --
+    # TestPythonHandler_GetDockerImage / TestTypeScriptHandler_GetDockerImage
+    # assert the exact tag GetDockerImage() returns, so their expected literal
+    # must track the full version (was minor, which never matched the full tag
+    # the handlers return — the loose assertion missed the 2.8.0 partial bump).
     Handler(
-        name="Language Test Hardcoded Image Tags (minor version)",
+        name="Language Test Hardcoded Image Tags (full version)",
         globs=["src/core/cli/handlers/language_test.go"],
         pattern=(
             r"(mcpmesh/(?:registry|python-runtime|typescript-runtime"
             r"|java-runtime|ui|cli):)OLD(?![\d.\-+])"
         ),
         replacement=r"\g<1>NEW",
-        version_format="minor",
     ),
 ]
 
@@ -736,7 +738,12 @@ def _guard_patterns(old: str) -> list[re.Pattern]:
     return [
         re.compile(img + o + boundary),
         re.compile(r"mcp-mesh(?:>=|==)" + op),
-        re.compile(r"@mcpmesh/[^\"']*[\"']\^?" + o + boundary),
+        # package.json: "@mcpmesh/sdk": "^X" / "@mcpmesh/core": "X" (the key
+        # quote, ": ", then the value's opening quote sit between the package
+        # name and the version), plus the npm `@mcpmesh/sdk@^X` shorthand.
+        re.compile(
+            r"@mcpmesh/[^\"'@\s]+(?:[\"']\s*:\s*[\"']|@)\^?" + o + boundary
+        ),
         re.compile(r"<mcp-mesh\.version>" + o + r"</mcp-mesh\.version>"),
         re.compile(r"--version\s+v?" + o + boundary),
         re.compile(r'tag:\s*"' + o + r'"'),
@@ -744,12 +751,16 @@ def _guard_patterns(old: str) -> list[re.Pattern]:
     ]
 
 
-def coverage_guard(old: str) -> list[str]:
+def coverage_guard(old: str) -> tuple[bool, list[str]]:
     """Final safety net: after a bump, scan every tracked file for mesh-shaped
-    references that still carry the OLD version. Returns a list of
-    'path:lineno: text' survivors (empty = clean). Vendored trees
-    (node_modules) and history files are skipped; third-party version pins on
-    the same line are allowlisted."""
+    references that still carry the OLD version.
+
+    Returns ``(ran, survivors)``. ``ran`` is False when the scan could not
+    execute (git unavailable / errored) — the caller must fail closed rather
+    than treat that as clean. When ``ran`` is True, ``survivors`` is the list
+    of 'path:lineno: text' hits (empty = clean). Vendored trees (node_modules)
+    and history files are skipped; third-party version pins on the same line
+    are allowlisted."""
     try:
         out = subprocess.run(
             ["git", "ls-files"],
@@ -758,9 +769,8 @@ def coverage_guard(old: str) -> list[str]:
             text=True,
             check=True,
         ).stdout
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        print("⚠️  Coverage guard skipped: git not available.")
-        return []
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return (False, [])
 
     patterns = _guard_patterns(old)
     survivors: list[str] = []
@@ -778,7 +788,7 @@ def coverage_guard(old: str) -> list[str]:
                 continue
             if any(p.search(line) for p in patterns):
                 survivors.append(f"{rel}:{lineno}: {line.strip()}")
-    return survivors
+    return (True, survivors)
 
 
 # ---------------------------------------------------------------------------
@@ -885,8 +895,15 @@ def main() -> int:
     # Final step: verify no mesh-shaped reference to the OLD version survived.
     # Skipped on --dry-run (nothing was written, so every ref would "survive").
     if not dry_run:
-        survivors = coverage_guard(old)
+        ran, survivors = coverage_guard(old)
         print()
+        if not ran:
+            print(
+                "❌ Coverage guard did NOT run (git ls-files unavailable or "
+                "errored). Failing closed — cannot confirm the bump is "
+                "complete. Re-run from a git checkout with git on PATH."
+            )
+            return 1
         if survivors:
             print(
                 f"❌ Coverage guard: {len(survivors)} stale mesh-shaped "

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -24,6 +24,7 @@ Design:
 import argparse
 import os
 import re
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -147,6 +148,13 @@ def _glob_to_regex(pattern: str) -> re.Pattern:
     return re.compile("^" + "".join(parts) + "$")
 
 
+# Directory names never worth descending into: they hold no first-party
+# version pins we bump, but (especially node_modules) are enormous and, when
+# combined with the tutorial/example symlink webs, blow up the walk time.
+# Excludes still filter results defensively; pruning here is a pure speedup.
+_WALK_PRUNE_DIRS = frozenset({"node_modules", ".git", ".venv"})
+
+
 def _walk_files(base: Path):
     """Recursively yield every file under `base`, following symlinks but
     detecting cycles by tracking realpaths in the current ancestor chain.
@@ -154,6 +162,7 @@ def _walk_files(base: Path):
     Uses a stack so each branch carries its own ancestor set — multiple
     symlinks pointing to the same target are still each visited (we only
     skip a directory if descending would re-enter one of OUR ancestors).
+    Directories in `_WALK_PRUNE_DIRS` are not descended into.
     """
     if not base.exists():
         return
@@ -172,6 +181,8 @@ def _walk_files(base: Path):
                 if e.is_file(follow_symlinks=True):
                     yield Path(e.path)
                 elif e.is_dir(follow_symlinks=True):
+                    if e.name in _WALK_PRUNE_DIRS:
+                        continue
                     rp = os.path.realpath(e.path)
                     if rp in ancestors:
                         continue
@@ -309,12 +320,13 @@ HANDLERS: list[Handler] = [
         replacement=r"\g<1>NEW\2",
     ),
     # --- Category 6: Java Example POMs ------------------------------------
+    # Recurse the whole examples/ tree (multi-module examples nest POMs under
+    # subdirs like benchmark-chain/svc-a/pom.xml that the old two shallow
+    # globs missed). node_modules excluded defensively.
     Handler(
         name="Java Example POMs",
-        globs=[
-            "examples/java/*/pom.xml",
-            "examples/toolcalls/*/pom.xml",
-        ],
+        globs=["examples/**/pom.xml"],
+        excludes=["**/node_modules/**"],
         pattern=r"(<mcp-mesh\.version>)OLD(</mcp-mesh\.version>)",
         replacement=r"\g<1>NEW\2",
     ),
@@ -436,10 +448,15 @@ HANDLERS: list[Handler] = [
         pattern=r"(e\.g\.,\s*v)OLD",
         replacement=r"\g<1>NEW",
     ),
-    # --- Category 16: TypeScript Toolcall Examples -----------------------
+    # --- Category 16: TypeScript Example Packages (@mcpmesh/*) -----------
+    # Recurse the whole examples/ tree (was limited to toolcalls/*-ts). The
+    # version regex only matches pinned versions, so `file:` workspace refs
+    # (e.g. "@mcpmesh/sdk": "file:../..") are left untouched. node_modules
+    # excluded so vendored packages aren't rewritten.
     Handler(
-        name="TypeScript Toolcall Examples",
-        globs=["examples/toolcalls/*-ts/package.json"],
+        name="TypeScript Example Packages (@mcpmesh/*)",
+        globs=["examples/**/package.json"],
+        excludes=["**/node_modules/**"],
         # Match "@mcpmesh/x": "OLD" or "@mcpmesh/x": "^OLD" (replace with ^NEW)
         pattern=r'("@mcpmesh/[^"]+?":\s*")\^?OLD(")',
         replacement=r"\g<1>^NEW\2",
@@ -685,6 +702,86 @@ def bump_test_documentation(old: str, new: str, dry_run: bool) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Post-bump coverage guard
+# ---------------------------------------------------------------------------
+
+# Files whose stale version strings are intentional history, not live pins.
+_GUARD_ALLOWLIST_FILES = re.compile(r"(?:^|/)(?:RELEASE_NOTES\.md|CHANGELOG[^/]*)$")
+
+# Lines mentioning these third-party projects legitimately carry their OWN
+# versions, which can collide numerically with ours.
+_GUARD_ALLOWLIST_TOKENS = (
+    "spiffe",
+    "xyflow",
+    "python-dateutil",
+    "dateutil",
+    "grafana-tempo",
+    "grafana/tempo",
+    "/tempo:",
+    "tempo_",
+    "tempo/releases",
+)
+
+
+def _guard_patterns(old: str) -> list[re.Pattern]:
+    """Mesh-shaped contexts in which a surviving OLD version = a missed bump."""
+    o = re.escape(old)
+    om = re.escape(to_minor(old))
+    op = re.escape(to_pep440(old))
+    img = (
+        r"mcpmesh/(?:registry|python-runtime|typescript-runtime"
+        r"|java-runtime|ui|cli):"
+    )
+    boundary = r"(?![\d.\-+])"
+    return [
+        re.compile(img + o + boundary),
+        re.compile(r"mcp-mesh(?:>=|==)" + op),
+        re.compile(r"@mcpmesh/[^\"']*[\"']\^?" + o + boundary),
+        re.compile(r"<mcp-mesh\.version>" + o + r"</mcp-mesh\.version>"),
+        re.compile(r"--version\s+v?" + o + boundary),
+        re.compile(r'tag:\s*"' + o + r'"'),
+        re.compile(r'tag:\s*"' + om + r'"'),
+    ]
+
+
+def coverage_guard(old: str) -> list[str]:
+    """Final safety net: after a bump, scan every tracked file for mesh-shaped
+    references that still carry the OLD version. Returns a list of
+    'path:lineno: text' survivors (empty = clean). Vendored trees
+    (node_modules) and history files are skipped; third-party version pins on
+    the same line are allowlisted."""
+    try:
+        out = subprocess.run(
+            ["git", "ls-files"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("⚠️  Coverage guard skipped: git not available.")
+        return []
+
+    patterns = _guard_patterns(old)
+    survivors: list[str] = []
+    for rel in out.splitlines():
+        if not rel:
+            continue
+        if "node_modules/" in rel or _GUARD_ALLOWLIST_FILES.search(rel):
+            continue
+        try:
+            text = (PROJECT_ROOT / rel).read_text()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if any(tok in line for tok in _GUARD_ALLOWLIST_TOKENS):
+                continue
+            if any(p.search(line) for p in patterns):
+                survivors.append(f"{rel}:{lineno}: {line.strip()}")
+    return survivors
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -784,6 +881,25 @@ def main() -> int:
             "Reminder: run 'cargo generate-lockfile' in src/runtime/core "
             "to refresh Cargo.lock with the new mcp-mesh-core version"
         )
+
+    # Final step: verify no mesh-shaped reference to the OLD version survived.
+    # Skipped on --dry-run (nothing was written, so every ref would "survive").
+    if not dry_run:
+        survivors = coverage_guard(old)
+        print()
+        if survivors:
+            print(
+                f"❌ Coverage guard: {len(survivors)} stale mesh-shaped "
+                f"reference(s) to {old} survived the bump:"
+            )
+            for s in survivors:
+                print(f"  {s}")
+            print(
+                "Add or broaden a handler in scripts/bump_version.py to cover "
+                "these, then re-run."
+            )
+            return 1
+        print(f"✅ Coverage guard: no stale mesh-shaped references to {old} remain.")
 
     return 0
 

--- a/scripts/test_bump_version.py
+++ b/scripts/test_bump_version.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Lightweight checks for scripts/bump_version.py's coverage-guard regexes.
+
+Run directly (`python scripts/test_bump_version.py`) or via pytest. These
+exercise `_guard_patterns` against representative lines so a future edit that
+breaks mesh-shaped detection (like the @mcpmesh package.json form that the
+first cut of the guard silently missed) fails loudly.
+"""
+
+import importlib.util
+import pathlib
+
+_spec = importlib.util.spec_from_file_location(
+    "bump_version", pathlib.Path(__file__).with_name("bump_version.py")
+)
+bv = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bv)
+
+
+def _matches(old: str, line: str) -> bool:
+    return any(p.search(line) for p in bv._guard_patterns(old))
+
+
+def test_mcpmesh_package_json_forms():
+    old = "2.8.0"
+    # The form the first guard cut missed: version sits after `": "`, not
+    # immediately after the package-name quote.
+    assert _matches(old, '    "@mcpmesh/sdk": "^2.8.0"')       # caret, spaced
+    assert _matches(old, '    "@mcpmesh/core": "2.8.0"')       # no caret
+    assert _matches(old, '"@mcpmesh/sdk":"^2.8.0"')            # unspaced
+    assert _matches(old, "npm install @mcpmesh/sdk@^2.8.0")    # npm shorthand
+
+
+def test_other_mesh_contexts():
+    old = "2.8.0"
+    assert _matches(old, "FROM mcpmesh/python-runtime:2.8.0")
+    assert _matches(old, "        <mcp-mesh.version>2.8.0</mcp-mesh.version>")
+    assert _matches(old, "RUN pip install mcp-mesh>=2.8.0")
+    assert _matches(old, '  tag: "2.8.0"')
+    assert _matches(old, '  tag: "2.8"')  # minor-tag form
+
+
+def test_non_mesh_lines_ignored():
+    old = "2.8.0"
+    assert not _matches(old, '        "node": ">=12.8.0"')      # engines range
+    assert not _matches(old, 'version = "2.8.0"  # crate')      # third-party
+    assert not _matches(old, "FROM mcpmesh/python-runtime:2.8.01")  # boundary
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print(f"ok  {fn.__name__}")
+    print(f"\n{len(fns)} checks passed")

--- a/src/core/cli/handlers/java_handler.go
+++ b/src/core/cli/handlers/java_handler.go
@@ -79,7 +79,7 @@ func (h *JavaHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns Java Dockerfile content
 func (h *JavaHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh Java agent
-FROM mcpmesh/java-runtime:2.7.0
+FROM mcpmesh/java-runtime:2.8.0
 
 WORKDIR /app
 
@@ -156,7 +156,7 @@ func (h *JavaHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the Java runtime Docker image
 func (h *JavaHandler) GetDockerImage() string {
-	return "mcpmesh/java-runtime:2.7.0"
+	return "mcpmesh/java-runtime:2.8.0"
 }
 
 // ValidatePrerequisites checks Java environment

--- a/src/core/cli/handlers/language_test.go
+++ b/src/core/cli/handlers/language_test.go
@@ -398,10 +398,11 @@ func TestPythonHandler_GetDockerImage(t *testing.T) {
 	if image == "" {
 		t.Error("GetDockerImage() returned empty string")
 	}
-	// Should contain python
-	if image != "mcpmesh/python-runtime:2.8" && image != "mcpmesh/python-runtime:latest" {
-		// Just check it's not empty - version may vary
-		t.Logf("Docker image: %s", image)
+	// Must equal the exact release tag GetDockerImage() ships (kept in sync by
+	// scripts/bump_version.py). Hard failure, not a log — this is the assertion
+	// that should have caught the 2.8.0 partial bump.
+	if want := "mcpmesh/python-runtime:2.8.0"; image != want {
+		t.Errorf("GetDockerImage() = %q, want %q", image, want)
 	}
 }
 
@@ -411,10 +412,11 @@ func TestTypeScriptHandler_GetDockerImage(t *testing.T) {
 	if image == "" {
 		t.Error("GetDockerImage() returned empty string")
 	}
-	// Should contain typescript
-	if image != "mcpmesh/typescript-runtime:2.8" && image != "mcpmesh/typescript-runtime:latest" {
-		// Just check it's not empty - version may vary
-		t.Logf("Docker image: %s", image)
+	// Must equal the exact release tag GetDockerImage() ships (kept in sync by
+	// scripts/bump_version.py). Hard failure, not a log — this is the assertion
+	// that should have caught the 2.8.0 partial bump.
+	if want := "mcpmesh/typescript-runtime:2.8.0"; image != want {
+		t.Errorf("GetDockerImage() = %q, want %q", image, want)
 	}
 }
 

--- a/src/core/cli/handlers/language_test.go
+++ b/src/core/cli/handlers/language_test.go
@@ -399,7 +399,7 @@ func TestPythonHandler_GetDockerImage(t *testing.T) {
 		t.Error("GetDockerImage() returned empty string")
 	}
 	// Should contain python
-	if image != "mcpmesh/python-runtime:2.7" && image != "mcpmesh/python-runtime:latest" {
+	if image != "mcpmesh/python-runtime:2.8" && image != "mcpmesh/python-runtime:latest" {
 		// Just check it's not empty - version may vary
 		t.Logf("Docker image: %s", image)
 	}
@@ -412,7 +412,7 @@ func TestTypeScriptHandler_GetDockerImage(t *testing.T) {
 		t.Error("GetDockerImage() returned empty string")
 	}
 	// Should contain typescript
-	if image != "mcpmesh/typescript-runtime:2.7" && image != "mcpmesh/typescript-runtime:latest" {
+	if image != "mcpmesh/typescript-runtime:2.8" && image != "mcpmesh/typescript-runtime:latest" {
 		// Just check it's not empty - version may vary
 		t.Logf("Docker image: %s", image)
 	}

--- a/src/core/cli/handlers/python_handler.go
+++ b/src/core/cli/handlers/python_handler.go
@@ -86,7 +86,7 @@ func (h *PythonHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns Python Dockerfile content
 func (h *PythonHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh Python agent
-FROM mcpmesh/python-runtime:2.7.0
+FROM mcpmesh/python-runtime:2.8.0
 
 WORKDIR /app
 
@@ -170,7 +170,7 @@ func (h *PythonHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the Python runtime Docker image
 func (h *PythonHandler) GetDockerImage() string {
-	return "mcpmesh/python-runtime:2.7.0"
+	return "mcpmesh/python-runtime:2.8.0"
 }
 
 // ValidatePrerequisites checks Python environment

--- a/src/core/cli/handlers/typescript_handler.go
+++ b/src/core/cli/handlers/typescript_handler.go
@@ -92,7 +92,7 @@ func (h *TypeScriptHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns TypeScript Dockerfile content
 func (h *TypeScriptHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh TypeScript agent
-FROM mcpmesh/typescript-runtime:2.7.0
+FROM mcpmesh/typescript-runtime:2.8.0
 
 WORKDIR /app
 
@@ -167,7 +167,7 @@ func (h *TypeScriptHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the TypeScript runtime Docker image
 func (h *TypeScriptHandler) GetDockerImage() string {
-	return "mcpmesh/typescript-runtime:2.7.0"
+	return "mcpmesh/typescript-runtime:2.8.0"
 }
 
 // ValidatePrerequisites checks TypeScript environment

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -108,6 +108,27 @@ export MCP_MESH_DEBOUNCE_DELAY=1.0
 export MCP_MESH_TOOL_WORKERS=1
 ```
 
+### Tool Isolation (Python / TypeScript)
+
+```bash
+# Default: true. Runs each async tool body off the main event loop — Python
+# dispatches it to the mesh worker loop, TypeScript runs it on a worker
+# thread — so a blocking or long-running tool call cannot stall the main
+# loop that serves /health, /ready, the FastMCP/HTTP transport, and registry
+# heartbeats.
+#
+# Set to false to revert to legacy inline execution on the main loop.
+#
+# Scope and carve-outs:
+# - Python: only async tools are wrapped (sync tools already run off-loop via
+#   FastMCP); streaming tools are always inline (progress notifications must
+#   run on the main loop).
+# - TypeScript: requires `tsx` in your dependencies. A2A-consumer tools and
+#   MeshJob/task tools force-disable isolation (their injected handles cannot
+#   cross the worker_threads boundary) regardless of this setting.
+export MCP_MESH_TOOL_ISOLATION=true
+```
+
 ### Strict DI Diagnostics (Python)
 
 ```bash

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -123,9 +123,12 @@ export MCP_MESH_TOOL_WORKERS=1
 # - Python: only async tools are wrapped (sync tools already run off-loop via
 #   FastMCP); streaming tools are always inline (progress notifications must
 #   run on the main loop).
-# - TypeScript: requires `tsx` in your dependencies. A2A-consumer tools and
-#   MeshJob/task tools force-disable isolation (their injected handles cannot
-#   cross the worker_threads boundary) regardless of this setting.
+# - TypeScript: when the agent's entrypoint is a TypeScript source file
+#   (.ts/.mts/.cts/.tsx), the worker loads it through `tsx`, which must be in
+#   your dependencies; a precompiled .js entrypoint needs nothing extra.
+#   A2A-consumer tools and MeshJob/task tools force-disable isolation (their
+#   injected handles cannot cross the worker_threads boundary) regardless of
+#   this setting.
 export MCP_MESH_TOOL_ISOLATION=true
 ```
 

--- a/src/core/cli/scaffold.go
+++ b/src/core/cli/scaffold.go
@@ -72,9 +72,9 @@ Documentation:
 
 Infrastructure:
   Docker Images:
-    mcpmesh/registry:2.7.0            - Registry service
-    mcpmesh/python-runtime:2.7.0      - Python agent runtime (has mcp-mesh SDK)
-    mcpmesh/typescript-runtime:2.7.0  - TypeScript agent runtime (has @mcpmesh/sdk)
+    mcpmesh/registry:2.8.0            - Registry service
+    mcpmesh/python-runtime:2.8.0      - Python agent runtime (has mcp-mesh SDK)
+    mcpmesh/typescript-runtime:2.8.0  - TypeScript agent runtime (has @mcpmesh/sdk)
 
   Helm Charts (for Kubernetes - OCI registry, no helm repo add needed):
     oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core   - Registry + PostgreSQL + observability

--- a/src/core/cli/scaffold/compose.go
+++ b/src/core/cli/scaffold/compose.go
@@ -1087,7 +1087,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
 #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
 {{ .Name }}:
-  image: mcpmesh/python-runtime:2.7.0
+  image: mcpmesh/python-runtime:2.8.0
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1132,7 +1132,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # NOTE: In dev mode, npm install runs on startup and source is mounted.
 #       In production (Dockerfile), dependencies are pre-installed in the image.
 {{ .Name }}:
-  image: mcpmesh/typescript-runtime:2.7.0
+  image: mcpmesh/typescript-runtime:2.8.0
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1175,7 +1175,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # Agent: {{ .Name }} (Java/Spring Boot)
 # NOTE: In dev mode, maven builds on startup. In production, use the Dockerfile.
 {{ .Name }}:
-  image: mcpmesh/java-runtime:2.7.0
+  image: mcpmesh/java-runtime:2.8.0
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1856,7 +1856,7 @@ services:
       - {{ .NetworkName }}
 
   registry:
-    image: mcpmesh/registry:2.7.0
+    image: mcpmesh/registry:2.8.0
     container_name: {{ .ProjectName }}-registry
     hostname: registry
     ports:
@@ -1965,7 +1965,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   {{ .Name }}:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root
@@ -2011,7 +2011,7 @@ services:
   # NOTE: In dev mode, npm install runs on startup and source is mounted.
   #       In production (Dockerfile), dependencies are pre-installed in the image.
   {{ .Name }}:
-    image: mcpmesh/typescript-runtime:2.7.0
+    image: mcpmesh/typescript-runtime:2.8.0
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root
@@ -2055,7 +2055,7 @@ services:
   # Java Agent: {{ .Name }}
   # NOTE: In dev mode, maven builds on startup. In production, use the Dockerfile.
   {{ .Name }}:
-    image: mcpmesh/java-runtime:2.7.0
+    image: mcpmesh/java-runtime:2.8.0
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root

--- a/src/core/cli/scaffold/compose_test.go
+++ b/src/core/cli/scaffold/compose_test.go
@@ -52,9 +52,9 @@ services:
     environment:
       POSTGRES_USER: customuser
   registry:
-    image: mcpmesh/registry:2.7.0
+    image: mcpmesh/registry:2.8.0
   agent1:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     container_name: test-agent1
     environment:
       CUSTOM_VAR: "user-added-value"
@@ -110,9 +110,9 @@ func TestGenerateDockerCompose_ForceRegenerate(t *testing.T) {
   postgres:
     image: postgres:15-alpine
   registry:
-    image: mcpmesh/registry:2.7.0
+    image: mcpmesh/registry:2.8.0
   agent1:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     environment:
       CUSTOM_VAR: "should-be-gone"
 networks:
@@ -157,9 +157,9 @@ func TestGenerateDockerCompose_NoNewAgents(t *testing.T) {
   postgres:
     image: postgres:15-alpine
   registry:
-    image: mcpmesh/registry:2.7.0
+    image: mcpmesh/registry:2.8.0
   agent1:
-    image: mcpmesh/python-runtime:2.7.0
+    image: mcpmesh/python-runtime:2.8.0
     environment:
       CUSTOM_VAR: "preserved"
 networks:

--- a/src/runtime/core/src/napi.rs
+++ b/src/runtime/core/src/napi.rs
@@ -368,6 +368,17 @@ impl JsAgentHandle {
     ///
     /// This is an async method that blocks until an event is available.
     /// Returns a JsMeshEvent with eventType "shutdown" when the runtime has shut down.
+    ///
+    /// # Cancel-safety (issue #1256)
+    /// The event pull is delegated to [`RustAgentHandle::pull_next_event`],
+    /// which keeps the liveness timeout *inside* the future and never removes
+    /// a message from the channel it does not return. The previous raw
+    /// `rx.recv()` pattern carried the same lost-event exposure that #1256
+    /// fixed for the Python binding: a cancellation firing after the mpsc pop
+    /// but before delivery could silently drop a dequeued event and stall a
+    /// dependency edge. The internal timeout produces liveness ticks (`None`)
+    /// that we transparently loop over, so callers keep the "blocks until the
+    /// next real event" contract with no cancellable window mid-delivery.
     #[napi]
     pub async fn next_event(&self) -> Result<JsMeshEvent> {
         let handle = self.inner.lock().await;
@@ -376,10 +387,18 @@ impl JsAgentHandle {
         let event_rx = handle.event_rx();
         drop(handle); // Release the lock before awaiting
 
-        let mut rx = event_rx.lock().await;
-        match rx.recv().await {
-            Some(event) => Ok(event.into()),
-            None => Ok(MeshEvent::shutdown().into()),
+        loop {
+            match RustAgentHandle::pull_next_event(
+                event_rx.clone(),
+                std::time::Duration::from_secs(1),
+            )
+            .await
+            {
+                Some(event) => return Ok(event.into()),
+                // Liveness tick: no event within the internal timeout. Re-await
+                // cancel-safely instead of surfacing a null to the TS loop.
+                None => continue,
+            }
         }
     }
 

--- a/src/runtime/core/src/registry.rs
+++ b/src/runtime/core/src/registry.rs
@@ -1093,18 +1093,15 @@ mod tests {
         let req = minimal_request("cyc-agent", &server.url());
         let result = client.send_heartbeat(&req).await;
 
-        match result {
-            Err(RegistryError::SemanticRejection { message }) => {
+        match &result {
+            Err(err @ RegistryError::SemanticRejection { message }) => {
                 assert!(
                     message.contains("required dependency cycle"),
                     "message must carry the registry reason, got: {message}"
                 );
                 // Issue #1260: the Display form must not print a status code —
                 // the HTTP transport succeeded (200 OK); only the reason matters.
-                let rendered = RegistryError::SemanticRejection {
-                    message: message.clone(),
-                }
-                .to_string();
+                let rendered = err.to_string();
                 assert!(
                     !rendered.contains("200"),
                     "semantic rejection must not surface an HTTP status, got: {rendered}"

--- a/src/runtime/core/src/registry.rs
+++ b/src/runtime/core/src/registry.rs
@@ -31,6 +31,13 @@ pub enum RegistryError {
     #[error("Registry returned error: {status} - {message}")]
     RegistryError { status: u16, message: String },
 
+    /// A semantic rejection carried in a 200-OK body ({@code status:"error"}),
+    /// e.g. a required-dependency cycle. The HTTP transport succeeded, so the
+    /// status code is meaningless noise here — surface only the registry's
+    /// reason (issue #1260).
+    #[error("Registry rejected agent: {message}")]
+    SemanticRejection { message: String },
+
     #[error("Unexpected response: {0}")]
     UnexpectedResponse(String),
 
@@ -596,8 +603,7 @@ impl RegistryClient {
                     "Registry rejected agent '{}': {}",
                     request.agent_id, parsed.message
                 );
-                return Err(RegistryError::RegistryError {
-                    status: 200,
+                return Err(RegistryError::SemanticRejection {
                     message: parsed.message,
                 });
             }
@@ -1088,11 +1094,20 @@ mod tests {
         let result = client.send_heartbeat(&req).await;
 
         match result {
-            Err(RegistryError::RegistryError { status, message }) => {
-                assert_eq!(status, 200);
+            Err(RegistryError::SemanticRejection { message }) => {
                 assert!(
                     message.contains("required dependency cycle"),
                     "message must carry the registry reason, got: {message}"
+                );
+                // Issue #1260: the Display form must not print a status code —
+                // the HTTP transport succeeded (200 OK); only the reason matters.
+                let rendered = RegistryError::SemanticRejection {
+                    message: message.clone(),
+                }
+                .to_string();
+                assert!(
+                    !rendered.contains("200"),
+                    "semantic rejection must not surface an HTTP status, got: {rendered}"
                 );
             }
             other => panic!("expected semantic RegistryError, got {other:?}"),

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -900,7 +900,7 @@ public class MeshAutoConfiguration {
         // tool so the heartbeat path wires proxies the same way it does for
         // @MeshTool / @MeshRoute / @MeshA2A. Dedup is by capability name across
         // all four sources — see collectKnownCapabilities().
-        addMeshDependsOnDependencies(allTools);
+        addMeshDependsOnDependencies(allTools, routeRegistryProvider);
 
         if (consumerOnly) {
             MeshRouteRegistry routeRegistry = routeRegistryProvider.getIfAvailable();
@@ -1007,7 +1007,8 @@ public class MeshAutoConfiguration {
      * capability already appears in any prior source. Within
      * {@code @MeshDependsOn} itself the first occurrence wins.
      */
-    private void addMeshDependsOnDependencies(List<AgentSpec.ToolSpec> tools) {
+    private void addMeshDependsOnDependencies(List<AgentSpec.ToolSpec> tools,
+            ObjectProvider<MeshRouteRegistry> routeRegistryProvider) {
         Map<String, Object> beans = applicationContext.getBeansWithAnnotation(MeshDependsOn.class);
         if (beans.isEmpty()) {
             return;
@@ -1038,6 +1039,40 @@ public class MeshAutoConfiguration {
                     continue;
                 }
                 if (!seenCapabilities.add(capability)) {
+                    // Cross-source required-wins (2.8.1, extends #1249): the
+                    // capability is already declared by a prior source
+                    // (@MeshTool / @MeshRoute / @MeshA2A) OR an earlier
+                    // @MeshDependsOn bean. The edge itself is deduped away, but
+                    // a required=true @MeshDependsOn must not be silently
+                    // downgraded to the prior source's flag — required WINS
+                    // across sources, matching the within-source merge in
+                    // MeshRouteRegistry.getUniqueDependencySpecs.
+                    if (dep.required()) {
+                        // Scan BOTH the already-folded tool specs and the
+                        // pending `deps` list: a same-source @MeshDependsOn
+                        // sibling declared earlier in this loop lives in `deps`
+                        // (not yet folded into `tools`), so an order like
+                        // {optional bean, required bean} would otherwise drop
+                        // the required flag.
+                        boolean upgraded =
+                            upgradeExistingDependencyToRequired(tools, deps, capability);
+                        // The request-time 503 route perimeter reads the route
+                        // registry's own DependencySpec, not the AgentSpec copy
+                        // upgraded above — promote it too so the perimeter and
+                        // the wire advertisement agree (no split-brain).
+                        MeshRouteRegistry routeRegistry = routeRegistryProvider.getIfAvailable();
+                        if (routeRegistry != null
+                                && routeRegistry.promoteCapabilityToRequired(capability)) {
+                            upgraded = true;
+                        }
+                        if (upgraded) {
+                            log.info("@MeshDependsOn capability '{}' on {} already declared by another "
+                                    + "source — upgrading the deduped dependency to required=true "
+                                    + "(required wins across sources)",
+                                capability, targetClass.getName());
+                            continue;
+                        }
+                    }
                     log.debug("@MeshDependsOn capability '{}' on {} already declared by another source — skipping",
                         capability, targetClass.getName());
                     continue;
@@ -1128,6 +1163,49 @@ public class MeshAutoConfiguration {
             }
         }
         return seen;
+    }
+
+    /**
+     * Cross-source required-wins helper (2.8.1): promote every existing
+     * {@link AgentSpec.DependencySpec} matching {@code capability} to
+     * {@code required=true}, scanning BOTH the already-folded {@code tools}
+     * specs (prior {@code @MeshTool} / {@code @MeshRoute} / {@code @MeshA2A}
+     * sources) and the {@code pendingDeps} list still being accumulated for
+     * the synthetic {@code __mesh_depends_on_deps} tool (same-source
+     * {@code @MeshDependsOn} siblings declared earlier in the fold loop).
+     * Called when a {@code @MeshDependsOn} edge declares {@code required=true}
+     * for a capability that is already declared — the dependency edge is
+     * deduped away, but the required flag must still win rather than inherit
+     * the earlier declaration's (possibly non-required) value.
+     *
+     * @return {@code true} when at least one matching dependency spec was found
+     *         and upgraded; {@code false} when the capability is only present
+     *         as a producer surface (no consumable dependency spec to upgrade).
+     */
+    private static boolean upgradeExistingDependencyToRequired(
+            List<AgentSpec.ToolSpec> tools,
+            List<AgentSpec.DependencySpec> pendingDeps,
+            String capability) {
+        boolean upgraded = false;
+        for (AgentSpec.ToolSpec tool : tools) {
+            List<AgentSpec.DependencySpec> deps = tool.getDependencies();
+            if (deps == null) {
+                continue;
+            }
+            for (AgentSpec.DependencySpec dep : deps) {
+                if (capability.equals(dep.getCapability())) {
+                    dep.setRequired(true);
+                    upgraded = true;
+                }
+            }
+        }
+        for (AgentSpec.DependencySpec dep : pendingDeps) {
+            if (capability.equals(dep.getCapability())) {
+                dep.setRequired(true);
+                upgraded = true;
+            }
+        }
+        return upgraded;
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
@@ -179,6 +179,31 @@ public class MeshRouteRegistry {
     }
 
     /**
+     * Cross-source required-wins (2.8.1): promote every route dependency
+     * matching {@code capability} to required=true. Called when another
+     * declaration source (e.g. a {@code @MeshDependsOn} bean) marks the same
+     * capability required — without this, the merged agent spec would
+     * advertise the edge as required while the request-time 503 perimeter
+     * ({@link MeshRouteHandlerInterceptor}, which reads the route's own
+     * {@link DependencySpec#isRequired()}) still soft-served a null dependency
+     * (split-brain).
+     *
+     * @return {@code true} when at least one route dependency was promoted.
+     */
+    public boolean promoteCapabilityToRequired(String capability) {
+        boolean promoted = false;
+        for (RouteMetadata route : routesByPath.values()) {
+            for (DependencySpec dep : route.getDependencies()) {
+                if (capability.equals(dep.getCapability()) && !dep.isRequired()) {
+                    dep.setRequired(true);
+                    promoted = true;
+                }
+            }
+        }
+        return promoted;
+    }
+
+    /**
      * Surface the {@code expectedType} declared on each {@code @MeshDependency}
      * across all registered routes. Returns the Class<?> reference for every
      * capability whose source annotation set {@code expectedType} to a
@@ -382,7 +407,11 @@ public class MeshRouteRegistry {
         private final String parameterName;
         private final Class<?> expectedType;
         private final SchemaMode schemaMode;
-        private final boolean required;
+        // Not final: cross-source required-wins (2.8.1) may promote a route
+        // dependency to required=true after construction when a @MeshDependsOn
+        // on the same capability declares required — see
+        // MeshRouteRegistry.promoteCapabilityToRequired.
+        private boolean required;
         private Type returnType;  // Set by BeanPostProcessor after construction
 
         public DependencySpec(String capability, String[] tags, String version, String parameterName) {
@@ -483,6 +512,19 @@ public class MeshRouteRegistry {
          */
         public boolean isRequired() {
             return required;
+        }
+
+        /**
+         * Promote this route dependency to required=true (cross-source
+         * required-wins, 2.8.1). Only ever flips false→true — a source that
+         * declares required wins over one that does not, and no source can
+         * downgrade an already-required edge. The request-time 503 perimeter
+         * ({@link MeshRouteHandlerInterceptor}) reads {@link #isRequired()}
+         * live, so this keeps the perimeter aligned with the merged agent-spec
+         * wire advertisement.
+         */
+        public void setRequired(boolean required) {
+            this.required = required;
         }
 
         public Type getReturnType() { return returnType; }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependsOnIntegrationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependsOnIntegrationTest.java
@@ -155,6 +155,53 @@ class MeshDependsOnIntegrationTest {
         @Bean public SharedCapDeclarer sharedCapDeclarer() { return new SharedCapDeclarer(); }
     }
 
+    // Cross-source required-wins (2.8.1): the SAME capability is declared
+    // non-required on a @MeshRoute and required=true on a @MeshDependsOn. The
+    // dependency edge is deduped away on the @MeshDependsOn side, but the
+    // required flag must win — the surviving route dependency must be
+    // upgraded to required=true rather than keeping the route's default.
+    @RestController
+    static class OptionalRouteController {
+        @PostMapping("/opt-route")
+        @MeshRoute(dependencies = @MeshDependency(capability = "xsrc_cap"))
+        public String handle() { return "ok"; }
+    }
+
+    @Component
+    @MeshDependsOn(@MeshDependency(capability = "xsrc_cap", required = true))
+    static class RequiredXsrcDeclarer {}
+
+    @Configuration
+    @MeshAgent(name = "xsrc-required-agent")
+    static class CrossSourceRequiredAgentConfig {
+        @Bean public OptionalRouteController optionalRouteController() { return new OptionalRouteController(); }
+        @Bean public RequiredXsrcDeclarer requiredXsrcDeclarer() { return new RequiredXsrcDeclarer(); }
+    }
+
+    // Within-@MeshDependsOn order independence (2.8.1): required must win the
+    // dedupe regardless of declaration order. Both orderings are exercised
+    // deterministically via a single annotation's ordered value() array:
+    //   * opt_first_cap: optional declared BEFORE required (the required flag
+    //     lives in the pending deps list and must be upgraded there);
+    //   * req_first_cap: required declared BEFORE optional (the later optional
+    //     must not downgrade the earlier required).
+    @Component
+    @MeshDependsOn({
+        @MeshDependency(capability = "opt_first_cap"),
+        @MeshDependency(capability = "opt_first_cap", required = true),
+        @MeshDependency(capability = "req_first_cap", required = true),
+        @MeshDependency(capability = "req_first_cap")
+    })
+    static class OrderIndependenceDeclarer {}
+
+    @Configuration
+    @MeshAgent(name = "order-independence-agent")
+    static class OrderIndependenceAgentConfig {
+        @Bean public OrderIndependenceDeclarer orderIndependenceDeclarer() {
+            return new OrderIndependenceDeclarer();
+        }
+    }
+
     // Name-conflict guard: user already has a bean named "conflicting_cap"
     @Component
     @MeshDependsOn(@MeshDependency(capability = "conflicting_cap"))
@@ -585,6 +632,86 @@ class MeshDependsOnIntegrationTest {
                 assertThat(routeHasShared)
                     .as("'shared_cap' must remain on __mesh_route_deps")
                     .isTrue();
+            });
+    }
+
+    @Test
+    @DisplayName("Cross-source required-wins: required=true @MeshDependsOn upgrades a non-required @MeshRoute edge")
+    void crossSourceRequiredWins() {
+        baseRunner
+            .withUserConfiguration(CrossSourceRequiredAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+
+                // The @MeshDependsOn edge is deduped away (already on the route),
+                // so xsrc_cap must NOT appear on __mesh_depends_on_deps.
+                boolean dependsOnHasXsrc = spec.getTools().stream()
+                    .filter(t -> "__mesh_depends_on_deps".equals(t.getCapability()))
+                    .flatMap(t -> t.getDependencies().stream())
+                    .anyMatch(d -> "xsrc_cap".equals(d.getCapability()));
+                assertThat(dependsOnHasXsrc)
+                    .as("xsrc_cap must be deduped off __mesh_depends_on_deps (already on the route)")
+                    .isFalse();
+
+                // The surviving route dependency must be upgraded to required=true:
+                // required wins across sources even though the route declared it
+                // with the default (non-required) flag.
+                AgentSpec.DependencySpec routeDep = spec.getTools().stream()
+                    .filter(t -> "__mesh_route_deps".equals(t.getCapability()))
+                    .flatMap(t -> t.getDependencies().stream())
+                    .filter(d -> "xsrc_cap".equals(d.getCapability()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                        "xsrc_cap dependency missing from __mesh_route_deps tool"));
+                assertThat(routeDep.isRequired())
+                    .as("required=true @MeshDependsOn must upgrade the non-required @MeshRoute edge "
+                        + "(required wins across sources)")
+                    .isTrue();
+
+                // No perimeter split-brain: the request-time 503 perimeter
+                // reads the route registry's OWN DependencySpec, not the
+                // AgentSpec copy asserted above. It must also be promoted to
+                // required=true — otherwise the wire advertises required while
+                // the route soft-serves a null dependency.
+                io.mcpmesh.spring.web.MeshRouteRegistry routeRegistry =
+                    context.getBean(io.mcpmesh.spring.web.MeshRouteRegistry.class);
+                boolean perimeterRequired = routeRegistry.getAllRoutes().stream()
+                    .flatMap(r -> r.getDependencies().stream())
+                    .filter(d -> "xsrc_cap".equals(d.getCapability()))
+                    .findFirst()
+                    .map(io.mcpmesh.spring.web.MeshRouteRegistry.DependencySpec::isRequired)
+                    .orElseThrow(() -> new AssertionError(
+                        "xsrc_cap dependency missing from the route registry"));
+                assertThat(perimeterRequired)
+                    .as("route registry DependencySpec (503 perimeter source) must also be "
+                        + "promoted to required=true — no split-brain with the wire spec")
+                    .isTrue();
+            });
+    }
+
+    @Test
+    @DisplayName("Within-@MeshDependsOn required-wins is order-independent (both orderings)")
+    void withinDependsOnRequiredWinsOrderIndependent() {
+        baseRunner
+            .withUserConfiguration(OrderIndependenceAgentConfig.class)
+            .run(context -> {
+                assertThat(context).hasNotFailed();
+                AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+
+                for (String cap : new String[] {"opt_first_cap", "req_first_cap"}) {
+                    AgentSpec.DependencySpec dep = spec.getTools().stream()
+                        .filter(t -> "__mesh_depends_on_deps".equals(t.getCapability()))
+                        .flatMap(t -> t.getDependencies().stream())
+                        .filter(d -> cap.equals(d.getCapability()))
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError(
+                            cap + " dependency missing from __mesh_depends_on_deps tool"));
+                    assertThat(dep.isRequired())
+                        .as("required must win the within-@MeshDependsOn dedupe for '%s' "
+                            + "regardless of declaration order", cap)
+                        .isTrue();
+                }
             });
     }
 

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -1,7 +1,7 @@
 # MCP Mesh Python Package Configuration
 
 [build-system]
-requires = ["hatchling>=1.21.0,<1.30"]  # <1.30: hatchling 1.30.0 emits Metadata-Version 2.5 which twine rejects (revert when twine supports 2.5)
+requires = ["hatchling>=1.21.0"]
 build-backend = "hatchling.build"
 
 [project]

--- a/src/runtime/python/tests/unit/test_route_empty_collection_1039.py
+++ b/src/runtime/python/tests/unit/test_route_empty_collection_1039.py
@@ -1,0 +1,90 @@
+"""Route-layer regression for empty-collection returns (issue #1039).
+
+#1039 reported that a ``@mesh.route`` gateway returning a dependency's empty
+list produced ``null`` on the HTTP wire (not ``[]``). Root cause: the consumer
+proxy collapsed empty MCP content to ``None`` — fixed producer-side by #1251
+(FastMCP now emits ``structuredContent {"result": []}`` for empty returns) and
+consumer-side by #1250 (both proxy transports recover the value). Once the
+proxy hands back ``[]``, a route handler that ``return await dep(...)`` yields
+``[]`` and FastAPI serializes it as ``[]``.
+
+These tests exercise the ACTUAL route layer end to end: a real ``@mesh.route``
+handler mounted on a FastAPI app, driven by ``TestClient``, with the injected
+dependency resolved (via the same ``_mesh_update_dependency`` funnel the
+heartbeat uses) to a stub proxy that returns a fixed value. We assert the HTTP
+wire body — ``[]`` for an empty-list return, and ``null`` preserved for a
+genuine ``None`` return.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mesh
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from mesh.types import McpMeshTool
+
+
+class _StubProxy:
+    """Stand-in for the injected McpMeshTool proxy — returns a fixed value.
+
+    Mirrors the shape the DI wrapper expects of a resolved dependency: an
+    async-callable with an ``isAvailable()`` probe. Returning the value
+    directly (rather than an MCP envelope) models the state AFTER the proxy's
+    own #1250 recovery — i.e. the exact value a route handler awaits.
+    """
+
+    def __init__(self, value: Any):
+        self._value = value
+        self.endpoint = "http://stub:9000"
+
+    def isAvailable(self) -> bool:  # noqa: N802 (mesh proxy contract)
+        return True
+
+    async def __call__(self, **kwargs: Any) -> Any:
+        return self._value
+
+
+def _build_route_app(return_value: Any) -> FastAPI:
+    """A FastAPI app with one real @mesh.route handler whose dependency is
+    resolved to a stub proxy returning ``return_value``."""
+    app = FastAPI()
+
+    # No return annotation: FastAPI serializes the raw value (no response_model
+    # coercion), which isolates the wire-encoding contract #1039 is about —
+    # [] → "[]", None → "null" — rather than response-model type validation.
+    @mesh.route(dependencies=["list_notifications"])
+    async def list_endpoint(list_notifications: McpMeshTool = None):
+        return await list_notifications(user_id="alice")
+
+    # Resolve the dependency exactly as a heartbeat would: index-based update
+    # of the wrapper's injected-deps array with a live proxy.
+    list_endpoint._mesh_update_dependency(0, _StubProxy(return_value))
+
+    app.get("/api/notifications")(list_endpoint)
+    return app
+
+
+def test_route_empty_list_wire_body_is_empty_list_not_null():
+    client = TestClient(_build_route_app([]))
+    resp = client.get("/api/notifications")
+    assert resp.status_code == 200
+    # #1039 symptom: the body must be "[]", never "null".
+    assert resp.text == "[]"
+    assert resp.json() == []
+
+
+def test_route_populated_list_wire_body_unchanged():
+    client = TestClient(_build_route_app([{"id": 1}, {"id": 2}]))
+    resp = client.get("/api/notifications")
+    assert resp.status_code == 200
+    assert resp.json() == [{"id": 1}, {"id": 2}]
+
+
+def test_route_genuine_none_return_wire_body_is_null():
+    client = TestClient(_build_route_app(None))
+    resp = client.get("/api/notifications")
+    assert resp.status_code == 200
+    # The "no result" contract is preserved: None still serializes to null.
+    assert resp.text == "null"

--- a/src/ui/eslint.config.mjs
+++ b/src/ui/eslint.config.mjs
@@ -1,18 +1,42 @@
 import { defineConfig, globalIgnores } from "eslint/config";
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+import globals from "globals";
 
 const eslintConfig = defineConfig([
-  globalIgnores(["dist/**", "node_modules/**"]),
+  globalIgnores(["dist/**", "node_modules/**", "*.config.*", "*.tsbuildinfo"]),
   {
-    files: ["**/*.js", "**/*.jsx"],
+    files: ["**/*.js", "**/*.jsx", "**/*.mjs"],
+    ...js.configs.recommended,
+    languageOptions: {
+      globals: { ...globals.browser, ...globals.node },
+    },
     rules: {
       "no-unused-vars": "warn",
       "no-undef": "error",
     },
   },
+  ...tseslint.configs.recommended.map((config) => ({
+    ...config,
+    files: ["**/*.ts", "**/*.tsx"],
+  })),
   {
     files: ["**/*.ts", "**/*.tsx"],
+    plugins: { "react-hooks": reactHooks },
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+      globals: { ...globals.browser },
+    },
     rules: {
-      "no-unused-vars": "off",
+      ...reactHooks.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
     },
   },
 ]);

--- a/src/ui/eslint.config.mjs
+++ b/src/ui/eslint.config.mjs
@@ -22,13 +22,13 @@ const eslintConfig = defineConfig([
     files: ["**/*.ts", "**/*.tsx"],
   })),
   {
-    files: ["**/*.ts", "**/*.tsx"],
+    files: ["**/*.ts", "**/*.tsx", "**/*.jsx"],
     plugins: { "react-hooks": reactHooks },
     languageOptions: {
       parserOptions: {
         ecmaFeatures: { jsx: true },
       },
-      globals: { ...globals.browser },
+      globals: { ...globals.browser, ...globals.node },
     },
     rules: {
       ...reactHooks.configs.recommended.rules,

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -32,9 +32,12 @@
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^4",
         "eslint": "^9",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "globals": "^17.7.0",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5",
+        "typescript-eslint": "^8.62.1",
         "vite": "^6"
       }
     },
@@ -901,6 +904,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/js": {
@@ -2527,6 +2543,301 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
+      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/type-utils": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.62.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
+      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
+      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.1",
+        "@typescript-eslint/types": "^8.62.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
+      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
+      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
+      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
+      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
+      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.1",
+        "@typescript-eslint/tsconfig-utils": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/visitor-keys": "8.62.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
+      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.1",
+        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
+      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -3264,6 +3575,19 @@
         }
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -3484,9 +3808,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4660,6 +4984,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4701,6 +5038,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
+      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.1",
+        "@typescript-eslint/parser": "8.62.1",
+        "@typescript-eslint/typescript-estree": "8.62.1",
+        "@typescript-eslint/utils": "8.62.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -33,9 +33,12 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^4",
     "eslint": "^9",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "globals": "^17.7.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5",
+    "typescript-eslint": "^8.62.1",
     "vite": "^6"
   }
 }

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -102,12 +102,12 @@ Edit `config.yaml` to set versions:
 
 ```yaml
 packages:
-  cli_version: "2.7.0" # @mcpmesh/cli
-  sdk_python_version: "2.7.0" # mcp-mesh (pip) - PEP 440 format
-  sdk_typescript_version: "2.7.0" # @mcpmesh/sdk
+  cli_version: "2.8.0" # @mcpmesh/cli
+  sdk_python_version: "2.8.0" # mcp-mesh (pip) - PEP 440 format
+  sdk_typescript_version: "2.8.0" # @mcpmesh/sdk
 
 docker:
-  base_image: "tsuite-mesh:2.7.0"
+  base_image: "tsuite-mesh:2.8.0"
 ```
 
 ## Environment Variables

--- a/tests/integration/suites/README.md
+++ b/tests/integration/suites/README.md
@@ -108,7 +108,7 @@ const agent = mesh(server, {
 ```bash
 docker run --rm -it \
   -v $(pwd)/suites/uc01_registry/artifacts:/uc-artifacts:ro \
-  tsuite-mesh:2.7.0 bash
+  tsuite-mesh:2.8.0 bash
 ```
 
 ### Common issues:
@@ -123,9 +123,9 @@ Available in test.yaml via `${config.X}`:
 
 | Variable                                 | Example      |
 | ---------------------------------------- | ------------ |
-| `config.packages.cli_version`            | 2.7.0 |
-| `config.packages.sdk_python_version`     | 2.7.0 |
-| `config.packages.sdk_typescript_version` | 2.7.0 |
+| `config.packages.cli_version`            | 2.8.0 |
+| `config.packages.sdk_python_version`     | 2.8.0 |
+| `config.packages.sdk_typescript_version` | 2.8.0 |
 
 ## Issue Reporting Policy
 

--- a/tests/lib-tests/README.md
+++ b/tests/lib-tests/README.md
@@ -68,7 +68,7 @@ tsuite --uc uc04_build_image
 
 After successful run, you'll have:
 
-- `tsuite-mesh:2.7.0` (or current version) Docker image
+- `tsuite-mesh:2.8.0` (or current version) Docker image
 
 Verify with:
 
@@ -82,11 +82,11 @@ Edit `config.yaml` to update versions:
 
 ```yaml
 packages:
-  cli_version: "2.7.0"
-  sdk_python_version: "2.7.0" # PEP 440 format for Python
-  sdk_typescript_version: "2.7.0"
-  core_version: "2.7.0"
-  sdk_java_version: "2.7.0"
+  cli_version: "2.8.0"
+  sdk_python_version: "2.8.0" # PEP 440 format for Python
+  sdk_typescript_version: "2.8.0"
+  core_version: "2.8.0"
+  sdk_java_version: "2.8.0"
 ```
 
 ## Next Steps

--- a/tests/lib-tests/config.yaml
+++ b/tests/lib-tests/config.yaml
@@ -10,11 +10,11 @@ suite:
 
 packages:
   # Version to test - update this for each release
-  cli_version: "2.7.0"
-  sdk_python_version: "2.7.0" # PEP 440 format for pip
-  sdk_typescript_version: "2.7.0"
-  core_version: "2.7.0"
-  sdk_java_version: "2.7.0"
+  cli_version: "2.8.0"
+  sdk_python_version: "2.8.0" # PEP 440 format for pip
+  sdk_typescript_version: "2.8.0"
+  core_version: "2.8.0"
+  sdk_java_version: "2.8.0"
 
 # Docker settings for the base image build
 docker:


### PR DESCRIPTION
## Summary
Third and final 2.8.1 PR — the hygiene batch.

- **#1260 items**: cancel-safe napi `next_event` (adopts the reviewed `pull_next_event` primitive); cross-source `required=true`-wins dependency dedupe in Java — order-independent across beans, with the route 503 perimeter promoted in lockstep (no wire-vs-local split-brain); "error: 200" log replaced with a `SemanticRejection` variant; `examples/required-dependency/` (Python + Java, scaffold-complete, pinned 2.8.0); `MCP_MESH_TOOL_ISOLATION` documented on both surfaces; TS-aware flat eslint config for src/ui (parse errors on every file → 0). gofmt baseline: deferred — decision recorded for the owner (one-shot reformat + CI fmt-check recommended, post-in-flight-PRs).
- **#1039**: verified already fixed by the #1250/#1251 empty-return work — pinned with a genuine route-layer test (TestClient through a live `@mesh.route` handler: `[]` → `[]`, `None` → `null`).
- **#1108**: hatchling pin reverted — twine 6.2.0 accepts Metadata-Version 2.5 (verified empirically) and hatchling 1.30.1 fixed the original emission bug; `twine check` passes on the built package.
- **Version-bump pipeline hardening** (from the scaffold-still-2.7.0 field observation): `scripts/bump_version.py` gains deep `examples/**` globs (57 POMs + 17 package.json now covered vs a handful), directory pruning (>2min → ~9s), and a post-bump **no-stale-versions guard** (mesh-shaped git-grep, allowlisted third-party pins, non-zero on survivors). The **partial 2.8.0 bump that shipped** is applied: CLI handlers' default runtime images, helm values `tag: "2.7"→"2.8"`, scaffold/compose sources, docker-compose examples, test configs — plus ancient example stragglers (1.1.0/1.4.1/2.1.0) brought to 2.8.0. Java scaffold Dockerfile templates consolidate consecutive RUNs (DL3059) so future scaffolds lint clean.

## Review Notes
Zero-context review applied: 1 blocker (example pinned to a runtime predating the feature it demonstrates) and 3 warnings (order-dependent required-loss, route-perimeter split-brain, tautological #1039 test) — all fixed. Design note recorded: agent-wide required-wins promotion is intended semantics (one deduped wire edge; any required source wins). `SemanticRejection` remains retryable (unchanged); tightening is a future candidate.

## Test plan
- [x] Rust core 482+, Java starter suites (incl. 21-test dedupe matrix), Python unit suites green
- [x] src-tests 12/12
- [x] Full integration: **531 passed, 0 failed** (clean run, no flakes)
- [x] bump script: dry-run 2.8.0→2.9.0 coverage verified; guard positive/negative tested; rendered scaffold templates hadolint-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new required-dependency examples for Java and Python, including runnable provider/consumer apps and deployment configs.
  * Documented tool isolation behavior and a new environment setting for controlling tool execution.

* **Bug Fixes**
  * Improved dependency handling so required capabilities stay required across merged configurations.
  * Fixed event delivery and route response behavior for more reliable runtime handling.

* **Updates**
  * Bumped runtime, SDK, and example image versions to 2.8.0 across docs, samples, Helm values, and compose files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->