### PR TITLE
fix(cli,di): group-scoped stop + required-dep guard on direct tool calls (2.8.2)

### DIFF
--- a/src/core/cli/lifecycle/group_zombie_darwin.go
+++ b/src/core/cli/lifecycle/group_zombie_darwin.go
@@ -1,0 +1,49 @@
+//go:build darwin
+
+package lifecycle
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// groupAllZombie reports whether process group pgid is non-empty and EVERY
+// member is a zombie (state 'Z'). See the linux build's doc comment for the
+// full rationale (zombies hold no port/FDs; an unreaped orphan zombie in a
+// container must not hang the group-drain waits forever).
+//
+// Returns:
+//   - (true, nil)  at least one member was found and ALL members are zombies
+//   - (false, nil) a live (non-zombie) member exists, or the group is empty
+//   - (false, err) the ps scan itself failed — inconclusive; caller MUST NOT
+//     treat this as "dead"
+//
+// Uses `ps -A -o pgid=,stat=` (ps is part of the Darwin base system). Each line
+// is `<pgid> <stat>`; stat may carry flag suffixes (e.g. "Z+", "Ss"), so we key
+// on the first character.
+func groupAllZombie(pgid int) (bool, error) {
+	if pgid <= 1 {
+		return false, nil
+	}
+	out, err := exec.Command("ps", "-A", "-o", "pgid=,stat=").Output()
+	if err != nil {
+		return false, err
+	}
+	found := false
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		pg, err := strconv.Atoi(fields[0])
+		if err != nil || pg != pgid {
+			continue
+		}
+		found = true
+		if fields[1][0] != 'Z' {
+			return false, nil // a live member exists — group not drained
+		}
+	}
+	return found, nil
+}

--- a/src/core/cli/lifecycle/group_zombie_linux.go
+++ b/src/core/cli/lifecycle/group_zombie_linux.go
@@ -1,0 +1,73 @@
+//go:build linux
+
+package lifecycle
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// groupAllZombie reports whether process group pgid is non-empty and EVERY
+// member is a zombie (Z) or dead-pending (X).
+//
+// Why this exists: a zombie has already exited and released all of its
+// resources — ports, sockets, file descriptors — and only occupies a
+// process-table slot awaiting a reaper. In a container whose PID 1 does not
+// reap orphans (a bare shell/test-harness entrypoint), a grandchild that
+// outlived its parent is reparented to that non-reaping PID 1 and its zombie
+// can linger indefinitely. kill(-pgid, 0) keeps reporting such a group as
+// "alive", which would hang the group-drain waits in kill.go forever. Treating
+// an all-zombie group as dead lets stop/reload make progress: the port is
+// already free, so there is nothing left to wait for.
+//
+// Returns:
+//   - (true, nil)  at least one member was found and ALL members are zombies
+//   - (false, nil) a live (non-zombie) member exists, or the group is empty
+//   - (false, err) the /proc scan itself failed — inconclusive; the caller
+//     MUST NOT treat this as "dead"
+//
+// Reads /proc/<pid>/stat directly (no procps dependency) mirroring isZombie.
+// The stat line is `pid (comm) state ppid pgrp ...`; (comm) may contain spaces
+// and parens, so we anchor on the LAST ')' and read the space-separated fields
+// that follow: field 0 = state, field 2 = pgrp.
+func groupAllZombie(pgid int) (bool, error) {
+	if pgid <= 1 {
+		return false, nil
+	}
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return false, err
+	}
+	found := false
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := strconv.Atoi(e.Name()); err != nil {
+			continue // not a PID directory
+		}
+		data, err := os.ReadFile("/proc/" + e.Name() + "/stat")
+		if err != nil {
+			continue // process vanished mid-scan — skip, not fatal
+		}
+		s := string(data)
+		lastParen := strings.LastIndex(s, ")")
+		if lastParen < 0 || lastParen+2 >= len(s) {
+			continue
+		}
+		fields := strings.Fields(s[lastParen+1:])
+		if len(fields) < 3 {
+			continue
+		}
+		pg, err := strconv.Atoi(fields[2])
+		if err != nil || pg != pgid {
+			continue
+		}
+		found = true
+		if state := fields[0]; state != "Z" && state != "X" {
+			return false, nil // a live member exists — group not drained
+		}
+	}
+	return found, nil
+}

--- a/src/core/cli/lifecycle/group_zombie_other.go
+++ b/src/core/cli/lifecycle/group_zombie_other.go
@@ -1,0 +1,11 @@
+//go:build !linux && !darwin
+
+package lifecycle
+
+// groupAllZombie is a no-op on platforms without a supported process-table
+// probe: it reports "not all-zombie" so the group-drain waits fall back to
+// their kill(-pgid, 0) behavior unchanged. (Windows uses a separate lifecycle
+// path entirely.)
+func groupAllZombie(pgid int) (bool, error) {
+	return false, nil
+}

--- a/src/core/cli/lifecycle/kill.go
+++ b/src/core/cli/lifecycle/kill.go
@@ -172,22 +172,27 @@ func pollUntilGroupDead(pid int, timeout time.Duration) bool {
 }
 
 // groupConfirmedDead is the shared "is this process group effectively gone"
-// predicate used by pollUntilGroupDead. The group counts as dead when ANY of:
+// predicate used by pollUntilGroupDead. The group counts as dead when EITHER:
 //
 //  1. the group probe reports empty (kill(-pid, 0) -> ESRCH); or
-//  2. the originally tracked PID is itself a zombie (init-reaped orphan case
-//     that pollUntilDead already handled); or
-//  3. every REMAINING member of the group is a zombie — a SIGKILLed child in a
+//  2. every REMAINING member of the group is a zombie — a SIGKILLed child in a
 //     container whose PID 1 does not reap keeps kill(-pid, 0) reporting the
 //     group "alive" indefinitely even though the zombie holds no port or FDs.
 //     Without this, the group-drain waits would hang the full timeout and the
 //     watch-reload path would then skip the restart (issue surfaced by
 //     tc29_watch_mixed). Probe errors stay inconclusive — never treated as dead.
