### PR TITLE
feat(java): @McpMeshService view as a @MeshTool parameter (RFC #1280 phase 2)

### DIFF
--- a/docs/java/annotations.md
+++ b/docs/java/annotations.md
@@ -148,7 +148,13 @@ public interface MediaService {
 | -------------- | -------- | -------------------------------------------------------------------------- |
 | `minAvailable` | No       | Availability floor; below it every facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (default `0` = no floor) |
 
-Each method expands into an ordinary dependency edge, so a view over N capabilities shows as N dependencies in `meshctl list`. For the full semantics — param-mapping rules, return types, `required`/optional behavior, and the availability floor — see the [Dependency Injection](dependency-injection.md#service-views-with-mcpmeshservice) guide.
+Each method expands into an ordinary dependency edge, so a view over N capabilities shows as N dependencies in `meshctl list`. A view is consumed two ways: `@Autowired` as a facade bean, or passed as a `@MeshTool` **parameter** — where its methods become dependency edges on that tool and any `required` view method joins the tool's pre-invoke `dependency_unavailable` guard:
+
+```java
+public Result process(@Param("id") String id, MediaService media) { ... }  // view param → per-method edges
+```
+
+For the full semantics — param-mapping rules, return types, `required`/optional behavior, the availability floor, and both consumption styles — see the [Dependency Injection](dependency-injection.md#service-views-with-mcpmeshservice) guide.
 
 ## @MeshLlm
 

--- a/docs/java/dependency-injection.md
+++ b/docs/java/dependency-injection.md
@@ -215,12 +215,29 @@ public class MediaGatewayApplication {
 - Parameters follow the `@MeshTool` convention: **0 params** → no-arg call; **exactly 1 unannotated POJO/record param** → that object becomes the params (scalars still need `@Param`); **2+ params** → each needs `@Param("name")`.
 - Return `T` (synchronous), `CompletableFuture<T>` (async), or `java.util.concurrent.Flow.Publisher<String>` (streaming).
 
+### Views as tool parameters
+
+A view can also be consumed as a `@MeshTool` method **parameter** instead of an autowired bean. The view's methods then become dependency edges **on that tool** — declared after the tool's explicit `@Selector` deps, name-sorted per view, and in parameter order when a method takes several views — so the tool's dep count in `meshctl list` includes them. A view parameter must **not** carry `@Param`.
+
+```java
+@MeshTool(capability = "process_media",
+          dependencies = @Selector(capability = "audit_log"))
+public Result processMedia(
+        @Param(value = "assetId", description = "Asset id") String assetId,
+        McpMeshTool<String> auditLog,
+        MediaService media) {   // view param → media_caption + media_thumbnail + media_transcribe edges
+    ...
+}
+```
+
+The same interface can be used both ways at once — autowired as a bean **and** passed as a tool parameter. The two consumption styles resolve independently (each dependency event feeds both the tool's wrapper slot and the shared bean facade), but shared capabilities register as a **single** wire edge: the tool-declared edge wins, and the bean path's synthetic carrier only registers capabilities not already declared elsewhere — so `meshctl list` shows N edges, not 2N. `minAvailable` still applies at the facade. Crucially, a `required = true` view method now participates in **that tool's** pre-invoke guard: if the edge is unresolved the tool returns the structured `dependency_unavailable` refusal before the handler runs, on both the direct and claim paths — exactly like a tool-declared `@Selector` dependency.
+
 ### Required, optional, and the availability floor
 
 `required = true` on a view method behaves like a class-level `@MeshDependsOn` required dependency (see [Required Dependencies](#required-dependencies) below): it participates in cross-source required-wins dedupe, flips the registry-side availability of that capability's carrier when unresolved (visible in `meshctl list` and the registry API), and promotes any matching route-perimeter 503 guard. An optional method whose provider is down throws `MeshToolUnavailableException` on **that call only**; catch it for graceful degradation while the rest of the view keeps working.
 
-!!! note "One difference from a tool-declared slot"
-    A view is class-level, so the framework cannot know which `@MeshTool` methods call it and does **not** add a pre-invoke structured `dependency_unavailable` refusal to those tools — a call to a required-but-unresolved view method simply throws `MeshToolUnavailableException`, surfacing as an ordinary tool error. If a specific `@MeshTool` needs the pre-invoke structured refusal for a capability, declare it as a `@MeshTool` dependency slot (`dependencies = @Selector(...)`) instead; tool-declared slots get the guard, views do not.
+!!! note "One difference when injected as a bean"
+    An autowired view facade is class-level, so the framework cannot know which `@MeshTool` methods call it and does **not** add a pre-invoke structured `dependency_unavailable` refusal to those tools — a call to a required-but-unresolved view method simply throws `MeshToolUnavailableException`, surfacing as an ordinary tool error. To get the pre-invoke structured refusal for a capability, either declare it as a `@MeshTool` dependency slot (`dependencies = @Selector(...)`), or pass the view as a `@MeshTool` parameter (see [Views as tool parameters](#views-as-tool-parameters) above) — the view's edges become tool-declared and its `required` methods join that tool's guard.
 
 The optional `@McpMeshService(minAvailable = N)` adds a consumer-local availability floor: when fewer than `N` of the view's methods currently resolve, **every** facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (settle-grace-aware). The default `0` means no floor — each method soft- or hard-fails per its own `required` flag.
 

--- a/examples/java/service-view/README.md
+++ b/examples/java/service-view/README.md
@@ -16,7 +16,7 @@ changes. The group is a typed view; the capability remains the atom.
 | `caption-provider`    | 8110 | `media_caption`    | Provider A — captions an asset         |
 | `thumbnail-provider`  | 8111 | `media_thumbnail`  | Provider B — thumbnails an asset       |
 | `transcribe-provider` | 8112 | `media_transcribe` | Provider C — transcribes an asset      |
-| `media-gateway`       | 8113 | `process_media`    | Consumer — one `MediaService` view     |
+| `media-gateway`       | 8113 | `process_media`, `process_media_strict` | Consumer — one `MediaService` view, consumed two ways |
 
 The consumer declares one interface aggregating all three capabilities:
 
@@ -46,6 +46,48 @@ calls the methods directly — no manual proxy wiring. `caption` is `required`;
   `MeshToolUnavailableException` when their provider is absent; the gateway
   catches it and substitutes a fallback, exactly as the feature intends. The
   `required` `caption` edge is expected to always resolve.
+
+## Two ways to consume a service view
+
+The gateway exposes the SAME fan-out logic through two tools, one per
+consumption style:
+
+| Tool                    | View injected as        | Scope        | Missing REQUIRED `caption` provider                                                   | View edges in `meshctl list` |
+|-------------------------|-------------------------|--------------|--------------------------------------------------------------------------------------|------------------------------|
+| `process_media`         | constructor bean (phase 1) | app-wide  | handler runs, then the `caption(...)` call throws `MeshToolUnavailableException`      | none of its own (deduped)    |
+| `process_media_strict`  | `@MeshTool` parameter (phase 2) | tool-scoped | tool returns the structured `dependency_unavailable` refusal **before** the handler runs | yes — 3 edges on this tool   |
+
+> Both tools share the SAME `MediaService` interface, so the three capabilities
+> register **once**, not twice. The bean path's synthetic carrier dedupes against
+> `process_media_strict`'s tool-declared edges (the tool-declared edge wins), so
+> `meshctl list` shows three view edges total — on `process_media_strict` — not
+> six. Had no tool consumed the view, the bean path would register those three on
+> its own synthetic carrier instead.
+
+```java
+// Phase 1 — bean: app-wide facade, no tool-boundary refusal
+@MeshTool(capability = "process_media")
+public Map<String, Object> processMedia(@Param("assetId") String assetId,
+                                        @Param("text") String text) {
+    return combine(this.media, assetId, text);        // this.media is @Autowired
+}
+
+// Phase 2 — tool parameter: view methods become dependency edges ON THIS TOOL,
+// positionally after any explicit @Selector deps; required edges gate the tool.
+@MeshTool(capability = "process_media_strict")
+public Map<String, Object> processStrict(@Param("assetId") String assetId,
+                                         @Param("text") String text,
+                                         MediaService media) {   // NOT @Param
+    return combine(media, assetId, text);
+}
+```
+
+Because `caption` is `required = true`, the tool-parameter form gets a
+tool-boundary pre-invoke guard: the mesh refuses the call with a structured
+error the instant the caption edge is unresolved, so the handler body never runs
+with a missing required dependency. The bean form has no such boundary — the
+view is app-wide and a missing required capability only surfaces as an exception
+mid-handler.
 
 ## Method rules (recap)
 
@@ -78,10 +120,12 @@ meshctl start examples/java/service-view/transcribe-provider
 meshctl start examples/java/service-view/media-gateway
 ```
 
-Once all four are healthy, call the gateway's entry-point tool:
+Once all four are healthy, call either entry-point tool — both fan out across
+all three providers and return the same shape:
 
 ```bash
-meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+meshctl call process_media        '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+meshctl call process_media_strict '{"assetId": "asset-1", "text": "a cat on a sofa"}'
 ```
 
 Expected output — one interface, three different serving agents:
@@ -95,15 +139,22 @@ Expected output — one interface, three different serving agents:
 }
 ```
 
-### See graceful degradation
+`process_media_strict` also lists the three view edges as its own dependencies:
 
-Stop one optional provider and call again — only that method degrades. Allow a
-few seconds for the consumer's next heartbeat to rebind before the degraded
-call; an immediate call can still hit the old provider proxy and succeed:
+```bash
+meshctl list   # media-gateway's process_media_strict shows media_caption, media_thumbnail, media_transcribe
+```
+
+### See graceful degradation (optional edge)
+
+Stop one OPTIONAL provider and call again — only that method degrades, in BOTH
+tools. Allow a few seconds for the consumer's next heartbeat to rebind before
+the degraded call; an immediate call can still hit the old provider proxy and
+succeed:
 
 ```bash
 meshctl stop transcribe-provider
-meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+meshctl call process_media_strict '{"assetId": "asset-1", "text": "a cat on a sofa"}'
 ```
 
 ```json
@@ -117,6 +168,41 @@ meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
 
 The `caption` and `thumbnail` methods still resolve to their own agents — proof
 that each view method is an independent dependency edge.
+
+### See the tool-boundary refusal (required edge)
+
+Now stop the REQUIRED `caption-provider` and contrast the two consumption
+styles:
+
+```bash
+meshctl stop caption-provider
+
+# Phase 2 — tool parameter: refused BEFORE the handler runs, with a structured error
+meshctl call process_media_strict '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+```
+
+The call comes back as an MCP error result — `isError: true`, with the structured
+refusal as JSON escaped inside `content[0].text`:
+
+```json
+{
+  "content": [
+    { "type": "text", "text": "{\"error\": \"dependency_unavailable\", \"capability\": \"media_caption\"}" }
+  ],
+  "isError": true
+}
+```
+
+```bash
+# Phase 1 — bean: no tool-boundary gate; the handler runs and the required
+# caption call throws MeshToolUnavailableException, surfacing as a plain tool error
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+```
+
+Only the tool-parameter form (`process_media_strict`) turns a missing REQUIRED
+view method into a clean, structured pre-invoke refusal — the phase-2 payoff.
+Restart `caption-provider` (and `transcribe-provider`) to return to the healthy
+output above.
 
 Each agent directory also ships the full scaffolded file set (`Dockerfile`,
 `helm-values.yaml`, etc.) for Docker/Kubernetes deployment — see

--- a/examples/java/service-view/media-gateway/README.md
+++ b/examples/java/service-view/media-gateway/README.md
@@ -2,8 +2,15 @@
 
 The consumer in the [`@McpMeshService` service-view example](../README.md).
 Declares one typed `MediaService` interface aggregating three capabilities and
-exposes a `process_media` tool that fans a request out across all three view
-methods — each served by a different provider agent.
+exposes two tools that fan a request out across all three view methods — each
+served by a different provider agent — demonstrating BOTH consumption styles:
+
+- `process_media` — the view is a constructor-injected Spring bean (phase 1).
+- `process_media_strict` — the view is a `@MeshTool` method parameter (phase 2),
+  so its methods become dependency edges on that tool and the `required`
+  `caption` edge gates the tool with the structured `dependency_unavailable`
+  refusal. See the [top-level README](../README.md) for the side-by-side
+  contrast and demo commands.
 
 ## Overview
 
@@ -48,7 +55,8 @@ meshctl start examples/java/service-view/media-gateway
 The agent will start on port 8113 by default. Then:
 
 ```bash
-meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+meshctl call process_media        '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+meshctl call process_media_strict '{"assetId": "asset-1", "text": "a cat on a sofa"}'
 ```
 
 ## Project Structure

--- a/examples/java/service-view/media-gateway/src/main/java/com/example/mediagateway/MediaGatewayApplication.java
+++ b/examples/java/service-view/media-gateway/src/main/java/com/example/mediagateway/MediaGatewayApplication.java
@@ -15,16 +15,24 @@ import java.util.Map;
 /**
  * MediaGateway - the consumer in the {@code @McpMeshService} service-view demo.
  *
- * <p>Autowires the {@link MediaService} facade and exposes a single
- * {@code process_media} tool that fans one request out across all three view
- * methods. Because each method binds its own capability, the returned
- * {@code servedBy} fields show THREE different provider agents answering through
- * ONE typed interface.
+ * <p>Demonstrates BOTH ways to consume a service view, side by side, over the
+ * same {@link #combine} fan-out logic:
  *
- * <p>The optional {@code thumbnail}/{@code transcribe} methods are wrapped in a
- * {@link MeshToolUnavailableException} catch so the gateway keeps working (with
- * a degraded fallback) whenever those providers are down — while the REQUIRED
- * {@code caption} method is expected to always resolve.
+ * <ul>
+ *   <li>{@code process_media} — the view is a constructor-injected Spring bean
+ *       (phase 1). App-wide facade; there is no tool-boundary refusal, so a
+ *       missing REQUIRED capability surfaces as a
+ *       {@link MeshToolUnavailableException} thrown from the call.</li>
+ *   <li>{@code process_media_strict} — the view is a {@code @MeshTool} METHOD
+ *       PARAMETER (phase 2). Each view method becomes a dependency edge ON THAT
+ *       TOOL, so the REQUIRED {@code caption} edge gates the tool with the
+ *       structured {@code dependency_unavailable} refusal BEFORE the handler
+ *       runs, and the edges show up in the tool's dependency count.</li>
+ * </ul>
+ *
+ * <p>Either way the optional {@code thumbnail}/{@code transcribe} methods are
+ * wrapped in a {@link MeshToolUnavailableException} catch so the gateway keeps
+ * working (with a degraded fallback) whenever those providers are down.
  */
 @MeshAgent(
     name = "media-gateway",
@@ -49,8 +57,11 @@ public class MediaGatewayApplication {
     }
 
     /**
-     * Process one media asset through all three view methods and combine the
-     * results. Each capability may be served by a different provider agent.
+     * Phase-1 style: consume the view via the constructor-injected bean.
+     *
+     * <p>App-wide facade with no tool-boundary refusal — if {@code caption} has
+     * no provider, the {@code media.caption(...)} call throws
+     * {@link MeshToolUnavailableException}, which propagates out as a tool error.
      *
      * @param assetId the media asset identifier
      * @param text    source description / audio text
@@ -58,19 +69,58 @@ public class MediaGatewayApplication {
      */
     @MeshTool(
         capability = "process_media",
-        description = "Runs an asset through caption, thumbnail and transcribe via one service view",
+        description = "Runs an asset through one service view injected as a bean",
         tags = {"media", "gateway"}
     )
     public Map<String, Object> processMedia(
         @Param(value = "assetId", description = "Media asset identifier") String assetId,
         @Param(value = "text", description = "Source description / audio text") String text
     ) {
-        log.info("Processing media asset '{}' through the MediaService view", assetId);
+        log.info("process_media: asset '{}' via constructor-injected view bean", assetId);
+        return combine(this.media, assetId, text);
+    }
 
+    /**
+     * Phase-2 style: consume the view via a {@code @MeshTool} METHOD PARAMETER.
+     *
+     * <p>The {@code MediaService} parameter (NOT {@code @Param}-annotated) expands
+     * into three dependency edges on THIS tool. Because {@code caption} is
+     * {@code required=true}, the mesh runtime returns the structured
+     * {@code {"error":"dependency_unavailable","capability":"media_caption"}}
+     * refusal BEFORE this method body runs whenever the caption edge is
+     * unresolved — so here {@code caption} is guaranteed present, while the
+     * optional edges still degrade gracefully.
+     *
+     * @param assetId the media asset identifier
+     * @param text    source description / audio text
+     * @param media   the service-view facade, injected as a tool dependency
+     * @return a combined map showing the value and serving provider per capability
+     */
+    @MeshTool(
+        capability = "process_media_strict",
+        description = "Runs an asset through one service view injected as a tool parameter",
+        tags = {"media", "gateway"}
+    )
+    public Map<String, Object> processStrict(
+        @Param(value = "assetId", description = "Media asset identifier") String assetId,
+        @Param(value = "text", description = "Source description / audio text") String text,
+        MediaService media
+    ) {
+        log.info("process_media_strict: asset '{}' via tool-parameter view", assetId);
+        return combine(media, assetId, text);
+    }
+
+    /**
+     * Shared fan-out: run one asset through all three view methods and combine
+     * the results. Each capability may be served by a different provider agent;
+     * the two optional methods degrade gracefully when their provider is absent.
+     */
+    private static Map<String, Object> combine(MediaService media, String assetId, String text) {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("assetId", assetId);
 
-        // REQUIRED edge — expected to resolve; a failure surfaces to the caller.
+        // REQUIRED edge — in the tool-parameter path a missing provider is
+        // refused before we get here; in the bean path it throws.
         MediaService.CaptionResult caption = media.caption(new MediaService.CaptionRequest(assetId, text));
         result.put("caption", entry(caption.caption(), caption.provider()));
 

--- a/src/core/cli/man/content/decorators_java.md
+++ b/src/core/cli/man/content/decorators_java.md
@@ -200,7 +200,13 @@ public interface MediaService {
 | -------------- | -------- | -------------------------------------------------------------------------- |
 | `minAvailable` | No       | Availability floor; below it every facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (default `0` = no floor) |
 
-Each method expands into an ordinary dependency edge, so a view over N capabilities shows as N dependencies in `meshctl list`. For the full semantics — param-mapping rules, return types, `required`/optional behavior, and the availability floor — see `meshctl man dependency-injection --java`.
+Each method expands into an ordinary dependency edge, so a view over N capabilities shows as N dependencies in `meshctl list`. A view is consumed two ways: `@Autowired` as a facade bean, or passed as a `@MeshTool` **parameter** — where its methods become dependency edges on that tool and any `required` view method joins the tool's pre-invoke `dependency_unavailable` guard:
+
+```java
+public Result process(@Param("id") String id, MediaService media) { ... }  // view param → per-method edges
+```
+
+For the full semantics — param-mapping rules, return types, `required`/optional behavior, the availability floor, and both consumption styles — see `meshctl man dependency-injection --java`.
 
 ## @MeshLlm
 

--- a/src/core/cli/man/content/dependency-injection_java.md
+++ b/src/core/cli/man/content/dependency-injection_java.md
@@ -262,11 +262,28 @@ public class MediaGatewayApplication {
 - Parameters follow the `@MeshTool` convention: **0 params** → no-arg call; **exactly 1 unannotated POJO/record param** → that object becomes the params (scalars still need `@Param`); **2+ params** → each needs `@Param("name")`.
 - Return `T` (synchronous), `CompletableFuture<T>` (async), or `java.util.concurrent.Flow.Publisher<String>` (streaming).
 
+### Views as tool parameters
+
+A view can also be consumed as a `@MeshTool` method **parameter** instead of an autowired bean. The view's methods then become dependency edges **on that tool** — declared after the tool's explicit `@Selector` deps, name-sorted per view, and in parameter order when a method takes several views — so the tool's dep count in `meshctl list` includes them. A view parameter must **not** carry `@Param`.
+
+```java
+@MeshTool(capability = "process_media",
+          dependencies = @Selector(capability = "audit_log"))
+public Result processMedia(
+        @Param(value = "assetId", description = "Asset id") String assetId,
+        McpMeshTool<String> auditLog,
+        MediaService media) {   // view param → media_caption + media_thumbnail + media_transcribe edges
+    ...
+}
+```
+
+The same interface can be used both ways at once — autowired as a bean **and** passed as a tool parameter. The two consumption styles resolve independently (each dependency event feeds both the tool's wrapper slot and the shared bean facade), but shared capabilities register as a **single** wire edge: the tool-declared edge wins, and the bean path's synthetic carrier only registers capabilities not already declared elsewhere — so `meshctl list` shows N edges, not 2N. `minAvailable` still applies at the facade. Crucially, a `required = true` view method now participates in **that tool's** pre-invoke guard: if the edge is unresolved the tool returns the structured `dependency_unavailable` refusal before the handler runs, on both the direct and claim paths — exactly like a tool-declared `@Selector` dependency.
+
 ### Required, optional, and the availability floor
 
 `required = true` on a view method behaves like a class-level `@MeshDependsOn` required dependency (see [Required Dependencies](#required-dependencies) below): it participates in cross-source required-wins dedupe, flips the registry-side availability of that capability's carrier when unresolved (visible in `meshctl list` and the registry API), and promotes any matching route-perimeter 503 guard. An optional method whose provider is down throws `MeshToolUnavailableException` on **that call only**; catch it for graceful degradation while the rest of the view keeps working.
 
-> **One difference from a tool-declared slot.** A view is class-level, so the framework cannot know which `@MeshTool` methods call it and does **not** add a pre-invoke structured `dependency_unavailable` refusal to those tools — a call to a required-but-unresolved view method simply throws `MeshToolUnavailableException`, surfacing as an ordinary tool error. If a specific `@MeshTool` needs the pre-invoke structured refusal for a capability, declare it as a `@MeshTool` dependency slot (`dependencies = @Selector(...)`) instead; tool-declared slots get the guard, views do not.
+> **One difference when injected as a bean.** An autowired view facade is class-level, so the framework cannot know which `@MeshTool` methods call it and does **not** add a pre-invoke structured `dependency_unavailable` refusal to those tools — a call to a required-but-unresolved view method simply throws `MeshToolUnavailableException`, surfacing as an ordinary tool error. To get the pre-invoke structured refusal for a capability, either declare it as a `@MeshTool` dependency slot (`dependencies = @Selector(...)`), or pass the view as a `@MeshTool` parameter (see [Views as tool parameters](#views-as-tool-parameters) above) — the view's edges become tool-declared and its `required` methods join that tool's guard.
 
 The optional `@McpMeshService(minAvailable = N)` adds a consumer-local availability floor: when fewer than `N` of the view's methods currently resolve, **every** facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (settle-grace-aware). The default `0` means no floor — each method soft- or hard-fails per its own `required` flag.
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/InjectorViewProxyBinding.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/InjectorViewProxyBinding.java
@@ -1,0 +1,50 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.types.McpMeshTool;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * RFC #1280 phase-1 (bean path) proxy strategy for
+ * {@link McpMeshServiceInvocationHandler}: each view method resolves to
+ * {@link MeshDependencyInjector}'s SHARED per-capability proxy. The proxy is
+ * stable (the injector mutates its endpoint in place on rebind), so it is cached
+ * per method. Settle waits key on the capability name — the same key space the
+ * injector's {@code updateToolDependency.markResolved} counts down.
+ */
+class InjectorViewProxyBinding implements McpMeshServiceInvocationHandler.ViewProxyBinding {
+
+    private final ConfigurableListableBeanFactory beanFactory;
+    private final AtomicReference<MeshDependencyInjector> injectorRef;
+    private final Map<Method, McpMeshTool<?>> proxyCache = new ConcurrentHashMap<>();
+
+    InjectorViewProxyBinding(ConfigurableListableBeanFactory beanFactory,
+                             AtomicReference<MeshDependencyInjector> injectorRef) {
+        this.beanFactory = beanFactory;
+        this.injectorRef = injectorRef;
+    }
+
+    @Override
+    public McpMeshTool<?> proxyFor(McpMeshServiceRegistrar.ServiceMethodBinding binding) {
+        return proxyCache.computeIfAbsent(binding.method(), m ->
+            injector().getToolProxy(binding.capability(), binding.resolvedProxyType()));
+    }
+
+    @Override
+    public String settleKey(McpMeshServiceRegistrar.ServiceMethodBinding binding) {
+        return binding.capability();
+    }
+
+    private MeshDependencyInjector injector() {
+        MeshDependencyInjector injector = injectorRef.get();
+        if (injector == null) {
+            injector = beanFactory.getBean(MeshDependencyInjector.class);
+            injectorRef.compareAndSet(null, injector);
+        }
+        return injector;
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceInvocationHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceInvocationHandler.java
@@ -4,7 +4,6 @@ import io.mcpmesh.types.McpMeshTool;
 import io.mcpmesh.types.MeshServiceUnavailableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 
@@ -43,15 +42,33 @@ class McpMeshServiceInvocationHandler implements InvocationHandler {
 
     private static final Logger log = LoggerFactory.getLogger(McpMeshServiceInvocationHandler.class);
 
+    /**
+     * Pluggable per-method proxy + settle-key lookup — the ONLY difference
+     * between the two facade paths (RFC #1280 phase 1 vs phase 2). Floor / param
+     * / return / dispatch logic is shared.
+     *
+     * <ul>
+     *   <li><b>Bean path (phase 1):</b> injector-backed — {@code proxyFor} returns
+     *       {@link MeshDependencyInjector}'s shared per-capability proxy;
+     *       {@code settleKey} is the capability name.</li>
+     *   <li><b>Tool-param path (phase 2):</b> wrapper-slot-backed — {@code proxyFor}
+     *       reads the {@link MeshToolWrapper}'s per-method slot proxy;
+     *       {@code settleKey} is the {@code funcId:dep_N} composite key.</li>
+     * </ul>
+     */
+    interface ViewProxyBinding {
+        /** Non-null proxy for the binding's method (unresolved → an unavailable sentinel). */
+        McpMeshTool<?> proxyFor(McpMeshServiceRegistrar.ServiceMethodBinding binding);
+
+        /** Settle-wait key for the binding's capability (capability name or funcId:dep_N). */
+        String settleKey(McpMeshServiceRegistrar.ServiceMethodBinding binding);
+    }
+
     private final String serviceName;
     private final int minAvailable;
     private final Map<Method, McpMeshServiceRegistrar.ServiceMethodBinding> bindings;
-    private final ConfigurableListableBeanFactory beanFactory;
-    private final AtomicReference<MeshDependencyInjector> injectorRef;
+    private final ViewProxyBinding proxyBinding;
     private final ObjectMapper objectMapper;
-
-    /** Per-method resolved proxy cache — the proxy reference is stable. */
-    private final Map<Method, McpMeshTool<?>> proxyCache = new ConcurrentHashMap<>();
 
     /**
      * Cache for the binding lookup of a Method that isn't an exact key in
@@ -74,13 +91,11 @@ class McpMeshServiceInvocationHandler implements InvocationHandler {
             Class<?> iface,
             int minAvailable,
             List<McpMeshServiceRegistrar.ServiceMethodBinding> bindingList,
-            ConfigurableListableBeanFactory beanFactory,
-            AtomicReference<MeshDependencyInjector> injectorRef,
+            ViewProxyBinding proxyBinding,
             ObjectMapper objectMapper) {
         this.serviceName = iface.getSimpleName();
         this.minAvailable = minAvailable;
-        this.beanFactory = beanFactory;
-        this.injectorRef = injectorRef;
+        this.proxyBinding = proxyBinding;
         this.objectMapper = objectMapper;
         Map<Method, McpMeshServiceRegistrar.ServiceMethodBinding> map = new LinkedHashMap<>();
         for (McpMeshServiceRegistrar.ServiceMethodBinding b : bindingList) {
@@ -192,7 +207,10 @@ class McpMeshServiceInvocationHandler implements InvocationHandler {
             }
             McpMeshTool<?> proxy = proxyFor(b);
             if (!proxy.isAvailable() && !settled) {
-                settle.awaitDependency(b.capability(), b.capability());
+                settle.awaitDependency(proxyBinding.settleKey(b), b.capability());
+                // The wrapper-slot path replaces the slot with a NEW proxy on
+                // resolution (the injector path mutates in place), so re-read.
+                proxy = proxyFor(b);
             }
             if (proxy.isAvailable()) {
                 available++;
@@ -228,19 +246,9 @@ class McpMeshServiceInvocationHandler implements InvocationHandler {
         return available;
     }
 
-    /** Lazily resolve + cache the per-method proxy (stable reference). */
+    /** Resolve the per-method proxy via the pluggable strategy (never null). */
     private McpMeshTool<?> proxyFor(McpMeshServiceRegistrar.ServiceMethodBinding binding) {
-        return proxyCache.computeIfAbsent(binding.method(), m ->
-            injector().getToolProxy(binding.capability(), binding.resolvedProxyType()));
-    }
-
-    private MeshDependencyInjector injector() {
-        MeshDependencyInjector injector = injectorRef.get();
-        if (injector == null) {
-            injector = beanFactory.getBean(MeshDependencyInjector.class);
-            injectorRef.compareAndSet(null, injector);
-        }
-        return injector;
+        return proxyBinding.proxyFor(binding);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceRegistrar.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceRegistrar.java
@@ -234,7 +234,24 @@ public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProces
             new Class<?>[] {iface},
             new McpMeshServiceInvocationHandler(
                 iface, metadata.minAvailable(), metadata.bindings(),
-                beanFactory, injectorRef, objectMapper));
+                new InjectorViewProxyBinding(beanFactory, injectorRef), objectMapper));
+    }
+
+    /**
+     * Reusable interface→bindings analysis (RFC #1280 phase 2). Both the
+     * class-level bean path ({@link #postProcessBeanDefinitionRegistry}) and the
+     * {@code @MeshTool} view-parameter path ({@link McpMeshServiceToolSupport})
+     * call this so the bridge/synthetic filtering, {@link ResolvableType}
+     * resolution, diamond dedupe, and per-method param/return validation are
+     * defined exactly once. Uses a fresh conflicting-type map (a single view is
+     * self-contained); the scanning path uses the shared-map overload to detect
+     * conflicts across DIFFERENT discovered views.
+     *
+     * @param iface an interface annotated {@link McpMeshService}
+     */
+    static ServiceViewMetadata analyze(Class<?> iface) {
+        McpMeshService annotation = AnnotationUtils.findAnnotation(iface, McpMeshService.class);
+        return buildMetadata(iface, annotation, new LinkedHashMap<>());
     }
 
     /**
@@ -243,7 +260,7 @@ public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProces
      * {@link Class#getMethods()} order is NOT guaranteed by the JVM, and the
      * downstream wire-dependency expansion must be reproducible.
      */
-    private ServiceViewMetadata buildMetadata(Class<?> iface, McpMeshService annotation,
+    static ServiceViewMetadata buildMetadata(Class<?> iface, McpMeshService annotation,
                                               Map<String, CapabilityBinding> capabilityTypes) {
         List<Method> methods = collectViewMethods(iface);
 
@@ -333,7 +350,7 @@ public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProces
      * and parameter types are resolved against the concrete view interface by
      * {@link #analyzeReturn}/{@link #analyzeParams} via {@link ResolvableType}.
      */
-    private List<Method> collectViewMethods(Class<?> iface) {
+    private static List<Method> collectViewMethods(Class<?> iface) {
         Map<String, Method> bySignature = new LinkedHashMap<>();
         for (Method method : iface.getMethods()) {
             if (method.isBridge() || method.isSynthetic()) {
@@ -375,11 +392,11 @@ public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProces
             }
         }
         List<Method> methods = new ArrayList<>(bySignature.values());
-        methods.sort(Comparator.comparing(Method::getName).thenComparing(this::signatureKey));
+        methods.sort(Comparator.comparing(Method::getName).thenComparing(McpMeshServiceRegistrar::signatureKey));
         return methods;
     }
 
-    private String signatureKey(Method method) {
+    private static String signatureKey(Method method) {
         StringBuilder sb = new StringBuilder(method.getName()).append('(');
         Class<?>[] params = method.getParameterTypes();
         for (int i = 0; i < params.length; i++) {
@@ -406,7 +423,7 @@ public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProces
      * {@code interface View extends Base<Item>} binds {@code Item} rather than a
      * {@code TypeVariable} that silently deserializes to a {@code Map}.
      */
-    private ReturnBinding analyzeReturn(Class<?> iface, Method method) {
+    private static ReturnBinding analyzeReturn(Class<?> iface, Method method) {
         ResolvableType returnType = ResolvableType.forMethodReturnType(method, iface);
         Class<?> raw = returnType.resolve(Object.class);
 
@@ -451,7 +468,7 @@ public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProces
      * (the type must be Jackson-object-convertible — MED-1); otherwise EVERY
      * param must carry {@code @Param("name")} — a mixed signature is a boot-fail.
      */
-    private ParamBinding analyzeParams(Class<?> iface, Method method) {
+    private static ParamBinding analyzeParams(Class<?> iface, Method method) {
         Parameter[] params = method.getParameters();
         if (params.length == 0) {
             return new ParamBinding(ParamMode.NONE, new String[0]);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceToolSupport.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceToolSupport.java
@@ -1,0 +1,163 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
+import io.mcpmesh.types.McpMeshTool;
+import io.mcpmesh.types.MeshToolUnavailableException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+/**
+ * RFC #1280 phase 2: shared support for using a {@link McpMeshService} interface
+ * as a {@code @MeshTool} PARAMETER. One view parameter expands to N ordinary
+ * dependency edges ON THAT TOOL, positionally paired AFTER the explicit
+ * {@code @Selector} deps — the same pairing precedent as the MeshJob
+ * type-detected slot.
+ *
+ * <p>Detection + the interface→bindings analysis are shared with the phase-1
+ * bean path via {@link McpMeshServiceRegistrar#analyze(Class)}: the same
+ * bridge/synthetic filtering, {@link org.springframework.core.ResolvableType}
+ * resolution, diamond dedupe, and param/return validation apply.
+ */
+final class McpMeshServiceToolSupport {
+
+    private McpMeshServiceToolSupport() {
+    }
+
+    /** A {@code @MeshTool} parameter that is a service-view facade. */
+    record ViewParamInfo(int position, McpMeshServiceRegistrar.ServiceViewMetadata view) {
+    }
+
+    /** Whether {@code type} is an interface annotated {@link McpMeshService}. */
+    static boolean isServiceView(Class<?> type) {
+        return type.isInterface() && type.isAnnotationPresent(McpMeshService.class);
+    }
+
+    /**
+     * Detect service-view parameters on a {@code @MeshTool} method, in parameter
+     * order. A view parameter must NOT carry {@code @Param} (boot-fail). The
+     * interface itself is analyzed + validated via the shared analyzer, so all
+     * phase-1 interface-level validations apply here too.
+     */
+    static List<ViewParamInfo> analyzeViewParams(Method method) {
+        List<ViewParamInfo> views = new ArrayList<>();
+        Parameter[] params = method.getParameters();
+        for (int i = 0; i < params.length; i++) {
+            Class<?> type = params[i].getType();
+            if (!isServiceView(type)) {
+                continue;
+            }
+            if (params[i].isAnnotationPresent(Param.class)) {
+                throw new IllegalStateException(String.format(
+                    "@MeshTool method %s of %s: @McpMeshService view parameter #%d (%s) must NOT "
+                        + "carry @Param — a service-view parameter is injected, not an MCP input.",
+                    method.getName(), method.getDeclaringClass().getName(), i, type.getSimpleName()));
+            }
+            views.add(new ViewParamInfo(i, McpMeshServiceRegistrar.analyze(type)));
+        }
+        return views;
+    }
+
+    /**
+     * Build the JDK-proxy facade for a view parameter, backed by the wrapper's
+     * per-method slot array (phase-2 proxy strategy). Reuses
+     * {@link McpMeshServiceInvocationHandler} — floor / param / return / dispatch
+     * logic is identical to the bean path.
+     */
+    static Object buildFacade(McpMeshServiceRegistrar.ServiceViewMetadata view,
+                              McpMeshServiceInvocationHandler.ViewProxyBinding proxyBinding,
+                              ObjectMapper objectMapper) {
+        Class<?> iface = view.iface();
+        return Proxy.newProxyInstance(
+            iface.getClassLoader(),
+            new Class<?>[] {iface},
+            new McpMeshServiceInvocationHandler(
+                iface, view.minAvailable(), view.bindings(), proxyBinding, objectMapper));
+    }
+
+    /**
+     * Phase-2 proxy strategy: per-method proxies come from the
+     * {@link MeshToolWrapper}'s slot array (per-consumer-slot typed proxies from
+     * {@link McpMeshToolProxyFactory}, funcId:dep_N key space), NOT the shared
+     * injector proxies. A slot may be null (unresolved) → an unavailable
+     * sentinel is returned so the handler's floor/dispatch logic is uniform.
+     */
+    static final class WrapperSlotViewProxyBinding
+            implements McpMeshServiceInvocationHandler.ViewProxyBinding {
+
+        @SuppressWarnings("rawtypes")
+        private final AtomicReferenceArray<McpMeshTool> proxies;
+        private final Map<Method, Integer> methodToLocal;
+        private final int[] localToDeclaredIndex;
+        private final String funcId;
+        private final McpMeshTool<?>[] sentinels;
+
+        WrapperSlotViewProxyBinding(
+                @SuppressWarnings("rawtypes") AtomicReferenceArray<McpMeshTool> proxies,
+                Map<Method, Integer> methodToLocal,
+                int[] localToDeclaredIndex,
+                String funcId,
+                List<McpMeshServiceRegistrar.ServiceMethodBinding> bindings) {
+            this.proxies = proxies;
+            this.methodToLocal = methodToLocal;
+            this.localToDeclaredIndex = localToDeclaredIndex;
+            this.funcId = funcId;
+            this.sentinels = new McpMeshTool<?>[bindings.size()];
+            for (McpMeshServiceRegistrar.ServiceMethodBinding b : bindings) {
+                this.sentinels[methodToLocal.get(b.method())] = new UnavailableMeshTool(b.capability());
+            }
+        }
+
+        @Override
+        public McpMeshTool<?> proxyFor(McpMeshServiceRegistrar.ServiceMethodBinding binding) {
+            int local = methodToLocal.get(binding.method());
+            McpMeshTool<?> proxy = proxies.get(local);
+            return proxy != null ? proxy : sentinels[local];
+        }
+
+        @Override
+        public String settleKey(McpMeshServiceRegistrar.ServiceMethodBinding binding) {
+            int local = methodToLocal.get(binding.method());
+            return MeshToolWrapperRegistry.buildDependencyKey(funcId, localToDeclaredIndex[local]);
+        }
+    }
+
+    /**
+     * Stand-in for an unresolved view-edge slot: mirrors an unresolved
+     * {@code McpMeshToolProxy} so the handler's dispatch is uniform — synchronous
+     * calls throw {@link MeshToolUnavailableException}; async calls fail the
+     * future; streams throw.
+     */
+    static final class UnavailableMeshTool implements McpMeshTool<Object> {
+        private final String capability;
+
+        UnavailableMeshTool(String capability) {
+            this.capability = capability;
+        }
+
+        @Override public Object call() { throw unavailable(); }
+        @Override public Object call(Map<String, Object> params) { throw unavailable(); }
+        @Override public Object call(Object... args) { throw unavailable(); }
+        @Override public CompletableFuture<Object> callAsync() { return CompletableFuture.failedFuture(unavailable()); }
+        @Override public CompletableFuture<Object> callAsync(Map<String, Object> params) { return CompletableFuture.failedFuture(unavailable()); }
+        @Override public CompletableFuture<Object> callAsync(Object... args) { return CompletableFuture.failedFuture(unavailable()); }
+        @Override public String getCapability() { return capability; }
+        @Override public String getEndpoint() { return null; }
+        @Override public String getFunctionName() { return null; }
+        @Override public boolean isAvailable() { return false; }
+        @Override public Flow.Publisher<String> stream(Map<String, Object> params) { throw unavailable(); }
+
+        private MeshToolUnavailableException unavailable() {
+            return new MeshToolUnavailableException(capability);
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
@@ -282,6 +282,13 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
         // Extract dependency names from @MeshTool(dependencies=...)
         List<String> dependencyNames = extractDependencyNames(annotation);
 
+        // RFC #1280 phase 2: detect @McpMeshService view parameters (+ validate
+        // + boot-fail on @Param). Their method edges are appended to the tool's
+        // declared dependency list by the wrapper, in the SAME order the wire
+        // spec (MeshToolRegistry.extractAllDependencies) uses.
+        List<McpMeshServiceToolSupport.ViewParamInfo> viewParams =
+            McpMeshServiceToolSupport.analyzeViewParams(method);
+
         // Create wrapper. Phase B MeshJob substrate: the `task` flag controls
         // whether inbound calls bearing X-Mesh-Job-Id dispatch through the
         // job pipeline (JobController injection + auto-complete).
@@ -296,7 +303,8 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
             dependencyNames,
             objectMapper,
             annotation.task(),
-            annotation.retryOn()
+            annotation.retryOn(),
+            viewParams
         );
 
         // Issue #1268: thread the per-declared-dependency required flags so

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
@@ -53,7 +53,7 @@ public class MeshToolRegistry {
             // on the record so existing readers (heartbeat builder,
             // tests) are unaffected.
             new ArrayList<>(Arrays.asList(annotation.tags())),
-            extractDependencies(annotation.dependencies()),
+            extractAllDependencies(annotation, method),
             extractInputSchema(method),
             outputType,
             // Issue #547 Phase 4: per-tool override (default true = current behavior).
@@ -435,6 +435,30 @@ public class MeshToolRegistry {
             }
         }
 
+        return deps;
+    }
+
+    /**
+     * RFC #1280 phase 2: the tool's full declared dependency list = explicit
+     * {@code @Selector} deps FIRST, then each {@code @McpMeshService} view
+     * parameter's method edges (parameter order, method-name order). This order
+     * MUST match {@link MeshToolWrapper}'s declared-index space so the Rust
+     * core's {@code funcId:dep_N} resolution events land on the right slot.
+     */
+    private List<DependencyInfo> extractAllDependencies(MeshTool annotation, Method method) {
+        List<DependencyInfo> deps = extractDependencies(annotation.dependencies());
+        for (McpMeshServiceToolSupport.ViewParamInfo vp
+                : McpMeshServiceToolSupport.analyzeViewParams(method)) {
+            for (McpMeshServiceRegistrar.ServiceMethodBinding b : vp.view().bindings()) {
+                deps.add(new DependencyInfo(
+                    b.capability(),
+                    Arrays.asList(b.tags()),
+                    b.version(),
+                    b.schemaExpectedType(),
+                    b.schemaMode(),
+                    b.required()));
+            }
+        }
         return deps;
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -3,6 +3,7 @@ package io.mcpmesh.spring;
 import tools.jackson.databind.ObjectMapper;
 import io.mcpmesh.JobContext;
 import io.mcpmesh.JobController;
+import io.mcpmesh.McpMeshService;
 import io.mcpmesh.MeshJob;
 import io.mcpmesh.MeshJobSubmitter;
 import io.mcpmesh.Param;
@@ -19,6 +20,7 @@ import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.AnnotationUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -151,6 +153,24 @@ public class MeshToolWrapper implements McpToolHandler {
      */
     private final int meshJobDepIndex;
 
+    // RFC #1280 phase 2: @McpMeshService view parameters. Each view param is a
+    // facade whose N methods are ordinary tool dependency edges APPENDED after
+    // the explicit @Selector deps (declared indices >= explicitDepCount), in
+    // parameter order then method-name order. The facade reads live per-method
+    // proxy slots, so registry resolution events for a view edge update the
+    // correct view slot's method proxy.
+    private final List<ViewSlot> viewSlots;
+    /** Param positions that are view facades (exempt from @Param / MCP schema). */
+    private final Set<Integer> viewParamPositions;
+    /** Number of explicit @Selector deps — the prefix that pairs with McpMeshTool/MeshJob slots. */
+    private final int explicitDepCount;
+    /** Declared dep index → view slot ordinal (-1 if not a view edge). */
+    private final int[] depIndexToViewSlot;
+    /** Declared dep index → local method index within its view slot (-1 otherwise). */
+    private final int[] depIndexToViewLocal;
+    /** Declared dep index → view-method binding (null if not a view edge). */
+    private final McpMeshServiceRegistrar.ServiceMethodBinding[] depIndexToViewBinding;
+
     // Consumer-side: MeshJobSubmitter to inject when MeshJob slot is present
     // and this method depends on a task=true capability. Set by the runtime
     // wiring (MeshAutoConfiguration / MeshEventProcessor) once the registry
@@ -236,6 +256,31 @@ public class MeshToolWrapper implements McpToolHandler {
             ObjectMapper objectMapper,
             boolean task,
             Class<? extends Throwable>[] retryOn) {
+        this(funcId, capability, description, bean, method, dependencyNames,
+            objectMapper, task, retryOn, List.of());
+    }
+
+    /**
+     * Full constructor with {@code @McpMeshService} view parameters (RFC #1280
+     * phase 2). Each view param's method bindings are appended to the tool's
+     * declared dependency list as ordinary edges (after the explicit
+     * {@code @Selector} deps), and a per-param facade is built whose methods
+     * delegate to the wrapper's per-method proxy slots.
+     *
+     * @param viewParams service-view parameters (position + validated bindings),
+     *                   in parameter order; empty for the classic path.
+     */
+    public MeshToolWrapper(
+            String funcId,
+            String capability,
+            String description,
+            Object bean,
+            Method method,
+            List<String> dependencyNames,
+            ObjectMapper objectMapper,
+            boolean task,
+            Class<? extends Throwable>[] retryOn,
+            List<McpMeshServiceToolSupport.ViewParamInfo> viewParams) {
 
         this.funcId = funcId;
         this.capability = capability;
@@ -244,14 +289,18 @@ public class MeshToolWrapper implements McpToolHandler {
         this.method = method;
         this.task = task;
         this.retryOn = retryOn != null ? retryOn : EMPTY_RETRY_ON;
-        this.dependencyNames = dependencyNames != null ? dependencyNames : List.of();
-        // Default all-optional (#1268) until MeshToolBeanPostProcessor threads
-        // the per-dep required flags via setDependencyRequired.
-        this.dependencyRequired = new boolean[this.dependencyNames.size()];
         this.objectMapper = objectMapper;
 
         // Make method accessible (for private methods)
         method.setAccessible(true);
+
+        // RFC #1280 phase 2: record view-param positions so analyzeParameters
+        // treats them as an injected slot kind (exempt from @Param / MCP schema).
+        List<McpMeshServiceToolSupport.ViewParamInfo> vps = viewParams != null ? viewParams : List.of();
+        this.viewParamPositions = new HashSet<>();
+        for (McpMeshServiceToolSupport.ViewParamInfo vp : vps) {
+            this.viewParamPositions.add(vp.position());
+        }
 
         // Analyze parameters via the resolver so MeshJob index is captured.
         MeshJobResolver.Resolved resolved = MeshJobResolver.resolve(method);
@@ -269,11 +318,84 @@ public class MeshToolWrapper implements McpToolHandler {
         this.injectedDeps = new AtomicReferenceArray<>(meshToolPositions.size());
         this.injectedLlmAgents = new AtomicReferenceArray<>(llmAgentPositions.size());
 
-        // Build the declared-index ↔ slot-ordinal translation (see field
-        // javadoc). Eligible positions = McpMeshTool + MeshJob parameter
-        // positions in parameter order; dependencies[k] pairs with the
-        // k-th eligible position.
-        this.depIndexToSlot = new int[this.dependencyNames.size()];
+        // Build the FULL declared dependency list: explicit @Selector deps
+        // (positionally paired with McpMeshTool/MeshJob slots) then each view
+        // param's method edges (parameter order, method-name order). The two
+        // segments occupy disjoint declared-index ranges — view edges are NEVER
+        // paired with McpMeshTool slots.
+        List<String> explicitNames = dependencyNames != null ? dependencyNames : List.of();
+        this.explicitDepCount = explicitNames.size();
+        List<String> fullNames = new ArrayList<>(explicitNames);
+        List<ViewSlot> slots = new ArrayList<>();
+        List<Integer> edgeViewSlot = new ArrayList<>();
+        List<Integer> edgeViewLocal = new ArrayList<>();
+        List<McpMeshServiceRegistrar.ServiceMethodBinding> edgeBinding = new ArrayList<>();
+        for (int vsOrd = 0; vsOrd < vps.size(); vsOrd++) {
+            McpMeshServiceToolSupport.ViewParamInfo vp = vps.get(vsOrd);
+            List<McpMeshServiceRegistrar.ServiceMethodBinding> bindings = vp.view().bindings();
+            int m = bindings.size();
+            int declaredStart = fullNames.size();
+            @SuppressWarnings("rawtypes")
+            AtomicReferenceArray<McpMeshTool> proxies = new AtomicReferenceArray<>(m);
+            Map<Method, Integer> methodToLocal = new HashMap<>();
+            int[] localToDeclared = new int[m];
+            for (int local = 0; local < m; local++) {
+                McpMeshServiceRegistrar.ServiceMethodBinding b = bindings.get(local);
+                methodToLocal.put(b.method(), local);
+                localToDeclared[local] = declaredStart + local;
+                // Double-edge detection (RFC #1280 phase 2, LOW): a view edge
+                // capability already declared on this tool (by an explicit
+                // @Selector dep or an earlier view) produces two independent
+                // edges — kept, consistent with duplicate explicit deps, but
+                // WARNed so the accidental case has a signal.
+                if (fullNames.contains(b.capability())) {
+                    String priorSource = fullNames.indexOf(b.capability()) < explicitDepCount
+                        ? "an explicit @Selector dependency"
+                        : "another @McpMeshService view parameter";
+                    log.warn("Tool {} declares capability '{}' more than once: @McpMeshService view "
+                            + "{} (method {}) duplicates {} — two dependency edges are kept "
+                            + "(matches duplicate explicit deps); rename one if unintended.",
+                        funcId, b.capability(), vp.view().iface().getName(), b.method().getName(),
+                        priorSource);
+                }
+                fullNames.add(b.capability());
+                edgeViewSlot.add(vsOrd);
+                edgeViewLocal.add(local);
+                edgeBinding.add(b);
+            }
+            McpMeshServiceToolSupport.WrapperSlotViewProxyBinding strategy =
+                new McpMeshServiceToolSupport.WrapperSlotViewProxyBinding(
+                    proxies, methodToLocal, localToDeclared, funcId, bindings);
+            Object facade = McpMeshServiceToolSupport.buildFacade(vp.view(), strategy, objectMapper);
+            slots.add(new ViewSlot(vp.position(), facade, proxies, bindings, declaredStart));
+        }
+        this.viewSlots = List.copyOf(slots);
+        this.dependencyNames = List.copyOf(fullNames);
+        int fullSize = fullNames.size();
+
+        // Per-declared-dependency required flags (#1268). View-edge suffix is
+        // fixed here from each @Selector.required(); the explicit prefix stays
+        // all-optional until MeshToolBeanPostProcessor calls setDependencyRequired
+        // (which preserves this suffix).
+        boolean[] required = new boolean[fullSize];
+        this.depIndexToViewSlot = new int[fullSize];
+        this.depIndexToViewLocal = new int[fullSize];
+        this.depIndexToViewBinding = new McpMeshServiceRegistrar.ServiceMethodBinding[fullSize];
+        Arrays.fill(this.depIndexToViewSlot, -1);
+        Arrays.fill(this.depIndexToViewLocal, -1);
+        for (int e = 0; e < edgeBinding.size(); e++) {
+            int declaredIndex = explicitDepCount + e;
+            required[declaredIndex] = edgeBinding.get(e).required();
+            this.depIndexToViewSlot[declaredIndex] = edgeViewSlot.get(e);
+            this.depIndexToViewLocal[declaredIndex] = edgeViewLocal.get(e);
+            this.depIndexToViewBinding[declaredIndex] = edgeBinding.get(e);
+        }
+        this.dependencyRequired = required;
+
+        // Declared-index ↔ McpMeshTool-slot translation (see field javadoc).
+        // ONLY the explicit prefix pairs with eligible positions; view edges
+        // (index >= explicitDepCount) keep depIndexToSlot = -1.
+        this.depIndexToSlot = new int[fullSize];
         this.slotToDepIndex = new int[meshToolPositions.size()];
         Arrays.fill(this.depIndexToSlot, -1);
         Arrays.fill(this.slotToDepIndex, -1);
@@ -283,15 +405,9 @@ public class MeshToolWrapper implements McpToolHandler {
             Collections.sort(eligiblePositions);
         }
         int meshJobDep = -1;
-        for (int k = 0; k < eligiblePositions.size() && k < this.dependencyNames.size(); k++) {
+        for (int k = 0; k < eligiblePositions.size() && k < explicitDepCount; k++) {
             int paramPos = eligiblePositions.get(k);
             if (meshJobParamIndex != null && paramPos == meshJobParamIndex) {
-                // MeshJob-backed dependency: the submitter is wired
-                // locally (JobsRuntimeManager), never by a proxy event —
-                // no slot, no settle key. Capture the declared dependency
-                // index paired with the MeshJob param so the consumer-side
-                // wiring can bind the submitter to the EXACT declared
-                // capability (mirrors Python's positional MeshJob→dep_index).
                 meshJobDep = k;
                 continue;
             }
@@ -304,9 +420,10 @@ public class MeshToolWrapper implements McpToolHandler {
         // Generate input schema (excluding injected params)
         this.inputSchema = generateInputSchema();
 
-        log.debug("Created wrapper for {} with {} MCP params, {} mesh deps, {} LLM agents, task={}, meshJobParamIndex={}",
+        log.debug("Created wrapper for {} with {} MCP params, {} mesh deps, {} LLM agents, "
+                + "{} view param(s), {} declared deps, task={}, meshJobParamIndex={}",
             funcId, mcpParams.size(), meshToolPositions.size(), llmAgentPositions.size(),
-            task, meshJobParamIndex);
+            viewSlots.size(), fullSize, task, meshJobParamIndex);
     }
 
     /**
@@ -323,7 +440,12 @@ public class MeshToolWrapper implements McpToolHandler {
             Parameter param = params[i];
             Class<?> type = param.getType();
 
-            if (MeshJob.class.isAssignableFrom(type)) {
+            if (viewParamPositions.contains(i)) {
+                // RFC #1280 phase 2: @McpMeshService view facade param — injected
+                // (a facade whose methods are tool dependency edges), exempt from
+                // @Param and the MCP input schema. Its edges are wired separately.
+                continue;
+            } else if (MeshJob.class.isAssignableFrom(type)) {
                 // Phase B MeshJob substrate: this slot is filled separately
                 // by the dispatch wrapper (JobController on inbound job
                 // dispatch, MeshJobSubmitter on consumer side). No @Param
@@ -366,6 +488,24 @@ public class MeshToolWrapper implements McpToolHandler {
                 // LLM agent - will be injected
                 llmAgentPositions.add(i);
             } else {
+                // RFC #1280 phase 2: near-miss view param — annotated with
+                // @McpMeshService but NOT a directly-annotated interface (a
+                // class, or a sub-interface that only inherits the annotation).
+                // isServiceView requires interface + DIRECT annotation, so these
+                // fall through here; give a dedicated message rather than the
+                // generic "must have @Param" one. Sub-interface support is
+                // deliberately deferred — the annotation must be direct.
+                if (AnnotationUtils.findAnnotation(type, McpMeshService.class) != null) {
+                    throw new IllegalStateException(
+                        "@McpMeshService view used as a tool parameter must be a directly-annotated "
+                            + "interface: parameter at position " + i + " (type " + type.getName()
+                            + ") in method " + method.getName() + " of "
+                            + method.getDeclaringClass().getName() + " is "
+                            + (type.isInterface()
+                                ? "a sub-interface that only inherits @McpMeshService (annotate it directly)"
+                                : "a class annotated @McpMeshService (service views must be interfaces)")
+                            + ".");
+                }
                 // Regular MCP parameter - must have @Param
                 Param paramAnn = param.getAnnotation(Param.class);
                 if (paramAnn != null) {
@@ -380,7 +520,8 @@ public class MeshToolWrapper implements McpToolHandler {
                     // No @Param annotation on non-injectable parameter
                     throw new IllegalStateException(
                         "Parameter at position " + i + " in method " + method.getName() +
-                        " must have @Param annotation. Injectable types (McpMeshTool, MeshLlmAgent, MeshJob) are exempt."
+                        " must have @Param annotation. Injectable types (McpMeshTool, MeshLlmAgent, "
+                        + "MeshJob, A2AClient, @McpMeshService view interfaces) are exempt."
                     );
                 }
             }
@@ -432,6 +573,21 @@ public class MeshToolWrapper implements McpToolHandler {
         if (depIndex < 0 || depIndex >= depIndexToSlot.length) {
             return;
         }
+        // RFC #1280 phase 2: a view-edge index lands in its view slot's per-method
+        // proxy array (NOT a McpMeshTool param slot), then counts down the same
+        // funcId:dep_N settle latch.
+        int viewSlotOrd = depIndexToViewSlot[depIndex];
+        if (viewSlotOrd >= 0) {
+            int local = depIndexToViewLocal[depIndex];
+            viewSlots.get(viewSlotOrd).proxies.set(local, proxy);
+            log.debug("Updated view edge {} at declared index {} (view slot {}, method {}) for {}",
+                proxy != null ? proxy.getCapability() : "null", depIndex, viewSlotOrd, local, funcId);
+            if (proxy != null && proxy.isAvailable()) {
+                MeshSettleState.getInstance().markResolved(
+                    MeshToolWrapperRegistry.buildDependencyKey(funcId, depIndex));
+            }
+            return;
+        }
         int slot = depIndexToSlot[depIndex];
         if (slot < 0) {
             log.debug("Ignoring dependency update at declared index {} for {} — "
@@ -462,8 +618,11 @@ public class MeshToolWrapper implements McpToolHandler {
         if (required == null) {
             return;
         }
-        boolean[] flags = new boolean[dependencyNames.size()];
-        for (int i = 0; i < flags.length && i < required.size(); i++) {
+        // Overwrite ONLY the explicit @Selector prefix; the view-edge suffix was
+        // fixed at construction from each @Selector.required() (RFC #1280 phase 2)
+        // and must be preserved — the caller only knows the explicit flags.
+        boolean[] flags = this.dependencyRequired.clone();
+        for (int i = 0; i < explicitDepCount && i < required.size(); i++) {
             flags[i] = Boolean.TRUE.equals(required.get(i));
         }
         this.dependencyRequired = flags;
@@ -495,15 +654,40 @@ public class MeshToolWrapper implements McpToolHandler {
     @SuppressWarnings("rawtypes")
     String firstUnresolvedRequiredDependency() {
         boolean[] req = this.dependencyRequired;
-        for (int slot = 0; slot < meshToolPositions.size(); slot++) {
-            int depIdx = slotToDepIndex[slot];
-            if (depIdx < 0 || depIdx >= req.length || !req[depIdx]) {
+        // Iterate declared indices so BOTH McpMeshTool-slot deps AND view-edge
+        // deps (RFC #1280 phase 2) participate in the required guard. MeshJob /
+        // excess indices have no McpMeshTool backing and are not gated here
+        // (unchanged — the submitter is wired locally).
+        for (int depIdx = 0; depIdx < dependencyNames.size(); depIdx++) {
+            if (depIdx >= req.length || !req[depIdx]) {
                 continue;
             }
-            McpMeshTool proxy = injectedDeps.get(slot);
+            boolean backed = depIndexToViewSlot[depIdx] >= 0 || depIndexToSlot[depIdx] >= 0;
+            if (!backed) {
+                continue;
+            }
+            McpMeshTool proxy = currentProxyForDeclaredIndex(depIdx);
             if (proxy == null || !proxy.isAvailable()) {
                 return dependencyNames.get(depIdx);
             }
+        }
+        return null;
+    }
+
+    /**
+     * The current proxy backing a declared dependency index: a view edge's
+     * per-method slot proxy, or a McpMeshTool param slot proxy, or {@code null}
+     * for a MeshJob/excess index (no McpMeshTool backing).
+     */
+    @SuppressWarnings("rawtypes")
+    private McpMeshTool currentProxyForDeclaredIndex(int depIdx) {
+        int viewSlotOrd = depIndexToViewSlot[depIdx];
+        if (viewSlotOrd >= 0) {
+            return viewSlots.get(viewSlotOrd).proxies.get(depIndexToViewLocal[depIdx]);
+        }
+        int slot = depIndexToSlot[depIdx];
+        if (slot >= 0) {
+            return injectedDeps.get(slot);
         }
         return null;
     }
@@ -1002,6 +1186,24 @@ public class MeshToolWrapper implements McpToolHandler {
             }
 
             fullArgs[paramPos] = proxy;
+        }
+
+        // RFC #1280 phase 2: fill @McpMeshService view-facade params. Run the
+        // same per-slot settle-grace wait on each view edge (funcId:dep_N) so the
+        // required-dependency guard (evaluated AFTER buildFullArgs) sees resolved
+        // required view edges rather than prematurely refusing while settling.
+        // The facade itself is stable — it reads the live per-method proxy slots.
+        for (ViewSlot viewSlot : viewSlots) {
+            for (int local = 0; local < viewSlot.bindings.size(); local++) {
+                int declaredIndex = viewSlot.declaredStart + local;
+                McpMeshTool proxy = viewSlot.proxies.get(local);
+                if ((proxy == null || !proxy.isAvailable()) && !settleState.isSettled()) {
+                    settleState.awaitDependency(
+                        MeshToolWrapperRegistry.buildDependencyKey(funcId, declaredIndex),
+                        dependencyNames.get(declaredIndex));
+                }
+            }
+            fullArgs[viewSlot.position] = viewSlot.facade;
         }
 
         // Fill MeshLlmAgent dependencies and set context for template rendering
@@ -1779,11 +1981,18 @@ public class MeshToolWrapper implements McpToolHandler {
      * @return The return type, or null if not specified or index out of bounds
      */
     public Type getDependencyReturnType(int depIndex) {
-        if (depIndex >= 0 && depIndex < depIndexToSlot.length) {
-            int slot = depIndexToSlot[depIndex];
-            if (slot >= 0 && slot < meshToolReturnTypes.size()) {
-                return meshToolReturnTypes.get(slot);
-            }
+        if (depIndex < 0 || depIndex >= depIndexToSlot.length) {
+            return null;
+        }
+        // RFC #1280 phase 2: a view edge deserializes to its method's resolved
+        // return type (so the per-slot typed proxy gives typed responses).
+        McpMeshServiceRegistrar.ServiceMethodBinding viewBinding = depIndexToViewBinding[depIndex];
+        if (viewBinding != null) {
+            return viewBinding.resolvedProxyType();
+        }
+        int slot = depIndexToSlot[depIndex];
+        if (slot >= 0 && slot < meshToolReturnTypes.size()) {
+            return meshToolReturnTypes.get(slot);
         }
         return null;
     }
@@ -1799,7 +2008,9 @@ public class MeshToolWrapper implements McpToolHandler {
     List<Integer> getSettleDepIndices() {
         List<Integer> indices = new ArrayList<>();
         for (int depIndex = 0; depIndex < depIndexToSlot.length; depIndex++) {
-            if (depIndexToSlot[depIndex] >= 0) {
+            // McpMeshTool slots AND view edges (RFC #1280 phase 2) both receive
+            // a funcId:dep_N resolution event, so both get settle keys.
+            if (depIndexToSlot[depIndex] >= 0 || depIndexToViewSlot[depIndex] >= 0) {
                 indices.add(depIndex);
             }
         }
@@ -1823,6 +2034,31 @@ public class MeshToolWrapper implements McpToolHandler {
     // =========================================================================
     // Inner Classes
     // =========================================================================
+
+    /**
+     * RFC #1280 phase 2: a {@code @McpMeshService} view-facade parameter. Holds
+     * the facade to inject and the per-method proxy slot array that registry
+     * resolution events populate (a null slot = an unresolved edge; the facade
+     * substitutes an unavailable sentinel).
+     */
+    private static final class ViewSlot {
+        final int position;
+        final Object facade;
+        @SuppressWarnings("rawtypes")
+        final AtomicReferenceArray<McpMeshTool> proxies;
+        final List<McpMeshServiceRegistrar.ServiceMethodBinding> bindings;
+        final int declaredStart;
+
+        ViewSlot(int position, Object facade,
+                 @SuppressWarnings("rawtypes") AtomicReferenceArray<McpMeshTool> proxies,
+                 List<McpMeshServiceRegistrar.ServiceMethodBinding> bindings, int declaredStart) {
+            this.position = position;
+            this.facade = facade;
+            this.proxies = proxies;
+            this.bindings = bindings;
+            this.declaredStart = declaredStart;
+        }
+    }
 
     /**
      * Metadata for an MCP parameter.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceIntegrationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceIntegrationTest.java
@@ -973,6 +973,42 @@ class McpMeshServiceIntegrationTest {
     static class EmptyConfig {
     }
 
+    // RFC #1280 phase 2: a view used as BOTH a phase-1 bean and a @MeshTool param.
+    public static class CoexistTool {
+        @MeshTool(capability = "coexist_tool")
+        public String run(@Param("x") String x, io.mcpmesh.spring.svtool.ToolViews.CoexistView view) {
+            return "ok";
+        }
+    }
+
+    @Configuration
+    @MeshAgent(name = "coexist-agent")
+    static class CoexistConfig {
+        @Bean public CoexistTool coexistTool() { return new CoexistTool(); }
+    }
+
+    @Test
+    @DisplayName("Phase 2: bean-path and tool-param usage of the same view coexist independently")
+    void beanAndToolParamCoexist() {
+        runnerFor("io.mcpmesh.spring.svtool", CoexistConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            // Phase-1 bean path: the facade bean is registered + injectable.
+            assertThat(context.getBean(io.mcpmesh.spring.svtool.ToolViews.CoexistView.class))
+                .as("phase-1 facade bean must still exist").isNotNull();
+            // Phase-2 tool-param path: the tool's DependencySpec list carries the
+            // view edges as ordinary tool deps.
+            AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+            List<String> toolDeps = spec.getTools().stream()
+                .filter(t -> "coexist_tool".equals(t.getCapability()))
+                .flatMap(t -> t.getDependencies().stream())
+                .map(AgentSpec.DependencySpec::getCapability)
+                .toList();
+            assertThat(toolDeps)
+                .as("tool-param view edges must be the tool's own dependencies")
+                .containsExactly("coexist.one", "coexist.two");
+        });
+    }
+
     /**
      * Minimal Logback appender recording level + message for a target logger.
      */

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceIntegrationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceIntegrationTest.java
@@ -873,8 +873,12 @@ class McpMeshServiceIntegrationTest {
             assertThat(context).hasNotFailed();
             Views.FloorService floor = context.getBean(Views.FloorService.class);
             CompletableFuture<String> future = floor.deltaAsync();
-            assertThat(future).isCompletedExceptionally();
-            assertThatThrownBy(future::join).hasCauseInstanceOf(MeshServiceUnavailableException.class);
+            // The floored async path runs enforceFloor off-thread (common pool),
+            // so the future completes exceptionally a beat later — AWAIT it
+            // (bounded, no sleep) instead of sampling its immediate state.
+            assertThatThrownBy(() -> future.get(5, java.util.concurrent.TimeUnit.SECONDS))
+                .isInstanceOf(java.util.concurrent.ExecutionException.class)
+                .hasCauseInstanceOf(MeshServiceUnavailableException.class);
         });
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceToolParamTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceToolParamTest.java
@@ -1,0 +1,582 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.core.MeshObjectMappers;
+import io.mcpmesh.types.McpMeshTool;
+import io.mcpmesh.types.MeshServiceUnavailableException;
+import io.mcpmesh.types.MeshToolUnavailableException;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * RFC #1280 phase 2: {@link McpMeshService} interface as a {@code @MeshTool}
+ * PARAMETER. One view param expands to N ordinary dependency edges ON THAT
+ * TOOL, positionally paired AFTER the explicit {@code @Selector} deps.
+ *
+ * <p>Unit-tests the below-FFI machinery directly (wrapper construction +
+ * updateDependency + invoke), mirroring {@link MeshToolWrapperRequiredDepGuardTest}.
+ */
+class McpMeshServiceToolParamTest {
+
+    private static final ObjectMapper MAPPER = MeshObjectMappers.create();
+
+    // ---- Fixtures -----------------------------------------------------------
+
+    @McpMeshService
+    public interface MediaService {
+        @Selector(capability = "media.caption")
+        String caption(@Param("id") String id);
+
+        @Selector(capability = "media.transcribe")
+        String transcribe(@Param("id") String id);
+
+        @Selector(capability = "media.thumbnail")
+        String thumbnail(@Param("id") String id);
+    }
+
+    /** Records the params map it was called with; returns "RESP:"+capability. */
+    static class ViewStub implements McpMeshTool<String> {
+        final String cap;
+        final boolean available;
+        volatile Map<String, Object> lastParams;
+
+        ViewStub(String cap, boolean available) {
+            this.cap = cap;
+            this.available = available;
+        }
+
+        @Override public String call() { return "RESP:" + cap; }
+        @Override public String call(Map<String, Object> params) { lastParams = params; return "RESP:" + cap; }
+        @Override public String call(Object... args) { return "RESP:" + cap; }
+        @Override public CompletableFuture<String> callAsync() { return CompletableFuture.completedFuture("RESP:" + cap); }
+        @Override public CompletableFuture<String> callAsync(Map<String, Object> params) { return CompletableFuture.completedFuture("RESP:" + cap); }
+        @Override public CompletableFuture<String> callAsync(Object... keyValuePairs) { return CompletableFuture.completedFuture("RESP:" + cap); }
+        @Override public String getCapability() { return cap; }
+        @Override public String getEndpoint() { return "http://stub"; }
+        @Override public String getFunctionName() { return cap; }
+        @Override public boolean isAvailable() { return available; }
+    }
+
+    public static class MediaProcessor {
+        @MeshTool(capability = "process_media",
+            dependencies = @Selector(capability = "audit_log"))
+        public Map<String, Object> processMedia(
+                @Param("assetId") String assetId,
+                McpMeshTool<String> auditLog,
+                MediaService media) {
+            Map<String, Object> out = new java.util.LinkedHashMap<>();
+            out.put("caption", media.caption(assetId));
+            out.put("transcribe", media.transcribe(assetId));
+            return out;
+        }
+    }
+
+    private static Method processMediaMethod() throws Exception {
+        return MediaProcessor.class.getMethod("processMedia",
+            String.class, McpMeshTool.class, MediaService.class);
+    }
+
+    private static MeshToolWrapper mediaWrapper(MediaProcessor bean) throws Exception {
+        Method m = processMediaMethod();
+        MeshToolWrapper w = new MeshToolWrapper(
+            "MediaProcessor.processMedia", "process_media", "test", bean, m,
+            List.of("audit_log"), JsonMapper.builder().build(), false, null,
+            McpMeshServiceToolSupport.analyzeViewParams(m));
+        w.setDependencyRequired(List.of(false)); // audit_log optional
+        return w;
+    }
+
+    // ---- Detection + expansion order ----------------------------------------
+
+    @Test
+    void expansion_explicitFirst_thenViewEdgesNameSorted() throws Exception {
+        MeshToolWrapper w = mediaWrapper(new MediaProcessor());
+        // Explicit dep FIRST, then the view's methods in method-name order
+        // (caption, thumbnail, transcribe).
+        assertEquals(List.of("audit_log", "media.caption", "media.thumbnail", "media.transcribe"),
+            w.getDependencyNames());
+        // Return types: audit_log McpMeshTool<String>, each view edge = String.
+        assertEquals(String.class, w.getDependencyReturnType(0));
+        assertEquals(String.class, w.getDependencyReturnType(1));
+        assertEquals(String.class, w.getDependencyReturnType(3));
+        // Every McpMeshTool slot AND view edge gets a funcId:dep_N settle key.
+        assertEquals(List.of(0, 1, 2, 3), w.getSettleDepIndices());
+    }
+
+    // ---- Event routing to the right per-method proxy ------------------------
+
+    @Test
+    void updateDependency_routesViewEdgeToCorrectMethodProxy() throws Exception {
+        MediaProcessor bean = new MediaProcessor();
+        MeshToolWrapper w = mediaWrapper(bean);
+
+        // caption = declared index 1, transcribe = declared index 3.
+        ViewStub caption = new ViewStub("media.caption", true);
+        ViewStub transcribe = new ViewStub("media.transcribe", true);
+        w.updateDependency(1, caption);
+        w.updateDependency(3, transcribe);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> out = (Map<String, Object>) w.invoke(Map.of("assetId", "asset-7"));
+
+        assertEquals("RESP:media.caption", out.get("caption"));
+        assertEquals("RESP:media.transcribe", out.get("transcribe"));
+        // The @Param("id") facade method built a params map from the arg.
+        assertEquals(Map.of("id", "asset-7"), caption.lastParams);
+    }
+
+    // ---- Skew: MeshJob + explicit dep + view param in one signature ---------
+
+    public static class SkewProcessor {
+        @MeshTool(capability = "skew_tool", task = true, dependencies = {
+            @Selector(capability = "job_cap"),
+            @Selector(capability = "db_cap")
+        })
+        public Map<String, Object> skew(MeshJob job, McpMeshTool<String> db, MediaService media) {
+            Map<String, Object> out = new java.util.LinkedHashMap<>();
+            out.put("caption", media.caption("x"));
+            return out;
+        }
+    }
+
+    @Test
+    void skew_jobPlusExplicitPlusView_indicesAlign() throws Exception {
+        SkewProcessor bean = new SkewProcessor();
+        Method m = SkewProcessor.class.getMethod("skew",
+            MeshJob.class, McpMeshTool.class, MediaService.class);
+        MeshToolWrapper w = new MeshToolWrapper(
+            "SkewProcessor.skew", "skew_tool", "test", bean, m,
+            List.of("job_cap", "db_cap"), JsonMapper.builder().build(), true, null,
+            McpMeshServiceToolSupport.analyzeViewParams(m));
+
+        // Declared list: job_cap(0), db_cap(1), then view edges 2..4.
+        assertEquals(List.of("job_cap", "db_cap", "media.caption", "media.thumbnail", "media.transcribe"),
+            w.getDependencyNames());
+        // db_cap is declared index 1 but McpMeshTool slot 0 (MeshJob consumes
+        // declared index 0). View edges never collide with that slot.
+        assertEquals(String.class, w.getDependencyReturnType(1)); // db
+        assertEquals(String.class, w.getDependencyReturnType(2)); // caption
+        // MeshJob-backed dep (index 0) gets NO settle key; db + view edges do.
+        assertEquals(List.of(1, 2, 3, 4), w.getSettleDepIndices());
+
+        // Route a view edge (index 2) and a db-slot proxy (index 1); the facade
+        // method must reach the VIEW proxy, not the db slot.
+        w.updateDependency(1, new ViewStub("db_cap", true));
+        w.updateDependency(2, new ViewStub("media.caption", true));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> out = (Map<String, Object>) w.invoke(Map.of());
+        assertEquals("RESP:media.caption", out.get("caption"));
+    }
+
+    // ---- Required view edge → pre-invoke refusal ----------------------------
+
+    @McpMeshService
+    public interface ReqView {
+        @Selector(capability = "req.a", required = true)
+        String a(@Param("id") String id);
+
+        @Selector(capability = "req.b")
+        String b(@Param("id") String id);
+    }
+
+    public static class ReqProcessor {
+        final java.util.concurrent.atomic.AtomicBoolean handlerRan =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
+
+        @MeshTool(capability = "req_tool")
+        public Map<String, Object> run(@Param("x") String x, ReqView view) {
+            handlerRan.set(true);
+            Map<String, Object> out = new java.util.LinkedHashMap<>();
+            out.put("a", view.a(x));
+            return out;
+        }
+    }
+
+    private static MeshToolWrapper reqWrapper(ReqProcessor bean) throws Exception {
+        Method m = ReqProcessor.class.getMethod("run", String.class, ReqView.class);
+        MeshToolWrapper w = new MeshToolWrapper(
+            "ReqProcessor.run", "req_tool", "test", bean, m,
+            List.of(), JsonMapper.builder().build(), false, null,
+            McpMeshServiceToolSupport.analyzeViewParams(m));
+        w.setDependencyRequired(List.of());
+        return w;
+    }
+
+    @Test
+    void requiredViewEdge_participatesInFirstUnresolvedRequired() throws Exception {
+        MeshToolWrapper w = reqWrapper(new ReqProcessor());
+        // req.a is required=true and unresolved → the tool's required-dep guard
+        // names it (declared index 0: a < b by method name).
+        assertEquals("req.a", w.firstUnresolvedRequiredDependency());
+
+        Object refusal = w.invoke(Map.of("x", "v"));
+        assertInstanceOf(CallToolResult.class, refusal);
+        assertEquals(Boolean.TRUE, ((CallToolResult) refusal).isError());
+        String text = ((TextContent) ((CallToolResult) refusal).content().get(0)).text();
+        assertTrue(text.contains("\"capability\":\"req.a\""), text);
+
+        // Resolve the required edge → guard clears, handler runs.
+        w.updateDependency(0, new ViewStub("req.a", true));
+        assertNull(w.firstUnresolvedRequiredDependency());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> out = (Map<String, Object>) w.invoke(Map.of("x", "v"));
+        assertEquals("RESP:req.a", out.get("a"));
+    }
+
+    // ---- minAvailable floor via a tool view param ---------------------------
+
+    @McpMeshService(minAvailable = 2)
+    public interface FloorView {
+        @Selector(capability = "fl.a") String a(@Param("id") String id);
+        @Selector(capability = "fl.b") String b(@Param("id") String id);
+        @Selector(capability = "fl.c") String c(@Param("id") String id);
+    }
+
+    public static class FloorProcessor {
+        @MeshTool(capability = "floor_tool")
+        public String run(@Param("x") String x, FloorView view) {
+            return view.a(x);
+        }
+    }
+
+    @Test
+    void floorViaToolParam_belowFloorThrows_atFloorWorks() throws Exception {
+        FloorProcessor bean = new FloorProcessor();
+        Method m = FloorProcessor.class.getMethod("run", String.class, FloorView.class);
+        MeshToolWrapper w = new MeshToolWrapper(
+            "FloorProcessor.run", "floor_tool", "test", bean, m,
+            List.of(), JsonMapper.builder().build(), false, null,
+            McpMeshServiceToolSupport.analyzeViewParams(m));
+        w.setDependencyRequired(List.of());
+
+        // Below floor (0/3) → the facade method throws the service-level error,
+        // which propagates out of invoke.
+        Exception below = assertThrows(Exception.class, () -> w.invoke(Map.of("x", "v")));
+        assertInstanceOf(MeshServiceUnavailableException.class, unwrap(below));
+
+        // Resolve 2/3 (fl.a + fl.b) → floor satisfied; fl.a resolved so a() works.
+        w.updateDependency(0, new ViewStub("fl.a", true)); // fl.a = index 0
+        w.updateDependency(1, new ViewStub("fl.b", true)); // fl.b = index 1
+        assertEquals("RESP:fl.a", w.invoke(Map.of("x", "v")));
+    }
+
+    private static Throwable unwrap(Throwable t) {
+        return (t.getCause() != null && t instanceof RuntimeException && t.getCause() != t)
+            ? t.getCause() : t;
+    }
+
+    // ---- @Param on a view param → boot-fail ---------------------------------
+
+    public static class BadViewParamBean {
+        @MeshTool(capability = "bad_tool")
+        public String run(@Param("x") String x, @Param("media") MediaService media) {
+            return "x";
+        }
+    }
+
+    @Test
+    void paramOnViewParam_bootFails() throws Exception {
+        Method m = BadViewParamBean.class.getMethod("run", String.class, MediaService.class);
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> McpMeshServiceToolSupport.analyzeViewParams(m));
+        assertTrue(ex.getMessage().contains("must NOT carry"), ex.getMessage());
+    }
+
+    // ---- Wire serialization of the expanded tool DependencySpec list --------
+
+    @Test
+    void wireSpec_containsExplicitThenViewEdges_requiredSerialization() throws Exception {
+        MeshToolRegistry reg = new MeshToolRegistry();
+        Method media = processMediaMethod();
+        reg.registerTool(new MediaProcessor(), media, media.getAnnotation(MeshTool.class));
+        Method req = ReqProcessor.class.getMethod("run", String.class, ReqView.class);
+        reg.registerTool(new ReqProcessor(), req, req.getAnnotation(MeshTool.class));
+
+        AgentSpec.ToolSpec mediaSpec = reg.getToolSpecs().stream()
+            .filter(t -> "process_media".equals(t.getCapability())).findFirst().orElseThrow();
+        assertEquals(List.of("audit_log", "media.caption", "media.thumbnail", "media.transcribe"),
+            mediaSpec.getDependencies().stream().map(AgentSpec.DependencySpec::getCapability).toList());
+
+        AgentSpec.ToolSpec reqSpec = reg.getToolSpecs().stream()
+            .filter(t -> "req_tool".equals(t.getCapability())).findFirst().orElseThrow();
+        AgentSpec.DependencySpec reqA = reqSpec.getDependencies().stream()
+            .filter(d -> "req.a".equals(d.getCapability())).findFirst().orElseThrow();
+        AgentSpec.DependencySpec reqB = reqSpec.getDependencies().stream()
+            .filter(d -> "req.b".equals(d.getCapability())).findFirst().orElseThrow();
+        assertTrue(reqA.isRequired());
+        assertFalse(reqB.isRequired());
+        assertTrue(MAPPER.writeValueAsString(reqA).contains("\"required\":true"));
+        assertFalse(MAPPER.writeValueAsString(reqB).contains("required"));
+    }
+
+    // ---- MED-1: near-miss view params → dedicated boot-fail ------------------
+
+    @McpMeshService
+    public static class AnnotatedClassView {
+        // A CLASS annotated @McpMeshService — not a valid service view.
+    }
+
+    @McpMeshService
+    public interface AnnotatedBaseView {
+        @Selector(capability = "base.x")
+        String x(@Param("id") String id);
+    }
+
+    public interface SubView extends AnnotatedBaseView {
+        // Inherits @McpMeshService but does NOT carry it directly.
+    }
+
+    public static class ClassParamBean {
+        @MeshTool(capability = "cp_tool")
+        public String run(@Param("x") String x, AnnotatedClassView bad) {
+            return "x";
+        }
+    }
+
+    public static class SubIfaceParamBean {
+        @MeshTool(capability = "si_tool")
+        public String run(@Param("x") String x, SubView bad) {
+            return "x";
+        }
+    }
+
+    private static MeshToolWrapper wrapperFor(Object bean, String funcId, String cap, Method m,
+                                              List<String> explicit) {
+        return new MeshToolWrapper(funcId, cap, "test", bean, m, explicit,
+            JsonMapper.builder().build(), false, null,
+            McpMeshServiceToolSupport.analyzeViewParams(m));
+    }
+
+    @Test
+    void nearMiss_classAnnotatedAsView_dedicatedBootFail() throws Exception {
+        Method m = ClassParamBean.class.getMethod("run", String.class, AnnotatedClassView.class);
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> wrapperFor(new ClassParamBean(), "ClassParamBean.run", "cp_tool", m, List.of()));
+        assertTrue(ex.getMessage().contains("must be a directly-annotated interface"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("class annotated @McpMeshService"), ex.getMessage());
+        assertTrue(ex.getMessage().contains(ClassParamBean.class.getName()), ex.getMessage());
+    }
+
+    @Test
+    void nearMiss_subInterfaceInheritsAnnotation_dedicatedBootFail() throws Exception {
+        Method m = SubIfaceParamBean.class.getMethod("run", String.class, SubView.class);
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> wrapperFor(new SubIfaceParamBean(), "SubIfaceParamBean.run", "si_tool", m, List.of()));
+        assertTrue(ex.getMessage().contains("must be a directly-annotated interface"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("only inherits @McpMeshService"), ex.getMessage());
+    }
+
+    // ---- MED-2: claim-path refusal for an unresolved required VIEW edge ------
+
+    @Test
+    void invokeForClaim_requiredViewEdgeUnresolved_releasesAndDoesNotInvoke() throws Exception {
+        ReqProcessor bean = new ReqProcessor();
+        MeshToolWrapper w = reqWrapper(bean);
+
+        AtomicReference<String> released = new AtomicReference<>();
+        // The guard is the FIRST statement in invokeForClaim — BEFORE buildFullArgs
+        // (and its settle wait), same as slot deps: an unresolved required view
+        // edge releases the lease instead of invoking the handler.
+        Object result = w.invokeForClaim(Map.of("x", "v"), null, null, released::set);
+
+        assertNull(result, "guard must return null (job re-queues), not a handler result");
+        assertFalse(bean.handlerRan.get(), "handler MUST NOT run for an unresolved required view edge");
+        assertNotNull(released.get(), "the lease MUST be released so the job re-queues");
+        assertTrue(released.get().contains("req.a"), released.get());
+    }
+
+    // ---- MED-3: down-transition — resolve, unavailable event, re-resolve -----
+
+    @Test
+    void viewEdge_downThenReResolve_sentinelSubstitution() throws Exception {
+        MediaProcessor bean = new MediaProcessor();
+        MeshToolWrapper w = mediaWrapper(bean);
+        w.updateDependency(3, new ViewStub("media.transcribe", true)); // keep transcribe up
+
+        // Resolve caption → OK.
+        w.updateDependency(1, new ViewStub("media.caption", true));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> ok = (Map<String, Object>) w.invoke(Map.of("assetId", "x"));
+        assertEquals("RESP:media.caption", ok.get("caption"));
+
+        // Registry unavailable event → the facade method now throws via the
+        // unavailable sentinel.
+        w.updateDependency(1, null);
+        Exception down = assertThrows(Exception.class, () -> w.invoke(Map.of("assetId", "x")));
+        assertInstanceOf(MeshToolUnavailableException.class, unwrap(down));
+
+        // Re-resolve → OK again.
+        w.updateDependency(1, new ViewStub("media.caption", true));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> again = (Map<String, Object>) w.invoke(Map.of("assetId", "x"));
+        assertEquals("RESP:media.caption", again.get("caption"));
+    }
+
+    // ---- MED-4: two view params + explicit dep — offset arithmetic ----------
+
+    @McpMeshService
+    public interface AudioService {
+        @Selector(capability = "audio.x") String x(@Param("id") String id);
+        @Selector(capability = "audio.y") String y(@Param("id") String id);
+    }
+
+    public static class MultiViewProcessor {
+        @MeshTool(capability = "multi_tool", dependencies = @Selector(capability = "audit_log"))
+        public Map<String, Object> run(@Param("id") String id, McpMeshTool<String> auditLog,
+                                       MediaService media, AudioService audio) {
+            Map<String, Object> out = new java.util.LinkedHashMap<>();
+            out.put("caption", media.caption(id));
+            out.put("audioX", audio.x(id));
+            return out;
+        }
+    }
+
+    @Test
+    void multiViewParams_offsetArithmeticAndRouting() throws Exception {
+        MultiViewProcessor bean = new MultiViewProcessor();
+        Method m = MultiViewProcessor.class.getMethod("run",
+            String.class, McpMeshTool.class, MediaService.class, AudioService.class);
+        MeshToolWrapper w = wrapperFor(bean, "MultiViewProcessor.run", "multi_tool", m,
+            List.of("audit_log"));
+
+        // audit_log(0), view1 media edges 1..3 (caption,thumbnail,transcribe),
+        // view2 audio edges start at explicitDepCount + view1.size() = 1 + 3 = 4.
+        assertEquals(List.of("audit_log", "media.caption", "media.thumbnail", "media.transcribe",
+                "audio.x", "audio.y"),
+            w.getDependencyNames());
+
+        // Events route to the right facade method on BOTH views.
+        w.updateDependency(1, new ViewStub("media.caption", true)); // view1 caption
+        w.updateDependency(4, new ViewStub("audio.x", true));       // view2 x
+        @SuppressWarnings("unchecked")
+        Map<String, Object> out = (Map<String, Object>) w.invoke(Map.of("id", "a1"));
+        assertEquals("RESP:media.caption", out.get("caption"));
+        assertEquals("RESP:audio.x", out.get("audioX"));
+
+        // Wire list order matches the declared-index order.
+        MeshToolRegistry reg = new MeshToolRegistry();
+        reg.registerTool(bean, m, m.getAnnotation(MeshTool.class));
+        AgentSpec.ToolSpec spec = reg.getToolSpecs().stream()
+            .filter(t -> "multi_tool".equals(t.getCapability())).findFirst().orElseThrow();
+        assertEquals(List.of("audit_log", "media.caption", "media.thumbnail", "media.transcribe",
+                "audio.x", "audio.y"),
+            spec.getDependencies().stream().map(AgentSpec.DependencySpec::getCapability).toList());
+    }
+
+    // ---- MED-5: duplicate capability between explicit dep and view edge ------
+
+    @McpMeshService
+    public interface AuditView {
+        @Selector(capability = "audit_log") String log(@Param("id") String id);
+    }
+
+    public static class DupCapProcessor {
+        @MeshTool(capability = "dup_tool", dependencies = @Selector(capability = "audit_log"))
+        public String run(@Param("x") String x, AuditView view) {
+            return "x";
+        }
+    }
+
+    @Test
+    void duplicateCapability_explicitAndViewEdge_warnsButKeepsBothEdges() throws Exception {
+        LogCapture capture = LogCapture.attach(MeshToolWrapper.class);
+        try {
+            Method m = DupCapProcessor.class.getMethod("run", String.class, AuditView.class);
+            MeshToolWrapper w = wrapperFor(new DupCapProcessor(), "DupCapProcessor.run", "dup_tool",
+                m, List.of("audit_log"));
+            // Behavior unchanged: two independent edges kept.
+            assertEquals(List.of("audit_log", "audit_log"), w.getDependencyNames());
+            assertTrue(capture.events.stream().anyMatch(e -> "WARN".equals(e.level)
+                    && e.message.contains("DupCapProcessor.run")
+                    && e.message.contains("audit_log")
+                    && e.message.contains("explicit @Selector")),
+                "a duplicate-capability WARN must name the tool, capability, and both sources");
+        } finally {
+            capture.detach();
+        }
+    }
+
+    // ---- MED-7: bean-path and tool-param strategies are independent ----------
+
+    @Test
+    void beanAndToolStrategies_operateIndependently() throws Exception {
+        // Bean-path facade (injector strategy) for MediaService, unresolved.
+        McpMeshServiceRegistrar.ServiceViewMetadata meta =
+            McpMeshServiceRegistrar.analyze(MediaService.class);
+        AtomicReference<MeshDependencyInjector> injectorRef =
+            new AtomicReference<>(new MeshDependencyInjector());
+        MediaService beanFacade = (MediaService) Proxy.newProxyInstance(
+            MediaService.class.getClassLoader(),
+            new Class<?>[] {MediaService.class},
+            new McpMeshServiceInvocationHandler(MediaService.class, meta.minAvailable(),
+                meta.bindings(), new InjectorViewProxyBinding(null, injectorRef), MAPPER));
+        assertThrows(MeshToolUnavailableException.class, () -> beanFacade.caption("x"),
+            "bean-path facade starts unresolved");
+
+        // Tool-param facade (wrapper-slot strategy) for the SAME capability —
+        // resolve ONLY the tool slot; the tool path works.
+        MediaProcessor bean = new MediaProcessor();
+        MeshToolWrapper w = mediaWrapper(bean);
+        w.updateDependency(1, new ViewStub("media.caption", true));
+        w.updateDependency(3, new ViewStub("media.transcribe", true));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> out = (Map<String, Object>) w.invoke(Map.of("assetId", "x"));
+        assertEquals("RESP:media.caption", out.get("caption"));
+
+        // The bean path is STILL unresolved — the two strategies key different
+        // spaces (injector shared proxy vs wrapper funcId:dep_N slot).
+        assertThrows(MeshToolUnavailableException.class, () -> beanFacade.caption("x"),
+            "resolving the tool slot must NOT resolve the bean-path injector proxy");
+    }
+
+    /** Minimal Logback appender recording level + message for a target logger. */
+    static final class LogCapture {
+        final java.util.List<LogEvent> events = new java.util.concurrent.CopyOnWriteArrayList<>();
+        private final ch.qos.logback.classic.Logger target;
+        private final ch.qos.logback.core.AppenderBase<ch.qos.logback.classic.spi.ILoggingEvent> appender;
+
+        private LogCapture(ch.qos.logback.classic.Logger target) {
+            this.target = target;
+            this.appender = new ch.qos.logback.core.AppenderBase<>() {
+                @Override
+                protected void append(ch.qos.logback.classic.spi.ILoggingEvent event) {
+                    events.add(new LogEvent(event.getLevel().toString(), event.getFormattedMessage()));
+                }
+            };
+        }
+
+        static LogCapture attach(Class<?> loggerClass) {
+            ch.qos.logback.classic.Logger logger =
+                (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(loggerClass);
+            LogCapture capture = new LogCapture(logger);
+            capture.appender.setContext(logger.getLoggerContext());
+            capture.appender.start();
+            logger.addAppender(capture.appender);
+            return capture;
+        }
+
+        void detach() {
+            target.detachAppender(appender);
+            appender.stop();
+        }
+
+        record LogEvent(String level, String message) {}
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svtool/ToolViews.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svtool/ToolViews.java
@@ -1,0 +1,24 @@
+package io.mcpmesh.spring.svtool;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+
+/**
+ * RFC #1280 phase-2 coexistence fixture: a view usable BOTH as a phase-1 bean
+ * (discovered facade) AND as a {@code @MeshTool} parameter — independent edges.
+ */
+public final class ToolViews {
+
+    private ToolViews() {
+    }
+
+    @McpMeshService
+    public interface CoexistView {
+        @Selector(capability = "coexist.one")
+        String one(@Param("id") String id);
+
+        @Selector(capability = "coexist.two")
+        String two(@Param("id") String id);
+    }
+}

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/JavaViewConsumerApplication.java
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/JavaViewConsumerApplication.java
@@ -2,6 +2,7 @@ package com.example.serviceview;
 
 import io.mcpmesh.MeshAgent;
 import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
 import io.mcpmesh.types.MeshServiceUnavailableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,17 +17,23 @@ import java.util.Map;
  * uc37 fixture — Java consumer proving RFC #1280 {@code @McpMeshService}
  * service views end-to-end.
  *
- * <p>Two views are discovered from this package:
+ * <p>Three views are discovered from this package:
  * <ul>
  *   <li>{@link ReportService} — alpha/bravo (optional) + charlie (required),
- *       three capabilities backed by three DIFFERENT Python provider agents.</li>
+ *       three view-cap-* capabilities backed by three DIFFERENT Python
+ *       provider agents. Consumed as a constructor-injected bean (phase 1).</li>
  *   <li>{@link FlooredService} — alpha+bravo with {@code minAvailable = 2}.</li>
+ *   <li>{@link ToolParamService} — three tp-cap-* capabilities (charlie
+ *       required), consumed as a {@code @MeshTool} METHOD PARAMETER
+ *       (RFC #1280 phase 2) by {@code view_tool_param}.</li>
  * </ul>
  *
- * <p>The registration must expand to exactly THREE dependency edges under the
- * synthetic {@code __mesh_service_deps} tool (the FlooredService bindings
- * dedupe onto the ReportService edges), so the registry reports
- * {@code total_dependencies == 3} (tc04).
+ * <p>Registration carries TWO dependency surfaces: the bean-path views expand
+ * to exactly THREE view-cap-* edges under the synthetic
+ * {@code __mesh_service_deps} tool (FlooredService dedupes onto ReportService),
+ * and the tool-param view expands to THREE tp-cap-* edges on the
+ * {@code view_tool_param} tool's OWN dependency list — so the registry reports
+ * {@code total_dependencies == 6} (tc04/tc07).
  *
  * <p>The {@code @MeshTool} surfaces below are the observation points the TCs
  * call via {@code meshctl call}:
@@ -49,8 +56,9 @@ import java.util.Map;
  *       know which tool bodies call which view methods, so RFC #1280's
  *       contract is "availability per method, identical to standalone
  *       edges". Do not rewrite this fixture (or tc03) to expect the
- *       envelope; a consumer wanting the pre-invoke refusal declares the
- *       capability as a tool dependency slot.</li>
+ *       envelope; a consumer wanting the pre-invoke refusal uses the
+ *       phase-2 tool-PARAMETER form instead — see {@code view_tool_param}
+ *       below, which DOES get it (tc06).</li>
  *   <li>{@code view_floored} — calls {@code FlooredService.alphaFloored()},
  *       reporting a floor breach via the typed
  *       {@link MeshServiceUnavailableException} getters. With provider-bravo
@@ -58,6 +66,16 @@ import java.util.Map;
  *       is healthy (tc05). Any other exception propagates on purpose: a
  *       MeshToolUnavailableException here would mean the floor did NOT gate
  *       the call, and the raw tool error fails the tc05 assertions.</li>
+ *   <li>{@code view_tool_param} — RFC #1280 PHASE 2: takes
+ *       {@link ToolParamService} as a METHOD PARAMETER (no {@code @Param}),
+ *       so its three tp-cap-* methods become dependency edges ON THIS TOOL
+ *       (per-consumer-slot proxies, appended after explicit deps in
+ *       method-name order). The REQUIRED {@code charlie()} edge therefore
+ *       DOES participate in the issue #1273 pre-invoke guard: calling this
+ *       tool while tp-cap-charlie is unresolved returns the structured
+ *       {@code {"error":"dependency_unavailable","capability":"tp-cap-charlie"}}
+ *       refusal BEFORE this body runs (tc06) — the exact envelope the
+ *       class-level {@code view_critical} path above does NOT get (tc03).</li>
  * </ul>
  */
 @MeshAgent(
@@ -136,6 +154,30 @@ public class JavaViewConsumerApplication {
                 out.put("floor_total", e.getMethodsTotal());
                 out.put("floor_min", e.getMinAvailable());
             }
+            return out;
+        }
+
+        /**
+         * RFC #1280 phase 2 entry point (tc06/tc07): the
+         * {@link ToolParamService} PARAMETER (deliberately NOT
+         * {@code @Param}-annotated — it is injected, not an MCP input)
+         * expands into three tp-cap-* dependency edges on THIS tool. With
+         * tp-cap-charlie (required) unresolved, the #1273 pre-invoke guard
+         * refuses with the structured dependency_unavailable envelope before
+         * this body runs, so the per-method catches below only ever see
+         * OPTIONAL-edge degradation.
+         */
+        @MeshTool(
+            capability = "view_tool_param",
+            description = "Call all three ToolParamService view methods (view injected as a tool parameter) and report which agent served each")
+        public Map<String, Object> viewToolParam(
+                @Param("label") String label,
+                ToolParamService view) {
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("label", label);
+            reportOne(out, "alpha", view::alpha);
+            reportOne(out, "bravo", view::bravo);
+            reportOne(out, "charlie", view::charlie);
             return out;
         }
 

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/ToolParamService.java
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/ToolParamService.java
@@ -1,0 +1,40 @@
+package com.example.serviceview;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+import java.util.Map;
+
+/**
+ * uc37 phase-2 service view (RFC #1280): consumed as a {@code @MeshTool}
+ * METHOD PARAMETER by {@code view_tool_param}. Each method becomes an
+ * ordinary dependency edge ON THAT TOOL (appended after explicit
+ * {@code @Selector} deps, method-name order), with a per-consumer-slot proxy
+ * — and, the headline, the REQUIRED {@code charlie()} edge participates in
+ * the tool's pre-invoke guard: calling the tool while tp-cap-charlie is
+ * unresolved returns the structured
+ * {@code {"error":"dependency_unavailable","capability":"tp-cap-charlie"}}
+ * refusal (issue #1273 envelope) BEFORE user code runs. Contrast with the
+ * class-level {@link ReportService} bean path, which does NOT get the
+ * envelope (see tc03 vs tc06).
+ *
+ * <p>DELIBERATELY a distinct capability namespace (tp-cap-*) from
+ * {@link ReportService}'s view-cap-*: the agent-spec fold dedupes bean-path
+ * view edges against every earlier source INCLUDING tool-declared deps, so
+ * reusing view-cap-* here would dedupe the {@code __mesh_service_deps}
+ * synthetic away entirely and break tc03/tc04's registry surface. Distinct
+ * names keep BOTH dependency carriers observable: 3 edges on the
+ * {@code view_tool_param} tool + 3 on the synthetic (tc07 asserts both).
+ */
+@McpMeshService
+public interface ToolParamService {
+
+    @Selector(capability = "tp-cap-alpha")
+    Map<String, Object> alpha();
+
+    @Selector(capability = "tp-cap-bravo")
+    Map<String, Object> bravo();
+
+    @Selector(capability = "tp-cap-charlie", required = true)
+    Map<String, Object> charlie();
+}

--- a/tests/integration/suites/uc37_service_view_java/fixtures/provider-alpha/main.py
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/provider-alpha/main.py
@@ -21,6 +21,17 @@ async def alpha_tool() -> dict:
     return {"agent": "provider-alpha", "cap": "view-cap-alpha", "msg": "hello-from-alpha"}
 
 
+# RFC #1280 phase 2 (tc06/tc07): same provider also backs the tp-cap-*
+# namespace consumed by the Java view_tool_param tool's view PARAMETER —
+# deliberately distinct from view-cap-* so the consumer's two dependency
+# carriers (per-tool edges vs the __mesh_service_deps synthetic) stay
+# independently observable in the registry.
+@app.tool()
+@mesh.tool(capability="tp-cap-alpha", description="Self-identifying tool-param payload from provider-alpha")
+async def tp_alpha_tool() -> dict:
+    return {"agent": "provider-alpha", "cap": "tp-cap-alpha", "msg": "hello-from-alpha-tp"}
+
+
 @mesh.agent(
     name="provider-alpha",
     version="1.0.0",

--- a/tests/integration/suites/uc37_service_view_java/fixtures/provider-bravo/main.py
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/provider-bravo/main.py
@@ -21,6 +21,15 @@ async def bravo_tool() -> dict:
     return {"agent": "provider-bravo", "cap": "view-cap-bravo", "msg": "hello-from-bravo"}
 
 
+# RFC #1280 phase 2 (tc06/tc07): tp-cap-* namespace for the Java
+# view_tool_param tool's view PARAMETER — see provider-alpha for why the
+# namespace is distinct from view-cap-*.
+@app.tool()
+@mesh.tool(capability="tp-cap-bravo", description="Self-identifying tool-param payload from provider-bravo")
+async def tp_bravo_tool() -> dict:
+    return {"agent": "provider-bravo", "cap": "tp-cap-bravo", "msg": "hello-from-bravo-tp"}
+
+
 @mesh.agent(
     name="provider-bravo",
     version="1.0.0",

--- a/tests/integration/suites/uc37_service_view_java/fixtures/provider-charlie/main.py
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/provider-charlie/main.py
@@ -22,6 +22,16 @@ async def charlie_tool() -> dict:
     return {"agent": "provider-charlie", "cap": "view-cap-charlie", "msg": "hello-from-charlie"}
 
 
+# RFC #1280 phase 2 (tc06/tc07): tp-cap-charlie is the REQUIRED edge of the
+# Java view_tool_param tool's view PARAMETER — killing THIS process drives
+# the tool's structured dependency_unavailable refusal (tc06). Namespace is
+# distinct from view-cap-* (see provider-alpha).
+@app.tool()
+@mesh.tool(capability="tp-cap-charlie", description="Self-identifying tool-param payload from provider-charlie")
+async def tp_charlie_tool() -> dict:
+    return {"agent": "provider-charlie", "cap": "tp-cap-charlie", "msg": "hello-from-charlie-tp"}
+
+
 @mesh.agent(
     name="provider-charlie",
     version="1.0.0",

--- a/tests/integration/suites/uc37_service_view_java/tc03_required_view_edge/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc03_required_view_edge/test.yaml
@@ -31,9 +31,10 @@
 #      is "availability per method, identical to standalone edges" — the
 #      facade call raises MeshToolUnavailableException and the wrapper
 #      surfaces it through the ordinary error path. Do NOT "fix" this TC to
-#      expect the #1273 envelope; a consumer that wants the pre-invoke
-#      refusal declares the capability as a @MeshTool dependency slot
-#      instead of (or in addition to) the view.
+#      expect the #1273 envelope; the RFC #1280 PHASE 2 tool-PARAMETER form
+#      is the path that DOES get it — its view methods become the tool's own
+#      declared dependency edges. See tc06_tool_param_refusal for exactly
+#      that contrast case on this same consumer.
 #   4. Organic recovery: restart provider-charlie -> view_critical answers
 #      ok again and __mesh_service_deps re-derives available=true, with no
 #      consumer restart.

--- a/tests/integration/suites/uc37_service_view_java/tc04_deps_accounting/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc04_deps_accounting/test.yaml
@@ -1,31 +1,36 @@
 # tc04_deps_accounting — registration-time dependency expansion (RFC #1280):
-# a 3-method @McpMeshService view registers as exactly THREE ordinary
-# dependency edges under the synthetic __mesh_service_deps tool, visible in
-# the registry's dependency accounting.
+# the bean-path views register as THREE ordinary dependency edges under the
+# synthetic __mesh_service_deps tool, and (phase 2) the tool-param view adds
+# THREE more edges on the view_tool_param tool itself — both visible in the
+# registry's dependency accounting.
 #
 # Topology: ONLY the Java consumer — no providers on purpose. Dependency
 # expansion is a registration-time contract, and registering with all edges
-# unresolved also proves a view (even with a required edge) never blocks
+# unresolved also proves a view (even with required edges) never blocks
 # agent startup/registration (soft-fail philosophy: required gates
 # availability, not boot).
 #
 # Design guarantees under test:
-#   1. total_dependencies == 3 for the consumer: ReportService's three
-#      methods expand 1:1 into DependencySpecs, and FlooredService's two
-#      bindings (same capabilities, same resolved type) DEDUPE onto them —
-#      5 method bindings across 2 views, 3 wire edges.
+#   1. total_dependencies == 6 for the consumer:
+#      - bean path: ReportService's three view-cap-* methods expand 1:1 into
+#        __mesh_service_deps DependencySpecs, and FlooredService's two
+#        bindings (same capabilities, same resolved type) DEDUPE onto them —
+#        5 method bindings across 2 views, 3 wire edges;
+#      - tool-param path (phase 2): ToolParamService's three tp-cap-* methods
+#        become the view_tool_param tool's OWN dependency edges — 3 more.
+#      (Per-carrier structure is tc07's subject; here we pin the total.)
 #   2. The synthetic __mesh_service_deps capability is registered alongside
 #      the consumer's real tool capabilities (view_report, view_critical,
-#      view_floored).
+#      view_floored, view_tool_param).
 #   3. The consumer registers and reports healthy with ZERO providers up —
-#      including the required view-cap-charlie edge.
+#      including the required view-cap-charlie and tp-cap-charlie edges.
 #
 # Timing: registration wait is liveness-only (issue #1193); no view calls
 # are made, so no settle interaction. The /agents snapshot is polled only
 # for the consumer's appearance, never for dependency resolution.
 
-name: "Service views: 3-method view expands to 3 registry dependencies (Java)"
-description: "Consumer-only start: java-view-consumer registers healthy with total_dependencies=3 (cross-view dedupe) and the synthetic __mesh_service_deps capability"
+name: "Service views: bean + tool-param views expand to 6 registry dependencies (Java)"
+description: "Consumer-only start: java-view-consumer registers healthy with total_dependencies=6 (3 deduped bean-path edges + 3 tool-param edges) and the synthetic __mesh_service_deps capability"
 tags:
   - integration
   - java
@@ -77,17 +82,18 @@ assertions:
   # IDIOM: equality lives INSIDE the jq filter so the interpolation yields a
   # bare true/false; no '}' in interpolation bodies.
 
-  # Guarantee 1: the expanded-and-deduped dependency count
-  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .total_dependencies == 3)} == 'true'"
-    message: "the consumer must register exactly 3 dependencies: ReportService's 3 methods expand 1:1 and FlooredService's 2 shared-capability bindings dedupe onto them"
+  # Guarantee 1: the expanded-and-deduped dependency count across BOTH
+  # carriers (3 bean-path synthetic + 3 tool-param edges)
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .total_dependencies == 6)} == 'true'"
+    message: "the consumer must register exactly 6 dependencies: 3 deduped bean-path view-cap-* edges on __mesh_service_deps + 3 tp-cap-* edges on the view_tool_param tool"
 
   # Guarantee 2: the synthetic dependency-carrier capability is registered
   - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"__mesh_service_deps\")] | length == 1)} == 'true'"
     message: "the synthetic __mesh_service_deps capability must be registered exactly once"
 
   # ...alongside the real tool capabilities
-  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"view_report\" or .name == \"view_critical\" or .name == \"view_floored\")] | length == 3)} == 'true'"
-    message: "the consumer's three real @MeshTool capabilities must register alongside the view expansion"
+  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"view_report\" or .name == \"view_critical\" or .name == \"view_floored\" or .name == \"view_tool_param\")] | length == 4)} == 'true'"
+    message: "the consumer's four real @MeshTool capabilities must register alongside the view expansion"
 
   # Guarantee 3: providerless registration — a view never blocks boot
   - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .status == \"healthy\")} == 'true'"

--- a/tests/integration/suites/uc37_service_view_java/tc06_tool_param_refusal/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc06_tool_param_refusal/test.yaml
@@ -1,0 +1,292 @@
+# tc06_tool_param_refusal — RFC #1280 PHASE 2: a @McpMeshService view as a
+# @MeshTool METHOD PARAMETER. The CONTRAST case to tc03: because the view's
+# methods become dependency edges ON THE TOOL ITSELF, the REQUIRED
+# tp-cap-charlie edge participates in the issue #1273 pre-invoke guard, and
+# the tool's invocation is refused with the STRUCTURED
+# {"error":"dependency_unavailable","capability":"tp-cap-charlie"} envelope —
+# the exact envelope tc03 documents the class-level bean path does NOT get.
+# (tc03 says "class-level edges don't get the envelope — see tc06"; this is
+# the inverse pointer.)
+#
+# Topology: same three Python providers as tc01 (each also publishes its
+# tp-cap-* twin) + the Java consumer, whose view_tool_param tool takes the
+# ToolParamService view as a parameter. provider-charlie (backing the
+# required tp-cap-charlie edge) is the kill/restart target.
+#
+# Design guarantees under test:
+#   1. Baseline: view_tool_param answers with the per-method report — each
+#      tp-cap-* method served by its own provider (per-consumer-slot proxies
+#      resolve exactly like explicit @Selector deps).
+#   2. Kill provider-charlie -> invoking view_tool_param returns the
+#      structured refusal: isError=true and the body
+#      {"error":"dependency_unavailable","capability":"tp-cap-charlie"} —
+#      BEFORE user code runs (the fixture's per-method catches would
+#      otherwise report charlie_error instead; seeing the envelope proves
+#      the guard fired, not the handler).
+#   3. Registry: the required edge is the TOOL's own dep, so capability
+#      view_tool_param itself derives available=false with unavailable_reason
+#      naming tp-cap-charlie (per-tool #1249 derivation — the uc34 b-cap
+#      precedent) WHILE the consumer stays registered and healthy.
+#   4. Restart provider-charlie -> the tool answers the full report again and
+#      view_tool_param re-derives available=true, with no consumer restart.
+#
+# Timing: transitions ride the default health debounce (~15-25s) plus one
+# consumer heartbeat — polled with deadlines. No dependency-resolution waits
+# (issue #1193): the baseline call rides the settle window.
+
+name: "Service views phase 2: required tool-param edge refuses with structured dependency_unavailable (Java)"
+description: "Kill provider-charlie: view_tool_param (view as tool PARAMETER) is refused with isError + error=dependency_unavailable/capability=tp-cap-charlie and its capability derives unavailable; restart: both recover"
+tags:
+  - integration
+  - java
+  - python
+  - registry
+  - service-view
+  - rfc-1280
+  - required-deps
+  - availability
+  - issue-1249
+  - slow
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/provider-alpha /workspace/
+      cp -rL /uc-artifacts/provider-bravo /workspace/
+      cp -rL /uc-artifacts/provider-charlie /workspace/
+      cp -rL /uc-artifacts/java-view-consumer /workspace/
+
+  - name: "Install provider-alpha deps"
+    handler: pip-install
+    path: /workspace/provider-alpha
+
+  - name: "Install provider-bravo deps"
+    handler: pip-install
+    path: /workspace/provider-bravo
+
+  - name: "Install provider-charlie deps"
+    handler: pip-install
+    path: /workspace/provider-charlie
+
+  - name: "Install Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-view-consumer
+    timeout: 600
+
+  - name: "Start provider-alpha (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-alpha/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Start provider-bravo (port 9102)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-bravo/main.py --env MCP_MESH_HTTP_PORT=9102 -d
+
+  - name: "Start provider-charlie (port 9103)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-charlie/main.py --env MCP_MESH_HTTP_PORT=9103 -d
+
+  - name: "Start java-view-consumer (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-consumer --env MCP_MESH_HTTP_PORT=9201 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193): 240s deadline covers the cold JVM start.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "provider-alpha provider-bravo provider-charlie java-view-consumer"
+
+  # Baseline: the full per-method report through the tool-param facade.
+  # ENVELOPE: Java tools carry the payload ONLY as an escaped JSON string in
+  # content[0].text (no structuredContent) — parse via
+  # `.content[0].text | fromjson` (suite idiom), equality inside the jq
+  # filter; anchored key:value pairing so cross-wired slots cannot pass.
+  - name: "Wait for full tool-param report (baseline)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 90); do
+        RESP=$(meshctl call view_tool_param '{"label":"tc06"}' --raw 2>&1 || true)
+        A=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .alpha_agent == "provider-alpha"' 2>/dev/null || echo "")
+        B=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .bravo_agent == "provider-bravo"' 2>/dev/null || echo "")
+        C=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .charlie_agent == "provider-charlie"' 2>/dev/null || echo "")
+        if [ "$A" = "true" ] && [ "$B" = "true" ] && [ "$C" = "true" ]; then
+          echo "TP_BASELINE_BOUND=1 after ~$((i*2))s"
+          [ "$(echo "$RESP" | jq -r '.content[0].text | fromjson | .charlie_cap == "tp-cap-charlie"' 2>/dev/null)" = "true" ] && echo "TP_CHARLIE_CAP_OK=1"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: view_tool_param never reported all three tp-cap bindings within 180s"
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: tp_baseline
+    timeout: 200
+
+  # Pure-JSON snapshot for the baseline availability assertion.
+  - name: "Capture baseline /agents snapshot"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_baseline
+
+  - name: "Kill provider-charlie"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop provider-charlie
+    capture: kill_charlie
+
+  # Guarantee 2: the STRUCTURED refusal. Poll until the guard fires — the
+  # window between provider death and the consumer heartbeat dropping the
+  # slot may transiently surface a handler-level charlie_error report;
+  # ONLY the envelope with error=dependency_unavailable AND the exact
+  # capability name counts as the verdict (uc34's established assertion
+  # shape `.error == "..." and .capability == "..."`, applied to the tool
+  # result's content[0].text instead of a route's 503 body).
+  - name: "Wait for the structured dependency_unavailable refusal"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 60); do
+        RESP=$(meshctl call view_tool_param '{"label":"tc06"}' --raw 2>&1 || true)
+        REF=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .error == "dependency_unavailable" and .capability == "tp-cap-charlie"' 2>/dev/null || echo "")
+        if [ "$REF" = "true" ]; then
+          echo "TP_REFUSAL_STRUCTURED=1 after ~$((i*2))s"
+          [ "$(echo "$RESP" | jq -r '.isError == true' 2>/dev/null)" = "true" ] && echo "TP_REFUSAL_ISERROR=1"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: the structured dependency_unavailable refusal never appeared within 120s"
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: tp_refusal
+    timeout: 140
+
+  # Guarantee 3: per-tool derived availability — the required edge belongs
+  # to view_tool_param itself.
+  - name: "Wait for view_tool_param to derive unavailable"
+    handler: shell
+    workdir: /workspace
+    command: |
+      AVAIL=""
+      for i in $(seq 1 60); do
+        AVAIL=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name == "java-view-consumer") | .capabilities[] | select(.name == "view_tool_param") | .available' 2>/dev/null || echo "")
+        if [ "$AVAIL" = "false" ]; then
+          echo "TP_CAP_UNAVAILABLE=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: view_tool_param never derived available=false within 120s (last=$AVAIL)"
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name == "java-view-consumer")' 2>/dev/null || true
+      exit 1
+    capture: wait_tp_cap_down
+    timeout: 140
+
+  # Pure-JSON snapshot WHILE the required tool edge is broken.
+  - name: "Capture /agents snapshot during outage"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_during_outage
+
+  - name: "Restart provider-charlie"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-charlie/main.py --env MCP_MESH_HTTP_PORT=9103 -d
+
+  # Guarantee 4: organic recovery — no consumer restart.
+  - name: "Wait for view_tool_param recovery"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 75); do
+        RESP=$(meshctl call view_tool_param '{"label":"tc06"}' --raw 2>&1 || true)
+        RECOVERED=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .charlie_agent == "provider-charlie"' 2>/dev/null || echo "")
+        if [ "$RECOVERED" = "true" ]; then
+          echo "TP_RECOVERED=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: view_tool_param never recovered within 150s of restarting provider-charlie"
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: tp_recovery
+    timeout: 170
+
+  - name: "Wait for view_tool_param to re-derive available"
+    handler: shell
+    workdir: /workspace
+    command: |
+      AVAIL=""
+      for i in $(seq 1 60); do
+        AVAIL=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name == "java-view-consumer") | .capabilities[] | select(.name == "view_tool_param") | .available' 2>/dev/null || echo "")
+        if [ "$AVAIL" = "true" ]; then
+          echo "TP_CAP_RECOVERED=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: view_tool_param never re-derived available=true within 120s (last=$AVAIL)"
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name == "java-view-consumer")' 2>/dev/null || true
+      exit 1
+    capture: wait_tp_cap_recovered
+    timeout: 140
+
+assertions:
+  # IDIOM: equality lives INSIDE the jq filter so the interpolation yields a
+  # bare true/false; no '}' in interpolation bodies.
+
+  # Guarantee 1: per-method resolution through the tool-param facade
+  - expr: "${captured.tp_baseline} contains 'TP_BASELINE_BOUND=1'"
+    message: "each tool-param view method must resolve to its OWN provider (per-consumer-slot proxies, same resolution as explicit @Selector deps)"
+  - expr: "${captured.tp_baseline} contains 'TP_CHARLIE_CAP_OK=1'"
+    message: "the required charlie() method must carry provider-charlie's tp-cap-charlie payload at baseline"
+  - expr: "${jq:captured.agents_baseline:(.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"view_tool_param\") | .available == true and .unavailable_reason == null)} == 'true'"
+    message: "baseline: view_tool_param must be available with no unavailable_reason while all providers are up"
+
+  # Guarantee 2: THE structured pre-invoke refusal (the tc03 contrast)
+  - expr: "${captured.tp_refusal} contains 'TP_REFUSAL_STRUCTURED=1'"
+    message: "the tool must be refused with the structured contract (error=dependency_unavailable, capability=tp-cap-charlie) — a charlie_error report would mean user code ran with a dead REQUIRED proxy (guard did not fire); contrast tc03, where the class-level bean path legitimately gets no envelope"
+  - expr: "${captured.tp_refusal} contains 'TP_REFUSAL_ISERROR=1'"
+    message: "the refusal must be an isError=true tool result (issue #1273 envelope), not a successful report"
+
+  # Guarantee 3: the required edge is the TOOL's own dep
+  - expr: "${captured.wait_tp_cap_down} contains 'TP_CAP_UNAVAILABLE=1'"
+    message: "capability view_tool_param must derive available=false — the required tp-cap-charlie edge belongs to THIS tool (per-tool #1249 derivation)"
+  - expr: "${jq:captured.agents_during_outage:(.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"view_tool_param\") | .unavailable_reason // \"\" | contains(\"tp-cap-charlie\"))} == 'true'"
+    message: "view_tool_param's unavailable_reason must name the broken required edge (tp-cap-charlie)"
+  - expr: "${jq:captured.agents_during_outage:([.agents[] | select(.name == \"java-view-consumer\")] | length == 1)} == 'true'"
+    message: "java-view-consumer must still be REGISTERED while the required tool edge is broken"
+  - expr: "${jq:captured.agents_during_outage:(.agents[] | select(.name == \"java-view-consumer\") | .status == \"healthy\")} == 'true'"
+    message: "java-view-consumer must still be HEALTHY — unavailability is capability-level derived state"
+
+  # Guarantee 4: organic recovery
+  - expr: "${captured.tp_recovery} contains 'TP_RECOVERED=1'"
+    message: "view_tool_param must answer the full report again after provider-charlie restarts, with no consumer restart"
+  - expr: "${captured.wait_tp_cap_recovered} contains 'TP_CAP_RECOVERED=1'"
+    message: "capability view_tool_param must re-derive available=true after the provider returns"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc37_service_view_java/tc07_tool_param_deps_accounting/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc07_tool_param_deps_accounting/test.yaml
@@ -1,0 +1,132 @@
+# tc07_tool_param_deps_accounting — RFC #1280 phase 2 registration
+# accounting: the tool-param view's edges are the view_tool_param tool's OWN
+# dependencies (per-tool carrier), coexisting with — not folded into — the
+# bean-path __mesh_service_deps synthetic.
+#
+# Topology: ONLY the Java consumer, no providers (registration-time contract,
+# same posture as tc04).
+#
+# The registry's public API does not expose per-tool dependency LISTS
+# (CapabilityInfo carries name/available/unavailable_reason only), so "the
+# edges hang on THAT tool" is proven through the per-capability #1249
+# derivation, which IS keyed by the declaring tool:
+#   1. total_dependencies == 6: 3 tp-cap-* edges on view_tool_param + the 3
+#      deduped view-cap-* edges on __mesh_service_deps. (If the tool-param
+#      edges had been folded into the synthetic — or vice versa — the total
+#      and the per-capability reasons below could not BOTH hold.)
+#   2. With no providers up, capability view_tool_param derives
+#      available=false with unavailable_reason naming tp-cap-charlie — its
+#      OWN required edge, unresolved. A dep-less tool cannot derive
+#      unavailable, so this pins the edges to that tool.
+#   3. In the SAME snapshot, __mesh_service_deps derives available=false
+#      naming view-cap-charlie — the bean-path carrier survives, with its
+#      OWN distinct required edge (dedupe did NOT collapse the carriers:
+#      tp-cap-* vs view-cap-* namespaces are disjoint by design, see
+#      ToolParamService.java).
+#   4. The consumer's dep-less tool capabilities (view_report,
+#      view_critical, view_floored) stay available=true — the edges are NOT
+#      smeared agent-wide — and the consumer registers healthy.
+#
+# Timing: registration wait is liveness-only (issue #1193); the availability
+# polls below wait for the registry's initial DERIVATION of already-declared
+# edges (a registry-side computation), not for dependency resolution — with
+# no providers there is nothing to resolve.
+
+name: "Service views phase 2: tool-param edges are the tool's own deps, alongside the bean-path synthetic (Java)"
+description: "Consumer-only start: total_dependencies=6; view_tool_param derives unavailable naming its OWN required tp-cap-charlie edge while __mesh_service_deps independently names view-cap-charlie; dep-less tools stay available"
+tags:
+  - integration
+  - java
+  - registry
+  - service-view
+  - rfc-1280
+  - required-deps
+  - availability
+  - slow
+timeout: 900
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: cp -rL /uc-artifacts/java-view-consumer /workspace/
+
+  - name: "Install Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-view-consumer
+    timeout: 600
+
+  - name: "Start java-view-consumer (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-consumer --env MCP_MESH_HTTP_PORT=9201 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193): 240s deadline covers the cold JVM start.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "java-view-consumer"
+
+  # Wait for the registry's initial derivation of BOTH carriers' required
+  # edges (unresolved-with-no-provider => available=false). Registry-side
+  # computation, not dep resolution.
+  - name: "Wait for both dependency carriers to derive unavailable"
+    handler: shell
+    workdir: /workspace
+    command: |
+      TP=""; SV=""
+      for i in $(seq 1 60); do
+        SNAP=$(curl -s http://localhost:8000/agents)
+        TP=$(echo "$SNAP" | jq -r '.agents[] | select(.name == "java-view-consumer") | .capabilities[] | select(.name == "view_tool_param") | .available' 2>/dev/null || echo "")
+        SV=$(echo "$SNAP" | jq -r '.agents[] | select(.name == "java-view-consumer") | .capabilities[] | select(.name == "__mesh_service_deps") | .available' 2>/dev/null || echo "")
+        if [ "$TP" = "false" ] && [ "$SV" = "false" ]; then
+          echo "BOTH_CARRIERS_DERIVED=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: carriers never derived unavailable within 120s (view_tool_param=$TP __mesh_service_deps=$SV)"
+      curl -s http://localhost:8000/agents | jq '.agents[] | select(.name == "java-view-consumer")' 2>/dev/null || true
+      exit 1
+    capture: wait_carriers_derived
+    timeout: 140
+
+  # Pure-JSON snapshot for the jq assertions (state is static: no providers).
+  - name: "Capture /agents snapshot"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_snapshot
+
+assertions:
+  # IDIOM: equality lives INSIDE the jq filter so the interpolation yields a
+  # bare true/false; no '}' in interpolation bodies.
+
+  - expr: "${captured.wait_carriers_derived} contains 'BOTH_CARRIERS_DERIVED=1'"
+    message: "both dependency carriers (view_tool_param and __mesh_service_deps) must derive available=false with no providers up"
+
+  # Guarantee 1: the combined dependency total across both carriers
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .total_dependencies == 6)} == 'true'"
+    message: "total_dependencies must be 6: the 3 tp-cap-* edges on the view_tool_param tool PLUS the 3 deduped view-cap-* edges on __mesh_service_deps"
+
+  # Guarantee 2: the tool-param edges hang on the TOOL itself
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"view_tool_param\") | .unavailable_reason // \"\" | contains(\"tp-cap-charlie\"))} == 'true'"
+    message: "view_tool_param's unavailable_reason must name ITS OWN required tp-cap-charlie edge — a dep-less tool cannot derive unavailable, so this pins the view edges to the tool"
+
+  # Guarantee 3: the bean-path synthetic survives with its OWN edge
+  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"__mesh_service_deps\")] | length == 1)} == 'true'"
+    message: "the __mesh_service_deps synthetic must still be registered exactly once — the tool-param expansion must not fold the bean-path views away"
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"__mesh_service_deps\") | .unavailable_reason // \"\" | contains(\"view-cap-charlie\"))} == 'true'"
+    message: "__mesh_service_deps' unavailable_reason must name view-cap-charlie — the bean-path carrier keeps its own distinct required edge"
+
+  # Guarantee 4: edges are per-tool, not agent-wide
+  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"view_report\" or .name == \"view_critical\" or .name == \"view_floored\") | select(.available == true)] | length == 3)} == 'true'"
+    message: "the dep-less tool capabilities must all stay available=true — view edges belong to their declaring carrier, never the whole agent"
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .status == \"healthy\")} == 'true'"
+    message: "the consumer must register HEALTHY with zero providers up — required view edges gate availability, never startup"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Phase 2 of RFC #1280: a `@McpMeshService` view interface used as a `@MeshTool` method **parameter** expands into N ordinary dependency edges on that tool. Zero wire/registry changes — the tool's `DependencySpec` list just grows.

- **Detection & pairing**: a view param is a new type-detected slot kind (MeshJob precedent). Explicit `@Selector` deps pair with `McpMeshTool`/`MeshJob` slots exactly as before (bounded to the explicit count — zero behavior change for existing signatures); view edges occupy a disjoint declared-index range `[explicitDepCount, …)`, view params in parameter order, methods name-sorted per view. Wire order and wrapper tables derive from the same deterministic analyzer.
- **Semantic payoff**: `required = true` view methods participate in the tool's pre-invoke guard — the structured `dependency_unavailable` refusal on direct **and** claim paths (lease released, handler never runs), and per-tool registry availability derivation. This is the tool-scoped alternative the phase-1 bean-path admonition now points to.
- **Plumbing**: per-consumer-slot typed proxies (`funcId:dep_N` space, settle keys included); facade logic shared with phase 1 via a pluggable proxy-binding strategy (injector-backed bean path / wrapper-slot-backed tool path); unavailable sentinel for unresolved slots; `minAvailable` floor unchanged at the facade.
- **Boot-fail & signals**: `@Param` on a view param; dedicated near-miss messages for class-annotated or annotation-inheriting types (sub-interface support deliberately deferred); duplicate capability between an explicit dep and a view edge WARNs (behavior matches duplicate explicit deps).
- **Example**: `process_media_strict` in `examples/java/service-view/` — both consumption styles side by side, with the honest refusal contrast (pre-invoke envelope vs mid-handler raw exception) and the same-interface dedupe explained.
- **Integration**: uc37 grows to 7 TCs — tc06 asserts the structured refusal envelope end-to-end on a disjoint `tp-cap-*` namespace (cross-referenced with tc03's class-level contrast), tc07 pins the dual dependency-carrier accounting.
- **Docs**: "Views as tool parameters" on all four Java surfaces; the phase-1 admonition revised; same-interface reuse documented precisely (shared capabilities register as a single wire edge — tool-declared wins).

## Review Notes

- Two zero-context review rounds: the core round traced every consumer of the declared-index machinery (the historically skew-prone area) — 0 HIGH, zero behavior change for view-free signatures confirmed; all MED/LOW findings fixed (near-miss boot-fail, claim-path/down-transition/multi-view tests, dup-capability WARN, behavioral coexistence test). The checklist round's one WARNING (docs overclaiming "independent sets of edges" for same-interface reuse) fixed on all surfaces.
- Tool path has no self-produced-capability dedup for explicit deps today; view edges deliberately match that existing behavior (verified, reported, unchanged).
- Deferred with rationale: sub-interface view detection; consolidating the post-processor/registry double call of the shared analyzer (same deterministic source, invariant commented) — phase-3 candidates.

## Test plan

- [x] Java starter suite 614/614, SDK 98/98
- [x] src-tests 12/12 (fresh `tsuite-mesh:local` with phase-2 runtime)
- [x] `tsuite run --suite-path tests/integration --uc uc37_service_view_java` — 7/7 on k8s, including tc06's verbatim envelope `{"error":"dependency_unavailable","capability":"tp-cap-charlie"}` and phase-1 TC regression pass
- [x] Example modules compile; `go build ./src/core/cli/...` + mkdocs strict green

Closes #1285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using service views as tool parameters, with clearer handling of required vs. optional dependencies.
  * Expanded example apps to show both standard and strict service-view usage paths.

* **Bug Fixes**
  * Improved dependency tracking and availability behavior so missing requirements are reported more consistently before execution.

* **Documentation**
  * Updated Java docs and examples to explain service-view consumption, dependency ordering, and refusal behavior more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->