### PR TITLE
feat(cli,ui): display grouping for dot-namespaced capabilities (RFC #1280 phase 4)

### DIFF
--- a/cmd/mcp-mesh-ui/dist/index.html
+++ b/cmd/mcp-mesh-ui/dist/index.html
@@ -10,8 +10,8 @@
       window.__MESH_BASE_PATH__ = window.__MESH_BASE_PATH__ || "";
       window.__MESH_REGISTRY_URL__ = window.__MESH_REGISTRY_URL__ || "";
     </script>
-    <script type="module" crossorigin src="./assets/index-DB82OHvj.js"></script>
-    <link rel="stylesheet" crossorigin href="./assets/index-CmRhQHvZ.css">
+    <script type="module" crossorigin src="./assets/index-BH6sKVIS.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-D-K0AOPU.css">
   </head>
   <body class="antialiased">
     <div id="root"></div>

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -76,6 +76,7 @@ meshctl list                   # List healthy agents
 meshctl list --all             # Include unhealthy
 meshctl list --tools           # List all tools
 meshctl list --tools=add       # Show tool schema
+meshctl list --services        # Dot-namespaced capabilities grouped as services
 meshctl status                 # Show wiring details
 meshctl status my-agent        # Specific agent
 ```

--- a/docs/java/capabilities-tags.md
+++ b/docs/java/capabilities-tags.md
@@ -165,7 +165,7 @@ When an agent requests a dependency, the registry resolves it by:
 | `domain_action` | `auth_validate` | Domain-specific  |
 | `service`       | `llm`           | Generic services |
 
-A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
+A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix. `meshctl list --services` and the meshui agent-detail view render dotted capabilities as grouped services — display-only, derived entirely from the name.
 
 ## Versioning
 

--- a/docs/python/capabilities-tags.md
+++ b/docs/python/capabilities-tags.md
@@ -182,7 +182,7 @@ def my_tool(date: mesh.McpMeshTool = None, weather: mesh.McpMeshTool = None):
 | `domain_action` | `auth_validate` | Domain-specific  |
 | `service`       | `llm`           | Generic services |
 
-A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
+A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix. `meshctl list --services` and the meshui agent-detail view render dotted capabilities as grouped services — display-only, derived entirely from the name.
 
 ## Versioning
 

--- a/docs/typescript/capabilities-tags.md
+++ b/docs/typescript/capabilities-tags.md
@@ -210,7 +210,7 @@ agent.addTool({
 | `domain_action` | `auth_validate` | Domain-specific  |
 | `service`       | `llm`           | Generic services |
 
-A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
+A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix. `meshctl list --services` and the meshui agent-detail view render dotted capabilities as grouped services — display-only, derived entirely from the name.
 
 The TypeScript SDK performs no local capability-name validation — it forwards capability strings to the registry as-is, so a malformed name is rejected at registration time by the registry, not by the TS runtime. The segment-wise format above is the contract the registry enforces.
 

--- a/examples/java/service-view/README.md
+++ b/examples/java/service-view/README.md
@@ -177,6 +177,22 @@ Expected output — one interface, three different serving agents:
 meshctl list   # media-gateway's process_media_strict shows media.caption, media.thumbnail, media.transcribe
 ```
 
+The three producer capabilities also render as one grouped service — the
+per-method view: one `media` service, three methods, three different provider
+agents:
+
+```bash
+meshctl list --services
+```
+
+```
+SERVICE  METHOD      AGENT                STATUS
+------------------------------------------------------------------
+media    caption     caption-provider     available
+media    thumbnail   thumbnail-provider   available
+media    transcribe  transcribe-provider  available
+```
+
 You can also call any producer capability directly by its dotted name —
 `meshctl call` matches the capability name as-is:
 
@@ -240,7 +256,8 @@ meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
 ```
 
 Only the tool-parameter form (`process_media_strict`) turns a missing REQUIRED
-view method into a clean, structured pre-invoke refusal — the phase-2 payoff.
+view method into a clean, structured pre-invoke refusal — the guarantee the
+tool-parameter form adds.
 Restart `caption-provider` (and `transcribe-provider`) to return to the healthy
 output above.
 

--- a/src/core/cli/call.go
+++ b/src/core/cli/call.go
@@ -42,9 +42,9 @@ type MCPError struct {
 
 // MCPCallResult holds the result and trace information from an MCP call
 type MCPCallResult struct {
-	Result   json.RawMessage
-	TraceID  string // X-Trace-Id header
-	SpanID   string // X-Span-Id header
+	Result  json.RawMessage
+	TraceID string // X-Trace-Id header
+	SpanID  string // X-Span-Id header
 }
 
 // TraceContext holds trace IDs for distributed tracing
@@ -496,11 +496,13 @@ func findAgentWithTool(client *http.Client, registryURL, agentName, toolName str
 	}
 
 	if len(matches) > 1 {
-		// Framework-internal helpers (__mesh_job_*) auto-register on every
-		// MeshJob-capable agent and read/write the same registry-backed state.
-		// Picking any healthy match is semantically correct. Only apply the
-		// ambiguity UX (issue #956 item #14) to capability tools.
-		if agentName == "" && isFrameworkInternalTool(toolName) {
+		// MeshJob helpers (__mesh_job_*) auto-register on every MeshJob-capable
+		// agent and read/write the same registry-backed job state, so picking any
+		// healthy match is semantically correct. This bypass is scoped to the
+		// shared-state helpers ONLY — other __mesh_* synthetics (e.g. the
+		// per-agent __mesh_*_deps carriers) still get the ambiguity UX (issue
+		// #956 item #14) since matches[0] would route nondeterministically.
+		if agentName == "" && isSharedStateJobHelper(toolName) {
 			return matches[0].endpoint, matches[0].functionName, nil
 		}
 		rows := make([]toolCollisionRow, len(matches))
@@ -617,11 +619,12 @@ func findAgentWithToolIngress(client *http.Client, ingressURL, ingressDomain, ag
 	}
 
 	if len(matches) > 1 {
-		// Framework-internal helpers (__mesh_job_*) auto-register on every
-		// MeshJob-capable agent and read/write the same registry-backed state.
-		// Picking any healthy match is semantically correct. Only apply the
-		// ambiguity UX (issue #956 item #14) to capability tools.
-		if agentName == "" && isFrameworkInternalTool(toolName) {
+		// MeshJob helpers (__mesh_job_*) auto-register on every MeshJob-capable
+		// agent and read/write the same registry-backed job state, so picking any
+		// healthy match is semantically correct. Scoped to the shared-state
+		// helpers ONLY — other __mesh_* synthetics (e.g. per-agent __mesh_*_deps
+		// carriers) still get the ambiguity UX (issue #956 item #14).
+		if agentName == "" && isSharedStateJobHelper(toolName) {
 			m := matches[0]
 			if m.agent.Endpoint == "" {
 				return "", "", "", fmt.Errorf("agent '%s' has tool '%s' but no endpoint", m.agent.ID, m.functionName)

--- a/src/core/cli/call_test.go
+++ b/src/core/cli/call_test.go
@@ -168,8 +168,11 @@ func TestIsFrameworkInternalTool(t *testing.T) {
 		{"job_status framework", "__mesh_job_status", true},
 		{"job_result framework", "__mesh_job_result", true},
 		{"job_cancel framework", "__mesh_job_cancel", true},
+		{"service_deps synthetic", "__mesh_service_deps", true},
+		{"route_deps synthetic", "__mesh_route_deps", true},
+		{"depends_on_deps synthetic", "__mesh_depends_on_deps", true},
 		{"normal tool", "get_weather", false},
-		{"dunder but not mesh_job", "__init__", false},
+		{"dunder but not mesh", "__init__", false},
 		{"empty", "", false},
 	}
 	for _, c := range cases {
@@ -896,5 +899,48 @@ func TestAuditShortIsHelpful(t *testing.T) {
 	low := strings.ToLower(cmd.Short)
 	if !strings.Contains(low, "rout") {
 		t.Errorf("audit Short does not convey routing context: %q", cmd.Short)
+	}
+}
+
+// TestIsSharedStateJobHelper covers MED-3's split predicate: the collision
+// bypass is scoped to the shared-state MeshJob helpers, NOT the per-agent
+// __mesh_*_deps carriers (which stay ambiguous).
+func TestIsSharedStateJobHelper(t *testing.T) {
+	cases := map[string]bool{
+		"__mesh_job_status":      true,
+		"__mesh_job_result":      true,
+		"__mesh_service_deps":    false,
+		"__mesh_route_deps":      false,
+		"__mesh_depends_on_deps": false,
+		"get_weather":            false,
+		"":                       false,
+	}
+	for in, want := range cases {
+		if got := isSharedStateJobHelper(in); got != want {
+			t.Errorf("isSharedStateJobHelper(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// TestFindAgentWithTool_DepsCarrierStillDisambiguates verifies MED-3: a
+// per-agent __mesh_*_deps carrier registered by multiple agents must NOT get the
+// job-helper collision bypass — it errors with the disambiguation UX.
+func TestFindAgentWithTool_DepsCarrierStillDisambiguates(t *testing.T) {
+	agents := []AgentWithCapabilities{
+		{
+			ID: "agent-a-aaa", Name: "agent-a", Endpoint: "http://agent-a:8080", Status: "healthy",
+			Capabilities: []ToolInfo{{Name: "__mesh_service_deps", FunctionName: "__mesh_service_deps"}},
+		},
+		{
+			ID: "agent-b-bbb", Name: "agent-b", Endpoint: "http://agent-b:8080", Status: "healthy",
+			Capabilities: []ToolInfo{{Name: "__mesh_service_deps", FunctionName: "__mesh_service_deps"}},
+		},
+	}
+	srv := mockRegistryWithAgents(t, agents)
+	defer srv.Close()
+
+	_, _, err := findAgentWithTool(http.DefaultClient, srv.URL, "", "__mesh_service_deps")
+	if err == nil {
+		t.Fatalf("expected a disambiguation error for a multi-agent __mesh_service_deps carrier, got nil")
 	}
 }

--- a/src/core/cli/list.go
+++ b/src/core/cli/list.go
@@ -67,6 +67,12 @@ Tools listing:
   meshctl list --tools=get_current_time           # Show tool call spec and input schema
   meshctl list --tools=system-agent:get_time      # Show tool details for specific agent
 
+Service grouping (RFC #1280 — derived from dot-namespaced capabilities):
+  meshctl list --services                         # Mesh-wide capabilities grouped by service
+                                                  #   (service = capability segments before the last dot;
+                                                  #    e.g. media.caption → service "media", method "caption")
+  meshctl list --services --json                  # Structured grouped JSON (services → methods → providers)
+
 Schema registry (issue #547):
   meshctl list --schemas                          # Most recent 100 canonical schemas
   meshctl list --schemas --limit 20               # Most recent 20
@@ -88,7 +94,12 @@ Schema registry (issue #547):
 	// Tools listing - use --tools to list all, --tools=<name> for specific tool details
 	cmd.Flags().StringP("tools", "t", "", "List tools: use --tools or -t to list all, --tools=<tool> for details")
 	cmd.Flags().Lookup("tools").NoOptDefVal = "all" // "all" means list all tools
-	cmd.Flags().Bool("show-framework", false, "Include framework-internal tools (__mesh_job_*) in --tools output")
+	cmd.Flags().Bool("show-framework", false, "Include framework-internal tools (__mesh_* synthetics) in --tools / --services output")
+
+	// RFC #1280 phase 4: mesh-wide service-grouped view. Grouping is DERIVED
+	// from dot-namespaced capability names (group = segments before the last
+	// dot); undotted capabilities are ungrouped and summarized as a count.
+	cmd.Flags().Bool("services", false, "Group capabilities into services derived from dotted capability names (e.g. media.caption → service 'media'); combines with --all, --json, --show-framework")
 
 	// Schema registry listing (issue #547). When set, --schemas short-circuits
 	// the agent listing and queries GET /schemas instead.
@@ -284,6 +295,13 @@ func runListCommand(cmd *cobra.Command, args []string) error {
 	if toolsFlagChanged {
 		showFramework, _ := cmd.Flags().GetBool("show-framework")
 		return runToolsListCommand(finalRegistryURL, toolsFlag, jsonOutput, !showAll, showFramework)
+	}
+
+	// RFC #1280 phase 4: mesh-wide service-grouped view (derived from dotted
+	// capability names). Short-circuits the agent listing like --tools/--schemas.
+	if servicesFlag, _ := cmd.Flags().GetBool("services"); servicesFlag {
+		showFramework, _ := cmd.Flags().GetBool("show-framework")
+		return runServicesListCommand(finalRegistryURL, jsonOutput, !showAll, showFramework)
 	}
 
 	// Collect all information
@@ -1581,22 +1599,88 @@ func printVerboseDetails(agents []EnhancedAgent) {
 
 		if len(agent.Tools) > 0 {
 			fmt.Printf("  Tools:\n")
-			for _, tool := range agent.Tools {
-				if tool.Available != nil && !*tool.Available {
-					reason := tool.UnavailableReason
-					if reason == "" {
-						reason = "required dependency unavailable"
+			// RFC #1280 phase 4: dotted capabilities render under a service
+			// header; undotted ones keep the flat "- <name> (<capability>)" form.
+			for _, group := range groupCapabilitiesByService(agent.Tools) {
+				if group.Service != "" {
+					fmt.Printf("    %s/ (%d %s)\n", group.Service, len(group.Tools), pluralMethods(len(group.Tools)))
+					for _, tool := range group.Tools {
+						fmt.Printf("    %s\n", formatVerboseToolLine(tool, "  "))
 					}
-					fmt.Printf("    - %s (%s) %s[unavailable: %s]%s\n",
-						tool.Name, tool.Capability, colorRed, reason, colorReset)
 				} else {
-					fmt.Printf("    - %s (%s)\n", tool.Name, tool.Capability)
+					for _, tool := range group.Tools {
+						fmt.Printf("    %s\n", formatVerboseToolLine(tool, ""))
+					}
+				}
+			}
+		}
+
+		// RFC #1280 phase 4: dependency resolutions are the consumer-side, per-
+		// method multi-agent binding view — group dotted deps by service, each
+		// row keeping its resolved provider agent id + status.
+		if len(agent.DependencyResolutions) > 0 {
+			fmt.Printf("  Dependencies:\n")
+			for _, group := range groupResolutionsByService(agent.DependencyResolutions) {
+				if group.Service != "" {
+					fmt.Printf("    %s/ (%d %s)\n", group.Service, len(group.Resolutions), pluralMethods(len(group.Resolutions)))
+					for _, res := range group.Resolutions {
+						fmt.Printf("    %s\n", formatVerboseResolutionLine(res, "  "))
+					}
+				} else {
+					for _, res := range group.Resolutions {
+						fmt.Printf("    %s\n", formatVerboseResolutionLine(res, ""))
+					}
 				}
 			}
 		}
 
 		fmt.Println()
 	}
+}
+
+// formatVerboseToolLine renders one "- <name> (<capability>)" tool line with the
+// existing red unavailable suffix. indent is extra leading whitespace applied
+// under a service header.
+func formatVerboseToolLine(tool ToolInfo, indent string) string {
+	if tool.Available != nil && !*tool.Available {
+		reason := tool.UnavailableReason
+		if reason == "" {
+			reason = "required dependency unavailable"
+		}
+		return fmt.Sprintf("%s- %s (%s) %s[unavailable: %s]%s",
+			indent, tool.Name, tool.Capability, colorRed, reason, colorReset)
+	}
+	return fmt.Sprintf("%s- %s (%s)", indent, tool.Name, tool.Capability)
+}
+
+// formatVerboseResolutionLine renders one dependency-resolution line
+// "- <capability> → <provider> [<status>]", keeping the provider agent id so a
+// service's methods can show their (possibly different) bound providers.
+func formatVerboseResolutionLine(res DependencyResolution, indent string) string {
+	provider := res.ProviderAgentID
+	if provider == "" {
+		provider = "(unresolved)"
+	}
+	status := res.Status
+	if status == "" {
+		status = "unknown"
+	}
+	statusColor := colorReset
+	switch strings.ToLower(res.Status) {
+	case "available", "resolved":
+		statusColor = colorGreen
+	case "unavailable", "unresolved", "":
+		statusColor = colorRed
+	}
+	return fmt.Sprintf("%s- %s → %s %s[%s]%s",
+		indent, res.Capability, provider, statusColor, status, colorReset)
+}
+
+func pluralMethods(n int) string {
+	if n == 1 {
+		return "method"
+	}
+	return "methods"
 }
 
 func formatDuration(d time.Duration) string {
@@ -2364,10 +2448,324 @@ func formatToolUnavailableMarker(tool ToolListItem) string {
 	return ""
 }
 
+// =============================================================================
+// RFC #1280 phase 4 — display-only service grouping DERIVED from dotted
+// capability names. group = segments before the LAST dot; undotted names are
+// ungrouped. Zero wire/registry changes.
+// =============================================================================
+
+// splitServiceCapability splits a dotted capability into its service prefix and
+// method by the LAST dot: "media.v2.caption" → ("media.v2", "caption"). An
+// undotted name (or a degenerate leading/trailing-dot name the registry would
+// have rejected) is ungrouped: "greeting" → ("", "greeting").
+func splitServiceCapability(name string) (service, method string) {
+	idx := strings.LastIndex(name, ".")
+	if idx <= 0 || idx == len(name)-1 {
+		return "", name
+	}
+	return name[:idx], name[idx+1:]
+}
+
+// serviceGroup is a service prefix and its capabilities (already method-sorted).
+type serviceGroup struct {
+	Service string // "" for the ungrouped bucket
+	Tools   []ToolInfo
+}
+
+// groupCapabilitiesByService groups tools by their derived service prefix.
+// Ordering is deterministic: services sorted alphabetically FIRST, then the
+// ungrouped ("") bucket LAST; within each group, tools are sorted by capability.
+func groupCapabilitiesByService(tools []ToolInfo) []serviceGroup {
+	byService := map[string][]ToolInfo{}
+	for _, t := range tools {
+		svc, _ := splitServiceCapability(t.Capability)
+		byService[svc] = append(byService[svc], t)
+	}
+	services := make([]string, 0, len(byService))
+	for s := range byService {
+		if s != "" {
+			services = append(services, s)
+		}
+	}
+	sort.Strings(services)
+	if _, ok := byService[""]; ok {
+		services = append(services, "") // ungrouped last
+	}
+	out := make([]serviceGroup, 0, len(services))
+	for _, s := range services {
+		ts := byService[s]
+		sort.Slice(ts, func(i, j int) bool { return ts[i].Capability < ts[j].Capability })
+		out = append(out, serviceGroup{Service: s, Tools: ts})
+	}
+	return out
+}
+
+// resolutionGroup is the dependency-resolution analogue of serviceGroup.
+type resolutionGroup struct {
+	Service     string
+	Resolutions []DependencyResolution
+}
+
+// groupResolutionsByService groups dependency resolutions by their derived
+// service prefix, same ordering contract as groupCapabilitiesByService (services
+// sorted first, ungrouped last; sorted by capability within a group).
+func groupResolutionsByService(res []DependencyResolution) []resolutionGroup {
+	byService := map[string][]DependencyResolution{}
+	for _, r := range res {
+		svc, _ := splitServiceCapability(r.Capability)
+		byService[svc] = append(byService[svc], r)
+	}
+	services := make([]string, 0, len(byService))
+	for s := range byService {
+		if s != "" {
+			services = append(services, s)
+		}
+	}
+	sort.Strings(services)
+	if _, ok := byService[""]; ok {
+		services = append(services, "")
+	}
+	out := make([]resolutionGroup, 0, len(services))
+	for _, s := range services {
+		rs := byService[s]
+		sort.Slice(rs, func(i, j int) bool { return rs[i].Capability < rs[j].Capability })
+		out = append(out, resolutionGroup{Service: s, Resolutions: rs})
+	}
+	return out
+}
+
+// --- mesh-wide service view (--services) ------------------------------------
+
+// svcProvider is one agent that provides a service method.
+type svcProvider struct {
+	AgentID           string `json:"agent_id"`
+	AgentName         string `json:"agent_name"`
+	Available         *bool  `json:"available,omitempty"`
+	UnavailableReason string `json:"unavailable_reason,omitempty"`
+}
+
+// svcMethod is one capability (method) and every agent providing it.
+type svcMethod struct {
+	Method     string        `json:"method"`
+	Capability string        `json:"capability"`
+	Providers  []svcProvider `json:"providers"`
+}
+
+// svcEntry is one service prefix and its methods.
+type svcEntry struct {
+	Service string      `json:"service"`
+	Methods []svcMethod `json:"methods"`
+}
+
+// serviceGroupView is the assembled mesh-wide grouped view (--services). The
+// JSON shape is {services:[{service,methods:[{method,capability,providers:[...]}]}],
+// ungrouped:[{method,capability,providers}]}. Both top-level fields are ALWAYS
+// arrays (never null/omitted) so consumers can iterate unconditionally.
+type serviceGroupView struct {
+	Services  []svcEntry  `json:"services"`
+	Ungrouped []svcMethod `json:"ungrouped"`
+}
+
+// ungroupedCount is the number of distinct undotted capabilities (each is a
+// `--tools` row hidden from the grouped view).
+func (v serviceGroupView) ungroupedCount() int { return len(v.Ungrouped) }
+
+// buildServiceGroupView assembles the mesh-wide grouped view across every
+// agent's capabilities. One provider entry per (capability, agent). Ordering is
+// deterministic: services then methods (by capability) then providers (by
+// agent id); the ungrouped bucket is capability-sorted. When showFramework is
+// false, framework-internal __mesh_* synthetics are excluded (same predicate/key
+// as `--tools`); when true they group by their names as ordinary entries.
+func buildServiceGroupView(agents []EnhancedAgent, showFramework bool) serviceGroupView {
+	// service -> capability -> method accumulator
+	type acc struct {
+		method    string
+		providers []svcProvider
+		seenAgent map[string]bool
+	}
+	grouped := map[string]map[string]*acc{}
+	ungrouped := map[string]*acc{}
+
+	addProvider := func(bucket map[string]*acc, capability, method string, p svcProvider) {
+		a := bucket[capability]
+		if a == nil {
+			a = &acc{method: method, seenAgent: map[string]bool{}}
+			bucket[capability] = a
+		}
+		// Dedupe by agent id: an agent registering the same capability via two
+		// functions yields identical provider rows (the entry carries no
+		// function name), so keep the first.
+		if a.seenAgent[p.AgentID] {
+			return
+		}
+		a.seenAgent[p.AgentID] = true
+		a.providers = append(a.providers, p)
+	}
+
+	for _, agent := range agents {
+		for _, tool := range agent.Tools {
+			// Exclude framework-internal __mesh_* synthetics unless --show-framework
+			// — the SAME predicate (on the same function-name key) `--tools` uses,
+			// so the ungrouped count reconciles with `--tools` (RFC #1280 phase 4).
+			funcName := tool.FunctionName
+			if funcName == "" {
+				funcName = tool.Name
+			}
+			if !showFramework && isFrameworkInternalTool(funcName) {
+				continue
+			}
+			svc, method := splitServiceCapability(tool.Capability)
+			p := svcProvider{
+				AgentID:           agent.ID,
+				AgentName:         agent.Name,
+				Available:         tool.Available,
+				UnavailableReason: tool.UnavailableReason,
+			}
+			if svc == "" {
+				addProvider(ungrouped, tool.Capability, method, p)
+				continue
+			}
+			if grouped[svc] == nil {
+				grouped[svc] = map[string]*acc{}
+			}
+			addProvider(grouped[svc], tool.Capability, method, p)
+		}
+	}
+
+	sortProviders := func(ps []svcProvider) {
+		sort.Slice(ps, func(i, j int) bool { return ps[i].AgentID < ps[j].AgentID })
+	}
+	buildMethods := func(bucket map[string]*acc) []svcMethod {
+		caps := make([]string, 0, len(bucket))
+		for c := range bucket {
+			caps = append(caps, c)
+		}
+		sort.Strings(caps)
+		methods := make([]svcMethod, 0, len(caps))
+		for _, c := range caps {
+			a := bucket[c]
+			sortProviders(a.providers)
+			methods = append(methods, svcMethod{Method: a.method, Capability: c, Providers: a.providers})
+		}
+		return methods
+	}
+
+	services := make([]string, 0, len(grouped))
+	for s := range grouped {
+		services = append(services, s)
+	}
+	sort.Strings(services)
+
+	// Always non-nil slices so --json emits [] (never null) when empty.
+	view := serviceGroupView{Services: []svcEntry{}}
+	for _, s := range services {
+		view.Services = append(view.Services, svcEntry{Service: s, Methods: buildMethods(grouped[s])})
+	}
+	view.Ungrouped = buildMethods(ungrouped)
+	return view
+}
+
+// runServicesListCommand renders the mesh-wide, service-grouped capability view
+// derived from dot-namespaced capability names (RFC #1280 phase 4).
+func runServicesListCommand(registryURL string, jsonOutput, healthyOnly, showFramework bool) error {
+	agents, err := getEnhancedAgents(registryURL)
+	if err != nil {
+		return fmt.Errorf("failed to get agents from registry: %w", err)
+	}
+	if healthyOnly {
+		agents = filterHealthyAgents(agents)
+	}
+
+	view := buildServiceGroupView(agents, showFramework)
+
+	if jsonOutput {
+		data, err := json.MarshalIndent(view, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	return outputServiceGroupView(view)
+}
+
+// serviceProviderStatus renders the STATUS cell for a provider row.
+func serviceProviderStatus(p svcProvider) string {
+	if p.Available != nil && !*p.Available {
+		reason := p.UnavailableReason
+		if reason == "" {
+			reason = "required dependency unavailable"
+		}
+		return fmt.Sprintf("%sunavailable (%s)%s", colorRed, reason, colorReset)
+	}
+	return "available"
+}
+
+func outputServiceGroupView(view serviceGroupView) error {
+	if len(view.Services) == 0 {
+		fmt.Println("No dot-namespaced services found")
+		if n := view.ungroupedCount(); n > 0 {
+			fmt.Printf("\n(%d ungrouped %s not shown — use --tools)\n", n, pluralCapabilities(n))
+		}
+		return nil
+	}
+
+	// Column widths. Providers are shown by agent name (falling back to id).
+	svcWidth, methodWidth, agentWidth := len("SERVICE"), len("METHOD"), len("AGENT")
+	agentLabel := func(p svcProvider) string {
+		if p.AgentName != "" {
+			return p.AgentName
+		}
+		return p.AgentID
+	}
+	for _, e := range view.Services {
+		if len(e.Service) > svcWidth {
+			svcWidth = len(e.Service)
+		}
+		for _, m := range e.Methods {
+			if len(m.Method) > methodWidth {
+				methodWidth = len(m.Method)
+			}
+			for _, p := range m.Providers {
+				if l := len(agentLabel(p)); l > agentWidth {
+					agentWidth = l
+				}
+			}
+		}
+	}
+
+	fmt.Printf("%-*s  %-*s  %-*s  %s\n", svcWidth, "SERVICE", methodWidth, "METHOD", agentWidth, "AGENT", "STATUS")
+	fmt.Println(strings.Repeat("-", svcWidth+methodWidth+agentWidth+30))
+	for _, e := range view.Services {
+		for _, m := range e.Methods {
+			for _, p := range m.Providers {
+				// Service repeated per row (matches the other list tables).
+				fmt.Printf("%-*s  %-*s  %-*s  %s\n",
+					svcWidth, e.Service, methodWidth, m.Method,
+					agentWidth, agentLabel(p), serviceProviderStatus(p))
+			}
+		}
+	}
+
+	if n := view.ungroupedCount(); n > 0 {
+		fmt.Printf("\n(%d ungrouped %s not shown — use --tools)\n", n, pluralCapabilities(n))
+	}
+	return nil
+}
+
+func pluralCapabilities(n int) string {
+	if n == 1 {
+		return "capability"
+	}
+	return "capabilities"
+}
+
 // runToolsListCommand handles the --tools flag. When showFramework is false
-// (default), framework-internal tools whose function name starts with
-// "__mesh_job_" are filtered out of both the list view and the per-tool
-// lookup so end users see only application capabilities (issue #956 #15).
+// (default), framework-internal tools whose function name starts with the
+// reserved "__mesh_" prefix are filtered out of both the list view and the
+// per-tool lookup so end users see only application capabilities (issue #956
+// #15, RFC #1280).
 func runToolsListCommand(registryURL, toolSpec string, jsonOutput, healthyOnly, showFramework bool) error {
 	// Get enhanced agents from registry
 	enhancedAgents, err := getEnhancedAgents(registryURL)
@@ -2499,11 +2897,26 @@ type toolCollisionRow struct {
 }
 
 // isFrameworkInternalTool reports whether a tool function name is a
-// framework-internal capability (e.g. __mesh_job_status, __mesh_job_result)
-// that the runtime registers automatically on every MeshJob-capable agent.
-// These flood `meshctl list --tools` with noise and are hidden by default.
-// Pass --show-framework to surface them. See issue #956 item #15.
+// framework-internal, wire-level synthetic that the runtime registers
+// automatically — the MeshJob helpers (__mesh_job_status/result/cancel) and the
+// synthetic dependency-carrier tools (__mesh_service_deps, __mesh_route_deps,
+// __mesh_a2a_deps, __mesh_depends_on_deps). All share the reserved "__mesh_"
+// prefix, none is a user-callable capability, and they flood `meshctl list
+// --tools` / the --services grouping with noise, so they are hidden by default.
+// Pass --show-framework to surface them. See issue #956 item #15, RFC #1280.
 func isFrameworkInternalTool(funcName string) bool {
+	return strings.HasPrefix(funcName, "__mesh_")
+}
+
+// isSharedStateJobHelper reports whether a tool function name is a MeshJob
+// helper (__mesh_job_status/result/cancel). These auto-register on EVERY
+// MeshJob-capable agent and read/write the SAME registry-backed job state, so a
+// bare multi-agent match can pick any healthy one deterministically-enough
+// (issue #956 #14). This is DELIBERATELY narrower than isFrameworkInternalTool:
+// the synthetic dependency-carrier tools (__mesh_*_deps) are PER-AGENT wire
+// artifacts with no shared state, so they must NOT get the collision bypass —
+// only the "hide from listing" treatment.
+func isSharedStateJobHelper(funcName string) bool {
 	return strings.HasPrefix(funcName, "__mesh_job_")
 }
 
@@ -2554,9 +2967,16 @@ func outputToolsList(tools []ToolListItem, jsonOutput bool) error {
 		return nil
 	}
 
-	// Sort by tool name
+	// Sort by capability so dot-namespaced service members cluster together
+	// (RFC #1280 phase 4). Tie-break by tool name then agent id for determinism.
 	sort.Slice(tools, func(i, j int) bool {
-		return tools[i].ToolName < tools[j].ToolName
+		if tools[i].Capability != tools[j].Capability {
+			return tools[i].Capability < tools[j].Capability
+		}
+		if tools[i].ToolName != tools[j].ToolName {
+			return tools[i].ToolName < tools[j].ToolName
+		}
+		return tools[i].AgentID < tools[j].AgentID
 	})
 
 	// Calculate column widths

--- a/src/core/cli/list_test.go
+++ b/src/core/cli/list_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -625,4 +626,244 @@ func TestProcessAgentData_ParsesAvailability(t *testing.T) {
 
 	// And the derived aggregate the row marker uses.
 	assert.Equal(t, 1, countUnavailableCapabilities(agent))
+}
+
+// --- RFC #1280 phase 4: service grouping (display-only) ---------------------
+
+func TestSplitServiceCapability(t *testing.T) {
+	cases := []struct {
+		name, wantService, wantMethod string
+	}{
+		{"media.caption", "media", "caption"},       // single-segment prefix
+		{"media.v2.caption", "media.v2", "caption"}, // multi-segment prefix
+		{"greeting", "", "greeting"},                // undotted → ungrouped
+		{"a.b.c.d", "a.b.c", "d"},                   // deep nesting
+		{".leading", "", ".leading"},                // degenerate → ungrouped
+		{"trailing.", "", "trailing."},              // degenerate → ungrouped
+	}
+	for _, c := range cases {
+		svc, method := splitServiceCapability(c.name)
+		assert.Equal(t, c.wantService, svc, "service for %q", c.name)
+		assert.Equal(t, c.wantMethod, method, "method for %q", c.name)
+	}
+}
+
+func TestGroupCapabilitiesByService(t *testing.T) {
+	tools := []ToolInfo{
+		{Name: "zeta", Capability: "media.zeta"},
+		{Name: "caption", Capability: "media.caption"},
+		{Name: "greeting", Capability: "greeting"}, // ungrouped
+		{Name: "encode", Capability: "audio.encode"},
+		{Name: "solo", Capability: "solo.only"}, // single tool in a group
+	}
+	groups := groupCapabilitiesByService(tools)
+
+	// Services sorted alphabetically, ungrouped LAST.
+	require.Len(t, groups, 4)
+	assert.Equal(t, "audio", groups[0].Service)
+	assert.Equal(t, "media", groups[1].Service)
+	assert.Equal(t, "solo", groups[2].Service)
+	assert.Equal(t, "", groups[3].Service) // ungrouped last
+
+	// Methods sorted by capability within a group.
+	require.Len(t, groups[1].Tools, 2)
+	assert.Equal(t, "media.caption", groups[1].Tools[0].Capability)
+	assert.Equal(t, "media.zeta", groups[1].Tools[1].Capability)
+
+	// Single tool in a group.
+	require.Len(t, groups[2].Tools, 1)
+	assert.Equal(t, "solo.only", groups[2].Tools[0].Capability)
+
+	// Ungrouped bucket.
+	require.Len(t, groups[3].Tools, 1)
+	assert.Equal(t, "greeting", groups[3].Tools[0].Capability)
+}
+
+func TestGroupCapabilitiesByService_NoDots(t *testing.T) {
+	groups := groupCapabilitiesByService([]ToolInfo{
+		{Capability: "b"}, {Capability: "a"},
+	})
+	require.Len(t, groups, 1)
+	assert.Equal(t, "", groups[0].Service)
+	assert.Equal(t, "a", groups[0].Tools[0].Capability)
+	assert.Equal(t, "b", groups[0].Tools[1].Capability)
+}
+
+func TestBuildServiceGroupView_MultiAgentAndUngrouped(t *testing.T) {
+	base := time.Now()
+	capA := testAgent("caption-provider-abc", "caption-provider", "healthy", base, nil)
+	capA.Tools = []ToolInfo{{Name: "caption", Capability: "media.caption", Available: boolPtr(true)}}
+
+	// Same capability from a second agent → one provider row per (cap, agent).
+	capB := testAgent("caption-backup-def", "caption-backup", "healthy", base, nil)
+	capB.Tools = []ToolInfo{{Name: "caption", Capability: "media.caption", Available: boolPtr(true)}}
+
+	thumb := testAgent("thumb-xyz", "thumb-provider", "healthy", base, nil)
+	thumb.Tools = []ToolInfo{
+		{Name: "thumbnail", Capability: "media.thumbnail", Available: boolPtr(false), UnavailableReason: "dep down"},
+		{Name: "greet", Capability: "greeting"}, // ungrouped
+		// Framework-internal synthetics must be excluded entirely — they must
+		// not appear in any group NOR inflate the ungrouped count (the note
+		// sends users to --tools, which filters these identically).
+		{Name: "__mesh_service_deps", FunctionName: "__mesh_service_deps", Capability: "__mesh_service_deps"},
+		{Name: "__mesh_job_status", FunctionName: "__mesh_job_status", Capability: "__mesh_job_status"},
+	}
+
+	view := buildServiceGroupView([]EnhancedAgent{thumb, capB, capA}, false)
+
+	// One service ("media"), methods sorted by capability.
+	require.Len(t, view.Services, 1)
+	assert.Equal(t, "media", view.Services[0].Service)
+	methods := view.Services[0].Methods
+	require.Len(t, methods, 2)
+	assert.Equal(t, "media.caption", methods[0].Capability)
+	assert.Equal(t, "caption", methods[0].Method)
+	assert.Equal(t, "media.thumbnail", methods[1].Capability)
+
+	// media.caption has two providers, sorted by agent id.
+	require.Len(t, methods[0].Providers, 2)
+	assert.Equal(t, "caption-backup-def", methods[0].Providers[0].AgentID)
+	assert.Equal(t, "caption-provider-abc", methods[0].Providers[1].AgentID)
+
+	// Ungrouped capability tracked + counted — framework synthetics excluded,
+	// so only "greeting" remains and N is 1 (reconciles with --tools).
+	require.Len(t, view.Ungrouped, 1)
+	assert.Equal(t, "greeting", view.Ungrouped[0].Capability)
+	assert.Equal(t, 1, view.ungroupedCount())
+
+	// No __mesh_* synthetic leaks anywhere in the view.
+	for _, e := range view.Services {
+		for _, m := range e.Methods {
+			assert.NotContains(t, m.Capability, "__mesh_", "framework synthetic must not appear in a service group")
+		}
+	}
+	for _, m := range view.Ungrouped {
+		assert.NotContains(t, m.Capability, "__mesh_", "framework synthetic must not appear in the ungrouped bucket")
+	}
+}
+
+func TestServiceProviderStatus(t *testing.T) {
+	assert.Equal(t, "available", serviceProviderStatus(svcProvider{Available: boolPtr(true)}))
+	assert.Equal(t, "available", serviceProviderStatus(svcProvider{})) // nil = available
+	un := serviceProviderStatus(svcProvider{Available: boolPtr(false), UnavailableReason: "dep down"})
+	assert.Contains(t, un, "unavailable")
+	assert.Contains(t, un, "dep down")
+	assert.Contains(t, un, colorRed)
+}
+
+func TestGroupResolutionsByService(t *testing.T) {
+	res := []DependencyResolution{
+		{Capability: "media.thumbnail", ProviderAgentID: "t1", Status: "available"},
+		{Capability: "media.caption", ProviderAgentID: "c1", Status: "available"},
+		{Capability: "date_service", ProviderAgentID: "d1", Status: "unresolved"}, // ungrouped
+	}
+	groups := groupResolutionsByService(res)
+	require.Len(t, groups, 2)
+	assert.Equal(t, "media", groups[0].Service)
+	require.Len(t, groups[0].Resolutions, 2)
+	assert.Equal(t, "media.caption", groups[0].Resolutions[0].Capability) // sorted
+	assert.Equal(t, "media.thumbnail", groups[0].Resolutions[1].Capability)
+	assert.Equal(t, "", groups[1].Service) // ungrouped last
+	assert.Equal(t, "date_service", groups[1].Resolutions[0].Capability)
+}
+
+// TestServiceGroupView_EmptyMarshalsArrays guards the HIGH-1 fix: an empty
+// --services --json view must emit {"services":[],"ungrouped":[]} (arrays, never
+// null/omitted) so consumers iterate unconditionally.
+func TestServiceGroupView_EmptyMarshalsArrays(t *testing.T) {
+	view := buildServiceGroupView(nil, false)
+	require.NotNil(t, view.Services)
+	require.NotNil(t, view.Ungrouped)
+
+	data, err := json.Marshal(view)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"services":[],"ungrouped":[]}`, string(data))
+}
+
+// TestBuildServiceGroupView_ShowFramework verifies MED-2: with showFramework the
+// __mesh_* synthetics group by their names as ordinary entries.
+func TestBuildServiceGroupView_ShowFramework(t *testing.T) {
+	base := time.Now()
+	agent := testAgent("a-1", "a", "healthy", base, nil)
+	agent.Tools = []ToolInfo{
+		{Name: "caption", Capability: "media.caption"},
+		{Name: "__mesh_service_deps", FunctionName: "__mesh_service_deps", Capability: "__mesh_service_deps"},
+		{Name: "__mesh_job_status", FunctionName: "__mesh_job_status", Capability: "__mesh_job_status"},
+	}
+
+	// Default: synthetics excluded.
+	hidden := buildServiceGroupView([]EnhancedAgent{agent}, false)
+	require.Len(t, hidden.Services, 1)
+	assert.Equal(t, "media", hidden.Services[0].Service)
+	assert.Empty(t, hidden.Ungrouped)
+
+	// --show-framework: synthetics appear as ordinary entries (undotted →
+	// ungrouped by their names).
+	shown := buildServiceGroupView([]EnhancedAgent{agent}, true)
+	caps := map[string]bool{}
+	for _, m := range shown.Ungrouped {
+		caps[m.Capability] = true
+	}
+	assert.True(t, caps["__mesh_service_deps"], "framework synthetic must appear with --show-framework")
+	assert.True(t, caps["__mesh_job_status"], "framework synthetic must appear with --show-framework")
+}
+
+// TestOutputServiceGroupView_TableAndNote covers the table rendering + the
+// ungrouped-note path (both flagged as untested).
+func TestOutputServiceGroupView_TableAndNote(t *testing.T) {
+	base := time.Now()
+	a := testAgent("cap-1", "caption-provider", "healthy", base, nil)
+	a.Tools = []ToolInfo{
+		{Name: "caption", Capability: "media.caption", Available: boolPtr(true)},
+		{Name: "thumbnail", Capability: "media.thumbnail", Available: boolPtr(false), UnavailableReason: "dep down"},
+		{Name: "greet", Capability: "greeting"}, // ungrouped → note
+	}
+	view := buildServiceGroupView([]EnhancedAgent{a}, false)
+
+	out := captureStdout(t, func() {
+		require.NoError(t, outputServiceGroupView(view))
+	})
+	assert.Contains(t, out, "SERVICE")
+	assert.Contains(t, out, "METHOD")
+	assert.Contains(t, out, "media")
+	assert.Contains(t, out, "caption")
+	assert.Contains(t, out, "caption-provider")
+	assert.Contains(t, out, "available")
+	assert.Contains(t, out, "unavailable (dep down)")
+	// One ungrouped capability -> singular note pointing at --tools.
+	assert.Contains(t, out, "(1 ungrouped capability not shown — use --tools)")
+}
+
+// TestOutputServiceGroupView_EmptyWithUngroupedNote covers the no-services path.
+func TestOutputServiceGroupView_EmptyWithUngroupedNote(t *testing.T) {
+	base := time.Now()
+	a := testAgent("u-1", "u", "healthy", base, nil)
+	a.Tools = []ToolInfo{{Name: "greet", Capability: "greeting"}, {Name: "farewell", Capability: "farewell"}}
+	view := buildServiceGroupView([]EnhancedAgent{a}, false)
+
+	out := captureStdout(t, func() {
+		require.NoError(t, outputServiceGroupView(view))
+	})
+	assert.Contains(t, out, "No dot-namespaced services found")
+	assert.Contains(t, out, "(2 ungrouped capabilities not shown — use --tools)")
+}
+
+// TestBuildServiceGroupView_DedupeProviderByAgent verifies one provider row per
+// (capability, agent): an agent registering the same capability via two
+// functions produces indistinguishable provider entries, so they collapse.
+func TestBuildServiceGroupView_DedupeProviderByAgent(t *testing.T) {
+	base := time.Now()
+	a := testAgent("dup-1", "dup-provider", "healthy", base, nil)
+	a.Tools = []ToolInfo{
+		{Name: "caption_a", FunctionName: "caption_a", Capability: "media.caption", Available: boolPtr(true)},
+		{Name: "caption_b", FunctionName: "caption_b", Capability: "media.caption", Available: boolPtr(true)},
+	}
+
+	view := buildServiceGroupView([]EnhancedAgent{a}, false)
+	require.Len(t, view.Services, 1)
+	require.Len(t, view.Services[0].Methods, 1)
+	assert.Equal(t, "media.caption", view.Services[0].Methods[0].Capability)
+	require.Len(t, view.Services[0].Methods[0].Providers, 1,
+		"one provider row per (capability, agent) despite two registering functions")
+	assert.Equal(t, "dup-1", view.Services[0].Methods[0].Providers[0].AgentID)
 }

--- a/src/core/cli/man/content/capabilities.md
+++ b/src/core/cli/man/content/capabilities.md
@@ -174,7 +174,7 @@ def my_tool(date: mesh.McpMeshTool = None, weather: mesh.McpMeshTool = None):
 | `domain_action` | `auth_validate` | Domain-specific  |
 | `service`       | `llm`           | Generic services |
 
-A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
+A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix. `meshctl list --services` and the meshui agent-detail view render dotted capabilities as grouped services — display-only, derived entirely from the name.
 
 ## Versioning
 

--- a/src/core/cli/man/content/capabilities_java.md
+++ b/src/core/cli/man/content/capabilities_java.md
@@ -159,7 +159,7 @@ So when several providers share the same capability and tags, the one with the *
 | `domain_action` | `auth_validate` | Domain-specific  |
 | `service`       | `llm`           | Generic services |
 
-A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
+A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix. `meshctl list --services` and the meshui agent-detail view render dotted capabilities as grouped services — display-only, derived entirely from the name.
 
 ## Versioning
 

--- a/src/core/cli/man/content/capabilities_typescript.md
+++ b/src/core/cli/man/content/capabilities_typescript.md
@@ -204,7 +204,7 @@ agent.addTool({
 | `domain_action` | `auth_validate` | Domain-specific  |
 | `service`       | `llm`           | Generic services |
 
-A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix.
+A capability name is one or more **dot-separated segments**, each matching `^[a-zA-Z][a-zA-Z0-9_-]*$` — a leading letter followed by letters, digits, underscores, or hyphens, with no leading, trailing, or consecutive dots. Single-segment names like `weather_data` are the common case; **dot-namespacing** (`media.caption`, `billing.v2.invoice`) is the convention for grouping related capabilities under a service prefix. `meshctl list --services` and the meshui agent-detail view render dotted capabilities as grouped services — display-only, derived entirely from the name.
 
 The TypeScript SDK performs no local capability-name validation — it forwards capability strings to the registry as-is, so a malformed name is rejected at registration time by the registry, not by the TS runtime. The segment-wise format above is the contract the registry enforces.
 

--- a/src/core/cli/man/content/cli.md
+++ b/src/core/cli/man/content/cli.md
@@ -157,10 +157,15 @@ meshctl list --filter hello        # Substring match on agent ID
 meshctl list --since 1h            # Active in the last hour
 
 # Tools
-meshctl list --tools               # All tools across all agents
+meshctl list --tools               # All tools across all agents (sorted by capability)
 meshctl list -t                    # Short form
 meshctl list --tools=get_weather   # Show input schema for one tool
 meshctl list --tools=system-agent:get_time   # Tool details on a specific agent
+
+# Service view — dot-namespaced capabilities grouped by name (RFC #1280)
+meshctl list --services            # Mesh-wide SERVICE / METHOD / AGENT / STATUS table
+meshctl list --services --all      # Include unhealthy providers
+meshctl list --services --json     # Structured services → methods → providers
 
 # Schemas (issue #547)
 meshctl list --schemas             # Most recent 100 canonical schemas
@@ -176,6 +181,33 @@ tool with its reason (`[unavailable: required dep '…' unresolved]`); the
 `--tools=<name>` prints an `Availability:` line naming the broken edge. The
 markers appear only on healthy agents — an unhealthy agent's capabilities are
 all unavailable by definition, so the row status already says so.
+
+**Grouped service views (`--services`).** `meshctl list --services` renders one
+row per (capability, agent), with the SERVICE column derived from the
+dot-namespaced capability name — the group is every segment before the last
+dot, so `media.caption` and `media.thumbnail` group under `media`, and
+`media.v2.caption` groups under `media.v2`:
+
+```
+SERVICE  METHOD      AGENT             STATUS
+---------------------------------------------------------------
+media    caption     caption-provider  available
+media    thumbnail   thumb-provider    unavailable (dep down)
+media    transcribe  transcribe-prov   available
+```
+
+Undotted capabilities are not services and are excluded, with a trailing note
+`(N ungrouped capabilities not shown — use --tools)`. `--services` combines with
+`--all` (include unhealthy providers), `--json` (structured
+`services → methods → providers`), and `--show-framework` (include the `__mesh_*`
+synthetics); `--filter`, `--since`, and `--verbose` do not apply to this view.
+Grouping is display-only, derived entirely from the capability name —
+nothing group-shaped is registered. The same grouping also surfaces elsewhere:
+the standalone `meshctl list --verbose` (agent view) folds dotted capabilities
+into its Tools section under `service/ (N methods)` headers and adds a
+Dependencies section listing per-method provider bindings
+(`media.caption → caption-provider-abc [available]`), and `--tools` sorts by
+capability so members of a service cluster together.
 
 ### `meshctl call`
 

--- a/src/ui/components/agents/AgentDetail.tsx
+++ b/src/ui/components/agents/AgentDetail.tsx
@@ -1,7 +1,8 @@
-import { Agent, Capability } from "@/lib/types";
+import { Agent, Capability, DependencyResolution } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { getAgentTypeLabel, getDepStatusColor, extractAgentName } from "@/lib/api";
+import { groupByService, splitServiceCapability } from "@/lib/service-group";
 import { useMesh } from "@/lib/mesh-context";
 import { AgentTraces } from "./AgentTraces";
 import { AgentBadges } from "./AgentBadges";
@@ -33,17 +34,40 @@ function EmptyState({ message }: { message: string }) {
   );
 }
 
+// RFC #1280: header for a dot-namespaced service group (Capabilities +
+// Dependencies tabs). Mirrors the LLM tab's section-header styling with a
+// method-count badge alongside.
+function ServiceHeader({ name, count }: { name: string; count: number }) {
+  return (
+    <div className="flex items-center gap-2">
+      <h4 className="text-xs font-medium uppercase tracking-wider text-muted-foreground font-mono">
+        {name}
+      </h4>
+      <Badge variant="outline" className="text-[10px] px-1.5 py-0 text-muted-foreground border-muted-foreground/30">
+        {count} {count === 1 ? "method" : "methods"}
+      </Badge>
+    </div>
+  );
+}
+
 // Issue #970: shared row renderer so the visible + framework capability lists
 // can share styling. The `framework` flag adds a muted badge so users can tell
 // __mesh_job_* tools apart at a glance when they're shown.
-function renderCapabilityRow(cap: Capability, key: string, framework: boolean) {
+// RFC #1280: when `method` is set (row lives inside a service group) it is
+// shown prominently; the full dotted name stays visible in the name badge.
+function renderCapabilityRow(cap: Capability, key: string, framework: boolean, method?: string) {
   return (
     <div
       key={key}
       className="rounded-lg border border-border/50 px-4 py-3"
     >
       <div className="flex items-center gap-2 flex-wrap">
-        <span className="text-sm font-medium text-foreground font-mono">
+        {method && (
+          <span className="text-sm font-semibold text-foreground font-mono">
+            {method}
+          </span>
+        )}
+        <span className={`text-sm font-medium font-mono ${method ? "text-muted-foreground" : "text-foreground"}`}>
           {cap.function_name}
         </span>
         <Badge variant="outline" className="text-xs">
@@ -100,18 +124,62 @@ function renderCapabilityRow(cap: Capability, key: string, framework: boolean) {
   );
 }
 
+// Dependency resolution row. Extracted so grouped (service) and ungrouped
+// dependencies share one renderer (RFC #1280). Rows are unchanged from the
+// prior inline markup — Provider / StatusBadge / mcp_tool / endpoint intact.
+function renderDependencyRow(dep: DependencyResolution, key: string) {
+  return (
+    <div
+      key={key}
+      className="rounded-lg border border-border/50 px-4 py-3"
+    >
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-medium text-foreground font-mono">
+            {dep.function_name}
+          </span>
+          <Badge variant="outline" className="text-xs">
+            {dep.capability}
+          </Badge>
+          {dep.tags?.map((tag) => (
+            <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+        <StatusBadge status={dep.status} />
+      </div>
+      <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+        {dep.provider_agent_id && (
+          <span>
+            Provider: <span className={getDepStatusColor(dep.status)}>{dep.provider_agent_id}</span>
+          </span>
+        )}
+        {dep.mcp_tool && <span>MCP Tool: {dep.mcp_tool}</span>}
+        {dep.endpoint && (
+          <span className="font-mono truncate max-w-xs">
+            {dep.endpoint}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function AgentDetail({ agent }: AgentDetailProps) {
   const hasLLM =
     (agent.llm_tool_resolutions && agent.llm_tool_resolutions.length > 0) ||
     (agent.llm_provider_resolutions && agent.llm_provider_resolutions.length > 0);
 
   const capabilities = agent.capabilities ?? [];
-  // Issue #970: framework-internal MeshJob tools (__mesh_job_*) are noise in
-  // the UI by default — partition them out and show user-visible capabilities,
-  // with a toggle to reveal the framework set. Mirrors the CLI's --tools view
-  // which hides them unless --show-framework is passed (cli/list.go:85).
-  const fw = capabilities.filter((c) => c.function_name?.startsWith("__mesh_job_"));
-  const visible = capabilities.filter((c) => !c.function_name?.startsWith("__mesh_job_"));
+  // Issue #970: framework-internal tools (__mesh_* — MeshJob producers,
+  // service-deps, etc.) are noise in the UI by default — partition them out
+  // and show user-visible capabilities, with a toggle to reveal the framework
+  // set. Mirrors the CLI's --tools view which hides them unless
+  // --show-framework is passed (cli/list.go isFrameworkInternalTool, keyed on
+  // the whole __mesh_ prefix).
+  const fw = capabilities.filter((c) => c.function_name?.startsWith("__mesh_"));
+  const visible = capabilities.filter((c) => !c.function_name?.startsWith("__mesh_"));
   const [showFw, setShowFw] = useState(false);
   const agentName = extractAgentName(agent.id);
   const { traceActivity } = useMesh();
@@ -172,7 +240,31 @@ export function AgentDetail({ agent }: AgentDetailProps) {
                   Only framework-internal capabilities are registered.
                 </p>
               )}
-              {visible.map((cap, idx) => renderCapabilityRow(cap, `visible-${idx}`, false))}
+              {(() => {
+                // RFC #1280: group dot-namespaced capabilities under a service
+                // header; undotted capabilities render flat below the groups.
+                const { services, ungrouped } = groupByService(visible, (c) => c.name);
+                return (
+                  <>
+                    {services.map((svc) => (
+                      <div key={`cap-svc-${svc.name}`} className="space-y-2">
+                        <ServiceHeader name={svc.name} count={svc.items.length} />
+                        <div className="space-y-2 border-l border-border/50 pl-3">
+                          {svc.items.map((cap) =>
+                            renderCapabilityRow(
+                              cap,
+                              `cap-${cap.function_name}-${cap.name}`,
+                              false,
+                              splitServiceCapability(cap.name).method,
+                            ),
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                    {ungrouped.map((cap) => renderCapabilityRow(cap, `cap-${cap.function_name}-${cap.name}`, false))}
+                  </>
+                );
+              })()}
               {showFw && fw.map((cap, idx) => renderCapabilityRow(cap, `fw-${idx}`, true))}
               {fw.length > 0 && (
                 <button
@@ -193,42 +285,32 @@ export function AgentDetail({ agent }: AgentDetailProps) {
             <EmptyState message="No dependencies" />
           ) : (
             <div className="space-y-2">
-              {agent.dependency_resolutions.map((dep, idx) => (
-                <div
-                  key={`${dep.function_name}-${idx}`}
-                  className="rounded-lg border border-border/50 px-4 py-3"
-                >
-                  <div className="flex items-center justify-between flex-wrap gap-2">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-sm font-medium text-foreground font-mono">
-                        {dep.function_name}
-                      </span>
-                      <Badge variant="outline" className="text-xs">
-                        {dep.capability}
-                      </Badge>
-                      {dep.tags?.map((tag) => (
-                        <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0">
-                          {tag}
-                        </Badge>
-                      ))}
-                    </div>
-                    <StatusBadge status={dep.status} />
-                  </div>
-                  <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-                    {dep.provider_agent_id && (
-                      <span>
-                        Provider: <span className={getDepStatusColor(dep.status)}>{dep.provider_agent_id}</span>
-                      </span>
+              {(() => {
+                // RFC #1280: group dot-namespaced dependencies by their
+                // capability's service. One service group can have methods
+                // bound to DIFFERENT provider_agent_id values.
+                const { services, ungrouped } = groupByService(
+                  agent.dependency_resolutions,
+                  (d) => d.capability,
+                );
+                return (
+                  <>
+                    {services.map((svc) => (
+                      <div key={`dep-svc-${svc.name}`} className="space-y-2">
+                        <ServiceHeader name={svc.name} count={svc.items.length} />
+                        <div className="space-y-2 border-l border-border/50 pl-3">
+                          {svc.items.map((dep) =>
+                            renderDependencyRow(dep, `dep-${dep.function_name}-${dep.capability}`),
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                    {ungrouped.map((dep) =>
+                      renderDependencyRow(dep, `dep-${dep.function_name}-${dep.capability}`),
                     )}
-                    {dep.mcp_tool && <span>MCP Tool: {dep.mcp_tool}</span>}
-                    {dep.endpoint && (
-                      <span className="font-mono truncate max-w-xs">
-                        {dep.endpoint}
-                      </span>
-                    )}
-                  </div>
-                </div>
-              ))}
+                  </>
+                );
+              })()}
             </div>
           )}
         </TabsContent>

--- a/src/ui/lib/service-group.ts
+++ b/src/ui/lib/service-group.ts
@@ -1,0 +1,85 @@
+/**
+ * RFC #1280 phase 4: display grouping of dot-namespaced capability names.
+ *
+ * Capability names may be dot-namespaced (e.g. "media.caption",
+ * "media.thumbnail"). The grouping rule is a LAST-dot split:
+ *   service = everything before the last dot ("media")
+ *   method  = the final segment ("caption")
+ * Undotted names have no service and stay ungrouped.
+ */
+
+export interface ServiceMethod {
+  /** The service segment (everything before the last dot). */
+  service: string;
+  /** The method segment (the final dotted segment). */
+  method: string;
+}
+
+/**
+ * Split a capability name on its LAST dot. Names without a dot (or with a
+ * leading/trailing dot that would produce an empty segment) are treated as
+ * ungrouped: `service` is empty and `method` is the whole name.
+ */
+export function splitServiceCapability(name: string): ServiceMethod {
+  const idx = name.lastIndexOf(".");
+  if (idx <= 0 || idx === name.length - 1) {
+    return { service: "", method: name };
+  }
+  return { service: name.slice(0, idx), method: name.slice(idx + 1) };
+}
+
+export interface ServiceGroup<T> {
+  name: string;
+  items: T[];
+}
+
+export interface GroupedByService<T> {
+  /** Dotted items grouped by service, services sorted, items sorted by method. */
+  services: ServiceGroup<T>[];
+  /** Undotted items, sorted by name (byte-order, for parity with the CLI). */
+  ungrouped: T[];
+}
+
+/**
+ * Partition `items` by their capability name's service segment. Items whose
+ * name is undotted land in `ungrouped`; the rest are grouped by service. All
+ * ordering uses byte-order comparison for parity with the CLI: services are
+ * sorted by name, each group's items by method name, and the ungrouped bucket
+ * by name.
+ */
+export function groupByService<T>(
+  items: T[],
+  getName: (item: T) => string,
+): GroupedByService<T> {
+  const byService = new Map<string, Array<{ method: string; item: T }>>();
+  const ungrouped: T[] = [];
+
+  for (const item of items) {
+    const { service, method } = splitServiceCapability(getName(item));
+    if (!service) {
+      ungrouped.push(item);
+      continue;
+    }
+    const bucket = byService.get(service) ?? [];
+    bucket.push({ method, item });
+    byService.set(service, bucket);
+  }
+
+  // Byte-order comparison (not localeCompare) for parity with the CLI's
+  // sort.Strings, so mixed-case service/method names order identically in
+  // both surfaces.
+  const byteOrder = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+
+  const services: ServiceGroup<T>[] = Array.from(byService.entries())
+    .sort(([a], [b]) => byteOrder(a, b))
+    .map(([name, entries]) => ({
+      name,
+      items: entries
+        .sort((a, b) => byteOrder(a.method, b.method))
+        .map((e) => e.item),
+    }));
+
+  ungrouped.sort((a, b) => byteOrder(getName(a), getName(b)));
+
+  return { services, ungrouped };
+}

--- a/tests/integration/suites/uc37_service_view_java/tc09_services_display/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc09_services_display/test.yaml
@@ -1,0 +1,200 @@
+# tc09_services_display — RFC #1280 PHASE 4: `meshctl list --services`, the
+# mesh-wide SERVICE/METHOD/AGENT/STATUS view derived from dot-namespaced
+# capability names (group = segments before the last dot; undotted
+# capabilities fall into an "ungrouped" bucket surfaced only as a trailing
+# "use --tools" note in table form).
+#
+# Topology: java-view-producer (dotted svc.alpha/svc.bravo via the phase-3
+# sugar) + provider-alpha (undotted view-cap-alpha/tp-cap-alpha) — the
+# undotted agent gives the ungrouped bucket something user-visible to carry.
+#
+# Design guarantees under test (the --json output is THE contract; the table
+# check is secondary and deliberately tolerant):
+#   1. Grouping: service "svc" exists with exactly the methods alpha+bravo,
+#      each carrying capability svc.<method> and ONE provider whose
+#      agent_name is java-view-producer with available==true.
+#   2. Ungrouped bucket: the undotted view-cap-alpha lands in .ungrouped —
+#      MEMBERSHIP only, never an exact bucket count. The grouped view DOES
+#      exclude framework-internal __mesh_* synthetics by default (same
+#      predicate as --tools; --show-framework opts them back in for both
+#      views), so the bucket carries only user capabilities — but its size
+#      is still topology-dependent: any other agent in the test container's
+#      mesh may contribute its own undotted capabilities, so pinning N would
+#      couple this TC to unrelated fixtures.
+#   3. Table form renders the header, the producer row, and the trailing
+#      ungrouped note ("use --tools").
+#   4. Healthy-only default: after `meshctl stop java-view-producer` the
+#      default --services view drops every svc row (graceful stop removes
+#      the agent from the healthy set), while the ungrouped view-cap-alpha
+#      entry SURVIVES — the drop is producer-scoped, not view-wide. Kept
+#      deliberately light: this is a display TC, lifecycle is tc02/tc03/tc06.
+#
+# Timing: registration wait is liveness-only (issue #1193); no dependency
+# edges are exercised, so no settle interaction. TC timeout = cold-cache
+# step-budget sum (tc08 lesson), from the ACTUAL step timeouts below: copy
+# 120 + pip 120 + maven 600 + starts 2x120 + registration 260 + gate poll
+# 140 + captures 2x120 + stop 120 + drop poll 140 + post-stop capture 120
+# = 2100, rounded up with slack to 2400.
+
+name: "Service views phase 4: meshctl list --services groups dotted capabilities (Java)"
+description: "java-view-producer's svc.alpha/svc.bravo render as service 'svc' in --services --json with available providers; undotted caps land in ungrouped; stopping the producer drops the svc rows from the healthy-only default"
+tags:
+  - integration
+  - java
+  - python
+  - registry
+  - service-view
+  - rfc-1280
+  - meshctl
+  - slow
+timeout: 2400
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/provider-alpha /workspace/
+      cp -rL /uc-artifacts/java-view-producer /workspace/
+
+  - name: "Install provider-alpha deps"
+    handler: pip-install
+    path: /workspace/provider-alpha
+
+  - name: "Install producer Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-view-producer
+    timeout: 600
+
+  - name: "Start provider-alpha (port 9101)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start provider-alpha/main.py --env MCP_MESH_HTTP_PORT=9101 -d
+
+  - name: "Start java-view-producer (port 9202)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-producer --env MCP_MESH_HTTP_PORT=9202 -d
+
+  # Liveness only (issue #1193): 240s deadline covers the cold JVM start.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "provider-alpha java-view-producer"
+
+  # Gate: poll the grouped JSON until the svc service carries both methods
+  # (the producer's tools may land a beat after its registration row).
+  # Equality inside the jq filter, as everywhere in this suite.
+  - name: "Wait for service 'svc' with both methods"
+    handler: shell
+    workdir: /workspace
+    command: |
+      OK=""
+      for i in $(seq 1 60); do
+        OK=$(meshctl list --services --json 2>/dev/null | jq -r '(.services[] | select(.service == "svc") | [.methods[] | select(.capability == "svc.alpha" or .capability == "svc.bravo")] | length == 2)' 2>/dev/null || echo "")
+        if [ "$OK" = "true" ]; then
+          echo "SVC_GROUP_VISIBLE=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: --services never showed service 'svc' with both methods within 120s (last=$OK)"
+      meshctl list --services --json 2>/dev/null || true
+      exit 1
+    capture: wait_svc_group
+    timeout: 140
+
+  # Pure-JSON capture: THE contract surface for the assertions below.
+  - name: "Capture --services --json"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list --services --json
+    capture: services_json
+
+  # Secondary, deliberately tolerant table capture.
+  - name: "Capture --services table"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list --services 2>&1
+    capture: services_table
+
+  - name: "Stop java-view-producer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop java-view-producer
+    capture: stop_producer
+
+  # Guarantee 4: the healthy-only default drops the producer's svc rows.
+  # Graceful stop removes the agent immediately; poll covers a slower path.
+  - name: "Wait for svc rows to drop from the default view"
+    handler: shell
+    workdir: /workspace
+    command: |
+      N=""
+      for i in $(seq 1 60); do
+        N=$(meshctl list --services --json 2>/dev/null | jq -r '[.services[] | select(.service == "svc")] | length' 2>/dev/null || echo "")
+        if [ "$N" = "0" ]; then
+          echo "SVC_GROUP_DROPPED=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: service 'svc' still listed 120s after stopping the producer (last count=$N)"
+      meshctl list --services --json 2>/dev/null || true
+      exit 1
+    capture: wait_svc_dropped
+    timeout: 140
+
+  # Pure-JSON capture after the stop (state stable: producer gone).
+  - name: "Capture --services --json after stop"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list --services --json
+    capture: services_json_after_stop
+
+assertions:
+  # IDIOM: equality lives INSIDE the jq filter so the interpolation yields a
+  # bare true/false; no '}' in interpolation bodies.
+
+  - expr: "${captured.wait_svc_group} contains 'SVC_GROUP_VISIBLE=1'"
+    message: "the grouped view must show service 'svc' with both methods once the producer registers"
+
+  # Guarantee 1: the grouped JSON contract
+  - expr: "${jq:captured.services_json:([.services[] | select(.service == \"svc\")] | length == 1)} == 'true'"
+    message: "exactly one service entry 'svc' must be derived from the dotted capabilities"
+  - expr: "${jq:captured.services_json:(.services[] | select(.service == \"svc\") | [.methods[] | select((.method == \"alpha\" and .capability == \"svc.alpha\") or (.method == \"bravo\" and .capability == \"svc.bravo\"))] | length == 2)} == 'true'"
+    message: "service 'svc' must carry exactly the methods alpha (svc.alpha) and bravo (svc.bravo) — method name = the segment after the last dot"
+  - expr: "${jq:captured.services_json:(.services[] | select(.service == \"svc\") | .methods[] | select(.capability == \"svc.alpha\") | [.providers[] | select(.agent_name == \"java-view-producer\" and .available == true)] | length == 1)} == 'true'"
+    message: "svc.alpha must have exactly one provider: java-view-producer, available==true"
+  - expr: "${jq:captured.services_json:(.services[] | select(.service == \"svc\") | .methods[] | select(.capability == \"svc.bravo\") | [.providers[] | select(.agent_name == \"java-view-producer\" and .available == true)] | length == 1)} == 'true'"
+    message: "svc.bravo must have exactly one provider: java-view-producer, available==true"
+
+  # Guarantee 2: the ungrouped bucket (membership only — see header)
+  - expr: "${jq:captured.services_json:([.ungrouped[] | select(.capability == \"view-cap-alpha\")] | length == 1)} == 'true'"
+    message: "the undotted view-cap-alpha must land in the ungrouped bucket, never inside a service group"
+
+  # Guarantee 3: the secondary table form (tolerant, structural)
+  - expr: "${captured.services_table} contains 'SERVICE'"
+    message: "the table form must render the SERVICE/METHOD/AGENT/STATUS header"
+  - expr: "${captured.services_table} contains 'java-view-producer'"
+    message: "the table form must render the producer's agent row"
+  - expr: "${captured.services_table} contains 'use --tools'"
+    message: "the table form must carry the trailing ungrouped-capabilities note pointing at --tools"
+
+  # Guarantee 4: healthy-only default drops the stopped producer's rows...
+  - expr: "${captured.wait_svc_dropped} contains 'SVC_GROUP_DROPPED=1'"
+    message: "stopping the producer must drop every svc row from the healthy-only default view"
+  - expr: "${jq:captured.services_json_after_stop:([.services[] | select(.service == \"svc\")] | length == 0)} == 'true'"
+    message: "no 'svc' service entry may remain after the producer is stopped"
+
+  # ...while the ungrouped bucket (backed by the still-running provider-alpha)
+  # survives — the drop is producer-scoped, not view-wide
+  - expr: "${jq:captured.services_json_after_stop:([.ungrouped[] | select(.capability == \"view-cap-alpha\")] | length == 1)} == 'true'"
+    message: "view-cap-alpha must still be in the ungrouped bucket after the producer stop — provider-alpha is untouched"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

Phase 4 of RFC #1280 — the display arc. Dot-namespaced capabilities render as grouped services with per-method provider bindings. Grouping is derived entirely from the name (group = segments before the last dot): no metadata field, zero wire/registry changes, display-only.

**meshctl**
- New `meshctl list --services`: mesh-wide SERVICE / METHOD / AGENT / STATUS table, one deduped provider row per (capability, agent); undotted capabilities excluded with a "(N ungrouped capabilities not shown — use --tools)" note; combines with `--all`, `--json` (structured services→methods→providers; `services`/`ungrouped` are always arrays, never null), and `--show-framework`.
- `meshctl list --verbose`: dotted capabilities grouped under `service/ (N methods)` headers, plus a new grouped Dependencies section showing per-method provider bindings (`media.caption → caption-provider-abc [available]`) — one service, methods bound to different agents.
- `--tools` now sorts by capability so service members cluster.
- Framework-synthetic filtering unified: the listing-hide predicate covers the whole reserved `__mesh_` prefix (previously `__mesh_job_` only — the `__mesh_*_deps` carriers were leaking into `--tools`), while the `call` multi-match collision bypass stays scoped to the shared-state `__mesh_job_` family so per-agent carriers correctly get the disambiguation error. `--show-framework` reveals synthetics in both views.

**meshui**
- `AgentDetail` Capabilities and Dependencies tabs group dotted capabilities under service headers, reusing the existing row renderers; the Dependencies tab is the per-method multi-provider visual. Framework partition, sort order (byte-order), and grouping rule are in exact parity with the CLI (`src/ui/lib/service-group.ts` mirrors the Go helper).

**Tests/docs**
- uc37 tc09: json-first `--services` assertions including the empty-view array contract and the healthy-only drop after producer stop. Suite validated 9/9 on k8s (src-tests 12/12, fresh image).
- CLI man page + docs/cli, one-sentence notes on the six capability-naming surfaces, example README `--services` table (separator rows match the renderer's exact width math).

## Review Notes

- Two review rounds; notable catches fixed: `--services --json` emitting `"services": null` when empty (would have failed tc09's post-stop poll every run); `--show-framework` documented but unwired; the collision-bypass over-broadening; React key collisions in the multi-provider pattern; CLI↔UI predicate/sort parity.
- **Release-note callouts when this ships**: (1) `meshctl list --tools` now hides all `__mesh_*` framework synthetics (previously only `__mesh_job_*`) and sorts by capability; `--show-framework` reveals them. (2) The new `--services` view.
- Pipeline note: `cmd/mcp-mesh-ui/dist/index.html` is tracked while hashed assets are gitignored (pre-existing convention) — release builds must run `make ui-server-build` before compiling meshui, as today.

## Test plan

- [x] `go test ./src/core/cli/...` green (grouping helpers, services view incl. empty-marshal + table rendering + framework filtering + provider dedupe, predicate split)
- [x] meshui: lint clean, `make ui-server-build` green (embed path compiles)
- [x] src-tests 12/12; `tsuite run --suite-path tests/integration --uc uc37_service_view_java` — 9/9 on k8s incl. tc09 (empty-array contract observed verbatim post-stop)
- [x] `go build ./src/core/cli/...` + mkdocs strict green

Closes #1289

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `meshctl list --services` view that groups dot-namespaced capabilities into services with methods and providers.
  * Updated the agent detail UI to display grouped capabilities and dependencies instead of only flat lists.
  * Added service-grouped output support in JSON, table, and verbose views.

* **Bug Fixes**
  * Improved handling of framework-internal capabilities and tool-collision edge cases.
  * Refined sorting and grouping so related capabilities appear together consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->