+//
+// It deliberately does NOT short-circuit on the TRACKED PID being a zombie:
+// for a multi-process group the tracked PID is the group *leader*, and a zombie
+// leader can still have LIVE children (e.g. a Maven parent that exited while
+// its child JVM ignores SIGTERM and holds the port). Treating a zombie leader
+// as "group dead" would mask those children and abort the SIGKILL escalation.
+// The leader-only-zombie case is covered by predicate (2) — groupAllZombieFn
+// finds the sole member is a zombie and reports the group drained. Single-PID
+// (non-group) zombie handling lives in pollUntilDead, which is correct there
+// because that path tracks exactly one process.
 func groupConfirmedDead(pid int) bool {
 	if !groupAliveFn(pid) {
-		return true
-	}
-	if z, err := isZombieFn(pid); err == nil && z {
 		return true
 	}
 	if az, err := groupAllZombieFn(pid); err == nil && az {

--- a/src/core/cli/lifecycle/kill.go
+++ b/src/core/cli/lifecycle/kill.go
@@ -87,6 +87,12 @@ func IsAliveOrGroupAlive(pid int) bool {
 // groupAliveFn is overridable for tests; production uses IsAliveOrGroupAlive.
 var groupAliveFn = IsAliveOrGroupAlive
 
+// groupAllZombieFn is overridable for tests; production uses groupAllZombie
+// (platform-specific). Reports whether every remaining member of the process
+// group is a zombie — see the platform files for the container/non-reaping-init
+// rationale.
+var groupAllZombieFn = groupAllZombie
+
 // readPIDFromFile reads and parses a PID file. Returns (0, nil) if missing.
 func readPIDFromFile(path string) (int, error) {
 	data, err := os.ReadFile(path)
@@ -157,18 +163,34 @@ func pollUntilDead(pid int, timeout time.Duration) bool {
 func pollUntilGroupDead(pid int, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if !groupAliveFn(pid) {
-			return true
-		}
-		if z, err := isZombieFn(pid); err == nil && z {
+		if groupConfirmedDead(pid) {
 			return true
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
+	return groupConfirmedDead(pid)
+}
+
+// groupConfirmedDead is the shared "is this process group effectively gone"
+// predicate used by pollUntilGroupDead. The group counts as dead when ANY of:
+//
+//  1. the group probe reports empty (kill(-pid, 0) -> ESRCH); or
+//  2. the originally tracked PID is itself a zombie (init-reaped orphan case
+//     that pollUntilDead already handled); or
+//  3. every REMAINING member of the group is a zombie — a SIGKILLed child in a
+//     container whose PID 1 does not reap keeps kill(-pid, 0) reporting the
+//     group "alive" indefinitely even though the zombie holds no port or FDs.
+//     Without this, the group-drain waits would hang the full timeout and the
+//     watch-reload path would then skip the restart (issue surfaced by
+//     tc29_watch_mixed). Probe errors stay inconclusive — never treated as dead.
+func groupConfirmedDead(pid int) bool {
 	if !groupAliveFn(pid) {
 		return true
 	}
 	if z, err := isZombieFn(pid); err == nil && z {
+		return true
+	}
+	if az, err := groupAllZombieFn(pid); err == nil && az {
 		return true
 	}
 	return false
@@ -200,8 +222,8 @@ func signalGroupOrPID(pid int, sig syscall.Signal) error {
 //  1. read <root>/pids/<name>.pid
 //  2. if missing -> return (false, nil)
 //  3. if process already dead -> remove PID file (and .group), return (false, nil)
-//  4. SIGTERM (process group preferred), poll up to timeout
-//  5. if still alive -> SIGKILL, poll up to 1s
+//  4. SIGTERM (process group preferred), poll until the whole group is dead
+//  5. if the group is still alive -> SIGKILL the group, poll up to 3s
 //  6. on confirmed death -> remove PID file (and .group), return (true, nil)
 //  7. on verify failure -> return error WITHOUT removing files (preserve state)
 //
@@ -251,16 +273,26 @@ func KillVerifyAndCleanup(name string, timeout time.Duration) (killed bool, err 
 		return true, nil
 	}
 
-	// Graceful: SIGTERM + poll.
+	// Graceful: SIGTERM to the whole process group, then wait for the ENTIRE
+	// group to die — not just the parent. For multi-process agents (e.g. a
+	// Maven `mvn spring-boot:run` parent whose child JVM holds the port) the
+	// parent can exit while the child lingers bound to the port and still
+	// heartbeating. Polling parent-only (pollUntilDead) would report "stopped"
+	// the instant the parent exits and remove the PID files while the child
+	// survives; a child that slow-walks or ignores SIGTERM would then never be
+	// force-killed. Mirror the orphan branch above: poll the group and escalate
+	// SIGKILL to the group at the timeout so stop blocks until the port is
+	// actually released.
 	_ = signalGroupOrPID(pid, syscall.SIGTERM)
-	if !pollUntilDead(pid, timeout) {
-		// Force: SIGKILL + extended poll. Window is 3s so a parent that's slow
-		// to reap (or has exited entirely, leaving init to reap) doesn't trip a
-		// false-negative — pollUntilDead also treats zombies as dead, so the
-		// only way to time out here is genuine refusal-to-die.
+	if !pollUntilGroupDead(pid, timeout) {
+		// Force: SIGKILL the whole group + extended poll. Window is 3s so a
+		// parent that's slow to reap (or has exited entirely, leaving init to
+		// reap) doesn't trip a false-negative — pollUntilGroupDead also treats
+		// zombies as dead, so the only way to time out here is a group member
+		// genuinely refusing to die.
 		_ = signalGroupOrPID(pid, syscall.SIGKILL)
-		if !pollUntilDead(pid, 3*time.Second) {
-			return false, fmt.Errorf("lifecycle: process %d (%s) still alive after SIGKILL", pid, name)
+		if !pollUntilGroupDead(pid, 3*time.Second) {
+			return false, fmt.Errorf("lifecycle: process group %d (%s) still alive after SIGKILL", pid, name)
 		}
 	}
 
@@ -285,4 +317,26 @@ func KillPIDVerify(pid int, timeout time.Duration) bool {
 	}
 	_ = signalGroupOrPID(pid, syscall.SIGKILL)
 	return pollUntilDead(pid, 3*time.Second)
+}
+
+// KillGroupVerify is the group-aware sibling of KillPIDVerify: TERM the process
+// group, wait for the WHOLE group to drain, escalate to SIGKILL on timeout, and
+// wait again. It routes through pollUntilGroupDead so callers inherit the
+// zombie-aware group-drain check — an all-zombie group (e.g. a SIGKILLed child
+// orphaned to a non-reaping container PID 1) counts as drained rather than
+// hanging the timeout. Returns true on confirmed group death.
+//
+// Used by the watch-mode paths (terminateAgent, the restart fallback) that hold
+// a bare PID with no <name>.pid bookkeeping. The 3s post-SIGKILL window matches
+// KillVerifyAndCleanup.
+func KillGroupVerify(pid int, timeout time.Duration) bool {
+	if pid <= 1 {
+		return true
+	}
+	_ = signalGroupOrPID(pid, syscall.SIGTERM)
+	if pollUntilGroupDead(pid, timeout) {
+		return true
+	}
+	_ = signalGroupOrPID(pid, syscall.SIGKILL)
+	return pollUntilGroupDead(pid, 3*time.Second)
 }

--- a/src/core/cli/lifecycle/kill_test.go
+++ b/src/core/cli/lifecycle/kill_test.go
@@ -439,6 +439,93 @@ func TestKillVerifyAndCleanup_GroupOnlyZombies_CleansUp(t *testing.T) {
 	}
 }
 
+// TestGroupConfirmedDead_ZombieLeaderLiveChild_NotDead is the PR #1275 review
+// guard: a zombie group LEADER must not by itself confirm the group dead while
+// a LIVE child remains. Pre-fix groupConfirmedDead short-circuited on the
+// tracked PID's zombie state, which would mask a live TERM-ignoring child and
+// abort the SIGKILL escalation.
+func TestGroupConfirmedDead_ZombieLeaderLiveChild_NotDead(t *testing.T) {
+	prevGroup, prevZombie, prevAllZ := groupAliveFn, isZombieFn, groupAllZombieFn
+	groupAliveFn = func(pid int) bool { return true }                    // child keeps group non-empty
+	isZombieFn = func(pid int) (bool, error) { return true, nil }        // LEADER is a zombie
+	groupAllZombieFn = func(pid int) (bool, error) { return false, nil } // ...but a live child exists
+	t.Cleanup(func() {
+		groupAliveFn = prevGroup
+		isZombieFn = prevZombie
+		groupAllZombieFn = prevAllZ
+	})
+
+	if groupConfirmedDead(12345) {
+		t.Error("groupConfirmedDead must be false: zombie leader + live child is NOT a dead group")
+	}
+	if pollUntilGroupDead(12345, 100*time.Millisecond) {
+		t.Error("pollUntilGroupDead must not confirm death while a live child remains — escalation must proceed")
+	}
+}
+
+// TestKillVerifyAndCleanup_ZombieLeaderLiveChild_Escalates is the real-process
+// version: the group leader (recorded PID) exits and becomes a zombie held by
+// this test process (a non-reaping parent, mirroring a container PID 1), while
+// a child that ignores SIGTERM lingers in the same group holding "the port".
+// KillVerifyAndCleanup must NOT short-circuit on the zombie leader — it must
+// wait out the SIGTERM window and SIGKILL the child. Discriminator: elapsed
+// time >= the SIGTERM window (pre-fix returned in ~ms via the leader-zombie
+// shortcut), plus the group ends up with no live member.
+func TestKillVerifyAndCleanup_ZombieLeaderLiveChild_Escalates(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	// Outer sh = group leader (recorded PID): it backgrounds a SIGTERM-ignoring
+	// child in the same group, then exits -> becomes a zombie (we never Wait it
+	// until cleanup). The child stays alive and ignores SIGTERM.
+	cmd := exec.Command("sh", "-c", `sh -c "trap '' TERM; sleep 60" & exit 0`)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Skipf("sh not available: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		_ = cmd.Wait()
+	})
+
+	// Let the leader exit into Z state and the child settle in the group.
+	time.Sleep(250 * time.Millisecond)
+
+	g := NewGroupID()
+	if err := WriteAgent("zleader", pid, g); err != nil {
+		t.Fatal(err)
+	}
+
+	const termTimeout = 800 * time.Millisecond
+	start := time.Now()
+	killed, err := KillVerifyAndCleanup("zleader", termTimeout)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("KillVerifyAndCleanup: %v", err)
+	}
+	if !killed {
+		t.Error("expected killed=true")
+	}
+	if elapsed < termTimeout {
+		t.Errorf("returned in %v (< SIGTERM window %v) — leader-zombie shortcut masked the live child", elapsed, termTimeout)
+	}
+	// The child must be dead: no live (non-zombie) member left in the group.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if az, err := groupAllZombie(pid); err == nil && az {
+			break
+		}
+		if !IsAliveOrGroupAlive(pid) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if az, _ := groupAllZombie(pid); IsAliveOrGroupAlive(pid) && !az {
+		t.Errorf("a live child survived in group %d — escalation did not kill it", pid)
+	}
+}
+
 // TestKillVerifyAndCleanup_ParentDeadGroupRefusesToDie verifies that when the
 // orphan group survives SIGTERM and SIGKILL the function errors and does NOT
 // remove the PID file — the user must be able to retry.
@@ -463,20 +550,24 @@ func TestKillVerifyAndCleanup_ParentDeadGroupRefusesToDie(t *testing.T) {
 	}
 }
 
-// TestPollUntilGroupDead_TreatsZombieAsDead guards the zombie-as-dead invariant
-// in the group-aware poll loop — init-reaped orphans must not be a false
-// negative.
-func TestPollUntilGroupDead_TreatsZombieAsDead(t *testing.T) {
-	prevGroup, prevZombie := groupAliveFn, isZombieFn
-	groupAliveFn = func(pid int) bool { return true } // never empty
-	isZombieFn = func(pid int) (bool, error) { return true, nil }
+// TestPollUntilGroupDead_TreatsAllZombieGroupAsDead guards the zombie-as-dead
+// invariant in the group-aware poll loop: when the group probe still reports
+// "alive" (an unreaped orphan zombie keeps kill(-pgid, 0) from returning ESRCH)
+// but EVERY remaining member is a zombie, the group counts as dead. The signal
+// is groupAllZombieFn, NOT the tracked PID's own zombie state — a zombie leader
+// with a live child must still be treated as alive (see
+// TestGroupConfirmedDead_ZombieLeaderLiveChild_NotDead).
+func TestPollUntilGroupDead_TreatsAllZombieGroupAsDead(t *testing.T) {
+	prevGroup, prevAllZ := groupAliveFn, groupAllZombieFn
+	groupAliveFn = func(pid int) bool { return true } // zombie present -> probe never empty
+	groupAllZombieFn = func(pid int) (bool, error) { return true, nil }
 	t.Cleanup(func() {
 		groupAliveFn = prevGroup
-		isZombieFn = prevZombie
+		groupAllZombieFn = prevAllZ
 	})
 
 	if !pollUntilGroupDead(12345, 100*time.Millisecond) {
-		t.Error("pollUntilGroupDead must treat zombie as dead even when group probe stays alive")
+		t.Error("pollUntilGroupDead must treat an all-zombie group as dead even when the group probe stays alive")
 	}
 }
 

--- a/src/core/cli/lifecycle/kill_test.go
+++ b/src/core/cli/lifecycle/kill_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -191,6 +192,250 @@ func TestKillVerifyAndCleanup_ParentDeadGroupAlive_SignalsGroup(t *testing.T) {
 	}
 	if _, err := os.Stat(GroupFile("orphan")); !os.IsNotExist(err) {
 		t.Errorf("group file should be removed after group reap")
+	}
+}
+
+// TestKillVerifyAndCleanup_GracefulBranch_WaitsForGroupDeath is the #1274
+// regression: in the graceful branch (parent alive at entry) the wait MUST be
+// group-scoped, not parent-scoped. Here the parent stays "alive" per the
+// single-PID stub throughout, while the group flips dead shortly after SIGTERM
+// — stop must observe the GROUP transition and clean up. Pre-fix the graceful
+// branch polled pollUntilDead(parent), which never saw the parent die and
+// would have timed out; this asserts the group probe drives the wait.
+func TestKillVerifyAndCleanup_GracefulBranch_WaitsForGroupDeath(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	const pid = 55555
+	useStubAlive(t, map[int]bool{pid: true})      // parent alive -> graceful branch
+	useStubGroupAlive(t, map[int]bool{pid: true}) // group alive initially
+
+	// Flip the group dead shortly after SIGTERM so pollUntilGroupDead observes
+	// the transition rather than timing out.
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		setGroupAlive(pid, false)
+	}()
+
+	g := NewGroupID()
+	_ = WriteAgent("graceful-group", pid, g)
+
+	start := time.Now()
+	killed, err := KillVerifyAndCleanup("graceful-group", 2*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !killed {
+		t.Error("killed should be true when the group was reaped in the graceful branch")
+	}
+	if elapsed := time.Since(start); elapsed < 60*time.Millisecond {
+		t.Errorf("returned in %v — graceful branch did not wait on the group", elapsed)
+	}
+	if _, err := os.Stat(PIDFile("graceful-group")); !os.IsNotExist(err) {
+		t.Errorf("pid file should be removed after group reap")
+	}
+	if _, err := os.Stat(GroupFile("graceful-group")); !os.IsNotExist(err) {
+		t.Errorf("group file should be removed after group reap")
+	}
+}
+
+// TestKillVerifyAndCleanup_GracefulBranch_GroupRefusesToDie verifies that in
+// the graceful branch a group that survives both SIGTERM and SIGKILL causes an
+// error naming the process GROUP and preserves the PID file for retry — the
+// parent being "alive" per the single-PID stub must not short-circuit the
+// group escalation.
+func TestKillVerifyAndCleanup_GracefulBranch_GroupRefusesToDie(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	const pid = 55556
+	useStubAlive(t, map[int]bool{pid: true})      // parent alive -> graceful branch
+	useStubGroupAlive(t, map[int]bool{pid: true}) // group never dies
+
+	g := NewGroupID()
+	_ = WriteAgent("graceful-undead", pid, g)
+
+	_, err := KillVerifyAndCleanup("graceful-undead", 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error when the group can't be killed in the graceful branch")
+	}
+	if !strings.Contains(err.Error(), "process group") {
+		t.Errorf("error should reference the process group, got: %v", err)
+	}
+	if _, statErr := os.Stat(PIDFile("graceful-undead")); statErr != nil {
+		t.Errorf("PID file should be preserved on verify failure: %v", statErr)
+	}
+}
+
+// TestKillVerifyAndCleanup_GracefulBranch_ParentDiesChildLingers_RealProcess
+// reproduces the field-measured #1274 symptom with real processes: a group
+// leader (recorded PID, like an `mvn spring-boot:run` parent) that dies on
+// SIGTERM while a child that IGNORES SIGTERM lingers in the same group. The
+// discriminator is elapsed time: pre-fix the graceful branch polled the parent
+// only and returned within milliseconds of the parent's death (leaking the
+// child); post-fix it blocks for the whole SIGTERM window waiting on the
+// group, then SIGKILLs the child. We assert the call blocked (did not return
+// early) AND the group is fully drained afterward.
+func TestKillVerifyAndCleanup_GracefulBranch_ParentDiesChildLingers_RealProcess(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	// Outer sh is the group leader (recorded PID). It backgrounds an inner sh
+	// that ignores SIGTERM and sleeps, then the outer sh sleeps 5s so it is
+	// still alive when KillVerifyAndCleanup enters the graceful branch. On the
+	// group SIGTERM the outer sh dies (default action) while the inner sh
+	// survives — exactly the parent-dies-first, child-lingers shape.
+	cmd := exec.Command("sh", "-c", `sh -c "trap '' TERM; sleep 60" & sleep 5`)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Skipf("sh not available: %v", err)
+	}
+	pid := cmd.Process.Pid
+	waitDone := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(waitDone)
+	}()
+	t.Cleanup(func() {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+		<-waitDone
+	})
+
+	// Let the inner child fork into the group before we act.
+	time.Sleep(250 * time.Millisecond)
+
+	g := NewGroupID()
+	if err := WriteAgent("linger", pid, g); err != nil {
+		t.Fatal(err)
+	}
+
+	const termTimeout = 800 * time.Millisecond
+	start := time.Now()
+	killed, err := KillVerifyAndCleanup("linger", termTimeout)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("KillVerifyAndCleanup: %v", err)
+	}
+	if !killed {
+		t.Error("expected killed=true")
+	}
+	// Pre-fix this returns in ~milliseconds (parent died on SIGTERM); the fix
+	// makes it wait out the SIGTERM window on the TERM-ignoring child.
+	if elapsed < termTimeout {
+		t.Errorf("returned in %v (< SIGTERM window %v) — graceful branch did not wait on the lingering child",
+			elapsed, termTimeout)
+	}
+	// The child was SIGKILLed; poll for the group to drain (init reaps the
+	// orphan zombie asynchronously).
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !IsAliveOrGroupAlive(pid) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if IsAliveOrGroupAlive(pid) {
+		t.Errorf("process group %d still alive after stop — lingering child was not killed", pid)
+	}
+	if _, err := os.Stat(PIDFile("linger")); !os.IsNotExist(err) {
+		t.Errorf("pid file should be removed")
+	}
+}
+
+// useStubGroupAllZombie overrides groupAllZombieFn for a test.
+func useStubGroupAllZombie(t *testing.T, allZombie bool, err error) {
+	t.Helper()
+	prev := groupAllZombieFn
+	groupAllZombieFn = func(pid int) (bool, error) { return allZombie, err }
+	t.Cleanup(func() { groupAllZombieFn = prev })
+}
+
+// TestGroupAllZombie_RealZombie verifies the platform probe against a REAL
+// unreaped zombie: a child in its own process group that has exited but whose
+// parent (this test process) never Wait()s it. This mirrors the container
+// case where a SIGKILLed orphan reparents to a non-reaping PID 1 — the zombie
+// lingers in the process table, kill(-pgid, 0) still reports the group as
+// "alive" (nil on Linux, EPERM on Darwin), yet groupAllZombie must recognize
+// the group holds nothing live so the drain waits can make progress.
+func TestGroupAllZombie_RealZombie(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 0")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Skipf("sh not available: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() { _ = cmd.Wait() }) // reap only in cleanup — hold the zombie
+
+	// Let the child exit and settle into Z state.
+	time.Sleep(150 * time.Millisecond)
+
+	az, err := groupAllZombie(pid)
+	if err != nil {
+		t.Fatalf("groupAllZombie errored: %v", err)
+	}
+	if !az {
+		t.Fatalf("groupAllZombie(%d) = false, want true (only member is a zombie)", pid)
+	}
+
+	// And the poll must treat it as dead promptly rather than timing out.
+	if !pollUntilGroupDead(pid, 500*time.Millisecond) {
+		t.Errorf("pollUntilGroupDead did not treat an all-zombie group as dead")
+	}
+}
+
+// TestGroupAllZombie_LiveGroupNotAllZombie verifies the probe does NOT report a
+// group with a live member as all-zombie (guards against prematurely declaring
+// a still-running agent dead).
+func TestGroupAllZombie_LiveGroupNotAllZombie(t *testing.T) {
+	cmd := exec.Command("sleep", "30")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn sleep: %v", err)
+	}
+	pid := cmd.Process.Pid
+	go func() { _ = cmd.Wait() }()
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	az, err := groupAllZombie(pid)
+	if err != nil {
+		t.Fatalf("groupAllZombie errored: %v", err)
+	}
+	if az {
+		t.Errorf("groupAllZombie(%d) = true for a live group, want false", pid)
+	}
+}
+
+// TestKillVerifyAndCleanup_GroupOnlyZombies_CleansUp is the tc29_watch_mixed
+// container regression at the unit level: the parent PID is gone and the group
+// probe still reports "alive" (an unreaped zombie child), but groupAllZombie
+// confirms nothing live remains. KillVerifyAndCleanup must therefore SUCCEED
+// (remove the bookkeeping) instead of hanging the full timeout and erroring —
+// which is what caused the watch-reload path to skip the restart.
+func TestKillVerifyAndCleanup_GroupOnlyZombies_CleansUp(t *testing.T) {
+	tmp := t.TempDir()
+	defer WithRoot(tmp)()
+
+	const pid = 55557
+	useStubAlive(t, map[int]bool{})               // parent already reaped/gone
+	useStubGroupAlive(t, map[int]bool{pid: true}) // group probe: zombie present -> "alive"
+	useStubGroupAllZombie(t, true, nil)           // ...but every member is a zombie
+
+	g := NewGroupID()
+	_ = WriteAgent("zombie-group", pid, g)
+
+	start := time.Now()
+	killed, err := KillVerifyAndCleanup("zombie-group", 3*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error (should treat all-zombie group as drained): %v", err)
+	}
+	if !killed {
+		t.Error("expected killed=true for an all-zombie orphan group")
+	}
+	if elapsed := time.Since(start); elapsed > 1*time.Second {
+		t.Errorf("took %v — should not hang the full timeout on a zombie group", elapsed)
+	}
+	if _, err := os.Stat(PIDFile("zombie-group")); !os.IsNotExist(err) {
+		t.Errorf("pid file should be removed")
 	}
 }
 
