### PR TITLE
feat(java,registry): producer sugar + dot-namespaced capabilities (RFC #1280 phase 3)

### DIFF
--- a/docs/java/annotations.md
+++ b/docs/java/annotations.md
@@ -133,28 +133,49 @@ Specifies capability and tag selection for dependencies, LLM providers, and filt
 
 ## @McpMeshService
 
-Marks an interface as a consumer-owned **service view**: one typed facade that aggregates several capability dependencies. Each abstract method binds one capability via a method-level `@Selector`, and each method delegates to its own resolved proxy — so different methods can resolve to different provider agents. Spring auto-discovers the interface and injects a facade bean you `@Autowired`.
+Aggregates several capabilities behind one typed **service view**, and — on a class — publishes a bean's methods as capabilities. Where you put it decides the role:
+
+| Placement | Role |
+| --------- | ---- |
+| On an **interface** (`@McpMeshService`) | Consumer **service view** — each abstract method binds one capability via a method-level `@Selector`; consumed as an `@Autowired` facade bean or a `@MeshTool` parameter |
+| On a **Spring bean class** (`@McpMeshService("prefix")`) | Producer sugar — publishes each eligible public method as capability `prefix.<methodName>` |
+
+**As a consumer view (interface):**
 
 ```java
 @McpMeshService
 public interface MediaService {
-    @Selector(capability = "media_caption", required = true) CaptionResult    caption(CaptionRequest req);
-    @Selector(capability = "media_thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
-    @Selector(capability = "media_transcribe")               TranscriptResult transcribe(TranscribeRequest req);
+    @Selector(capability = "media.caption", required = true) CaptionResult    caption(CaptionRequest req);
+    @Selector(capability = "media.thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
+    @Selector(capability = "media.transcribe")               TranscriptResult transcribe(TranscribeRequest req);
 }
 ```
 
-| Attribute      | Required | Description                                                                 |
-| -------------- | -------- | -------------------------------------------------------------------------- |
-| `minAvailable` | No       | Availability floor; below it every facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (default `0` = no floor) |
-
-Each method expands into an ordinary dependency edge, so a view over N capabilities shows as N dependencies in `meshctl list`. A view is consumed two ways: `@Autowired` as a facade bean, or passed as a `@MeshTool` **parameter** — where its methods become dependency edges on that tool and any `required` view method joins the tool's pre-invoke `dependency_unavailable` guard:
+Each method expands into an ordinary dependency edge, so a view over N capabilities shows as N dependencies in `meshctl list`. It is consumed two ways: `@Autowired` as a facade bean, or passed as a `@MeshTool` **parameter** — where its methods become dependency edges on that tool and any `required` view method joins the tool's pre-invoke `dependency_unavailable` guard:
 
 ```java
 public Result process(@Param("id") String id, MediaService media) { ... }  // view param → per-method edges
 ```
 
-For the full semantics — param-mapping rules, return types, `required`/optional behavior, the availability floor, and both consumption styles — see the [Dependency Injection](dependency-injection.md#service-views-with-mcpmeshservice) guide.
+**As a producer (class):**
+
+```java
+@Component
+@McpMeshService("media")
+public class MediaProvider {
+    public CaptionResult   caption(CaptionRequest req)     { ... }  // → capability "media.caption"
+    public ThumbnailResult thumbnail(ThumbnailRequest req) { ... }  // → capability "media.thumbnail"
+}
+```
+
+Public instance methods declared on the class are published name-sorted; a method carrying its own `@MeshTool` wins (use it for a custom capability/tags/version). Overloads boot-fail.
+
+| Attribute      | Required   | Description                                                                 |
+| -------------- | ---------- | -------------------------------------------------------------------------- |
+| `value`        | On a class | Capability prefix for producer publishing (segment-validated); omit on a consumer interface |
+| `minAvailable` | No         | Consumer-view availability floor; below it every facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (default `0`). Ignored (WARN) on a producer class |
+
+For the full semantics — param-mapping rules, return types, `required`/optional behavior, the availability floor, both consumption styles, and producer publishing — see the [Dependency Injection](dependency-injection.md#service-views-with-mcpmeshservice) guide.
 
 ## @MeshLlm
 

--- a/docs/java/capabilities-tags.md
+++ b/docs/java/capabilities-tags.md
@@ -165,6 +165,8 @@ When an agent requests a dependency, the registry resolves it by:
 | `domain_action` | `auth_validate` | Domain-specific  |
 | `service`       | `llm`           | Generic services |
 
+A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
+
 ## Versioning
 
 Capabilities support semantic versioning:

--- a/docs/java/dependency-injection.md
+++ b/docs/java/dependency-injection.md
@@ -263,7 +263,7 @@ public class MediaProvider {
 - Methods publish in **name-sorted** order. Only **public, instance** methods **declared on the class itself** are published — non-public, `static`, `Object`, and inherited-from-superclass methods are skipped.
 - An **explicit `@MeshTool`** on a method wins — use it whenever a method needs a custom capability, tags, version, or description; producer sugar synthesizes none of those.
 - **Overloaded** public methods collide on `prefix.<name>` and boot-fail: rename one, make one non-public, or give one an explicit `@MeshTool`.
-- `minAvailable` is a consumer-view attribute; on a producer class it logs a WARN and is ignored. A `@McpMeshService` class that Spring doesn't manage as a bean WARNs at scan time and publishes nothing.
+- `minAvailable` is a consumer-view attribute; on a producer class it logs a WARN and is ignored. A `@McpMeshService` class that Spring doesn't manage as a bean WARNs during startup, after bean initialization, and publishes nothing.
 
 !!! note "Discovery caveat"
     An auto-registered facade **bean** requires `@McpMeshService` directly on the interface. An interface that only *inherits* `@McpMeshService` from a super-interface is still usable as a `@MeshTool` view parameter, but is not auto-discovered as a bean.

--- a/docs/java/dependency-injection.md
+++ b/docs/java/dependency-injection.md
@@ -163,9 +163,9 @@ The differentiator: **each method delegates to its own per-capability resolved p
 ```java
 @McpMeshService
 public interface MediaService {
-    @Selector(capability = "media_caption", required = true) CaptionResult    caption(CaptionRequest req);
-    @Selector(capability = "media_thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
-    @Selector(capability = "media_transcribe")               TranscriptResult transcribe(TranscribeRequest req);
+    @Selector(capability = "media.caption", required = true) CaptionResult    caption(CaptionRequest req);
+    @Selector(capability = "media.thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
+    @Selector(capability = "media.transcribe")               TranscriptResult transcribe(TranscribeRequest req);
 
     record CaptionRequest(String assetId, String text) {}
     record ThumbnailRequest(String assetId, int width) {}
@@ -225,7 +225,7 @@ A view can also be consumed as a `@MeshTool` method **parameter** instead of an 
 public Result processMedia(
         @Param(value = "assetId", description = "Asset id") String assetId,
         McpMeshTool<String> auditLog,
-        MediaService media) {   // view param → media_caption + media_thumbnail + media_transcribe edges
+        MediaService media) {   // view param → media.caption + media.thumbnail + media.transcribe edges
     ...
 }
 ```
@@ -242,6 +242,31 @@ The same interface can be used both ways at once — autowired as a bean **and**
 The optional `@McpMeshService(minAvailable = N)` adds a consumer-local availability floor: when fewer than `N` of the view's methods currently resolve, **every** facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (settle-grace-aware). The default `0` means no floor — each method soft- or hard-fails per its own `required` flag.
 
 A service view is **consumer-local**, not a shared contract: two consumers may aggregate the same capabilities differently, and there is no group versioning or interface-level availability summary. Each method resolves independently.
+
+### Publishing a service (producer side)
+
+The same annotation works on the **provider** side too. Put class-level `@McpMeshService("prefix")` on a Spring bean and each eligible public method is published as an ordinary mesh tool under the capability `prefix.<methodName>` — pure sugar over writing one `@MeshTool` per method.
+
+```java
+@Component
+@McpMeshService("media")
+public class MediaProvider {
+    public CaptionResult   caption(CaptionRequest req)     { ... }   // → capability "media.caption"
+    public ThumbnailResult thumbnail(ThumbnailRequest req) { ... }   // → capability "media.thumbnail"
+
+    @MeshTool(capability = "transcribe_gpu", tags = {"gpu"})          // custom name — @MeshTool overrides the prefix.<method> derivation
+    public TranscriptResult transcribe(TranscribeRequest req) { ... }
+}
+```
+
+- The `prefix` is entirely yours, segment-validated at boot (each dot-separated segment `^[a-zA-Z][a-zA-Z0-9_-]*$`, e.g. `media` or `media.v2`). The blank default `@McpMeshService` marks a consumer view and boot-fails on a producer class.
+- Methods publish in **name-sorted** order. Only **public, instance** methods **declared on the class itself** are published — non-public, `static`, `Object`, and inherited-from-superclass methods are skipped.
+- An **explicit `@MeshTool`** on a method wins — use it whenever a method needs a custom capability, tags, version, or description; producer sugar synthesizes none of those.
+- **Overloaded** public methods collide on `prefix.<name>` and boot-fail: rename one, make one non-public, or give one an explicit `@MeshTool`.
+- `minAvailable` is a consumer-view attribute; on a producer class it logs a WARN and is ignored. A `@McpMeshService` class that Spring doesn't manage as a bean WARNs at scan time and publishes nothing.
+
+!!! note "Discovery caveat"
+    An auto-registered facade **bean** requires `@McpMeshService` directly on the interface. An interface that only *inherits* `@McpMeshService` from a super-interface is still usable as a `@MeshTool` view parameter, but is not auto-discovered as a bean.
 
 ## `McpMeshTool<T>` API Reference
 

--- a/docs/python/capabilities-tags.md
+++ b/docs/python/capabilities-tags.md
@@ -182,6 +182,8 @@ def my_tool(date: mesh.McpMeshTool = None, weather: mesh.McpMeshTool = None):
 | `domain_action` | `auth_validate` | Domain-specific  |
 | `service`       | `llm`           | Generic services |
 
+A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
+
 ## Versioning
 
 Capabilities support semantic versioning:

--- a/docs/typescript/capabilities-tags.md
+++ b/docs/typescript/capabilities-tags.md
@@ -212,6 +212,8 @@ agent.addTool({
 
 A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
 
+The TypeScript SDK performs no local capability-name validation — it forwards capability strings to the registry as-is, so a malformed name is rejected at registration time by the registry, not by the TS runtime. The segment-wise format above is the contract the registry enforces.
+
 ## Versioning
 
 Capabilities support semantic versioning:

--- a/docs/typescript/capabilities-tags.md
+++ b/docs/typescript/capabilities-tags.md
@@ -210,6 +210,8 @@ agent.addTool({
 | `domain_action` | `auth_validate` | Domain-specific  |
 | `service`       | `llm`           | Generic services |
 
+A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
+
 ## Versioning
 
 Capabilities support semantic versioning:

--- a/examples/java/service-view/README.md
+++ b/examples/java/service-view/README.md
@@ -13,19 +13,47 @@ changes. The group is a typed view; the capability remains the atom.
 
 | Agent                 | Port | Capability         | Role                                   |
 |-----------------------|------|--------------------|----------------------------------------|
-| `caption-provider`    | 8110 | `media_caption`    | Provider A — captions an asset         |
-| `thumbnail-provider`  | 8111 | `media_thumbnail`  | Provider B — thumbnails an asset       |
-| `transcribe-provider` | 8112 | `media_transcribe` | Provider C — transcribes an asset      |
+| `caption-provider`    | 8110 | `media.caption`    | Provider A — captions an asset         |
+| `thumbnail-provider`  | 8111 | `media.thumbnail`  | Provider B — thumbnails an asset       |
+| `transcribe-provider` | 8112 | `media.transcribe` | Provider C — transcribes an asset      |
 | `media-gateway`       | 8113 | `process_media`, `process_media_strict` | Consumer — one `MediaService` view, consumed two ways |
+
+Each provider publishes ONE slice of the shared, dotted `media.*` namespace, and
+the consumer aggregates all three behind one typed interface.
+
+## Producer side: publish a service, not N tools
+
+Each provider is a producer-sugar bean: a class annotated
+`@McpMeshService("media")` publishes each of its public methods as a mesh tool
+under the capability `media.<methodName>` — no per-method `@MeshTool` needed.
+
+```java
+@Component
+@McpMeshService("media")            // prefix is entirely user-chosen; nothing is hard-coded in the mesh
+public class MediaCaptionService {
+    public CaptionResult caption(@Param("assetId") String assetId,   // → capability "media.caption"
+                                 @Param("text") String text) { ... }
+}
+```
+
+- **Dotted capability names are first-class** across the stack — registry,
+  Python, and Java validators all accept segment-wise names like `media.caption`.
+  The published capability is simply `prefix + "." + methodName`.
+- **The prefix is yours.** `"media"` carries no special meaning; pick any
+  segment-wise name (e.g. `"media.v2"`). The three agents here all use `"media"`,
+  so together they populate one namespace from three independent processes.
+- **Methods are published name-sorted**, and an explicit `@MeshTool` on a method
+  still WINS — reach for it only when a method needs custom `tags`, `version`, or
+  `description`; the sugar intentionally uses annotation defaults otherwise.
 
 The consumer declares one interface aggregating all three capabilities:
 
 ```java
 @McpMeshService
 public interface MediaService {
-    @Selector(capability = "media_caption", required = true) CaptionResult    caption(CaptionRequest req);
-    @Selector(capability = "media_thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
-    @Selector(capability = "media_transcribe")               TranscriptResult transcribe(TranscribeRequest req);
+    @Selector(capability = "media.caption", required = true) CaptionResult    caption(CaptionRequest req);
+    @Selector(capability = "media.thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
+    @Selector(capability = "media.transcribe")               TranscriptResult transcribe(TranscribeRequest req);
 }
 ```
 
@@ -33,6 +61,10 @@ Spring auto-discovers the interface (classpath scan under the app's package) and
 registers a facade bean named `mediaService`. The gateway `@Autowired`s it and
 calls the methods directly — no manual proxy wiring. `caption` is `required`;
 `thumbnail` and `transcribe` are optional.
+
+> Note the symmetry: the same `@McpMeshService` annotation marks a producer
+> (on a `@Component` CLASS, with a prefix) and a consumer view (on an INTERFACE,
+> no prefix). A blank prefix is valid only on the interface form.
 
 ## What it demonstrates
 
@@ -142,7 +174,15 @@ Expected output — one interface, three different serving agents:
 `process_media_strict` also lists the three view edges as its own dependencies:
 
 ```bash
-meshctl list   # media-gateway's process_media_strict shows media_caption, media_thumbnail, media_transcribe
+meshctl list   # media-gateway's process_media_strict shows media.caption, media.thumbnail, media.transcribe
+```
+
+You can also call any producer capability directly by its dotted name —
+`meshctl call` matches the capability name as-is:
+
+```bash
+meshctl call media.caption '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+# -> {"assetId":"asset-1","caption":"A scene showing a cat on a sofa.","provider":"caption-provider"}
 ```
 
 ### See graceful degradation (optional edge)
@@ -187,7 +227,7 @@ refusal as JSON escaped inside `content[0].text`:
 ```json
 {
   "content": [
-    { "type": "text", "text": "{\"error\": \"dependency_unavailable\", \"capability\": \"media_caption\"}" }
+    { "type": "text", "text": "{\"error\": \"dependency_unavailable\", \"capability\": \"media.caption\"}" }
   ],
   "isError": true
 }

--- a/examples/java/service-view/caption-provider/README.md
+++ b/examples/java/service-view/caption-provider/README.md
@@ -1,13 +1,18 @@
 # caption-provider
 
 Provider A in the [`@McpMeshService` service-view example](../README.md). Publishes
-the `media_caption` capability, bound by `MediaService.caption(...)` in the
+the `media.caption` capability, bound by `MediaService.caption(...)` in the
 `media-gateway` consumer.
 
 ## Overview
 
 A Java/Spring Boot MCP Mesh agent. Turns an asset id + source text into a
 deterministic caption.
+
+The capability is published with producer sugar: `MediaCaptionService` is a
+`@Component` annotated `@McpMeshService("media")`, so its public `caption(...)`
+method is exposed as the dotted capability `media.caption` — no per-method
+`@MeshTool` required.
 
 ## Getting Started
 
@@ -39,7 +44,8 @@ caption-provider/
 ├── Dockerfile
 ├── helm-values.yaml
 └── src/main/java/com/example/captionprovider/
-    └── CaptionProviderApplication.java
+    ├── CaptionProviderApplication.java  # agent bootstrap
+    └── MediaCaptionService.java         # @McpMeshService("media") producer bean
 ```
 
 ## Docker

--- a/examples/java/service-view/caption-provider/src/main/java/com/example/captionprovider/CaptionProviderApplication.java
+++ b/examples/java/service-view/caption-provider/src/main/java/com/example/captionprovider/CaptionProviderApplication.java
@@ -1,8 +1,6 @@
 package com.example.captionprovider;
 
 import io.mcpmesh.MeshAgent;
-import io.mcpmesh.MeshTool;
-import io.mcpmesh.Param;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -11,15 +9,18 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 /**
  * CaptionProvider - one leaf of the {@code @McpMeshService} service-view demo.
  *
- * <p>Publishes a single capability, {@code media_caption}. The
- * {@code media-gateway} consumer binds this capability through the
- * {@code MediaService.caption(...)} view method — a different agent than the
- * ones backing {@code thumbnail(...)} and {@code transcribe(...)}.
+ * <p>Agent bootstrap only. The capability itself is published by the
+ * producer-sugar bean {@link MediaCaptionService}: a class annotated
+ * {@code @McpMeshService("media")} publishes each public method as
+ * {@code media.<methodName>}, so its {@code caption(...)} method becomes the
+ * dotted capability {@code media.caption} — one slice of the shared
+ * {@code media.*} namespace that {@code thumbnail-provider} and
+ * {@code transcribe-provider} also publish into.
  */
 @MeshAgent(
     name = "caption-provider",
     version = "1.0.0",
-    description = "Generates a human caption for a media asset",
+    description = "Publishes media.caption into the shared media.* namespace",
     port = 8110
 )
 @SpringBootApplication
@@ -31,27 +32,4 @@ public class CaptionProviderApplication {
         log.info("Starting CaptionProvider Agent...");
         SpringApplication.run(CaptionProviderApplication.class, args);
     }
-
-    /**
-     * Produce a deterministic caption from an asset id and source text.
-     *
-     * @param assetId the media asset identifier
-     * @param text    source description text
-     * @return a caption record, tagged with this provider's name
-     */
-    @MeshTool(
-        capability = "media_caption",
-        description = "Generates a human caption for a media asset",
-        tags = {"media"}
-    )
-    public CaptionResult caption(
-        @Param(value = "assetId", description = "Media asset identifier") String assetId,
-        @Param(value = "text", description = "Source description text") String text
-    ) {
-        String caption = "A scene showing " + text.trim().toLowerCase() + ".";
-        return new CaptionResult(assetId, caption, "caption-provider");
-    }
-
-    /** Caption result — {@code provider} makes the serving agent visible downstream. */
-    public record CaptionResult(String assetId, String caption, String provider) {}
 }

--- a/examples/java/service-view/caption-provider/src/main/java/com/example/captionprovider/MediaCaptionService.java
+++ b/examples/java/service-view/caption-provider/src/main/java/com/example/captionprovider/MediaCaptionService.java
@@ -1,0 +1,39 @@
+package com.example.captionprovider;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
+import org.springframework.stereotype.Component;
+
+/**
+ * Producer-sugar bean (RFC #1280 phase 3): a class annotated
+ * {@code @McpMeshService("media")} publishes each public method as a mesh tool
+ * under the capability {@code media.<methodName>}. The {@code "media"} prefix is
+ * entirely user-chosen — nothing about it is hard-coded in the mesh.
+ *
+ * <p>This bean exposes one public method, {@code caption}, so it publishes
+ * exactly one capability: {@code media.caption}. Dotted capability names are
+ * first-class across the stack; the input schema still comes from the
+ * {@code @Param} annotations, exactly as a hand-written {@code @MeshTool} would.
+ */
+@Component
+@McpMeshService("media")
+public class MediaCaptionService {
+
+    /**
+     * Produce a deterministic caption from an asset id and source text.
+     *
+     * @param assetId the media asset identifier
+     * @param text    source description text
+     * @return a caption record, tagged with this provider's name
+     */
+    public CaptionResult caption(
+        @Param(value = "assetId", description = "Media asset identifier") String assetId,
+        @Param(value = "text", description = "Source description text") String text
+    ) {
+        String caption = "A scene showing " + text.trim().toLowerCase() + ".";
+        return new CaptionResult(assetId, caption, "caption-provider");
+    }
+
+    /** Caption result — {@code provider} makes the serving agent visible downstream. */
+    public record CaptionResult(String assetId, String caption, String provider) {}
+}

--- a/examples/java/service-view/media-gateway/README.md
+++ b/examples/java/service-view/media-gateway/README.md
@@ -20,9 +20,9 @@ view:
 ```java
 @McpMeshService
 public interface MediaService {
-    @Selector(capability = "media_caption", required = true) CaptionResult    caption(CaptionRequest req);
-    @Selector(capability = "media_thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
-    @Selector(capability = "media_transcribe")               TranscriptResult transcribe(TranscribeRequest req);
+    @Selector(capability = "media.caption", required = true) CaptionResult    caption(CaptionRequest req);
+    @Selector(capability = "media.thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
+    @Selector(capability = "media.transcribe")               TranscriptResult transcribe(TranscribeRequest req);
 }
 ```
 

--- a/examples/java/service-view/media-gateway/src/main/java/com/example/mediagateway/MediaGatewayApplication.java
+++ b/examples/java/service-view/media-gateway/src/main/java/com/example/mediagateway/MediaGatewayApplication.java
@@ -86,7 +86,7 @@ public class MediaGatewayApplication {
      * <p>The {@code MediaService} parameter (NOT {@code @Param}-annotated) expands
      * into three dependency edges on THIS tool. Because {@code caption} is
      * {@code required=true}, the mesh runtime returns the structured
-     * {@code {"error":"dependency_unavailable","capability":"media_caption"}}
+     * {@code {"error":"dependency_unavailable","capability":"media.caption"}}
      * refusal BEFORE this method body runs whenever the caption edge is
      * unresolved — so here {@code caption} is guaranteed present, while the
      * optional edges still degrade gracefully.

--- a/examples/java/service-view/media-gateway/src/main/java/com/example/mediagateway/MediaService.java
+++ b/examples/java/service-view/media-gateway/src/main/java/com/example/mediagateway/MediaService.java
@@ -11,10 +11,14 @@ import io.mcpmesh.Selector;
  * changes.
  *
  * <ul>
- *   <li>{@link #caption} → {@code media_caption} (caption-provider), REQUIRED</li>
- *   <li>{@link #thumbnail} → {@code media_thumbnail} (thumbnail-provider), optional</li>
- *   <li>{@link #transcribe} → {@code media_transcribe} (transcribe-provider), optional</li>
+ *   <li>{@link #caption} → {@code media.caption} (caption-provider), REQUIRED</li>
+ *   <li>{@link #thumbnail} → {@code media.thumbnail} (thumbnail-provider), optional</li>
+ *   <li>{@link #transcribe} → {@code media.transcribe} (transcribe-provider), optional</li>
  * </ul>
+ *
+ * <p>The capabilities use dotted names ({@code media.*}) — first-class across
+ * the stack — matching the shared namespace the three producer-sugar agents
+ * publish into.
  *
  * <p>Spring auto-discovers this interface on the classpath and registers a
  * facade bean named {@code mediaService}; the {@code media-gateway} agent
@@ -25,13 +29,13 @@ import io.mcpmesh.Selector;
 @McpMeshService
 public interface MediaService {
 
-    @Selector(capability = "media_caption", required = true)
+    @Selector(capability = "media.caption", required = true)
     CaptionResult caption(CaptionRequest req);
 
-    @Selector(capability = "media_thumbnail")
+    @Selector(capability = "media.thumbnail")
     ThumbnailResult thumbnail(ThumbnailRequest req);
 
-    @Selector(capability = "media_transcribe")
+    @Selector(capability = "media.transcribe")
     TranscriptResult transcribe(TranscribeRequest req);
 
     // ---- Single-POJO request records (one unannotated param per method) -------

--- a/examples/java/service-view/thumbnail-provider/README.md
+++ b/examples/java/service-view/thumbnail-provider/README.md
@@ -1,7 +1,7 @@
 # thumbnail-provider
 
 Provider B in the [`@McpMeshService` service-view example](../README.md). Publishes
-the `media_thumbnail` capability, bound by the OPTIONAL
+the `media.thumbnail` capability, bound by the OPTIONAL
 `MediaService.thumbnail(...)` view method in the `media-gateway` consumer — stop
 this agent to see the gateway degrade gracefully.
 
@@ -9,6 +9,11 @@ this agent to see the gateway degrade gracefully.
 
 A Java/Spring Boot MCP Mesh agent. Turns an asset id + width into a deterministic
 thumbnail descriptor.
+
+The capability is published with producer sugar: `MediaThumbnailService` is a
+`@Component` annotated `@McpMeshService("media")`, so its public `thumbnail(...)`
+method is exposed as the dotted capability `media.thumbnail` — no per-method
+`@MeshTool` required.
 
 ## Getting Started
 
@@ -40,7 +45,8 @@ thumbnail-provider/
 ├── Dockerfile
 ├── helm-values.yaml
 └── src/main/java/com/example/thumbnailprovider/
-    └── ThumbnailProviderApplication.java
+    ├── ThumbnailProviderApplication.java  # agent bootstrap
+    └── MediaThumbnailService.java         # @McpMeshService("media") producer bean
 ```
 
 ## Docker

--- a/examples/java/service-view/thumbnail-provider/src/main/java/com/example/thumbnailprovider/MediaThumbnailService.java
+++ b/examples/java/service-view/thumbnail-provider/src/main/java/com/example/thumbnailprovider/MediaThumbnailService.java
@@ -1,0 +1,37 @@
+package com.example.thumbnailprovider;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
+import org.springframework.stereotype.Component;
+
+/**
+ * Producer-sugar bean (RFC #1280 phase 3): {@code @McpMeshService("media")}
+ * publishes each public method as {@code media.<methodName>}. This bean's single
+ * public method {@code thumbnail} publishes the dotted capability
+ * {@code media.thumbnail} — a second slice of the same {@code media.*} namespace
+ * served by a different agent.
+ */
+@Component
+@McpMeshService("media")
+public class MediaThumbnailService {
+
+    /**
+     * Produce a deterministic thumbnail descriptor from an asset id and width.
+     *
+     * @param assetId the media asset identifier
+     * @param width   requested thumbnail width in pixels
+     * @return a thumbnail record, tagged with this provider's name
+     */
+    public ThumbnailResult thumbnail(
+        @Param(value = "assetId", description = "Media asset identifier") String assetId,
+        @Param(value = "width", description = "Requested thumbnail width in pixels") int width
+    ) {
+        int w = width > 0 ? width : 128;
+        int h = Math.max(1, w * 9 / 16);
+        String uri = "thumb://" + assetId + "?w=" + w + "&h=" + h;
+        return new ThumbnailResult(assetId, uri, w + "x" + h, "thumbnail-provider");
+    }
+
+    /** Thumbnail result — {@code provider} makes the serving agent visible downstream. */
+    public record ThumbnailResult(String assetId, String uri, String size, String provider) {}
+}

--- a/examples/java/service-view/thumbnail-provider/src/main/java/com/example/thumbnailprovider/ThumbnailProviderApplication.java
+++ b/examples/java/service-view/thumbnail-provider/src/main/java/com/example/thumbnailprovider/ThumbnailProviderApplication.java
@@ -1,8 +1,6 @@
 package com.example.thumbnailprovider;
 
 import io.mcpmesh.MeshAgent;
-import io.mcpmesh.MeshTool;
-import io.mcpmesh.Param;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -11,16 +9,17 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 /**
  * ThumbnailProvider - one leaf of the {@code @McpMeshService} service-view demo.
  *
- * <p>Publishes a single capability, {@code media_thumbnail}. The
- * {@code media-gateway} consumer binds this capability through the OPTIONAL
- * {@code MediaService.thumbnail(...)} view method — stop this agent and the
- * gateway degrades gracefully while {@code caption(...)} and
- * {@code transcribe(...)} keep working.
+ * <p>Agent bootstrap only. The capability is published by the producer-sugar
+ * bean {@link MediaThumbnailService}, whose {@code thumbnail(...)} method becomes
+ * the dotted capability {@code media.thumbnail}. The {@code media-gateway}
+ * consumer binds it through the OPTIONAL {@code MediaService.thumbnail(...)} view
+ * method — stop this agent and the gateway degrades gracefully while
+ * {@code media.caption} and {@code media.transcribe} keep working.
  */
 @MeshAgent(
     name = "thumbnail-provider",
     version = "1.0.0",
-    description = "Generates a thumbnail descriptor for a media asset",
+    description = "Publishes media.thumbnail into the shared media.* namespace",
     port = 8111
 )
 @SpringBootApplication
@@ -32,29 +31,4 @@ public class ThumbnailProviderApplication {
         log.info("Starting ThumbnailProvider Agent...");
         SpringApplication.run(ThumbnailProviderApplication.class, args);
     }
-
-    /**
-     * Produce a deterministic thumbnail descriptor from an asset id and width.
-     *
-     * @param assetId the media asset identifier
-     * @param width   requested thumbnail width in pixels
-     * @return a thumbnail record, tagged with this provider's name
-     */
-    @MeshTool(
-        capability = "media_thumbnail",
-        description = "Generates a thumbnail descriptor for a media asset",
-        tags = {"media"}
-    )
-    public ThumbnailResult thumbnail(
-        @Param(value = "assetId", description = "Media asset identifier") String assetId,
-        @Param(value = "width", description = "Requested thumbnail width in pixels") int width
-    ) {
-        int w = width > 0 ? width : 128;
-        int h = Math.max(1, w * 9 / 16);
-        String uri = "thumb://" + assetId + "?w=" + w + "&h=" + h;
-        return new ThumbnailResult(assetId, uri, w + "x" + h, "thumbnail-provider");
-    }
-
-    /** Thumbnail result — {@code provider} makes the serving agent visible downstream. */
-    public record ThumbnailResult(String assetId, String uri, String size, String provider) {}
 }

--- a/examples/java/service-view/transcribe-provider/README.md
+++ b/examples/java/service-view/transcribe-provider/README.md
@@ -1,13 +1,18 @@
 # transcribe-provider
 
 Provider C in the [`@McpMeshService` service-view example](../README.md). Publishes
-the `media_transcribe` capability, bound by the OPTIONAL
+the `media.transcribe` capability, bound by the OPTIONAL
 `MediaService.transcribe(...)` view method in the `media-gateway` consumer.
 
 ## Overview
 
 A Java/Spring Boot MCP Mesh agent. Turns an asset id + source text into a
 deterministic transcript.
+
+The capability is published with producer sugar: `MediaTranscribeService` is a
+`@Component` annotated `@McpMeshService("media")`, so its public `transcribe(...)`
+method is exposed as the dotted capability `media.transcribe` — no per-method
+`@MeshTool` required.
 
 ## Getting Started
 
@@ -39,7 +44,8 @@ transcribe-provider/
 ├── Dockerfile
 ├── helm-values.yaml
 └── src/main/java/com/example/transcribeprovider/
-    └── TranscribeProviderApplication.java
+    ├── TranscribeProviderApplication.java  # agent bootstrap
+    └── MediaTranscribeService.java         # @McpMeshService("media") producer bean
 ```
 
 ## Docker

--- a/examples/java/service-view/transcribe-provider/src/main/java/com/example/transcribeprovider/MediaTranscribeService.java
+++ b/examples/java/service-view/transcribe-provider/src/main/java/com/example/transcribeprovider/MediaTranscribeService.java
@@ -1,0 +1,36 @@
+package com.example.transcribeprovider;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
+import org.springframework.stereotype.Component;
+
+/**
+ * Producer-sugar bean (RFC #1280 phase 3): {@code @McpMeshService("media")}
+ * publishes each public method as {@code media.<methodName>}. This bean's single
+ * public method {@code transcribe} publishes the dotted capability
+ * {@code media.transcribe} — the third slice of the same {@code media.*}
+ * namespace served by a different agent.
+ */
+@Component
+@McpMeshService("media")
+public class MediaTranscribeService {
+
+    /**
+     * Produce a deterministic transcript from an asset id and source text.
+     *
+     * @param assetId the media asset identifier
+     * @param text    source audio text
+     * @return a transcript record, tagged with this provider's name
+     */
+    public TranscriptResult transcribe(
+        @Param(value = "assetId", description = "Media asset identifier") String assetId,
+        @Param(value = "text", description = "Source audio text") String text
+    ) {
+        int words = text.trim().isEmpty() ? 0 : text.trim().split("\\s+").length;
+        String transcript = "[" + assetId + "] " + text.trim().toUpperCase();
+        return new TranscriptResult(assetId, transcript, words, "transcribe-provider");
+    }
+
+    /** Transcript result — {@code provider} makes the serving agent visible downstream. */
+    public record TranscriptResult(String assetId, String transcript, int wordCount, String provider) {}
+}

--- a/examples/java/service-view/transcribe-provider/src/main/java/com/example/transcribeprovider/TranscribeProviderApplication.java
+++ b/examples/java/service-view/transcribe-provider/src/main/java/com/example/transcribeprovider/TranscribeProviderApplication.java
@@ -1,8 +1,6 @@
 package com.example.transcribeprovider;
 
 import io.mcpmesh.MeshAgent;
-import io.mcpmesh.MeshTool;
-import io.mcpmesh.Param;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -11,15 +9,15 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 /**
  * TranscribeProvider - one leaf of the {@code @McpMeshService} service-view demo.
  *
- * <p>Publishes a single capability, {@code media_transcribe}. The
- * {@code media-gateway} consumer binds this capability through the OPTIONAL
- * {@code MediaService.transcribe(...)} view method — a third, independent agent
- * from the ones backing {@code caption(...)} and {@code thumbnail(...)}.
+ * <p>Agent bootstrap only. The capability is published by the producer-sugar
+ * bean {@link MediaTranscribeService}, whose {@code transcribe(...)} method
+ * becomes the dotted capability {@code media.transcribe} — a third, independent
+ * slice of the shared {@code media.*} namespace, served by its own agent.
  */
 @MeshAgent(
     name = "transcribe-provider",
     version = "1.0.0",
-    description = "Generates a transcript for a media asset",
+    description = "Publishes media.transcribe into the shared media.* namespace",
     port = 8112
 )
 @SpringBootApplication
@@ -31,28 +29,4 @@ public class TranscribeProviderApplication {
         log.info("Starting TranscribeProvider Agent...");
         SpringApplication.run(TranscribeProviderApplication.class, args);
     }
-
-    /**
-     * Produce a deterministic transcript from an asset id and source text.
-     *
-     * @param assetId the media asset identifier
-     * @param text    source audio text
-     * @return a transcript record, tagged with this provider's name
-     */
-    @MeshTool(
-        capability = "media_transcribe",
-        description = "Generates a transcript for a media asset",
-        tags = {"media"}
-    )
-    public TranscriptResult transcribe(
-        @Param(value = "assetId", description = "Media asset identifier") String assetId,
-        @Param(value = "text", description = "Source audio text") String text
-    ) {
-        int words = text.trim().isEmpty() ? 0 : text.trim().split("\\s+").length;
-        String transcript = "[" + assetId + "] " + text.trim().toUpperCase();
-        return new TranscriptResult(assetId, transcript, words, "transcribe-provider");
-    }
-
-    /** Transcript result — {@code provider} makes the serving agent visible downstream. */
-    public record TranscriptResult(String assetId, String transcript, int wordCount, String provider) {}
 }

--- a/src/core/cli/man/content/capabilities.md
+++ b/src/core/cli/man/content/capabilities.md
@@ -174,6 +174,8 @@ def my_tool(date: mesh.McpMeshTool = None, weather: mesh.McpMeshTool = None):
 | `domain_action` | `auth_validate` | Domain-specific  |
 | `service`       | `llm`           | Generic services |
 
+A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
+
 ## Versioning
 
 Providers declare a concrete version on `@mesh.tool` / `@mesh.llm_provider` (default `"1.0.0"` if unset):

--- a/src/core/cli/man/content/capabilities_java.md
+++ b/src/core/cli/man/content/capabilities_java.md
@@ -159,6 +159,8 @@ So when several providers share the same capability and tags, the one with the *
 | `domain_action` | `auth_validate` | Domain-specific  |
 | `service`       | `llm`           | Generic services |
 
+A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
+
 ## Versioning
 
 Providers declare a concrete version (default `"1.0.0"` if unset):

--- a/src/core/cli/man/content/capabilities_typescript.md
+++ b/src/core/cli/man/content/capabilities_typescript.md
@@ -204,6 +204,8 @@ agent.addTool({
 | `domain_action` | `auth_validate` | Domain-specific  |
 | `service`       | `llm`           | Generic services |
 
+A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
+
 ## Versioning
 
 Providers declare a concrete version (default `"1.0.0"` if unset):

--- a/src/core/cli/man/content/capabilities_typescript.md
+++ b/src/core/cli/man/content/capabilities_typescript.md
@@ -206,6 +206,8 @@ agent.addTool({
 
 A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
 
+The TypeScript SDK performs no local capability-name validation — it forwards capability strings to the registry as-is, so a malformed name is rejected at registration time by the registry, not by the TS runtime. The segment-wise format above is the contract the registry enforces.
+
 ## Versioning
 
 Providers declare a concrete version (default `"1.0.0"` if unset):

--- a/src/core/cli/man/content/decorators_java.md
+++ b/src/core/cli/man/content/decorators_java.md
@@ -185,28 +185,49 @@ Specifies capability and tag selection for dependencies, LLM providers, and filt
 
 ## @McpMeshService
 
-Marks an interface as a consumer-owned **service view**: one typed facade that aggregates several capability dependencies. Each abstract method binds one capability via a method-level `@Selector`, and each method delegates to its own resolved proxy — so different methods can resolve to different provider agents. Spring auto-discovers the interface and injects a facade bean you `@Autowired`.
+Aggregates several capabilities behind one typed **service view**, and — on a class — publishes a bean's methods as capabilities. Where you put it decides the role:
+
+| Placement | Role |
+| --------- | ---- |
+| On an **interface** (`@McpMeshService`) | Consumer **service view** — each abstract method binds one capability via a method-level `@Selector`; consumed as an `@Autowired` facade bean or a `@MeshTool` parameter |
+| On a **Spring bean class** (`@McpMeshService("prefix")`) | Producer sugar — publishes each eligible public method as capability `prefix.<methodName>` |
+
+**As a consumer view (interface):**
 
 ```java
 @McpMeshService
 public interface MediaService {
-    @Selector(capability = "media_caption", required = true) CaptionResult    caption(CaptionRequest req);
-    @Selector(capability = "media_thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
-    @Selector(capability = "media_transcribe")               TranscriptResult transcribe(TranscribeRequest req);
+    @Selector(capability = "media.caption", required = true) CaptionResult    caption(CaptionRequest req);
+    @Selector(capability = "media.thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
+    @Selector(capability = "media.transcribe")               TranscriptResult transcribe(TranscribeRequest req);
 }
 ```
 
-| Attribute      | Required | Description                                                                 |
-| -------------- | -------- | -------------------------------------------------------------------------- |
-| `minAvailable` | No       | Availability floor; below it every facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (default `0` = no floor) |
-
-Each method expands into an ordinary dependency edge, so a view over N capabilities shows as N dependencies in `meshctl list`. A view is consumed two ways: `@Autowired` as a facade bean, or passed as a `@MeshTool` **parameter** — where its methods become dependency edges on that tool and any `required` view method joins the tool's pre-invoke `dependency_unavailable` guard:
+Each method expands into an ordinary dependency edge, so a view over N capabilities shows as N dependencies in `meshctl list`. It is consumed two ways: `@Autowired` as a facade bean, or passed as a `@MeshTool` **parameter** — where its methods become dependency edges on that tool and any `required` view method joins the tool's pre-invoke `dependency_unavailable` guard:
 
 ```java
 public Result process(@Param("id") String id, MediaService media) { ... }  // view param → per-method edges
 ```
 
-For the full semantics — param-mapping rules, return types, `required`/optional behavior, the availability floor, and both consumption styles — see `meshctl man dependency-injection --java`.
+**As a producer (class):**
+
+```java
+@Component
+@McpMeshService("media")
+public class MediaProvider {
+    public CaptionResult   caption(CaptionRequest req)     { ... }  // → capability "media.caption"
+    public ThumbnailResult thumbnail(ThumbnailRequest req) { ... }  // → capability "media.thumbnail"
+}
+```
+
+Public instance methods declared on the class are published name-sorted; a method carrying its own `@MeshTool` wins (use it for a custom capability/tags/version). Overloads boot-fail.
+
+| Attribute      | Required   | Description                                                                 |
+| -------------- | ---------- | -------------------------------------------------------------------------- |
+| `value`        | On a class | Capability prefix for producer publishing (segment-validated); omit on a consumer interface |
+| `minAvailable` | No         | Consumer-view availability floor; below it every facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (default `0`). Ignored (WARN) on a producer class |
+
+For the full semantics — param-mapping rules, return types, `required`/optional behavior, the availability floor, both consumption styles, and producer publishing — see `meshctl man dependency-injection --java`.
 
 ## @MeshLlm
 

--- a/src/core/cli/man/content/dependency-injection_java.md
+++ b/src/core/cli/man/content/dependency-injection_java.md
@@ -210,9 +210,9 @@ The differentiator: **each method delegates to its own per-capability resolved p
 ```java
 @McpMeshService
 public interface MediaService {
-    @Selector(capability = "media_caption", required = true) CaptionResult    caption(CaptionRequest req);
-    @Selector(capability = "media_thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
-    @Selector(capability = "media_transcribe")               TranscriptResult transcribe(TranscribeRequest req);
+    @Selector(capability = "media.caption", required = true) CaptionResult    caption(CaptionRequest req);
+    @Selector(capability = "media.thumbnail")                ThumbnailResult  thumbnail(ThumbnailRequest req);
+    @Selector(capability = "media.transcribe")               TranscriptResult transcribe(TranscribeRequest req);
 
     record CaptionRequest(String assetId, String text) {}
     record ThumbnailRequest(String assetId, int width) {}
@@ -272,7 +272,7 @@ A view can also be consumed as a `@MeshTool` method **parameter** instead of an 
 public Result processMedia(
         @Param(value = "assetId", description = "Asset id") String assetId,
         McpMeshTool<String> auditLog,
-        MediaService media) {   // view param → media_caption + media_thumbnail + media_transcribe edges
+        MediaService media) {   // view param → media.caption + media.thumbnail + media.transcribe edges
     ...
 }
 ```
@@ -288,6 +288,30 @@ The same interface can be used both ways at once — autowired as a bean **and**
 The optional `@McpMeshService(minAvailable = N)` adds a consumer-local availability floor: when fewer than `N` of the view's methods currently resolve, **every** facade call fails with `MeshServiceUnavailableException` — synchronous methods throw, `CompletableFuture` methods return a failed future (settle-grace-aware). The default `0` means no floor — each method soft- or hard-fails per its own `required` flag.
 
 A service view is **consumer-local**, not a shared contract: two consumers may aggregate the same capabilities differently, and there is no group versioning or interface-level availability summary. Each method resolves independently.
+
+### Publishing a service (producer side)
+
+The same annotation works on the **provider** side too. Put class-level `@McpMeshService("prefix")` on a Spring bean and each eligible public method is published as an ordinary mesh tool under the capability `prefix.<methodName>` — pure sugar over writing one `@MeshTool` per method.
+
+```java
+@Component
+@McpMeshService("media")
+public class MediaProvider {
+    public CaptionResult   caption(CaptionRequest req)     { ... }   // → capability "media.caption"
+    public ThumbnailResult thumbnail(ThumbnailRequest req) { ... }   // → capability "media.thumbnail"
+
+    @MeshTool(capability = "transcribe_gpu", tags = {"gpu"})          // custom name — @MeshTool overrides the prefix.<method> derivation
+    public TranscriptResult transcribe(TranscribeRequest req) { ... }
+}
+```
+
+- The `prefix` is entirely yours, segment-validated at boot (each dot-separated segment `^[a-zA-Z][a-zA-Z0-9_-]*$`, e.g. `media` or `media.v2`). The blank default `@McpMeshService` marks a consumer view and boot-fails on a producer class.
+- Methods publish in **name-sorted** order. Only **public, instance** methods **declared on the class itself** are published — non-public, `static`, `Object`, and inherited-from-superclass methods are skipped.
+- An **explicit `@MeshTool`** on a method wins — use it whenever a method needs a custom capability, tags, version, or description; producer sugar synthesizes none of those.
+- **Overloaded** public methods collide on `prefix.<name>` and boot-fail: rename one, make one non-public, or give one an explicit `@MeshTool`.
+- `minAvailable` is a consumer-view attribute; on a producer class it logs a WARN and is ignored. A `@McpMeshService` class that Spring doesn't manage as a bean WARNs at scan time and publishes nothing.
+
+> **Discovery caveat.** An auto-registered facade **bean** requires `@McpMeshService` directly on the interface. An interface that only *inherits* `@McpMeshService` from a super-interface is still usable as a `@MeshTool` view parameter, but is not auto-discovered as a bean.
 
 ## `McpMeshTool<T>` API Reference
 

--- a/src/core/cli/man/content/dependency-injection_java.md
+++ b/src/core/cli/man/content/dependency-injection_java.md
@@ -309,7 +309,7 @@ public class MediaProvider {
 - Methods publish in **name-sorted** order. Only **public, instance** methods **declared on the class itself** are published — non-public, `static`, `Object`, and inherited-from-superclass methods are skipped.
 - An **explicit `@MeshTool`** on a method wins — use it whenever a method needs a custom capability, tags, version, or description; producer sugar synthesizes none of those.
 - **Overloaded** public methods collide on `prefix.<name>` and boot-fail: rename one, make one non-public, or give one an explicit `@MeshTool`.
-- `minAvailable` is a consumer-view attribute; on a producer class it logs a WARN and is ignored. A `@McpMeshService` class that Spring doesn't manage as a bean WARNs at scan time and publishes nothing.
+- `minAvailable` is a consumer-view attribute; on a producer class it logs a WARN and is ignored. A `@McpMeshService` class that Spring doesn't manage as a bean WARNs during startup, after bean initialization, and publishes nothing.
 
 > **Discovery caveat.** An auto-registered facade **bean** requires `@McpMeshService` directly on the interface. An interface that only *inherits* `@McpMeshService` from a super-interface is still usable as a `@MeshTool` view parameter, but is not auto-discovered as a bean.
 

--- a/src/core/registry/validation.go
+++ b/src/core/registry/validation.go
@@ -32,8 +32,12 @@ func NewAgentRegistrationValidator() *AgentRegistrationValidator {
 	return &AgentRegistrationValidator{
 		// Kubernetes-style name validation (matches Python)
 		agentNamePattern: regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`),
-		// Capability name validation (matches Python)
-		capabilityNamePattern: regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`),
+		// Capability name validation (matches Python). RFC #1280 v3: dot-separated
+		// segments, each following the flat rule (letter-led, alnum/_/-). Strictly
+		// widens the old single-segment pattern — every previously-valid flat name
+		// still matches — and forbids leading/trailing/consecutive dots so phase-4
+		// display grouping has well-defined segmentation.
+		capabilityNamePattern: regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*(\.[a-zA-Z][a-zA-Z0-9_-]*)*$`),
 		// Semantic version validation (matches Python)
 		semanticVersionPattern: regexp.MustCompile(`^\d+\.\d+\.\d+(-[a-zA-Z0-9-]+)?$`),
 	}
@@ -322,7 +326,7 @@ func (v *AgentRegistrationValidator) validateCapabilityName(name string) error {
 	}
 
 	if !v.capabilityNamePattern.MatchString(name) {
-		return fmt.Errorf("capability name must start with a letter and contain only letters, numbers, underscores, and hyphens")
+		return fmt.Errorf("capability name must be one or more dot-separated segments, each starting with a letter and containing only letters, numbers, underscores, and hyphens")
 	}
 
 	return nil

--- a/src/core/registry/validation_test.go
+++ b/src/core/registry/validation_test.go
@@ -84,3 +84,47 @@ func TestValidateAgentDescription(t *testing.T) {
 		}
 	})
 }
+
+// TestValidateCapabilityName covers the RFC #1280 v3 dot-namespacing widening:
+// a capability name is one or more dot-separated segments, each following the
+// existing flat rule (letter-led, alnum/underscore/hyphen). Strictly widens the
+// old single-segment pattern; leading/trailing/consecutive dots are rejected.
+func TestValidateCapabilityName(t *testing.T) {
+	v := NewAgentRegistrationValidator()
+
+	valid := []string{
+		"greeting",       // existing flat name still valid
+		"smart_greet",    // underscore
+		"weather-report", // hyphen
+		"a",              // single letter
+		"media.caption",  // two segments
+		"a.b",            // minimal dotted
+		"a.b.c",          // three segments
+		"llm.chat",       // phase-1/2 dotted dependency style
+		"a1.b2_c-3",      // digits/underscore/hyphen within segments
+	}
+	for _, name := range valid {
+		if err := v.validateCapabilityName(name); err != nil {
+			t.Errorf("expected %q to be valid, got error: %v", name, err)
+		}
+	}
+
+	invalid := []string{
+		"",       // empty
+		".a",     // leading dot
+		"a.",     // trailing dot
+		"a..b",   // consecutive dots
+		"a.-b",   // segment must start with a letter
+		"1a.b",   // must start with a letter
+		"a.1b",   // second segment must start with a letter
+		".",      // just a dot
+		"a.b.",   // trailing dot after multiple segments
+		"a b",    // space
+		"a.b\n",  // trailing newline (anchored $ = end of text, not before newline)
+	}
+	for _, name := range invalid {
+		if err := v.validateCapabilityName(name); err == nil {
+			t.Errorf("expected %q to be rejected, but it passed", name)
+		}
+	}
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/McpMeshService.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/McpMeshService.java
@@ -7,8 +7,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks an interface as a consumer-owned <b>service view</b>: a typed
- * aggregation of ordinary capability dependencies (RFC #1280).
+ * Two related roles depending on the annotated type (RFC #1280):
+ *
+ * <h2>On an INTERFACE — consumer-owned service view</h2>
+ * A typed aggregation of ordinary capability dependencies.
  *
  * <p>Each abstract method of the interface binds exactly one capability via a
  * method-level {@link Selector}, and calling that method delegates to the
@@ -33,6 +35,16 @@ import java.lang.annotation.Target;
  * directly. A Spring bean (named by the decapitalized simple interface name) is
  * registered automatically.
  *
+ * <p><b>Scanning rule:</b> a scanned bean view requires {@code @McpMeshService}
+ * <i>directly</i> on the interface. An interface that only INHERITS the
+ * annotation from a super-interface is NOT auto-discovered as a bean view
+ * (co-discovering it would always pull in the annotated parent too — duplicate
+ * facades and parent-type injection ambiguity). Inherited-annotation interfaces
+ * ARE usable as tool-parameter views (there the user names the type explicitly,
+ * so there is no discovery ambiguity). When a view inherits from multiple
+ * annotated parents, {@code minAvailable} is read from an arbitrary one of them;
+ * declare it on the leaf interface if it matters.
+ *
  * <h2>Method rules</h2>
  * <ul>
  *   <li>Every abstract method must carry {@link Selector} with a non-empty
@@ -51,11 +63,46 @@ import java.lang.annotation.Target;
  * There is no group versioning and no interface-level availability summary —
  * any scalar "is the view up?" would lie about partial availability, since each
  * method resolves independently.
+ *
+ * <h2>On a CLASS — producer sugar (phase 3)</h2>
+ * <p>A {@code @Component} class annotated {@code @McpMeshService("prefix")}
+ * publishes each eligible public instance method as an ordinary mesh tool with
+ * capability {@code "prefix.<methodName>"}. Pure sugar over N {@code @MeshTool}
+ * declarations — each method becomes a normal tool through the existing
+ * {@code @MeshTool} machinery (same {@code @Param} rules, injectable slots, and
+ * schema generation); there are no wire or registry changes.
+ *
+ * <pre>{@code
+ * @McpMeshService("media")   // prefix is user-chosen; nothing hard-coded in mesh
+ * @Component
+ * public class MediaTools {
+ *     public CaptionResult caption(@Param("text") String text) { ... }   // → "media.caption"
+ *     public ThumbResult   thumbnail(@Param("assetId") String id) { ... } // → "media.thumbnail"
+ * }
+ * }</pre>
+ *
+ * <p>A method carrying its own {@link MeshTool} wins: it publishes only under
+ * that declaration (no auto-publish, no double). Non-public methods, static
+ * methods, and {@link Object} overrides are ignored. Per-class tag/version
+ * defaults are NOT provided — a method needing tags/version/description uses an
+ * explicit {@code @MeshTool} instead.
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface McpMeshService {
+
+    /**
+     * The capability-name prefix.
+     *
+     * <p><b>On a producer CLASS:</b> REQUIRED (blank → boot-fail) — each
+     * published method's capability is {@code value + "." + methodName}.
+     *
+     * <p><b>On a consumer INTERFACE (service view):</b> optional and currently
+     * inert — reserved for phase-4 display grouping. Method capabilities on a
+     * view come from each method's own {@link Selector}, not this prefix.
+     */
+    String value() default "";
 
     /**
      * Opt-in availability floor. When fewer than {@code minAvailable} of the
@@ -66,6 +113,9 @@ public @interface McpMeshService {
      * <p>Default {@code 0} means "no floor": each method independently soft-
      * or hard-fails per its own {@link Selector#required()} flag, exactly like
      * a directly-injected {@code McpMeshTool}.
+     *
+     * <p><b>Meaningful only on an interface (view).</b> On a producer class it
+     * is ignored with a WARN (a consumer-only attribute).
      */
     int minAvailable() default 0;
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceRegistrar.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceRegistrar.java
@@ -96,6 +96,15 @@ public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProces
     private final List<ServiceViewMetadata> discovered = new CopyOnWriteArrayList<>();
 
     /**
+     * Directly-annotated {@code @McpMeshService} CLASS names found by the SAME
+     * scan pass that discovers view interfaces (RFC #1280 phase-3 review, item
+     * 3): producer candidates. A late {@link org.springframework.beans.factory.SmartInitializingSingleton}
+     * WARNs for any of these the {@link MeshToolBeanPostProcessor} did NOT
+     * actually see as a bean — ground-truth comparison, no false positives.
+     */
+    private final List<String> annotatedProducerClasses = new CopyOnWriteArrayList<>();
+
+    /**
      * The validated views discovered in this context, sorted by interface name
      * for a deterministic dependency-expansion order.
      */
@@ -103,6 +112,11 @@ public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProces
         List<ServiceViewMetadata> copy = new ArrayList<>(discovered);
         copy.sort(Comparator.comparing(v -> v.iface().getName()));
         return copy;
+    }
+
+    /** Directly-annotated @McpMeshService class names found during scanning. */
+    public List<String> discoveredProducerClasses() {
+        return List.copyOf(annotatedProducerClasses);
     }
 
     @Override
@@ -133,13 +147,20 @@ public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProces
         // route / @MeshDependsOn is idempotent.
         MeshSettleState settleState = MeshSettleState.getInstance();
 
-        // MED-4: match ONLY interfaces directly annotated with @McpMeshService.
-        // - useDefaultFilters=false + a non-meta AnnotationTypeFilter so composed
-        //   annotations are out of scope.
-        // - isCandidateComponent accepts non-interface candidates too, so a
-        //   @McpMeshService on a class is DISCOVERED (and boot-fails below with a
-        //   clear message) rather than silently ignored; annotation types are
-        //   excluded.
+        // ONE scan pass handles both roles (RFC #1280 phase-3 review, item 3):
+        // directly-annotated INTERFACES become bean views here; directly-annotated
+        // CLASSES are collected as producer candidates for the late non-bean WARN.
+        //
+        // Scanned bean views require @McpMeshService DIRECTLY on the interface.
+        // Deliberate rule: a sub-interface that only INHERITS the annotation is
+        // NOT co-discovered — co-discovery would always pull in the annotated
+        // parent too (duplicate facades, parent-type injection ambiguity,
+        // generic-narrowing type clashes). Sub-interface inheritance IS supported
+        // for tool-parameter views ({@code isServiceView} uses findAnnotation),
+        // where the user explicitly names the type so there is no ambiguity.
+        // - useDefaultFilters=false + AnnotationTypeFilter(considerMeta=false,
+        //   considerInterfaces=false): direct annotation only; composed/meta
+        //   annotations and inherited-from-super-interface stay out of scope.
         ClassPathScanningCandidateComponentProvider scanner =
             new ClassPathScanningCandidateComponentProvider(false) {
                 @Override
@@ -172,16 +193,17 @@ public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProces
                         className, t.getMessage());
                     continue;
                 }
-                McpMeshService annotation = AnnotationUtils.findAnnotation(type, McpMeshService.class);
+                // DIRECT annotation only (getAnnotation, not findAnnotation): a
+                // sub-interface inheriting @McpMeshService is not a scanned view.
+                McpMeshService annotation = type.getAnnotation(McpMeshService.class);
                 if (annotation == null) {
                     continue;
                 }
-                // MED-4: @McpMeshService is only meaningful on an interface.
                 if (!type.isInterface()) {
-                    throw new IllegalStateException(String.format(
-                        "@McpMeshService must be on an interface: %s is a %s. Service views are "
-                            + "consumer-owned typed interfaces with no implementation.",
-                        type.getName(), type.isEnum() ? "enum" : "class"));
+                    // Producer CLASS candidate — record for the late non-bean
+                    // WARN (item 3); publication itself is the post-processor's job.
+                    annotatedProducerClasses.add(className);
+                    continue;
                 }
 
                 // Validation is boot-fail: an invalid view surfaces immediately
@@ -296,22 +318,30 @@ public class McpMeshServiceRegistrar implements BeanDefinitionRegistryPostProces
                 ? override
                 : (modeRequested ? returnBinding.rawType() : null);
 
-            // Cross-view conflicting-type policy (reuse of MeshCapabilityBeanRegistrar
-            // conflicting-expectedType semantics): the same capability bound by
-            // two methods must resolve to the same raw type.
+            // Cross-view conflicting-type policy: the same capability bound by
+            // two methods must resolve to the same raw type — EXCEPT Object,
+            // which is the dynamic/untyped marker in the proxy machinery
+            // (collapses to "<dynamic>" in the type-keyed cache). Object coexists
+            // with any concrete type; a conflict fires only between two DIFFERENT
+            // concrete types. A concrete type wins the shared proxy typing (an
+            // Object binding then reads dynamically — existing untyped-dep
+            // semantics), so an annotated generic parent (T→Object) and a
+            // narrowed sub both binding the capability boot and work.
+            Class<?> incoming = returnBinding.rawType();
             CapabilityBinding prior = capabilityTypes.get(capability);
-            if (prior != null && prior.rawType() != returnBinding.rawType()) {
+            if (prior == null || (prior.rawType() == Object.class && incoming != Object.class)) {
+                // First binding, or upgrade Object → concrete.
+                capabilityTypes.put(capability, new CapabilityBinding(
+                    incoming, iface.getName(), method.getName()));
+            } else if (incoming != Object.class && prior.rawType() != Object.class
+                    && prior.rawType() != incoming) {
                 throw new IllegalStateException(String.format(
                     "Capability '%s' is bound by @McpMeshService methods with conflicting resolved "
                         + "types: %s (%s.%s) vs %s (%s.%s). Align the return types or split into "
                         + "separate capabilities.",
                     capability,
                     prior.rawType().getName(), prior.viewName(), prior.methodName(),
-                    returnBinding.rawType().getName(), iface.getName(), method.getName()));
-            }
-            if (prior == null) {
-                capabilityTypes.put(capability, new CapabilityBinding(
-                    returnBinding.rawType(), iface.getName(), method.getName()));
+                    incoming.getName(), iface.getName(), method.getName()));
             }
 
             bindings.add(new ServiceMethodBinding(

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceToolSupport.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshServiceToolSupport.java
@@ -4,6 +4,7 @@ import io.mcpmesh.McpMeshService;
 import io.mcpmesh.Param;
 import io.mcpmesh.types.McpMeshTool;
 import io.mcpmesh.types.MeshToolUnavailableException;
+import org.springframework.core.annotation.AnnotationUtils;
 import tools.jackson.databind.ObjectMapper;
 
 import java.lang.reflect.Method;
@@ -37,9 +38,14 @@ final class McpMeshServiceToolSupport {
     record ViewParamInfo(int position, McpMeshServiceRegistrar.ServiceViewMetadata view) {
     }
 
-    /** Whether {@code type} is an interface annotated {@link McpMeshService}. */
+    /**
+     * Whether {@code type} is an interface carrying {@link McpMeshService} —
+     * directly OR inherited from a super-interface (RFC #1280 phase-2 cleanup
+     * 7a: sub-interface views). Classes are the producer path, never a view.
+     */
     static boolean isServiceView(Class<?> type) {
-        return type.isInterface() && type.isAnnotationPresent(McpMeshService.class);
+        return type.isInterface()
+            && AnnotationUtils.findAnnotation(type, McpMeshService.class) != null;
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -544,6 +544,38 @@ public class MeshAutoConfiguration {
     }
 
     /**
+     * RFC #1280 phase-3 review (item 2): WARN for a {@code @McpMeshService}
+     * producer CLASS that was scanned but NEVER seen as a bean (so its methods
+     * are silently unpublished). Runs as a {@link SmartInitializingSingleton} so
+     * the comparison is against GROUND TRUTH — the classes
+     * {@link MeshToolBeanPostProcessor} actually processed as beans by the time
+     * every singleton exists — eliminating the false positive a bean-definition
+     * scan hits for {@code @Bean} factory methods that declare an interface /
+     * supertype return type.
+     */
+    @Bean
+    @ConditionalOnMissingBean(name = "mcpMeshServiceProducerWarner")
+    public SmartInitializingSingleton mcpMeshServiceProducerWarner(
+            ObjectProvider<McpMeshServiceRegistrar> registrarProvider,
+            ObjectProvider<MeshToolBeanPostProcessor> beanPostProcessorProvider) {
+        return () -> {
+            McpMeshServiceRegistrar registrar = registrarProvider.getIfAvailable();
+            MeshToolBeanPostProcessor bpp = beanPostProcessorProvider.getIfAvailable();
+            if (registrar == null || bpp == null) {
+                return;
+            }
+            Set<String> published = bpp.seenProducerClassNames();
+            for (String className : registrar.discoveredProducerClasses()) {
+                if (!published.contains(className)) {
+                    log.warn("@McpMeshService class {} is not a Spring bean — its methods will NOT be "
+                            + "published. Annotate it @Component (or register it as a @Bean) to publish "
+                            + "its methods as tools.", className);
+                }
+            }
+        };
+    }
+
+    /**
      * Late-phase complement to {@link #meshDependsOnBeanRegistrar}: walks the
      * fully-built {@link AgentSpec} and registers a singleton
      * {@link McpMeshTool} bean for every capability declared by any of the

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
@@ -1,6 +1,7 @@
 package io.mcpmesh.spring;
 
 import tools.jackson.databind.ObjectMapper;
+import io.mcpmesh.McpMeshService;
 import io.mcpmesh.MeshTool;
 import io.mcpmesh.Selector;
 import org.slf4j.Logger;
@@ -11,11 +12,15 @@ import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.core.MethodIntrospector;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.ClassUtils;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Bean post-processor that scans beans for {@code @MeshTool} annotations.
@@ -34,6 +39,40 @@ import java.util.Map;
 public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
 
     private static final Logger log = LoggerFactory.getLogger(MeshToolBeanPostProcessor.class);
+
+    /**
+     * RFC #1280 phase 3: a capability name (and a producer prefix) is one or more
+     * dot-separated segments, each following the flat rule. MUST stay in lock-step
+     * with the registry's segment-wise capability pattern
+     * (src/core/registry/validation.go, support_types.py).
+     */
+    private static final Pattern CAPABILITY_NAME_PATTERN =
+        Pattern.compile("^[a-zA-Z][a-zA-Z0-9_-]*(\\.[a-zA-Z][a-zA-Z0-9_-]*)*$");
+
+    /**
+     * Whether {@code name} is a valid mesh capability name (segment-wise).
+     * Package-private + static so the producer capability derivation can be unit
+     * tested without a real {@link Method} — Java method names may legally
+     * contain {@code $} or Unicode letters that the capability grammar rejects.
+     */
+    static boolean isValidCapabilityName(String name) {
+        return name != null && CAPABILITY_NAME_PATTERN.matcher(name).matches();
+    }
+
+    /**
+     * Producer classes the post-processor actually SAW as beans (RFC #1280
+     * phase-3 review, item 2): the ground-truth set the late non-bean WARN
+     * compares the registrar's scanned producer classes against, so a producer
+     * registered via a @Bean factory method (declared return type = an
+     * interface/supertype) is never falsely flagged.
+     */
+    private final java.util.Set<String> seenProducerClassNames =
+        java.util.concurrent.ConcurrentHashMap.newKeySet();
+
+    /** Producer class names this post-processor saw as beans (ground truth). */
+    public java.util.Set<String> seenProducerClassNames() {
+        return java.util.Collections.unmodifiableSet(seenProducerClassNames);
+    }
 
     private final MeshToolRegistry registry;
     private final MeshToolWrapperRegistry wrapperRegistry;
@@ -117,14 +156,173 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
                     "remove retryOn or set task = true.");
             }
 
+            // RFC #1280 phase 2 (item 7b): analyze @McpMeshService view params
+            // ONCE and hand the result to both the registry and the wrapper.
+            List<McpMeshServiceToolSupport.ViewParamInfo> viewParams =
+                McpMeshServiceToolSupport.analyzeViewParams(method);
+
             // Register with legacy registry (for agent spec generation)
-            registry.registerTool(bean, method, annotation);
+            registry.registerTool(bean, method, annotation, viewParams);
 
             // Create wrapper for MCP SDK integration
-            createAndRegisterWrapper(bean, targetClass, method, annotation);
+            createAndRegisterWrapper(bean, targetClass, method, annotation, viewParams);
         });
 
+        // RFC #1280 phase 3: producer sugar — a class annotated @McpMeshService
+        // publishes each eligible method as a tool under "<prefix>.<methodName>".
+        // Resolve the USER class first (ClassUtils.getUserClass strips a CGLIB
+        // $$-enhanced subclass regardless of TargetClassAware; a no-op for JDK
+        // proxy classes). Use the DIRECT class annotation (getAnnotation), NOT
+        // findAnnotation: a phase-1 facade bean is a JDK proxy whose CLASS
+        // implements a @McpMeshService INTERFACE — findAnnotation would see that
+        // inherited annotation and mis-classify the consumer facade as a
+        // producer. A genuine producer carries @McpMeshService directly on its
+        // @Component class (proxy classes carry no declared annotations).
+        Class<?> userClass = ClassUtils.getUserClass(targetClass);
+        McpMeshService service = userClass.getAnnotation(McpMeshService.class);
+        if (service != null && !userClass.isInterface()) {
+            // Ground truth for the late non-bean WARN: this annotated class WAS
+            // seen as a bean (item 2), regardless of how many methods it publishes.
+            seenProducerClassNames.add(userClass.getName());
+            publishServiceMethods(bean, userClass, service);
+        }
+
         return bean;
+    }
+
+    /**
+     * RFC #1280 phase 3: publish each eligible method of a producer class
+     * annotated {@code @McpMeshService("prefix")} as an ordinary mesh tool with
+     * capability {@code "prefix.<methodName>"}. Pure sugar: each method is routed
+     * through the SAME {@code registerTool} + {@code createAndRegisterWrapper}
+     * path a hand-written {@code @MeshTool} takes (schemas, duplicate-capability
+     * boot-fail, injectable slots, {@code @McpMeshService} view params — all fall
+     * out unchanged). A method carrying its own {@code @MeshTool} wins.
+     */
+    private void publishServiceMethods(Object bean, Class<?> targetClass, McpMeshService service) {
+        String prefix = service.value();
+        if (prefix == null || prefix.isBlank()) {
+            throw new IllegalStateException("@McpMeshService on producer class "
+                + targetClass.getName() + " needs a name prefix: @McpMeshService(\"<prefix>\"). "
+                + "The blank default is only valid on a consumer interface (service view).");
+        }
+        validatePrefix(prefix, targetClass);
+        if (service.minAvailable() != 0) {
+            log.warn("@McpMeshService on producer class {} sets minAvailable={} — ignored "
+                + "(minAvailable is a consumer-view attribute, not a producer one).",
+                targetClass.getName(), service.minAvailable());
+        }
+
+        // Sort by method name (then erased signature) for deterministic
+        // publication order — same determinism rule as the view analyzer.
+        List<Method> eligible = new ArrayList<>();
+        for (Method method : targetClass.getDeclaredMethods()) {
+            if (isEligibleProducerMethod(method)
+                    // Explicit @MeshTool wins — that method already published
+                    // under its own declaration above; no auto-publish, no double.
+                    && AnnotationUtils.findAnnotation(method, MeshTool.class) == null) {
+                eligible.add(method);
+            }
+        }
+        eligible.sort(java.util.Comparator.comparing(Method::getName)
+            .thenComparing(m -> java.util.Arrays.toString(m.getParameterTypes())));
+
+        int published = 0;
+        Map<String, Method> byName = new HashMap<>();
+        for (Method method : eligible) {
+            // Overloaded public methods collide on prefix.<name> — fail fast
+            // with an explicit message (clearer than the generic
+            // duplicate-capability error the synthesized tools would trip).
+            Method clash = byName.putIfAbsent(method.getName(), method);
+            if (clash != null) {
+                throw new IllegalStateException(String.format(
+                    "@McpMeshService producer '%s' on %s: overloaded public methods '%s' both map to "
+                        + "capability '%s.%s' — a producer capability name is prefix + method name, so "
+                        + "overloads collide. Rename one, make one non-public, or give one an explicit "
+                        + "@MeshTool(capability=...).",
+                    prefix, targetClass.getName(), method.getName(), prefix, method.getName()));
+            }
+            String capability = prefix + "." + method.getName();
+            // Validate the FULL derived capability, not just the prefix: Java
+            // method names may legally contain '$' (generated/interop code) or
+            // Unicode letters that the capability grammar rejects — catch it at
+            // BOOT with the declaration site, not as a remote registry 4xx later.
+            if (!isValidCapabilityName(capability)) {
+                throw new IllegalStateException(String.format(
+                    "@McpMeshService producer '%s' on %s: method '%s' derives capability '%s', which "
+                        + "is not a valid capability name (each dot-separated segment must start with "
+                        + "a letter and contain only letters, numbers, underscores, and hyphens). "
+                        + "Rename the method or give it an explicit @MeshTool(capability=...).",
+                    prefix, targetClass.getName(), method.getName(), capability));
+            }
+            MeshTool synth = synthesizeMeshTool(capability, method);
+            List<McpMeshServiceToolSupport.ViewParamInfo> viewParams =
+                McpMeshServiceToolSupport.analyzeViewParams(method);
+            registry.registerTool(bean, method, synth, viewParams);
+            createAndRegisterWrapper(bean, targetClass, method, synth, viewParams);
+            log.debug("@McpMeshService producer: published {}.{} as capability '{}'",
+                targetClass.getSimpleName(), method.getName(), capability);
+            published++;
+        }
+        log.info("@McpMeshService producer '{}' on {}: published {} method(s)",
+            prefix, targetClass.getName(), published);
+    }
+
+    /**
+     * Validate the producer prefix against the same segment-wise capability rule
+     * the registry enforces (each dot-separated segment {@code ^[a-zA-Z][a-zA-Z0-9_-]*$}).
+     * This is an early, prefix-specific error; the FULL derived capability
+     * (prefix + "." + methodName) is validated per method in
+     * {@link #publishServiceMethods} because a method name is NOT guaranteed to
+     * be a valid segment (it may contain {@code $} or Unicode letters).
+     */
+    private static void validatePrefix(String prefix, Class<?> targetClass) {
+        if (!CAPABILITY_NAME_PATTERN.matcher(prefix).matches()) {
+            throw new IllegalStateException(String.format(
+                "@McpMeshService prefix '%s' on producer class %s is invalid — it must be one or more "
+                    + "dot-separated segments, each starting with a letter and containing only letters, "
+                    + "numbers, underscores, and hyphens (e.g. \"media\" or \"media.v2\").",
+                prefix, targetClass.getName()));
+        }
+    }
+
+    /**
+     * Eligible producer method: public, instance (non-static), declared on the
+     * class itself, and not a compiler bridge/synthetic or an {@link Object}
+     * override (equals/hashCode/toString). Non-public methods are ignored
+     * silently (normal Java visibility semantics).
+     */
+    private static boolean isEligibleProducerMethod(Method method) {
+        int mods = method.getModifiers();
+        return Modifier.isPublic(mods)
+            && !Modifier.isStatic(mods)
+            && !method.isBridge()
+            && !method.isSynthetic()
+            && !isObjectMethod(method);
+    }
+
+    /** Whether {@code method} overrides a public {@link Object} method. */
+    private static boolean isObjectMethod(Method method) {
+        String name = method.getName();
+        Class<?>[] p = method.getParameterTypes();
+        return switch (name) {
+            case "toString", "hashCode" -> p.length == 0;
+            case "equals" -> p.length == 1 && p[0] == Object.class;
+            default -> false;
+        };
+    }
+
+    /**
+     * Synthesize a {@link MeshTool} with the derived capability; all other
+     * attributes take their annotation defaults (description="", version="1.0.0",
+     * empty tags/dependencies/retryOn, no outputType, task=false). Producer sugar
+     * is intentionally minimal — a method needing tags/version/description uses
+     * an explicit {@code @MeshTool}.
+     */
+    private static MeshTool synthesizeMeshTool(String capability, Method method) {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("capability", capability);
+        return AnnotationUtils.synthesizeAnnotation(attributes, MeshTool.class, method);
     }
 
     /**
@@ -274,7 +472,8 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
             Object bean,
             Class<?> targetClass,
             Method method,
-            MeshTool annotation) {
+            MeshTool annotation,
+            List<McpMeshServiceToolSupport.ViewParamInfo> viewParams) {
 
         // Generate funcId: "com.example.ClassName.methodName"
         String funcId = targetClass.getName() + "." + method.getName();
@@ -282,12 +481,11 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
         // Extract dependency names from @MeshTool(dependencies=...)
         List<String> dependencyNames = extractDependencyNames(annotation);
 
-        // RFC #1280 phase 2: detect @McpMeshService view parameters (+ validate
-        // + boot-fail on @Param). Their method edges are appended to the tool's
-        // declared dependency list by the wrapper, in the SAME order the wire
-        // spec (MeshToolRegistry.extractAllDependencies) uses.
-        List<McpMeshServiceToolSupport.ViewParamInfo> viewParams =
-            McpMeshServiceToolSupport.analyzeViewParams(method);
+        // RFC #1280 phase 2 (item 7b): view params are pre-computed ONCE by the
+        // caller (postProcessAfterInitialization) and shared with MeshToolRegistry.
+        // Their method edges are appended to the tool's declared dependency list
+        // by the wrapper, in the SAME order the wire spec
+        // (MeshToolRegistry.extractAllDependencies) uses.
 
         // Create wrapper. Phase B MeshJob substrate: the `task` flag controls
         // whether inbound calls bearing X-Mesh-Job-Id dispatch through the

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
@@ -36,6 +36,23 @@ public class MeshToolRegistry {
      * @param annotation The @MeshTool annotation
      */
     public void registerTool(Object bean, Method method, MeshTool annotation) {
+        registerTool(bean, method, annotation,
+            McpMeshServiceToolSupport.analyzeViewParams(method));
+    }
+
+    /**
+     * RFC #1280 phase 2 (item 7b): overload taking pre-computed view params so
+     * {@link MeshToolBeanPostProcessor} analyzes each method's
+     * {@code @McpMeshService} parameters exactly ONCE and hands the result to
+     * both the wrapper and this registry (killing the phase-2 double-derivation).
+     *
+     * @param viewParams the method's {@code @McpMeshService} view params;
+     *                   callers pass {@link List#of()} when there are none
+     *                   (never {@code null})
+     */
+    public void registerTool(Object bean, Method method, MeshTool annotation,
+            List<McpMeshServiceToolSupport.ViewParamInfo> viewParams) {
+        Objects.requireNonNull(viewParams, "viewParams must not be null (pass List.of() when none)");
         String capability = annotation.capability();
 
         Class<?> outputType = annotation.outputType();
@@ -53,7 +70,7 @@ public class MeshToolRegistry {
             // on the record so existing readers (heartbeat builder,
             // tests) are unaffected.
             new ArrayList<>(Arrays.asList(annotation.tags())),
-            extractAllDependencies(annotation, method),
+            extractAllDependencies(annotation, viewParams),
             extractInputSchema(method),
             outputType,
             // Issue #547 Phase 4: per-tool override (default true = current behavior).
@@ -445,10 +462,10 @@ public class MeshToolRegistry {
      * MUST match {@link MeshToolWrapper}'s declared-index space so the Rust
      * core's {@code funcId:dep_N} resolution events land on the right slot.
      */
-    private List<DependencyInfo> extractAllDependencies(MeshTool annotation, Method method) {
+    private List<DependencyInfo> extractAllDependencies(MeshTool annotation,
+            List<McpMeshServiceToolSupport.ViewParamInfo> viewParams) {
         List<DependencyInfo> deps = extractDependencies(annotation.dependencies());
-        for (McpMeshServiceToolSupport.ViewParamInfo vp
-                : McpMeshServiceToolSupport.analyzeViewParams(method)) {
+        for (McpMeshServiceToolSupport.ViewParamInfo vp : viewParams) {
             for (McpMeshServiceRegistrar.ServiceMethodBinding b : vp.view().bindings()) {
                 deps.add(new DependencyInfo(
                     b.capability(),

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -488,23 +488,21 @@ public class MeshToolWrapper implements McpToolHandler {
                 // LLM agent - will be injected
                 llmAgentPositions.add(i);
             } else {
-                // RFC #1280 phase 2: near-miss view param — annotated with
-                // @McpMeshService but NOT a directly-annotated interface (a
-                // class, or a sub-interface that only inherits the annotation).
-                // isServiceView requires interface + DIRECT annotation, so these
-                // fall through here; give a dedicated message rather than the
-                // generic "must have @Param" one. Sub-interface support is
-                // deliberately deferred — the annotation must be direct.
-                if (AnnotationUtils.findAnnotation(type, McpMeshService.class) != null) {
+                // RFC #1280 phase 2/3: near-miss view param. A @McpMeshService
+                // INTERFACE param (direct or inherited) is a valid view and was
+                // already skipped into viewParamPositions above; only a
+                // @McpMeshService-annotated CLASS reaches here — a class cannot
+                // be a view param (a class-level @McpMeshService publishes methods
+                // as tools on the producer side, it is not an injectable view).
+                if (!type.isInterface()
+                        && AnnotationUtils.findAnnotation(type, McpMeshService.class) != null) {
                     throw new IllegalStateException(
-                        "@McpMeshService view used as a tool parameter must be a directly-annotated "
-                            + "interface: parameter at position " + i + " (type " + type.getName()
+                        "view parameters must be @McpMeshService interfaces; a class-level "
+                            + "@McpMeshService publishes methods as tools (producer side). "
+                            + "Parameter at position " + i + " (type " + type.getName()
                             + ") in method " + method.getName() + " of "
-                            + method.getDeclaringClass().getName() + " is "
-                            + (type.isInterface()
-                                ? "a sub-interface that only inherits @McpMeshService (annotate it directly)"
-                                : "a class annotated @McpMeshService (service views must be interfaces)")
-                            + ".");
+                            + method.getDeclaringClass().getName()
+                            + " is a class annotated @McpMeshService.");
                 }
                 // Regular MCP parameter - must have @Param
                 Param paramAnn = param.getAnnotation(Param.class);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -491,9 +491,10 @@ public class MeshToolWrapper implements McpToolHandler {
                 // RFC #1280 phase 2/3: near-miss view param. A @McpMeshService
                 // INTERFACE param (direct or inherited) is a valid view and was
                 // already skipped into viewParamPositions above; only a
-                // @McpMeshService-annotated CLASS reaches here — a class cannot
-                // be a view param (a class-level @McpMeshService publishes methods
-                // as tools on the producer side, it is not an injectable view).
+                // non-interface type that carries or inherits @McpMeshService
+                // reaches here — a class cannot be a view param (a class-level
+                // @McpMeshService publishes methods as tools on the producer
+                // side, it is not an injectable view).
                 if (!type.isInterface()
                         && AnnotationUtils.findAnnotation(type, McpMeshService.class) != null) {
                     throw new IllegalStateException(
@@ -502,7 +503,8 @@ public class MeshToolWrapper implements McpToolHandler {
                             + "Parameter at position " + i + " (type " + type.getName()
                             + ") in method " + method.getName() + " of "
                             + method.getDeclaringClass().getName()
-                            + " is a class annotated @McpMeshService.");
+                            + " carries or inherits @McpMeshService but is not an interface, "
+                            + "so it cannot be a view parameter.");
                 }
                 // Regular MCP parameter - must have @Param
                 Param paramAnn = param.getAnnotation(Param.class);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceIntegrationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceIntegrationTest.java
@@ -647,11 +647,22 @@ class McpMeshServiceIntegrationTest {
     @Test
     @DisplayName("MED-4: @McpMeshService on a class boot-fails")
     void meshServiceOnClassBootFail() {
-        runnerFor("io.mcpmesh.spring.svbad.onclass", PlainAgentConfig.class).run(context -> {
+        // Phase 3: a producer class annotated @McpMeshService with a BLANK prefix
+        // boot-fails (needs a name prefix).
+        runnerFor("io.mcpmesh.spring.svbad.onclass", BlankPrefixConfig.class).run(context -> {
             assertThat(context).hasFailed();
             assertThat(collectMessages(context.getStartupFailure()))
-                .contains("@McpMeshService must be on an interface");
+                .contains("needs a name prefix");
         });
+    }
+
+    @Configuration
+    @MeshAgent(name = "blank-prefix-agent")
+    static class BlankPrefixConfig {
+        @Bean
+        public io.mcpmesh.spring.svbad.onclass.OnClass.BlankPrefixProducer blankPrefixProducer() {
+            return new io.mcpmesh.spring.svbad.onclass.OnClass.BlankPrefixProducer();
+        }
     }
 
     @Test
@@ -975,6 +986,113 @@ class McpMeshServiceIntegrationTest {
 
     @Configuration
     static class EmptyConfig {
+    }
+
+    @Test
+    @DisplayName("HIGH-1a: a sub-interface inheriting @McpMeshService is NOT auto-discovered as a bean view")
+    void subInterfaceInheritedAnnotationNotScanned() {
+        runnerFor("io.mcpmesh.spring.svscan", PlainAgentConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            // Directly-annotated parent → facade bean registered.
+            assertThat(context.containsBean("scanParent"))
+                .as("directly-annotated view interface is a scanned bean").isTrue();
+            // Sub-interface that only inherits the annotation → NOT scanned.
+            assertThat(context.containsBean("scanChild"))
+                .as("inherited-annotation sub-interface must NOT be auto-discovered").isFalse();
+        });
+    }
+
+    @Configuration
+    @MeshAgent(name = "factory-producer-agent")
+    static class FactoryProducerConfig {
+        // Declared return type is the interface (supertype) — a bean-def scan
+        // would not see the impl class; the ground-truth WARN must not fire.
+        @Bean
+        public io.mcpmesh.spring.svfactory.FactoryFixtures.MediaApi mediaApi() {
+            return new io.mcpmesh.spring.svfactory.FactoryFixtures.MediaImpl();
+        }
+    }
+
+    @Test
+    @DisplayName("item 2: a producer registered via @Bean (interface return) publishes and does NOT false-WARN")
+    void producerViaBeanFactoryInterfaceReturn_publishesNoFalseWarn() {
+        LogCapture capture = LogCapture.attach(MeshAutoConfiguration.class);
+        try {
+            runnerFor("io.mcpmesh.spring.svfactory", FactoryProducerConfig.class).run(context -> {
+                assertThat(context).hasNotFailed();
+                AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+                assertThat(spec.getTools().stream().map(AgentSpec.ToolSpec::getCapability))
+                    .as("the @Bean-registered producer's method is published")
+                    .contains("fmedia.go");
+            });
+            assertThat(capture.events)
+                .as("no false 'not a Spring bean' WARN for a @Bean-registered producer")
+                .noneMatch(e -> "WARN".equals(e.level)
+                    && e.message.contains("is not a Spring bean")
+                    && e.message.contains("MediaImpl"));
+        } finally {
+            capture.detach();
+        }
+    }
+
+    @Test
+    @DisplayName("MED-3: a @McpMeshService producer class that is not a Spring bean WARNs")
+    void annotatedNonBeanClassWarns() {
+        // The WARN is emitted by the late SmartInitializingSingleton in
+        // MeshAutoConfiguration (ground-truth comparison), not the registrar.
+        LogCapture capture = LogCapture.attach(MeshAutoConfiguration.class);
+        try {
+            runnerFor("io.mcpmesh.spring.svnonbean", PlainAgentConfig.class).run(context -> {
+                assertThat(context).hasNotFailed();
+            });
+            assertThat(capture.events)
+                .anyMatch(e -> "WARN".equals(e.level)
+                    && e.message.contains("is not a Spring bean")
+                    && e.message.contains("NonBeanProducer")
+                    && e.message.contains("@Component"));
+        } finally {
+            capture.detach();
+        }
+    }
+
+    @Configuration
+    @MeshAgent(name = "producer-consumer-agent")
+    static class ProducerConsumerConfig {
+        @Bean
+        public io.mcpmesh.spring.svprod.ProdFixtures.MediaProducer mediaProducer() {
+            return new io.mcpmesh.spring.svprod.ProdFixtures.MediaProducer();
+        }
+    }
+
+    @Test
+    @DisplayName("Phase 3 end-to-end: a producer class + a consumer view bind media.caption within one agent")
+    void producerAndConsumerViewWireWithinAgent() {
+        runnerFor("io.mcpmesh.spring.svprod", ProducerConsumerConfig.class).run(context -> {
+            assertThat(context).hasNotFailed();
+            AgentSpec spec = context.getBean(MeshRuntime.class).getAgentSpec();
+
+            // Producer side: both sugar tools are published with dotted names.
+            List<String> producedCaps = spec.getTools().stream()
+                .map(AgentSpec.ToolSpec::getCapability)
+                .filter(c -> c != null && c.startsWith("media."))
+                .toList();
+            assertThat(producedCaps).contains("media.caption", "media.thumbnail");
+
+            // Consumer side: the view facade bean is registered + injectable.
+            assertThat(context.getBean(io.mcpmesh.spring.svprod.ProdFixtures.MediaConsumerView.class))
+                .as("consumer view facade bean must exist").isNotNull();
+
+            // Within-agent binding: media.caption is produced locally, so the
+            // consumer view edge is self-produced (phase-1 dedup) rather than a
+            // registry dependency — it must NOT appear on __mesh_service_deps.
+            boolean onServiceDeps = spec.getTools().stream()
+                .filter(t -> "__mesh_service_deps".equals(t.getCapability()))
+                .flatMap(t -> t.getDependencies().stream())
+                .anyMatch(d -> "media.caption".equals(d.getCapability()));
+            assertThat(onServiceDeps)
+                .as("a self-produced view edge must be deduped off __mesh_service_deps")
+                .isFalse();
+        });
     }
 
     // RFC #1280 phase 2: a view used as BOTH a phase-1 bean and a @MeshTool param.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceIntegrationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceIntegrationTest.java
@@ -645,8 +645,8 @@ class McpMeshServiceIntegrationTest {
     }
 
     @Test
-    @DisplayName("MED-4: @McpMeshService on a class boot-fails")
-    void meshServiceOnClassBootFail() {
+    @DisplayName("Phase 3: a producer class with a blank prefix boot-fails (needs a name prefix)")
+    void producerClassBlankPrefixBootFails() {
         // Phase 3: a producer class annotated @McpMeshService with a BLANK prefix
         // boot-fails (needs a name prefix).
         runnerFor("io.mcpmesh.spring.svbad.onclass", BlankPrefixConfig.class).run(context -> {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceProducerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceProducerTest.java
@@ -1,0 +1,470 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.core.MeshObjectMappers;
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * RFC #1280 phase 3: producer sugar — a class annotated {@code @McpMeshService("prefix")}
+ * publishes each eligible method as an ordinary mesh tool with capability
+ * {@code "prefix.<methodName>"}. Drives {@link MeshToolBeanPostProcessor} directly
+ * (mirrors {@link MeshToolInheritanceScanTest}).
+ */
+class McpMeshServiceProducerTest {
+
+    private static final ObjectMapper MAPPER = MeshObjectMappers.create();
+
+    private static MeshToolBeanPostProcessor processor(MeshToolRegistry registry) {
+        return new MeshToolBeanPostProcessor(
+            registry,
+            new MeshToolWrapperRegistry(new McpMeshToolProxyFactory()),
+            JsonMapper.builder().build());
+    }
+
+    private static List<String> capabilities(MeshToolRegistry registry) {
+        return registry.getToolSpecs().stream()
+            .map(AgentSpec.ToolSpec::getCapability).sorted().toList();
+    }
+
+    // ---- Publication --------------------------------------------------------
+
+    @McpMeshService("media")
+    public static class MediaTools {
+        public String caption(@Param("text") String text) {
+            return "cap:" + text;
+        }
+
+        public String thumbnail(@Param("assetId") String assetId) {
+            return "thumb:" + assetId;
+        }
+    }
+
+    @Test
+    void publishesEachMethodWithPrefixedCapability() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        processor(registry).postProcessAfterInitialization(new MediaTools(), "media");
+
+        assertEquals(List.of("media.caption", "media.thumbnail"), capabilities(registry));
+        // Schemas come from the existing @MeshTool machinery — each method's
+        // @Param drives the input schema.
+        assertTrue(registry.getTool("media.caption").inputSchema().toString().contains("text"));
+        assertTrue(registry.getTool("media.thumbnail").inputSchema().toString().contains("assetId"));
+    }
+
+    @Test
+    void dottedCapabilityRoundTripsInSpec() throws Exception {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        processor(registry).postProcessAfterInitialization(new MediaTools(), "media");
+
+        AgentSpec.ToolSpec spec = registry.getToolSpecs().stream()
+            .filter(t -> "media.caption".equals(t.getCapability())).findFirst().orElseThrow();
+        // The dotted capability name survives serialization intact.
+        assertTrue(MAPPER.writeValueAsString(spec).contains("\"capability\":\"media.caption\""));
+    }
+
+    // ---- Blank prefix boot-fail ---------------------------------------------
+
+    @McpMeshService
+    public static class BlankPrefixTools {
+        public String greet(@Param("name") String name) {
+            return name;
+        }
+    }
+
+    @Test
+    void blankPrefixBootFails() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> processor(registry).postProcessAfterInitialization(new BlankPrefixTools(), "b"));
+        assertTrue(ex.getMessage().contains("needs a name prefix"), ex.getMessage());
+    }
+
+    // ---- minAvailable on a producer class → WARN + ignore -------------------
+
+    @McpMeshService(value = "svc", minAvailable = 2)
+    public static class MinAvailableTools {
+        public String a(@Param("x") String x) {
+            return x;
+        }
+    }
+
+    @Test
+    void minAvailableOnClassWarnsAndIsIgnored() {
+        LogCapture capture = LogCapture.attach(MeshToolBeanPostProcessor.class);
+        try {
+            MeshToolRegistry registry = new MeshToolRegistry();
+            processor(registry).postProcessAfterInitialization(new MinAvailableTools(), "m");
+            // Still publishes (soft-fail philosophy).
+            assertEquals(List.of("svc.a"), capabilities(registry));
+            assertTrue(capture.events.stream().anyMatch(e -> "WARN".equals(e.level)
+                    && e.message.contains("minAvailable")
+                    && e.message.contains(MinAvailableTools.class.getName())),
+                "minAvailable on a producer class must WARN");
+        } finally {
+            capture.detach();
+        }
+    }
+
+    // ---- Explicit @MeshTool wins (no double publish) ------------------------
+
+    @McpMeshService("shop")
+    public static class MixedTools {
+        @MeshTool(capability = "custom_cart")
+        public String cart(@Param("id") String id) {
+            return id;
+        }
+
+        public String browse(@Param("q") String q) {
+            return q;
+        }
+    }
+
+    @Test
+    void explicitMeshToolWins_noDoublePublish() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        processor(registry).postProcessAfterInitialization(new MixedTools(), "mixed");
+        // cart publishes under its OWN @MeshTool capability (NOT "shop.cart");
+        // browse gets the sugar name.
+        assertEquals(List.of("custom_cart", "shop.browse"), capabilities(registry));
+    }
+
+    // ---- Non-public methods ignored -----------------------------------------
+
+    @McpMeshService("vis")
+    public static class VisibilityTools {
+        public String pub(@Param("x") String x) {
+            return x;
+        }
+
+        protected String prot(@Param("x") String x) {
+            return x;
+        }
+
+        String pkg(@Param("x") String x) {
+            return x;
+        }
+
+        private String priv(@Param("x") String x) {
+            return x;
+        }
+
+        public static String stat(@Param("x") String x) {
+            return x;
+        }
+    }
+
+    @Test
+    void nonPublicAndStaticMethodsIgnored() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        processor(registry).postProcessAfterInitialization(new VisibilityTools(), "v");
+        assertEquals(List.of("vis.pub"), capabilities(registry));
+    }
+
+    // ---- Object overrides ignored (footgun guard) ---------------------------
+
+    @McpMeshService("obj")
+    public static class ObjectOverrideTools {
+        public String work(@Param("x") String x) {
+            return x;
+        }
+
+        @Override
+        public String toString() {
+            return "ObjectOverrideTools";
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return this == o;
+        }
+
+        @Override
+        public int hashCode() {
+            return 1;
+        }
+    }
+
+    @Test
+    void objectOverridesIgnored() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        processor(registry).postProcessAfterInitialization(new ObjectOverrideTools(), "o");
+        assertEquals(List.of("obj.work"), capabilities(registry));
+    }
+
+    // ---- Duplicate capability boot-fail through the sugar path --------------
+
+    @McpMeshService("dup")
+    public static class DupSugarTools {
+        public String same(@Param("x") String x) {
+            return x;
+        }
+    }
+
+    public static class DupExplicitTools {
+        @MeshTool(capability = "dup.same")
+        public String other(@Param("x") String x) {
+            return x;
+        }
+    }
+
+    @Test
+    void duplicateCapabilityThroughSugarBootFails() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        MeshToolBeanPostProcessor bpp = processor(registry);
+        // Explicit tool claims "dup.same" first.
+        bpp.postProcessAfterInitialization(new DupExplicitTools(), "explicit");
+        // The sugar path generates the SAME capability → the existing #1164
+        // duplicate-capability boot error fires unchanged.
+        assertThrows(IllegalStateException.class,
+            () -> bpp.postProcessAfterInitialization(new DupSugarTools(), "sugar"));
+    }
+
+    // ---- Injectable slot types fall out naturally (rule 3) ------------------
+
+    @McpMeshService("inj")
+    public static class InjectableTools {
+        // A producer method may take an injectable McpMeshTool slot; it goes
+        // through the same wrapper machinery. Without an explicit @MeshTool it
+        // has no declared dependency, so the slot stays null (graceful
+        // degradation) — no boot-fail.
+        public String enrich(@Param("x") String x, McpMeshTool<String> helper) {
+            return x;
+        }
+    }
+
+    @Test
+    void injectableSlotParamsPublishWithoutError() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        assertDoesNotThrow(() ->
+            processor(registry).postProcessAfterInitialization(new InjectableTools(), "i"));
+        assertEquals(List.of("inj.enrich"), capabilities(registry));
+        // No @MeshTool(dependencies=), so the tool declares zero deps.
+        assertTrue(registry.getTool("inj.enrich").dependencies().isEmpty());
+    }
+
+    // ---- item 7b: registry consumes PASSED view params (no re-derivation) ---
+
+    @McpMeshService
+    public interface EdgeView {
+        @Selector(capability = "edge.x")
+        String x(@Param("id") String id);
+    }
+
+    public static class ViewParamBean {
+        @MeshTool(capability = "vp_tool")
+        public String run(@Param("x") String x, EdgeView view) {
+            return x;
+        }
+    }
+
+    @Test
+    void registryUsesPassedViewParams_notReDerived() throws Exception {
+        // Passing an EMPTY viewParams list to the overload yields a tool with NO
+        // view edges even though the method HAS a view param — proving the
+        // registry consumes the caller's single analysis instead of re-deriving.
+        MeshToolRegistry registry = new MeshToolRegistry();
+        var m = ViewParamBean.class.getMethod("run", String.class, EdgeView.class);
+        registry.registerTool(new ViewParamBean(), m, m.getAnnotation(MeshTool.class), List.of());
+
+        AgentSpec.ToolSpec spec = registry.getToolSpecs().stream()
+            .filter(t -> "vp_tool".equals(t.getCapability())).findFirst().orElseThrow();
+        assertTrue(spec.getDependencies() == null || spec.getDependencies().isEmpty(),
+            "empty passed viewParams → no view edges (registry did not re-derive)");
+    }
+
+    // ---- MED-4: prefix validated segment-wise at boot -----------------------
+
+    @McpMeshService("bad prefix")
+    public static class SpacePrefixTools {
+        public String a(@Param("x") String x) { return x; }
+    }
+
+    @McpMeshService("a..b")
+    public static class DoubleDotPrefixTools {
+        public String a(@Param("x") String x) { return x; }
+    }
+
+    @McpMeshService("1media")
+    public static class DigitStartPrefixTools {
+        public String a(@Param("x") String x) { return x; }
+    }
+
+    @McpMeshService("media.v2")
+    public static class DottedPrefixTools {
+        public String go(@Param("x") String x) { return x; }
+    }
+
+    @Test
+    void invalidPrefixBootFails() {
+        for (Object bad : List.of(new SpacePrefixTools(), new DoubleDotPrefixTools(),
+                new DigitStartPrefixTools())) {
+            MeshToolRegistry registry = new MeshToolRegistry();
+            IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> processor(registry).postProcessAfterInitialization(bad, "b"),
+                () -> "expected boot-fail for " + bad.getClass().getSimpleName());
+            assertTrue(ex.getMessage().contains("prefix") && ex.getMessage().contains("invalid"),
+                ex.getMessage());
+        }
+    }
+
+    @Test
+    void multiSegmentPrefixIsValid() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        processor(registry).postProcessAfterInitialization(new DottedPrefixTools(), "d");
+        assertEquals(List.of("media.v2.go"), capabilities(registry));
+    }
+
+    @Test
+    void isValidCapabilityName_rejectsDollarAndUnicodeSegments() {
+        // A derived capability is validated in FULL (prefix + "." + methodName);
+        // Java method names may contain '$' or Unicode letters that the grammar
+        // rejects (unit-testable without a real Method).
+        assertTrue(MeshToolBeanPostProcessor.isValidCapabilityName("media"));
+        assertTrue(MeshToolBeanPostProcessor.isValidCapabilityName("media.caption"));
+        assertTrue(MeshToolBeanPostProcessor.isValidCapabilityName("media.v2"));
+        assertFalse(MeshToolBeanPostProcessor.isValidCapabilityName("media.go$1"),
+            "'$' is legal in a Java identifier but not a capability segment");
+        assertFalse(MeshToolBeanPostProcessor.isValidCapabilityName("media.café"),
+            "Unicode letters are legal in Java identifiers but not capability segments");
+        assertFalse(MeshToolBeanPostProcessor.isValidCapabilityName("media."));
+        assertFalse(MeshToolBeanPostProcessor.isValidCapabilityName(null));
+    }
+
+    // ---- MED-5: deterministic publication order -----------------------------
+
+    @McpMeshService("ord")
+    public static class UnorderedTools {
+        public String zulu(@Param("x") String x) { return x; }
+        public String alpha(@Param("x") String x) { return x; }
+        public String mike(@Param("x") String x) { return x; }
+    }
+
+    @Test
+    void publicationOrderIsMethodNameSorted() {
+        LogCapture capture = LogCapture.attachDebug(MeshToolBeanPostProcessor.class);
+        try {
+            MeshToolRegistry registry = new MeshToolRegistry();
+            processor(registry).postProcessAfterInitialization(new UnorderedTools(), "u");
+            List<String> publishedOrder = capture.events.stream()
+                .filter(e -> e.message.contains("published") && e.message.contains("ord."))
+                .map(e -> e.message.replaceAll(".*published UnorderedTools\\.(\\w+).*", "$1"))
+                .toList();
+            assertEquals(List.of("alpha", "mike", "zulu"), publishedOrder,
+                "producer methods must publish in method-name order");
+        } finally {
+            capture.detach();
+        }
+    }
+
+    // ---- MED-6: overloaded public methods collide on prefix.name ------------
+
+    @McpMeshService("ov")
+    public static class OverloadTools {
+        public String go(@Param("x") String x) { return x; }
+        public String go(@Param("x") String x, @Param("y") String y) { return x + y; }
+    }
+
+    @Test
+    void overloadedMethodsBootFailExplicitly() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> processor(registry).postProcessAfterInitialization(new OverloadTools(), "o"));
+        assertTrue(ex.getMessage().contains("overloaded"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("ov.go"), ex.getMessage());
+    }
+
+    // ---- MED-2: CGLIB-enhanced producer detected via getUserClass -----------
+
+    @Test
+    void cglibEnhancedProducerIsDetected() {
+        org.springframework.cglib.proxy.Enhancer enhancer =
+            new org.springframework.cglib.proxy.Enhancer();
+        enhancer.setSuperclass(MediaTools.class);
+        enhancer.setCallback(org.springframework.cglib.proxy.NoOp.INSTANCE);
+        MediaTools enhanced = (MediaTools) enhancer.create();
+        assertTrue(enhanced.getClass().getName().contains("$$"),
+            "sanity: the instance is a CGLIB subclass");
+
+        MeshToolRegistry registry = new MeshToolRegistry();
+        processor(registry).postProcessAfterInitialization(enhanced, "media");
+        // getUserClass strips the $$ subclass → the real @McpMeshService class.
+        assertEquals(List.of("media.caption", "media.thumbnail"), capabilities(registry));
+    }
+
+    // ---- item 9: superclass-inherited public methods NOT published ----------
+
+    public static class BaseProducer {
+        public String base(@Param("x") String x) { return x; }
+    }
+
+    @McpMeshService("sub")
+    public static class SubProducer extends BaseProducer {
+        public String own(@Param("x") String x) { return x; }
+    }
+
+    @Test
+    void superclassInheritedMethodsNotPublished() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        processor(registry).postProcessAfterInitialization(new SubProducer(), "sub");
+        // Only the DECLARED method — inherited "base" is not published.
+        assertEquals(List.of("sub.own"), capabilities(registry));
+    }
+
+    /** Minimal Logback appender recording level + message for a target logger. */
+    static final class LogCapture {
+        final java.util.List<LogEvent> events = new java.util.concurrent.CopyOnWriteArrayList<>();
+        private final ch.qos.logback.classic.Logger target;
+        private final ch.qos.logback.core.AppenderBase<ch.qos.logback.classic.spi.ILoggingEvent> appender;
+
+        private LogCapture(ch.qos.logback.classic.Logger target) {
+            this.target = target;
+            this.appender = new ch.qos.logback.core.AppenderBase<>() {
+                @Override
+                protected void append(ch.qos.logback.classic.spi.ILoggingEvent event) {
+                    events.add(new LogEvent(event.getLevel().toString(), event.getFormattedMessage()));
+                }
+            };
+        }
+
+        static LogCapture attach(Class<?> loggerClass) {
+            ch.qos.logback.classic.Logger logger =
+                (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(loggerClass);
+            LogCapture capture = new LogCapture(logger);
+            // Store the prior level UNCONDITIONALLY so detach() restores it
+            // verbatim — never clobbering an explicitly-configured level.
+            capture.priorLevel = logger.getLevel();
+            capture.appender.setContext(logger.getLoggerContext());
+            capture.appender.start();
+            logger.addAppender(capture.appender);
+            return capture;
+        }
+
+        /** Attach and force DEBUG so debug-level lines are captured. */
+        static LogCapture attachDebug(Class<?> loggerClass) {
+            LogCapture capture = attach(loggerClass);
+            capture.target.setLevel(ch.qos.logback.classic.Level.DEBUG);
+            return capture;
+        }
+
+        private ch.qos.logback.classic.Level priorLevel;
+
+        void detach() {
+            target.setLevel(priorLevel); // restore verbatim (may be null = inherit)
+            target.detachAppender(appender);
+            appender.stop();
+        }
+
+        record LogEvent(String level, String message) {}
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceToolParamTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceToolParamTest.java
@@ -374,7 +374,11 @@ class McpMeshServiceToolParamTest {
         assertTrue(ex.getMessage().contains("view parameters must be @McpMeshService interfaces"),
             ex.getMessage());
         assertTrue(ex.getMessage().contains("publishes methods as tools (producer side)"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("carries or inherits @McpMeshService but is not an interface"),
+            ex.getMessage());
         assertTrue(ex.getMessage().contains(ClassParamBean.class.getName()), ex.getMessage());
+        assertTrue(ex.getMessage().contains(AnnotatedClassView.class.getName()),
+            "message names the resolved parameter type: " + ex.getMessage());
     }
 
     @Test

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceToolParamTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpMeshServiceToolParamTest.java
@@ -365,22 +365,146 @@ class McpMeshServiceToolParamTest {
     }
 
     @Test
-    void nearMiss_classAnnotatedAsView_dedicatedBootFail() throws Exception {
+    void nearMiss_classAnnotatedAsView_rewordedBootFail() throws Exception {
+        // A CLASS annotated @McpMeshService is the producer path, NOT a valid
+        // view param — the reworded message points that out.
         Method m = ClassParamBean.class.getMethod("run", String.class, AnnotatedClassView.class);
         IllegalStateException ex = assertThrows(IllegalStateException.class,
             () -> wrapperFor(new ClassParamBean(), "ClassParamBean.run", "cp_tool", m, List.of()));
-        assertTrue(ex.getMessage().contains("must be a directly-annotated interface"), ex.getMessage());
-        assertTrue(ex.getMessage().contains("class annotated @McpMeshService"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("view parameters must be @McpMeshService interfaces"),
+            ex.getMessage());
+        assertTrue(ex.getMessage().contains("publishes methods as tools (producer side)"), ex.getMessage());
         assertTrue(ex.getMessage().contains(ClassParamBean.class.getName()), ex.getMessage());
     }
 
     @Test
-    void nearMiss_subInterfaceInheritsAnnotation_dedicatedBootFail() throws Exception {
+    void subInterfaceInheritsAnnotation_isAValidViewParam() throws Exception {
+        // Phase-2 cleanup 7a: a sub-interface that INHERITS @McpMeshService is a
+        // valid view param — its inherited method edge is published on the tool.
+        SubIfaceParamBean bean = new SubIfaceParamBean();
         Method m = SubIfaceParamBean.class.getMethod("run", String.class, SubView.class);
+        MeshToolWrapper w = wrapperFor(bean, "SubIfaceParamBean.run", "si_tool", m, List.of());
+        assertEquals(List.of("base.x"), w.getDependencyNames());
+        assertEquals(String.class, w.getDependencyReturnType(0));
+    }
+
+    // ---- HIGH-1b + item-9: generic narrowing / grandparent / diamond params --
+
+    public record GItem(String id) {
+    }
+
+    @McpMeshService
+    public interface GenBase<T> {
+        @Selector(capability = "gen.item")
+        T get(@Param("id") String id);
+    }
+
+    public interface ItemSub extends GenBase<GItem> {
+    }
+
+    public static class GenParamBean {
+        @MeshTool(capability = "gen_tool")
+        public String run(@Param("x") String x, ItemSub view) {
+            return x;
+        }
+    }
+
+    @Test
+    void genericParentNarrowedSubAsParam_getsConcreteTyping() throws Exception {
+        // A generic annotated parent (T) narrowed by a sub used as a view param
+        // resolves to the CONCRETE type (Item), not Object — the concrete wins
+        // the proxy typing (HIGH-1b: Object is non-conflicting/dynamic).
+        Method m = GenParamBean.class.getMethod("run", String.class, ItemSub.class);
+        MeshToolWrapper w = wrapperFor(new GenParamBean(), "GenParamBean.run", "gen_tool", m, List.of());
+        assertEquals(List.of("gen.item"), w.getDependencyNames());
+        assertEquals(GItem.class, w.getDependencyReturnType(0));
+    }
+
+    public record CX(String x) {
+    }
+
+    public record CY(int y) {
+    }
+
+    @McpMeshService
+    public interface TwoConcreteView {
+        @Selector(capability = "cc")
+        CX a(@Param("id") String id);
+
+        @Selector(capability = "cc")
+        CY b(@Param("id") String id);
+    }
+
+    public static class TwoConcreteBean {
+        @MeshTool(capability = "cc_tool")
+        public String run(@Param("x") String x, TwoConcreteView view) {
+            return x;
+        }
+    }
+
+    @Test
+    void twoDifferentConcreteTypesForSameCapability_bootFails() throws Exception {
+        Method m = TwoConcreteBean.class.getMethod("run", String.class, TwoConcreteView.class);
         IllegalStateException ex = assertThrows(IllegalStateException.class,
-            () -> wrapperFor(new SubIfaceParamBean(), "SubIfaceParamBean.run", "si_tool", m, List.of()));
-        assertTrue(ex.getMessage().contains("must be a directly-annotated interface"), ex.getMessage());
-        assertTrue(ex.getMessage().contains("only inherits @McpMeshService"), ex.getMessage());
+            () -> McpMeshServiceToolSupport.analyzeViewParams(m));
+        assertTrue(ex.getMessage().contains("conflicting resolved"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("cc"), ex.getMessage());
+    }
+
+    @McpMeshService
+    public interface GrandP {
+        @Selector(capability = "gp.x")
+        String x(@Param("id") String id);
+    }
+
+    public interface Par extends GrandP {
+    }
+
+    public interface Chi extends Par {
+    }
+
+    public static class GrandParamBean {
+        @MeshTool(capability = "gp_tool")
+        public String run(@Param("x") String x, Chi view) {
+            return x;
+        }
+    }
+
+    @Test
+    void transitiveGrandparentInheritance_isValidViewParam() throws Exception {
+        Method m = GrandParamBean.class.getMethod("run", String.class, Chi.class);
+        MeshToolWrapper w = wrapperFor(new GrandParamBean(), "GrandParamBean.run", "gp_tool", m, List.of());
+        assertEquals(List.of("gp.x"), w.getDependencyNames());
+    }
+
+    @McpMeshService
+    public interface D1 {
+        @Selector(capability = "d.x")
+        String x(@Param("id") String id);
+    }
+
+    @McpMeshService
+    public interface D2 {
+        @Selector(capability = "d.y")
+        String y(@Param("id") String id);
+    }
+
+    public interface Dia extends D1, D2 {
+    }
+
+    public static class DiaParamBean {
+        @MeshTool(capability = "dia_tool")
+        public String run(@Param("x") String x, Dia view) {
+            return x;
+        }
+    }
+
+    @Test
+    void diamondTwoAnnotatedParents_isValidViewParam() throws Exception {
+        Method m = DiaParamBean.class.getMethod("run", String.class, Dia.class);
+        MeshToolWrapper w = wrapperFor(new DiaParamBean(), "DiaParamBean.run", "dia_tool", m, List.of());
+        // Both parents' methods become edges, name-sorted (x < y → d.x, d.y).
+        assertEquals(List.of("d.x", "d.y"), w.getDependencyNames());
     }
 
     // ---- MED-2: claim-path refusal for an unresolved required VIEW edge ------

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/onclass/OnClass.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svbad/onclass/OnClass.java
@@ -1,14 +1,21 @@
 package io.mcpmesh.spring.svbad.onclass;
 
 import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
 
-/** Boot-fail (MED-4): @McpMeshService on a class rather than an interface. */
+/**
+ * Boot-fail: a producer class annotated {@code @McpMeshService} with a BLANK
+ * prefix (RFC #1280 phase 3 — a producer class requires a name prefix).
+ */
 public final class OnClass {
 
     private OnClass() {
     }
 
-    @McpMeshService
-    public static class NotAnInterfaceService {
+    @McpMeshService // blank value → boot-fail
+    public static class BlankPrefixProducer {
+        public String greet(@Param("name") String name) {
+            return "hi " + name;
+        }
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svfactory/FactoryFixtures.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svfactory/FactoryFixtures.java
@@ -1,0 +1,26 @@
+package io.mcpmesh.spring.svfactory;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
+
+/**
+ * RFC #1280 phase-3 review (item 2): a producer registered via a @Bean factory
+ * method whose DECLARED return type is an interface/supertype. A bean-definition
+ * scan would false-positive (getBeanClassName null, ResolvableType = the
+ * interface), so the WARN must compare against ground-truth published classes.
+ */
+public final class FactoryFixtures {
+
+    private FactoryFixtures() {
+    }
+
+    public interface MediaApi {
+    }
+
+    @McpMeshService("fmedia")
+    public static class MediaImpl implements MediaApi {
+        public String go(@Param("x") String x) {
+            return x;
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svnonbean/NonBeanFixtures.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svnonbean/NonBeanFixtures.java
@@ -1,0 +1,21 @@
+package io.mcpmesh.spring.svnonbean;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
+
+/**
+ * RFC #1280 phase-3 review (MED-3): a @McpMeshService producer CLASS that is NOT
+ * a Spring bean — must produce a WARN (soft-fail), not silence.
+ */
+public final class NonBeanFixtures {
+
+    private NonBeanFixtures() {
+    }
+
+    @McpMeshService("orphan")
+    public static class NonBeanProducer {
+        public String go(@Param("x") String x) {
+            return x;
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svprod/ProdFixtures.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svprod/ProdFixtures.java
@@ -1,0 +1,35 @@
+package io.mcpmesh.spring.svprod;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+
+/**
+ * RFC #1280 phase-3 end-to-end fixtures: a PRODUCER class publishing
+ * {@code media.*} tools and a CONSUMER view binding one of them — within a
+ * single agent.
+ */
+public final class ProdFixtures {
+
+    private ProdFixtures() {
+    }
+
+    /** Producer: publishes "media.caption" and "media.thumbnail". */
+    @McpMeshService("media")
+    public static class MediaProducer {
+        public String caption(@Param("text") String text) {
+            return "cap:" + text;
+        }
+
+        public String thumbnail(@Param("assetId") String assetId) {
+            return "thumb:" + assetId;
+        }
+    }
+
+    /** Consumer view binding the producer's capability by name. */
+    @McpMeshService
+    public interface MediaConsumerView {
+        @Selector(capability = "media.caption")
+        String caption(@Param("text") String text);
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svscan/ScanFixtures.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/svscan/ScanFixtures.java
@@ -1,0 +1,26 @@
+package io.mcpmesh.spring.svscan;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+
+/**
+ * RFC #1280 phase-3 review (HIGH-1a): a directly-annotated parent view + a
+ * sub-interface that only INHERITS the annotation. Only the parent is a scanned
+ * bean view; the sub-interface is NOT co-discovered.
+ */
+public final class ScanFixtures {
+
+    private ScanFixtures() {
+    }
+
+    @McpMeshService
+    public interface ScanParent {
+        @Selector(capability = "scan.p")
+        String p(@Param("id") String id);
+    }
+
+    public interface ScanChild extends ScanParent {
+        // Inherits @McpMeshService — must NOT be auto-discovered as a bean view.
+    }
+}

--- a/src/runtime/python/_mcp_mesh/shared/support_types.py
+++ b/src/runtime/python/_mcp_mesh/shared/support_types.py
@@ -97,12 +97,23 @@ class AgentCapability(BaseModel):
     @field_validator("name")
     @classmethod
     def validate_capability_name(cls, v):
-        """Validate capability name format."""
+        """Validate capability name format.
+
+        RFC #1280 v3: dot-separated segments, each following the flat rule
+        (letter-led, alnum/underscore/hyphen). Strictly widens the old
+        single-segment pattern — every previously-valid flat name still matches
+        — and forbids leading/trailing/consecutive dots so phase-4 display
+        grouping has well-defined segmentation. MUST match the Go registry's
+        capabilityNamePattern (src/core/registry/validation.go) exactly.
+        """
         import re
 
-        if not re.match(r"^[a-zA-Z][a-zA-Z0-9_-]*$", v):
+        # fullmatch (not match) so a trailing newline "a.b\n" is rejected like
+        # Go's MatchString on an anchored pattern.
+        if not re.fullmatch(r"[a-zA-Z][a-zA-Z0-9_-]*(\.[a-zA-Z][a-zA-Z0-9_-]*)*", v):
             raise ValueError(
-                "Capability name must start with letter and contain only letters, numbers, underscore, hyphen"
+                "Capability name must be one or more dot-separated segments, each starting with "
+                "a letter and containing only letters, numbers, underscore, hyphen"
             )
         return v
 

--- a/src/runtime/python/_mcp_mesh/shared/tests/test_capability_name_validation.py
+++ b/src/runtime/python/_mcp_mesh/shared/tests/test_capability_name_validation.py
@@ -1,0 +1,51 @@
+"""RFC #1280 v3: dot-namespacing for capability names.
+
+`AgentCapability.name` accepts one or more dot-separated segments, each following
+the flat rule (letter-led, alnum/underscore/hyphen). This strictly widens the old
+single-segment pattern (every previously-valid flat name still validates) and
+forbids leading/trailing/consecutive dots. MUST stay in lock-step with the Go
+registry's capabilityNamePattern (src/core/registry/validation.go).
+"""
+
+import pytest
+
+from _mcp_mesh.shared.support_types import AgentCapability
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "greeting",  # existing flat name still valid
+        "smart_greet",  # underscore
+        "weather-report",  # hyphen
+        "a",  # single letter
+        "media.caption",  # two segments
+        "a.b",  # minimal dotted
+        "a.b.c",  # three segments
+        "llm.chat",  # phase-1/2 dotted dependency style
+        "a1.b2_c-3",  # digits/underscore/hyphen within segments
+    ],
+)
+def test_valid_capability_names(name):
+    assert AgentCapability(name=name).name == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",  # empty
+        ".a",  # leading dot
+        "a.",  # trailing dot
+        "a..b",  # consecutive dots
+        "a.-b",  # segment must start with a letter
+        "1a.b",  # must start with a letter
+        "a.1b",  # second segment must start with a letter
+        ".",  # just a dot
+        "a.b.",  # trailing dot after multiple segments
+        "a b",  # space
+        "a.b\n",  # trailing newline (fullmatch, not match, rejects this)
+    ],
+)
+def test_invalid_capability_names(name):
+    with pytest.raises(ValueError):
+        AgentCapability(name=name)

--- a/tests/integration/suites/uc37_service_view_java/artifacts/java-view-producer
+++ b/tests/integration/suites/uc37_service_view_java/artifacts/java-view-producer
@@ -1,0 +1,1 @@
+../fixtures/java-view-producer

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/DottedService.java
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/DottedService.java
@@ -1,0 +1,30 @@
+package com.example.serviceview;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.Selector;
+
+import java.util.Map;
+
+/**
+ * uc37 phase-3 consumer view (RFC #1280): binds the DOT-SEPARATED
+ * {@code svc.*} capabilities published by the java-view-producer agent's
+ * {@code @McpMeshService("svc")} producer sugar. Both edges are OPTIONAL —
+ * this view exists to prove dotted capability names traverse the whole
+ * pipeline (widened registry validator -> registration -> dependency
+ * resolution -> facade call), not to exercise required semantics (tc03/tc06
+ * own those).
+ *
+ * <p>Consumed as a constructor-injected bean by the {@code view_dotted}
+ * observation tool (tc08). Adds two svc.* edges to the
+ * {@code __mesh_service_deps} synthetic (5 bean-path edges total — see
+ * tc04/tc07's dependency arithmetic).
+ */
+@McpMeshService
+public interface DottedService {
+
+    @Selector(capability = "svc.alpha")
+    Map<String, Object> alpha();
+
+    @Selector(capability = "svc.bravo")
+    Map<String, Object> bravo();
+}

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/JavaViewConsumerApplication.java
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/JavaViewConsumerApplication.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * uc37 fixture — Java consumer proving RFC #1280 {@code @McpMeshService}
  * service views end-to-end.
  *
- * <p>Three views are discovered from this package:
+ * <p>Four views are discovered from this package:
  * <ul>
  *   <li>{@link ReportService} — alpha/bravo (optional) + charlie (required),
  *       three view-cap-* capabilities backed by three DIFFERENT Python
@@ -26,14 +26,16 @@ import java.util.Map;
  *   <li>{@link ToolParamService} — three tp-cap-* capabilities (charlie
  *       required), consumed as a {@code @MeshTool} METHOD PARAMETER
  *       (RFC #1280 phase 2) by {@code view_tool_param}.</li>
+ *   <li>{@link DottedService} — two OPTIONAL DOTTED svc.* capabilities
+ *       published by java-view-producer's phase-3 producer sugar (tc08).</li>
  * </ul>
  *
  * <p>Registration carries TWO dependency surfaces: the bean-path views expand
- * to exactly THREE view-cap-* edges under the synthetic
- * {@code __mesh_service_deps} tool (FlooredService dedupes onto ReportService),
- * and the tool-param view expands to THREE tp-cap-* edges on the
+ * to FIVE edges under the synthetic {@code __mesh_service_deps} tool (three
+ * view-cap-* — FlooredService dedupes onto ReportService — plus DottedService's
+ * two svc.*), and the tool-param view expands to THREE tp-cap-* edges on the
  * {@code view_tool_param} tool's OWN dependency list — so the registry reports
- * {@code total_dependencies == 6} (tc04/tc07).
+ * {@code total_dependencies == 8} (tc04/tc07/tc08).
  *
  * <p>The {@code @MeshTool} surfaces below are the observation points the TCs
  * call via {@code meshctl call}:
@@ -76,6 +78,9 @@ import java.util.Map;
  *       {@code {"error":"dependency_unavailable","capability":"tp-cap-charlie"}}
  *       refusal BEFORE this body runs (tc06) — the exact envelope the
  *       class-level {@code view_critical} path above does NOT get (tc03).</li>
+ *   <li>{@code view_dotted} — RFC #1280 PHASE 3: reports the DOTTED svc.*
+ *       capabilities served by java-view-producer's producer sugar through
+ *       the {@link DottedService} bean-path view (tc08).</li>
  * </ul>
  */
 @MeshAgent(
@@ -99,6 +104,7 @@ public class JavaViewConsumerApplication {
 
         private final ReportService reportService;
         private final FlooredService flooredService;
+        private final DottedService dottedService;
 
         /**
          * Constructor injection of the auto-registered facade beans — the
@@ -106,9 +112,11 @@ public class JavaViewConsumerApplication {
          * as a BeanDefinitionRegistryPostProcessor). A boot failure here means
          * discovery/registration broke.
          */
-        ViewTools(ReportService reportService, FlooredService flooredService) {
+        ViewTools(ReportService reportService, FlooredService flooredService,
+                  DottedService dottedService) {
             this.reportService = reportService;
             this.flooredService = flooredService;
+            this.dottedService = dottedService;
         }
 
         @MeshTool(
@@ -154,6 +162,23 @@ public class JavaViewConsumerApplication {
                 out.put("floor_total", e.getMethodsTotal());
                 out.put("floor_min", e.getMinAvailable());
             }
+            return out;
+        }
+
+        /**
+         * RFC #1280 phase 3 entry point (tc08): reports the DOTTED svc.*
+         * capabilities published by java-view-producer's
+         * {@code @McpMeshService("svc")} producer sugar, consumed through the
+         * bean-path {@link DottedService} view. Same flat report shape as
+         * {@code view_report}.
+         */
+        @MeshTool(
+            capability = "view_dotted",
+            description = "Call both DottedService view methods (svc.* producer-sugar capabilities) and report which agent served each")
+        public Map<String, Object> dottedReport() {
+            Map<String, Object> out = new LinkedHashMap<>();
+            reportOne(out, "alpha", dottedService::alpha);
+            reportOne(out, "bravo", dottedService::bravo);
             return out;
         }
 

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/ToolParamService.java
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/src/main/java/com/example/serviceview/ToolParamService.java
@@ -24,7 +24,9 @@ import java.util.Map;
  * reusing view-cap-* here would dedupe the {@code __mesh_service_deps}
  * synthetic away entirely and break tc03/tc04's registry surface. Distinct
  * names keep BOTH dependency carriers observable: 3 edges on the
- * {@code view_tool_param} tool + 3 on the synthetic (tc07 asserts both).
+ * {@code view_tool_param} tool + the bean-path edges on the synthetic
+ * (tc07 asserts both; see JavaViewConsumerApplication's javadoc for the
+ * current dependency arithmetic).
  */
 @McpMeshService
 public interface ToolParamService {

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-producer/pom.xml
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-producer/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example.viewproducer</groupId>
+    <artifactId>java-view-producer</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>JavaViewProducer Agent</name>
+    <description>uc37 producer proving RFC #1280 phase-3 @McpMeshService("prefix") sugar + dotted capability names</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.2</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.8.2</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Compile-scope web starter (version managed by the Boot parent).
+             REQUIRED at runtime: the mesh starter marks it optional, and
+             without it snakeyaml + logback are absent — Boot 4's
+             YamlPropertySourceLoader then dies with "snakeyaml was not found
+             on the classpath" while parsing application.yml and the JVM
+             exits before ever registering. Same lesson as
+             java-view-consumer/pom.xml. -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.viewproducer.JavaViewProducerApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-producer/src/main/java/com/example/viewproducer/JavaViewProducerApplication.java
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-producer/src/main/java/com/example/viewproducer/JavaViewProducerApplication.java
@@ -1,0 +1,74 @@
+package com.example.viewproducer;
+
+import io.mcpmesh.McpMeshService;
+import io.mcpmesh.MeshAgent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * uc37 fixture — RFC #1280 PHASE 3 producer sugar: a {@code @Component} class
+ * annotated {@code @McpMeshService("svc")} publishes each public declared
+ * method as an ordinary mesh tool with a DOT-SEPARATED capability name
+ * ({@code svc.alpha}, {@code svc.bravo}) through the normal {@code @MeshTool}
+ * machinery.
+ *
+ * <p>This agent is ALSO the first thing to ever carry a dotted capability name
+ * through a real cluster registration — tc08 asserts the registry's widened
+ * capability-name validator accepts it end-to-end (Go
+ * {@code src/core/registry/validation.go}: dot-separated segments, each
+ * letter-led alnum/_/-). Payloads are self-identifying (agent + capability)
+ * so the consumer's {@code view_dotted} report proves routing, not just
+ * registration.
+ *
+ * <p>Keep the producer class MINIMAL: every public declared method becomes a
+ * published tool — do not add public helpers.
+ */
+@MeshAgent(
+    name = "java-view-producer",
+    version = "1.0.0",
+    description = "uc37 producer of svc.* dotted capabilities via @McpMeshService(\"svc\") sugar",
+    port = 9202
+)
+@SpringBootApplication
+public class JavaViewProducerApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(JavaViewProducerApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting java-view-producer (uc37 RFC #1280 phase-3 producer sugar)...");
+        SpringApplication.run(JavaViewProducerApplication.class, args);
+    }
+
+    /**
+     * Publishes "svc.alpha" and "svc.bravo" — nothing else. PUBLIC class,
+     * matching the phase-3 unit fixture (svprod.ProdFixtures.MediaProducer):
+     * the sugar publishes public declared methods, and a public declaring
+     * class keeps reflective invocation unambiguous.
+     */
+    @McpMeshService("svc")
+    @Component
+    public static class SvcTools {
+
+        public Map<String, Object> alpha() {
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("agent", "java-view-producer");
+            out.put("cap", "svc.alpha");
+            out.put("msg", "hello-from-svc-alpha");
+            return out;
+        }
+
+        public Map<String, Object> bravo() {
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("agent", "java-view-producer");
+            out.put("cap", "svc.bravo");
+            out.put("msg", "hello-from-svc-bravo");
+            return out;
+        }
+    }
+}

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-producer/src/main/resources/application.yml
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-producer/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+# uc37 java-view-producer configuration (RFC #1280 phase-3 producer sugar)
+
+spring:
+  application:
+    name: java-view-producer
+  main:
+    banner-mode: "off"
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9202}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:java-view-producer}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+
+logging:
+  level:
+    root: INFO
+    io.mcpmesh: DEBUG
+    com.example: DEBUG

--- a/tests/integration/suites/uc37_service_view_java/tc04_deps_accounting/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc04_deps_accounting/test.yaml
@@ -1,8 +1,9 @@
 # tc04_deps_accounting — registration-time dependency expansion (RFC #1280):
-# the bean-path views register as THREE ordinary dependency edges under the
-# synthetic __mesh_service_deps tool, and (phase 2) the tool-param view adds
-# THREE more edges on the view_tool_param tool itself — both visible in the
-# registry's dependency accounting.
+# the bean-path views register as FIVE ordinary dependency edges under the
+# synthetic __mesh_service_deps tool (3 view-cap-* deduped across two views
+# + 2 dotted svc.* from the phase-3 DottedService), and (phase 2) the
+# tool-param view adds THREE more edges on the view_tool_param tool itself —
+# both visible in the registry's dependency accounting.
 #
 # Topology: ONLY the Java consumer — no providers on purpose. Dependency
 # expansion is a registration-time contract, and registering with all edges
@@ -11,17 +12,17 @@
 # availability, not boot).
 #
 # Design guarantees under test:
-#   1. total_dependencies == 6 for the consumer:
-#      - bean path: ReportService's three view-cap-* methods expand 1:1 into
-#        __mesh_service_deps DependencySpecs, and FlooredService's two
-#        bindings (same capabilities, same resolved type) DEDUPE onto them —
-#        5 method bindings across 2 views, 3 wire edges;
+#   1. total_dependencies == 8 for the consumer:
+#      - bean path (5 edges on __mesh_service_deps): ReportService's three
+#        view-cap-* methods expand 1:1 (FlooredService's two bindings — same
+#        capabilities, same resolved type — DEDUPE onto them), plus
+#        DottedService's two dotted svc.* edges (phase 3, tc08);
 #      - tool-param path (phase 2): ToolParamService's three tp-cap-* methods
 #        become the view_tool_param tool's OWN dependency edges — 3 more.
 #      (Per-carrier structure is tc07's subject; here we pin the total.)
 #   2. The synthetic __mesh_service_deps capability is registered alongside
 #      the consumer's real tool capabilities (view_report, view_critical,
-#      view_floored, view_tool_param).
+#      view_floored, view_tool_param, view_dotted).
 #   3. The consumer registers and reports healthy with ZERO providers up —
 #      including the required view-cap-charlie and tp-cap-charlie edges.
 #
@@ -29,8 +30,8 @@
 # are made, so no settle interaction. The /agents snapshot is polled only
 # for the consumer's appearance, never for dependency resolution.
 
-name: "Service views: bean + tool-param views expand to 6 registry dependencies (Java)"
-description: "Consumer-only start: java-view-consumer registers healthy with total_dependencies=6 (3 deduped bean-path edges + 3 tool-param edges) and the synthetic __mesh_service_deps capability"
+name: "Service views: bean + tool-param views expand to 8 registry dependencies (Java)"
+description: "Consumer-only start: java-view-consumer registers healthy with total_dependencies=8 (5 deduped bean-path edges incl. dotted svc.* + 3 tool-param edges) and the synthetic __mesh_service_deps capability"
 tags:
   - integration
   - java
@@ -83,17 +84,17 @@ assertions:
   # bare true/false; no '}' in interpolation bodies.
 
   # Guarantee 1: the expanded-and-deduped dependency count across BOTH
-  # carriers (3 bean-path synthetic + 3 tool-param edges)
-  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .total_dependencies == 6)} == 'true'"
-    message: "the consumer must register exactly 6 dependencies: 3 deduped bean-path view-cap-* edges on __mesh_service_deps + 3 tp-cap-* edges on the view_tool_param tool"
+  # carriers (5 bean-path synthetic edges incl. dotted svc.* + 3 tool-param)
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .total_dependencies == 8)} == 'true'"
+    message: "the consumer must register exactly 8 dependencies: 5 deduped bean-path edges (3 view-cap-* + 2 dotted svc.*) on __mesh_service_deps + 3 tp-cap-* edges on the view_tool_param tool"
 
   # Guarantee 2: the synthetic dependency-carrier capability is registered
   - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"__mesh_service_deps\")] | length == 1)} == 'true'"
     message: "the synthetic __mesh_service_deps capability must be registered exactly once"
 
   # ...alongside the real tool capabilities
-  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"view_report\" or .name == \"view_critical\" or .name == \"view_floored\" or .name == \"view_tool_param\")] | length == 4)} == 'true'"
-    message: "the consumer's four real @MeshTool capabilities must register alongside the view expansion"
+  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"view_report\" or .name == \"view_critical\" or .name == \"view_floored\" or .name == \"view_tool_param\" or .name == \"view_dotted\")] | length == 5)} == 'true'"
+    message: "the consumer's five real @MeshTool capabilities must register alongside the view expansion"
 
   # Guarantee 3: providerless registration — a view never blocks boot
   - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .status == \"healthy\")} == 'true'"

--- a/tests/integration/suites/uc37_service_view_java/tc07_tool_param_deps_accounting/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc07_tool_param_deps_accounting/test.yaml
@@ -10,10 +10,11 @@
 # (CapabilityInfo carries name/available/unavailable_reason only), so "the
 # edges hang on THAT tool" is proven through the per-capability #1249
 # derivation, which IS keyed by the declaring tool:
-#   1. total_dependencies == 6: 3 tp-cap-* edges on view_tool_param + the 3
-#      deduped view-cap-* edges on __mesh_service_deps. (If the tool-param
-#      edges had been folded into the synthetic — or vice versa — the total
-#      and the per-capability reasons below could not BOTH hold.)
+#   1. total_dependencies == 8: 3 tp-cap-* edges on view_tool_param + the 5
+#      deduped bean-path edges (3 view-cap-* + 2 dotted svc.*, phase 3) on
+#      __mesh_service_deps. (If the tool-param edges had been folded into
+#      the synthetic — or vice versa — the total and the per-capability
+#      reasons below could not BOTH hold.)
 #   2. With no providers up, capability view_tool_param derives
 #      available=false with unavailable_reason naming tp-cap-charlie — its
 #      OWN required edge, unresolved. A dep-less tool cannot derive
@@ -24,8 +25,8 @@
 #      tp-cap-* vs view-cap-* namespaces are disjoint by design, see
 #      ToolParamService.java).
 #   4. The consumer's dep-less tool capabilities (view_report,
-#      view_critical, view_floored) stay available=true — the edges are NOT
-#      smeared agent-wide — and the consumer registers healthy.
+#      view_critical, view_floored, view_dotted) stay available=true — the
+#      edges are NOT smeared agent-wide — and the consumer registers healthy.
 #
 # Timing: registration wait is liveness-only (issue #1193); the availability
 # polls below wait for the registry's initial DERIVATION of already-declared
@@ -33,7 +34,7 @@
 # no providers there is nothing to resolve.
 
 name: "Service views phase 2: tool-param edges are the tool's own deps, alongside the bean-path synthetic (Java)"
-description: "Consumer-only start: total_dependencies=6; view_tool_param derives unavailable naming its OWN required tp-cap-charlie edge while __mesh_service_deps independently names view-cap-charlie; dep-less tools stay available"
+description: "Consumer-only start: total_dependencies=8; view_tool_param derives unavailable naming its OWN required tp-cap-charlie edge while __mesh_service_deps independently names view-cap-charlie; dep-less tools stay available"
 tags:
   - integration
   - java
@@ -108,8 +109,8 @@ assertions:
     message: "both dependency carriers (view_tool_param and __mesh_service_deps) must derive available=false with no providers up"
 
   # Guarantee 1: the combined dependency total across both carriers
-  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .total_dependencies == 6)} == 'true'"
-    message: "total_dependencies must be 6: the 3 tp-cap-* edges on the view_tool_param tool PLUS the 3 deduped view-cap-* edges on __mesh_service_deps"
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .total_dependencies == 8)} == 'true'"
+    message: "total_dependencies must be 8: the 3 tp-cap-* edges on the view_tool_param tool PLUS the 5 deduped bean-path edges (3 view-cap-* + 2 dotted svc.*) on __mesh_service_deps"
 
   # Guarantee 2: the tool-param edges hang on the TOOL itself
   - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"view_tool_param\") | .unavailable_reason // \"\" | contains(\"tp-cap-charlie\"))} == 'true'"
@@ -122,7 +123,7 @@ assertions:
     message: "__mesh_service_deps' unavailable_reason must name view-cap-charlie — the bean-path carrier keeps its own distinct required edge"
 
   # Guarantee 4: edges are per-tool, not agent-wide
-  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"view_report\" or .name == \"view_critical\" or .name == \"view_floored\") | select(.available == true)] | length == 3)} == 'true'"
+  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-consumer\") | .capabilities[] | select(.name == \"view_report\" or .name == \"view_critical\" or .name == \"view_floored\" or .name == \"view_dotted\") | select(.available == true)] | length == 4)} == 'true'"
     message: "the dep-less tool capabilities must all stay available=true — view edges belong to their declaring carrier, never the whole agent"
   - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .status == \"healthy\")} == 'true'"
     message: "the consumer must register HEALTHY with zero providers up — required view edges gate availability, never startup"

--- a/tests/integration/suites/uc37_service_view_java/tc08_producer_sugar_dotted/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc08_producer_sugar_dotted/test.yaml
@@ -1,0 +1,175 @@
+# tc08_producer_sugar_dotted — RFC #1280 PHASE 3 end-to-end: producer sugar
+# (@McpMeshService("svc") on a bean class publishes each public method as
+# capability "svc.<method>") AND the first DOTTED capability names ever to
+# traverse a real cluster registration (the Go registry validator was widened
+# to dot-separated segments — src/core/registry/validation.go — but no dotted
+# name had crossed the wire before this TC).
+#
+# Topology: java-view-producer (publishes svc.alpha + svc.bravo via the
+# sugar) + java-view-consumer (DottedService view binds both, surfaced by the
+# view_dotted tool). No Python providers — both agents are Java, and the
+# consumer's other views (view-cap-*, tp-cap-*) stay deliberately unresolved:
+# they are OPTIONAL or belong to other carriers and must not interfere.
+#
+# Design guarantees under test:
+#   1. VALIDATOR WIDENING E2E: the registry ACCEPTS the dotted registration —
+#      java-view-producer registers healthy and its capabilities list carries
+#      svc.alpha and svc.bravo (a validator rejection would 4xx the
+#      registration and the agent would never appear).
+#   2. Dotted names through the CLI call path: `meshctl call svc.alpha` (the
+#      capability-name fallback resolution) reaches the sugar-published tool
+#      and returns the self-identifying payload.
+#   3. Dotted names through dependency resolution + the view facade:
+#      view_dotted reports BOTH methods served by java-view-producer with the
+#      correct dotted capability payloads (svc.alpha / svc.bravo).
+#   4. Dependency accounting grew accordingly: the consumer registers
+#      total_dependencies == 8 (the DottedService edges landed on the
+#      __mesh_service_deps synthetic — same arithmetic tc04/tc07 pin).
+#
+# Timing: NO dependency-resolution waits (issue #1193) — registration waits
+# are liveness-only; the first view_dotted call rides the settle window. Two
+# cold JVMs, so the 240s registration deadline and long baseline polls apply.
+#
+# TC timeout = cold-cache worst case, summed from the step budgets: TWO
+# maven-install steps (600 each — this TC cannot rely on an earlier TC having
+# warmed the shared maven repo) + registration wait (260) + two call polls
+# (200 each) + copy/start/capture defaults (4 x 120) = 2340, rounded up with
+# slack to 2400. Heavier than the uc23 two-install convention (300-600) on
+# purpose: those rely on warm caches; the checklist flagged that reliance.
+
+name: "Service views phase 3: producer sugar publishes dotted svc.* capabilities end-to-end (Java)"
+description: "java-view-producer registers dotted svc.alpha/svc.bravo (widened validator e2e), meshctl call svc.alpha answers, view_dotted reports both methods served by the producer, consumer total_dependencies=8"
+tags:
+  - integration
+  - java
+  - registry
+  - service-view
+  - rfc-1280
+  - slow
+timeout: 2400
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/java-view-producer /workspace/
+      cp -rL /uc-artifacts/java-view-consumer /workspace/
+
+  - name: "Install producer Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-view-producer
+    timeout: 600
+
+  - name: "Install consumer Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-view-consumer
+    timeout: 600
+
+  - name: "Start java-view-producer (port 9202)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-producer --env MCP_MESH_HTTP_PORT=9202 -d
+
+  - name: "Start java-view-consumer (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-consumer --env MCP_MESH_HTTP_PORT=9201 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193): 240s deadline covers two cold JVM starts.
+  # The producer APPEARING here is already half of guarantee 1 — a validator
+  # rejection would keep it out of meshctl list entirely.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "java-view-producer java-view-consumer"
+
+  # Pure-JSON snapshot for the registration assertions (guarantees 1 + 4).
+  - name: "Capture /agents snapshot"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_snapshot
+
+  # Guarantee 2: the dotted name through the CLI call path (capability-name
+  # resolution). ENVELOPE: Java tools carry the payload ONLY as an escaped
+  # JSON string in content[0].text (no structuredContent) — parse via
+  # `.content[0].text | fromjson` (suite idiom), equality inside the jq
+  # filter. Poll: cold-JVM producer may still be warming its MCP endpoint.
+  - name: "Wait for direct dotted call (meshctl call svc.alpha)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 90); do
+        RESP=$(meshctl call svc.alpha '{}' --raw 2>&1 || true)
+        OK=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .agent == "java-view-producer" and .cap == "svc.alpha"' 2>/dev/null || echo "")
+        if [ "$OK" = "true" ]; then
+          echo "DOTTED_DIRECT_CALL_OK=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: meshctl call svc.alpha never answered with the producer payload within 180s"
+      echo "last response: $RESP"
+      meshctl logs java-view-producer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: direct_dotted_call
+    timeout: 200
+
+  # Guarantee 3: dotted names through dependency resolution + the view
+  # facade. Anchored key:value pairing (agent AND dotted cap judged in one
+  # filter per method) so a wrong-capability wiring cannot pass.
+  - name: "Wait for view_dotted report"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 90); do
+        RESP=$(meshctl call view_dotted '{}' --raw 2>&1 || true)
+        A=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .alpha_agent == "java-view-producer" and .alpha_cap == "svc.alpha"' 2>/dev/null || echo "")
+        B=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .bravo_agent == "java-view-producer" and .bravo_cap == "svc.bravo"' 2>/dev/null || echo "")
+        if [ "$A" = "true" ] && [ "$B" = "true" ]; then
+          echo "DOTTED_VIEW_BOUND=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: view_dotted never reported both svc.* methods served by java-view-producer within 180s"
+      echo "last response: $RESP"
+      meshctl logs java-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: dotted_view_report
+    timeout: 200
+
+assertions:
+  # IDIOM: equality lives INSIDE the jq filter so the interpolation yields a
+  # bare true/false; no '}' in interpolation bodies.
+
+  # Guarantee 1: the widened validator accepted the dotted registration
+  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-producer\")] | length == 1)} == 'true'"
+    message: "java-view-producer must be REGISTERED — a validator rejection of the dotted capabilities would keep the whole registration out"
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-producer\") | .status == \"healthy\")} == 'true'"
+    message: "java-view-producer must register HEALTHY with its dotted capabilities"
+  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"java-view-producer\") | .capabilities[] | select(.name == \"svc.alpha\" or .name == \"svc.bravo\")] | length == 2)} == 'true'"
+    message: "the producer's capability list must carry BOTH dotted names (svc.alpha, svc.bravo) — the e2e proof of the widened capability-name contract"
+
+  # Guarantee 2: the dotted name resolves through the CLI call path
+  - expr: "${captured.direct_dotted_call} contains 'DOTTED_DIRECT_CALL_OK=1'"
+    message: "meshctl call svc.alpha must reach the sugar-published tool and return the producer's self-identifying payload"
+
+  # Guarantee 3: the dotted names resolve through the view facade
+  - expr: "${captured.dotted_view_report} contains 'DOTTED_VIEW_BOUND=1'"
+    message: "view_dotted must report both methods served by java-view-producer with the correct dotted capability payloads (svc.alpha / svc.bravo)"
+
+  # Guarantee 4: dependency accounting grew with the dotted view edges
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"java-view-consumer\") | .total_dependencies == 8)} == 'true'"
+    message: "the consumer must register total_dependencies=8 — DottedService's two svc.* edges landed on the __mesh_service_deps synthetic (5 bean-path + 3 tool-param)"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Phase 3 of RFC #1280: producer-side publication sugar, and dot-namespacing promoted from accident to contract.

**Producer sugar (Java)**
- Class-level `@McpMeshService("prefix")` on a Spring bean publishes each eligible public declared method as capability `prefix.<methodName>` — a synthesized `@MeshTool` through the existing registration machinery, so schemas, duplicate-capability boot-fail, and injectable slots are all inherited. The prefix is entirely user-chosen; nothing is hard-coded in mesh.
- Explicit `@MeshTool` on a method wins (custom capability/tags/version); name-sorted publication (determinism); non-public/static/superclass-inherited/Object methods skipped; overload collisions and invalid derived capability names (`$`/Unicode method names included) boot-fail at the declaration site; `minAvailable` on a class WARNs; an annotated class Spring doesn't manage WARNs via a ground-truth check (scanned classes vs classes actually seen as beans — immune to `@Bean`-factory false positives).
- Detection = direct annotation on `ClassUtils.getUserClass(...)`: JDK-proxy view facades are never mis-classified as producers; CGLIB-enhanced producers are detected.

**Capability-name contract widened (cross-runtime)**
- Names are now one or more dot-separated segments, each `^[a-zA-Z][a-zA-Z0-9_-]*$`. Applied identically in the Go registry validator and the Python validator (`re.fullmatch` for engine parity), with mirrored test suites. Strictly widening — every existing name remains valid.
- Dotted names previously worked only because the tools registration path bypassed the validator; they are now first-class and e2e-proven: uc37 tc08 pushes `svc.alpha`/`svc.bravo` through a real cluster registration, direct `meshctl call svc.alpha`, and a consumer view binding. Dot-namespacing is the convention phase-4 display grouping builds on.
- Known parity gap (informational, unchanged): the TypeScript runtime has no capability-name validation layer today.

**Phase-2 deferrals resolved**
- Sub-interface views: valid as tool parameters (explicitly-named types, `findAnnotation`); scanned bean views require direct annotation (co-discovery of annotated parents was ambiguous and boot-fail-prone — deliberate rule, javadoc'd). `Object`-typed bindings (unresolved generics) are dynamic and non-conflicting in the type-conflict checks.
- Analyzer double-call consolidated: view-param analysis computed once per tool method, shared by the wire and wrapper paths; the registrar's classpath scan is a single pass serving both view discovery and producer-class detection.

**Deliverables**
- `examples/java/service-view` rewritten as the dotted showcase: three producer-sugar agents each publishing a slice of one `media.*` namespace, consumed by both view styles.
- uc37 grows to 8 TCs (tc08 = dotted names e2e, validated 8/8 on k8s with the rebuilt registry).
- Docs: producer-side section + three-role `@McpMeshService` layout on the four Java surfaces; capability-name contract updated on all six naming surfaces; media narrative fully dotted and internally consistent.

## Review Notes

- Three review rounds (core zero-context, fix verification, pre-PR checklist). Notable catches fixed along the way: JDK-proxy facades mis-classified as producers by `findAnnotation` (direct-annotation-on-user-class detection); sub-interface scanner co-discovery (reverted to direct-only); CGLIB `@Configuration` producers invisible to `getAnnotation` (getUserClass); full-capability boot validation (method names can carry `$`/Unicode); non-bean WARN ground-truthing.
- Release-note callout needed when this ships: the capability-name contract change (strictly widening) and the new producer sugar.
- Follow-up noted, not in scope: suite-wide TC timeout budgets share a latent warm-maven-cache reliance predating this PR.

## Test plan

- [x] Java starter suite 639/639, SDK 98/98
- [x] `go test ./src/core/registry/...` (widened validator + new cases), Python validator tests 20/20
- [x] src-tests 12/12 (image rebuild includes the registry change)
- [x] `tsuite run --suite-path tests/integration --uc uc37_service_view_java` — 8/8 on k8s incl. tc08 (first dotted registration, direct dotted CLI call, view binding)
- [x] Example modules compile; `go build ./src/core/cli/...` + mkdocs strict green

Closes #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dot-separated capability names across Java, Python, TypeScript, and CLI docs.
  * Enabled service publishing from Spring beans so public methods can be exposed as mesh tools under a shared prefix.

* **Bug Fixes**
  * Improved capability-name validation to reject invalid dot placement and malformed names.
  * Updated service-view discovery and dependency handling for dotted capabilities and inherited interfaces.

* **Documentation**
  * Expanded guidance and examples for consumer and producer usage, including updated `meshctl` examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->