### PR TITLE
feat(java): @McpMeshService service views — consumer-side typed facade (RFC #1280 phase 1)

### DIFF
--- a/docs/java/annotations.md
+++ b/docs/java/annotations.md
@@ -20,6 +20,7 @@ MCP Mesh provides annotations that transform regular Spring Boot methods into me
 | `@MeshTool`        | Register capability with DI               |
 | `@Param`           | Document tool parameters                  |
 | `@Selector`        | Capability/tag selection for dependencies |
+| `@McpMeshService`  | Typed service-view interface over several capabilities |
 | `@MeshLlm`         | Enable LLM-powered tools                  |
 | `@MeshLlmProvider` | Create zero-code LLM provider             |
 | `@MeshRoute`       | REST endpoint with mesh DI                |
@@ -127,6 +128,27 @@ Specifies capability and tag selection for dependencies, LLM providers, and filt
 | `version`    | No       | Semantic version constraint    |
 
 \*Required for dependencies; optional for LLM tool filters.
+
+`@Selector` is also used at the **method level** inside an `@McpMeshService` interface, where each abstract method carries one `@Selector` to bind its capability (see below).
+
+## @McpMeshService
+
+Marks an interface as a consumer-owned **service view**: one typed facade that aggregates several capability dependencies. Each abstract method binds one capability via a method-level `@Selector`, and each method delegates to its own resolved proxy — so different methods can resolve to different provider agents. Spring auto-discovers the interface and injects a facade bean you `@Autowired`.
+
+```java
+@McpMeshService
+public interface MediaService {
+    @Selector(capability = "media_caption", required = true) CaptionResult    caption(CaptionRequest req);
+    @Selector(capability = "media_thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
+    @Selector(capability = "media_transcribe")               TranscriptResult transcribe(TranscribeRequest req);
+}
+```
+
+| Attribute      | Required | Description                                                                 |
+| -------------- | -------- | -------------------------------------------------------------------------- |
+| `minAvailable` | No       | Availability floor; below it every facade call throws `MeshServiceUnavailableException` (default `0` = no floor) |
+
+Each method expands into an ordinary dependency edge, so a view over N capabilities shows as N dependencies in `meshctl list`. For the full semantics — param-mapping rules, return types, `required`/optional behavior, and the availability floor — see the [Dependency Injection](dependency-injection.md#service-views-with-mcpmeshservice) guide.
 
 ## @MeshLlm
 

--- a/docs/java/annotations.md
+++ b/docs/java/annotations.md
@@ -146,7 +146,7 @@ public interface MediaService {
 
 | Attribute      | Required | Description                                                                 |
 | -------------- | -------- | -------------------------------------------------------------------------- |
-| `minAvailable` | No       | Availability floor; below it every facade call throws `MeshServiceUnavailableException` (default `0` = no floor) |
+| `minAvailable` | No       | Availability floor; below it every facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (default `0` = no floor) |
 
 Each method expands into an ordinary dependency edge, so a view over N capabilities shows as N dependencies in `meshctl list`. For the full semantics — param-mapping rules, return types, `required`/optional behavior, and the availability floor — see the [Dependency Injection](dependency-injection.md#service-views-with-mcpmeshservice) guide.
 

--- a/docs/java/dependency-injection.md
+++ b/docs/java/dependency-injection.md
@@ -222,7 +222,7 @@ public class MediaGatewayApplication {
 !!! note "One difference from a tool-declared slot"
     A view is class-level, so the framework cannot know which `@MeshTool` methods call it and does **not** add a pre-invoke structured `dependency_unavailable` refusal to those tools — a call to a required-but-unresolved view method simply throws `MeshToolUnavailableException`, surfacing as an ordinary tool error. If a specific `@MeshTool` needs the pre-invoke structured refusal for a capability, declare it as a `@MeshTool` dependency slot (`dependencies = @Selector(...)`) instead; tool-declared slots get the guard, views do not.
 
-The optional `@McpMeshService(minAvailable = N)` adds a consumer-local availability floor: when fewer than `N` of the view's methods currently resolve, **every** facade call throws `MeshServiceUnavailableException` (settle-grace-aware). The default `0` means no floor — each method soft- or hard-fails per its own `required` flag.
+The optional `@McpMeshService(minAvailable = N)` adds a consumer-local availability floor: when fewer than `N` of the view's methods currently resolve, **every** facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (settle-grace-aware). The default `0` means no floor — each method soft- or hard-fails per its own `required` flag.
 
 A service view is **consumer-local**, not a shared contract: two consumers may aggregate the same capabilities differently, and there is no group versioning or interface-level availability summary. Each method resolves independently.
 

--- a/docs/java/dependency-injection.md
+++ b/docs/java/dependency-injection.md
@@ -115,6 +115,7 @@ public class HolidayChecker {
 | `@MeshTool` method needing remote helpers | `@MeshTool(dependencies = @Selector(...))` + parameter injection |
 | `@RestController` handler method | `@MeshRoute(dependencies = {...})` + `@MeshInject` parameter |
 | `@Service` / `@Component` / `Filter` / `@Scheduled` / any other Spring bean | **`@MeshDependsOn` + `@Qualifier`** |
+| Several capabilities behind one typed facade | **`@McpMeshService` interface + `@Autowired`** |
 
 `@MeshDependsOn` and `@MeshInject`/`@MeshRoute` are complementary — same heartbeat-driven proxy lifecycle, same auto-rewiring on topology change, same `isAvailable()` semantics. Pick the surface that matches where you need the dependency. If the same capability shows up via multiple sources the framework deduplicates: a single proxy and a single registry entry per capability name.
 
@@ -152,6 +153,78 @@ If you omit `expectedType` and the `@Qualifier`-injected field is declared as `M
 | `@Bean public Foo foo() { return new ConcreteFoo(); }` where `@MeshDependsOn` is ONLY on `ConcreteFoo` | ✗ — `findAnnotation` walks supertypes of the declared return type, not subtypes of it |
 
 Only the last shape is a real gap. If your factory method declares a supertype return, either narrow the declared return type to the concrete class, or place `@MeshDependsOn` on the supertype itself (or on the `@Configuration` class).
+
+## Service Views with `@McpMeshService`
+
+A **service view** aggregates several capability dependencies behind one typed interface. Annotate an interface with `@McpMeshService`; each abstract method binds one capability via a method-level `@Selector`. Spring auto-discovers the interface and injects a facade bean (named by the decapitalized interface name) that you `@Autowired` and call directly.
+
+The differentiator: **each method delegates to its own per-capability resolved proxy**, so different methods can resolve to different provider agents and rebind independently as the topology changes. The group is a typed view; the capability remains the atom. Nothing group-shaped crosses the wire — every method expands into an ordinary dependency edge with `required`/`tags`/`version`/settle semantics identical to a `@MeshDependsOn` dependency. A view over N capabilities therefore shows as **N separate dependencies** in `meshctl list`, not one.
+
+```java
+@McpMeshService
+public interface MediaService {
+    @Selector(capability = "media_caption", required = true) CaptionResult    caption(CaptionRequest req);
+    @Selector(capability = "media_thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
+    @Selector(capability = "media_transcribe")               TranscriptResult transcribe(TranscribeRequest req);
+
+    record CaptionRequest(String assetId, String text) {}
+    record ThumbnailRequest(String assetId, int width) {}
+    record CaptionResult(String assetId, String caption, String provider) {}
+    record ThumbnailResult(String assetId, String uri, String size, String provider) {}
+    record TranscriptResult(String assetId, String transcript, int wordCount, String provider) {}
+}
+```
+
+The consumer autowires the facade and calls its methods directly. Because each method is its own edge, the results below may come from three different provider agents through one interface:
+
+```java
+@MeshAgent(name = "media-gateway", version = "1.0.0", port = 8113)
+@SpringBootApplication
+public class MediaGatewayApplication {
+    private final MediaService media;
+
+    public MediaGatewayApplication(MediaService media) {
+        this.media = media;
+    }
+
+    @MeshTool(capability = "process_media",
+              description = "Run an asset through a media service view")
+    public Map<String, Object> processMedia(
+            @Param(value = "assetId", description = "Asset id") String assetId,
+            @Param(value = "text", description = "Source text") String text) {
+
+        Map<String, Object> out = new LinkedHashMap<>();
+
+        // REQUIRED edge — expected to resolve; a failure surfaces to the caller.
+        out.put("caption", media.caption(new MediaService.CaptionRequest(assetId, text)));
+
+        // OPTIONAL edge — degrade gracefully when its provider is offline.
+        try {
+            out.put("thumbnail", media.thumbnail(new MediaService.ThumbnailRequest(assetId, 320)));
+        } catch (MeshToolUnavailableException e) {
+            out.put("thumbnail", "(no thumbnail — provider offline)");
+        }
+        return out;
+    }
+}
+```
+
+### Method rules
+
+- Every abstract method must carry `@Selector` with a non-empty `capability`. `default` / `static` interface methods are allowed and are not expanded as edges.
+- Parameters follow the `@MeshTool` convention: **0 params** → no-arg call; **exactly 1 unannotated POJO/record param** → that object becomes the params (scalars still need `@Param`); **2+ params** → each needs `@Param("name")`.
+- Return `T` (synchronous), `CompletableFuture<T>` (async), or `java.util.concurrent.Flow.Publisher<String>` (streaming).
+
+### Required, optional, and the availability floor
+
+`required = true` on a view method behaves like a class-level `@MeshDependsOn` required dependency (see [Required Dependencies](#required-dependencies) below): it participates in cross-source required-wins dedupe, flips the registry-side availability of that capability's carrier when unresolved (visible in `meshctl list` and the registry API), and promotes any matching route-perimeter 503 guard. An optional method whose provider is down throws `MeshToolUnavailableException` on **that call only**; catch it for graceful degradation while the rest of the view keeps working.
+
+!!! note "One difference from a tool-declared slot"
+    A view is class-level, so the framework cannot know which `@MeshTool` methods call it and does **not** add a pre-invoke structured `dependency_unavailable` refusal to those tools — a call to a required-but-unresolved view method simply throws `MeshToolUnavailableException`, surfacing as an ordinary tool error. If a specific `@MeshTool` needs the pre-invoke structured refusal for a capability, declare it as a `@MeshTool` dependency slot (`dependencies = @Selector(...)`) instead; tool-declared slots get the guard, views do not.
+
+The optional `@McpMeshService(minAvailable = N)` adds a consumer-local availability floor: when fewer than `N` of the view's methods currently resolve, **every** facade call throws `MeshServiceUnavailableException` (settle-grace-aware). The default `0` means no floor — each method soft- or hard-fails per its own `required` flag.
+
+A service view is **consumer-local**, not a shared contract: two consumers may aggregate the same capabilities differently, and there is no group versioning or interface-level availability summary. Each method resolves independently.
 
 ## `McpMeshTool<T>` API Reference
 

--- a/examples/java/service-view/README.md
+++ b/examples/java/service-view/README.md
@@ -1,0 +1,129 @@
+# Service View Example — `@McpMeshService` (RFC #1280)
+
+**Three methods, three different provider agents, one typed interface.**
+
+A service view is a consumer-owned interface that aggregates several ordinary
+capability dependencies behind one typed facade. Each abstract method binds a
+single capability via a method-level `@Selector`, and calling that method
+delegates to the capability's own resolved proxy — so different methods resolve
+to **different provider agents** and rebind independently as the mesh topology
+changes. The group is a typed view; the capability remains the atom.
+
+## Agents
+
+| Agent                 | Port | Capability         | Role                                   |
+|-----------------------|------|--------------------|----------------------------------------|
+| `caption-provider`    | 8110 | `media_caption`    | Provider A — captions an asset         |
+| `thumbnail-provider`  | 8111 | `media_thumbnail`  | Provider B — thumbnails an asset       |
+| `transcribe-provider` | 8112 | `media_transcribe` | Provider C — transcribes an asset      |
+| `media-gateway`       | 8113 | `process_media`    | Consumer — one `MediaService` view     |
+
+The consumer declares one interface aggregating all three capabilities:
+
+```java
+@McpMeshService
+public interface MediaService {
+    @Selector(capability = "media_caption", required = true) CaptionResult    caption(CaptionRequest req);
+    @Selector(capability = "media_thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
+    @Selector(capability = "media_transcribe")               TranscriptResult transcribe(TranscribeRequest req);
+}
+```
+
+Spring auto-discovers the interface (classpath scan under the app's package) and
+registers a facade bean named `mediaService`. The gateway `@Autowired`s it and
+calls the methods directly — no manual proxy wiring. `caption` is `required`;
+`thumbnail` and `transcribe` are optional.
+
+## What it demonstrates
+
+- **Per-method multi-agent resolution.** One `process_media` call fans out
+  across all three view methods; the combined result's `servedBy` fields name
+  three different provider agents — `caption-provider`, `thumbnail-provider`,
+  `transcribe-provider` — answering through one interface.
+- **Independent rebinding.** Stop `thumbnail-provider` and only that method's
+  edge goes away; `caption` and `transcribe` keep resolving to their own agents.
+- **Graceful degradation.** The optional methods throw
+  `MeshToolUnavailableException` when their provider is absent; the gateway
+  catches it and substitutes a fallback, exactly as the feature intends. The
+  `required` `caption` edge is expected to always resolve.
+
+## Method rules (recap)
+
+- Every abstract method carries `@Selector` with a non-empty `capability`.
+- Parameters follow the `@MeshTool` convention: 0 params → no-arg call; exactly
+  one unannotated POJO/record param → single-object conversion (used here);
+  otherwise every param needs `@Param("name")`.
+- Return `T` (sync), `CompletableFuture<T>` (async), or
+  `Flow.Publisher<String>` (streaming).
+- Optional `@McpMeshService(minAvailable = N)` adds an availability floor: below
+  `N` resolvable methods, every facade call throws
+  `MeshServiceUnavailableException`.
+
+## Run it locally
+
+`meshctl start` runs each Maven agent and starts a local registry automatically
+if none is running. Use four terminals (or add `--detach`):
+
+```bash
+# Terminal 1 — provider A (also starts the local registry)
+meshctl start examples/java/service-view/caption-provider
+
+# Terminal 2 — provider B
+meshctl start examples/java/service-view/thumbnail-provider
+
+# Terminal 3 — provider C
+meshctl start examples/java/service-view/transcribe-provider
+
+# Terminal 4 — the consumer/gateway
+meshctl start examples/java/service-view/media-gateway
+```
+
+Once all four are healthy, call the gateway's entry-point tool:
+
+```bash
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+```
+
+Expected output — one interface, three different serving agents:
+
+```json
+{
+  "assetId": "asset-1",
+  "caption":    { "value": "A scene showing a cat on a sofa.",     "servedBy": "caption-provider" },
+  "thumbnail":  { "value": "thumb://asset-1?w=320&h=180 (320x180)", "servedBy": "thumbnail-provider" },
+  "transcript": { "value": "[asset-1] A CAT ON A SOFA [5 words]",   "servedBy": "transcribe-provider" }
+}
+```
+
+### See graceful degradation
+
+Stop one optional provider and call again — only that method degrades. Allow a
+few seconds for the consumer's next heartbeat to rebind before the degraded
+call; an immediate call can still hit the old provider proxy and succeed:
+
+```bash
+meshctl stop transcribe-provider
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+```
+
+```json
+{
+  "assetId": "asset-1",
+  "caption":    { "value": "A scene showing a cat on a sofa.",     "servedBy": "caption-provider" },
+  "thumbnail":  { "value": "thumb://asset-1?w=320&h=180 (320x180)", "servedBy": "thumbnail-provider" },
+  "transcript": { "value": "(no transcript — provider offline)",    "servedBy": "unavailable" }
+}
+```
+
+The `caption` and `thumbnail` methods still resolve to their own agents — proof
+that each view method is an independent dependency edge.
+
+Each agent directory also ships the full scaffolded file set (`Dockerfile`,
+`helm-values.yaml`, etc.) for Docker/Kubernetes deployment — see
+`meshctl man deployment`.
+
+## Documentation
+
+- Run `meshctl man decorators --java` for the decorator reference.
+- Run `meshctl man dependency-injection` for capability resolution, tags, and
+  availability semantics.

--- a/examples/java/service-view/caption-provider/.dockerignore
+++ b/examples/java/service-view/caption-provider/.dockerignore
@@ -1,0 +1,21 @@
+# Git
+.git
+.gitignore
+
+# Maven
+target/
+*.jar
+*.war
+
+# IDE
+.idea/
+.vscode/
+*.iml
+*.swp
+*.swo
+
+# OS
+.DS_Store
+
+# Documentation
+*.md

--- a/examples/java/service-view/caption-provider/Dockerfile
+++ b/examples/java/service-view/caption-provider/Dockerfile
@@ -1,0 +1,24 @@
+# Dockerfile for caption-provider MCP Mesh agent (Java/Spring Boot)
+FROM mcpmesh/java-runtime:2.8.2
+
+WORKDIR /app
+
+# Switch to root to copy files
+USER root
+
+# Copy Maven config and source
+COPY pom.xml .
+COPY src/ src/
+
+# Build the application and set permissions
+RUN mvn package -DskipTests -q && chown -R mcp-mesh:mcp-mesh /app
+
+# Switch back to non-root user
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 8110
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["java", "-jar"], so CMD only needs the jar path
+CMD ["target/caption-provider-1.0.0-SNAPSHOT.jar"]

--- a/examples/java/service-view/caption-provider/README.md
+++ b/examples/java/service-view/caption-provider/README.md
@@ -1,0 +1,74 @@
+# caption-provider
+
+Provider A in the [`@McpMeshService` service-view example](../README.md). Publishes
+the `media_caption` capability, bound by `MediaService.caption(...)` in the
+`media-gateway` consumer.
+
+## Overview
+
+A Java/Spring Boot MCP Mesh agent. Turns an asset id + source text into a
+deterministic caption.
+
+## Getting Started
+
+### Prerequisites
+
+- Java 17+
+- Maven 3.9+
+- MCP Mesh SDK
+
+### Running the Agent
+
+```bash
+mvn spring-boot:run
+```
+
+Or with meshctl (starts a local registry automatically if none is running):
+
+```bash
+meshctl start examples/java/service-view/caption-provider
+```
+
+The agent will start on port 8110 by default.
+
+## Project Structure
+
+```text
+caption-provider/
+├── pom.xml
+├── Dockerfile
+├── helm-values.yaml
+└── src/main/java/com/example/captionprovider/
+    └── CaptionProviderApplication.java
+```
+
+## Docker
+
+```bash
+# Build the image
+docker build -t caption-provider:latest .
+
+# Run the container
+docker run -p 8110:8110 caption-provider:latest
+```
+
+## Kubernetes
+
+```bash
+# Deploy using Helm
+helm install caption-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
+  -n mcp-mesh \
+  -f helm-values.yaml \
+  --set image.repository=your-registry/caption-provider \
+  --set image.tag=v1.0.0
+```
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- [Java SDK Reference](https://github.com/dhyansraj/mcp-mesh/tree/main/src/runtime/java)
+- Run `meshctl man decorators --java` for decorator reference
+
+## License
+
+MIT

--- a/examples/java/service-view/caption-provider/helm-values.yaml
+++ b/examples/java/service-view/caption-provider/helm-values.yaml
@@ -1,0 +1,41 @@
+# Helm values for deploying caption-provider with mcp-mesh-agent chart
+# Usage: helm install caption-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/caption-provider
+  tag: "v1.0.0"
+  pullPolicy: IfNotPresent
+
+agent:
+  name: caption-provider
+  runtime: java
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"
+
+# Optional: Secrets (creates a K8s Secret, injected via envFrom)
+# Uncomment to add — leaving commented avoids overriding base values
+# secrets:
+#   DATABASE_URL: "postgres://user:pass@host:5432/db"
+#   API_KEY: "your-api-key"

--- a/examples/java/service-view/caption-provider/pom.xml
+++ b/examples/java/service-view/caption-provider/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.captionprovider</groupId>
+    <artifactId>caption-provider</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>CaptionProvider Agent</name>
+    <description>MCP Mesh agent</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.8.2</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web (for HTTP server) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.captionprovider.CaptionProviderApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/java/service-view/caption-provider/src/main/java/com/example/captionprovider/CaptionProviderApplication.java
+++ b/examples/java/service-view/caption-provider/src/main/java/com/example/captionprovider/CaptionProviderApplication.java
@@ -1,0 +1,57 @@
+package com.example.captionprovider;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * CaptionProvider - one leaf of the {@code @McpMeshService} service-view demo.
+ *
+ * <p>Publishes a single capability, {@code media_caption}. The
+ * {@code media-gateway} consumer binds this capability through the
+ * {@code MediaService.caption(...)} view method — a different agent than the
+ * ones backing {@code thumbnail(...)} and {@code transcribe(...)}.
+ */
+@MeshAgent(
+    name = "caption-provider",
+    version = "1.0.0",
+    description = "Generates a human caption for a media asset",
+    port = 8110
+)
+@SpringBootApplication
+public class CaptionProviderApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(CaptionProviderApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting CaptionProvider Agent...");
+        SpringApplication.run(CaptionProviderApplication.class, args);
+    }
+
+    /**
+     * Produce a deterministic caption from an asset id and source text.
+     *
+     * @param assetId the media asset identifier
+     * @param text    source description text
+     * @return a caption record, tagged with this provider's name
+     */
+    @MeshTool(
+        capability = "media_caption",
+        description = "Generates a human caption for a media asset",
+        tags = {"media"}
+    )
+    public CaptionResult caption(
+        @Param(value = "assetId", description = "Media asset identifier") String assetId,
+        @Param(value = "text", description = "Source description text") String text
+    ) {
+        String caption = "A scene showing " + text.trim().toLowerCase() + ".";
+        return new CaptionResult(assetId, caption, "caption-provider");
+    }
+
+    /** Caption result — {@code provider} makes the serving agent visible downstream. */
+    public record CaptionResult(String assetId, String caption, String provider) {}
+}

--- a/examples/java/service-view/caption-provider/src/main/resources/application.yml
+++ b/examples/java/service-view/caption-provider/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${MCP_MESH_HTTP_PORT:8110}
+
+spring:
+  main:
+    banner-mode: off
+
+logging:
+  level:
+    root: INFO
+    io.mcpmesh: DEBUG

--- a/examples/java/service-view/media-gateway/.dockerignore
+++ b/examples/java/service-view/media-gateway/.dockerignore
@@ -1,0 +1,21 @@
+# Git
+.git
+.gitignore
+
+# Maven
+target/
+*.jar
+*.war
+
+# IDE
+.idea/
+.vscode/
+*.iml
+*.swp
+*.swo
+
+# OS
+.DS_Store
+
+# Documentation
+*.md

--- a/examples/java/service-view/media-gateway/Dockerfile
+++ b/examples/java/service-view/media-gateway/Dockerfile
@@ -1,0 +1,24 @@
+# Dockerfile for media-gateway MCP Mesh agent (Java/Spring Boot)
+FROM mcpmesh/java-runtime:2.8.2
+
+WORKDIR /app
+
+# Switch to root to copy files
+USER root
+
+# Copy Maven config and source
+COPY pom.xml .
+COPY src/ src/
+
+# Build the application and set permissions
+RUN mvn package -DskipTests -q && chown -R mcp-mesh:mcp-mesh /app
+
+# Switch back to non-root user
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 8113
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["java", "-jar"], so CMD only needs the jar path
+CMD ["target/media-gateway-1.0.0-SNAPSHOT.jar"]

--- a/examples/java/service-view/media-gateway/README.md
+++ b/examples/java/service-view/media-gateway/README.md
@@ -1,0 +1,95 @@
+# media-gateway
+
+The consumer in the [`@McpMeshService` service-view example](../README.md).
+Declares one typed `MediaService` interface aggregating three capabilities and
+exposes a `process_media` tool that fans a request out across all three view
+methods — each served by a different provider agent.
+
+## Overview
+
+A Java/Spring Boot MCP Mesh agent. `MediaService` is a consumer-owned service
+view:
+
+```java
+@McpMeshService
+public interface MediaService {
+    @Selector(capability = "media_caption", required = true) CaptionResult    caption(CaptionRequest req);
+    @Selector(capability = "media_thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
+    @Selector(capability = "media_transcribe")               TranscriptResult transcribe(TranscribeRequest req);
+}
+```
+
+Spring registers a `mediaService` facade bean automatically; the gateway
+`@Autowired`s it and calls the methods directly. The optional methods are
+wrapped in a `MeshToolUnavailableException` catch for graceful degradation.
+
+## Getting Started
+
+### Prerequisites
+
+- Java 17+
+- Maven 3.9+
+- MCP Mesh SDK
+- The three providers running (`caption-provider`, `thumbnail-provider`,
+  `transcribe-provider`)
+
+### Running the Agent
+
+```bash
+mvn spring-boot:run
+```
+
+Or with meshctl (starts a local registry automatically if none is running):
+
+```bash
+meshctl start examples/java/service-view/media-gateway
+```
+
+The agent will start on port 8113 by default. Then:
+
+```bash
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+```
+
+## Project Structure
+
+```text
+media-gateway/
+├── pom.xml
+├── Dockerfile
+├── helm-values.yaml
+└── src/main/java/com/example/mediagateway/
+    ├── MediaService.java            # the @McpMeshService service view
+    └── MediaGatewayApplication.java # the agent + process_media tool
+```
+
+## Docker
+
+```bash
+# Build the image
+docker build -t media-gateway:latest .
+
+# Run the container
+docker run -p 8113:8113 media-gateway:latest
+```
+
+## Kubernetes
+
+```bash
+# Deploy using Helm
+helm install media-gateway oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
+  -n mcp-mesh \
+  -f helm-values.yaml \
+  --set image.repository=your-registry/media-gateway \
+  --set image.tag=v1.0.0
+```
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- [Java SDK Reference](https://github.com/dhyansraj/mcp-mesh/tree/main/src/runtime/java)
+- Run `meshctl man decorators --java` for decorator reference
+
+## License
+
+MIT

--- a/examples/java/service-view/media-gateway/helm-values.yaml
+++ b/examples/java/service-view/media-gateway/helm-values.yaml
@@ -1,0 +1,41 @@
+# Helm values for deploying media-gateway with mcp-mesh-agent chart
+# Usage: helm install media-gateway oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/media-gateway
+  tag: "v1.0.0"
+  pullPolicy: IfNotPresent
+
+agent:
+  name: media-gateway
+  runtime: java
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"
+
+# Optional: Secrets (creates a K8s Secret, injected via envFrom)
+# Uncomment to add — leaving commented avoids overriding base values
+# secrets:
+#   DATABASE_URL: "postgres://user:pass@host:5432/db"
+#   API_KEY: "your-api-key"

--- a/examples/java/service-view/media-gateway/pom.xml
+++ b/examples/java/service-view/media-gateway/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.mediagateway</groupId>
+    <artifactId>media-gateway</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>MediaGateway Agent</name>
+    <description>MCP Mesh agent</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.8.2</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web (for HTTP server) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.mediagateway.MediaGatewayApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/java/service-view/media-gateway/src/main/java/com/example/mediagateway/MediaGatewayApplication.java
+++ b/examples/java/service-view/media-gateway/src/main/java/com/example/mediagateway/MediaGatewayApplication.java
@@ -1,0 +1,107 @@
+package com.example.mediagateway;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.types.MeshToolUnavailableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * MediaGateway - the consumer in the {@code @McpMeshService} service-view demo.
+ *
+ * <p>Autowires the {@link MediaService} facade and exposes a single
+ * {@code process_media} tool that fans one request out across all three view
+ * methods. Because each method binds its own capability, the returned
+ * {@code servedBy} fields show THREE different provider agents answering through
+ * ONE typed interface.
+ *
+ * <p>The optional {@code thumbnail}/{@code transcribe} methods are wrapped in a
+ * {@link MeshToolUnavailableException} catch so the gateway keeps working (with
+ * a degraded fallback) whenever those providers are down — while the REQUIRED
+ * {@code caption} method is expected to always resolve.
+ */
+@MeshAgent(
+    name = "media-gateway",
+    version = "1.0.0",
+    description = "Aggregates three media capabilities behind one typed service view",
+    port = 8113
+)
+@SpringBootApplication
+public class MediaGatewayApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(MediaGatewayApplication.class);
+
+    private final MediaService media;
+
+    public MediaGatewayApplication(MediaService media) {
+        this.media = media;
+    }
+
+    public static void main(String[] args) {
+        log.info("Starting MediaGateway Agent...");
+        SpringApplication.run(MediaGatewayApplication.class, args);
+    }
+
+    /**
+     * Process one media asset through all three view methods and combine the
+     * results. Each capability may be served by a different provider agent.
+     *
+     * @param assetId the media asset identifier
+     * @param text    source description / audio text
+     * @return a combined map showing the value and serving provider per capability
+     */
+    @MeshTool(
+        capability = "process_media",
+        description = "Runs an asset through caption, thumbnail and transcribe via one service view",
+        tags = {"media", "gateway"}
+    )
+    public Map<String, Object> processMedia(
+        @Param(value = "assetId", description = "Media asset identifier") String assetId,
+        @Param(value = "text", description = "Source description / audio text") String text
+    ) {
+        log.info("Processing media asset '{}' through the MediaService view", assetId);
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("assetId", assetId);
+
+        // REQUIRED edge — expected to resolve; a failure surfaces to the caller.
+        MediaService.CaptionResult caption = media.caption(new MediaService.CaptionRequest(assetId, text));
+        result.put("caption", entry(caption.caption(), caption.provider()));
+
+        // OPTIONAL edge — degrade gracefully if no thumbnail provider is present.
+        try {
+            MediaService.ThumbnailResult thumb =
+                media.thumbnail(new MediaService.ThumbnailRequest(assetId, 320));
+            result.put("thumbnail", entry(thumb.uri() + " (" + thumb.size() + ")", thumb.provider()));
+        } catch (MeshToolUnavailableException e) {
+            log.warn("thumbnail capability unavailable — degrading: {}", e.getMessage());
+            result.put("thumbnail", entry("(no thumbnail — provider offline)", "unavailable"));
+        }
+
+        // OPTIONAL edge — degrade gracefully if no transcribe provider is present.
+        try {
+            MediaService.TranscriptResult tx =
+                media.transcribe(new MediaService.TranscribeRequest(assetId, text));
+            result.put("transcript", entry(tx.transcript() + " [" + tx.wordCount() + " words]", tx.provider()));
+        } catch (MeshToolUnavailableException e) {
+            log.warn("transcribe capability unavailable — degrading: {}", e.getMessage());
+            result.put("transcript", entry("(no transcript — provider offline)", "unavailable"));
+        }
+
+        return result;
+    }
+
+    /** One combined-result entry: the value plus the provider agent that served it. */
+    private static Map<String, Object> entry(String value, String servedBy) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("value", value);
+        m.put("servedBy", servedBy);
+        return m;
+    }
+}

--- a/examples/java/service-view/media-gateway/src/main/java/com/example/mediagateway/MediaService.java
+++ b/examples/java/service-view/media-gateway/src/main/java/com/example/mediagateway/MediaService.java
@@ -1,0 +1,52 @@
+package com.example.mediagateway;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+/**
+ * A consumer-owned <b>service view</b> (RFC #1280): one typed interface that
+ * aggregates three independent capabilities. Each abstract method binds exactly
+ * one capability via its own {@link Selector}, so the three methods resolve to
+ * three DIFFERENT provider agents and rebind independently as the mesh topology
+ * changes.
+ *
+ * <ul>
+ *   <li>{@link #caption} → {@code media_caption} (caption-provider), REQUIRED</li>
+ *   <li>{@link #thumbnail} → {@code media_thumbnail} (thumbnail-provider), optional</li>
+ *   <li>{@link #transcribe} → {@code media_transcribe} (transcribe-provider), optional</li>
+ * </ul>
+ *
+ * <p>Spring auto-discovers this interface on the classpath and registers a
+ * facade bean named {@code mediaService}; the {@code media-gateway} agent
+ * {@code @Autowired}s it and calls the methods directly. Each optional method
+ * throws {@link io.mcpmesh.types.MeshToolUnavailableException} when its provider
+ * is absent, which the gateway catches for graceful degradation.
+ */
+@McpMeshService
+public interface MediaService {
+
+    @Selector(capability = "media_caption", required = true)
+    CaptionResult caption(CaptionRequest req);
+
+    @Selector(capability = "media_thumbnail")
+    ThumbnailResult thumbnail(ThumbnailRequest req);
+
+    @Selector(capability = "media_transcribe")
+    TranscriptResult transcribe(TranscribeRequest req);
+
+    // ---- Single-POJO request records (one unannotated param per method) -------
+
+    record CaptionRequest(String assetId, String text) {}
+
+    record ThumbnailRequest(String assetId, int width) {}
+
+    record TranscribeRequest(String assetId, String text) {}
+
+    // ---- Result records (field names mirror each provider's response) --------
+
+    record CaptionResult(String assetId, String caption, String provider) {}
+
+    record ThumbnailResult(String assetId, String uri, String size, String provider) {}
+
+    record TranscriptResult(String assetId, String transcript, int wordCount, String provider) {}
+}

--- a/examples/java/service-view/media-gateway/src/main/resources/application.yml
+++ b/examples/java/service-view/media-gateway/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${MCP_MESH_HTTP_PORT:8113}
+
+spring:
+  main:
+    banner-mode: off
+
+logging:
+  level:
+    root: INFO
+    io.mcpmesh: DEBUG

--- a/examples/java/service-view/thumbnail-provider/.dockerignore
+++ b/examples/java/service-view/thumbnail-provider/.dockerignore
@@ -1,0 +1,21 @@
+# Git
+.git
+.gitignore
+
+# Maven
+target/
+*.jar
+*.war
+
+# IDE
+.idea/
+.vscode/
+*.iml
+*.swp
+*.swo
+
+# OS
+.DS_Store
+
+# Documentation
+*.md

--- a/examples/java/service-view/thumbnail-provider/Dockerfile
+++ b/examples/java/service-view/thumbnail-provider/Dockerfile
@@ -1,0 +1,24 @@
+# Dockerfile for thumbnail-provider MCP Mesh agent (Java/Spring Boot)
+FROM mcpmesh/java-runtime:2.8.2
+
+WORKDIR /app
+
+# Switch to root to copy files
+USER root
+
+# Copy Maven config and source
+COPY pom.xml .
+COPY src/ src/
+
+# Build the application and set permissions
+RUN mvn package -DskipTests -q && chown -R mcp-mesh:mcp-mesh /app
+
+# Switch back to non-root user
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 8111
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["java", "-jar"], so CMD only needs the jar path
+CMD ["target/thumbnail-provider-1.0.0-SNAPSHOT.jar"]

--- a/examples/java/service-view/thumbnail-provider/README.md
+++ b/examples/java/service-view/thumbnail-provider/README.md
@@ -1,0 +1,75 @@
+# thumbnail-provider
+
+Provider B in the [`@McpMeshService` service-view example](../README.md). Publishes
+the `media_thumbnail` capability, bound by the OPTIONAL
+`MediaService.thumbnail(...)` view method in the `media-gateway` consumer — stop
+this agent to see the gateway degrade gracefully.
+
+## Overview
+
+A Java/Spring Boot MCP Mesh agent. Turns an asset id + width into a deterministic
+thumbnail descriptor.
+
+## Getting Started
+
+### Prerequisites
+
+- Java 17+
+- Maven 3.9+
+- MCP Mesh SDK
+
+### Running the Agent
+
+```bash
+mvn spring-boot:run
+```
+
+Or with meshctl (starts a local registry automatically if none is running):
+
+```bash
+meshctl start examples/java/service-view/thumbnail-provider
+```
+
+The agent will start on port 8111 by default.
+
+## Project Structure
+
+```text
+thumbnail-provider/
+├── pom.xml
+├── Dockerfile
+├── helm-values.yaml
+└── src/main/java/com/example/thumbnailprovider/
+    └── ThumbnailProviderApplication.java
+```
+
+## Docker
+
+```bash
+# Build the image
+docker build -t thumbnail-provider:latest .
+
+# Run the container
+docker run -p 8111:8111 thumbnail-provider:latest
+```
+
+## Kubernetes
+
+```bash
+# Deploy using Helm
+helm install thumbnail-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
+  -n mcp-mesh \
+  -f helm-values.yaml \
+  --set image.repository=your-registry/thumbnail-provider \
+  --set image.tag=v1.0.0
+```
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- [Java SDK Reference](https://github.com/dhyansraj/mcp-mesh/tree/main/src/runtime/java)
+- Run `meshctl man decorators --java` for decorator reference
+
+## License
+
+MIT

--- a/examples/java/service-view/thumbnail-provider/helm-values.yaml
+++ b/examples/java/service-view/thumbnail-provider/helm-values.yaml
@@ -1,0 +1,41 @@
+# Helm values for deploying thumbnail-provider with mcp-mesh-agent chart
+# Usage: helm install thumbnail-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/thumbnail-provider
+  tag: "v1.0.0"
+  pullPolicy: IfNotPresent
+
+agent:
+  name: thumbnail-provider
+  runtime: java
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"
+
+# Optional: Secrets (creates a K8s Secret, injected via envFrom)
+# Uncomment to add — leaving commented avoids overriding base values
+# secrets:
+#   DATABASE_URL: "postgres://user:pass@host:5432/db"
+#   API_KEY: "your-api-key"

--- a/examples/java/service-view/thumbnail-provider/pom.xml
+++ b/examples/java/service-view/thumbnail-provider/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.thumbnailprovider</groupId>
+    <artifactId>thumbnail-provider</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>ThumbnailProvider Agent</name>
+    <description>MCP Mesh agent</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.8.2</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web (for HTTP server) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.thumbnailprovider.ThumbnailProviderApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/java/service-view/thumbnail-provider/src/main/java/com/example/thumbnailprovider/ThumbnailProviderApplication.java
+++ b/examples/java/service-view/thumbnail-provider/src/main/java/com/example/thumbnailprovider/ThumbnailProviderApplication.java
@@ -1,0 +1,60 @@
+package com.example.thumbnailprovider;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * ThumbnailProvider - one leaf of the {@code @McpMeshService} service-view demo.
+ *
+ * <p>Publishes a single capability, {@code media_thumbnail}. The
+ * {@code media-gateway} consumer binds this capability through the OPTIONAL
+ * {@code MediaService.thumbnail(...)} view method — stop this agent and the
+ * gateway degrades gracefully while {@code caption(...)} and
+ * {@code transcribe(...)} keep working.
+ */
+@MeshAgent(
+    name = "thumbnail-provider",
+    version = "1.0.0",
+    description = "Generates a thumbnail descriptor for a media asset",
+    port = 8111
+)
+@SpringBootApplication
+public class ThumbnailProviderApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(ThumbnailProviderApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting ThumbnailProvider Agent...");
+        SpringApplication.run(ThumbnailProviderApplication.class, args);
+    }
+
+    /**
+     * Produce a deterministic thumbnail descriptor from an asset id and width.
+     *
+     * @param assetId the media asset identifier
+     * @param width   requested thumbnail width in pixels
+     * @return a thumbnail record, tagged with this provider's name
+     */
+    @MeshTool(
+        capability = "media_thumbnail",
+        description = "Generates a thumbnail descriptor for a media asset",
+        tags = {"media"}
+    )
+    public ThumbnailResult thumbnail(
+        @Param(value = "assetId", description = "Media asset identifier") String assetId,
+        @Param(value = "width", description = "Requested thumbnail width in pixels") int width
+    ) {
+        int w = width > 0 ? width : 128;
+        int h = Math.max(1, w * 9 / 16);
+        String uri = "thumb://" + assetId + "?w=" + w + "&h=" + h;
+        return new ThumbnailResult(assetId, uri, w + "x" + h, "thumbnail-provider");
+    }
+
+    /** Thumbnail result — {@code provider} makes the serving agent visible downstream. */
+    public record ThumbnailResult(String assetId, String uri, String size, String provider) {}
+}

--- a/examples/java/service-view/thumbnail-provider/src/main/resources/application.yml
+++ b/examples/java/service-view/thumbnail-provider/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${MCP_MESH_HTTP_PORT:8111}
+
+spring:
+  main:
+    banner-mode: off
+
+logging:
+  level:
+    root: INFO
+    io.mcpmesh: DEBUG

--- a/examples/java/service-view/transcribe-provider/.dockerignore
+++ b/examples/java/service-view/transcribe-provider/.dockerignore
@@ -1,0 +1,21 @@
+# Git
+.git
+.gitignore
+
+# Maven
+target/
+*.jar
+*.war
+
+# IDE
+.idea/
+.vscode/
+*.iml
+*.swp
+*.swo
+
+# OS
+.DS_Store
+
+# Documentation
+*.md

--- a/examples/java/service-view/transcribe-provider/Dockerfile
+++ b/examples/java/service-view/transcribe-provider/Dockerfile
@@ -1,0 +1,24 @@
+# Dockerfile for transcribe-provider MCP Mesh agent (Java/Spring Boot)
+FROM mcpmesh/java-runtime:2.8.2
+
+WORKDIR /app
+
+# Switch to root to copy files
+USER root
+
+# Copy Maven config and source
+COPY pom.xml .
+COPY src/ src/
+
+# Build the application and set permissions
+RUN mvn package -DskipTests -q && chown -R mcp-mesh:mcp-mesh /app
+
+# Switch back to non-root user
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 8112
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["java", "-jar"], so CMD only needs the jar path
+CMD ["target/transcribe-provider-1.0.0-SNAPSHOT.jar"]

--- a/examples/java/service-view/transcribe-provider/README.md
+++ b/examples/java/service-view/transcribe-provider/README.md
@@ -1,0 +1,74 @@
+# transcribe-provider
+
+Provider C in the [`@McpMeshService` service-view example](../README.md). Publishes
+the `media_transcribe` capability, bound by the OPTIONAL
+`MediaService.transcribe(...)` view method in the `media-gateway` consumer.
+
+## Overview
+
+A Java/Spring Boot MCP Mesh agent. Turns an asset id + source text into a
+deterministic transcript.
+
+## Getting Started
+
+### Prerequisites
+
+- Java 17+
+- Maven 3.9+
+- MCP Mesh SDK
+
+### Running the Agent
+
+```bash
+mvn spring-boot:run
+```
+
+Or with meshctl (starts a local registry automatically if none is running):
+
+```bash
+meshctl start examples/java/service-view/transcribe-provider
+```
+
+The agent will start on port 8112 by default.
+
+## Project Structure
+
+```text
+transcribe-provider/
+├── pom.xml
+├── Dockerfile
+├── helm-values.yaml
+└── src/main/java/com/example/transcribeprovider/
+    └── TranscribeProviderApplication.java
+```
+
+## Docker
+
+```bash
+# Build the image
+docker build -t transcribe-provider:latest .
+
+# Run the container
+docker run -p 8112:8112 transcribe-provider:latest
+```
+
+## Kubernetes
+
+```bash
+# Deploy using Helm
+helm install transcribe-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
+  -n mcp-mesh \
+  -f helm-values.yaml \
+  --set image.repository=your-registry/transcribe-provider \
+  --set image.tag=v1.0.0
+```
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- [Java SDK Reference](https://github.com/dhyansraj/mcp-mesh/tree/main/src/runtime/java)
+- Run `meshctl man decorators --java` for decorator reference
+
+## License
+
+MIT

--- a/examples/java/service-view/transcribe-provider/helm-values.yaml
+++ b/examples/java/service-view/transcribe-provider/helm-values.yaml
@@ -1,0 +1,41 @@
+# Helm values for deploying transcribe-provider with mcp-mesh-agent chart
+# Usage: helm install transcribe-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/transcribe-provider
+  tag: "v1.0.0"
+  pullPolicy: IfNotPresent
+
+agent:
+  name: transcribe-provider
+  runtime: java
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"
+
+# Optional: Secrets (creates a K8s Secret, injected via envFrom)
+# Uncomment to add — leaving commented avoids overriding base values
+# secrets:
+#   DATABASE_URL: "postgres://user:pass@host:5432/db"
+#   API_KEY: "your-api-key"

--- a/examples/java/service-view/transcribe-provider/pom.xml
+++ b/examples/java/service-view/transcribe-provider/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.transcribeprovider</groupId>
+    <artifactId>transcribe-provider</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>TranscribeProvider Agent</name>
+    <description>MCP Mesh agent</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.8.2</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web (for HTTP server) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.transcribeprovider.TranscribeProviderApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/java/service-view/transcribe-provider/src/main/java/com/example/transcribeprovider/TranscribeProviderApplication.java
+++ b/examples/java/service-view/transcribe-provider/src/main/java/com/example/transcribeprovider/TranscribeProviderApplication.java
@@ -1,0 +1,58 @@
+package com.example.transcribeprovider;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * TranscribeProvider - one leaf of the {@code @McpMeshService} service-view demo.
+ *
+ * <p>Publishes a single capability, {@code media_transcribe}. The
+ * {@code media-gateway} consumer binds this capability through the OPTIONAL
+ * {@code MediaService.transcribe(...)} view method — a third, independent agent
+ * from the ones backing {@code caption(...)} and {@code thumbnail(...)}.
+ */
+@MeshAgent(
+    name = "transcribe-provider",
+    version = "1.0.0",
+    description = "Generates a transcript for a media asset",
+    port = 8112
+)
+@SpringBootApplication
+public class TranscribeProviderApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(TranscribeProviderApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting TranscribeProvider Agent...");
+        SpringApplication.run(TranscribeProviderApplication.class, args);
+    }
+
+    /**
+     * Produce a deterministic transcript from an asset id and source text.
+     *
+     * @param assetId the media asset identifier
+     * @param text    source audio text
+     * @return a transcript record, tagged with this provider's name
+     */
+    @MeshTool(
+        capability = "media_transcribe",
+        description = "Generates a transcript for a media asset",
+        tags = {"media"}
+    )
+    public TranscriptResult transcribe(
+        @Param(value = "assetId", description = "Media asset identifier") String assetId,
+        @Param(value = "text", description = "Source audio text") String text
+    ) {
+        int words = text.trim().isEmpty() ? 0 : text.trim().split("\\s+").length;
+        String transcript = "[" + assetId + "] " + text.trim().toUpperCase();
+        return new TranscriptResult(assetId, transcript, words, "transcribe-provider");
+    }
+
+    /** Transcript result — {@code provider} makes the serving agent visible downstream. */
+    public record TranscriptResult(String assetId, String transcript, int wordCount, String provider) {}
+}

--- a/examples/java/service-view/transcribe-provider/src/main/resources/application.yml
+++ b/examples/java/service-view/transcribe-provider/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+server:
+  port: ${MCP_MESH_HTTP_PORT:8112}
+
+spring:
+  main:
+    banner-mode: off
+
+logging:
+  level:
+    root: INFO
+    io.mcpmesh: DEBUG

--- a/src/core/cli/man/content/decorators_java.md
+++ b/src/core/cli/man/content/decorators_java.md
@@ -198,7 +198,7 @@ public interface MediaService {
 
 | Attribute      | Required | Description                                                                 |
 | -------------- | -------- | -------------------------------------------------------------------------- |
-| `minAvailable` | No       | Availability floor; below it every facade call throws `MeshServiceUnavailableException` (default `0` = no floor) |
+| `minAvailable` | No       | Availability floor; below it every facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (default `0` = no floor) |
 
 Each method expands into an ordinary dependency edge, so a view over N capabilities shows as N dependencies in `meshctl list`. For the full semantics — param-mapping rules, return types, `required`/optional behavior, and the availability floor — see `meshctl man dependency-injection --java`.
 

--- a/src/core/cli/man/content/decorators_java.md
+++ b/src/core/cli/man/content/decorators_java.md
@@ -12,6 +12,7 @@ MCP Mesh provides annotations that transform regular Spring Boot methods into me
 | `@MeshTool`        | Register capability with DI               |
 | `@Param`           | Document tool parameters                  |
 | `@Selector`        | Capability/tag selection for dependencies |
+| `@McpMeshService`  | Typed service-view interface over several capabilities |
 | `@MeshLlm`         | Enable LLM-powered tools                  |
 | `@MeshLlmProvider` | Create zero-code LLM provider             |
 | `@MeshRoute`       | REST endpoint with mesh DI                |
@@ -179,6 +180,27 @@ Specifies capability and tag selection for dependencies, LLM providers, and filt
 | `version`    | No       | Semantic version constraint    |
 
 \*Required for dependencies; optional for LLM tool filters.
+
+`@Selector` is also used at the **method level** inside an `@McpMeshService` interface, where each abstract method carries one `@Selector` to bind its capability (see below).
+
+## @McpMeshService
+
+Marks an interface as a consumer-owned **service view**: one typed facade that aggregates several capability dependencies. Each abstract method binds one capability via a method-level `@Selector`, and each method delegates to its own resolved proxy — so different methods can resolve to different provider agents. Spring auto-discovers the interface and injects a facade bean you `@Autowired`.
+
+```java
+@McpMeshService
+public interface MediaService {
+    @Selector(capability = "media_caption", required = true) CaptionResult    caption(CaptionRequest req);
+    @Selector(capability = "media_thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
+    @Selector(capability = "media_transcribe")               TranscriptResult transcribe(TranscribeRequest req);
+}
+```
+
+| Attribute      | Required | Description                                                                 |
+| -------------- | -------- | -------------------------------------------------------------------------- |
+| `minAvailable` | No       | Availability floor; below it every facade call throws `MeshServiceUnavailableException` (default `0` = no floor) |
+
+Each method expands into an ordinary dependency edge, so a view over N capabilities shows as N dependencies in `meshctl list`. For the full semantics — param-mapping rules, return types, `required`/optional behavior, and the availability floor — see `meshctl man dependency-injection --java`.
 
 ## @MeshLlm
 

--- a/src/core/cli/man/content/dependency-injection_java.md
+++ b/src/core/cli/man/content/dependency-injection_java.md
@@ -162,6 +162,7 @@ public class HolidayChecker {
 | `@MeshTool` method needing remote helpers | `@MeshTool(dependencies = @Selector(...))` + parameter injection |
 | `@RestController` handler method | `@MeshRoute(dependencies = {...})` + `@MeshInject` parameter |
 | `@Service` / `@Component` / `Filter` / `@Scheduled` / any other Spring bean | **`@MeshDependsOn` + `@Qualifier`** |
+| Several capabilities behind one typed facade | **`@McpMeshService` interface + `@Autowired`** |
 
 `@MeshDependsOn` and `@MeshInject`/`@MeshRoute` are complementary — same heartbeat-driven proxy lifecycle, same auto-rewiring on topology change, same `isAvailable()` semantics. Pick the surface that matches where you need the dependency. If the same capability shows up via multiple sources the framework deduplicates: a single proxy and a single registry entry per capability name.
 
@@ -199,6 +200,77 @@ If you omit `expectedType` and the `@Qualifier`-injected field is declared as `M
 | `@Bean public Foo foo() { return new ConcreteFoo(); }` where `@MeshDependsOn` is ONLY on `ConcreteFoo` | ✗ — `findAnnotation` walks supertypes of the declared return type, not subtypes of it |
 
 Only the last shape is a real gap. If your factory method declares a supertype return, either narrow the declared return type to the concrete class, or place `@MeshDependsOn` on the supertype itself (or on the `@Configuration` class).
+
+## Service Views with `@McpMeshService`
+
+A **service view** aggregates several capability dependencies behind one typed interface. Annotate an interface with `@McpMeshService`; each abstract method binds one capability via a method-level `@Selector`. Spring auto-discovers the interface and injects a facade bean (named by the decapitalized interface name) that you `@Autowired` and call directly.
+
+The differentiator: **each method delegates to its own per-capability resolved proxy**, so different methods can resolve to different provider agents and rebind independently as the topology changes. The group is a typed view; the capability remains the atom. Nothing group-shaped crosses the wire — every method expands into an ordinary dependency edge with `required`/`tags`/`version`/settle semantics identical to a `@MeshDependsOn` dependency. A view over N capabilities therefore shows as **N separate dependencies** in `meshctl list`, not one.
+
+```java
+@McpMeshService
+public interface MediaService {
+    @Selector(capability = "media_caption", required = true) CaptionResult    caption(CaptionRequest req);
+    @Selector(capability = "media_thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
+    @Selector(capability = "media_transcribe")               TranscriptResult transcribe(TranscribeRequest req);
+
+    record CaptionRequest(String assetId, String text) {}
+    record ThumbnailRequest(String assetId, int width) {}
+    record CaptionResult(String assetId, String caption, String provider) {}
+    record ThumbnailResult(String assetId, String uri, String size, String provider) {}
+    record TranscriptResult(String assetId, String transcript, int wordCount, String provider) {}
+}
+```
+
+The consumer autowires the facade and calls its methods directly. Because each method is its own edge, the results below may come from three different provider agents through one interface:
+
+```java
+@MeshAgent(name = "media-gateway", version = "1.0.0", port = 8113)
+@SpringBootApplication
+public class MediaGatewayApplication {
+    private final MediaService media;
+
+    public MediaGatewayApplication(MediaService media) {
+        this.media = media;
+    }
+
+    @MeshTool(capability = "process_media",
+              description = "Run an asset through a media service view")
+    public Map<String, Object> processMedia(
+            @Param(value = "assetId", description = "Asset id") String assetId,
+            @Param(value = "text", description = "Source text") String text) {
+
+        Map<String, Object> out = new LinkedHashMap<>();
+
+        // REQUIRED edge — expected to resolve; a failure surfaces to the caller.
+        out.put("caption", media.caption(new MediaService.CaptionRequest(assetId, text)));
+
+        // OPTIONAL edge — degrade gracefully when its provider is offline.
+        try {
+            out.put("thumbnail", media.thumbnail(new MediaService.ThumbnailRequest(assetId, 320)));
+        } catch (MeshToolUnavailableException e) {
+            out.put("thumbnail", "(no thumbnail — provider offline)");
+        }
+        return out;
+    }
+}
+```
+
+### Method rules
+
+- Every abstract method must carry `@Selector` with a non-empty `capability`. `default` / `static` interface methods are allowed and are not expanded as edges.
+- Parameters follow the `@MeshTool` convention: **0 params** → no-arg call; **exactly 1 unannotated POJO/record param** → that object becomes the params (scalars still need `@Param`); **2+ params** → each needs `@Param("name")`.
+- Return `T` (synchronous), `CompletableFuture<T>` (async), or `java.util.concurrent.Flow.Publisher<String>` (streaming).
+
+### Required, optional, and the availability floor
+
+`required = true` on a view method behaves like a class-level `@MeshDependsOn` required dependency (see [Required Dependencies](#required-dependencies) below): it participates in cross-source required-wins dedupe, flips the registry-side availability of that capability's carrier when unresolved (visible in `meshctl list` and the registry API), and promotes any matching route-perimeter 503 guard. An optional method whose provider is down throws `MeshToolUnavailableException` on **that call only**; catch it for graceful degradation while the rest of the view keeps working.
+
+> **One difference from a tool-declared slot.** A view is class-level, so the framework cannot know which `@MeshTool` methods call it and does **not** add a pre-invoke structured `dependency_unavailable` refusal to those tools — a call to a required-but-unresolved view method simply throws `MeshToolUnavailableException`, surfacing as an ordinary tool error. If a specific `@MeshTool` needs the pre-invoke structured refusal for a capability, declare it as a `@MeshTool` dependency slot (`dependencies = @Selector(...)`) instead; tool-declared slots get the guard, views do not.
+
+The optional `@McpMeshService(minAvailable = N)` adds a consumer-local availability floor: when fewer than `N` of the view's methods currently resolve, **every** facade call throws `MeshServiceUnavailableException` (settle-grace-aware). The default `0` means no floor — each method soft- or hard-fails per its own `required` flag.
+
+A service view is **consumer-local**, not a shared contract: two consumers may aggregate the same capabilities differently, and there is no group versioning or interface-level availability summary. Each method resolves independently.
 
 ## `McpMeshTool<T>` API Reference
 

--- a/src/core/cli/man/content/dependency-injection_java.md
+++ b/src/core/cli/man/content/dependency-injection_java.md
@@ -268,7 +268,7 @@ public class MediaGatewayApplication {
 
 > **One difference from a tool-declared slot.** A view is class-level, so the framework cannot know which `@MeshTool` methods call it and does **not** add a pre-invoke structured `dependency_unavailable` refusal to those tools — a call to a required-but-unresolved view method simply throws `MeshToolUnavailableException`, surfacing as an ordinary tool error. If a specific `@MeshTool` needs the pre-invoke structured refusal for a capability, declare it as a `@MeshTool` dependency slot (`dependencies = @Selector(...)`) instead; tool-declared slots get the guard, views do not.
 
-The optional `@McpMeshService(minAvailable = N)` adds a consumer-local availability floor: when fewer than `N` of the view's methods currently resolve, **every** facade call throws `MeshServiceUnavailableException` (settle-grace-aware). The default `0` means no floor — each method soft- or hard-fails per its own `required` flag.
+The optional `@McpMeshService(minAvailable = N)` adds a consumer-local availability floor: when fewer than `N` of the view's methods currently resolve, **every** facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (settle-grace-aware). The default `0` means no floor — each method soft- or hard-fails per its own `required` flag.
 
 A service view is **consumer-local**, not a shared contract: two consumers may aggregate the same capabilities differently, and there is no group versioning or interface-level availability summary. Each method resolves independently.
 

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/McpMeshService.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/McpMeshService.java
@@ -1,0 +1,71 @@
+package io.mcpmesh;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an interface as a consumer-owned <b>service view</b>: a typed
+ * aggregation of ordinary capability dependencies (RFC #1280).
+ *
+ * <p>Each abstract method of the interface binds exactly one capability via a
+ * method-level {@link Selector}, and calling that method delegates to the
+ * capability's own resolved proxy. Different methods may therefore resolve to
+ * DIFFERENT provider agents and rebind independently as the mesh topology
+ * changes — the group is a typed view, the capability remains the atom. There
+ * are no wire or registry changes: every method is an ordinary dependency edge,
+ * expanded into the agent's registration exactly like a {@code @MeshDependsOn}
+ * dependency.
+ *
+ * <h2>Example</h2>
+ * <pre>{@code
+ * @McpMeshService
+ * public interface LlmService {
+ *     @Selector(capability = "llm.chat",   tags = {"+gpt"})                     ChatResult   chat(ChatRequest req);
+ *     @Selector(capability = "llm.vision", tags = {"+claude"}, required = true) VisionResult vision(VisionRequest req);
+ *     @Selector(capability = "llm.video",  tags = {"+gemini"})                  VideoResult  video(VideoRequest req);
+ * }
+ * }</pre>
+ *
+ * <p>The consumer {@code @Autowired}s {@code LlmService} and calls its methods
+ * directly. A Spring bean (named by the decapitalized simple interface name) is
+ * registered automatically.
+ *
+ * <h2>Method rules</h2>
+ * <ul>
+ *   <li>Every abstract method must carry {@link Selector} with a non-empty
+ *       {@code capability}.</li>
+ *   <li>Parameters follow the {@code @MeshTool} convention: 0 params → no-arg
+ *       call; exactly 1 param without {@link Param} → single-POJO conversion;
+ *       otherwise every param must carry {@code @Param("name")}.</li>
+ *   <li>Return {@code T} → synchronous call, {@code CompletableFuture<T>} →
+ *       async call, {@code java.util.concurrent.Flow.Publisher<String>} →
+ *       streaming call.</li>
+ *   <li>{@code default} / {@code static} interface methods are allowed and are
+ *       NOT expanded as dependency edges.</li>
+ * </ul>
+ *
+ * <p><b>Not a shared contract:</b> a service view is purely consumer-local.
+ * There is no group versioning and no interface-level availability summary —
+ * any scalar "is the view up?" would lie about partial availability, since each
+ * method resolves independently.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface McpMeshService {
+
+    /**
+     * Opt-in availability floor. When fewer than {@code minAvailable} of the
+     * view's methods currently resolve to a provider, EVERY facade call throws
+     * {@link io.mcpmesh.types.MeshServiceUnavailableException} — a
+     * consumer-local circuit breaker with no wire effect.
+     *
+     * <p>Default {@code 0} means "no floor": each method independently soft-
+     * or hard-fails per its own {@link Selector#required()} flag, exactly like
+     * a directly-injected {@code McpMeshTool}.
+     */
+    int minAvailable() default 0;
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/Selector.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/Selector.java
@@ -1,5 +1,6 @@
 package io.mcpmesh;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -9,6 +10,11 @@ import java.lang.annotation.Target;
  *
  * <p>Used in {@link MeshTool#dependencies()}, {@link MeshLlm#providerSelector()},
  * and {@link MeshLlm#filter()} to specify which capabilities to resolve.
+ *
+ * <p>Also usable directly on an abstract method of a {@link McpMeshService}
+ * interface (service views): the method binds the one capability named here,
+ * and calling it delegates to that capability's resolved proxy. The nested
+ * member usage inside the annotations above remains valid.
  *
  * <h2>Tag Syntax</h2>
  * <pre>
@@ -63,7 +69,7 @@ import java.lang.annotation.Target;
  * )
  * }</pre>
  */
-@Target({})
+@Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Selector {
 

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshServiceUnavailableException.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshServiceUnavailableException.java
@@ -1,0 +1,71 @@
+package io.mcpmesh.types;
+
+/**
+ * Thrown when a {@link io.mcpmesh.McpMeshService} view is below its declared
+ * availability floor ({@code minAvailable}).
+ *
+ * <p>When fewer than {@code minAvailable} of the view's methods currently
+ * resolve to a provider, EVERY facade call fails with this exception rather
+ * than delegating — a consumer-local circuit breaker with no wire effect. It
+ * carries the view interface name and the current/required availability counts
+ * so the failure is actionable.
+ *
+ * <p>Distinct from {@link MeshToolUnavailableException}, which is thrown by a
+ * single unresolved capability proxy. A view whose floor is satisfied delegates
+ * normally, and an individual optional-missing method may still raise
+ * {@code MeshToolUnavailableException} for its own call.
+ */
+public class MeshServiceUnavailableException extends RuntimeException {
+
+    private final String service;
+    private final int methodsAvailable;
+    private final int methodsTotal;
+    private final int minAvailable;
+
+    public MeshServiceUnavailableException(
+            String service, int methodsAvailable, int methodsTotal, int minAvailable) {
+        super("Mesh service view unavailable (" + service + "): "
+            + methodsAvailable + "/" + methodsTotal + " method(s) resolved, "
+            + "below the declared minAvailable=" + minAvailable + " floor");
+        this.service = service;
+        this.methodsAvailable = methodsAvailable;
+        this.methodsTotal = methodsTotal;
+        this.minAvailable = minAvailable;
+    }
+
+    /**
+     * Get the service-view interface name that was below its floor.
+     *
+     * @return The view interface name
+     */
+    public String getService() {
+        return service;
+    }
+
+    /**
+     * Get the number of view methods currently resolving to a provider.
+     *
+     * @return The available-method count
+     */
+    public int getMethodsAvailable() {
+        return methodsAvailable;
+    }
+
+    /**
+     * Get the total number of dependency-bound view methods.
+     *
+     * @return The total method count
+     */
+    public int getMethodsTotal() {
+        return methodsTotal;
+    }
+
+    /**
+     * Get the declared availability floor.
+     *
+     * @return The {@code minAvailable} floor
+     */
+    public int getMinAvailable() {
+        return minAvailable;
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceInvocationHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceInvocationHandler.java
@@ -117,18 +117,26 @@ class McpMeshServiceInvocationHandler implements InvocationHandler {
                 + " on service view " + serviceName);
         }
 
-        // Async floor breach surfaces as a failed future, not a synchronous
-        // throw (the method contract returns CompletableFuture).
-        if (binding.returnMode() == McpMeshServiceRegistrar.ReturnMode.ASYNC) {
-            try {
-                enforceFloor();
-            } catch (MeshServiceUnavailableException e) {
-                return CompletableFuture.failedFuture(e);
-            }
-        } else {
-            enforceFloor();
+        // A floored async method must not block the caller: the floor check can
+        // perform a bounded settle-window wait, so for ASYNC + a floor we run it
+        // OFF the caller thread and compose the delegate call — a floor breach
+        // surfaces as a failed future. Executor = the CompletableFuture common
+        // pool, matching McpMeshToolProxy.callAsync; the caller's trace context
+        // is captured and restored on the pool thread (TraceContext.wrapSupplier).
+        // With no floor (minAvailable == 0) enforceFloor is a no-op — there is
+        // nothing to wait on — so we delegate directly (callAsync is already
+        // async) and avoid an extra thread hop.
+        if (binding.returnMode() == McpMeshServiceRegistrar.ReturnMode.ASYNC && minAvailable > 0) {
+            McpMeshServiceRegistrar.ServiceMethodBinding b = binding;
+            return CompletableFuture
+                .supplyAsync(io.mcpmesh.spring.tracing.TraceContext.wrapSupplier(() -> {
+                    enforceFloor();
+                    return asCompletableFuture(delegate(b, proxyFor(b), args));
+                }))
+                .thenCompose(future -> future);
         }
 
+        enforceFloor();
         McpMeshTool<?> tool = proxyFor(binding);
         return delegate(binding, tool, args);
     }
@@ -168,31 +176,32 @@ class McpMeshServiceInvocationHandler implements InvocationHandler {
         if (minAvailable <= 0) {
             return; // no floor declared
         }
-        int available = countAvailable();
-        if (available < minAvailable) {
-            // Settling-window grace (#1193): wait out the unresolved capabilities
-            // up to the remaining settle budget, matching the injected-proxy
-            // path (McpMeshToolProxy.awaitSettleIfUnavailable). Once settled the
-            // waits are no-ops and the floor fails fast as before.
-            MeshSettleState settle = MeshSettleState.getInstance();
-            if (!settle.isSettled()) {
-                // Track availability incrementally for the early-exit decision
-                // (avoids an O(n) recount per iteration); a single authoritative
-                // recount follows the loop.
-                for (McpMeshServiceRegistrar.ServiceMethodBinding b : bindings.values()) {
-                    if (available >= minAvailable) {
-                        break;
-                    }
-                    McpMeshTool<?> proxy = proxyFor(b);
-                    if (!proxy.isAvailable()) {
-                        settle.awaitDependency(b.capability(), b.capability());
-                        if (proxy.isAvailable()) {
-                            available++;
-                        }
-                    }
-                }
-                available = countAvailable();
+        // Single pass (O(n)): count available bindings, and while the agent is
+        // still settling (#1193) perform a bounded, capability-keyed wait on the
+        // unresolved ones — matching McpMeshToolProxy.awaitSettleIfUnavailable.
+        // The running counter drives an early exit (never wait past the floor)
+        // and also counts side-effect resolutions (a capability resolved by
+        // another consumer's event while we waited on an earlier one). Once
+        // settled the waits are no-ops and the floor fails fast as before.
+        MeshSettleState settle = MeshSettleState.getInstance();
+        boolean settled = settle.isSettled();
+        int available = 0;
+        for (McpMeshServiceRegistrar.ServiceMethodBinding b : bindings.values()) {
+            if (available >= minAvailable) {
+                break;
             }
+            McpMeshTool<?> proxy = proxyFor(b);
+            if (!proxy.isAvailable() && !settled) {
+                settle.awaitDependency(b.capability(), b.capability());
+            }
+            if (proxy.isAvailable()) {
+                available++;
+            }
+        }
+        if (available < minAvailable) {
+            // Authoritative final count (single recount) — catches a capability
+            // that resolved after the pass had already visited it.
+            available = countAvailable();
         }
         boolean below = available < minAvailable;
         Boolean prev = belowFloor.getAndSet(below);
@@ -272,6 +281,12 @@ class McpMeshServiceInvocationHandler implements InvocationHandler {
             params.put(names[i], args[i]);
         }
         return params;
+    }
+
+    /** The ASYNC delegate result is always a {@code CompletableFuture} (callAsync). */
+    @SuppressWarnings("unchecked")
+    private static CompletableFuture<Object> asCompletableFuture(Object result) {
+        return (CompletableFuture<Object>) result;
     }
 
     /** Convert a single POJO argument to a params map for the stream path. */

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceInvocationHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceInvocationHandler.java
@@ -1,0 +1,291 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.types.McpMeshTool;
+import io.mcpmesh.types.MeshServiceUnavailableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * {@link InvocationHandler} backing a {@link io.mcpmesh.McpMeshService} view
+ * proxy (RFC #1280). Each abstract method delegates to its own per-capability
+ * {@link McpMeshTool} proxy resolved from the shared {@link MeshDependencyInjector}
+ * — so different methods may bind different provider agents and rebind
+ * independently as the mesh topology changes (the injector mutates the same
+ * proxy instance in place, so the cached reference stays live).
+ *
+ * <p>The {@code minAvailable} floor is enforced BEFORE any delegation: when
+ * fewer than {@code minAvailable} of the view's methods currently resolve,
+ * EVERY facade call fails with {@link MeshServiceUnavailableException}. During
+ * the startup settling window the floor check first performs the same bounded,
+ * capability-keyed wait the injected-proxy path uses, so a floored view does
+ * NOT fail fast while an unfloored one would wait (issue #1193 parity). This is
+ * a consumer-local circuit breaker with no wire effect.
+ *
+ * <p>{@code default}/{@code static} interface methods are dispatched via
+ * {@link InvocationHandler#invokeDefault} and are NOT dependency edges.
+ * {@link Object} methods ({@code toString}/{@code hashCode}/{@code equals}) are
+ * handled conventionally.
+ */
+class McpMeshServiceInvocationHandler implements InvocationHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(McpMeshServiceInvocationHandler.class);
+
+    private final String serviceName;
+    private final int minAvailable;
+    private final Map<Method, McpMeshServiceRegistrar.ServiceMethodBinding> bindings;
+    private final ConfigurableListableBeanFactory beanFactory;
+    private final AtomicReference<MeshDependencyInjector> injectorRef;
+    private final ObjectMapper objectMapper;
+
+    /** Per-method resolved proxy cache — the proxy reference is stable. */
+    private final Map<Method, McpMeshTool<?>> proxyCache = new ConcurrentHashMap<>();
+
+    /**
+     * Cache for the binding lookup of a Method that isn't an exact key in
+     * {@link #bindings} — e.g. a covariantly-overridden method invoked through a
+     * SUPER-interface reference dispatches the super method, whose
+     * {@code equals} misses. Resolved by name + parameter types, cached so the
+     * reflective fallback costs once per Method.
+     */
+    private final Map<Method, McpMeshServiceRegistrar.ServiceMethodBinding> resolvedBindings =
+        new ConcurrentHashMap<>();
+
+    /**
+     * Floor-transition tracker for observability. {@code null} = never
+     * evaluated; {@code TRUE} = currently below floor. Only meaningful when
+     * {@code minAvailable > 0}.
+     */
+    private final AtomicReference<Boolean> belowFloor = new AtomicReference<>();
+
+    McpMeshServiceInvocationHandler(
+            Class<?> iface,
+            int minAvailable,
+            List<McpMeshServiceRegistrar.ServiceMethodBinding> bindingList,
+            ConfigurableListableBeanFactory beanFactory,
+            AtomicReference<MeshDependencyInjector> injectorRef,
+            ObjectMapper objectMapper) {
+        this.serviceName = iface.getSimpleName();
+        this.minAvailable = minAvailable;
+        this.beanFactory = beanFactory;
+        this.injectorRef = injectorRef;
+        this.objectMapper = objectMapper;
+        Map<Method, McpMeshServiceRegistrar.ServiceMethodBinding> map = new LinkedHashMap<>();
+        for (McpMeshServiceRegistrar.ServiceMethodBinding b : bindingList) {
+            map.put(b.method(), b);
+        }
+        this.bindings = map;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        // Object methods handled conventionally.
+        if (method.getDeclaringClass() == Object.class) {
+            return switch (method.getName()) {
+                case "toString" -> renderToString();
+                case "hashCode" -> System.identityHashCode(proxy);
+                case "equals" -> proxy == (args != null ? args[0] : null);
+                default -> throw new UnsupportedOperationException(method.getName());
+            };
+        }
+
+        // default/static interface methods: NOT dependency edges — dispatch to
+        // the interface's own implementation. invokeDefault resolves the
+        // most-specific override and works under JPMS (issue: MethodHandles
+        // privateLookupIn needs an accessible module).
+        if (method.isDefault()) {
+            return InvocationHandler.invokeDefault(proxy, method, args);
+        }
+
+        McpMeshServiceRegistrar.ServiceMethodBinding binding = resolveBinding(method);
+        if (binding == null) {
+            // Genuinely unknown method (not just a super-interface dispatch of a
+            // covariant override — that is resolved by name + parameter types).
+            throw new IllegalStateException("No mesh binding for method " + method
+                + " on service view " + serviceName);
+        }
+
+        // Async floor breach surfaces as a failed future, not a synchronous
+        // throw (the method contract returns CompletableFuture).
+        if (binding.returnMode() == McpMeshServiceRegistrar.ReturnMode.ASYNC) {
+            try {
+                enforceFloor();
+            } catch (MeshServiceUnavailableException e) {
+                return CompletableFuture.failedFuture(e);
+            }
+        } else {
+            enforceFloor();
+        }
+
+        McpMeshTool<?> tool = proxyFor(binding);
+        return delegate(binding, tool, args);
+    }
+
+    /**
+     * Resolve the binding for {@code method}: the exact-key hit is the common
+     * path; a covariant override invoked through a super-interface reference
+     * misses (the super {@link Method} is dispatched) and is resolved by name +
+     * parameter types, cached so the reflective fallback runs once per Method.
+     */
+    private McpMeshServiceRegistrar.ServiceMethodBinding resolveBinding(Method method) {
+        McpMeshServiceRegistrar.ServiceMethodBinding direct = bindings.get(method);
+        if (direct != null) {
+            return direct;
+        }
+        return resolvedBindings.computeIfAbsent(method, m -> {
+            for (McpMeshServiceRegistrar.ServiceMethodBinding b : bindings.values()) {
+                Method bound = b.method();
+                if (bound.getName().equals(m.getName())
+                        && Arrays.equals(bound.getParameterTypes(), m.getParameterTypes())) {
+                    return b;
+                }
+            }
+            return null;
+        });
+    }
+
+    /**
+     * Enforce the {@code minAvailable} floor across the whole view. Counts the
+     * methods whose per-capability proxy is currently available; below the floor
+     * during the settling window it performs a bounded, capability-keyed wait on
+     * the unresolved capabilities before a single authoritative recount, then
+     * fails only if still below. Logs INFO on floor-state transitions and DEBUG
+     * per-method counts.
+     */
+    private void enforceFloor() {
+        if (minAvailable <= 0) {
+            return; // no floor declared
+        }
+        int available = countAvailable();
+        if (available < minAvailable) {
+            // Settling-window grace (#1193): wait out the unresolved capabilities
+            // up to the remaining settle budget, matching the injected-proxy
+            // path (McpMeshToolProxy.awaitSettleIfUnavailable). Once settled the
+            // waits are no-ops and the floor fails fast as before.
+            MeshSettleState settle = MeshSettleState.getInstance();
+            if (!settle.isSettled()) {
+                // Track availability incrementally for the early-exit decision
+                // (avoids an O(n) recount per iteration); a single authoritative
+                // recount follows the loop.
+                for (McpMeshServiceRegistrar.ServiceMethodBinding b : bindings.values()) {
+                    if (available >= minAvailable) {
+                        break;
+                    }
+                    McpMeshTool<?> proxy = proxyFor(b);
+                    if (!proxy.isAvailable()) {
+                        settle.awaitDependency(b.capability(), b.capability());
+                        if (proxy.isAvailable()) {
+                            available++;
+                        }
+                    }
+                }
+                available = countAvailable();
+            }
+        }
+        boolean below = available < minAvailable;
+        Boolean prev = belowFloor.getAndSet(below);
+        if (prev == null || prev != below) {
+            log.info("service view {} {}: methods_available={}/{} (minAvailable={})",
+                serviceName, below ? "below floor" : "restored",
+                available, bindings.size(), minAvailable);
+        } else {
+            log.debug("service view {} methods_available={}/{}", serviceName, available, bindings.size());
+        }
+        if (below) {
+            throw new MeshServiceUnavailableException(
+                serviceName, available, bindings.size(), minAvailable);
+        }
+    }
+
+    private int countAvailable() {
+        int available = 0;
+        for (McpMeshServiceRegistrar.ServiceMethodBinding b : bindings.values()) {
+            if (proxyFor(b).isAvailable()) {
+                available++;
+            }
+        }
+        return available;
+    }
+
+    /** Lazily resolve + cache the per-method proxy (stable reference). */
+    private McpMeshTool<?> proxyFor(McpMeshServiceRegistrar.ServiceMethodBinding binding) {
+        return proxyCache.computeIfAbsent(binding.method(), m ->
+            injector().getToolProxy(binding.capability(), binding.resolvedProxyType()));
+    }
+
+    private MeshDependencyInjector injector() {
+        MeshDependencyInjector injector = injectorRef.get();
+        if (injector == null) {
+            injector = beanFactory.getBean(MeshDependencyInjector.class);
+            injectorRef.compareAndSet(null, injector);
+        }
+        return injector;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Object delegate(McpMeshServiceRegistrar.ServiceMethodBinding binding,
+                            McpMeshTool<?> tool, Object[] args) {
+        if (binding.paramMode() == McpMeshServiceRegistrar.ParamMode.SINGLE_POJO
+                && (args == null || args[0] == null)) {
+            throw new IllegalArgumentException("@McpMeshService " + serviceName + "."
+                + binding.method().getName() + " single-object parameter must not be null");
+        }
+        McpMeshTool raw = tool;
+        return switch (binding.returnMode()) {
+            case SYNC -> switch (binding.paramMode()) {
+                case NONE -> raw.call();
+                case SINGLE_POJO -> raw.call(args[0]);
+                case PARAM_MAP -> raw.call(buildParamMap(binding, args));
+            };
+            case ASYNC -> switch (binding.paramMode()) {
+                case NONE -> raw.callAsync();
+                case SINGLE_POJO -> raw.callAsync(args[0]);
+                case PARAM_MAP -> raw.callAsync(buildParamMap(binding, args));
+            };
+            case STREAM -> switch (binding.paramMode()) {
+                case NONE -> raw.stream();
+                case SINGLE_POJO -> raw.stream(pojoToMap(args[0]));
+                case PARAM_MAP -> raw.stream(buildParamMap(binding, args));
+            };
+        };
+    }
+
+    private Map<String, Object> buildParamMap(
+            McpMeshServiceRegistrar.ServiceMethodBinding binding, Object[] args) {
+        // LinkedHashMap: preserve declared parameter order (deterministic wire
+        // payload), mirroring the @MeshTool param-map assembly.
+        Map<String, Object> params = new LinkedHashMap<>();
+        String[] names = binding.paramNames();
+        for (int i = 0; i < names.length; i++) {
+            params.put(names[i], args[i]);
+        }
+        return params;
+    }
+
+    /** Convert a single POJO argument to a params map for the stream path. */
+    private Map<String, Object> pojoToMap(Object arg) {
+        return objectMapper.convertValue(arg, new TypeReference<Map<String, Object>>() {});
+    }
+
+    private String renderToString() {
+        String counts;
+        try {
+            counts = countAvailable() + "/" + bindings.size();
+        } catch (RuntimeException e) {
+            counts = "?/" + bindings.size();
+        }
+        return "McpMeshService[" + serviceName + ", " + counts + " available]";
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceRegistrar.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceRegistrar.java
@@ -468,6 +468,7 @@ public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProces
             return new ParamBinding(ParamMode.SINGLE_POJO, new String[0]);
         }
         String[] names = new String[params.length];
+        Set<String> seenNames = new LinkedHashSet<>();
         for (int i = 0; i < params.length; i++) {
             Param param = params[i].getAnnotation(Param.class);
             if (param == null || param.value().isBlank()) {
@@ -476,6 +477,13 @@ public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProces
                         + "parameter must carry @Param(\"name\") (parameter #%d does not). Use a "
                         + "single POJO parameter for object-style calls, or annotate all params.",
                     iface.getName(), method.getName(), params.length, i));
+            }
+            // Duplicate @Param names would silently overwrite in the params map.
+            if (!seenNames.add(param.value())) {
+                throw new IllegalStateException(String.format(
+                    "@McpMeshService interface %s: method '%s' declares duplicate @Param name "
+                        + "'%s' (parameter #%d) — every parameter name must be unique.",
+                    iface.getName(), method.getName(), param.value(), i));
             }
             names[i] = param.value();
         }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceRegistrar.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceRegistrar.java
@@ -1,0 +1,576 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
+import io.mcpmesh.SchemaMode;
+import io.mcpmesh.Selector;
+import io.mcpmesh.core.MeshObjectMappers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.util.ClassUtils;
+import tools.jackson.databind.ObjectMapper;
+
+import java.beans.Introspector;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.time.temporal.Temporal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Flow;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * RFC #1280 (Phase 1): discovers consumer-owned <b>service view</b> interfaces
+ * annotated with {@link McpMeshService} and registers one JDK-proxy bean per
+ * interface. Each abstract method binds a single capability via a method-level
+ * {@link Selector} and delegates to that capability's own resolved
+ * {@link io.mcpmesh.types.McpMeshTool} proxy — so different methods may resolve
+ * to different provider agents and rebind independently.
+ *
+ * <p>Mirrors {@link MeshCapabilityBeanRegistrar}: runs as a
+ * {@link BeanDefinitionRegistryPostProcessor} so the facade beans exist BEFORE
+ * user singletons are autowired, and shares the same lazy-injector /
+ * name-conflict / conflicting-type / settle-declared policies.
+ *
+ * <p>Discovery follows the Spring-Data-repository pattern — service views are
+ * bare interfaces with no implementation, so a
+ * {@link ClassPathScanningCandidateComponentProvider} with an
+ * {@code isCandidateComponent} override that accepts independent interfaces is
+ * used, scoped to the {@link AutoConfigurationPackages} base packages. When the
+ * auto-configuration packages are unavailable (e.g. no {@code @SpringBootApplication}
+ * registered them), discovery is skipped with a WARN — same resilience posture
+ * as the sibling registrar's non-{@code ConfigurableListableBeanFactory} guard.
+ */
+public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProcessor {
+
+    private static final Logger log = LoggerFactory.getLogger(McpMeshServiceRegistrar.class);
+
+    /** Non-object-convertible reference types the single-POJO param rule rejects. */
+    private static final Set<Class<?>> SCALAR_LIKE = Set.of(
+        java.util.Date.class, java.util.Calendar.class, java.math.BigDecimal.class,
+        java.math.BigInteger.class, UUID.class);
+
+    /** Shared with every facade proxy so the injector lookup happens once. */
+    private final AtomicReference<MeshDependencyInjector> injectorRef = new AtomicReference<>();
+
+    /** Jackson mapper for the stream single-POJO → params-map conversion. */
+    private final ObjectMapper objectMapper = MeshObjectMappers.create();
+
+    /**
+     * Views discovered + validated in {@link #postProcessBeanDefinitionRegistry}.
+     * Read later by {@code MeshAutoConfiguration.addMcpMeshServiceDependencies}
+     * to expand each method into a wire dependency edge. This is the
+     * registrar-instance holder the auto-config reads (the registrar IS a bean),
+     * so each application context gets its own fresh view set — no JVM-static
+     * leakage across test contexts.
+     */
+    private final List<ServiceViewMetadata> discovered = new CopyOnWriteArrayList<>();
+
+    /**
+     * The validated views discovered in this context, sorted by interface name
+     * for a deterministic dependency-expansion order.
+     */
+    public List<ServiceViewMetadata> discoveredServices() {
+        List<ServiceViewMetadata> copy = new ArrayList<>(discovered);
+        copy.sort(Comparator.comparing(v -> v.iface().getName()));
+        return copy;
+    }
+
+    @Override
+    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+        if (!(registry instanceof ConfigurableListableBeanFactory beanFactory)) {
+            log.debug("BeanDefinitionRegistry is not a ConfigurableListableBeanFactory ({}); "
+                + "skipping @McpMeshService discovery", registry.getClass().getName());
+            return;
+        }
+        if (!AutoConfigurationPackages.has(beanFactory)) {
+            log.warn("No @AutoConfigurationPackages registered — skipping @McpMeshService discovery. "
+                + "Service views require a @SpringBootApplication (or @AutoConfigurationPackage) "
+                + "to establish the base packages to scan.");
+            return;
+        }
+
+        List<String> basePackages = AutoConfigurationPackages.get(beanFactory);
+        ClassLoader classLoader = beanFactory.getBeanClassLoader();
+
+        // Settling-window grace (#1193): every view method's capability is a
+        // dependency edge in the capability key space (same as @MeshRoute /
+        // @MeshDependsOn — NOT the funcId:dep_N composite tool-wrapper space),
+        // so a facade call firing during the startup settling window performs a
+        // bounded, capability-keyed wait instead of failing fast — parity with
+        // MeshCapabilityBeanRegistrar. markResolved is counted down by
+        // MeshDependencyInjector.updateToolDependency the moment an endpoint
+        // lands. registerDeclared is a Set add: a capability also declared by a
+        // route / @MeshDependsOn is idempotent.
+        MeshSettleState settleState = MeshSettleState.getInstance();
+
+        // MED-4: match ONLY interfaces directly annotated with @McpMeshService.
+        // - useDefaultFilters=false + a non-meta AnnotationTypeFilter so composed
+        //   annotations are out of scope.
+        // - isCandidateComponent accepts non-interface candidates too, so a
+        //   @McpMeshService on a class is DISCOVERED (and boot-fails below with a
+        //   clear message) rather than silently ignored; annotation types are
+        //   excluded.
+        ClassPathScanningCandidateComponentProvider scanner =
+            new ClassPathScanningCandidateComponentProvider(false) {
+                @Override
+                protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
+                    return beanDefinition.getMetadata().isIndependent()
+                        && !beanDefinition.getMetadata().isAnnotation();
+                }
+            };
+        scanner.addIncludeFilter(new AnnotationTypeFilter(McpMeshService.class, false, false));
+        scanner.setResourceLoader(new PathMatchingResourcePatternResolver(classLoader));
+
+        // Cross-view conflicting-type detection: a capability bound by two view
+        // methods (same or different views) must resolve to the same raw type.
+        Map<String, CapabilityBinding> capabilityTypes = new LinkedHashMap<>();
+        Set<String> seenClasses = new LinkedHashSet<>();
+
+        int registered = 0;
+        int conflicts = 0;
+        for (String basePackage : basePackages) {
+            for (BeanDefinition candidate : scanner.findCandidateComponents(basePackage)) {
+                String className = candidate.getBeanClassName();
+                if (className == null || !seenClasses.add(className)) {
+                    continue;
+                }
+                Class<?> type;
+                try {
+                    type = ClassUtils.forName(className, classLoader);
+                } catch (Throwable t) {
+                    log.warn("Failed to load @McpMeshService candidate {} — skipping: {}",
+                        className, t.getMessage());
+                    continue;
+                }
+                McpMeshService annotation = AnnotationUtils.findAnnotation(type, McpMeshService.class);
+                if (annotation == null) {
+                    continue;
+                }
+                // MED-4: @McpMeshService is only meaningful on an interface.
+                if (!type.isInterface()) {
+                    throw new IllegalStateException(String.format(
+                        "@McpMeshService must be on an interface: %s is a %s. Service views are "
+                            + "consumer-owned typed interfaces with no implementation.",
+                        type.getName(), type.isEnum() ? "enum" : "class"));
+                }
+
+                // Validation is boot-fail: an invalid view surfaces immediately
+                // with a clear message, matching the @MeshTool missing-@Param
+                // and conflicting-expectedType boot-fail style.
+                ServiceViewMetadata metadata = buildMetadata(type, annotation, capabilityTypes);
+                discovered.add(metadata);
+
+                // Declare each view-method capability for the settle window,
+                // independently of facade-bean registration below (a
+                // name-conflicting view still contributes its dependency edges
+                // to the spec, so its capabilities remain declared settle keys).
+                for (ServiceMethodBinding binding : metadata.bindings()) {
+                    settleState.registerDeclared(binding.capability());
+                }
+
+                String beanName = Introspector.decapitalize(type.getSimpleName());
+                if (registry.containsBeanDefinition(beanName) || beanFactory.containsSingleton(beanName)) {
+                    log.error("Cannot register @McpMeshService facade bean for '{}' — bean name '{}' "
+                            + "already in use by a user-owned bean. Rename the interface OR the "
+                            + "conflicting bean. The service view will not be injectable.",
+                        type.getName(), beanName);
+                    conflicts++;
+                    continue;
+                }
+
+                @SuppressWarnings({"unchecked", "rawtypes"})
+                BeanDefinitionBuilder builder = BeanDefinitionBuilder
+                    .genericBeanDefinition((Class) type, () -> createFacade(beanFactory, metadata));
+                registry.registerBeanDefinition(beanName, builder.getBeanDefinition());
+                registered++;
+            }
+        }
+        if (registered > 0 || conflicts > 0) {
+            log.info("@McpMeshService: registered {} service-view facade bean(s) "
+                + "(skipped {} due to name conflict)", registered, conflicts);
+        }
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        // No-op: all wiring is done in postProcessBeanDefinitionRegistry.
+    }
+
+    /** Build the JDK proxy backing a service-view facade bean. */
+    private Object createFacade(ConfigurableListableBeanFactory beanFactory, ServiceViewMetadata metadata) {
+        Class<?> iface = metadata.iface();
+        return Proxy.newProxyInstance(
+            iface.getClassLoader(),
+            new Class<?>[] {iface},
+            new McpMeshServiceInvocationHandler(
+                iface, metadata.minAvailable(), metadata.bindings(),
+                beanFactory, injectorRef, objectMapper));
+    }
+
+    /**
+     * Validate every abstract method of a view and build its ordered binding
+     * list. Methods are sorted deterministically (by name + parameter erasure) —
+     * {@link Class#getMethods()} order is NOT guaranteed by the JVM, and the
+     * downstream wire-dependency expansion must be reproducible.
+     */
+    private ServiceViewMetadata buildMetadata(Class<?> iface, McpMeshService annotation,
+                                              Map<String, CapabilityBinding> capabilityTypes) {
+        List<Method> methods = collectViewMethods(iface);
+
+        List<ServiceMethodBinding> bindings = new ArrayList<>();
+        for (Method method : methods) {
+            Selector selector = method.getAnnotation(Selector.class);
+            if (selector == null) {
+                throw new IllegalStateException(String.format(
+                    "@McpMeshService interface %s: abstract method '%s' must be annotated with "
+                        + "@Selector (each service-view method binds exactly one capability).",
+                    iface.getName(), method.getName()));
+            }
+            String capability = selector.capability();
+            if (capability == null || capability.isBlank()) {
+                throw new IllegalStateException(String.format(
+                    "@McpMeshService interface %s: method '%s' has @Selector with an empty "
+                        + "capability.", iface.getName(), method.getName()));
+            }
+
+            ReturnBinding returnBinding = analyzeReturn(iface, method);
+            ParamBinding paramBinding = analyzeParams(iface, method);
+
+            // Schema-matching expected type: an explicit @Selector.expectedType
+            // wins; otherwise derive from the method's return type ONLY when a
+            // schemaMode is requested (parity with the @MeshDependsOn path,
+            // which never enables schema matching implicitly).
+            Class<?> override = selector.expectedType();
+            if (override == Void.class || override == void.class) {
+                override = null;
+            }
+            boolean modeRequested = selector.schemaMode() != SchemaMode.NONE;
+            Class<?> schemaExpectedType = override != null
+                ? override
+                : (modeRequested ? returnBinding.rawType() : null);
+
+            // Cross-view conflicting-type policy (reuse of MeshCapabilityBeanRegistrar
+            // conflicting-expectedType semantics): the same capability bound by
+            // two methods must resolve to the same raw type.
+            CapabilityBinding prior = capabilityTypes.get(capability);
+            if (prior != null && prior.rawType() != returnBinding.rawType()) {
+                throw new IllegalStateException(String.format(
+                    "Capability '%s' is bound by @McpMeshService methods with conflicting resolved "
+                        + "types: %s (%s.%s) vs %s (%s.%s). Align the return types or split into "
+                        + "separate capabilities.",
+                    capability,
+                    prior.rawType().getName(), prior.viewName(), prior.methodName(),
+                    returnBinding.rawType().getName(), iface.getName(), method.getName()));
+            }
+            if (prior == null) {
+                capabilityTypes.put(capability, new CapabilityBinding(
+                    returnBinding.rawType(), iface.getName(), method.getName()));
+            }
+
+            bindings.add(new ServiceMethodBinding(
+                method, capability, selector.tags(), selector.version(), selector.required(),
+                selector.schemaMode(), schemaExpectedType, returnBinding.resolvedType(),
+                returnBinding.rawType(), paramBinding.paramMode(), returnBinding.returnMode(),
+                paramBinding.paramNames()));
+        }
+
+        // MED-7: a negative or unsatisfiable floor is a declaration mistake.
+        int minAvailable = annotation.minAvailable();
+        if (minAvailable < 0) {
+            throw new IllegalStateException(String.format(
+                "@McpMeshService interface %s: minAvailable must be >= 0 (got %d).",
+                iface.getName(), minAvailable));
+        }
+        if (minAvailable > bindings.size()) {
+            throw new IllegalStateException(String.format(
+                "@McpMeshService interface %s: minAvailable=%d exceeds the number of "
+                    + "dependency-bound methods (%d) — the floor can never be satisfied.",
+                iface.getName(), minAvailable, bindings.size()));
+        }
+        if (bindings.isEmpty()) {
+            log.warn("@McpMeshService interface {} declares no abstract methods — "
+                + "the facade bean is a no-op view.", iface.getName());
+        }
+        return new ServiceViewMetadata(iface, minAvailable, List.copyOf(bindings));
+    }
+
+    /**
+     * Collect the abstract view methods, skipping bridge/synthetic methods and
+     * deduping diamond-inherited identical signatures (same name + erased
+     * parameter types from multiple super-interfaces collapse to one binding).
+     * Conflicting {@code @Selector} metadata on diamond duplicates is a
+     * boot-fail. Covariant overrides keep the most-specific declaration; return
+     * and parameter types are resolved against the concrete view interface by
+     * {@link #analyzeReturn}/{@link #analyzeParams} via {@link ResolvableType}.
+     */
+    private List<Method> collectViewMethods(Class<?> iface) {
+        Map<String, Method> bySignature = new LinkedHashMap<>();
+        for (Method method : iface.getMethods()) {
+            if (method.isBridge() || method.isSynthetic()) {
+                continue; // compiler-generated covariant/erasure bridges
+            }
+            if (method.isDefault() || Modifier.isStatic(method.getModifiers())) {
+                continue; // default/static methods are not dependency edges
+            }
+            String signature = signatureKey(method);
+            Method existing = bySignature.get(signature);
+            if (existing == null) {
+                bySignature.put(signature, method);
+                continue;
+            }
+            Selector existingSel = existing.getAnnotation(Selector.class);
+            Selector incomingSel = method.getAnnotation(Selector.class);
+            if (existingSel != null && incomingSel != null
+                    && !selectorsEquivalent(existingSel, incomingSel)) {
+                throw new IllegalStateException(String.format(
+                    "@McpMeshService interface %s: diamond-inherited method '%s' carries "
+                        + "conflicting @Selector metadata across super-interfaces. Declare a single "
+                        + "consistent @Selector for this method.",
+                    iface.getName(), method.getName()));
+            }
+            // Prefer the annotated / more-specific-return declaration.
+            if (existingSel == null && incomingSel != null) {
+                // Annotated incoming wins over an unannotated survivor.
+                bySignature.put(signature, method);
+            } else if (existingSel != null && incomingSel == null) {
+                // Never replace an annotated survivor with an unannotated
+                // duplicate — otherwise the outcome would depend on
+                // Class#getMethods() iteration order (identical return types
+                // make the covariant test below true either way).
+                continue;
+            } else if (existing.getReturnType().isAssignableFrom(method.getReturnType())) {
+                // Both annotated (equivalent) or both unannotated: keep the
+                // most-specific (covariant) return declaration.
+                bySignature.put(signature, method);
+            }
+        }
+        List<Method> methods = new ArrayList<>(bySignature.values());
+        methods.sort(Comparator.comparing(Method::getName).thenComparing(this::signatureKey));
+        return methods;
+    }
+
+    private String signatureKey(Method method) {
+        StringBuilder sb = new StringBuilder(method.getName()).append('(');
+        Class<?>[] params = method.getParameterTypes();
+        for (int i = 0; i < params.length; i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append(params[i].getName());
+        }
+        return sb.append(')').toString();
+    }
+
+    private static boolean selectorsEquivalent(Selector a, Selector b) {
+        return a.capability().equals(b.capability())
+            && Arrays.equals(a.tags(), b.tags())
+            && a.version().equals(b.version())
+            && a.required() == b.required()
+            && a.expectedType() == b.expectedType()
+            && a.schemaMode() == b.schemaMode();
+    }
+
+    /**
+     * Resolve the return mode + the proxy type passed to {@code getToolProxy}.
+     * Return type is resolved against the concrete view interface (MED-3), so
+     * {@code interface View extends Base<Item>} binds {@code Item} rather than a
+     * {@code TypeVariable} that silently deserializes to a {@code Map}.
+     */
+    private ReturnBinding analyzeReturn(Class<?> iface, Method method) {
+        ResolvableType returnType = ResolvableType.forMethodReturnType(method, iface);
+        Class<?> raw = returnType.resolve(Object.class);
+
+        if (raw == CompletableFuture.class) {
+            ResolvableType arg = returnType.getGeneric(0);
+            Class<?> argRaw = arg.resolve();
+            if (arg == ResolvableType.NONE || argRaw == null) {
+                throw new IllegalStateException(String.format(
+                    "@McpMeshService interface %s: method '%s' returns a raw CompletableFuture — "
+                        + "declare CompletableFuture<T> with a concrete result type.",
+                    iface.getName(), method.getName()));
+            }
+            return new ReturnBinding(ReturnMode.ASYNC, asReflectType(arg), argRaw);
+        }
+        // MED-8: any other Future / CompletionStage (incl. CompletableFuture
+        // subclasses) is unsupported — the async contract is CompletableFuture<T>.
+        if (Future.class.isAssignableFrom(raw) || CompletionStage.class.isAssignableFrom(raw)) {
+            throw new IllegalStateException(String.format(
+                "@McpMeshService interface %s: method '%s' returns %s — async view methods must "
+                    + "return CompletableFuture<T>.",
+                iface.getName(), method.getName(), raw.getName()));
+        }
+        if (Flow.Publisher.class.isAssignableFrom(raw)) {
+            Class<?> chunk = returnType.getGeneric(0).resolve();
+            if (chunk != String.class) {
+                throw new IllegalStateException(String.format(
+                    "@McpMeshService interface %s: method '%s' returns Flow.Publisher<%s> — "
+                        + "streaming views must return Flow.Publisher<String>.",
+                    iface.getName(), method.getName(),
+                    chunk == null ? "?" : chunk.getSimpleName()));
+            }
+            // Chunk type is String; the proxy return type is irrelevant to
+            // stream() but keeping it String avoids clobbering the shared proxy.
+            return new ReturnBinding(ReturnMode.STREAM, String.class, String.class);
+        }
+        return new ReturnBinding(ReturnMode.SYNC, asReflectType(returnType), raw);
+    }
+
+    /**
+     * Resolve the parameter mode (mirrors the {@code @MeshTool} convention):
+     * 0 params → no-arg; exactly 1 param without {@link Param} → single-POJO
+     * (the type must be Jackson-object-convertible — MED-1); otherwise EVERY
+     * param must carry {@code @Param("name")} — a mixed signature is a boot-fail.
+     */
+    private ParamBinding analyzeParams(Class<?> iface, Method method) {
+        Parameter[] params = method.getParameters();
+        if (params.length == 0) {
+            return new ParamBinding(ParamMode.NONE, new String[0]);
+        }
+        if (params.length == 1 && params[0].getAnnotation(Param.class) == null) {
+            Class<?> paramType = ResolvableType.forMethodParameter(method, 0, iface).resolve(Object.class);
+            if (!isObjectConvertible(paramType)) {
+                throw new IllegalStateException(String.format(
+                    "@McpMeshService interface %s: method '%s' single unannotated parameter of type "
+                        + "%s cannot be converted to a params object — single unannotated parameters "
+                        + "must be a POJO/record; use @Param for scalar parameters.",
+                    iface.getName(), method.getName(), paramType.getName()));
+            }
+            return new ParamBinding(ParamMode.SINGLE_POJO, new String[0]);
+        }
+        String[] names = new String[params.length];
+        for (int i = 0; i < params.length; i++) {
+            Param param = params[i].getAnnotation(Param.class);
+            if (param == null || param.value().isBlank()) {
+                throw new IllegalStateException(String.format(
+                    "@McpMeshService interface %s: method '%s' has %d parameters, so every "
+                        + "parameter must carry @Param(\"name\") (parameter #%d does not). Use a "
+                        + "single POJO parameter for object-style calls, or annotate all params.",
+                    iface.getName(), method.getName(), params.length, i));
+            }
+            names[i] = param.value();
+        }
+        return new ParamBinding(ParamMode.PARAM_MAP, names);
+    }
+
+    /**
+     * Whether a lone unannotated parameter type can round-trip to a JSON object
+     * (params map). {@link Map} is fine; scalars/collections/arrays are not —
+     * they would blow up {@code McpMeshTool.call(Object...)} (odd-length
+     * key-value handling) or Jackson's convert-to-map.
+     */
+    private static boolean isObjectConvertible(Class<?> type) {
+        if (Map.class.isAssignableFrom(type)) {
+            return true;
+        }
+        if (type.isPrimitive() || type.isArray() || type.isEnum()) {
+            return false;
+        }
+        if (CharSequence.class.isAssignableFrom(type)
+                || Number.class.isAssignableFrom(type)
+                || Boolean.class == type || Character.class == type
+                || Collection.class.isAssignableFrom(type)
+                || Temporal.class.isAssignableFrom(type)
+                || SCALAR_LIKE.contains(type)
+                || type.getName().startsWith("java.time.")) {
+            return false;
+        }
+        return true;
+    }
+
+    private static Type asReflectType(ResolvableType resolvable) {
+        Type type = resolvable.getType();
+        if (type instanceof Class<?>) {
+            return type;
+        }
+        if (type instanceof ParameterizedType pt && allArgsConcrete(pt)) {
+            return pt;
+        }
+        Class<?> resolved = resolvable.resolve();
+        return resolved != null ? resolved : Object.class;
+    }
+
+    private static boolean allArgsConcrete(ParameterizedType pt) {
+        for (Type arg : pt.getActualTypeArguments()) {
+            if (arg instanceof Class<?>) {
+                continue;
+            }
+            if (arg instanceof ParameterizedType nested && allArgsConcrete(nested)) {
+                continue;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    // ---- Metadata carriers ----------------------------------------------------
+
+    /** Parameter-binding strategy for a view method. */
+    public enum ParamMode { NONE, SINGLE_POJO, PARAM_MAP }
+
+    /** Return-binding strategy for a view method. */
+    public enum ReturnMode { SYNC, ASYNC, STREAM }
+
+    private record ReturnBinding(ReturnMode returnMode, Type resolvedType, Class<?> rawType) {}
+
+    private record ParamBinding(ParamMode paramMode, String[] paramNames) {}
+
+    private record CapabilityBinding(Class<?> rawType, String viewName, String methodName) {}
+
+    /**
+     * A single validated view method → capability binding. Carries both the
+     * call-time delegation metadata (used by
+     * {@link McpMeshServiceInvocationHandler}) and the wire-expansion metadata
+     * (used by {@code MeshAutoConfiguration.addMcpMeshServiceDependencies}).
+     */
+    public record ServiceMethodBinding(
+        Method method,
+        String capability,
+        String[] tags,
+        String version,
+        boolean required,
+        SchemaMode schemaMode,
+        Class<?> schemaExpectedType,
+        Type resolvedProxyType,
+        Class<?> resolvedRawType,
+        ParamMode paramMode,
+        ReturnMode returnMode,
+        String[] paramNames) {
+    }
+
+    /** A discovered + validated service view. */
+    public record ServiceViewMetadata(
+        Class<?> iface,
+        int minAvailable,
+        List<ServiceMethodBinding> bindings) {
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -76,6 +76,7 @@ public class MeshAutoConfiguration {
     private static final String A2A_DEPS_TOOL = "__mesh_a2a_deps";
     private static final String DEPENDS_ON_DEPS_TOOL = "__mesh_depends_on_deps";
     private static final String ROUTE_DEPS_TOOL = "__mesh_route_deps";
+    private static final String SERVICE_DEPS_TOOL = "__mesh_service_deps";
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -484,10 +485,11 @@ public class MeshAutoConfiguration {
             ObjectMapper objectMapper,
             ObjectProvider<MeshRouteRegistry> routeRegistryProvider,
             ObjectProvider<MeshA2ARegistry> a2aRegistryProvider,
-            A2AConsumerBeanPostProcessor a2aConsumerBeanPostProcessor) {
+            A2AConsumerBeanPostProcessor a2aConsumerBeanPostProcessor,
+            ObjectProvider<McpMeshServiceRegistrar> serviceRegistrarProvider) {
         return new MeshAgentSpecFinalizer(() -> finalizeAgentSpec(runtime.getAgentSpec(),
             toolRegistry, llmRegistry, objectMapper, routeRegistryProvider,
-            a2aRegistryProvider, a2aConsumerBeanPostProcessor));
+            a2aRegistryProvider, a2aConsumerBeanPostProcessor, serviceRegistrarProvider));
     }
 
     /**
@@ -524,6 +526,21 @@ public class MeshAutoConfiguration {
     @ConditionalOnMissingBean(name = "meshDependsOnBeanRegistrar")
     public static MeshCapabilityBeanRegistrar meshDependsOnBeanRegistrar() {
         return new MeshCapabilityBeanRegistrar();
+    }
+
+    /**
+     * RFC #1280: register a JDK-proxy facade bean per {@link io.mcpmesh.McpMeshService}
+     * service-view interface so consumers can {@code @Autowired} the typed view
+     * and have each method delegate to its own per-capability proxy. Like
+     * {@link #meshDependsOnBeanRegistrar} this runs as a
+     * {@link org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor}
+     * (via a {@code static} factory method) so the facade beans exist before
+     * user singletons are autowired.
+     */
+    @Bean
+    @ConditionalOnMissingBean(name = "mcpMeshServiceRegistrar")
+    public static McpMeshServiceRegistrar mcpMeshServiceRegistrar() {
+        return new McpMeshServiceRegistrar();
     }
 
     /**
@@ -857,7 +874,8 @@ public class MeshAutoConfiguration {
             ObjectMapper objectMapper,
             ObjectProvider<MeshRouteRegistry> routeRegistryProvider,
             ObjectProvider<MeshA2ARegistry> a2aRegistryProvider,
-            A2AConsumerBeanPostProcessor a2aConsumerBeanPostProcessor) {
+            A2AConsumerBeanPostProcessor a2aConsumerBeanPostProcessor,
+            ObjectProvider<McpMeshServiceRegistrar> serviceRegistrarProvider) {
 
         // Helper tools (MeshJob substrate) and LLM provider handlers are
         // registered eagerly in meshRuntime() — see the comment there. By
@@ -902,15 +920,30 @@ public class MeshAutoConfiguration {
         // all four sources — see collectKnownCapabilities().
         addMeshDependsOnDependencies(allTools, routeRegistryProvider);
 
+        // RFC #1280: 5th dependency source — @McpMeshService service views.
+        // Folded LAST so each view method dedupes against every earlier source
+        // (@MeshTool / @MeshRoute / @MeshA2A / @MeshDependsOn) and runs through
+        // the same cross-source required-wins promotion.
+        addMcpMeshServiceDependencies(allTools, serviceRegistrarProvider, routeRegistryProvider,
+            a2aRegistryProvider);
+
         if (consumerOnly) {
             MeshRouteRegistry routeRegistry = routeRegistryProvider.getIfAvailable();
             boolean hasRoutes = routeRegistry != null && routeRegistry.hasRoutes();
-            if (!hasRoutes) {
+            // A @McpMeshService view is a valid mesh consumer surface (#12): an
+            // app whose ONLY mesh surface is a service view should start as a
+            // consumer without a declared agent name, exactly like a route-only
+            // app. hasServiceViews is folded into the gate AND the error message.
+            McpMeshServiceRegistrar serviceRegistrar = serviceRegistrarProvider.getIfAvailable();
+            boolean hasServiceViews = serviceRegistrar != null
+                && !serviceRegistrar.discoveredServices().isEmpty();
+            if (!hasRoutes && !hasServiceViews) {
                 throw new IllegalStateException(
-                    "Agent name is required. Set MCP_MESH_AGENT_NAME, mesh.agent.name, "
-                        + "or @MeshAgent(name=...)");
+                    "Agent name is required for a producer agent. Set MCP_MESH_AGENT_NAME, "
+                        + "mesh.agent.name, or @MeshAgent(name=...) — or expose a @MeshRoute / "
+                        + "@McpMeshService consumer surface to run name-less as a mesh consumer.");
             }
-            log.info("Consumer-only mode confirmed: {} @MeshRoute dependency tool(s) registered",
+            log.info("Consumer-only mode confirmed: {} route/service consumer surface(s) registered",
                 allTools.size());
         }
 
@@ -1123,6 +1156,205 @@ public class MeshAutoConfiguration {
         tools.add(syntheticDepsTool(DEPENDS_ON_DEPS_TOOL,
             "Synthetic tool for @MeshDependsOn dependency resolution", deps));
         log.info("Added {} @MeshDependsOn dependencies to agent registration", deps.size());
+    }
+
+    /**
+     * RFC #1280: expand every {@link io.mcpmesh.McpMeshService} service view's
+     * abstract methods into wire dependency edges under a synthetic
+     * {@code __mesh_service_deps} tool. Each method is an ordinary capability
+     * dependency — zero wire/registry changes — so the group is a purely
+     * consumer-local typed view while the capability remains the atom.
+     *
+     * <p>Determinism is a hard requirement: {@link McpMeshServiceRegistrar#discoveredServices()}
+     * returns views sorted by interface name and each view's bindings are
+     * pre-sorted by method name/signature, so the emitted dependency order is
+     * reproducible regardless of {@link Class#getMethods()} JVM ordering.
+     *
+     * <p>Dedup + cross-source required-wins mirror
+     * {@link #addMeshDependsOnDependencies} exactly: a capability already
+     * declared by an earlier source is deduped away, but a {@code required=true}
+     * view method still promotes the surviving edge (AgentSpec + route-registry
+     * perimeter) to required.
+     */
+    private void addMcpMeshServiceDependencies(List<AgentSpec.ToolSpec> tools,
+            ObjectProvider<McpMeshServiceRegistrar> serviceRegistrarProvider,
+            ObjectProvider<MeshRouteRegistry> routeRegistryProvider,
+            ObjectProvider<MeshA2ARegistry> a2aRegistryProvider) {
+        McpMeshServiceRegistrar registrar = serviceRegistrarProvider.getIfAvailable();
+        if (registrar == null) {
+            return;
+        }
+        List<McpMeshServiceRegistrar.ServiceViewMetadata> views = registrar.discoveredServices();
+        if (views.isEmpty()) {
+            return;
+        }
+
+        // includeProducers=true: a view method binding a capability the agent
+        // itself produces is dropped (no self-edge) — same policy as
+        // @MeshDependsOn.
+        Set<String> seenCapabilities = collectKnownCapabilities(tools, true);
+        // Capabilities THIS agent produces (real @MeshTool, not synthetic
+        // __mesh_ helper/dep tools). A view method binding a self-produced
+        // capability can never resolve through the registry (#6).
+        Set<String> producerCapabilities = collectProducerCapabilities(tools);
+        // Cross-source resolved-type map (#5): every injector-backed source that
+        // stamps a proxy return type for a capability — @MeshRoute / @MeshA2A
+        // (expectedType) and @MeshDependsOn (expectedType). A view method
+        // binding the same capability to a DIFFERENT resolved type would clobber
+        // the shared proxy, so it boot-fails like the existing conflict policy.
+        Map<String, Class<?>> otherSourceTypes = collectOtherSourceExpectedTypes(
+            routeRegistryProvider, a2aRegistryProvider);
+        MeshSettleState settleState = MeshSettleState.getInstance();
+        List<AgentSpec.DependencySpec> deps = new ArrayList<>();
+        var jsonMapper = JsonMapper.builder().build();
+        boolean clusterStrict = io.mcpmesh.spring.MeshSchemaSupport.clusterStrictEnabled();
+
+        for (McpMeshServiceRegistrar.ServiceViewMetadata view : views) {
+            for (McpMeshServiceRegistrar.ServiceMethodBinding binding : view.bindings()) {
+                String capability = binding.capability();
+
+                // #5: cross-source resolved-type conflict — fail fast, identical
+                // types are fine. Skip when either side is untyped (Object).
+                Class<?> viewType = binding.resolvedRawType();
+                Class<?> otherType = otherSourceTypes.get(capability);
+                if (viewType != null && viewType != Object.class
+                        && otherType != null && otherType != Object.class
+                        && viewType != otherType) {
+                    throw new IllegalStateException(String.format(
+                        "Capability '%s' is bound with conflicting resolved types across sources: "
+                            + "%s (@McpMeshService %s.%s) vs %s (another injector-backed source "
+                            + "expectedType). Align the types or split into separate capabilities.",
+                        capability, viewType.getName(), view.iface().getName(),
+                        binding.method().getName(), otherType.getName()));
+                }
+
+                // #6: self-produced capability — the edge is deduped away and can
+                // never resolve. Soft-fail per mesh philosophy: WARN + markResolved
+                // so the eager-settle latch isn't stranded on a dead key.
+                if (producerCapabilities.contains(capability)) {
+                    log.warn("@McpMeshService method {}.{} binds capability '{}' produced by this "
+                            + "agent — the method will never resolve; call the local bean directly.",
+                        view.iface().getName(), binding.method().getName(), capability);
+                    settleState.markResolved(capability);
+                    seenCapabilities.add(capability);
+                    continue;
+                }
+
+                if (!seenCapabilities.add(capability)) {
+                    // Cross-source required-wins (mirrors addMeshDependsOnDependencies):
+                    // the edge is deduped away, but a required view method must
+                    // still upgrade the surviving edge rather than inherit the
+                    // prior source's flag.
+                    if (binding.required()) {
+                        boolean upgraded =
+                            upgradeExistingDependencyToRequired(tools, deps, capability);
+                        MeshRouteRegistry routeRegistry = routeRegistryProvider.getIfAvailable();
+                        if (routeRegistry != null
+                                && routeRegistry.promoteCapabilityToRequired(capability)) {
+                            upgraded = true;
+                        }
+                        if (upgraded) {
+                            log.info("@McpMeshService capability '{}' on {} already declared by another "
+                                    + "source — upgrading the deduped dependency to required=true "
+                                    + "(required wins across sources)",
+                                capability, view.iface().getName());
+                            continue;
+                        }
+                    }
+                    log.debug("@McpMeshService capability '{}' on {} already declared by another source — skipping",
+                        capability, view.iface().getName());
+                    continue;
+                }
+
+                AgentSpec.DependencySpec agentDep = new AgentSpec.DependencySpec();
+                agentDep.setCapability(capability);
+                if (binding.tags().length > 0) {
+                    // Issue #1158: tags is contractually a JSON-array string.
+                    try {
+                        agentDep.setTags(jsonMapper.writeValueAsString(binding.tags()));
+                    } catch (Exception e) {
+                        log.warn("Failed to serialize tags for dependency '{}' — registering with no tag constraint: {}",
+                            capability, e.getMessage());
+                        agentDep.setTags("[]");
+                    }
+                }
+                if (binding.version() != null && !binding.version().isEmpty()) {
+                    agentDep.setVersion(binding.version());
+                }
+                agentDep.setRequired(binding.required());
+                // Schema matching: expected type is the method return type
+                // (or an explicit @Selector.expectedType override), applied only
+                // when a schemaMode is requested — resolved in the registrar.
+                MeshRouteRegistry.applySchemaMatching(
+                    agentDep, capability, binding.schemaExpectedType(),
+                    binding.schemaMode(), clusterStrict);
+                deps.add(agentDep);
+            }
+        }
+
+        if (deps.isEmpty()) {
+            return;
+        }
+
+        tools.add(syntheticDepsTool(SERVICE_DEPS_TOOL,
+            "Synthetic tool for @McpMeshService dependency resolution", deps));
+        log.info("Added {} @McpMeshService dependencies to agent registration", deps.size());
+    }
+
+    /**
+     * Capabilities this agent PRODUCES via a real {@code @MeshTool} (function
+     * name not carrying the {@code __mesh_} synthetic/helper prefix). Used by
+     * {@link #addMcpMeshServiceDependencies} to detect self-produced view edges.
+     */
+    private static Set<String> collectProducerCapabilities(List<AgentSpec.ToolSpec> tools) {
+        Set<String> producers = new LinkedHashSet<>();
+        for (AgentSpec.ToolSpec tool : tools) {
+            String fn = tool.getFunctionName();
+            String cap = tool.getCapability();
+            if (fn != null && !fn.startsWith("__mesh_") && cap != null && !cap.isEmpty()) {
+                producers.add(cap);
+            }
+        }
+        return producers;
+    }
+
+    /**
+     * Collect capability → resolved expected-type from every OTHER injector-backed
+     * source that stamps a proxy return type: {@code @MeshRoute} / {@code @MeshA2A}
+     * (via their registries' {@code getExpectedTypesByCapability}) and
+     * {@code @MeshDependsOn} (re-read off the annotations — the AgentSpec
+     * dependency only carries the derived schema strings, not the Class).
+     */
+    private Map<String, Class<?>> collectOtherSourceExpectedTypes(
+            ObjectProvider<MeshRouteRegistry> routeRegistryProvider,
+            ObjectProvider<MeshA2ARegistry> a2aRegistryProvider) {
+        Map<String, Class<?>> types = new LinkedHashMap<>();
+        MeshRouteRegistry routeRegistry = routeRegistryProvider.getIfAvailable();
+        if (routeRegistry != null) {
+            types.putAll(routeRegistry.getExpectedTypesByCapability());
+        }
+        MeshA2ARegistry a2aRegistry = a2aRegistryProvider.getIfAvailable();
+        if (a2aRegistry != null) {
+            a2aRegistry.getExpectedTypesByCapability().forEach(types::putIfAbsent);
+        }
+        for (Object bean : applicationContext.getBeansWithAnnotation(MeshDependsOn.class).values()) {
+            Class<?> targetClass = org.springframework.aop.support.AopUtils.getTargetClass(bean);
+            MeshDependsOn annotation = org.springframework.core.annotation.AnnotationUtils
+                .findAnnotation(targetClass, MeshDependsOn.class);
+            if (annotation == null) {
+                continue;
+            }
+            for (MeshDependency dep : annotation.value()) {
+                Class<?> expectedType = dep.expectedType();
+                if (expectedType == Void.class || expectedType == void.class) {
+                    continue;
+                }
+                if (dep.capability() != null && !dep.capability().isBlank()) {
+                    types.putIfAbsent(dep.capability(), expectedType);
+                }
+            }
+        }
+        return types;
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -1213,6 +1213,20 @@ public class MeshAutoConfiguration {
             for (McpMeshServiceRegistrar.ServiceMethodBinding binding : view.bindings()) {
                 String capability = binding.capability();
 
+                // #6: self-produced capability takes the soft-fail path FIRST —
+                // the edge is deduped away and can never resolve, so WARN +
+                // markResolved (so the eager-settle latch isn't stranded) and
+                // skip. Ordered ahead of the cross-source conflict check so a
+                // self-produced capability is never turned into a boot-fail.
+                if (producerCapabilities.contains(capability)) {
+                    log.warn("@McpMeshService method {}.{} binds capability '{}' produced by this "
+                            + "agent — the method will never resolve; call the local bean directly.",
+                        view.iface().getName(), binding.method().getName(), capability);
+                    settleState.markResolved(capability);
+                    seenCapabilities.add(capability);
+                    continue;
+                }
+
                 // #5: cross-source resolved-type conflict — fail fast, identical
                 // types are fine. Skip when either side is untyped (Object).
                 Class<?> viewType = binding.resolvedRawType();
@@ -1226,18 +1240,6 @@ public class MeshAutoConfiguration {
                             + "expectedType). Align the types or split into separate capabilities.",
                         capability, viewType.getName(), view.iface().getName(),
                         binding.method().getName(), otherType.getName()));
-                }
-
-                // #6: self-produced capability — the edge is deduped away and can
-                // never resolve. Soft-fail per mesh philosophy: WARN + markResolved
-                // so the eager-settle latch isn't stranded on a dead key.
-                if (producerCapabilities.contains(capability)) {
-                    log.warn("@McpMeshService method {}.{} binds capability '{}' produced by this "
-                            + "agent — the method will never resolve; call the local bean directly.",
-                        view.iface().getName(), binding.method().getName(), capability);
-                    settleState.markResolved(capability);
-                    seenCapabilities.add(capability);
-                    continue;
                 }
 
                 if (!seenCapabilities.add(capability)) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshSettleState.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshSettleState.java
@@ -218,6 +218,11 @@ public final class MeshSettleState {
         return resolved.contains(depKey);
     }
 
+    /** Test accessor: whether {@code depKey} was registered as declared. */
+    boolean isDeclared(String depKey) {
+        return declared.contains(depKey);
+    }
+
     int getWaitCount() {
         return waitCount;
     }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceIntegrationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceIntegrationTest.java
@@ -1,0 +1,964 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.core.MeshObjectMappers;
+import io.mcpmesh.spring.sv.Views;
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshDependsOn;
+import io.mcpmesh.spring.web.MeshRouteAutoConfiguration;
+import io.mcpmesh.types.McpMeshTool;
+import io.mcpmesh.types.MeshServiceUnavailableException;
+import io.mcpmesh.types.MeshToolUnavailableException;
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Flow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+
+/**
+ * RFC #1280 (Phase 1): {@link io.mcpmesh.McpMeshService} service views. A
+ * consumer-owned typed interface whose abstract methods each bind one capability
+ * via {@link io.mcpmesh.Selector}; a facade bean is registered per interface and
+ * each method delegates to its own per-capability proxy.
+ *
+ * <p>Mirrors {@link MeshDependsOnIntegrationTest}: the Rust-FFI boot is
+ * suppressed by neutralizing the {@link MeshRuntime} bean. Discovery is
+ * classpath-scanning scoped to {@link AutoConfigurationPackages}, so each test
+ * registers the fixture base package via an initializer.
+ */
+@DisplayName("RFC #1280 — @McpMeshService service views")
+class McpMeshServiceIntegrationTest {
+
+    private static final ObjectMapper MAPPER = MeshObjectMappers.create();
+
+    // ---- Rust-FFI neutralizer (copied from MeshDependsOnIntegrationTest) ----
+
+    static class MeshRuntimeNeutralizer implements BeanPostProcessor {
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+            if (bean instanceof MeshRuntime real && !(bean instanceof NoOpRuntime)) {
+                return new NoOpRuntime(real.getAgentSpec());
+            }
+            return bean;
+        }
+    }
+
+    static class NoOpRuntime extends MeshRuntime {
+        NoOpRuntime(AgentSpec spec) {
+            super(spec);
+        }
+        @Override public void start() { /* skip native FFI */ }
+        @Override public void stop() { /* no-op */ }
+        @Override public boolean isRunning() { return false; }
+    }
+
+    @Configuration
+    static class CommonTestConfig {
+        @Bean
+        public MeshRuntimeNeutralizer meshRuntimeNeutralizer() {
+            return new MeshRuntimeNeutralizer();
+        }
+    }
+
+    // ---- Recording injector: observes delegation type + param mapping -------
+
+    static class RecordingTool implements McpMeshTool<Object> {
+        final String capability;
+        volatile boolean available = true;
+        volatile String lastMethod;
+        volatile Object[] lastArgs;
+        volatile Map<String, Object> lastMap;
+
+        RecordingTool(String capability) {
+            this.capability = capability;
+        }
+
+        @Override public Object call() { lastMethod = "call0"; return null; }
+        @Override public Object call(Map<String, Object> params) { lastMethod = "callMap"; lastMap = params; return null; }
+        @Override public Object call(Object... args) { lastMethod = "callVarargs"; lastArgs = args; return null; }
+        @Override public CompletableFuture<Object> callAsync() { lastMethod = "callAsync0"; return CompletableFuture.completedFuture(null); }
+        @Override public CompletableFuture<Object> callAsync(Map<String, Object> params) { lastMethod = "callAsyncMap"; lastMap = params; return CompletableFuture.completedFuture(null); }
+        @Override public CompletableFuture<Object> callAsync(Object... args) { lastMethod = "callAsyncVarargs"; lastArgs = args; return CompletableFuture.completedFuture(null); }
+        @Override public String getCapability() { return capability; }
+        @Override public String getEndpoint() { return "recording"; }
+        @Override public String getFunctionName() { return "fn"; }
+        @Override public boolean isAvailable() { return available; }
+        @Override public Flow.Publisher<String> stream(Map<String, Object> params) {
+            lastMethod = "streamMap"; lastMap = params;
+            return subscriber -> subscriber.onSubscribe(new Flow.Subscription() {
+                @Override public void request(long n) { subscriber.onComplete(); }
+                @Override public void cancel() { }
+            });
+        }
+    }
+
+    static class RecordingInjector extends MeshDependencyInjector {
+        final Map<String, RecordingTool> tools = new ConcurrentHashMap<>();
+        final Map<String, Type> requestedTypes = new ConcurrentHashMap<>();
+
+        @Override
+        public McpMeshTool getToolProxy(String capability) {
+            return tools.computeIfAbsent(capability, RecordingTool::new);
+        }
+
+        @Override
+        public McpMeshTool getToolProxy(String capability, Type returnType) {
+            requestedTypes.put(capability, returnType);
+            return getToolProxy(capability);
+        }
+    }
+
+    /**
+     * Recording injector whose per-capability tools start UNAVAILABLE and whose
+     * {@code updateToolDependency} both flips availability and counts down the
+     * settle latch — mirrors the real injector's contract so the floor-wait
+     * (settle grace) path can be exercised without HTTP.
+     */
+    static class SettleAwareRecordingInjector extends MeshDependencyInjector {
+        final Map<String, RecordingTool> tools = new ConcurrentHashMap<>();
+
+        @Override
+        public McpMeshTool getToolProxy(String capability) {
+            return tools.computeIfAbsent(capability, c -> {
+                RecordingTool t = new RecordingTool(c);
+                t.available = false;
+                return t;
+            });
+        }
+
+        @Override
+        public McpMeshTool getToolProxy(String capability, Type returnType) {
+            return getToolProxy(capability);
+        }
+
+        @Override
+        public void updateToolDependency(String capability, String endpoint, String functionName) {
+            RecordingTool t = (RecordingTool) getToolProxy(capability);
+            t.available = endpoint != null;
+            if (endpoint != null) {
+                MeshSettleState.getInstance().markResolved(capability);
+            }
+        }
+    }
+
+    @Configuration
+    @MeshAgent(name = "sv-floor-wait-agent")
+    static class FloorWaitConfig {
+        @Bean public MeshDependencyInjector meshDependencyInjector() { return new SettleAwareRecordingInjector(); }
+    }
+
+    // ---- Test configs -------------------------------------------------------
+
+    static class LlmConsumer {
+        final Views.LlmService service;
+        LlmConsumer(Views.LlmService service) {
+            this.service = service;
+        }
+    }
+
+    @Configuration
+    @MeshAgent(name = "sv-recording-agent")
+    static class RecordingAgentConfig {
+        @Bean public MeshDependencyInjector meshDependencyInjector() { return new RecordingInjector(); }
+        @Bean public LlmConsumer llmConsumer(Views.LlmService service) { return new LlmConsumer(service); }
+    }
+
+    @Configuration
+    @MeshAgent(name = "sv-agent")
+    static class PlainAgentConfig {
+    }
+
+    @MeshDependsOn(@MeshDependency(capability = "rw_cap"))
+    static class RwDependsOn {
+    }
+
+    @Configuration
+    @MeshAgent(name = "sv-required-wins-agent")
+    static class RequiredWinsAgentConfig {
+        @Bean public RwDependsOn rwDependsOn() { return new RwDependsOn(); }
+    }
+
+    /** Recording injector only — no view-specific consumer beans. */
+    @Configuration
+    @MeshAgent(name = "sv-recording-only-agent")
+    static class RecordingInjectorConfig {
+        @Bean public MeshDependencyInjector meshDependencyInjector() { return new RecordingInjector(); }
+    }
+
+    // Self-produced capability (#6): @MeshTool producer whose capability a view binds.
+    static class SelfProducer {
+        @MeshTool(capability = "self.produced")
+        public String produce(@Param("x") String x) { return x; }
+    }
+
+    @Configuration
+    @MeshAgent(name = "sv-self-agent")
+    static class SelfProducedConfig {
+        @Bean public SelfProducer selfProducer() { return new SelfProducer(); }
+    }
+
+    // Cross-source conflict (#5): @MeshDependsOn declares xs.cap with a type.
+    @MeshDependsOn(@MeshDependency(capability = "xs.cap",
+        expectedType = io.mcpmesh.spring.svxsrc.XsrcViews.TypeY.class))
+    static class XsrcConflictDependsOn {
+    }
+
+    @Configuration
+    @MeshAgent(name = "sv-xsrc-conflict-agent")
+    static class XsrcConflictConfig {
+        @Bean public XsrcConflictDependsOn xsrcConflictDependsOn() { return new XsrcConflictDependsOn(); }
+    }
+
+    @MeshDependsOn(@MeshDependency(capability = "xs.cap",
+        expectedType = io.mcpmesh.spring.svxsrc.XsrcViews.TypeX.class))
+    static class XsrcMatchDependsOn {
+    }
+
+    @Configuration
+    @MeshAgent(name = "sv-xsrc-match-agent")
+    static class XsrcMatchConfig {
+        @Bean public XsrcMatchDependsOn xsrcMatchDependsOn() { return new XsrcMatchDependsOn(); }
+    }
+
+    // Facade name-conflict (#name-conflict policy): user owns "llmService".
+    static class UserOwnedBean {
+    }
+
+    @Configuration
+    @MeshAgent(name = "sv-name-conflict-agent")
+    static class NameConflictConfig {
+        @Bean(name = "llmService") public UserOwnedBean llmService() { return new UserOwnedBean(); }
+    }
+
+    @Configuration
+    @MeshAgent(name = "sv-multi-agent")
+    static class MultiAgentConfig {
+    }
+
+    // ---- Runner helpers -----------------------------------------------------
+
+    private WebApplicationContextRunner runnerFor(String basePackage, Class<?>... userConfigs) {
+        WebApplicationContextRunner runner = new WebApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(MeshAutoConfiguration.class,
+                MeshRouteAutoConfiguration.class))
+            .withInitializer(ctx -> AutoConfigurationPackages.register(
+                (BeanDefinitionRegistry) ctx.getBeanFactory(), basePackage))
+            .withUserConfiguration(CommonTestConfig.class);
+        return runner.withUserConfiguration(userConfigs);
+    }
+
+    private static AgentSpec.DependencySpec serviceDep(AgentSpec spec, String capability) {
+        return spec.getTools().stream()
+            .filter(t -> "__mesh_service_deps".equals(t.getCapability()))
+            .flatMap(t -> t.getDependencies().stream())
+            .filter(d -> capability.equals(d.getCapability()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError(
+                capability + " missing from __mesh_service_deps tool"));
+    }
+
+    // ---- Tests --------------------------------------------------------------
+
+    @Test
+    @DisplayName("Facade bean is registered and @Autowired-injectable")
+    void facadeBeanRegisteredAndInjectable() {
+        runnerFor("io.mcpmesh.spring.sv", RecordingAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            Object bean = context.getBean(Views.LlmService.class);
+            assertThat(bean).isNotNull();
+            assertThat(Proxy.isProxyClass(bean.getClass()))
+                .as("facade must be a JDK proxy").isTrue();
+            LlmConsumer consumer = context.getBean(LlmConsumer.class);
+            assertThat(consumer.service).as("view must be constructor-injectable").isNotNull();
+        });
+    }
+
+    @Test
+    @DisplayName("Methods delegate to the correct per-capability proxy with the right resolved Type")
+    void methodsDelegateWithResolvedTypes() {
+        runnerFor("io.mcpmesh.spring.sv", RecordingAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            RecordingInjector injector = (RecordingInjector) context.getBean(MeshDependencyInjector.class);
+            Views.LlmService svc = context.getBean(Views.LlmService.class);
+
+            svc.chat(new Views.ChatRequest("hi"));
+            assertThat(injector.tools.get("llm.chat").lastMethod).isEqualTo("callVarargs");
+            assertThat(injector.requestedTypes.get("llm.chat"))
+                .as("sync method resolves the proxy to its return type")
+                .isEqualTo(Views.ChatResult.class);
+
+            svc.fetchAsync(new Views.Query("x"));
+            assertThat(injector.tools.get("llm.async").lastMethod).isEqualTo("callAsyncVarargs");
+            assertThat(injector.requestedTypes.get("llm.async"))
+                .as("CompletableFuture<T> resolves the proxy to the unwrapped T")
+                .isEqualTo(Views.Item.class);
+        });
+    }
+
+    @Test
+    @DisplayName("Param mapping: 0-arg → call(), single-POJO → call(pojo), multi-@Param → call(map)")
+    void paramMappingModes() {
+        runnerFor("io.mcpmesh.spring.sv", RecordingAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            RecordingInjector injector = (RecordingInjector) context.getBean(MeshDependencyInjector.class);
+            Views.LlmService svc = context.getBean(Views.LlmService.class);
+
+            // 0-arg
+            svc.list();
+            assertThat(injector.tools.get("llm.list").lastMethod).isEqualTo("call0");
+
+            // single POJO
+            Views.ChatRequest req = new Views.ChatRequest("hi");
+            svc.chat(req);
+            RecordingTool chat = injector.tools.get("llm.chat");
+            assertThat(chat.lastMethod).isEqualTo("callVarargs");
+            assertThat(chat.lastArgs).containsExactly(req);
+
+            // multi @Param → ordered LinkedHashMap
+            svc.lookup("7", "us");
+            RecordingTool lookup = injector.tools.get("llm.lookup");
+            assertThat(lookup.lastMethod).isEqualTo("callMap");
+            assertThat(lookup.lastMap).containsExactly(entry("id", "7"), entry("region", "us"));
+
+            // stream param-map
+            svc.streamIt("q1");
+            RecordingTool stream = injector.tools.get("llm.stream");
+            assertThat(stream.lastMethod).isEqualTo("streamMap");
+            assertThat(stream.lastMap).containsExactly(entry("q", "q1"));
+        });
+    }
+
+    @Test
+    @DisplayName("default interface method + toString are handled locally, not as edges")
+    void defaultMethodAndToString() {
+        runnerFor("io.mcpmesh.spring.sv", RecordingAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            Views.LlmService svc = context.getBean(Views.LlmService.class);
+            assertThat(svc.label()).isEqualTo("llm-view");
+            assertThat(svc.toString()).contains("LlmService").contains("available");
+
+            // The default method's body is not a capability, so no such edge.
+            AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+            boolean hasLabelEdge = spec.getTools().stream()
+                .filter(t -> "__mesh_service_deps".equals(t.getCapability()))
+                .flatMap(t -> t.getDependencies().stream())
+                .anyMatch(d -> d.getCapability() != null && d.getCapability().contains("label"));
+            assertThat(hasLabelEdge).isFalse();
+        });
+    }
+
+    @Test
+    @DisplayName("Deterministic expansion: dependencies sorted by method name regardless of declaration order")
+    void deterministicExpansion() {
+        runnerFor("io.mcpmesh.spring.sv", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+            List<String> detCaps = spec.getTools().stream()
+                .filter(t -> "__mesh_service_deps".equals(t.getCapability()))
+                .flatMap(t -> t.getDependencies().stream())
+                .map(AgentSpec.DependencySpec::getCapability)
+                .filter(c -> c.startsWith("det."))
+                .toList();
+            // Methods declared zeta, yankee, alpha → sorted alpha, yankee, zeta.
+            assertThat(detCaps).containsExactly("det.alpha", "det.yankee", "det.zeta");
+        });
+    }
+
+    @Test
+    @DisplayName("Wire serialization: required=true view edge serializes, required=false omitted")
+    void wireSerialization() {
+        runnerFor("io.mcpmesh.spring.sv", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+
+            AgentSpec.DependencySpec req = serviceDep(spec, "wire.req");
+            AgentSpec.DependencySpec opt = serviceDep(spec, "wire.opt");
+            assertThat(req.isRequired()).isTrue();
+            assertThat(opt.isRequired()).isFalse();
+
+            assertThat(MAPPER.writeValueAsString(req))
+                .as("required view dep must serialize \"required\":true")
+                .contains("\"required\":true");
+            assertThat(MAPPER.writeValueAsString(opt))
+                .as("optional view dep must OMIT the required field")
+                .doesNotContain("required");
+        });
+    }
+
+    @Test
+    @DisplayName("Required-wins: a required view edge upgrades a deduped optional @MeshDependsOn edge")
+    void requiredWinsAcrossSources() {
+        runnerFor("io.mcpmesh.spring.sv", RequiredWinsAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+
+            // rw_cap is folded first via @MeshDependsOn, so the service source
+            // dedupes it away — it must NOT be on __mesh_service_deps.
+            boolean onService = spec.getTools().stream()
+                .filter(t -> "__mesh_service_deps".equals(t.getCapability()))
+                .flatMap(t -> t.getDependencies().stream())
+                .anyMatch(d -> "rw_cap".equals(d.getCapability()));
+            assertThat(onService)
+                .as("rw_cap must be deduped off __mesh_service_deps (already on @MeshDependsOn)")
+                .isFalse();
+
+            // The surviving @MeshDependsOn edge must be upgraded to required=true.
+            AgentSpec.DependencySpec dependsOn = spec.getTools().stream()
+                .filter(t -> "__mesh_depends_on_deps".equals(t.getCapability()))
+                .flatMap(t -> t.getDependencies().stream())
+                .filter(d -> "rw_cap".equals(d.getCapability()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("rw_cap missing from __mesh_depends_on_deps"));
+            assertThat(dependsOn.isRequired())
+                .as("required view edge must upgrade the deduped optional @MeshDependsOn edge")
+                .isTrue();
+        });
+    }
+
+    @Test
+    @DisplayName("minAvailable floor: below floor → MeshServiceUnavailableException on ANY method")
+    void floorBelowThrowsServiceUnavailable() {
+        runnerFor("io.mcpmesh.spring.sv", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            Views.FloorService floor = context.getBean(Views.FloorService.class);
+            // No endpoints resolved → 0/3 available, below the minAvailable=2 floor.
+            assertThatThrownBy(floor::alpha)
+                .isInstanceOf(MeshServiceUnavailableException.class);
+            assertThatThrownBy(floor::charlie)
+                .isInstanceOf(MeshServiceUnavailableException.class);
+        });
+    }
+
+    @Test
+    @DisplayName("minAvailable floor: at/above floor → optional-missing method throws only MeshToolUnavailableException")
+    void floorSatisfiedDelegatesPerMethod() {
+        runnerFor("io.mcpmesh.spring.sv", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            MeshDependencyInjector injector = context.getBean(MeshDependencyInjector.class);
+            Views.FloorService floor = context.getBean(Views.FloorService.class);
+
+            // Resolve two of the three methods → 2/3 available == minAvailable.
+            injector.updateToolDependency("floor.a", "http://localhost:9", "fn");
+            injector.updateToolDependency("floor.b", "http://localhost:9", "fn");
+
+            // Floor satisfied: charlie (still unresolved) throws its OWN
+            // tool-unavailable error, NOT the service-level floor error.
+            assertThatThrownBy(floor::charlie)
+                .isInstanceOf(MeshToolUnavailableException.class)
+                .isNotInstanceOf(MeshServiceUnavailableException.class);
+        });
+    }
+
+    @Test
+    @DisplayName("Rebinding: updateToolDependency reflects in the shared proxy the facade uses (stable reference)")
+    void rebindingReflectsInFacadeProxy() {
+        runnerFor("io.mcpmesh.spring.sv", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            MeshDependencyInjector injector = context.getBean(MeshDependencyInjector.class);
+            Views.LlmService svc = context.getBean(Views.LlmService.class);
+
+            // First call caches the shared proxy in the facade handler and
+            // creates the injector's per-capability proxy (still unresolved).
+            assertThatThrownBy(() -> svc.chat(new Views.ChatRequest("hi")))
+                .isInstanceOf(MeshToolUnavailableException.class);
+
+            // The facade resolves llm.chat through the injector's SHARED proxy;
+            // rebinding it in place must be visible without any re-injection.
+            McpMeshTool<?> shared = injector.getToolProxy("llm.chat");
+            injector.updateToolDependency("llm.chat", "http://ep-1", "fn");
+            assertThat(shared.isAvailable()).isTrue();
+            assertThat(shared.getEndpoint()).isEqualTo("http://ep-1");
+
+            injector.updateToolDependency("llm.chat", "http://ep-2", "fn");
+            assertThat(shared.getEndpoint())
+                .as("the same proxy instance rebinds in place")
+                .isEqualTo("http://ep-2");
+        });
+    }
+
+    @Test
+    @DisplayName("Settle grace: view-method capabilities are registered as declared in MeshSettleState")
+    void viewCapabilitiesRegisteredAsDeclared() {
+        // registerDeclared populates the declared set regardless of window
+        // state, so the suite-wide disabled settle posture is fine — no window
+        // arming (which would leak an armed window into sibling tests).
+        runnerFor("io.mcpmesh.spring.sv", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            MeshSettleState state = MeshSettleState.getInstance();
+            // Capability key space (same as routes / @MeshDependsOn), covering
+            // required + optional, sync/async/stream edges alike.
+            assertThat(state.isDeclared("llm.chat")).isTrue();
+            assertThat(state.isDeclared("llm.vision")).isTrue();
+            assertThat(state.isDeclared("llm.stream")).isTrue();
+            assertThat(state.isDeclared("floor.a")).isTrue();
+            assertThat(state.isDeclared("wire.opt")).isTrue();
+        });
+    }
+
+    @Test
+    @DisplayName("Boot-fail: abstract view method missing @Selector")
+    void bootFailMissingSelector() {
+        runnerFor("io.mcpmesh.spring.svbad.selector", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(collectMessages(context.getStartupFailure()))
+                .contains("missing")
+                .contains("@Selector");
+        });
+    }
+
+    @Test
+    @DisplayName("Boot-fail: 2+ params with a missing @Param")
+    void bootFailMixedParams() {
+        runnerFor("io.mcpmesh.spring.svbad.params", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(collectMessages(context.getStartupFailure()))
+                .contains("twoArgs")
+                .contains("@Param");
+        });
+    }
+
+    @Test
+    @DisplayName("Boot-fail: same capability bound to conflicting resolved types")
+    void bootFailConflictingTypes() {
+        runnerFor("io.mcpmesh.spring.svbad.conflict", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasFailed();
+            String message = collectMessages(context.getStartupFailure());
+            assertThat(message)
+                .contains("cc.cap")
+                .contains("TypeX")
+                .contains("TypeY");
+        });
+    }
+
+    // ---- MED-3: generics / covariance / diamond -----------------------------
+
+    @Test
+    @DisplayName("MED-3: generic super-interface resolves the concrete bound type")
+    void genericSuperInterfaceResolvesConcreteType() {
+        runnerFor("io.mcpmesh.spring.svgen", RecordingInjectorConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            RecordingInjector injector = (RecordingInjector) context.getBean(MeshDependencyInjector.class);
+            io.mcpmesh.spring.svgen.GenericViews.GenericView view =
+                context.getBean(io.mcpmesh.spring.svgen.GenericViews.GenericView.class);
+            view.get();
+            assertThat(injector.requestedTypes.get("gen.get"))
+                .as("Base<Item> must bind Item, not a TypeVariable/Object")
+                .isEqualTo(io.mcpmesh.spring.svgen.GenericViews.Item.class);
+        });
+    }
+
+    @Test
+    @DisplayName("MED-3: covariant override skips the bridge method and binds the specific return")
+    void covariantOverrideResolvesConcreteType() {
+        runnerFor("io.mcpmesh.spring.svgen", RecordingInjectorConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            RecordingInjector injector = (RecordingInjector) context.getBean(MeshDependencyInjector.class);
+            io.mcpmesh.spring.svgen.GenericViews.CovView view =
+                context.getBean(io.mcpmesh.spring.svgen.GenericViews.CovView.class);
+            view.thing();
+            assertThat(injector.requestedTypes.get("cov.thing"))
+                .isEqualTo(io.mcpmesh.spring.svgen.GenericViews.Item.class);
+        });
+    }
+
+    @Test
+    @DisplayName("MED-3: diamond inheritance collapses to a single dependency edge")
+    void diamondInheritanceSingleBinding() {
+        runnerFor("io.mcpmesh.spring.svgen", MultiAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+            long count = spec.getTools().stream()
+                .filter(t -> "__mesh_service_deps".equals(t.getCapability()))
+                .flatMap(t -> t.getDependencies().stream())
+                .filter(d -> "diamond.x".equals(d.getCapability()))
+                .count();
+            assertThat(count).as("diamond-inherited method must expand once").isEqualTo(1L);
+        });
+    }
+
+    @Test
+    @DisplayName("MED-3: annotated+unannotated diamond dedupe keeps the annotated binding deterministically")
+    void mixedAnnotationDiamondKeepsAnnotatedBinding() {
+        runnerFor("io.mcpmesh.spring.svgen", MultiAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+            long count = spec.getTools().stream()
+                .filter(t -> "__mesh_service_deps".equals(t.getCapability()))
+                .flatMap(t -> t.getDependencies().stream())
+                .filter(d -> "diamond.mixed".equals(d.getCapability()))
+                .count();
+            assertThat(count)
+                .as("annotated diamond member must survive the dedupe as a single edge")
+                .isEqualTo(1L);
+        });
+    }
+
+    @Test
+    @DisplayName("MED-2 fallback: covariant override invoked through a super-interface reference routes correctly")
+    void superInterfaceReferenceRoutesCovariantOverride() {
+        runnerFor("io.mcpmesh.spring.svgen", RecordingInjectorConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            RecordingInjector injector = (RecordingInjector) context.getBean(MeshDependencyInjector.class);
+            io.mcpmesh.spring.svgen.GenericViews.CovView view =
+                context.getBean(io.mcpmesh.spring.svgen.GenericViews.CovView.class);
+            // Call through the SUPER-interface reference: dispatches CovBase.thing(),
+            // whose Method misses the exact binding key — the name+params fallback
+            // must resolve it instead of throwing.
+            io.mcpmesh.spring.svgen.GenericViews.CovBase ref = view;
+            Object result = ref.thing();
+            assertThat(result).isNull(); // RecordingTool returns null, but the call routed
+            assertThat(injector.tools.get("cov.thing").lastMethod).isEqualTo("call0");
+        });
+    }
+
+    // ---- MED-1 / MED-4 / MED-7 / MED-8: boot-fail validation -----------------
+
+    @Test
+    @DisplayName("MED-1: single unannotated scalar parameter boot-fails")
+    void scalarParamBootFail() {
+        runnerFor("io.mcpmesh.spring.svbad.scalarparam", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(collectMessages(context.getStartupFailure()))
+                .contains("get").contains("POJO/record").contains("@Param");
+        });
+    }
+
+    @Test
+    @DisplayName("MED-4: @McpMeshService on a class boot-fails")
+    void meshServiceOnClassBootFail() {
+        runnerFor("io.mcpmesh.spring.svbad.onclass", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(collectMessages(context.getStartupFailure()))
+                .contains("@McpMeshService must be on an interface");
+        });
+    }
+
+    @Test
+    @DisplayName("MED-7: minAvailable exceeding bound-method count boot-fails")
+    void unsatisfiableFloorBootFail() {
+        runnerFor("io.mcpmesh.spring.svbad.unsatfloor", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(collectMessages(context.getStartupFailure()))
+                .contains("minAvailable").contains("can never be satisfied");
+        });
+    }
+
+    @Test
+    @DisplayName("MED-7: negative minAvailable boot-fails")
+    void negativeFloorBootFail() {
+        runnerFor("io.mcpmesh.spring.svbad.negfloor", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(collectMessages(context.getStartupFailure()))
+                .contains("minAvailable must be >= 0");
+        });
+    }
+
+    @Test
+    @DisplayName("MED-8: raw CompletableFuture boot-fails")
+    void rawFutureBootFail() {
+        runnerFor("io.mcpmesh.spring.svbad.rawfuture", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(collectMessages(context.getStartupFailure()))
+                .contains("raw CompletableFuture");
+        });
+    }
+
+    @Test
+    @DisplayName("MED-8: non-CompletableFuture Future/CompletionStage boot-fails")
+    void badFutureBootFail() {
+        runnerFor("io.mcpmesh.spring.svbad.badfuture", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(collectMessages(context.getStartupFailure()))
+                .contains("must return CompletableFuture<T>");
+        });
+    }
+
+    @Test
+    @DisplayName("MED-8: Flow.Publisher<non-String> boot-fails")
+    void badStreamBootFail() {
+        runnerFor("io.mcpmesh.spring.svbad.badstream", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(collectMessages(context.getStartupFailure()))
+                .contains("Flow.Publisher<String>");
+        });
+    }
+
+    @Test
+    @DisplayName("Boot-fail: @Selector with a blank capability")
+    void blankCapabilityBootFail() {
+        runnerFor("io.mcpmesh.spring.svbad.blankcap", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(collectMessages(context.getStartupFailure()))
+                .contains("empty").contains("capability");
+        });
+    }
+
+    // ---- MED-5: cross-source resolved-type conflict --------------------------
+
+    @Test
+    @DisplayName("MED-5: view + @MeshDependsOn same capability, different types → boot-fail")
+    void crossSourceTypeConflictBootFail() {
+        runnerFor("io.mcpmesh.spring.svxsrc", XsrcConflictConfig.class).run(context -> {
+            assertThat(context).hasFailed();
+            String message = collectMessages(context.getStartupFailure());
+            assertThat(message)
+                .contains("xs.cap").contains("TypeX").contains("TypeY");
+        });
+    }
+
+    @Test
+    @DisplayName("MED-5: view + @MeshDependsOn same capability, identical type → boots")
+    void crossSourceMatchingTypeBoots() {
+        runnerFor("io.mcpmesh.spring.svxsrc", XsrcMatchConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+        });
+    }
+
+    // ---- MED-6: self-produced capability -------------------------------------
+
+    @Test
+    @DisplayName("MED-6: self-produced view edge is deduped with WARN + markResolved")
+    void selfProducedCapabilityWarnsAndResolves() {
+        LogCapture capture = LogCapture.attach(MeshAutoConfiguration.class);
+        try {
+            runnerFor("io.mcpmesh.spring.svself", SelfProducedConfig.class).run(context -> {
+                assertThat(context).hasNotFailed();
+                AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+
+                boolean onService = spec.getTools().stream()
+                    .filter(t -> "__mesh_service_deps".equals(t.getCapability()))
+                    .flatMap(t -> t.getDependencies().stream())
+                    .anyMatch(d -> "self.produced".equals(d.getCapability()));
+                assertThat(onService)
+                    .as("self-produced capability must not become a registry dependency")
+                    .isFalse();
+
+                assertThat(MeshSettleState.getInstance().isResolved("self.produced"))
+                    .as("self-produced capability must be markResolved so the eager latch isn't stranded")
+                    .isTrue();
+            });
+            assertThat(capture.events)
+                .anyMatch(e -> e.message.contains("self.produced")
+                    && e.message.contains("produced by this"));
+        } finally {
+            capture.detach();
+        }
+    }
+
+    // ---- MED-2 / MED-10 / MED-11: floor + settle + async + null --------------
+
+    @Test
+    @DisplayName("MED-2: floored view waits out the settling window and passes when deps resolve mid-window")
+    void floorWaitsThenSatisfiedMidWindow() {
+        MeshSettleState.resetForTests(10.0);
+        try {
+            runnerFor("io.mcpmesh.spring.sv", FloorWaitConfig.class).run(context -> {
+                assertThat(context).hasNotFailed();
+                MeshDependencyInjector injector = context.getBean(MeshDependencyInjector.class);
+                Views.FloorService floor = context.getBean(Views.FloorService.class);
+                MeshSettleState state = MeshSettleState.getInstance();
+
+                Thread resolver = new Thread(() -> {
+                    try {
+                        Thread.sleep(150);
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    }
+                    injector.updateToolDependency("floor.a", "ep", "fn");
+                    injector.updateToolDependency("floor.b", "ep", "fn");
+                });
+                resolver.start();
+
+                long start = System.nanoTime();
+                floor.alpha(); // must NOT throw MeshServiceUnavailableException
+                long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+                resolver.join(2000);
+
+                assertThat(elapsedMs)
+                    .as("floored call must wait for the deps to resolve, not fail fast")
+                    .isGreaterThanOrEqualTo(100L);
+                assertThat(state.getWaitCount())
+                    .as("the below-floor call must trigger the settle wait")
+                    .isGreaterThanOrEqualTo(1);
+            });
+        } finally {
+            MeshSettleState.resetForTests();
+        }
+    }
+
+    @Test
+    @DisplayName("MED-10: async floor breach surfaces as a failed future, not a synchronous throw")
+    void asyncFloorBreachReturnsFailedFuture() {
+        runnerFor("io.mcpmesh.spring.sv", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            Views.FloorService floor = context.getBean(Views.FloorService.class);
+            CompletableFuture<String> future = floor.deltaAsync();
+            assertThat(future).isCompletedExceptionally();
+            assertThatThrownBy(future::join).hasCauseInstanceOf(MeshServiceUnavailableException.class);
+        });
+    }
+
+    @Test
+    @DisplayName("MED-11: null single-POJO argument throws IllegalArgumentException naming the method")
+    void nullSinglePojoArgThrows() {
+        runnerFor("io.mcpmesh.spring.sv", RecordingAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            Views.LlmService svc = context.getBean(Views.LlmService.class);
+            assertThatThrownBy(() -> svc.chat(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("chat");
+        });
+    }
+
+    // ---- MED-12: consumer-only gate ------------------------------------------
+
+    @Test
+    @DisplayName("MED-12: an app whose only mesh surface is a service view boots name-less")
+    void consumerOnlyViewBoots() {
+        runnerFor("io.mcpmesh.spring.svconsumer", EmptyConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context.getBean(io.mcpmesh.spring.svconsumer.ConsumerViews.ConsumerView.class))
+                .isNotNull();
+        });
+    }
+
+    // ---- Facade proxy semantics + name-conflict ------------------------------
+
+    @Test
+    @DisplayName("Name-conflict: user bean wins, but the view's edges + settle keys still register")
+    void nameConflictSkipsFacadeButKeepsEdgesAndSettleKeys() {
+        runnerFor("io.mcpmesh.spring.sv", NameConflictConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context.getBean("llmService"))
+                .as("user-owned bean must not be overwritten by the facade")
+                .isInstanceOf(UserOwnedBean.class);
+            AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+            assertThat(serviceDep(spec, "llm.chat"))
+                .as("skipped facade still contributes its dependency edges").isNotNull();
+            assertThat(MeshSettleState.getInstance().isDeclared("llm.chat"))
+                .as("skipped facade still declares its settle keys").isTrue();
+        });
+    }
+
+    @Test
+    @DisplayName("Facade proxy equals/hashCode behave by identity")
+    void facadeEqualsHashCode() {
+        runnerFor("io.mcpmesh.spring.sv", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            Views.LlmService svc = context.getBean(Views.LlmService.class);
+            assertThat(svc.equals(svc)).isTrue();
+            assertThat(svc.equals("not-a-view")).isFalse();
+            assertThat(svc.hashCode()).isEqualTo(svc.hashCode());
+        });
+    }
+
+    @Test
+    @DisplayName("Rebinding: markUnavailable then re-resolve reflects in the shared proxy")
+    void rebindThroughMarkUnavailable() {
+        runnerFor("io.mcpmesh.spring.sv", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            MeshDependencyInjector injector = context.getBean(MeshDependencyInjector.class);
+            McpMeshTool<?> shared = injector.getToolProxy("llm.chat");
+
+            injector.updateToolDependency("llm.chat", "http://ep-1", "fn");
+            assertThat(shared.isAvailable()).isTrue();
+
+            injector.updateToolDependency("llm.chat", null, "fn"); // markUnavailable
+            assertThat(shared.isAvailable()).isFalse();
+
+            injector.updateToolDependency("llm.chat", "http://ep-2", "fn"); // re-resolve
+            assertThat(shared.isAvailable()).isTrue();
+            assertThat(shared.getEndpoint()).isEqualTo("http://ep-2");
+        });
+    }
+
+    @Test
+    @DisplayName("Cross-view determinism: two views expand in interface-name order")
+    void crossViewExpansionDeterminism() {
+        runnerFor("io.mcpmesh.spring.svmulti", MultiAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+            List<String> caps = spec.getTools().stream()
+                .filter(t -> "__mesh_service_deps".equals(t.getCapability()))
+                .flatMap(t -> t.getDependencies().stream())
+                .map(AgentSpec.DependencySpec::getCapability)
+                .filter(c -> c.startsWith("mv."))
+                .toList();
+            // AlphaView < ZuluView by interface name despite reverse declaration.
+            assertThat(caps).containsExactly("mv.alpha", "mv.zulu");
+        });
+    }
+
+    @Configuration
+    static class EmptyConfig {
+    }
+
+    /**
+     * Minimal Logback appender recording level + message for a target logger.
+     */
+    static final class LogCapture {
+        final java.util.List<LogEvent> events = new java.util.concurrent.CopyOnWriteArrayList<>();
+        private final ch.qos.logback.classic.Logger target;
+        private final ch.qos.logback.core.AppenderBase<ch.qos.logback.classic.spi.ILoggingEvent> appender;
+
+        private LogCapture(ch.qos.logback.classic.Logger target) {
+            this.target = target;
+            this.appender = new ch.qos.logback.core.AppenderBase<>() {
+                @Override
+                protected void append(ch.qos.logback.classic.spi.ILoggingEvent event) {
+                    events.add(new LogEvent(event.getLevel().toString(), event.getFormattedMessage()));
+                }
+            };
+        }
+
+        static LogCapture attach(Class<?> loggerClass) {
+            ch.qos.logback.classic.Logger logger =
+                (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(loggerClass);
+            LogCapture capture = new LogCapture(logger);
+            capture.appender.setContext(logger.getLoggerContext());
+            capture.appender.start();
+            logger.addAppender(capture.appender);
+            return capture;
+        }
+
+        void detach() {
+            target.detachAppender(appender);
+            appender.stop();
+        }
+
+        record LogEvent(String level, String message) {}
+    }
+
+    private static String collectMessages(Throwable failure) {
+        StringBuilder sb = new StringBuilder();
+        Throwable t = failure;
+        while (t != null) {
+            if (t.getMessage() != null) {
+                sb.append(t.getMessage()).append('\n');
+            }
+            t = t.getCause();
+        }
+        return sb.toString();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceIntegrationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceIntegrationTest.java
@@ -705,6 +705,16 @@ class McpMeshServiceIntegrationTest {
     }
 
     @Test
+    @DisplayName("MED-4: duplicate @Param names boot-fail")
+    void duplicateParamNameBootFail() {
+        runnerFor("io.mcpmesh.spring.svbad.duplicateparam", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasFailed();
+            assertThat(collectMessages(context.getStartupFailure()))
+                .contains("get").contains("duplicate @Param name").contains("id");
+        });
+    }
+
+    @Test
     @DisplayName("Boot-fail: @Selector with a blank capability")
     void blankCapabilityBootFail() {
         runnerFor("io.mcpmesh.spring.svbad.blankcap", PlainAgentConfig.class).run(context -> {
@@ -770,7 +780,7 @@ class McpMeshServiceIntegrationTest {
 
     @Test
     @DisplayName("MED-2: floored view waits out the settling window and passes when deps resolve mid-window")
-    void floorWaitsThenSatisfiedMidWindow() {
+    void floorWaitsThenSatisfiedMidWindow() throws Exception {
         MeshSettleState.resetForTests(10.0);
         try {
             runnerFor("io.mcpmesh.spring.sv", FloorWaitConfig.class).run(context -> {
@@ -779,28 +789,77 @@ class McpMeshServiceIntegrationTest {
                 Views.FloorService floor = context.getBean(Views.FloorService.class);
                 MeshSettleState state = MeshSettleState.getInstance();
 
-                Thread resolver = new Thread(() -> {
+                // Run the (blocking) floored call on its own thread so we can
+                // deterministically observe it PARKED in the settle wait before
+                // resolving — no wall-clock sleep/threshold.
+                java.util.concurrent.atomic.AtomicReference<Throwable> error =
+                    new java.util.concurrent.atomic.AtomicReference<>();
+                Thread caller = new Thread(() -> {
                     try {
-                        Thread.sleep(150);
-                    } catch (InterruptedException ignored) {
-                        Thread.currentThread().interrupt();
+                        floor.alpha();
+                    } catch (Throwable t) {
+                        error.set(t);
                     }
-                    injector.updateToolDependency("floor.a", "ep", "fn");
-                    injector.updateToolDependency("floor.b", "ep", "fn");
                 });
-                resolver.start();
+                caller.start();
 
-                long start = System.nanoTime();
-                floor.alpha(); // must NOT throw MeshServiceUnavailableException
-                long elapsedMs = (System.nanoTime() - start) / 1_000_000;
-                resolver.join(2000);
-
-                assertThat(elapsedMs)
-                    .as("floored call must wait for the deps to resolve, not fail fast")
-                    .isGreaterThanOrEqualTo(100L);
+                // Deterministic signal: the below-floor call must register a
+                // settle wait before we resolve anything.
+                long deadline = System.currentTimeMillis() + 3000;
+                while (state.getWaitCount() < 1 && System.currentTimeMillis() < deadline) {
+                    Thread.sleep(5);
+                }
                 assertThat(state.getWaitCount())
-                    .as("the below-floor call must trigger the settle wait")
+                    .as("the below-floor call must park in the settle wait")
                     .isGreaterThanOrEqualTo(1);
+                assertThat(caller.isAlive())
+                    .as("the call is still waiting, not failed fast").isTrue();
+
+                // Resolve two methods → floor satisfied → the wait unblocks.
+                injector.updateToolDependency("floor.a", "ep", "fn");
+                injector.updateToolDependency("floor.b", "ep", "fn");
+                caller.join(3000);
+
+                assertThat(caller.isAlive()).as("call must unblock once the floor is met").isFalse();
+                assertThat(error.get())
+                    .as("floor satisfied via the wait — no service-unavailable error")
+                    .isNull();
+            });
+        } finally {
+            MeshSettleState.resetForTests();
+        }
+    }
+
+    @Test
+    @DisplayName("MED-3: async floor check runs off-thread — the caller is not blocked by the settle wait")
+    void asyncFloorCheckDoesNotBlockCaller() throws Exception {
+        MeshSettleState.resetForTests(10.0);
+        try {
+            runnerFor("io.mcpmesh.spring.sv", FloorWaitConfig.class).run(context -> {
+                assertThat(context).hasNotFailed();
+                MeshDependencyInjector injector = context.getBean(MeshDependencyInjector.class);
+                Views.FloorService floor = context.getBean(Views.FloorService.class);
+                MeshSettleState state = MeshSettleState.getInstance();
+
+                // Below floor + armed window: the async method returns a future
+                // IMMEDIATELY (floor wait runs on the common pool), so the caller
+                // thread is never blocked.
+                CompletableFuture<String> future = floor.deltaAsync();
+                assertThat(future.isDone())
+                    .as("async method must return before the off-thread floor wait completes")
+                    .isFalse();
+
+                // The off-thread floor check parks in the settle wait.
+                long deadline = System.currentTimeMillis() + 3000;
+                while (state.getWaitCount() < 1 && System.currentTimeMillis() < deadline) {
+                    Thread.sleep(5);
+                }
+                assertThat(state.getWaitCount()).isGreaterThanOrEqualTo(1);
+
+                // Resolve two methods → floor satisfied → future completes.
+                injector.updateToolDependency("floor.a", "ep", "fn");
+                injector.updateToolDependency("floor.b", "ep", "fn");
+                assertThat(future.get(3, java.util.concurrent.TimeUnit.SECONDS)).isNull();
             });
         } finally {
             MeshSettleState.resetForTests();

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/sv/Views.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/sv/Views.java
@@ -1,0 +1,125 @@
+package io.mcpmesh.spring.sv;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+
+/**
+ * Valid {@link McpMeshService} fixtures for the RFC #1280 integration tests.
+ *
+ * <p>All views live in this single package so a test can scope classpath
+ * discovery to {@code io.mcpmesh.spring.sv} via {@code AutoConfigurationPackages}.
+ * The nested interfaces are static (implicitly, inside an interface/class) and
+ * therefore "independent" — discoverable by the registrar's Spring-Data-style
+ * scanner.
+ */
+public final class Views {
+
+    private Views() {
+    }
+
+    public record ChatRequest(String prompt) {
+    }
+
+    public record ChatResult(String text) {
+    }
+
+    public record Query(String q) {
+    }
+
+    public record Item(String id, String name) {
+    }
+
+    /**
+     * Behavior view: exercises every param mode (0-arg, single-POJO,
+     * multi-{@code @Param}), every return mode (sync, async, stream), a
+     * {@code default} method, and mixed required/optional edges.
+     */
+    @McpMeshService
+    public interface LlmService {
+
+        @Selector(capability = "llm.chat", tags = {"+gpt"})
+        ChatResult chat(ChatRequest req);
+
+        @Selector(capability = "llm.vision", tags = {"+claude"}, required = true)
+        Item vision(Query q);
+
+        @Selector(capability = "llm.list")
+        List<String> list();
+
+        @Selector(capability = "llm.lookup")
+        Item lookup(@Param("id") String id, @Param("region") String region);
+
+        @Selector(capability = "llm.async")
+        CompletableFuture<Item> fetchAsync(Query q);
+
+        @Selector(capability = "llm.stream")
+        Flow.Publisher<String> streamIt(@Param("q") String q);
+
+        /** default method — NOT a dependency edge. */
+        default String label() {
+            return "llm-view";
+        }
+    }
+
+    /**
+     * Determinism view: methods declared reverse-alphabetically so the test can
+     * assert the expanded dependency order is sorted by method name regardless.
+     */
+    @McpMeshService
+    public interface DeterminismService {
+
+        @Selector(capability = "det.zeta")
+        String zeta();
+
+        @Selector(capability = "det.yankee")
+        String yankee();
+
+        @Selector(capability = "det.alpha")
+        String alpha();
+    }
+
+    /** Floor view: {@code minAvailable=2} over four optional methods (one async). */
+    @McpMeshService(minAvailable = 2)
+    public interface FloorService {
+
+        @Selector(capability = "floor.a")
+        String alpha();
+
+        @Selector(capability = "floor.b")
+        String bravo();
+
+        @Selector(capability = "floor.c")
+        String charlie();
+
+        @Selector(capability = "floor.d")
+        CompletableFuture<String> deltaAsync();
+    }
+
+    /** Wire-serialization view: one required + one optional edge. */
+    @McpMeshService
+    public interface WireService {
+
+        @Selector(capability = "wire.req", required = true)
+        String req();
+
+        @Selector(capability = "wire.opt")
+        String opt();
+    }
+
+    /**
+     * Required-wins view: declares {@code rw_cap} required=true so a test can
+     * pair it with an optional {@code @MeshDependsOn} on the same capability and
+     * assert required wins across sources.
+     */
+    @McpMeshService
+    public interface RequiredWinsService {
+
+        @Selector(capability = "rw_cap", required = true)
+        String rw();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/badfuture/BadFuture.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/badfuture/BadFuture.java
@@ -1,0 +1,19 @@
+package io.mcpmesh.spring.svbad.badfuture;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+import java.util.concurrent.Future;
+
+/** Boot-fail (MED-8): a non-CompletableFuture Future/CompletionStage return. */
+public final class BadFuture {
+
+    private BadFuture() {
+    }
+
+    @McpMeshService
+    public interface BadFutureService {
+        @Selector(capability = "bf.cap")
+        Future<String> get();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/badstream/BadStream.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/badstream/BadStream.java
@@ -1,0 +1,19 @@
+package io.mcpmesh.spring.svbad.badstream;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+import java.util.concurrent.Flow;
+
+/** Boot-fail (MED-8): a streaming view whose chunk type is not String. */
+public final class BadStream {
+
+    private BadStream() {
+    }
+
+    @McpMeshService
+    public interface BadStreamService {
+        @Selector(capability = "bs.cap")
+        Flow.Publisher<Integer> get();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/blankcap/BlankCap.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/blankcap/BlankCap.java
@@ -1,0 +1,17 @@
+package io.mcpmesh.spring.svbad.blankcap;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+/** Boot-fail: @Selector with a blank capability. */
+public final class BlankCap {
+
+    private BlankCap() {
+    }
+
+    @McpMeshService
+    public interface BlankCapService {
+        @Selector(capability = "")
+        String get();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/conflict/Conflict.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/conflict/Conflict.java
@@ -1,0 +1,34 @@
+package io.mcpmesh.spring.svbad.conflict;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+/**
+ * Boot-fail fixture: two views bind the same capability to conflicting resolved
+ * types.
+ */
+public final class Conflict {
+
+    private Conflict() {
+    }
+
+    public record TypeX(String x) {
+    }
+
+    public record TypeY(int y) {
+    }
+
+    @McpMeshService
+    public interface ConflictAService {
+
+        @Selector(capability = "cc.cap")
+        TypeX m();
+    }
+
+    @McpMeshService
+    public interface ConflictBService {
+
+        @Selector(capability = "cc.cap")
+        TypeY n();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/duplicateparam/DuplicateParam.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/duplicateparam/DuplicateParam.java
@@ -1,0 +1,18 @@
+package io.mcpmesh.spring.svbad.duplicateparam;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+
+/** Boot-fail (MED-4): two parameters share the same @Param name. */
+public final class DuplicateParam {
+
+    private DuplicateParam() {
+    }
+
+    @McpMeshService
+    public interface DuplicateParamService {
+        @Selector(capability = "dp.cap")
+        String get(@Param("id") String a, @Param("id") String b);
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/negfloor/NegFloor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/negfloor/NegFloor.java
@@ -1,0 +1,17 @@
+package io.mcpmesh.spring.svbad.negfloor;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+/** Boot-fail (MED-7): a negative minAvailable floor. */
+public final class NegFloor {
+
+    private NegFloor() {
+    }
+
+    @McpMeshService(minAvailable = -1)
+    public interface NegFloorService {
+        @Selector(capability = "nf.a")
+        String a();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/onclass/OnClass.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/onclass/OnClass.java
@@ -1,0 +1,14 @@
+package io.mcpmesh.spring.svbad.onclass;
+
+import io.mcpmesh.McpMeshService;
+
+/** Boot-fail (MED-4): @McpMeshService on a class rather than an interface. */
+public final class OnClass {
+
+    private OnClass() {
+    }
+
+    @McpMeshService
+    public static class NotAnInterfaceService {
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/params/BadParams.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/params/BadParams.java
@@ -1,0 +1,22 @@
+package io.mcpmesh.spring.svbad.params;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+
+/**
+ * Boot-fail fixture: a view method with 2+ parameters where at least one is
+ * missing {@code @Param} (mixed signature).
+ */
+public final class BadParams {
+
+    private BadParams() {
+    }
+
+    @McpMeshService
+    public interface MixedParamsService {
+
+        @Selector(capability = "bp.cap")
+        String twoArgs(@Param("a") String a, String b);
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/rawfuture/RawFuture.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/rawfuture/RawFuture.java
@@ -1,0 +1,20 @@
+package io.mcpmesh.spring.svbad.rawfuture;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+import java.util.concurrent.CompletableFuture;
+
+/** Boot-fail (MED-8): raw CompletableFuture with no type argument. */
+public final class RawFuture {
+
+    private RawFuture() {
+    }
+
+    @McpMeshService
+    public interface RawFutureService {
+        @SuppressWarnings("rawtypes")
+        @Selector(capability = "rf.cap")
+        CompletableFuture get();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/scalarparam/ScalarParam.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/scalarparam/ScalarParam.java
@@ -1,0 +1,17 @@
+package io.mcpmesh.spring.svbad.scalarparam;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+/** Boot-fail (MED-1): a lone unannotated scalar parameter. */
+public final class ScalarParam {
+
+    private ScalarParam() {
+    }
+
+    @McpMeshService
+    public interface ScalarParamService {
+        @Selector(capability = "sp.cap")
+        String get(String id);
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/selector/BadSelector.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/selector/BadSelector.java
@@ -1,0 +1,21 @@
+package io.mcpmesh.spring.svbad.selector;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+/** Boot-fail fixture: an abstract view method with no {@code @Selector}. */
+public final class BadSelector {
+
+    private BadSelector() {
+    }
+
+    @McpMeshService
+    public interface MissingSelectorService {
+
+        @Selector(capability = "ok.cap")
+        String good();
+
+        // No @Selector — must fail context refresh at registration time.
+        String missing();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/unsatfloor/UnsatFloor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/unsatfloor/UnsatFloor.java
@@ -1,0 +1,20 @@
+package io.mcpmesh.spring.svbad.unsatfloor;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+/** Boot-fail (MED-7): minAvailable exceeds the number of bound methods. */
+public final class UnsatFloor {
+
+    private UnsatFloor() {
+    }
+
+    @McpMeshService(minAvailable = 3)
+    public interface UnsatFloorService {
+        @Selector(capability = "uf.a")
+        String a();
+
+        @Selector(capability = "uf.b")
+        String b();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svconsumer/ConsumerViews.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svconsumer/ConsumerViews.java
@@ -1,0 +1,20 @@
+package io.mcpmesh.spring.svconsumer;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+/**
+ * Consumer-only gate fixture (MED-12): an app whose ONLY mesh surface is a
+ * service view must boot name-less as a mesh consumer.
+ */
+public final class ConsumerViews {
+
+    private ConsumerViews() {
+    }
+
+    @McpMeshService
+    public interface ConsumerView {
+        @Selector(capability = "consumer.only")
+        String fetch();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svgen/GenericViews.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svgen/GenericViews.java
@@ -1,0 +1,74 @@
+package io.mcpmesh.spring.svgen;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+/**
+ * MED-3 fixtures: generic super-interfaces, covariant overrides (bridge-method
+ * skipping), and diamond inheritance.
+ */
+public final class GenericViews {
+
+    private GenericViews() {
+    }
+
+    public record Item(String id, String name) {
+    }
+
+    /** Generic base — the view binds T via {@code extends Base<Item>}. */
+    public interface Base<T> {
+        @Selector(capability = "gen.get")
+        T get();
+    }
+
+    @McpMeshService
+    public interface GenericView extends Base<Item> {
+    }
+
+    /** Covariant override: the concrete return is Item; a bridge {@code Object thing()} is generated. */
+    public interface CovBase {
+        Object thing();
+    }
+
+    @McpMeshService
+    public interface CovView extends CovBase {
+        @Override
+        @Selector(capability = "cov.thing")
+        Item thing();
+    }
+
+    /** Diamond: both super-interfaces declare the same @Selector method. */
+    public interface DiamondA {
+        @Selector(capability = "diamond.x")
+        String x();
+    }
+
+    public interface DiamondB {
+        @Selector(capability = "diamond.x")
+        String x();
+    }
+
+    @McpMeshService
+    public interface DiamondView extends DiamondA, DiamondB {
+    }
+
+    /**
+     * Diamond where only ONE super-interface annotates the shared signature. The
+     * annotated declaration must always win the dedupe regardless of
+     * {@code Class#getMethods()} iteration order — a single JVM run can't force
+     * the order, but the fixture pins the intent (boots with the annotated
+     * binding for {@code diamond.mixed}).
+     */
+    public interface AnnotatedSide {
+        @Selector(capability = "diamond.mixed")
+        String mixed();
+    }
+
+    public interface PlainSide {
+        String mixed();
+    }
+
+    @McpMeshService
+    public interface MixedDiamondView extends AnnotatedSide, PlainSide {
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svmulti/MultiViews.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svmulti/MultiViews.java
@@ -1,0 +1,27 @@
+package io.mcpmesh.spring.svmulti;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+/**
+ * Cross-view determinism fixture: two single-method views declared in reverse
+ * alphabetical order. {@code discoveredServices()} sorts views by interface
+ * name, so the expanded dependency order must be [mv.alpha, mv.zulu].
+ */
+public final class MultiViews {
+
+    private MultiViews() {
+    }
+
+    @McpMeshService
+    public interface ZuluView {
+        @Selector(capability = "mv.zulu")
+        String zulu();
+    }
+
+    @McpMeshService
+    public interface AlphaView {
+        @Selector(capability = "mv.alpha")
+        String alpha();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svself/SelfViews.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svself/SelfViews.java
@@ -1,0 +1,21 @@
+package io.mcpmesh.spring.svself;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+/**
+ * Self-produced capability fixture (MED-6): the view binds a capability the
+ * agent also produces via {@code @MeshTool}. The edge must be deduped away with
+ * a WARN and markResolved so the eager-settle latch is not stranded.
+ */
+public final class SelfViews {
+
+    private SelfViews() {
+    }
+
+    @McpMeshService
+    public interface SelfView {
+        @Selector(capability = "self.produced")
+        String get();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svxsrc/XsrcViews.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svxsrc/XsrcViews.java
@@ -1,0 +1,27 @@
+package io.mcpmesh.spring.svxsrc;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+/**
+ * Cross-source resolved-type conflict fixture (MED-5): a view binds {@code xs.cap}
+ * to {@link TypeX}. A test pairs it with a {@code @MeshDependsOn} declaring the
+ * same capability with a conflicting (or matching) expectedType.
+ */
+public final class XsrcViews {
+
+    private XsrcViews() {
+    }
+
+    public record TypeX(String x) {
+    }
+
+    public record TypeY(int y) {
+    }
+
+    @McpMeshService
+    public interface XsrcView {
+        @Selector(capability = "xs.cap")
+        TypeX get();
+    }
+}

--- a/tests/integration/suites/uc37_service_view_java/artifacts/java-view-consumer
+++ b/tests/integration/suites/uc37_service_view_java/artifacts/java-view-consumer
@@ -1,0 +1,1 @@
+../fixtures/java-view-consumer

--- a/tests/integration/suites/uc37_service_view_java/artifacts/provider-alpha
+++ b/tests/integration/suites/uc37_service_view_java/artifacts/provider-alpha
@@ -1,0 +1,1 @@
+../fixtures/provider-alpha

--- a/tests/integration/suites/uc37_service_view_java/artifacts/provider-bravo
+++ b/tests/integration/suites/uc37_service_view_java/artifacts/provider-bravo
@@ -1,0 +1,1 @@
+../fixtures/provider-bravo

--- a/tests/integration/suites/uc37_service_view_java/artifacts/provider-charlie
+++ b/tests/integration/suites/uc37_service_view_java/artifacts/provider-charlie
@@ -1,0 +1,1 @@
+../fixtures/provider-charlie

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/pom.xml
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.serviceview</groupId>
+    <artifactId>java-view-consumer</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>JavaViewConsumer Agent</name>
+    <description>uc37 consumer proving RFC #1280 @McpMeshService service views end-to-end</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.2</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.8.2</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Compile-scope web starter (version managed by the Boot parent).
+             REQUIRED at runtime: the mesh starter marks it optional, and
+             without it snakeyaml + logback are absent — Boot 4's
+             YamlPropertySourceLoader then dies with "snakeyaml was not found
+             on the classpath" while parsing application.yml and the JVM
+             exits before ever registering. Mirrors the working
+             uc23_meshjob_java/fixtures/long-task-provider-java block. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.serviceview.JavaViewConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/FlooredService.java
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/FlooredService.java
@@ -1,0 +1,27 @@
+package com.example.serviceview;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+import java.util.Map;
+
+/**
+ * uc37 floored service view (RFC #1280 {@code minAvailable}): two methods,
+ * floor of two. When EITHER capability loses its provider the whole view is
+ * below floor and EVERY facade call must fail with
+ * {@code MeshServiceUnavailableException} — including a call to the method
+ * whose own provider is still up (tc05's differentiator).
+ *
+ * <p>Both capabilities are also bound by {@link ReportService} with the same
+ * resolved type ({@code Map}), exercising the cross-view shared-capability
+ * dedupe: the wire registration must still expand to exactly 3 dependencies.
+ */
+@McpMeshService(minAvailable = 2)
+public interface FlooredService {
+
+    @Selector(capability = "view-cap-alpha")
+    Map<String, Object> alphaFloored();
+
+    @Selector(capability = "view-cap-bravo")
+    Map<String, Object> bravoFloored();
+}

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/JavaViewConsumerApplication.java
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/JavaViewConsumerApplication.java
@@ -1,0 +1,160 @@
+package com.example.serviceview;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.types.MeshServiceUnavailableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * uc37 fixture — Java consumer proving RFC #1280 {@code @McpMeshService}
+ * service views end-to-end.
+ *
+ * <p>Two views are discovered from this package:
+ * <ul>
+ *   <li>{@link ReportService} — alpha/bravo (optional) + charlie (required),
+ *       three capabilities backed by three DIFFERENT Python provider agents.</li>
+ *   <li>{@link FlooredService} — alpha+bravo with {@code minAvailable = 2}.</li>
+ * </ul>
+ *
+ * <p>The registration must expand to exactly THREE dependency edges under the
+ * synthetic {@code __mesh_service_deps} tool (the FlooredService bindings
+ * dedupe onto the ReportService edges), so the registry reports
+ * {@code total_dependencies == 3} (tc04).
+ *
+ * <p>The {@code @MeshTool} surfaces below are the observation points the TCs
+ * call via {@code meshctl call}:
+ * <ul>
+ *   <li>{@code view_report} — calls all three ReportService methods, catching
+ *       per-method failures, and reports which agent served each (flat
+ *       {@code <method>_agent}/{@code <method>_cap} keys on success,
+ *       {@code <method>_error}/{@code <method>_error_message} on failure).
+ *       Proves per-method multi-agent resolution (tc01) and independent
+ *       degradation/rebinding (tc02).</li>
+ *   <li>{@code view_critical} — calls the REQUIRED {@code charlie()} method
+ *       UNGUARDED. With provider-charlie down the call fails as a tool ERROR
+ *       naming the missing edge: the facade raises
+ *       {@code MeshToolUnavailableException} and the wrapper surfaces it
+ *       through the ordinary error path (tc03). NOTE: deliberately NOT the
+ *       issue #1273 pre-invoke {@code {"error":"dependency_unavailable"}}
+ *       envelope — that refusal is a property of tool-DECLARED dependency
+ *       slots ({@code @MeshTool(dependencies=...)}). A view is a CLASS-LEVEL
+ *       edge (same class as {@code @MeshDependsOn}): the framework cannot
+ *       know which tool bodies call which view methods, so RFC #1280's
+ *       contract is "availability per method, identical to standalone
+ *       edges". Do not rewrite this fixture (or tc03) to expect the
+ *       envelope; a consumer wanting the pre-invoke refusal declares the
+ *       capability as a tool dependency slot.</li>
+ *   <li>{@code view_floored} — calls {@code FlooredService.alphaFloored()},
+ *       reporting a floor breach via the typed
+ *       {@link MeshServiceUnavailableException} getters. With provider-bravo
+ *       down the ALPHA call must fail on the floor even though provider-alpha
+ *       is healthy (tc05). Any other exception propagates on purpose: a
+ *       MeshToolUnavailableException here would mean the floor did NOT gate
+ *       the call, and the raw tool error fails the tc05 assertions.</li>
+ * </ul>
+ */
+@MeshAgent(
+    name = "java-view-consumer",
+    version = "1.0.0",
+    description = "uc37 consumer proving RFC #1280 @McpMeshService service views",
+    port = 9201
+)
+@SpringBootApplication
+public class JavaViewConsumerApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(JavaViewConsumerApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting java-view-consumer (uc37 RFC #1280 service views)...");
+        SpringApplication.run(JavaViewConsumerApplication.class, args);
+    }
+
+    @Service
+    static class ViewTools {
+
+        private final ReportService reportService;
+        private final FlooredService flooredService;
+
+        /**
+         * Constructor injection of the auto-registered facade beans — the
+         * facade must exist before user singletons are wired (registrar runs
+         * as a BeanDefinitionRegistryPostProcessor). A boot failure here means
+         * discovery/registration broke.
+         */
+        ViewTools(ReportService reportService, FlooredService flooredService) {
+            this.reportService = reportService;
+            this.flooredService = flooredService;
+        }
+
+        @MeshTool(
+            capability = "view_report",
+            description = "Call all three ReportService view methods and report which agent served each")
+        public Map<String, Object> reportAll() {
+            Map<String, Object> out = new LinkedHashMap<>();
+            reportOne(out, "alpha", () -> reportService.alpha());
+            reportOne(out, "bravo", () -> reportService.bravo());
+            reportOne(out, "charlie", () -> reportService.charlie());
+            return out;
+        }
+
+        @MeshTool(
+            capability = "view_critical",
+            description = "Call the REQUIRED charlie() view method unguarded (tc03 refusal surface)")
+        public Map<String, Object> callCharlie() {
+            // Deliberately unguarded: with provider-charlie down, charlie()
+            // raises MeshToolUnavailableException here and the wrapper
+            // surfaces it as a tool error naming the edge — class-level view
+            // edges get no #1273 pre-invoke envelope (see class javadoc).
+            Map<String, Object> payload = reportService.charlie();
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("status", "ok");
+            out.put("charlie_agent", payload.get("agent"));
+            return out;
+        }
+
+        @MeshTool(
+            capability = "view_floored",
+            description = "Call FlooredService.alphaFloored(), reporting a minAvailable floor breach")
+        public Map<String, Object> flooredAlpha() {
+            Map<String, Object> out = new LinkedHashMap<>();
+            try {
+                Map<String, Object> payload = flooredService.alphaFloored();
+                out.put("floored_agent", payload.get("agent"));
+            } catch (MeshServiceUnavailableException e) {
+                // Typed floor breach: report the exception's own accounting so
+                // the TC asserts the exact floor arithmetic, not just a message.
+                out.put("floor_error", e.getClass().getSimpleName());
+                out.put("floor_service", e.getService());
+                out.put("floor_available", e.getMethodsAvailable());
+                out.put("floor_total", e.getMethodsTotal());
+                out.put("floor_min", e.getMinAvailable());
+            }
+            return out;
+        }
+
+        private void reportOne(Map<String, Object> out, String key, ViewCall call) {
+            try {
+                Map<String, Object> payload = call.invoke();
+                out.put(key + "_agent", payload.get("agent"));
+                out.put(key + "_cap", payload.get("cap"));
+            } catch (RuntimeException e) {
+                log.info("view method {} degraded: {}: {}", key,
+                    e.getClass().getSimpleName(), e.getMessage());
+                out.put(key + "_error", e.getClass().getSimpleName());
+                out.put(key + "_error_message", e.getMessage());
+            }
+        }
+
+        @FunctionalInterface
+        private interface ViewCall {
+            Map<String, Object> invoke();
+        }
+    }
+}

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/ReportService.java
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/ReportService.java
@@ -1,0 +1,29 @@
+package com.example.serviceview;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+import java.util.Map;
+
+/**
+ * uc37 primary service view (RFC #1280): three methods, three capabilities,
+ * three DIFFERENT provider agents. The group is a typed view — each method
+ * delegates to its own per-capability proxy and rebinds independently.
+ *
+ * <p>{@code charlie()} carries {@code required = true}: its edge feeds the
+ * issue #1249 availability derivation for the synthetic
+ * {@code __mesh_service_deps} capability and the tool-boundary refusal
+ * contract exercised by tc03.
+ */
+@McpMeshService
+public interface ReportService {
+
+    @Selector(capability = "view-cap-alpha")
+    Map<String, Object> alpha();
+
+    @Selector(capability = "view-cap-bravo")
+    Map<String, Object> bravo();
+
+    @Selector(capability = "view-cap-charlie", required = true)
+    Map<String, Object> charlie();
+}

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/resources/application.yml
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+# uc37 java-view-consumer configuration (RFC #1280 service views)
+
+spring:
+  application:
+    name: java-view-consumer
+  main:
+    banner-mode: "off"
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9201}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:java-view-consumer}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    root: INFO
+    io.mcpmesh: DEBUG
+    com.example: DEBUG

--- a/tests/integration/suites/uc37_service_view_java/fixtures/provider-alpha/main.py
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/provider-alpha/main.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""uc37 provider-alpha — self-identifying provider of view-cap-alpha (RFC #1280).
+
+One of THREE independent providers backing a single Java @McpMeshService
+view: each view method must resolve to a DIFFERENT provider agent. The
+payload names both the agent and the capability so the consumer's report
+tool can prove per-method binding (agent identity AND capability routing).
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Provider Alpha (uc37)")
+
+
+@app.tool()
+@mesh.tool(capability="view-cap-alpha", description="Self-identifying payload from provider-alpha")
+async def alpha_tool() -> dict:
+    return {"agent": "provider-alpha", "cap": "view-cap-alpha", "msg": "hello-from-alpha"}
+
+
+@mesh.agent(
+    name="provider-alpha",
+    version="1.0.0",
+    description="uc37 provider of view-cap-alpha for the Java service-view TCs",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9101")),
+    enable_http=True,
+    auto_run=True,
+)
+class ProviderAlpha:
+    pass

--- a/tests/integration/suites/uc37_service_view_java/fixtures/provider-alpha/requirements.txt
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/provider-alpha/requirements.txt
@@ -1,0 +1,1 @@
+# uc37 provider-alpha deps. mesh + fastmcp come from the runtime image.

--- a/tests/integration/suites/uc37_service_view_java/fixtures/provider-bravo/main.py
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/provider-bravo/main.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""uc37 provider-bravo — self-identifying provider of view-cap-bravo (RFC #1280).
+
+The OPTIONAL rebinding target: tc02 kills and restarts THIS provider to
+prove the corresponding view method degrades and heals independently of
+the other methods, with no consumer restart. tc05 kills it to drive the
+FlooredService view below its minAvailable=2 floor.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Provider Bravo (uc37)")
+
+
+@app.tool()
+@mesh.tool(capability="view-cap-bravo", description="Self-identifying payload from provider-bravo")
+async def bravo_tool() -> dict:
+    return {"agent": "provider-bravo", "cap": "view-cap-bravo", "msg": "hello-from-bravo"}
+
+
+@mesh.agent(
+    name="provider-bravo",
+    version="1.0.0",
+    description="uc37 provider of view-cap-bravo for the Java service-view TCs",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9102")),
+    enable_http=True,
+    auto_run=True,
+)
+class ProviderBravo:
+    pass

--- a/tests/integration/suites/uc37_service_view_java/fixtures/provider-bravo/requirements.txt
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/provider-bravo/requirements.txt
@@ -1,0 +1,1 @@
+# uc37 provider-bravo deps. mesh + fastmcp come from the runtime image.

--- a/tests/integration/suites/uc37_service_view_java/fixtures/provider-charlie/main.py
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/provider-charlie/main.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""uc37 provider-charlie — self-identifying provider of view-cap-charlie (RFC #1280).
+
+The REQUIRED edge target: the Java consumer's view binds view-cap-charlie
+with @Selector(required = true). tc03 kills and restarts THIS provider to
+drive the required-edge unavailable -> recovered transitions (issue #1249
+availability derivation on the synthetic __mesh_service_deps capability +
+the tool-boundary refusal contract).
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Provider Charlie (uc37)")
+
+
+@app.tool()
+@mesh.tool(capability="view-cap-charlie", description="Self-identifying payload from provider-charlie")
+async def charlie_tool() -> dict:
+    return {"agent": "provider-charlie", "cap": "view-cap-charlie", "msg": "hello-from-charlie"}
+
+
+@mesh.agent(
+    name="provider-charlie",
+    version="1.0.0",
+    description="uc37 provider of view-cap-charlie (required edge) for the Java service-view TCs",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9103")),
+    enable_http=True,
+    auto_run=True,
+)
+class ProviderCharlie:
+    pass

--- a/tests/integration/suites/uc37_service_view_java/fixtures/provider-charlie/requirements.txt
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/provider-charlie/requirements.txt
@@ -1,0 +1,1 @@
+# uc37 provider-charlie deps. mesh + fastmcp come from the runtime image.

--- a/tests/integration/suites/uc37_service_view_java/routines.yaml
+++ b/tests/integration/suites/uc37_service_view_java/routines.yaml
@@ -1,0 +1,21 @@
+# UC-level routines for uc37_service_view_java (RFC #1280 @McpMeshService).
+#
+# Availability transitions in this UC ride the registry's DEFAULT health
+# debounce (~3 missed heartbeats, ~15-25s) plus one consumer heartbeat —
+# no knob-cranked registry on purpose (mirrors uc34): the derived
+# availability and rebinding semantics must hold under stock timing, and
+# every TC polls with a deadline instead of sleeping fixed. The registry
+# is auto-started by the first `meshctl start`.
+
+routines:
+  # Stop everything started by this test (agents + registry + the consumer JVM).
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: |
+          meshctl stop 2>/dev/null || true
+          pkill -f "spring-boot:run" 2>/dev/null || true
+          pkill -f "java.*view-consumer" 2>/dev/null || true
+        ignore_errors: true

--- a/tests/integration/suites/uc37_service_view_java/routines.yaml
+++ b/tests/integration/suites/uc37_service_view_java/routines.yaml
@@ -8,14 +8,16 @@
 # is auto-started by the first `meshctl start`.
 
 routines:
-  # Stop everything started by this test (agents + registry + the consumer JVM).
+  # Stop everything started by this test (agents + registry). `meshctl stop`
+  # alone is sufficient for the mvn spring-boot:run JVM tree: meshctl starts
+  # agents with Setpgid and signals the WHOLE process group on stop (SIGTERM
+  # -> SIGKILL escalation), so the Maven parent and its forked java child
+  # die together — no pkill fallback needed (mirrors the uc23/uc30/uc34
+  # UC-level stop_all).
   stop_all:
     description: "Stop all mesh processes started by this test"
     steps:
       - handler: shell
         workdir: /workspace
-        command: |
-          meshctl stop 2>/dev/null || true
-          pkill -f "spring-boot:run" 2>/dev/null || true
-          pkill -f "java.*view-consumer" 2>/dev/null || true
+        command: meshctl stop 2>/dev/null || true
         ignore_errors: true

--- a/tests/integration/suites/uc37_service_view_java/tc01_per_method_multi_agent/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc01_per_method_multi_agent/test.yaml
@@ -1,0 +1,148 @@
+# tc01_per_method_multi_agent — THE service-view differentiator (RFC #1280):
+# one Java @McpMeshService interface whose three methods resolve to three
+# DIFFERENT provider agents.
+#
+# Topology: three independent Python providers (view-cap-alpha/bravo/charlie)
+# + the Java java-view-consumer whose ReportService view binds one capability
+# per method. The consumer's view_report @MeshTool calls all three view
+# methods and reports which agent served each (self-identifying payloads).
+#
+# Design guarantees under test:
+#   1. Each view method delegates to ITS OWN per-capability proxy: the report
+#      pairs alpha->provider-alpha, bravo->provider-bravo,
+#      charlie->provider-charlie. The pairing is verified with anchored
+#      key:value greps — a cross-wired binding (alpha served by bravo's
+#      agent) fails even though all three names appear somewhere.
+#   2. Each method carries its own capability payload (<m>_cap keys), proving
+#      capability routing, not just distinct endpoints.
+#   3. No method degrades at baseline: no *_error keys in the report.
+#
+# Timing: NO dependency-resolution waits (issue #1193) — registration waits
+# are liveness-only and the first view_report call rides the consumer's
+# settle window. The baseline poll's long deadline covers the cold-JVM
+# mvn spring-boot:run start.
+
+name: "Service views: per-method resolution to three different provider agents (Java)"
+description: "Java @McpMeshService with 3 methods -> 3 Python providers: view_report proves each method is served by its own agent with its own capability payload"
+tags:
+  - integration
+  - java
+  - python
+  - registry
+  - service-view
+  - rfc-1280
+  - slow
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/provider-alpha /workspace/
+      cp -rL /uc-artifacts/provider-bravo /workspace/
+      cp -rL /uc-artifacts/provider-charlie /workspace/
+      cp -rL /uc-artifacts/java-view-consumer /workspace/
+
+  - name: "Install provider-alpha deps"
+    handler: pip-install
+    path: /workspace/provider-alpha
+
+  - name: "Install provider-bravo deps"
+    handler: pip-install
+    path: /workspace/provider-bravo
+
+  - name: "Install provider-charlie deps"
+    handler: pip-install
+    path: /workspace/provider-charlie
+
+  - name: "Install Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-view-consumer
+    timeout: 600
+
+  - name: "Start provider-alpha (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-alpha/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Start provider-bravo (port 9102)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-bravo/main.py --env MCP_MESH_HTTP_PORT=9102 -d
+
+  - name: "Start provider-charlie (port 9103)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-charlie/main.py --env MCP_MESH_HTTP_PORT=9103 -d
+
+  - name: "Start java-view-consumer (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-consumer --env MCP_MESH_HTTP_PORT=9201 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193): 240s deadline covers the cold JVM start.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "provider-alpha provider-bravo provider-charlie java-view-consumer"
+
+  # Baseline: poll view_report until every method reports its OWN provider.
+  # ENVELOPE: Java tools carry the payload ONLY as an escaped JSON string in
+  # content[0].text (no structuredContent), so parse the actual contract via
+  # `.content[0].text | fromjson` (suite idiom, see uc22/uc23) — equality
+  # INSIDE the jq filter yields a bare true/false, and the parse keeps
+  # working if structuredContent is added later. Pairing stays anchored
+  # (key AND expected value judged in ONE filter) so cross-wired bindings
+  # cannot pass. Emits verdict markers the assertions key on.
+  - name: "Wait for full per-method report"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 90); do
+        RESP=$(meshctl call view_report '{}' --raw 2>&1 || true)
+        A=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .alpha_agent == "provider-alpha"' 2>/dev/null || echo "")
+        B=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .bravo_agent == "provider-bravo"' 2>/dev/null || echo "")
+        C=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .charlie_agent == "provider-charlie"' 2>/dev/null || echo "")
+        if [ "$A" = "true" ] && [ "$B" = "true" ] && [ "$C" = "true" ]; then
+          echo "REPORT_ALL_BOUND=1 after ~$((i*2))s"
+          [ "$(echo "$RESP" | jq -r '.content[0].text | fromjson | .alpha_cap == "view-cap-alpha"' 2>/dev/null)" = "true" ] && echo "ALPHA_CAP_OK=1"
+          [ "$(echo "$RESP" | jq -r '.content[0].text | fromjson | .bravo_cap == "view-cap-bravo"' 2>/dev/null)" = "true" ] && echo "BRAVO_CAP_OK=1"
+          [ "$(echo "$RESP" | jq -r '.content[0].text | fromjson | .charlie_cap == "view-cap-charlie"' 2>/dev/null)" = "true" ] && echo "CHARLIE_CAP_OK=1"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: view_report never reported all three provider bindings within 180s"
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: report_baseline
+    timeout: 200
+
+assertions:
+  # Guarantee 1: per-method binding to three DIFFERENT agents (anchored pairs
+  # verified in-shell; the markers are the verdicts).
+  - expr: "${captured.report_baseline} contains 'REPORT_ALL_BOUND=1'"
+    message: "each view method must resolve to its OWN provider agent (alpha->provider-alpha, bravo->provider-bravo, charlie->provider-charlie)"
+
+  # Guarantee 2: capability routing per method, not just distinct endpoints
+  - expr: "${captured.report_baseline} contains 'ALPHA_CAP_OK=1'"
+    message: "alpha() must carry provider-alpha's view-cap-alpha payload"
+  - expr: "${captured.report_baseline} contains 'BRAVO_CAP_OK=1'"
+    message: "bravo() must carry provider-bravo's view-cap-bravo payload"
+  - expr: "${captured.report_baseline} contains 'CHARLIE_CAP_OK=1'"
+    message: "charlie() must carry provider-charlie's view-cap-charlie payload"
+
+  # Guarantee 3: no degraded method at baseline
+  - expr: "${captured.report_baseline} not contains '_error'"
+    message: "no view method may degrade at baseline (all three providers up)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc37_service_view_java/tc02_dynamic_rebinding/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc02_dynamic_rebinding/test.yaml
@@ -1,0 +1,204 @@
+# tc02_dynamic_rebinding — per-method dynamic rebinding (RFC #1280): killing
+# ONE provider degrades ONLY the corresponding view method; restarting it
+# heals that method with NO consumer restart.
+#
+# Topology: same as tc01 (three Python providers + the Java view consumer).
+# provider-bravo (an OPTIONAL edge) is the kill/restart target.
+#
+# Design guarantees under test:
+#   1. Kill provider-bravo -> bravo() degrades: view_report reports
+#      bravo_error=MeshToolUnavailableException (the per-capability proxy's
+#      soft-fail contract for an optional edge, surfaced by the consumer's
+#      own catch — the tool call itself still succeeds).
+#   2. Method independence: IN THE SAME degraded report, alpha() and
+#      charlie() still answer from their own agents. The view never turns a
+#      single dead edge into whole-view failure (no floor declared).
+#   3. Restart provider-bravo -> bravo() heals organically (facade delegates
+#      to the shared proxy the injector mutates in place) — the consumer JVM
+#      is NEVER restarted in this test.
+#
+# Timing: the degrade transition rides the default health debounce (~3
+# missed heartbeats, ~15-25s) plus one consumer heartbeat — polled with
+# deadlines, never fixed sleeps. No dependency-resolution waits (issue #1193).
+
+name: "Service views: kill/restart one provider rebinds only its method (Java)"
+description: "Kill provider-bravo: bravo() degrades to MeshToolUnavailableException while alpha()/charlie() keep answering; restart: bravo() heals with no consumer restart"
+tags:
+  - integration
+  - java
+  - python
+  - registry
+  - service-view
+  - rfc-1280
+  - availability
+  - slow
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/provider-alpha /workspace/
+      cp -rL /uc-artifacts/provider-bravo /workspace/
+      cp -rL /uc-artifacts/provider-charlie /workspace/
+      cp -rL /uc-artifacts/java-view-consumer /workspace/
+
+  - name: "Install provider-alpha deps"
+    handler: pip-install
+    path: /workspace/provider-alpha
+
+  - name: "Install provider-bravo deps"
+    handler: pip-install
+    path: /workspace/provider-bravo
+
+  - name: "Install provider-charlie deps"
+    handler: pip-install
+    path: /workspace/provider-charlie
+
+  - name: "Install Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-view-consumer
+    timeout: 600
+
+  - name: "Start provider-alpha (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-alpha/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Start provider-bravo (port 9102)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-bravo/main.py --env MCP_MESH_HTTP_PORT=9102 -d
+
+  - name: "Start provider-charlie (port 9103)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-charlie/main.py --env MCP_MESH_HTTP_PORT=9103 -d
+
+  - name: "Start java-view-consumer (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-consumer --env MCP_MESH_HTTP_PORT=9201 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193): 240s deadline covers the cold JVM start.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "provider-alpha provider-bravo provider-charlie java-view-consumer"
+
+  # Baseline: all three methods bound to their own agents (settle gate).
+  - name: "Wait for full per-method report (baseline)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 90); do
+        RESP=$(meshctl call view_report '{}' --raw 2>&1 || true)
+        A=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .alpha_agent == "provider-alpha"' 2>/dev/null || echo "")
+        B=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .bravo_agent == "provider-bravo"' 2>/dev/null || echo "")
+        C=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .charlie_agent == "provider-charlie"' 2>/dev/null || echo "")
+        if [ "$A" = "true" ] && [ "$B" = "true" ] && [ "$C" = "true" ]; then
+          echo "BASELINE_BOUND=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: view_report never reported all three provider bindings within 180s"
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: report_baseline
+    timeout: 200
+
+  - name: "Kill provider-bravo"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop provider-bravo
+    capture: kill_bravo
+
+  # Degrade: poll until bravo reports an error WHILE alpha+charlie still
+  # answer in the SAME report — the independence check must be atomic to one
+  # response, or a transient could fake it. Parsed via
+  # `.content[0].text | fromjson` (Java envelope: escaped JSON string in
+  # content[0].text, no structuredContent), equality inside the jq filter.
+  - name: "Wait for bravo to degrade with alpha+charlie intact"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 60); do
+        RESP=$(meshctl call view_report '{}' --raw 2>&1 || true)
+        DEGRADED=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .bravo_error == "MeshToolUnavailableException"' 2>/dev/null || echo "")
+        if [ "$DEGRADED" = "true" ]; then
+          echo "BRAVO_DEGRADED=1 after ~$((i*2))s"
+          [ "$(echo "$RESP" | jq -r '.content[0].text | fromjson | .alpha_agent == "provider-alpha"' 2>/dev/null)" = "true" ] && echo "ALPHA_STILL_OK=1"
+          [ "$(echo "$RESP" | jq -r '.content[0].text | fromjson | .charlie_agent == "provider-charlie"' 2>/dev/null)" = "true" ] && echo "CHARLIE_STILL_OK=1"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: bravo_error never appeared within 120s of killing provider-bravo"
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: report_degraded
+    timeout: 140
+
+  - name: "Restart provider-bravo"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-bravo/main.py --env MCP_MESH_HTTP_PORT=9102 -d
+
+  # Recovery: the facade's cached proxy is mutated in place by the injector —
+  # bravo() must heal with NO consumer restart.
+  - name: "Wait for bravo to rebind"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 75); do
+        RESP=$(meshctl call view_report '{}' --raw 2>&1 || true)
+        REBOUND=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .bravo_agent == "provider-bravo"' 2>/dev/null || echo "")
+        if [ "$REBOUND" = "true" ]; then
+          echo "BRAVO_REBOUND=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: bravo_agent never reappeared within 150s of restarting provider-bravo"
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: report_recovered
+    timeout: 170
+
+assertions:
+  - expr: "${captured.report_baseline} contains 'BASELINE_BOUND=1'"
+    message: "all three view methods must bind to their own providers before the kill"
+
+  # Guarantee 1: only bravo degrades, with the per-capability soft-fail contract
+  - expr: "${captured.report_degraded} contains 'BRAVO_DEGRADED=1'"
+    message: "bravo() must degrade to MeshToolUnavailableException once provider-bravo dies (optional edge soft-fail)"
+
+  # Guarantee 2: method independence within the SAME degraded report
+  - expr: "${captured.report_degraded} contains 'ALPHA_STILL_OK=1'"
+    message: "alpha() must still answer from provider-alpha in the same report where bravo() is degraded"
+  - expr: "${captured.report_degraded} contains 'CHARLIE_STILL_OK=1'"
+    message: "charlie() must still answer from provider-charlie in the same report where bravo() is degraded"
+
+  # Guarantee 3: organic rebinding, no consumer restart (no restart step exists)
+  - expr: "${captured.report_recovered} contains 'BRAVO_REBOUND=1'"
+    message: "bravo() must heal after provider-bravo restarts, with no consumer restart"
+  - expr: "${captured.report_recovered} not contains 'bravo_error'"
+    message: "the recovered report must carry no bravo_error residue"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc37_service_view_java/tc03_required_view_edge/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc03_required_view_edge/test.yaml
@@ -1,0 +1,315 @@
+# tc03_required_view_edge — required=true on a view method (RFC #1280 x
+# issue #1249): the edge feeds the registry's derived availability AND the
+# consumer-side failure surface, and heals organically.
+#
+# Topology: same as tc01. provider-charlie backs the view's ONLY required
+# edge (ReportService.charlie(), @Selector(required = true)) and is the
+# kill/restart target.
+#
+# Design guarantees under test:
+#   1. Wire expansion: the required view edge registers under the synthetic
+#      __mesh_service_deps tool, so killing provider-charlie flips the
+#      consumer's __mesh_service_deps capability to available=false with
+#      unavailable_reason naming view-cap-charlie — WHILE the consumer agent
+#      itself stays registered and healthy (capability-level derived state,
+#      mirrors uc34 tc01).
+#   2. The capability stays the atom: the consumer's REAL tool capabilities
+#      (view_report, view_critical) do NOT flip — only the declaring
+#      synthetic capability carries the required edge. (This is also what
+#      keeps view_critical resolvable so the failure below is observable.)
+#   3. Consumer-side failure surface: invoking view_critical (whose body
+#      calls the required charlie() method UNGUARDED) while provider-charlie
+#      is down must FAIL as a tool ERROR naming the missing edge
+#      (MeshToolUnavailableException / view-cap-charlie in the message).
+#
+#      WHY NOT the structured {"error":"dependency_unavailable"} envelope:
+#      that pre-invoke refusal (issue #1273's MeshToolWrapper guard) is a
+#      property of tool-DECLARED dependency slots — @MeshTool(dependencies=
+#      ...) with an injected proxy parameter. A view is a CLASS-LEVEL edge
+#      (same class as @MeshDependsOn): the framework cannot know which
+#      @MeshTool bodies call which view methods, so the RFC #1280 contract
+#      is "availability per method, identical to standalone edges" — the
+#      facade call raises MeshToolUnavailableException and the wrapper
+#      surfaces it through the ordinary error path. Do NOT "fix" this TC to
+#      expect the #1273 envelope; a consumer that wants the pre-invoke
+#      refusal declares the capability as a @MeshTool dependency slot
+#      instead of (or in addition to) the view.
+#   4. Organic recovery: restart provider-charlie -> view_critical answers
+#      ok again and __mesh_service_deps re-derives available=true, with no
+#      consumer restart.
+#
+# Timing: transitions ride the default health debounce (~15-25s) plus one
+# consumer heartbeat — polled with deadlines. No dependency-resolution
+# waits (issue #1193).
+
+name: "Service views: required=true view edge — derived availability + error surface + recovery (Java)"
+description: "Kill provider-charlie: __mesh_service_deps flips unavailable naming view-cap-charlie while the consumer stays healthy, view_critical errors naming the missing edge (class-level edge, no #1273 envelope); restart: both recover"
+tags:
+  - integration
+  - java
+  - python
+  - registry
+  - service-view
+  - rfc-1280
+  - required-deps
+  - availability
+  - issue-1249
+  - slow
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/provider-alpha /workspace/
+      cp -rL /uc-artifacts/provider-bravo /workspace/
+      cp -rL /uc-artifacts/provider-charlie /workspace/
+      cp -rL /uc-artifacts/java-view-consumer /workspace/
+
+  - name: "Install provider-alpha deps"
+    handler: pip-install
+    path: /workspace/provider-alpha
+
+  - name: "Install provider-bravo deps"
+    handler: pip-install
+    path: /workspace/provider-bravo
+
+  - name: "Install provider-charlie deps"
+    handler: pip-install
+    path: /workspace/provider-charlie
+
+  - name: "Install Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-view-consumer
+    timeout: 600
+
+  - name: "Start provider-alpha (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-alpha/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Start provider-bravo (port 9102)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-bravo/main.py --env MCP_MESH_HTTP_PORT=9102 -d
+
+  - name: "Start provider-charlie (port 9103)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-charlie/main.py --env MCP_MESH_HTTP_PORT=9103 -d
+
+  - name: "Start java-view-consumer (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-consumer --env MCP_MESH_HTTP_PORT=9201 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193): 240s deadline covers the cold JVM start.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "provider-alpha provider-bravo provider-charlie java-view-consumer"
+
+  # Baseline: the required method answers through the facade (settle gate).
+  # ENVELOPE: Java tools carry the payload ONLY as an escaped JSON string in
+  # content[0].text (no structuredContent) — parse via
+  # `.content[0].text | fromjson` (suite idiom), equality inside the jq
+  # filter; keeps working if structuredContent is added later.
+  - name: "Wait for view_critical baseline ok"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 90); do
+        RESP=$(meshctl call view_critical '{}' --raw 2>&1 || true)
+        BOUND=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .charlie_agent == "provider-charlie"' 2>/dev/null || echo "")
+        if [ "$BOUND" = "true" ]; then
+          echo "CRITICAL_BASELINE_OK=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: view_critical never answered from provider-charlie within 180s"
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: critical_baseline
+    timeout: 200
+
+  # Pure-JSON snapshot for the baseline availability assertions.
+  - name: "Capture baseline /agents snapshot"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_baseline
+
+  - name: "Kill provider-charlie"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop provider-charlie
+    capture: kill_charlie
+
+  # Guarantee 1: the registry re-derives the synthetic capability once the
+  # death lands (graceful unregister is immediate; a hard death takes the
+  # ~15-25s health debounce).
+  - name: "Wait for __mesh_service_deps to flip unavailable"
+    handler: shell
+    workdir: /workspace
+    command: |
+      AVAIL=""
+      for i in $(seq 1 60); do
+        AVAIL=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name == "java-view-consumer") | .capabilities[] | select(.name == "__mesh_service_deps") | .available' 2>/dev/null || echo "")
+        if [ "$AVAIL" = "false" ]; then
+          echo "SERVICE_DEPS_UNAVAILABLE=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: __mesh_service_deps never flipped to available=false within 120s (last=$AVAIL)"
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name == "java-view-consumer")' 2>/dev/null || true
+      exit 1
+    capture: wait_deps_down
+    timeout: 140
+
+  # Pure-JSON snapshot WHILE the required edge is broken.
+  - name: "Capture /agents snapshot during outage"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_during_outage
+
+  # Guarantee 3: the call fails as a tool error naming the missing edge
+  # (class-level edge semantics — see the header; this is deliberately NOT
+  # the #1273 pre-invoke envelope). "Still ok?" is judged by parsing the
+  # success shape (`.content[0].text | fromjson | .status == "ok"`); the
+  # ERROR body may be PLAIN TEXT (not JSON), so its shape is judged
+  # STRUCTURALLY on the raw response — either the exception type or the
+  # capability name, never fromjson: the exact wording of a raw exception
+  # surfaced through the wrapper's error path is not a contract.
+  - name: "Wait for view_critical to error"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      SEEN_NOT_OK=0
+      for i in $(seq 1 60); do
+        RESP=$(meshctl call view_critical '{}' --raw 2>&1 || true)
+        OK=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .status == "ok"' 2>/dev/null || echo "")
+        if [ "$OK" != "true" ]; then
+          if [ "$SEEN_NOT_OK" = "0" ]; then
+            echo "CRITICAL_NOT_OK=1 after ~$((i*2))s"
+            SEEN_NOT_OK=1
+          fi
+          if echo "$RESP" | grep -q 'view-cap-charlie' || echo "$RESP" | grep -q 'MeshToolUnavailableException'; then
+            echo "ERROR_NAMES_MISSING_EDGE=1"
+            echo "$RESP"
+            exit 0
+          fi
+        fi
+        sleep 2
+      done
+      if [ "$SEEN_NOT_OK" = "1" ]; then
+        echo "ERROR: view_critical errored but never named the missing edge within 120s"
+      else
+        echo "ERROR: view_critical kept answering ok for 120s after provider-charlie died"
+      fi
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: critical_error
+    timeout: 140
+
+  - name: "Restart provider-charlie"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-charlie/main.py --env MCP_MESH_HTTP_PORT=9103 -d
+
+  # Guarantee 4: organic recovery — no consumer restart.
+  - name: "Wait for view_critical recovery"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 75); do
+        RESP=$(meshctl call view_critical '{}' --raw 2>&1 || true)
+        RECOVERED=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .charlie_agent == "provider-charlie"' 2>/dev/null || echo "")
+        if [ "$RECOVERED" = "true" ]; then
+          echo "CRITICAL_RECOVERED=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: view_critical never recovered within 150s of restarting provider-charlie"
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: critical_recovery
+    timeout: 170
+
+  # Pure-JSON snapshot after recovery.
+  - name: "Wait for __mesh_service_deps to re-derive available"
+    handler: shell
+    workdir: /workspace
+    command: |
+      AVAIL=""
+      for i in $(seq 1 60); do
+        AVAIL=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name == "java-view-consumer") | .capabilities[] | select(.name == "__mesh_service_deps") | .available' 2>/dev/null || echo "")
+        if [ "$AVAIL" = "true" ]; then
+          echo "SERVICE_DEPS_RECOVERED=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: __mesh_service_deps never re-derived available=true within 120s (last=$AVAIL)"
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name == "java-view-consumer")' 2>/dev/null || true
+      exit 1
+    capture: wait_deps_recovered
+    timeout: 140
+
+assertions:
+  # IDIOM: equality lives INSIDE the jq filter so the interpolation yields a
+  # bare true/false; no '}' in interpolation bodies.
+
+  - expr: "${captured.critical_baseline} contains 'CRITICAL_BASELINE_OK=1'"
+    message: "the required charlie() view method must answer through the facade while its provider is up"
+  - expr: "${jq:captured.agents_baseline:(.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"__mesh_service_deps\") | .available == true and .unavailable_reason == null)} == 'true'"
+    message: "baseline: the synthetic __mesh_service_deps capability must exist and be available with no unavailable_reason while all providers are up"
+
+  # Guarantee 1: derived availability on the synthetic capability
+  - expr: "${captured.wait_deps_down} contains 'SERVICE_DEPS_UNAVAILABLE=1'"
+    message: "killing provider-charlie must flip __mesh_service_deps to available=false within the health-debounce deadline (the required view edge feeds #1249 derivation)"
+  - expr: "${jq:captured.agents_during_outage:(.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"__mesh_service_deps\") | .unavailable_reason // \"\" | contains(\"view-cap-charlie\"))} == 'true'"
+    message: "__mesh_service_deps' unavailable_reason must name the broken required edge (view-cap-charlie)"
+
+  # ...WHILE the consumer agent stays registered and healthy
+  - expr: "${jq:captured.agents_during_outage:([.agents[] | select(.name == \"java-view-consumer\")] | length == 1)} == 'true'"
+    message: "java-view-consumer must still be REGISTERED while its required view edge is broken"
+  - expr: "${jq:captured.agents_during_outage:(.agents[] | select(.name == \"java-view-consumer\") | .status == \"healthy\")} == 'true'"
+    message: "java-view-consumer must still be HEALTHY — unavailability is capability-level derived state"
+
+  # Guarantee 2: the capability remains the atom — real tool capabilities
+  # do not inherit the synthetic capability's required edge
+  - expr: "${jq:captured.agents_during_outage:(.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"view_critical\") | .available == true)} == 'true'"
+    message: "view_critical must STAY available in the registry — the required edge belongs to the declaring (synthetic) capability, and staying resolvable is what makes the error surface observable"
+
+  # Guarantee 3: the class-level-edge error surface (structural, NOT the
+  # #1273 envelope — see the header comment before expecting one)
+  - expr: "${captured.critical_error} contains 'CRITICAL_NOT_OK=1'"
+    message: "view_critical must stop answering ok once the required provider dies"
+  - expr: "${captured.critical_error} contains 'ERROR_NAMES_MISSING_EDGE=1'"
+    message: "the tool error must name the missing edge (view-cap-charlie or MeshToolUnavailableException) — a view is a class-level edge, so the facade raises through the wrapper's ordinary error path rather than the tool-slot pre-invoke envelope"
+
+  # Guarantee 4: organic recovery
+  - expr: "${captured.critical_recovery} contains 'CRITICAL_RECOVERED=1'"
+    message: "view_critical must answer ok again after provider-charlie restarts, with no consumer restart"
+  - expr: "${captured.wait_deps_recovered} contains 'SERVICE_DEPS_RECOVERED=1'"
+    message: "__mesh_service_deps must re-derive available=true after the provider returns"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc37_service_view_java/tc04_deps_accounting/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc04_deps_accounting/test.yaml
@@ -1,0 +1,98 @@
+# tc04_deps_accounting — registration-time dependency expansion (RFC #1280):
+# a 3-method @McpMeshService view registers as exactly THREE ordinary
+# dependency edges under the synthetic __mesh_service_deps tool, visible in
+# the registry's dependency accounting.
+#
+# Topology: ONLY the Java consumer — no providers on purpose. Dependency
+# expansion is a registration-time contract, and registering with all edges
+# unresolved also proves a view (even with a required edge) never blocks
+# agent startup/registration (soft-fail philosophy: required gates
+# availability, not boot).
+#
+# Design guarantees under test:
+#   1. total_dependencies == 3 for the consumer: ReportService's three
+#      methods expand 1:1 into DependencySpecs, and FlooredService's two
+#      bindings (same capabilities, same resolved type) DEDUPE onto them —
+#      5 method bindings across 2 views, 3 wire edges.
+#   2. The synthetic __mesh_service_deps capability is registered alongside
+#      the consumer's real tool capabilities (view_report, view_critical,
+#      view_floored).
+#   3. The consumer registers and reports healthy with ZERO providers up —
+#      including the required view-cap-charlie edge.
+#
+# Timing: registration wait is liveness-only (issue #1193); no view calls
+# are made, so no settle interaction. The /agents snapshot is polled only
+# for the consumer's appearance, never for dependency resolution.
+
+name: "Service views: 3-method view expands to 3 registry dependencies (Java)"
+description: "Consumer-only start: java-view-consumer registers healthy with total_dependencies=3 (cross-view dedupe) and the synthetic __mesh_service_deps capability"
+tags:
+  - integration
+  - java
+  - registry
+  - service-view
+  - rfc-1280
+  - slow
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: cp -rL /uc-artifacts/java-view-consumer /workspace/
+
+  - name: "Install Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-view-consumer
+    timeout: 600
+
+  - name: "Start java-view-consumer (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-consumer --env MCP_MESH_HTTP_PORT=9201 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193): 240s deadline covers the cold JVM start.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "java-view-consumer"
+
+  # Pure-JSON snapshot for the jq assertions.
+  - name: "Capture /agents snapshot"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_snapshot
+
+  # Human-readable corroboration (also lands in failure logs).
+  - name: "Capture meshctl list"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list --all 2>&1 || meshctl list 2>&1
+    capture: agent_list
+
+assertions:
+  # IDIOM: equality lives INSIDE the jq filter so the interpolation yields a
+  # bare true/false; no '}' in interpolation bodies.
+
+  # Guarantee 1: the expanded-and-deduped dependency count
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .total_dependencies == 3)} == 'true'"
+    message: "the consumer must register exactly 3 dependencies: ReportService's 3 methods expand 1:1 and FlooredService's 2 shared-capability bindings dedupe onto them"
+
+  # Guarantee 2: the synthetic dependency-carrier capability is registered
+  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"__mesh_service_deps\")] | length == 1)} == 'true'"
+    message: "the synthetic __mesh_service_deps capability must be registered exactly once"
+
+  # ...alongside the real tool capabilities
+  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"view_report\" or .name == \"view_critical\" or .name == \"view_floored\")] | length == 3)} == 'true'"
+    message: "the consumer's three real @MeshTool capabilities must register alongside the view expansion"
+
+  # Guarantee 3: providerless registration — a view never blocks boot
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .status == \"healthy\")} == 'true'"
+    message: "the consumer must register HEALTHY with zero providers up — view edges (even required=true) gate availability, never startup"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc37_service_view_java/tc05_min_available_floor/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc05_min_available_floor/test.yaml
@@ -1,0 +1,204 @@
+# tc05_min_available_floor — the minAvailable circuit breaker (RFC #1280):
+# below the floor, EVERY facade call fails — including a call to a method
+# whose own provider is perfectly healthy. That healthy-method failure is
+# the floor's entire point and cannot be shown by per-method soft-fail.
+#
+# Topology: provider-alpha + provider-bravo + the Java consumer.
+# provider-charlie is NOT started (FlooredService doesn't bind it; the
+# unresolved ReportService edges are irrelevant here and must not interfere
+# — floors are per-view). provider-bravo is the kill/restart target.
+#
+# Design guarantees under test:
+#   1. Baseline: FlooredService(minAvailable=2) with both providers up —
+#      alphaFloored() answers from provider-alpha.
+#   2. Kill provider-bravo -> 1/2 methods resolve, below floor=2: the
+#      view_floored tool call to alphaFloored() (alpha still UP) fails with
+#      MeshServiceUnavailableException carrying the exact accounting:
+#      service=FlooredService, available=1, total=2, minAvailable=2. The
+#      fixture catches ONLY that exception type — a raw
+#      MeshToolUnavailableException (or an alpha payload) would mean the
+#      floor did not gate the call.
+#   3. Restart provider-bravo -> the floor restores organically and
+#      alphaFloored() delegates again, with no consumer restart.
+#
+# Timing: transitions ride the default health debounce (~15-25s) plus one
+# consumer heartbeat — polled with deadlines. No dependency-resolution
+# waits (issue #1193): the first facade call performs the bounded settle
+# wait itself (floored views share the injected-proxy settle-grace path).
+
+name: "Service views: minAvailable=2 floor fails a HEALTHY method when a sibling edge dies (Java)"
+description: "Kill provider-bravo: alphaFloored() (provider up!) fails with MeshServiceUnavailableException 1/2 below minAvailable=2; restart: the floor restores and the method delegates again"
+tags:
+  - integration
+  - java
+  - python
+  - registry
+  - service-view
+  - rfc-1280
+  - availability
+  - slow
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/provider-alpha /workspace/
+      cp -rL /uc-artifacts/provider-bravo /workspace/
+      cp -rL /uc-artifacts/java-view-consumer /workspace/
+
+  - name: "Install provider-alpha deps"
+    handler: pip-install
+    path: /workspace/provider-alpha
+
+  - name: "Install provider-bravo deps"
+    handler: pip-install
+    path: /workspace/provider-bravo
+
+  - name: "Install Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-view-consumer
+    timeout: 600
+
+  - name: "Start provider-alpha (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-alpha/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Start provider-bravo (port 9102)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-bravo/main.py --env MCP_MESH_HTTP_PORT=9102 -d
+
+  - name: "Start java-view-consumer (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-consumer --env MCP_MESH_HTTP_PORT=9201 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193): 240s deadline covers the cold JVM start.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "provider-alpha provider-bravo java-view-consumer"
+
+  # Baseline: floor satisfied (2/2), alphaFloored() delegates.
+  # ENVELOPE: Java tools carry the payload ONLY as an escaped JSON string in
+  # content[0].text (no structuredContent) — parse via
+  # `.content[0].text | fromjson` (suite idiom), equality inside the jq
+  # filter; keeps working if structuredContent is added later.
+  - name: "Wait for view_floored baseline ok"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 90); do
+        RESP=$(meshctl call view_floored '{}' --raw 2>&1 || true)
+        BOUND=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .floored_agent == "provider-alpha"' 2>/dev/null || echo "")
+        if [ "$BOUND" = "true" ]; then
+          echo "FLOOR_BASELINE_OK=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: view_floored never answered from provider-alpha within 180s"
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: floor_baseline
+    timeout: 200
+
+  - name: "Kill provider-bravo"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop provider-bravo
+    capture: kill_bravo
+
+  # Below floor: the ALPHA call must fail even though provider-alpha is up.
+  # The verdict markers pin the exact floor arithmetic from the typed
+  # exception's getters (1 available, 2 total, floor 2) — parsed from the
+  # Java envelope via fromjson with equality inside the jq filter, so the
+  # integer checks are exact (no substring false-positives).
+  - name: "Wait for the floor to breach on a healthy method"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 60); do
+        RESP=$(meshctl call view_floored '{}' --raw 2>&1 || true)
+        BREACHED=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .floor_error == "MeshServiceUnavailableException"' 2>/dev/null || echo "")
+        if [ "$BREACHED" = "true" ]; then
+          echo "FLOOR_BREACHED=1 after ~$((i*2))s"
+          [ "$(echo "$RESP" | jq -r '.content[0].text | fromjson | .floor_service == "FlooredService"' 2>/dev/null)" = "true" ] && echo "FLOOR_SERVICE_OK=1"
+          [ "$(echo "$RESP" | jq -r '.content[0].text | fromjson | .floor_available == 1' 2>/dev/null)" = "true" ] && echo "FLOOR_AVAILABLE_1=1"
+          [ "$(echo "$RESP" | jq -r '.content[0].text | fromjson | .floor_total == 2' 2>/dev/null)" = "true" ] && echo "FLOOR_TOTAL_2=1"
+          [ "$(echo "$RESP" | jq -r '.content[0].text | fromjson | .floor_min == 2' 2>/dev/null)" = "true" ] && echo "FLOOR_MIN_2=1"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: floor_error never appeared within 120s of killing provider-bravo"
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: floor_breached
+    timeout: 140
+
+  - name: "Restart provider-bravo"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-bravo/main.py --env MCP_MESH_HTTP_PORT=9102 -d
+
+  # Floor restores organically: alphaFloored() delegates again.
+  - name: "Wait for the floor to restore"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 75); do
+        RESP=$(meshctl call view_floored '{}' --raw 2>&1 || true)
+        RESTORED=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .floored_agent == "provider-alpha"' 2>/dev/null || echo "")
+        if [ "$RESTORED" = "true" ]; then
+          echo "FLOOR_RESTORED=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: view_floored never recovered within 150s of restarting provider-bravo"
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: floor_restored
+    timeout: 170
+
+assertions:
+  - expr: "${captured.floor_baseline} contains 'FLOOR_BASELINE_OK=1'"
+    message: "with both providers up (2/2 >= floor 2) alphaFloored() must delegate to provider-alpha"
+
+  # Guarantee 2: the healthy-method floor failure with exact accounting
+  - expr: "${captured.floor_breached} contains 'FLOOR_BREACHED=1'"
+    message: "below the floor, alphaFloored() must fail with MeshServiceUnavailableException even though provider-alpha is UP — a floored view is all-or-nothing"
+  - expr: "${captured.floor_breached} contains 'FLOOR_SERVICE_OK=1'"
+    message: "the floor exception must name the view interface (FlooredService)"
+  - expr: "${captured.floor_breached} contains 'FLOOR_AVAILABLE_1=1'"
+    message: "the floor exception must count exactly 1 available method"
+  - expr: "${captured.floor_breached} contains 'FLOOR_TOTAL_2=1'"
+    message: "the floor exception must count exactly 2 total methods"
+  - expr: "${captured.floor_breached} contains 'FLOOR_MIN_2=1'"
+    message: "the floor exception must carry the declared minAvailable=2"
+  - expr: "${captured.floor_breached} not contains 'floored_agent'"
+    message: "no delegation may happen while below floor — a floored_agent payload means the breaker did not trip"
+
+  # Guarantee 3: organic restore
+  - expr: "${captured.floor_restored} contains 'FLOOR_RESTORED=1'"
+    message: "the floor must restore after provider-bravo returns, with no consumer restart"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Phase 1 of RFC #1280 — the Java bean-path consumer facade. A service view is a consumer-owned typed aggregation of ordinary capability dependencies: an interface annotated `@McpMeshService` whose abstract methods each bind one capability via method-level `@Selector`. Each method delegates to its own per-capability resolved proxy, so **methods of one view may resolve to different provider agents** and rebind dynamically. The group is a typed view; the capability remains the atom — zero wire/registry changes.

- **SDK**: `@McpMeshService` (opt-in `minAvailable` floor), `@Selector` gains `METHOD` target (nested usage unchanged), `MeshServiceUnavailableException`.
- **Starter**: `McpMeshServiceRegistrar` — Spring-Data-style interface scan, one dynamic-proxy facade bean per view, boot-fail validation (missing/blank `@Selector`, scalar single params, mixed params, conflicting resolved types across views AND other consumer sources, unsatisfiable floor, unsupported future/stream types, `@McpMeshService` on a class); `McpMeshServiceInvocationHandler` — POJO/`@Param` param mapping, `T`/`CompletableFuture<T>`/`Flow.Publisher<String>` returns, settle-grace-aware floor, `invokeDefault` default-method dispatch, super-interface-reference resolution.
- **Registration**: view methods expand (sorted by name — deterministic) into `DependencySpec`s under synthetic `__mesh_service_deps`, through the existing cross-source required-wins dedupe; self-produced capabilities soft-fail with WARN + settle release; view capabilities are declared settle keys (same grace as `@MeshDependsOn`).
- **Example**: `examples/java/service-view/` — three single-capability providers + one view consumer showing per-method multi-agent resolution and graceful degradation.
- **Integration**: `uc37_service_view_java`, 5 TCs — per-method multi-agent resolution (anchored pairing), surgical dynamic rebinding, required-view-edge lifecycle, DEPS accounting, exact `minAvailable` floor arithmetic. Validated 5/5 on k8s against `tsuite-mesh:local`.
- **Docs**: service-views section + required-semantics admonition in the Java DI man page and mkdocs page; `@McpMeshService` section in the Java decorators/annotations pages.

## Review Notes

- Two independent zero-context review rounds ran; all HIGH/MED findings fixed (scalar-param boot-fail, settle-aware floor, bridge/synthetic + `ResolvableType` generic resolution, scanner annotation guard, cross-source type-conflict boot-fail, diamond-dedupe determinism, super-interface dispatch fallback).
- `required=true` on a view method behaves exactly like a class-level `@MeshDependsOn` required dep (registry carrier availability, required-wins, route-perimeter promotion) — it does NOT add the tool-boundary pre-invoke refusal, since the framework cannot know which tools call a class-level aggregation; documented on both doc surfaces.
- Filed separately during validation: #1282 (Java `tools/call` responses omit `structuredContent` — pre-existing cross-runtime envelope divergence, untouched here; the new TCs assert via the portable `content[0].text | fromjson` idiom).

## Test plan

- [x] Java starter suite 597/597, SDK 98/98 (unit + Spring context integration)
- [x] src-tests 12/12 (builds `tsuite-mesh:local`)
- [x] `tsuite run --suite-path tests/integration --uc uc37_service_view_java` — 5/5 on k8s
- [x] Example modules compile (`mvn package` all four)
- [x] `go build ./src/core/cli/...` (embedded man content) + mkdocs strict (only pre-existing git-log warning)

Closes #1283

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced `@McpMeshService`-based Java service views, enabling typed facades with per-method capability routing and a `minAvailable` availability floor (fail-fast with `MeshServiceUnavailableException` when breached).
  * Added support for method-level `@Selector` bindings and `@McpMeshService` discovery/registration in Spring.
* **Documentation**
  * Updated Java annotation and dependency-injection docs with service-view semantics and examples.
  * Added end-to-end Java service-view example(s) including caption/thumbnail/transcribe providers and a media gateway, with local run and deployment guidance.
* **Tests**
  * Added/expanded integration and failure-case coverage for routing, rebinding, required behavior, and floor enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->