@@ -404,9 +649,12 @@ func TestKillVerifyFailureLeavesFile(t *testing.T) {
 	defer WithRoot(tmp)()
 
 	// Stub: PID 99999 is always alive. Real signals to that PID will fail with
-	// ESRCH (which the kill helper ignores) but the alive check stays true,
-	// so the function should error and NOT remove the PID file.
+	// ESRCH (which the kill helper ignores) but the alive check stays true.
+	// The graceful branch enters because the parent probe reports alive, and it
+	// then polls the GROUP — so the group must also be stubbed alive for the
+	// "can never be killed" simulation to hold through the SIGKILL escalation.
 	useStubAlive(t, map[int]bool{99999: true})
+	useStubGroupAlive(t, map[int]bool{99999: true})
 
 	g := NewGroupID()
 	_ = WriteAgent("undead", 99999, g)

--- a/src/core/cli/man/content/cli.md
+++ b/src/core/cli/man/content/cli.md
@@ -52,14 +52,30 @@ meshctl start agent.py --dte --ui --env-file .env.dev
 meshctl start agent.py --connect-only --registry-url https://registry.example.com
 ```
 
+**`--watch` (auto-rebuild on file changes).** Watch mode restarts the agent
+when you *write content* to a watched source file. It triggers on filesystem
+Write / Create / Rename events — so saving an edit in your editor reloads the
+agent. A pure `touch` that only bumps the modification time emits a Chmod
+event and is deliberately ignored, so metadata-only changes don't cause
+spurious rebuilds. On each rebuild `stop` waits for the old process to fully
+exit before the new one binds, so the agent re-binds to the same configured
+port every time.
+
+Watch mode is a **rebuild trigger, not a crash supervisor.** If an agent exits
+on its own — a crash, an uncaught exception, or an external `kill` — the
+watcher does **not** respawn it. It stays down until the next content write to
+a watched file, at which point the normal rebuild path brings it back. Use
+`--watch` for the edit-save-reload development loop; for automatic restart of
+crashed processes, run under a real supervisor (systemd, Kubernetes, etc.).
+
 ### `meshctl stop`
 
-Stops detached processes. Without arguments, stops everything (agents + UI + registry). With names, stops only those agents and keeps shared services running.
+Stops detached processes. Without arguments, stops everything (agents + UI + registry). Pass one or more names to stop only those agents and keep shared services running.
 
 ```bash
 meshctl stop                    # Stop all agents + UI + registry
 meshctl stop my-agent           # Stop only my-agent
-meshctl stop agent1 agent2      # Stop multiple
+meshctl stop agent1 agent2      # Stop multiple agents by name
 meshctl stop --agents           # Stop all agents, keep registry/UI alive
 meshctl stop --keep-registry    # Stop everything except the registry
 meshctl stop --keep-ui          # Stop everything except the UI server
@@ -70,6 +86,27 @@ meshctl stop --force            # Force-kill processes (no graceful shutdown)
 meshctl stop --quiet            # Suppress output messages
 meshctl stop --timeout 30       # Per-process shutdown timeout in seconds (default 10)
 ```
+
+When multiple names are given, each agent is stopped independently: a name
+that isn't running is reported and the rest still stop, and the command exits
+non-zero if any named agent failed. The shared flags (`--timeout`, `--force`,
+`--keep-registry`, `--keep-ui`) apply to every named agent.
+
+**Process-group semantics.** `stop` terminates the agent's whole process
+*group*, not just the recorded PID. Detached agents lead their own process
+group, so a multi-process launcher (for example a Maven `mvn spring-boot:run`
+parent whose child JVM actually holds the port) is torn down completely:
+`stop` sends `SIGTERM` to the group, then **blocks until every process in the
+group has exited** — so by the time it returns the port is released. If the
+group is still alive when `--timeout` elapses, `stop` escalates to `SIGKILL`
+against the whole group. A child that ignores `SIGTERM` or shuts down slowly is
+therefore always force-killed at the deadline rather than leaked. Behavior is
+identical on macOS and Linux.
+
+The one exception is a descendant that deliberately leaves the group — a child
+that calls `setsid()` (or is spawned into a new session/process group) is no
+longer part of the agent's group and is invisible to the group probe, so `stop`
+cannot see or reap it. Such processes must manage their own shutdown.
 
 ### `meshctl logs`
 

--- a/src/core/cli/man/content/cli.md
+++ b/src/core/cli/man/content/cli.md
@@ -70,7 +70,7 @@ crashed processes, run under a real supervisor (systemd, Kubernetes, etc.).
 
 ### `meshctl stop`
 
-Stops detached processes. Without arguments, stops everything (agents + UI + registry). Pass one or more names to stop only those agents and keep shared services running.
+Stops detached processes. Without arguments, stops everything (agents + UI + registry). Pass one or more names to stop only those agents; the registry and UI server keep running as long as another agent still depends on them, and are torn down once the last dependent stops. Use `--keep-registry` / `--keep-ui` to hold a shared service up regardless.
 
 ```bash
 meshctl stop                    # Stop all agents + UI + registry

--- a/src/core/cli/man/content/tutorial.md
+++ b/src/core/cli/man/content/tutorial.md
@@ -541,7 +541,12 @@ Here's what each flag does:
 
 - **`--debug`** -- verbose logging. Useful for seeing dependency resolution.
 - **`-d`** -- detach mode. All five agents run in the background.
-- **`-w`** -- watch mode. Monitors agent directories and auto-restarts on changes.
+- **`-w`** -- watch mode. Rebuilds an agent when you *save a content change* to
+  one of its source files. It reacts to real writes, not to metadata-only
+  changes -- a bare `touch` that just bumps the modification time is ignored.
+  Watch mode is a rebuild trigger, **not** a crash supervisor: if an agent
+  crashes or you `kill` it, the watcher leaves it down until the next time you
+  save a file. Save any watched file to bring it back.
 
 If no registry is running, `meshctl` starts one automatically, same as Day 1.
 
@@ -638,7 +643,17 @@ is not `None`. The `if user_prefs else {}` guard in the function handles the
 case where the dependency wasn't resolved.
 
 **Watch mode doesn't pick up changes.** Verify that the file you edited is in
-the same directory that `meshctl start` is watching.
+the same directory that `meshctl start` is watching, and that you actually
+*wrote content* to it -- watch mode reacts to real writes, so a bare `touch`
+that only updates the modification time is ignored on purpose. Re-save the file
+to trigger a rebuild.
+
+**A crashed agent stays down under watch mode.** Watch mode is a rebuild
+trigger, not a crash supervisor. If an agent exits on its own (crash, uncaught
+exception, or an external `kill`), the watcher does not respawn it -- it waits
+for the next content write to a watched file. Save any watched file to bring it
+back, or use a real supervisor (systemd, Kubernetes) if you need automatic
+crash recovery.
 
 **Agent ports stay stable across reloads.** When using `-w` (watch mode),
 meshctl waits for the previous process to fully exit before spawning the new

--- a/src/core/cli/man/content/upgrading.md
+++ b/src/core/cli/man/content/upgrading.md
@@ -35,19 +35,19 @@ Job rows persist across a registry restart, but **leases cannot renew while the 
 
 On restart the orphan/expired-lease **reclaim sweep** races the owner's first renewing poll: whichever lands first wins. If the sweep reclaims first, a newer-SDK owner's next delta carries a stale epoch and is fenced (`claim_superseded`) — safe. But an **older, unfenced SDK** that is re-claimed by the same instance can produce **dual ownership** (double execution), because epoch-less deltas get owner-only validation with no fencing.
 
-**Therefore: drain before a live upgrade** rather than pulling the registry out from under running jobs.
+**Therefore: drain before a live upgrade** rather than pulling the registry out from under in-flight jobs.
 
 ```bash
-# 1. Pause new claims; block until every running job releases its owner
+# 1. Pause new claims; block until every in-flight job releases its owner
 meshctl registry drain --wait
 
-# 2. Upgrade / restart the registry (running jobs have finished; queue is safe)
+# 2. Upgrade / restart the registry (in-flight jobs have finished; queue is safe)
 
 # 3. Resume normal dispatch — queued jobs become claimable again (FIFO)
 meshctl registry resume
 ```
 
-While draining, new claims are paused (queued jobs stay queued — no attempt is burned), running jobs keep renewing their leases and complete normally, and submissions are still accepted for after resume. `drain --wait` returns once `live_claims` reaches zero, and aborts with an error if the registry stops draining mid-wait (a concurrent `resume` or restart) rather than falsely reporting the window is safe.
+While draining, new claims are paused (queued jobs stay queued — no attempt is burned), `working` jobs keep renewing their leases and complete normally, and submissions are still accepted for after resume. `drain --wait` returns once `live_claims` reaches zero, and aborts with an error if the registry stops draining mid-wait (a concurrent `resume` or restart) rather than falsely reporting the window is safe.
 
 > Note: an event-gated job parked in `input_required` counts as a live claim and holds the drain open until it is answered or completes — answer or cancel such jobs before draining if you need a bounded window.
 >

--- a/src/core/cli/stop.go
+++ b/src/core/cli/stop.go
@@ -104,21 +104,9 @@ func runStopCommand(cmd *cobra.Command, args []string) error {
 		shutdownTimeout = 0
 	}
 
-	// Handle specific agent stop (one or more names)
+	// Handle specific agent stop (one or more names).
 	if len(args) > 0 {
-		var failures []string
-		for _, name := range args {
-			if err := stopSpecificAgent(name, shutdownTimeout, quiet, keepRegistry, keepUI); err != nil {
-				failures = append(failures, fmt.Sprintf("%s: %v", name, err))
-				if !quiet {
-					fmt.Printf("Warning: failed to stop %s: %v\n", name, err)
-				}
-			}
-		}
-		if len(failures) > 0 {
-			return fmt.Errorf("failed to stop %d agent(s): %s", len(failures), strings.Join(failures, "; "))
-		}
-		return nil
+		return stopNamedAgents(args, shutdownTimeout, quiet, keepRegistry, keepUI)
 	}
 
 	// --registry: force-kill only the registry, after WARNing about deps.
@@ -148,6 +136,32 @@ func runStopCommand(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	return nil
+}
+
+// stopNamedAgents stops each of the named agents in turn, applying the same
+// flags (timeout, --keep-registry, --keep-ui) to every one. Failures are
+// collected per-agent so one un-stoppable agent never aborts the rest: each is
+// warned inline (unless quiet), and a single aggregated error naming every
+// failure is returned at the end so the command exits non-zero if ANY agent
+// failed. Returns nil only when every named agent stopped cleanly.
+//
+// A single name behaves exactly like the historical single-agent stop (one
+// iteration, its error surfaced verbatim); the per-agent group refcount reap
+// in stopSpecificAgent still runs for each name independently.
+func stopNamedAgents(names []string, timeout time.Duration, quiet, keepRegistry, keepUI bool) error {
+	var failures []string
+	for _, name := range names {
+		if err := stopSpecificAgent(name, timeout, quiet, keepRegistry, keepUI); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", name, err))
+			if !quiet {
+				fmt.Printf("Warning: failed to stop %s: %v\n", name, err)
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("failed to stop %d agent(s): %s", len(failures), strings.Join(failures, "; "))
+	}
 	return nil
 }
 

--- a/src/core/cli/stop_test.go
+++ b/src/core/cli/stop_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -97,6 +98,75 @@ func TestKillProcessByPID_RefusesPID1(t *testing.T) {
 
 	if !lifecycle.IsAlive(sleepPID) {
 		t.Errorf("benign sleep PID %d is dead — killProcessByPID(1, ...) appears to have broadcast", sleepPID)
+	}
+}
+
+// TestStopNamedAgents_AllUnknown verifies multi-name stop aggregates per-agent
+// failures: every unknown name is reported, and a single non-nil error naming
+// all failures (with the correct count) is returned so the command exits
+// non-zero.
+func TestStopNamedAgents_AllUnknown(t *testing.T) {
+	tmp := t.TempDir()
+	defer lifecycle.WithRoot(tmp)()
+
+	err := stopNamedAgents([]string{"ghost-a", "ghost-b"}, time.Second, true, false, false)
+	if err == nil {
+		t.Fatal("expected aggregated error for two unknown agents")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "2 agent(s)") {
+		t.Errorf("error should report a count of 2, got: %v", err)
+	}
+	for _, name := range []string{"ghost-a", "ghost-b"} {
+		if !strings.Contains(msg, name) {
+			t.Errorf("error should name %q, got: %v", name, err)
+		}
+	}
+}
+
+// TestStopNamedAgents_MixedKnownAndUnknown verifies that one un-stoppable agent
+// never aborts the rest: a tracked-but-dead agent is cleaned up successfully
+// (its PID file removed) while an unknown name fails, and the aggregated error
+// counts only the real failure.
+func TestStopNamedAgents_MixedKnownAndUnknown(t *testing.T) {
+	tmp := t.TempDir()
+	defer lifecycle.WithRoot(tmp)()
+
+	// A tracked agent whose PID is already dead: spawn a short sleep, kill and
+	// reap it so its PID is gone, then record it. stopSpecificAgent treats this
+	// as stale bookkeeping and cleans it up (no error).
+	dead := exec.Command("sleep", "30")
+	dead.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := dead.Start(); err != nil {
+		t.Fatalf("spawn sleep: %v", err)
+	}
+	deadPID := dead.Process.Pid
+	_ = dead.Process.Kill()
+	_ = dead.Wait()
+
+	if err := lifecycle.WriteAgent("known-dead", deadPID, lifecycle.NewGroupID()); err != nil {
+		t.Fatalf("WriteAgent: %v", err)
+	}
+
+	err := stopNamedAgents([]string{"known-dead", "ghost-x"}, time.Second, true, false, false)
+	if err == nil {
+		t.Fatal("expected an error because one name is unknown")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "1 agent(s)") {
+		t.Errorf("error should report exactly 1 failure, got: %v", err)
+	}
+	if !strings.Contains(msg, "ghost-x") {
+		t.Errorf("error should name the unknown agent, got: %v", err)
+	}
+	if strings.Contains(msg, "known-dead") {
+		t.Errorf("the tracked dead agent should have stopped cleanly, got: %v", err)
+	}
+	if _, statErr := lifecycle.LookupAgent("known-dead"); statErr != nil {
+		t.Errorf("LookupAgent after stop: %v", statErr)
+	}
+	if _, err := os.Stat(lifecycle.PIDFile("known-dead")); !os.IsNotExist(err) {
+		t.Errorf("known-dead pid file should be removed after stop")
 	}
 }
 

--- a/src/core/cli/watcher.go
+++ b/src/core/cli/watcher.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -278,29 +277,15 @@ func (aw *AgentWatcher) terminateAgent() {
 	}
 
 	pid := aw.currentCmd.Process.Pid
-	// Process group ID equals PID since we set Setpgid
-	pgid := pid
 
-	// Send SIGTERM to the process group
-	if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
-		// Process may already be dead
-		aw.currentCmd = nil
-		return
+	// TERM the whole group, wait for it to drain, escalate to SIGKILL on
+	// timeout. KillGroupVerify's group-drain wait is zombie-aware, so a child
+	// orphaned to a non-reaping container PID 1 (whose zombie keeps
+	// kill(-pgid, 0) reporting "alive") is recognized as drained instead of
+	// producing a spurious "still alive after SIGKILL" on every watcher stop.
+	if !lifecycle.KillGroupVerify(pid, aw.config.StopTimeout) && !aw.quiet {
+		fmt.Printf("[watch] WARN: process group %d (%s) still alive after SIGKILL\n", pid, aw.config.AgentName)
 	}
-
-	// Poll every 50ms until StopTimeout
-	deadline := time.Now().Add(aw.config.StopTimeout)
-	for time.Now().Before(deadline) {
-		if err := syscall.Kill(-pgid, 0); err != nil {
-			// Process group no longer exists
-			aw.currentCmd = nil
-			return
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-
-	// Force kill
-	syscall.Kill(-pgid, syscall.SIGKILL)
 	aw.currentCmd = nil
 }
 
@@ -348,29 +333,13 @@ func (aw *AgentWatcher) shutdownCurrentForRestart() error {
 		}
 	}
 
+	// Direct-PID fallback: TERM the group, wait for it to drain, escalate to
+	// SIGKILL. KillGroupVerify's group-drain wait is zombie-aware — a child
+	// orphaned to a non-reaping container PID 1 counts as drained rather than
+	// hanging the timeout and forcing us to (incorrectly) skip the restart.
 	pid := cmd.Process.Pid
-	pgid := pid
-	_ = syscall.Kill(-pgid, syscall.SIGTERM)
-	deadline := time.Now().Add(aw.config.StopTimeout)
-	for time.Now().Before(deadline) {
-		// Only ESRCH definitively means the process group is gone. Other
-		// errors (EPERM, etc.) mean we can't tell — keep polling rather
-		// than declare success prematurely.
-		if err := syscall.Kill(-pgid, 0); err == syscall.ESRCH {
-			return nil
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	_ = syscall.Kill(-pgid, syscall.SIGKILL)
-	deadline = time.Now().Add(1 * time.Second)
-	for time.Now().Before(deadline) {
-		if err := syscall.Kill(-pgid, 0); err == syscall.ESRCH {
-			return nil
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	if err := syscall.Kill(-pgid, 0); err != syscall.ESRCH {
-		return fmt.Errorf("process %d still alive after SIGKILL", pid)
+	if !lifecycle.KillGroupVerify(pid, aw.config.StopTimeout) {
+		return fmt.Errorf("process group %d still alive after SIGKILL", pid)
 	}
 	return nil
 }

--- a/src/core/cli/watcher.go
+++ b/src/core/cli/watcher.go
@@ -339,6 +339,14 @@ func (aw *AgentWatcher) shutdownCurrentForRestart() error {
 	// hanging the timeout and forcing us to (incorrectly) skip the restart.
 	pid := cmd.Process.Pid
 	if !lifecycle.KillGroupVerify(pid, aw.config.StopTimeout) {
+		// The group survived the kill. We cleared aw.currentCmd up front (to
+		// keep the exit reaper from racing our explicit kill); restore it so
+		// the watcher does NOT lose track of the still-live group. Otherwise a
+		// subsequent reload would see currentCmd==nil, treat the group as
+		// absent, and start a second process alongside the survivor.
+		aw.mu.Lock()
+		aw.currentCmd = cmd
+		aw.mu.Unlock()
 		return fmt.Errorf("process group %d still alive after SIGKILL", pid)
 	}
 	return nil

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -534,6 +534,31 @@ public class MeshToolWrapper implements McpToolHandler {
     }
 
     /**
+     * Best-effort lease release for the inbound job-dispatch required-dependency
+     * guard (issue #1273). Opens the controller via {@code opener}, releases the
+     * lease, and closes it — swallowing ANY failure (from {@code open()} OR
+     * {@code releaseLease()}) so the job stays retryable (re-queues on lease
+     * expiry) instead of surfacing to the caller as a tool-call error. The
+     * controller is always closed when it was opened. Package-private with a
+     * controller-factory seam so unit tests can drive the swallow path without
+     * an FFI-backed {@link JobController}.
+     */
+    void releaseLeaseForJobGuard(String jobId, String missingCap,
+            java.util.function.Supplier<JobController> opener) {
+        try {
+            JobController controller = opener.get();
+            try {
+                controller.releaseLease("required dependency unavailable: " + missingCap);
+            } finally {
+                controller.close();
+            }
+        } catch (Exception e) {
+            log.warn("Job-dispatch guard for tool={} job={}: lease release failed "
+                + "({}); job re-queues on lease expiry instead", funcId, jobId, e.toString());
+        }
+    }
+
+    /**
      * Update a MeshLlmAgent at the given index.
      *
      * @param llmIndex The LLM agent index
@@ -1233,14 +1258,9 @@ public class MeshToolWrapper implements McpToolHandler {
                 + "'{}' unavailable at invocation time — releasing lease so the job "
                 + "re-queues (NOT invoking, NOT failing)", funcId, jobId, missingRequiredJob);
             if (canInjectController) {
-                JobController controller = JobController.open(
-                    jobId, instanceId.get(), registryUrl.get(), claimEpoch);
-                try {
-                    controller.releaseLease(
-                        "required dependency unavailable: " + missingRequiredJob);
-                } finally {
-                    controller.close();
-                }
+                releaseLeaseForJobGuard(jobId, missingRequiredJob,
+                    () -> JobController.open(
+                        jobId, instanceId.get(), registryUrl.get(), claimEpoch));
             } else {
                 log.warn("Job-dispatch guard for tool={} job={}: cannot release lease "
                     + "(controller wiring incomplete); job re-queues on lease expiry",

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -15,6 +15,8 @@ import io.mcpmesh.spring.tracing.TraceContext;
 import io.mcpmesh.spring.tracing.TraceInfo;
 import io.mcpmesh.types.McpMeshTool;
 import io.mcpmesh.types.MeshLlmAgent;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -507,6 +509,31 @@ public class MeshToolWrapper implements McpToolHandler {
     }
 
     /**
+     * Build the structured {@code dependency_unavailable} tool result (issue
+     * #1273) for a required dependency that is unresolved at direct-invoke
+     * time. Same semantic class as the {@code @MeshRoute} perimeter's 503 body
+     * {@code {"error":"dependency_unavailable","capability":"<cap>"}}; surfaced
+     * here as an {@code isError=true} {@link CallToolResult} whose single
+     * {@link TextContent} carries that JSON, so callers classify it as
+     * retryable topology rather than an application failure.
+     */
+    private CallToolResult dependencyUnavailableResult(String capability) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("error", "dependency_unavailable");
+        body.put("capability", capability);
+        String json;
+        try {
+            json = objectMapper.writeValueAsString(body);
+        } catch (Exception e) {
+            // Trivial two-scalar map — serialization never realistically fails,
+            // but fall back to a hand-built envelope so the contract holds.
+            json = "{\"error\":\"dependency_unavailable\",\"capability\":\""
+                + capability + "\"}";
+        }
+        return new CallToolResult(List.of(new TextContent(json)), true, null, null);
+    }
+
+    /**
      * Update a MeshLlmAgent at the given index.
      *
      * @param llmIndex The LLM agent index
@@ -814,8 +841,38 @@ public class MeshToolWrapper implements McpToolHandler {
             return dispatchAsJob(cleanArgs, jobIdHeader, deadlineSecs, claimEpoch);
         }
 
-        // Build full argument array (MCP params + deps + LLM agents + a2a client)
+        // Build full argument array (MCP params + deps + LLM agents + a2a
+        // client). This runs the per-slot settle-grace wait (#1193), so a
+        // still-settling required dependency is given its full window before
+        // the guard below judges it — a fresh agent restart must block-then-
+        // succeed, not burst-refuse.
         Object[] fullArgs = buildFullArgs(cleanArgs);
+
+        // Issue #1273: direct-invoke required-dependency guard — evaluated
+        // AFTER buildFullArgs (i.e. AFTER settle grace), mirroring Python/TS
+        // and the @MeshRoute perimeter, all of which guard post-settle. The
+        // claim path ({@link #invokeForClaim}, #1268) and the route interceptor
+        // ({@link MeshRouteHandlerInterceptor}'s 503) already refuse before a
+        // handler can observe a null REQUIRED dependency — the plain tools/call
+        // dispatch did not. A required dep flapping DOWN→UP flips the registry
+        // view to available before THIS callee's own heartbeat refills its
+        // injection slot; a call landing in that ~sub-second window would invoke
+        // the handler with a null required proxy (an NPE-shaped 500 the caller
+        // can't classify). Refuse instead with the SAME dependency_unavailable
+        // semantic class as the route perimeter — surfaced here as an
+        // isError=true CallToolResult whose text carries
+        // {"error":"dependency_unavailable","capability":"<cap>"} so callers
+        // classify it as retryable topology, not application failure. Optional
+        // deps keep their null-passthrough. Routes never reach here (the
+        // interceptor 503s earlier, so no double-guard); the job-dispatch path
+        // guards separately (release-the-lease) and the claim path is unchanged.
+        String missingRequired = firstUnresolvedRequiredDependency();
+        if (missingRequired != null) {
+            log.warn("Direct-invoke guard for {}: required dependency '{}' unavailable "
+                + "at invocation time — refusing with dependency_unavailable (not "
+                + "invoking the handler with a null required proxy)", funcId, missingRequired);
+            return dependencyUnavailableResult(missingRequired);
+        }
 
         // Phase B MeshJob substrate: fill MeshJob slot for non-job paths.
         // - Consumer side (method has dependencies + jobSubmitter set): inject submitter.
@@ -1158,6 +1215,39 @@ public class MeshToolWrapper implements McpToolHandler {
         boolean canInjectController = meshJobParamIndex != null
             && instanceId.get() != null
             && registryUrl.get() != null;
+
+        // Issue #1273: required-dependency guard on the inbound JOB-header path
+        // (task tool called with X-Mesh-Job-Id — cross-runtime claim
+        // propagation). Settle grace already ran (buildFullArgs). A still-
+        // unresolved required dep here must NOT invoke the handler with a null
+        // proxy — and because this is a JOB-flavored invocation (the row is
+        // claimed / `working`), the correct recovery is to RELEASE THE LEASE so
+        // the job re-queues (retryable), mirroring {@link #invokeForClaim} and
+        // the claim dispatcher. Never a tool-error refusal and never a terminal
+        // fail (which would reproduce the very race the guard prevents). When
+        // the controller wiring is incomplete there is no lease to manage — the
+        // job re-queues on lease expiry instead.
+        String missingRequiredJob = firstUnresolvedRequiredDependency();
+        if (missingRequiredJob != null) {
+            log.warn("Job-dispatch guard for tool={} job={}: required dependency "
+                + "'{}' unavailable at invocation time — releasing lease so the job "
+                + "re-queues (NOT invoking, NOT failing)", funcId, jobId, missingRequiredJob);
+            if (canInjectController) {
+                JobController controller = JobController.open(
+                    jobId, instanceId.get(), registryUrl.get(), claimEpoch);
+                try {
+                    controller.releaseLease(
+                        "required dependency unavailable: " + missingRequiredJob);
+                } finally {
+                    controller.close();
+                }
+            } else {
+                log.warn("Job-dispatch guard for tool={} job={}: cannot release lease "
+                    + "(controller wiring incomplete); job re-queues on lease expiry",
+                    funcId, jobId);
+            }
+            return null;
+        }
 
         if (!canInjectController) {
             log.warn("Job dispatch for tool={} job={} is missing wiring " +

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ToolInvoker.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ToolInvoker.java
@@ -4,6 +4,9 @@ import io.mcpmesh.types.McpMeshTool;
 import io.mcpmesh.types.MeshLlmAgent.ToolInfo;
 import io.mcpmesh.types.MeshToolCallException;
 import io.mcpmesh.types.MeshToolUnavailableException;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.Content;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,13 +175,48 @@ public class ToolInvoker {
         try (SpanScope span = tracer != null ? tracer.startSpan("proxy_call_wrapper", spanMeta) : SpanScope.NOOP) {
             try {
                 Object result = handler.invoke(args);
+                // Issue #1273: a handler may RETURN an isError CallToolResult
+                // rather than throw (e.g. the direct-invoke required-dependency
+                // refusal). Local / self-dependency / LLM callers expect a raw
+                // value or an exception — mirror the remote path
+                // ({@link McpHttpClient}), which throws MeshToolCallException on
+                // isError — so an isError envelope never leaks back as a
+                // successful value.
+                if (result instanceof CallToolResult ctr
+                        && Boolean.TRUE.equals(ctr.isError())) {
+                    String errorText = firstTextContent(ctr);
+                    MeshToolCallException ex = new MeshToolCallException(
+                        capability, handler.getMethodName(), errorText);
+                    span.withError(ex);
+                    throw ex;
+                }
                 span.withResult(result);
                 return result;
+            } catch (MeshToolCallException e) {
+                // Already the caller-facing type (isError translation above) —
+                // don't double-wrap.
+                throw e;
             } catch (Exception e) {
                 span.withError(e);
                 throw new MeshToolCallException(capability, handler.getMethodName(), e);
             }
         }
+    }
+
+    /**
+     * Extract the text of the first {@link TextContent} block in a tool
+     * result, or a generic message when none is present. Used to surface an
+     * isError result's payload (issue #1273) to local callers.
+     */
+    private static String firstTextContent(CallToolResult ctr) {
+        if (ctr.content() != null) {
+            for (Content c : ctr.content()) {
+                if (c instanceof TextContent tc) {
+                    return tc.text();
+                }
+            }
+        }
+        return "Unknown tool error";
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRequiredDepGuardTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRequiredDepGuardTest.java
@@ -364,4 +364,17 @@ class MeshToolWrapperRequiredDepGuardTest {
             TraceContext.clearPropagatedHeaders();
         }
     }
+
+    @Test
+    void releaseLeaseForJobGuard_openThrows_swallowed_staysRetryable() throws Exception {
+        // A failure constructing the controller (e.g. JobController.open) must
+        // NOT escape — the job stays retryable (re-queues on lease expiry).
+        RequiredDepBean bean = new RequiredDepBean();
+        MeshToolWrapper wrapper = wrapperFor(bean, true);
+
+        assertDoesNotThrow(() -> wrapper.releaseLeaseForJobGuard(
+            "job-1", "lookup",
+            () -> { throw new RuntimeException("open failed"); }),
+            "a controller-open failure in the job guard must be swallowed (retryable)");
+    }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRequiredDepGuardTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRequiredDepGuardTest.java
@@ -3,7 +3,11 @@ package io.mcpmesh.spring;
 import io.mcpmesh.MeshJob;
 import io.mcpmesh.MeshTool;
 import io.mcpmesh.Param;
+import io.mcpmesh.spring.tracing.TraceContext;
 import io.mcpmesh.types.McpMeshTool;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -183,5 +187,181 @@ class MeshToolWrapperRequiredDepGuardTest {
         assertTrue(bean.handlerRan.get(), "handler must run when required deps are resolved");
         assertNotNull(bean.receivedDep.get(), "resolved required proxy must be injected");
         assertFalse(released.get(), "lease must NOT be released when required deps are resolved");
+    }
+
+    // ---- direct-invoke guard (issue #1273) ----------------------------------
+
+    /** Plain (non-task) consumer with ONE required McpMeshTool dependency. */
+    public static class DirectRequiredDepBean {
+        final AtomicBoolean handlerRan = new AtomicBoolean(false);
+        final AtomicReference<McpMeshTool<?>> receivedDep = new AtomicReference<>();
+
+        @MeshTool(capability = "enrich",
+            dependencies = @io.mcpmesh.Selector(capability = "lookup", required = true))
+        public Object enrich(
+                @Param("user_id") String userId,
+                McpMeshTool<String> lookup) {
+            handlerRan.set(true);
+            receivedDep.set(lookup);
+            java.util.Map<String, Object> out = new java.util.HashMap<>();
+            out.put("user_id", userId);
+            return out;
+        }
+    }
+
+    private static MeshToolWrapper directWrapperFor(DirectRequiredDepBean bean, boolean required)
+            throws Exception {
+        Method m = DirectRequiredDepBean.class.getMethod("enrich", String.class, McpMeshTool.class);
+        MeshToolWrapper w = new MeshToolWrapper(
+            "DirectRequiredDepBean.enrich",
+            "enrich",
+            "test",
+            bean,
+            m,
+            List.of("lookup"),
+            JsonMapper.builder().build());
+        w.setDependencyRequired(List.of(required));
+        return w;
+    }
+
+    @Test
+    void invoke_requiredSlotNull_refusesWithoutInvoking() throws Exception {
+        DirectRequiredDepBean bean = new DirectRequiredDepBean();
+        MeshToolWrapper wrapper = directWrapperFor(bean, true);
+
+        Object result = wrapper.invoke(Map.of("user_id", "alice"));
+
+        assertFalse(bean.handlerRan.get(),
+            "handler MUST NOT run when a required dependency is unresolved at direct invoke");
+        assertInstanceOf(CallToolResult.class, result,
+            "the refusal must be a structured tool result, not a raw value");
+        CallToolResult ctr = (CallToolResult) result;
+        assertEquals(Boolean.TRUE, ctr.isError(),
+            "the refusal must be an isError tool result (retryable topology, not app failure)");
+        String text = ((TextContent) ctr.content().get(0)).text();
+        assertTrue(text.contains("\"error\":\"dependency_unavailable\""),
+            "text must carry the dependency_unavailable envelope; got: " + text);
+        assertTrue(text.contains("\"capability\":\"lookup\""),
+            "the envelope must name the missing capability; got: " + text);
+    }
+
+    @Test
+    void invoke_requiredSlotResolved_invokesHandler() throws Exception {
+        DirectRequiredDepBean bean = new DirectRequiredDepBean();
+        MeshToolWrapper wrapper = directWrapperFor(bean, true);
+
+        wrapper.updateDependency(0, new StubProxy(true));
+
+        Object result = wrapper.invoke(Map.of("user_id", "bob"));
+
+        assertTrue(bean.handlerRan.get(),
+            "handler must run once the required dep resolves");
+        assertNotNull(bean.receivedDep.get(), "resolved required proxy must be injected");
+        assertFalse(result instanceof CallToolResult,
+            "a resolved call must return the handler result, not a refusal envelope");
+    }
+
+    @Test
+    void invoke_optionalSlotNull_invokesHandlerWithNull() throws Exception {
+        DirectRequiredDepBean bean = new DirectRequiredDepBean();
+        // Same signature, but the dep is declared OPTIONAL — null passthrough.
+        MeshToolWrapper wrapper = directWrapperFor(bean, false);
+
+        Object result = wrapper.invoke(Map.of("user_id", "carol"));
+
+        assertTrue(bean.handlerRan.get(),
+            "an optional dep must never gate a direct invoke even when null");
+        assertNull(bean.receivedDep.get(),
+            "the handler must observe null for the unresolved OPTIONAL dep");
+        assertFalse(result instanceof CallToolResult,
+            "an optional null dep must not produce a refusal envelope");
+    }
+
+    // ---- guard vs settle grace (issue #1273 review) -------------------------
+
+    @AfterEach
+    void resetSettleState() {
+        MeshSettleState.resetForTests();
+    }
+
+    @Test
+    void invoke_requiredDepLandsMidSettle_waitsThenInvokes() throws Exception {
+        // Arm a live settle window so the guard's underlying buildFullArgs
+        // BLOCKS on the slot latch (the guard is evaluated AFTER settle grace).
+        MeshSettleState.resetForTests(10.0);
+        MeshSettleState state = MeshSettleState.getInstance();
+        state.registerDeclared("DirectRequiredDepBean.enrich:dep_0");
+
+        DirectRequiredDepBean bean = new DirectRequiredDepBean();
+        MeshToolWrapper wrapper = directWrapperFor(bean, true);
+
+        // Land the required proxy mid-wait (mirrors a heartbeat resolving the
+        // dep during the settle window).
+        Thread resolver = new Thread(() -> {
+            try {
+                Thread.sleep(150);
+            } catch (InterruptedException ignored) {
+                Thread.currentThread().interrupt();
+            }
+            wrapper.updateDependency(0, new StubProxy(true));
+        });
+        resolver.start();
+
+        Object result = wrapper.invoke(Map.of("user_id", "dave"));
+        resolver.join(2000);
+
+        assertTrue(bean.handlerRan.get(),
+            "a required dep that lands within the settle window must NOT be refused — "
+                + "the guard must wait out settle grace first (a fresh restart must "
+                + "block-then-succeed, not burst-refuse)");
+        assertNotNull(bean.receivedDep.get(), "the resolved proxy must be injected");
+        assertFalse(result instanceof CallToolResult,
+            "a mid-settle resolution must not produce a refusal envelope");
+    }
+
+    @Test
+    void invoke_requiredDepDownAfterSettle_refuses() throws Exception {
+        // Settled state (timeout=0) → no grace window → fail-fast refusal.
+        MeshSettleState.resetForTests();
+        DirectRequiredDepBean bean = new DirectRequiredDepBean();
+        MeshToolWrapper wrapper = directWrapperFor(bean, true);
+
+        Object result = wrapper.invoke(Map.of("user_id", "erin"));
+
+        assertFalse(bean.handlerRan.get(),
+            "a required dep still down AFTER settle must be refused");
+        assertInstanceOf(CallToolResult.class, result);
+        assertEquals(Boolean.TRUE, ((CallToolResult) result).isError());
+        String text = ((TextContent) ((CallToolResult) result).content().get(0)).text();
+        assertTrue(text.contains("\"capability\":\"lookup\""), text);
+    }
+
+    // ---- guard vs job-header path (issue #1273 review) ----------------------
+
+    @Test
+    void jobHeaderDispatch_requiredDepUnresolved_doesNotInvoke_returnsNull() throws Exception {
+        // A task=true tool invoked with an X-Mesh-Job-Id header (cross-runtime
+        // claim propagation). instanceId/registryUrl are NOT wired, so
+        // canInjectController is false — the guard refuses-to-invoke and
+        // returns null WITHOUT constructing an FFI JobController. This proves
+        // the job-flavored path never emits a tool-error refusal and never
+        // runs the handler; the FFI-backed lease release for the wired case
+        // mirrors invokeForClaim (covered there / at integration level).
+        RequiredDepBean bean = new RequiredDepBean();
+        MeshToolWrapper wrapper = wrapperFor(bean, true); // task=true, required
+
+        MeshSettleState.resetForTests(); // settled — no grace
+        try {
+            TraceContext.setPropagatedHeaders(Map.of("x-mesh-job-id", "job-123"));
+            Object result = wrapper.invoke(Map.of("user_id", "frank"));
+
+            assertNull(result,
+                "the job-flavored guard must return null (job re-queues), not a "
+                    + "tool-error refusal");
+            assertFalse(bean.handlerRan.get(),
+                "the handler MUST NOT run with an unresolved required dep on the job path");
+        } finally {
+            TraceContext.clearPropagatedHeaders();
+        }
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/ToolInvokerLocalRefusalTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/ToolInvokerLocalRefusalTest.java
@@ -1,0 +1,64 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.types.MeshToolCallException;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #1273 (review item 5): {@link ToolInvoker#invokeLocal} must not leak a
+ * handler's {@code isError} {@link CallToolResult} back to local /
+ * self-dependency / LLM callers as a SUCCESS value. It mirrors the remote path
+ * ({@link McpHttpClient}), which throws {@link MeshToolCallException} on
+ * {@code isError} — so the direct-invoke {@code dependency_unavailable} refusal
+ * surfaces to local callers as the exception they already expect.
+ */
+class ToolInvokerLocalRefusalTest {
+
+    private static CallToolResult refusal(String capability) {
+        String json = "{\"error\":\"dependency_unavailable\",\"capability\":\""
+            + capability + "\"}";
+        return new CallToolResult(List.of(new TextContent(json)), true, null, null);
+    }
+
+    @Test
+    void invokeLocal_isErrorResult_throwsMeshToolCallException() throws Exception {
+        MeshToolWrapperRegistry registry = mock(MeshToolWrapperRegistry.class);
+        McpToolHandler handler = mock(McpToolHandler.class);
+        when(handler.getFuncId()).thenReturn("Bean.enrich");
+        when(handler.getMethodName()).thenReturn("enrich");
+        when(handler.invoke(Map.of())).thenReturn(refusal("lookup"));
+        when(registry.getHandlerByCapability("enrich")).thenReturn(handler);
+
+        ToolInvoker invoker = new ToolInvoker(null, registry, "agent-1");
+
+        MeshToolCallException ex = assertThrows(MeshToolCallException.class,
+            () -> invoker.invokeLocal("enrich", Map.of()));
+        assertTrue(ex.getMessage().contains("dependency_unavailable"),
+            "the exception must carry the refusal envelope; got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("lookup"),
+            "the exception must name the missing capability; got: " + ex.getMessage());
+    }
+
+    @Test
+    void invokeLocal_successResult_returnedAsIs() throws Exception {
+        MeshToolWrapperRegistry registry = mock(MeshToolWrapperRegistry.class);
+        McpToolHandler handler = mock(McpToolHandler.class);
+        when(handler.getFuncId()).thenReturn("Bean.enrich");
+        when(handler.getMethodName()).thenReturn("enrich");
+        when(handler.invoke(Map.of())).thenReturn("ok");
+        when(registry.getHandlerByCapability("enrich")).thenReturn(handler);
+
+        ToolInvoker invoker = new ToolInvoker(null, registry, "agent-1");
+
+        assertEquals("ok", invoker.invokeLocal("enrich", Map.of()),
+            "a non-error result must pass through unchanged");
+    }
+}

--- a/src/runtime/python/_mcp_mesh/engine/claim_dispatcher.py
+++ b/src/runtime/python/_mcp_mesh/engine/claim_dispatcher.py
@@ -44,6 +44,7 @@ re-claim storm once the leases expired.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 from typing import Any, Optional
@@ -51,6 +52,28 @@ from typing import Any, Optional
 from .job_dispatch import maybe_dispatch_as_job
 
 logger = logging.getLogger(__name__)
+
+
+def _dependency_unavailable_capability(exc: BaseException) -> Optional[str]:
+    """Return the capability named by a ``dependency_unavailable`` refusal, or
+    ``None`` when ``exc`` is an ordinary handler exception (issue #1273).
+
+    The DI wrapper's direct-dispatch guard raises a ``ToolError`` whose message
+    is the JSON envelope ``{"error":"dependency_unavailable","capability":"…"}``.
+    When a required dep flaps DOWN between the dispatcher's own pre-invoke gate
+    and the handler call, that refusal surfaces here — and because this is a
+    JOB invocation it must RELEASE the lease (retryable), not TERMINAL-fail.
+    Match on the JSON envelope (runtime-agnostic) rather than the exception
+    type so the contract, not the carrier, drives the classification.
+    """
+    try:
+        payload = json.loads(str(exc))
+    except (ValueError, TypeError):
+        return None
+    if isinstance(payload, dict) and payload.get("error") == "dependency_unavailable":
+        cap = payload.get("capability")
+        return cap if isinstance(cap, str) else None
+    return None
 
 
 # Polling cadence — matches the design's "backoff_min" / "backoff_max"
@@ -346,6 +369,25 @@ class PythonClaimDispatcher:
         try:
             await self.handler(**payload)
         except Exception as e:
+            # Issue #1273: the DI wrapper's direct-dispatch guard may raise a
+            # dependency_unavailable refusal if a required dep flapped DOWN
+            # between our pre-invoke gate above and the handler call. That is a
+            # topological race, NOT an application failure — RELEASE the lease
+            # (retryable) rather than TERMINAL-fail, so release semantics win
+            # over the wrapper's tool-error carrier (mirrors the guard 15 lines
+            # above and Java/TS job paths).
+            raced_cap = _dependency_unavailable_capability(e)
+            if raced_cap is not None:
+                logger.warning(
+                    "claim_dispatcher: releasing job=%s for capability=%s — "
+                    "required dependency '%s' flapped unavailable during handler "
+                    "dispatch; releasing lease for retry (not failing)",
+                    job_id,
+                    self.capability,
+                    raced_cap,
+                )
+                await self._release_lease(job_id, raced_cap, claim_epoch)
+                return
             logger.warning(
                 "claim_dispatcher: handler for job=%s capability=%s raised: %s",
                 job_id,

--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -9,6 +9,7 @@ the HTTP middleware layer for unified approach across MCP agents and FastAPI app
 import asyncio
 import functools
 import inspect
+import json
 import logging
 import weakref
 from collections.abc import Callable, Iterable
@@ -1284,6 +1285,7 @@ class DependencyInjector:
         func: Callable,
         dependencies: list[str],
         route_required_caps: Optional[list[Optional[str]]] = None,
+        tool_required_caps: Optional[list[Optional[str]]] = None,
     ) -> Callable:
         """
         Create in-place dependency injection by modifying the original function.
@@ -1300,8 +1302,21 @@ class DependencyInjector:
         dependency slot is ``required=True`` (perimeter 503), else ``None``.
         When any slot is required, the non-streaming DI wrapper returns HTTP
         503 (naming the capability) before invoking user code if that dep's
-        proxy is unavailable at call time. @mesh.tool never passes this —
-        mesh-internal calls are chain-gated, not perimeter-gated.
+        proxy is unavailable at call time. @mesh.tool passes
+        ``tool_required_caps`` instead — mesh-internal calls are chain-gated,
+        not perimeter-gated, but a direct ``tools/call`` for a tool with a
+        required dep is still refused (issue #1273).
+
+        ``tool_required_caps`` (issue #1273) is the @mesh.tool analogue set by
+        the tool decorator: an index-aligned list where each entry is the
+        capability name if that dependency slot is ``required=True`` (else
+        ``None``). When any slot is required, the tool DI wrapper REFUSES the
+        direct ``tools/call`` dispatch — raising a ``dependency_unavailable``
+        tool error (an ``isError`` result naming the capability, same semantic
+        class as the route perimeter's 503) rather than invoking the handler
+        with a null required proxy — if that dep is unresolved at call time.
+        This closes the same DOWN→UP flap window #1268 closed on the claim
+        path. Optional deps keep their None-passthrough.
         """
         func_id = f"{func.__module__}.{func.__qualname__}"
 
@@ -1309,6 +1324,12 @@ class DependencyInjector:
         # cheaply; None (the @mesh.tool case) short-circuits the whole check.
         _route_required_caps: list[Optional[str]] = list(route_required_caps or [])
         _has_route_required = any(c is not None for c in _route_required_caps)
+        # Issue #1273: @mesh.tool required-dep slots (index-aligned with
+        # ``dependencies``). The MeshJob-paired slot is nulled out below once
+        # ``mesh_job_index`` is known — its slot holds a locally-built
+        # submitter, never a resolved proxy, so gating on it would refuse
+        # every call (mirrors the claim dispatcher's mesh_job_dep_index skip).
+        _tool_required_caps: list[Optional[str]] = list(tool_required_caps or [])
 
         # Use new smart injection strategy
         mesh_positions = analyze_injection_strategy(func, dependencies)
@@ -1389,6 +1410,18 @@ class DependencyInjector:
         for _key in settle_keys:
             if _key is not None:
                 _settle_state.register_declared(_key)
+
+        # Issue #1273: exclude the MeshJob-paired dep slot from the tool
+        # required-dep refusal. Its dep_index is the rank of the MeshJob
+        # parameter position among the sorted eligible positions (same math
+        # as the settle loop and the claim dispatcher's mesh_job_dep_index).
+        # That slot injects a locally-built MeshJobSubmitter, never a resolved
+        # proxy, so leaving it in would refuse every call.
+        if mesh_job_index is not None and mesh_job_index in settle_eligible:
+            _mj_dep_index = settle_eligible.index(mesh_job_index)
+            if 0 <= _mj_dep_index < len(_tool_required_caps):
+                _tool_required_caps[_mj_dep_index] = None
+        _has_tool_required = any(c is not None for c in _tool_required_caps)
 
         # If no mesh positions to inject AND no MeshJob slot, fall back to
         # the minimal tracking wrapper. With a MeshJob slot we route to the
@@ -1528,6 +1561,49 @@ class DependencyInjector:
                 },
             )
 
+        # Issue #1273 tool-dispatch guard (shared by the async + sync
+        # dependency_wrapper closures): when a @mesh.tool has a required dep
+        # slot that is unresolved at direct ``tools/call`` time, raise a
+        # ``dependency_unavailable`` tool error naming the capability instead
+        # of invoking the handler with a null required proxy. FastMCP surfaces
+        # a raised ``ToolError`` as an ``isError`` result whose text carries
+        # the message, so the JSON body ``{"error":"dependency_unavailable",
+        # "capability":"<cap>"}`` reaches the caller — the SAME semantic class
+        # as the route perimeter's 503, letting callers classify it as
+        # retryable topology rather than application failure. Runs AFTER the
+        # settle wait / injection (so a still-settling dep gets its full window
+        # and caller-supplied mocks are honored) and is a no-op unless the tool
+        # declared a required dep (@mesh.tool sets ``tool_required_caps``).
+        def _tool_required_refusal(injected_deps, kwargs):
+            if not _has_tool_required:
+                return
+            unavailable = _first_unavailable_required(
+                func_id,
+                _tool_required_caps,
+                injected_deps,
+                self.get_dependency,
+                kwargs,
+                settle_params,
+            )
+            if unavailable is None:
+                return
+            from fastmcp.exceptions import ToolError
+
+            wrapper_logger.warning(
+                f"🚫 Tool '{func.__name__}': required dependency "
+                f"'{unavailable}' unavailable at invocation time — refusing "
+                f"with dependency_unavailable (not invoking the handler with a "
+                f"null required proxy)"
+            )
+            raise ToolError(
+                json.dumps(
+                    {
+                        "error": "dependency_unavailable",
+                        "capability": unavailable,
+                    }
+                )
+            )
+
         # Determine if we need async wrapper
         need_async_wrapper = inspect.iscoroutinefunction(func)
 
@@ -1592,6 +1668,12 @@ class DependencyInjector:
                 if _perimeter is not None:
                     return _perimeter
 
+                # Issue #1273 direct-dispatch guard (no-op for @mesh.route and
+                # for tools with no required dep). Raises ToolError → isError.
+                _tool_required_refusal(
+                    dependency_wrapper._mesh_injected_deps, kwargs
+                )
+
                 from ..tracing.execution_tracer import ExecutionTracer
                 from .job_dispatch import maybe_dispatch_as_job
 
@@ -1655,6 +1737,12 @@ class DependencyInjector:
                 )
                 if _perimeter is not None:
                     return _perimeter
+
+                # Issue #1273 direct-dispatch guard (sync variant). Raises
+                # ToolError → isError when a required tool dep is unresolved.
+                _tool_required_refusal(
+                    dependency_wrapper._mesh_injected_deps, kwargs
+                )
 
                 from ..tracing.execution_tracer import ExecutionTracer
 

--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -1449,6 +1449,25 @@ class DependencyInjector:
                     f"(e.g. 'dep: McpMeshTool = None')."
                 )
 
+            # Issue #1273: the @mesh.tool analogue — a required dep declared but
+            # the tool took the minimal path (no injectable McpMeshTool slot), so
+            # the direct-dispatch refusal (_tool_required_refusal) has nothing to
+            # evaluate. With NO slot the handler can never observe a null required
+            # proxy (the #1273 null-observation bug is structurally impossible
+            # here), so — exactly like the route perimeter above — enforcement
+            # stays OFF and we WARN instead: the mis-annotation (the dep param
+            # isn't typed McpMeshTool) is the thing to fix, not a refuse-all guard.
+            if _has_tool_required:
+                _req_caps = [c for c in _tool_required_caps if c is not None]
+                logger.warning(
+                    f"⚠️ Tool '{func.__name__}': required-dependency guard "
+                    f"INACTIVE — declared required {_req_caps} but the handler has "
+                    f"no injectable McpMeshTool parameter to receive them, so the "
+                    f"dependency_unavailable refusal cannot evaluate and is "
+                    f"skipped. Fix: annotate the intended parameter(s) as "
+                    f"McpMeshTool (e.g. 'dep: McpMeshTool = None')."
+                )
+
             if is_stream:
                 minimal_wrapper = _make_stream_wrapper(
                     func,

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -1226,11 +1226,24 @@ def tool(
             # Extract dependency names for injector (empty list for functions without dependencies)
             dependency_names = [dep["capability"] for dep in validated_dependencies]
 
+            # Issue #1273: index-aligned required-dep capabilities for the
+            # direct-dispatch guard — capability name where the slot is
+            # required=True, else None. Only carried when at least one slot is
+            # required (else None, so the wrapper's guard stays a no-op).
+            tool_required_caps = [
+                dep["capability"] if dep.get("required") else None
+                for dep in validated_dependencies
+            ]
+            if not any(c is not None for c in tool_required_caps):
+                tool_required_caps = None
+
             # Log the original function pointer
             logger.debug(f"🔸 ORIGINAL function pointer: {target} at {hex(id(target))}")
 
             injector = get_global_injector()
-            wrapped = injector.create_injection_wrapper(target, dependency_names)
+            wrapped = injector.create_injection_wrapper(
+                target, dependency_names, tool_required_caps=tool_required_caps
+            )
 
             # Log the wrapper function pointer
             logger.debug(

--- a/src/runtime/python/tests/unit/test_1273_direct_invoke_required.py
+++ b/src/runtime/python/tests/unit/test_1273_direct_invoke_required.py
@@ -1,0 +1,269 @@
+"""
+Unit tests for issue #1273: direct ``tools/call`` dispatch must refuse when a
+``required=True`` dependency slot is unresolved at invocation time.
+
+The claim path (#1268) and the @mesh.route perimeter (#1249, 503) already
+refuse before a handler can observe a null required dependency; this closes the
+same DOWN→UP flap window on the plain tool-dispatch path. A required slot that
+is unresolved at call time raises a ``dependency_unavailable`` tool error (an
+``isError`` result whose text carries ``{"error":"dependency_unavailable",
+"capability":"<cap>"}`` — the SAME semantic class as the route perimeter's 503)
+rather than invoking the handler with a null required proxy. Optional deps keep
+their documented None-passthrough.
+
+Mirrors the route-perimeter tests in ``test_1249_required_dependency.py`` but
+drives ``tool_required_caps`` (the @mesh.tool analogue of ``route_required_caps``)
+and asserts the raised ``ToolError`` rather than a 503 ``JSONResponse``.
+"""
+
+import asyncio
+import json
+import os
+from unittest.mock import patch
+
+import mesh
+import pytest
+from _mcp_mesh.engine import settle
+from _mcp_mesh.engine.dependency_injector import DependencyInjector
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+from fastmcp.exceptions import ToolError
+
+
+def _clear():
+    DecoratorRegistry.clear_all()
+    from _mcp_mesh.pipeline.mcp_startup import clear_debounce_coordinator
+
+    clear_debounce_coordinator()
+
+
+def _make_tool_wrapper(func, deps, required_caps):
+    injector = DependencyInjector()
+    with patch(
+        "_mcp_mesh.engine.dependency_injector.analyze_injection_strategy",
+        return_value=[0],
+    ):
+        return injector.create_injection_wrapper(
+            func, deps, tool_required_caps=required_caps
+        )
+
+
+class TestToolDirectInvokeRefusal:
+    def setup_method(self):
+        _clear()
+
+    def test_required_unavailable_raises_refusal_handler_not_invoked(self):
+        called = []
+
+        async def tool(lookup=None):
+            called.append(True)
+            return {"ok": True}
+
+        wrapper = _make_tool_wrapper(tool, ["lookup"], ["lookup"])
+        # Proxy unavailable (never resolved) — default injected_deps is [None].
+        with pytest.raises(ToolError) as excinfo:
+            asyncio.run(wrapper())
+
+        body = json.loads(str(excinfo.value))
+        assert body == {
+            "error": "dependency_unavailable",
+            "capability": "lookup",
+        }
+        assert called == []  # handler must NOT run
+
+    def test_required_available_runs_handler(self):
+        called = []
+
+        async def tool(lookup=None):
+            called.append(lookup)
+            return {"ok": True}
+
+        wrapper = _make_tool_wrapper(tool, ["lookup"], ["lookup"])
+        proxy = object()
+        wrapper._mesh_update_dependency(0, proxy)
+
+        result = asyncio.run(wrapper())
+        assert result == {"ok": True}
+        assert called == [proxy]  # handler ran with the live proxy
+
+    def test_optional_unavailable_runs_handler_with_none(self):
+        called = []
+
+        async def tool(lookup=None):
+            called.append(lookup)
+            return {"ok": True}
+
+        # No required caps → soft-fail preserved (None passthrough).
+        wrapper = _make_tool_wrapper(tool, ["lookup"], None)
+
+        result = asyncio.run(wrapper())
+        assert result == {"ok": True}
+        assert called == [None]  # ran with None injected, no refusal
+
+    def test_sync_tool_required_unavailable_raises_refusal(self):
+        called = []
+
+        def tool(lookup=None):
+            called.append(True)
+            return {"ok": True}
+
+        wrapper = _make_tool_wrapper(tool, ["lookup"], ["lookup"])
+        with pytest.raises(ToolError) as excinfo:
+            wrapper()
+
+        assert json.loads(str(excinfo.value))["capability"] == "lookup"
+        assert called == []
+
+    def test_sync_tool_required_available_runs_handler(self):
+        called = []
+
+        def tool(lookup=None):
+            called.append(lookup)
+            return {"ok": True}
+
+        wrapper = _make_tool_wrapper(tool, ["lookup"], ["lookup"])
+        proxy = object()
+        wrapper._mesh_update_dependency(0, proxy)
+
+        result = wrapper()
+        assert result == {"ok": True}
+        assert called == [proxy]
+
+    def test_caller_supplied_mock_satisfies_required_dep(self):
+        """Mock contract: an explicit fake for a required dep runs the handler.
+
+        Mirrors the route-perimeter mock skip — passing the parameter directly
+        must NOT trip the refusal even while the mesh proxy is unresolved.
+        """
+        called = []
+
+        async def tool(lookup=None):
+            called.append(lookup)
+            return {"ok": True}
+
+        wrapper = _make_tool_wrapper(tool, ["lookup"], ["lookup"])
+        fake = object()
+        result = asyncio.run(wrapper(lookup=fake))
+        assert result == {"ok": True}
+        assert called == [fake]
+
+
+class TestToolRequiredCapsWiring:
+    """The @mesh.tool decorator threads ``tool_required_caps`` into the
+    injector (index-aligned capability-or-None), so the guard is armed for
+    required tool deps and a no-op otherwise."""
+
+    def setup_method(self):
+        _clear()
+
+    def test_decorator_passes_tool_required_caps(self):
+        seen = {}
+
+        real = DependencyInjector.create_injection_wrapper
+
+        def spy(self, func, dependencies, route_required_caps=None, tool_required_caps=None):
+            seen["tool_required_caps"] = tool_required_caps
+            return real(
+                self,
+                func,
+                dependencies,
+                route_required_caps=route_required_caps,
+                tool_required_caps=tool_required_caps,
+            )
+
+        with patch.object(DependencyInjector, "create_injection_wrapper", spy):
+
+            @mesh.tool(
+                capability="enrich",
+                dependencies=[
+                    {"capability": "lookup", "required": True},
+                    "audit",
+                ],
+            )
+            def enrich(lookup: mesh.McpMeshTool = None, audit: mesh.McpMeshTool = None):
+                return "ok"
+
+        assert seen["tool_required_caps"] == ["lookup", None]
+
+    def test_decorator_omits_caps_when_no_required(self):
+        seen = {}
+
+        real = DependencyInjector.create_injection_wrapper
+
+        def spy(self, func, dependencies, route_required_caps=None, tool_required_caps=None):
+            seen["tool_required_caps"] = tool_required_caps
+            return real(
+                self,
+                func,
+                dependencies,
+                route_required_caps=route_required_caps,
+                tool_required_caps=tool_required_caps,
+            )
+
+        with patch.object(DependencyInjector, "create_injection_wrapper", spy):
+
+            @mesh.tool(capability="enrich", dependencies=["lookup"])
+            def enrich(lookup: mesh.McpMeshTool = None):
+                return "ok"
+
+        # No required slot → None (guard stays a no-op).
+        assert seen["tool_required_caps"] is None
+
+
+class TestToolGuardVsSettle:
+    """Issue #1273 review: the refusal is evaluated AFTER the settle wait, so a
+    required dep that lands within the settle window runs the handler (a fresh
+    restart must block-then-succeed, not burst-refuse); only a dep still down
+    once settled is refused."""
+
+    def setup_method(self):
+        _clear()
+        os.environ.pop("MCP_MESH_SETTLE_TIMEOUT", None)
+        settle._reset_settle_state_for_tests()
+
+    def teardown_method(self):
+        os.environ.pop("MCP_MESH_SETTLE_TIMEOUT", None)
+        settle._reset_settle_state_for_tests()
+
+    def test_required_dep_lands_mid_settle_invokes_no_refusal(self):
+        os.environ["MCP_MESH_SETTLE_TIMEOUT"] = "10"
+        settle._reset_settle_state_for_tests()
+
+        called = []
+
+        async def tool(lookup=None):
+            called.append(lookup)
+            return {"ok": True}
+
+        wrapper = _make_tool_wrapper(tool, ["lookup"], ["lookup"])
+        proxy = object()
+
+        async def run():
+            async def resolve_later():
+                await asyncio.sleep(0.2)
+                wrapper._mesh_update_dependency(0, proxy)
+
+            resolver = asyncio.create_task(resolve_later())
+            result = await wrapper()
+            await resolver
+            return result
+
+        result = asyncio.run(run())
+        assert result == {"ok": True}
+        assert called == [proxy]  # waited out settle, ran with the proxy
+
+    def test_required_dep_down_after_settle_refuses(self):
+        os.environ["MCP_MESH_SETTLE_TIMEOUT"] = "0"  # disabled → settled
+        settle._reset_settle_state_for_tests()
+
+        called = []
+
+        async def tool(lookup=None):
+            called.append(True)
+            return {"ok": True}
+
+        wrapper = _make_tool_wrapper(tool, ["lookup"], ["lookup"])
+        with pytest.raises(ToolError) as excinfo:
+            asyncio.run(wrapper())
+
+        assert json.loads(str(excinfo.value))["capability"] == "lookup"
+        assert called == []

--- a/src/runtime/python/tests/unit/test_1273_direct_invoke_required.py
+++ b/src/runtime/python/tests/unit/test_1273_direct_invoke_required.py
@@ -50,6 +50,16 @@ def _make_tool_wrapper(func, deps, required_caps):
 class TestToolDirectInvokeRefusal:
     def setup_method(self):
         _clear()
+        # Force a SETTLED state (no grace window) so the unavailable-cases refuse
+        # immediately regardless of env / prior-test order — the guard is
+        # evaluated after settle, so a leftover armed window would otherwise make
+        # these block instead of refuse (mirrors TestToolGuardVsSettle).
+        os.environ["MCP_MESH_SETTLE_TIMEOUT"] = "0"
+        settle._reset_settle_state_for_tests()
+
+    def teardown_method(self):
+        os.environ.pop("MCP_MESH_SETTLE_TIMEOUT", None)
+        settle._reset_settle_state_for_tests()
 
     def test_required_unavailable_raises_refusal_handler_not_invoked(self):
         called = []
@@ -267,3 +277,45 @@ class TestToolGuardVsSettle:
 
         assert json.loads(str(excinfo.value))["capability"] == "lookup"
         assert called == []
+
+
+class TestToolMinimalPathRequiredWarns:
+    """Issue #1273: a required dep declared on a tool with NO injectable
+    McpMeshTool slot takes the minimal path — the refusal has no slot to
+    evaluate (the handler can never observe the dep), so enforcement stays OFF
+    and a one-line INACTIVE warning is emitted (mirrors the route perimeter's
+    INACTIVE handling at #1249). The handler still runs."""
+
+    def setup_method(self):
+        _clear()
+        os.environ["MCP_MESH_SETTLE_TIMEOUT"] = "0"
+        settle._reset_settle_state_for_tests()
+
+    def teardown_method(self):
+        os.environ.pop("MCP_MESH_SETTLE_TIMEOUT", None)
+        settle._reset_settle_state_for_tests()
+
+    def test_required_dep_no_slot_warns_and_runs(self, caplog):
+        called = []
+
+        async def tool():  # zero injectable params → minimal path
+            called.append(True)
+            return {"ok": True}
+
+        injector = DependencyInjector()
+        with caplog.at_level("WARNING"):
+            # Real analyze_injection_strategy → mesh_positions == [] for a
+            # zero-param function → minimal wrapper.
+            wrapper = injector.create_injection_wrapper(
+                tool, ["lookup"], tool_required_caps=["lookup"]
+            )
+
+        assert any(
+            "required-dependency guard" in rec.message and "INACTIVE" in rec.message
+            for rec in caplog.records
+        ), "a slotless required dep must emit the INACTIVE guard warning"
+
+        # Enforcement is OFF (no slot to evaluate) — the handler still runs.
+        result = asyncio.run(wrapper())
+        assert result == {"ok": True}
+        assert called == [True]

--- a/src/runtime/python/tests/unit/test_claim_dispatcher_required_gate.py
+++ b/src/runtime/python/tests/unit/test_claim_dispatcher_required_gate.py
@@ -139,6 +139,83 @@ class TestPreInvokeGuard:
         assert called == [{}], "optional-dep handler must still be invoked"
         assert released == []
 
+    @pytest.mark.asyncio
+    async def test_wrapper_refusal_during_handler_releases_not_fails(
+        self, clean_injector
+    ):
+        """Issue #1273: the dispatcher's own gate passes (dep resolved) but the
+        handler — the DI wrapper — raises a dependency_unavailable refusal
+        because the required dep flapped DOWN mid-dispatch. That refusal must
+        RELEASE the lease (retryable), NEVER terminal-fail: release semantics
+        win over the wrapper's tool-error carrier."""
+        import json
+
+        from fastmcp.exceptions import ToolError
+
+        # Gate passes: dep_0 resolved locally when _dispatch checks it.
+        clean_injector._dependencies[f"{_FUNC_ID}:dep_0"] = object()
+
+        async def handler(**kwargs):
+            # Simulate the DI wrapper's #1273 guard firing on the race.
+            raise ToolError(
+                json.dumps(
+                    {"error": "dependency_unavailable", "capability": "cap_a"}
+                )
+            )
+
+        d = _make_dispatcher(handler=handler, required_deps=[(0, "cap_a")])
+
+        released: list = []
+        failed: list = []
+
+        async def fake_release(job_id, capability, claim_epoch=None):
+            released.append((job_id, capability))
+
+        async def fake_fail(job_id, error, claim_epoch=None):
+            failed.append((job_id, error))
+
+        d._release_lease = fake_release
+        d._report_terminal_fail = fake_fail
+
+        await d._dispatch({"id": "job-9", "submitted_payload": {}})
+
+        assert released == [("job-9", "cap_a")], (
+            "a mid-dispatch dependency_unavailable refusal must release the lease"
+        )
+        assert failed == [], (
+            "a mid-dispatch refusal must NEVER terminal-fail (that would "
+            "reproduce the very race the guard prevents)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_real_handler_exception_still_terminal_fails(
+        self, clean_injector
+    ):
+        """Regression: an ordinary handler exception (NOT a dependency_unavailable
+        refusal) still routes to terminal fail, unchanged by #1273."""
+        clean_injector._dependencies[f"{_FUNC_ID}:dep_0"] = object()
+
+        async def handler(**kwargs):
+            raise RuntimeError("boom")
+
+        d = _make_dispatcher(handler=handler, required_deps=[(0, "cap_a")])
+
+        released: list = []
+        failed: list = []
+        d._release_lease = lambda *a, **k: released.append(a)
+
+        async def fake_fail(job_id, error, claim_epoch=None):
+            failed.append((job_id, str(error)))
+
+        d._report_terminal_fail = fake_fail
+
+        await d._dispatch({"id": "job-10", "submitted_payload": {}})
+
+        assert released == [], "an app error must NOT release the lease"
+        assert failed and failed[0][0] == "job-10", (
+            "an ordinary handler exception must terminal-fail as before"
+        )
+
 
 class TestMeshJobDepExcludedFromGate:
     """A required dep paired with the MeshJob slot is a locally-constructed

--- a/src/runtime/typescript/src/__tests__/direct-invoke-required.spec.ts
+++ b/src/runtime/typescript/src/__tests__/direct-invoke-required.spec.ts
@@ -20,19 +20,16 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { z } from "zod";
 import { UserError } from "fastmcp";
 
-// Controllable job-header + controller seams. `readJobHeaders` is mocked so a
-// test can present an inbound JOB dispatch without the real allowlist filter
-// (x-mesh-job-id is not in the default propagate set); `makeJobController`
-// captures the lease-release call. Other exports pass through unchanged.
-// Declared via vi.hoisted so the hoisted vi.mock factory below can reference
-// them (they'd be in the temporal dead zone otherwise).
+// Only `makeJobController` is mocked (it wraps a napi JobController handle that
+// hits the registry). The REAL `readJobHeaders` runs against the raw inbound
+// `_mesh_headers` the test passes through `execute(...)` — so the job-header
+// extraction path (item 1's fix: raw headers, not the allowlist-filtered map)
+// is exercised end-to-end. Declared via vi.hoisted so the hoisted vi.mock
+// factory below can reference them (TDZ otherwise).
 const h = vi.hoisted(() => {
   const releaseLeaseMock = vi.fn(async () => {});
   const makeJobControllerMock = vi.fn(() => ({ releaseLease: releaseLeaseMock }));
-  const state: {
-    jobHeaderResult: [string | null, number | null, number | null];
-  } = { jobHeaderResult: [null, null, null] };
-  return { releaseLeaseMock, makeJobControllerMock, state };
+  return { releaseLeaseMock, makeJobControllerMock };
 });
 
 vi.mock("../inbound-job-dispatch.js", async (importActual) => {
@@ -40,7 +37,6 @@ vi.mock("../inbound-job-dispatch.js", async (importActual) => {
     await importActual<typeof import("../inbound-job-dispatch.js")>();
   return {
     ...actual,
-    readJobHeaders: () => h.state.jobHeaderResult,
     makeJobController:
       h.makeJobControllerMock as unknown as typeof actual.makeJobController,
   };
@@ -64,7 +60,6 @@ let warnSpy: ReturnType<typeof vi.spyOn> | null = null;
 const savedEnv: Record<string, string | undefined> = {};
 
 beforeEach(() => {
-  h.state.jobHeaderResult = [null, null, null];
   h.releaseLeaseMock.mockClear();
   h.makeJobControllerMock.mockClear();
   autoStartSpy = vi
@@ -193,9 +188,6 @@ describe("direct-invoke required-dep guard (#1273)", () => {
 
 describe("job-header path releases the lease, never throws (#1273)", () => {
   it("releases the lease (not a throw) when an inbound JOB dispatch hits an unresolved required dep", async () => {
-    // Present an inbound job dispatch: task tool + X-Mesh-Job-Id.
-    h.state.jobHeaderResult = ["job-77", null, 3];
-
     // registryUrl defaults from env (MCP_MESH_REGISTRY_URL →
     // http://localhost:8000), so this.config.registryUrl is non-empty.
     const fastmcp = makeFastMCPStub();
@@ -216,8 +208,18 @@ describe("job-header path releases the lease, never throws (#1273)", () => {
     });
     const execute = captureExecute(fastmcp);
 
+    // Present an inbound JOB dispatch by passing the job headers through the
+    // REAL extraction path in _mesh_headers. x-mesh-job-id is NOT in the
+    // propagate allowlist, so this only works because the guard reads the RAW
+    // inbound headers (item 1's fix), not the allowlist-filtered map.
+    const result = await execute({
+      _mesh_headers: {
+        "x-mesh-job-id": "job-77",
+        "x-mesh-claim-epoch": "3",
+      },
+    });
+
     // Must NOT throw — the job-flavored path releases the lease instead.
-    const result = await execute({});
     expect(result).toBe("");
     expect(calls).toHaveLength(0); // handler MUST NOT run
     expect(h.makeJobControllerMock).toHaveBeenCalledTimes(1);

--- a/src/runtime/typescript/src/__tests__/direct-invoke-required.spec.ts
+++ b/src/runtime/typescript/src/__tests__/direct-invoke-required.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * Issue #1273: direct `tools/call` dispatch must refuse when a `required=true`
+ * dependency slot is unresolved at invocation time.
+ *
+ * The claim path (#1268, requiredProbe) and the @mesh.route perimeter (#1249,
+ * 503) already refuse before a handler can observe a null required dependency;
+ * this closes the same DOWN→UP flap window on the plain tool-dispatch path.
+ * The guard is FLAVOR-AWARE (review follow-up):
+ *   - plain tools/call → structured `dependency_unavailable` refusal (a
+ *     `UserError` whose message carries the JSON envelope → FastMCP `isError`
+ *     result, the SAME semantic class as the route perimeter's 503), so the
+ *     caller classifies it as retryable topology.
+ *   - inbound JOB dispatch (task tool + X-Mesh-Job-Id) → RELEASE the lease so
+ *     the claimed row re-queues, mirroring the claim path — never a bare throw
+ *     (which would strand the row `working` until lease expiry).
+ * Optional deps keep their null-passthrough. The guard runs AFTER the settle
+ * wait (deps are built post-settle).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { z } from "zod";
+import { UserError } from "fastmcp";
+
+// Controllable job-header + controller seams. `readJobHeaders` is mocked so a
+// test can present an inbound JOB dispatch without the real allowlist filter
+// (x-mesh-job-id is not in the default propagate set); `makeJobController`
+// captures the lease-release call. Other exports pass through unchanged.
+// Declared via vi.hoisted so the hoisted vi.mock factory below can reference
+// them (they'd be in the temporal dead zone otherwise).
+const h = vi.hoisted(() => {
+  const releaseLeaseMock = vi.fn(async () => {});
+  const makeJobControllerMock = vi.fn(() => ({ releaseLease: releaseLeaseMock }));
+  const state: {
+    jobHeaderResult: [string | null, number | null, number | null];
+  } = { jobHeaderResult: [null, null, null] };
+  return { releaseLeaseMock, makeJobControllerMock, state };
+});
+
+vi.mock("../inbound-job-dispatch.js", async (importActual) => {
+  const actual =
+    await importActual<typeof import("../inbound-job-dispatch.js")>();
+  return {
+    ...actual,
+    readJobHeaders: () => h.state.jobHeaderResult,
+    makeJobController:
+      h.makeJobControllerMock as unknown as typeof actual.makeJobController,
+  };
+});
+
+import { MeshAgent } from "../agent.js";
+import { RouteRegistry } from "../route.js";
+import { resetSettleStateForTests } from "../settle.js";
+
+function makeFastMCPStub() {
+  return {
+    addTool: vi.fn(),
+    start: vi.fn(),
+    getApp: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+let autoStartSpy: ReturnType<typeof vi.spyOn> | null = null;
+let warnSpy: ReturnType<typeof vi.spyOn> | null = null;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  h.state.jobHeaderResult = [null, null, null];
+  h.releaseLeaseMock.mockClear();
+  h.makeJobControllerMock.mockClear();
+  autoStartSpy = vi
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .spyOn(MeshAgent.prototype as any, "_autoStart")
+    .mockImplementation(async () => {
+      /* no-op */
+    });
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    /* swallow */
+  });
+  savedEnv.MCP_MESH_SETTLE_TIMEOUT = process.env.MCP_MESH_SETTLE_TIMEOUT;
+  savedEnv.MCP_MESH_TOOL_ISOLATION = process.env.MCP_MESH_TOOL_ISOLATION;
+  process.env.MCP_MESH_TOOL_ISOLATION = "false";
+  // Settle immediately so an unresolved required slot is genuinely unresolved,
+  // not merely still-settling.
+  process.env.MCP_MESH_SETTLE_TIMEOUT = "0";
+  resetSettleStateForTests();
+  RouteRegistry.reset();
+});
+
+afterEach(() => {
+  autoStartSpy?.mockRestore();
+  autoStartSpy = null;
+  warnSpy?.mockRestore();
+  warnSpy = null;
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetSettleStateForTests();
+  RouteRegistry.reset();
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function captureExecute(fastmcp: any): (args: unknown) => Promise<string> {
+  return fastmcp.addTool.mock.calls[0][0].execute as (
+    args: unknown,
+  ) => Promise<string>;
+}
+
+describe("direct-invoke required-dep guard (#1273)", () => {
+  it("refuses with dependency_unavailable when a required slot is unresolved", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, { name: "guard-agent", httpPort: 0 });
+    const calls: unknown[] = [];
+    agent.addTool({
+      name: "enrich",
+      parameters: z.object({}),
+      dependencies: [{ capability: "lookup", required: true }],
+      execute: async (_args: unknown, dep: unknown) => {
+        calls.push(dep);
+        return "ran";
+      },
+    });
+    const execute = captureExecute(fastmcp);
+
+    let thrown: unknown;
+    try {
+      await execute({});
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(UserError);
+    const body = JSON.parse((thrown as Error).message);
+    expect(body).toEqual({
+      error: "dependency_unavailable",
+      capability: "lookup",
+    });
+    expect(calls).toHaveLength(0); // handler must NOT run
+    expect(h.releaseLeaseMock).not.toHaveBeenCalled(); // not a job flavor
+  });
+
+  it("invokes the handler once the required dep resolves", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, { name: "resolved-agent", httpPort: 0 });
+    const calls: unknown[] = [];
+    agent.addTool({
+      name: "enrich",
+      parameters: z.object({}),
+      dependencies: [{ capability: "lookup", required: true }],
+      execute: async (_args: unknown, dep: unknown) => {
+        calls.push(dep);
+        return "ran";
+      },
+    });
+
+    // Resolve the required dependency so a real proxy lands in the slot.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).handleDependencyAvailable(
+      "lookup",
+      "http://localhost:19999",
+      "remote_fn",
+      "provider-agent",
+      "enrich",
+      0,
+    );
+
+    const execute = captureExecute(fastmcp);
+    expect(await execute({})).toBe("ran");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).not.toBeNull(); // ran with the live proxy
+  });
+
+  it("passes null through for an unresolved OPTIONAL dep (regression)", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, { name: "optional-agent", httpPort: 0 });
+    const calls: unknown[] = [];
+    agent.addTool({
+      name: "enrich",
+      parameters: z.object({}),
+      // No `required` → optional; null passthrough preserved.
+      dependencies: [{ capability: "lookup" }],
+      execute: async (_args: unknown, dep: unknown) => {
+        calls.push(dep);
+        return dep ? "wired" : "unwired";
+      },
+    });
+    const execute = captureExecute(fastmcp);
+
+    expect(await execute({})).toBe("unwired");
+    expect(calls).toEqual([null]); // handler ran with null, no refusal
+  });
+});
+
+describe("job-header path releases the lease, never throws (#1273)", () => {
+  it("releases the lease (not a throw) when an inbound JOB dispatch hits an unresolved required dep", async () => {
+    // Present an inbound job dispatch: task tool + X-Mesh-Job-Id.
+    h.state.jobHeaderResult = ["job-77", null, 3];
+
+    // registryUrl defaults from env (MCP_MESH_REGISTRY_URL →
+    // http://localhost:8000), so this.config.registryUrl is non-empty.
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, {
+      name: "job-guard-agent",
+      httpPort: 0,
+    });
+    const calls: unknown[] = [];
+    agent.addTool({
+      name: "render",
+      task: true,
+      parameters: z.object({}),
+      dependencies: [{ capability: "lookup", required: true }],
+      execute: async (_args: unknown, dep: unknown) => {
+        calls.push(dep);
+        return "ran";
+      },
+    });
+    const execute = captureExecute(fastmcp);
+
+    // Must NOT throw — the job-flavored path releases the lease instead.
+    const result = await execute({});
+    expect(result).toBe("");
+    expect(calls).toHaveLength(0); // handler MUST NOT run
+    expect(h.makeJobControllerMock).toHaveBeenCalledTimes(1);
+    // makeJobController(jobId, agentId, registryUrl, claimEpoch)
+    const ctorArgs = h.makeJobControllerMock.mock
+      .calls[0] as unknown as unknown[];
+    expect(ctorArgs[0]).toBe("job-77");
+    expect(ctorArgs[3]).toBe(3);
+    expect(h.releaseLeaseMock).toHaveBeenCalledTimes(1);
+    const releaseArgs = h.releaseLeaseMock.mock.calls[0] as unknown as unknown[];
+    expect(String(releaseArgs[0])).toContain("lookup");
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -10,6 +10,7 @@
  */
 
 import type { FastMCP } from "fastmcp";
+import { UserError } from "fastmcp";
 import type { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { isMainThread } from "node:worker_threads";
@@ -670,6 +671,26 @@ export class MeshAgent {
       );
       const injectedCount = depsArray.filter((d) => d !== null).length;
 
+      // Issue #1273: detect a required dependency slot that is still
+      // unresolved AFTER the settle wait above (depsArray was built
+      // post-settle). The ACTION is deferred until the invocation flavor is
+      // known (see the flavor-aware guard below the header extraction) —
+      // direct tools/call refuses, an inbound JOB dispatch releases the
+      // lease. Optional deps keep null-passthrough; the MeshJob submitter
+      // slot is skipped (built locally, never a resolved proxy).
+      let missingRequiredCap: string | null = null;
+      for (let depIndex = 0; depIndex < normalizedDeps.length; depIndex++) {
+        const dep = normalizedDeps[depIndex];
+        if (
+          dep.required === true &&
+          depIndex !== meshJobDepIndex &&
+          depsArray[depIndex] == null
+        ) {
+          missingRequiredCap = dep.capability;
+          break;
+        }
+      }
+
       // Extract trace context from arguments (injected by upstream proxy)
       // This is the fallback mechanism since fastmcp doesn't expose HTTP headers
       let incomingTraceId: string | null = null;
@@ -708,6 +729,67 @@ export class MeshAgent {
       const spanId = generateSpanId();
       const parentSpanId = incomingParentSpan ?? null;
       const traceContext: TraceContext = { traceId, parentSpanId: spanId };
+
+      // Issue #1273: flavor-aware required-dependency guard. The claim path
+      // (requiredProbe, #1268) and the @mesh.route perimeter (503) already
+      // refuse before a handler can observe a null REQUIRED dep; the plain
+      // tool-dispatch path did not. A required dep flapping DOWN→UP flips the
+      // registry view available before THIS callee's own heartbeat refills
+      // its slot; a call landing in that window would invoke with a null
+      // required proxy. Now that the propagated headers are extracted we can
+      // tell the flavor apart:
+      //   - inbound JOB dispatch (task tool + X-Mesh-Job-Id) → RELEASE the
+      //     lease so the claimed row re-queues (retryable), mirroring the
+      //     claim path — NEVER a bare throw (which would strand the row
+      //     `working` until lease expiry) and never a terminal fail.
+      //   - plain tools/call → structured dependency_unavailable refusal
+      //     (UserError → isError result) so the caller classifies it as
+      //     retryable topology, not application failure.
+      if (missingRequiredCap !== null) {
+        const [guardJobId, , guardClaimEpoch] = readJobHeaders(propagatedHeaders);
+        const isJobDispatch =
+          isTaskTool &&
+          guardJobId !== null &&
+          !!this.config.registryUrl &&
+          !!this.agentId;
+        if (isJobDispatch) {
+          console.warn(
+            `[mesh-jobs] releasing job=${guardJobId} for tool '${toolName}' — ` +
+              `required dependency '${missingRequiredCap}' unavailable at ` +
+              `invocation time; releasing lease for retry (not invoking, not failing)`,
+          );
+          try {
+            const controller = makeJobController(
+              guardJobId as string,
+              this.agentId as string,
+              this.config.registryUrl as string,
+              guardClaimEpoch,
+            );
+            await controller.releaseLease(
+              `required dependency '${missingRequiredCap}' unavailable at ` +
+                `job-dispatch (issue #1273)`,
+            );
+          } catch (err) {
+            console.debug(
+              `[mesh-jobs] release-lease for job=${guardJobId} raised:`,
+              err,
+            );
+          }
+          // The row is released and will be re-claimed; nothing to return.
+          return "";
+        }
+        console.warn(
+          `🚫 Tool '${toolName}': required dependency '${missingRequiredCap}' ` +
+            `unavailable at invocation time — refusing with dependency_unavailable ` +
+            `(not invoking the handler with a null required proxy)`,
+        );
+        throw new UserError(
+          JSON.stringify({
+            error: "dependency_unavailable",
+            capability: missingRequiredCap,
+          }),
+        );
+      }
 
       const startTime = Date.now() / 1000;
       let success = true;

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -699,6 +699,14 @@ export class MeshAgent {
 
       // Extract _mesh_headers from args for header propagation
       let propagatedHeaders: Record<string, string> = {};
+      // Issue #1273: the RAW inbound _mesh_headers, lowercased but NOT
+      // allowlist-filtered. Job-dispatch infra headers (x-mesh-job-id /
+      // x-mesh-claim-epoch) are the DISPATCH DISCRIMINATOR, deliberately kept
+      // OUT of the propagate allowlist (so a nested outbound call doesn't look
+      // like a job dispatch to every downstream). They must therefore be read
+      // from the raw map — reading them off `propagatedHeaders` would drop them
+      // and misclassify a genuine inbound job dispatch as a plain tools/call.
+      let rawMeshHeaders: Record<string, string> | null = null;
 
       if (args && typeof args === "object") {
         const argsObj = args as Record<string, unknown>;
@@ -710,9 +718,13 @@ export class MeshAgent {
         }
         if (argsObj._mesh_headers && typeof argsObj._mesh_headers === "object") {
           const meshHeaders = argsObj._mesh_headers as Record<string, unknown>;
-          // Filter against allowlist
+          rawMeshHeaders = {};
           for (const [key, value] of Object.entries(meshHeaders)) {
-            if (typeof value === "string" && matchesPropagateHeader(key)) {
+            if (typeof value !== "string") continue;
+            // Raw copy for job-dispatch detection (bypasses the allowlist).
+            rawMeshHeaders[key.toLowerCase()] = value;
+            // Allowlist-filtered copy for onward propagation.
+            if (matchesPropagateHeader(key)) {
               propagatedHeaders[key.toLowerCase()] = value;
             }
           }
@@ -746,7 +758,11 @@ export class MeshAgent {
       //     (UserError → isError result) so the caller classifies it as
       //     retryable topology, not application failure.
       if (missingRequiredCap !== null) {
-        const [guardJobId, , guardClaimEpoch] = readJobHeaders(propagatedHeaders);
+        // Read job headers from the RAW inbound map (not the allowlist-filtered
+        // propagatedHeaders), so a genuine inbound job dispatch is classified as
+        // one — and released, not refused — even though x-mesh-job-id is not in
+        // the propagate allowlist.
+        const [guardJobId, , guardClaimEpoch] = readJobHeaders(rawMeshHeaders);
         const isJobDispatch =
           isTaskTool &&
           guardJobId !== null &&


### PR DESCRIPTION
## Summary
The 2.8.2 patch — both fixes field-reported by the first 2.8.1 adopter.

- **#1274 — meshctl stop**: the graceful branch verified and escalated against the parent PID only; a Maven agent's child JVM survived stop, held its port (~3 min measured), and kept heartbeating. Now group-scoped end to end, with a **zombie-aware drain probe** (on Linux an unreaped zombie group answers `kill(-pgid,0)` with success — a container PID 1 that doesn't reap would hang the wait forever; macOS reaps instantly, which masked it locally). Watch reload routes through the same logic (regression caught by tc29 and fixed); `terminateAgent` polls ESRCH-only with a WARN when a group survives SIGKILL. Multi-name stop (`stop a b c`, existed since v1.1.0 but invisible behind the old group-teardown semantics) is now unit-tested and documented, along with stop's group semantics (+ setsid-escape caveat) and the by-design watch behaviors (content-write trigger; watch ≠ crash supervisor).
- **#1273 — required-dep guard on direct tools/call**: the #1268 pre-invoke check now covers the last unguarded dispatch path. Cross-runtime invariant: **direct calls refuse after the settle window** with a structured `{"error":"dependency_unavailable","capability":...}` tool error (byte-identical envelopes); **all job-flavored invocations release the lease** (claim + inbound job-header paths — never terminal, never a stranded row); **local/self-dependency dispatch raises** (a refusal can't masquerade as success to LLM/local callers). Handlers never observe null for `required=true` dependencies on any invocation path. Docs rider: job-status wording aligned to the real `working` vocabulary.

## Review Notes
Zero-context review applied: 1 BLOCKER (Java guard fired before the settle-grace wait — every agent restart would have burst refusals; now guards after settle with an armed-settle test) + 4 warnings (job-header paths on Java/TS needed release-not-refuse semantics; Python claim path routed refusals to terminal fail; Java local dispatch returned refusals as success) — all fixed. The watch-reload regression the gate caught was root-caused to the zombie-group probe gap above.

## Test plan
- [x] Unit: Java 75+, Python full sweep, TS 81 + tsc clean, Go cli/lifecycle suites (darwin + linux-container zombie tests)
- [x] Live darwin validation: real mvn parent/child topology — stop blocks till port release, SIGKILL escalation, multi-name stop
- [x] src-tests 12/12; tc29_watch_mixed green 3× (2 scoped + full run)
- [x] Full integration: 530 passed / 1 known-class LLM flake, green on sequential re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct tool calls now clearly refuse when a required dependency is unavailable, with a structured error message.
  * Watch mode behavior is now documented more precisely, including when rebuilds trigger and how restarts work.

* **Bug Fixes**
  * Stop and shutdown flows now wait for the whole process group to exit, improving reliability during graceful shutdown.
  * Jobs with temporarily unavailable dependencies are now re-queued instead of failing immediately.

* **Documentation**
  * Expanded guidance for stopping agents, watch mode, and upgrade procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->