### PR TITLE
feat(python,ts): service views + producer sugar (RFC #1280, final item)

### DIFF
--- a/docs/python/decorators.md
+++ b/docs/python/decorators.md
@@ -86,6 +86,36 @@ async def greet(name: str, date_svc: mesh.McpMeshTool = None) -> str:
 | `mesh.McpMeshTool`  | Tool calls via proxy                   |
 | `mesh.MeshLlmAgent` | LLM agent injection (with `@mesh.llm`) |
 
+## @mesh.service
+
+Aggregates capabilities behind a typed view, or — with a prefix — publishes a class's methods as tools (RFC #1280).
+
+**Consumer view** — a class of `async` `@mesh.selector` stubs, injected as a `@mesh.tool` parameter:
+
+```python
+@mesh.service                       # or @mesh.service(min_available=2)
+class MediaService:
+    @mesh.selector("media.caption", required=True)
+    async def caption(self, args: dict) -> dict: ...
+    @mesh.selector("media.thumbnail")
+    async def thumbnail(self, args: dict) -> dict: ...
+
+@mesh.tool(capability="process_media")
+async def process_media(req: dict, media: MediaService = None):
+    return await media.caption({"text": req["text"]})
+```
+
+**Producer** — a prefixed class whose real methods publish as `prefix.<method>`:
+
+```python
+@mesh.service("media")              # publishes media.caption, media.thumbnail
+class MediaTools:
+    async def caption(self, args: dict) -> dict: ...
+    async def thumbnail(self, args: dict) -> dict: ...
+```
+
+Each view method is an ordinary dependency edge and each producer method an ordinary tool — both show as `N` entries in `meshctl list`. `required` view edges get the pre-invoke `dependency_unavailable` refusal; `min_available` (consumer-only) adds a floor. For the full semantics see the [Dependency Injection](dependency-injection.md#service-views-rfc-1280) guide.
+
 ## @mesh.llm
 
 Enables LLM-powered tools with automatic tool discovery.

--- a/docs/python/dependency-injection.md
+++ b/docs/python/dependency-injection.md
@@ -174,6 +174,61 @@ Streaming routes can't carry a pre-body 503, so they bypass the perimeter and ke
 
 **Inspecting availability.** Each capability in the agents/capabilities API carries `available` (boolean) and, when false, `unavailable_reason` naming the first broken edge — e.g. `required dep 'data_service' unavailable (provider agent-7 unhealthy)` or `required dep 'weather-api' unresolved (no provider matches tags=[+prod])`. The capability stays visible in the registry, UI, and `meshctl`; availability is distinct from presence.
 
+## Service Views (RFC #1280)
+
+A **service view** aggregates several capability dependencies behind one typed class. Decorate a class with `@mesh.service`; every public method is an **`async` stub** carrying `@mesh.selector("cap", ...)` that binds one capability. Pass the view class as a `@mesh.tool` parameter (detected by type, like `MeshJob`) and the framework injects a facade whose methods each delegate to their capability's own resolved proxy — so different methods can resolve to different provider agents and rebind independently.
+
+```python
+@mesh.service                       # or @mesh.service(min_available=2)
+class MediaService:
+    @mesh.selector("media.caption", required=True, tags=["+fast"])
+    async def caption(self, args: dict) -> dict: ...
+    @mesh.selector("media.thumbnail")
+    async def thumbnail(self, args: dict) -> dict: ...
+    @mesh.selector("media.transcribe")
+    async def transcribe(self, args: dict) -> dict: ...
+
+
+@app.tool()
+@mesh.tool(capability="process_media", dependencies=["audit_log"])
+async def process_media(
+    req: dict,
+    audit: mesh.McpMeshTool = None,
+    media: MediaService = None,
+):
+    caption = await media.caption({"text": req["text"]})   # dict → the target tool's named args
+    try:
+        thumb = await media.thumbnail({"asset_id": req["id"]})
+    except ToolError:                                       # optional method unresolved
+        thumb = None
+    return {"caption": caption, "thumbnail": thumb}
+```
+
+A facade call takes one `dict` that becomes the target tool's named arguments, and accepts a `headers=` kwarg for header propagation. Each view method expands into an ordinary dependency edge appended **after** the tool's explicit `dependencies` — name-sorted within a view, in parameter order across multiple views — so a view over N capabilities shows as **N dependencies** in `meshctl list`. Capability names are dot-namespaced (see the [naming rules](capabilities-tags.md#capability-naming-conventions)).
+
+- Every method must be `async def` with `@mesh.selector`; a **sync** stub or a selector-less public method **boot-fails** (make helpers private with a leading underscore).
+- A `required=True` method joins the tool's pre-invoke guard: an unresolved required edge makes the tool return the structured `dependency_unavailable` refusal before the handler runs (direct and claim paths). An unresolved **optional** method raises `ToolError` (`fastmcp.exceptions.ToolError`) carrying that same `dependency_unavailable` payload on its own call only — catch it to degrade gracefully.
+- `@mesh.service(min_available=N)` adds a consumer-local floor: below `N` resolved methods every facade call raises `mesh.MeshServiceUnavailableError` (settle-aware). Default `0` = no floor.
+- **Testing:** passing your own facade object for the view parameter skips the pre-invoke refusal and settle wait for that view — mock the facade directly in unit tests.
+- Views are a **tool-parameter** surface only: a view in `@mesh.route` boot-fails, and an undecorated subclass of a view is not a view (decorate the class directly).
+
+### Publishing a service (producer side)
+
+Give `@mesh.service` a **prefix** and the class becomes a producer: each public method (a real `async` implementation) publishes as an ordinary tool with capability `prefix.<method>`.
+
+```python
+@mesh.service("media")              # publishes media.caption, media.thumbnail
+class MediaTools:
+    async def caption(self, args: dict) -> dict:
+        return {"caption": f"a scene: {args['text']}"}
+    async def thumbnail(self, args: dict) -> dict:
+        return {"uri": f"thumb://{args['asset_id']}"}
+```
+
+- Methods publish **name-sorted** under dotted tool names; underscore-prefixed methods are skipped.
+- A method carrying its own `@mesh.tool` **wins** (keeps its declared capability/tags/version).
+- The class must be **zero-arg constructible** (instantiated once at decoration time to publish bound methods); the `prefix` is segment-validated against the dotted-capability grammar. A `@mesh.selector` inside a prefixed class is a **mixed-roles boot-fail**, and `min_available` is consumer-only.
+
 ## Proxy Configuration
 
 Configure proxy behavior via `dependency_kwargs`:

--- a/docs/python/dependency-injection.md
+++ b/docs/python/dependency-injection.md
@@ -199,7 +199,10 @@ async def process_media(
     caption = await media.caption({"text": req["text"]})   # dict → the target tool's named args
     try:
         thumb = await media.thumbnail({"asset_id": req["id"]})
-    except ToolError:                                       # optional method unresolved
+    except ToolError as e:
+        # swallow ONLY the unresolved-optional refusal, not provider-side errors
+        if "dependency_unavailable" not in str(e):
+            raise
         thumb = None
     return {"caption": caption, "thumbnail": thumb}
 ```

--- a/docs/typescript/dependency-injection.md
+++ b/docs/typescript/dependency-injection.md
@@ -224,6 +224,61 @@ agent.addTool({
 
 **Inspecting availability.** Each capability in the agents/capabilities API carries `available` (boolean) and, when false, `unavailable_reason` naming the first broken edge — e.g. `required dep 'data_service' unavailable (provider agent-7 unhealthy)` or `required dep 'weather-api' unresolved (no provider matches tags=[+prod])`. The capability stays visible in the registry, UI, and `meshctl`; availability is distinct from presence.
 
+## Service Views (RFC #1280)
+
+A **service view** aggregates several capability dependencies behind one typed facade. `mesh.serviceView({ methods })` returns a branded value you place as **one** entry in a tool's `dependencies` array; it expands into N ordinary edges (one per method, name-sorted) and the framework injects a single facade argument. Each method delegates to its own resolved proxy, so different methods can bind different provider agents and rebind independently.
+
+```ts
+const Media = mesh.serviceView({
+  methods: {
+    caption: { capability: "media.caption", required: true, tags: ["+fast"] },
+    thumbnail: "media.thumbnail",
+    transcribe: "media.transcribe",
+  },
+  // minAvailable: 2,
+});
+
+agent.addTool({
+  name: "process_media",
+  dependencies: ["audit_log", Media],
+  execute: async (args, auditLog, media) => {
+    // dep params are inferred; cast the view slot to type its methods
+    const svc = media as MeshServiceFacade<typeof Media>;
+    const caption = await svc.caption({ text: args.text });
+    let thumb: unknown = null;
+    try {
+      thumb = await svc.thumbnail({ id: args.id });
+    } catch (e) {
+      if (!(e instanceof TypeError)) throw e;               // optional method unresolved
+    }
+    return { caption, thumb };
+  },
+});
+```
+
+The view slot expands **in place** (name-sorted), so its edges keep contiguous indices and a view over N capabilities shows as **N dependencies** in `meshctl list`. A method spec is a capability string or an object (`capability`, `tags`, `version`, `required`, `expectedSchema`, `matchMode`). Leave the `execute` dependency params un-annotated (they're inferred) and cast the view slot at point of use — `const svc = view as MeshServiceFacade<typeof View>` — to type its method keys; a direct parameter annotation doesn't compile under `strictFunctionTypes`. Capability names are dot-namespaced (see the [naming rules](capabilities-tags.md#capability-naming-conventions)).
+
+- A `required` method joins the tool's pre-invoke guard: an unresolved required edge makes the tool refuse with a `UserError` carrying the structured `dependency_unavailable` payload before the handler runs (direct and claim paths). An unresolved **optional** method rejects with a `TypeError` (the null-proxy passthrough) on its own call only.
+- `minAvailable` adds a consumer-local floor: below it every facade call throws `MeshServiceUnavailableError` (settle-aware).
+- A view **forces inline execution** — per-tool worker isolation is disabled for a view-bearing tool, with a warning logged at registration when `MCP_MESH_TOOL_WORKERS>1`.
+- Views are a **tool-parameter** surface only: a `mesh.serviceView(...)` in `mesh.route(...)` or `mesh.a2a.mount(...)` dependencies is rejected.
+
+### Publishing a service (producer side)
+
+`agent.addService("prefix", { ... })` publishes each entry as an ordinary tool with capability `prefix.<method>` (name-sorted). An entry is a bare `execute` function or an object carrying `execute` plus `addTool` passthrough (`tags`, `description`, …); `name`/`capability` are derived and must not be supplied.
+
+```ts
+agent.addService("media", {
+  caption: async (args) => ({ caption: `a scene: ${args.text}` }),
+  thumbnail: {
+    execute: async (args) => ({ uri: `thumb://${args.id}` }),
+    tags: ["fast"],
+  },
+});
+```
+
+The `prefix` is segment-validated against the dotted-capability grammar — the SDK's only capability-name check, mirroring the registry contract. A derived name that collides with an existing tool throws.
+
 ## Proxy Configuration
 
 Configure proxy behavior via `dependencyKwargs` — an array indexed by dependency position (aligned with `dependencies`):

--- a/docs/typescript/mesh-functions.md
+++ b/docs/typescript/mesh-functions.md
@@ -85,6 +85,40 @@ agent.addTool({
 | `McpMeshTool`  | Tool calls via proxy                   |
 | `null`          | Dependency unavailable                 |
 
+## mesh.serviceView() / agent.addService()
+
+Service views aggregate capabilities behind one typed facade, or publish a group of tools under a dotted prefix (RFC #1280).
+
+**Consumer** — one `dependencies` entry expanding to N edges, injected as a facade argument:
+
+```ts
+const Media = mesh.serviceView({
+  methods: {
+    caption: { capability: "media.caption", required: true },
+    thumbnail: "media.thumbnail",
+  },
+});
+
+agent.addTool({
+  name: "process_media",
+  dependencies: [Media],
+  execute: async (args, media) =>
+    // dep params are inferred; cast the view slot to type its methods
+    (media as MeshServiceFacade<typeof Media>).caption({ text: args.text }),
+});
+```
+
+**Producer** — publish methods as `prefix.<method>` tools:
+
+```ts
+agent.addService("media", {
+  caption: async (args) => ({ caption: `a scene: ${args.text}` }),
+  thumbnail: async (args) => ({ uri: `thumb://${args.id}` }),
+});
+```
+
+`required` view edges get the pre-invoke `dependency_unavailable` refusal (a `UserError`); `minAvailable` (consumer-only) adds a floor; a view forces inline execution and is rejected in `mesh.route(...)` / `mesh.a2a.mount(...)`. For the full semantics see the [Dependency Injection](dependency-injection.md#service-views-rfc-1280) guide.
+
 ## mesh.llm()
 
 Creates an LLM-powered tool with automatic tool discovery.

--- a/examples/python/service-view/README.md
+++ b/examples/python/service-view/README.md
@@ -1,0 +1,181 @@
+# Service View Example — `@mesh.service` (RFC #1280, Python)
+
+**Three methods, three different provider agents, one typed interface.**
+
+This is the Python sibling of
+[`examples/java/service-view`](../../java/service-view) and
+[`examples/typescript/service-view`](../../typescript/service-view). All three
+tell the same story with the **same `media.*` capabilities**, so the agents are
+**cross-runtime interchangeable** — a Python gateway can consume the Java
+providers, a Java gateway can consume the TypeScript providers, and so on.
+
+A service view aggregates several ordinary capability dependencies behind one
+typed interface. Each method binds a single capability, and calling it delegates
+to that capability's own resolved proxy — so different methods resolve to
+**different provider agents** and rebind independently as topology changes.
+
+## Agents
+
+| Agent                 | Port | Capability         | Role                                   |
+|-----------------------|------|--------------------|----------------------------------------|
+| `caption-provider`    | 8120 | `media.caption`    | Provider A — captions an asset         |
+| `thumbnail-provider`  | 8121 | `media.thumbnail`  | Provider B — thumbnails an asset       |
+| `transcribe-provider` | 8122 | `media.transcribe` | Provider C — transcribes an asset      |
+| `media-gateway`       | 8123 | `process_media`    | Consumer — one `MediaService` view     |
+
+## Producer side: publish a service, not N tools
+
+Each provider is a producer-sugar class: `@mesh.service("media")` publishes each
+public async method as a mesh tool under the capability `media.<method>` — no
+per-method `@mesh.tool` needed.
+
+```python
+@mesh.service("media")          # prefix is entirely user-chosen; nothing is hard-coded
+class MediaCaptionService:
+    async def caption(self, assetId: str, text: str) -> dict:   # → capability "media.caption"
+        return {"assetId": assetId, "caption": ..., "provider": "caption-provider"}
+```
+
+- **Dotted capability names are first-class** across the stack — the
+  registry and the Python/Java/TypeScript runtimes all accept segment-wise names
+  like `media.caption`. The published capability is simply `prefix.<method>`.
+- **The prefix is yours** — `"media"` carries no special meaning. All three
+  agents use `"media"`, so together they populate one namespace from three
+  independent processes.
+- A method carrying its own `@mesh.tool` still WINS — reach for it only when a
+  method needs custom tags/version/description.
+
+## Consumer side: one typed view
+
+```python
+@mesh.service
+class MediaService:
+    @mesh.selector("media.caption", required=True)
+    async def caption(self, args: dict) -> dict: ...
+    @mesh.selector("media.thumbnail")
+    async def thumbnail(self, args: dict) -> dict: ...
+    @mesh.selector("media.transcribe")
+    async def transcribe(self, args: dict) -> dict: ...
+
+@mesh.tool(capability="process_media", tags=["media", "gateway"])
+async def process_media(assetId: str, text: str, media: MediaService = None) -> dict:
+    ...  # media is the injected facade, hidden from the MCP input schema
+```
+
+The view is injected as a **tool parameter**: each method becomes a dependency
+edge on `process_media`, expanded name-sorted. `caption` is `required`;
+`thumbnail`/`transcribe` are optional.
+
+## What it demonstrates
+
+- **Per-method multi-agent resolution.** One `process_media` call fans out
+  across all three methods; the combined result's `servedBy` fields name three
+  different provider agents answering through one interface.
+- **Independent rebinding.** Stop `thumbnail-provider` and only that method's
+  edge goes away; the others keep resolving to their own agents.
+- **Two refusal behaviors:**
+  - a missing **required** `caption` provider → the tool returns the structured
+    `dependency_unavailable` refusal BEFORE the handler runs;
+  - a missing **optional** provider → the facade call raises `ToolError`, which
+    the handler catches and substitutes a fallback (graceful degradation).
+
+## Run it locally
+
+`meshctl start` runs each agent and starts a local registry automatically if
+none is running. Use four terminals (or add `--detach`):
+
+```bash
+# Terminal 1 — provider A (also starts the local registry)
+meshctl start examples/python/service-view/caption-provider/main.py
+
+# Terminal 2 — provider B
+meshctl start examples/python/service-view/thumbnail-provider/main.py
+
+# Terminal 3 — provider C
+meshctl start examples/python/service-view/transcribe-provider/main.py
+
+# Terminal 4 — the consumer/gateway
+meshctl start examples/python/service-view/media-gateway/main.py
+```
+
+Once all four are healthy, call the gateway's entry-point tool:
+
+```bash
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+```
+
+Expected output — one interface, three different serving agents:
+
+```json
+{
+  "assetId": "asset-1",
+  "caption":    { "value": "A scene showing a cat on a sofa.",     "servedBy": "caption-provider" },
+  "thumbnail":  { "value": "thumb://asset-1?w=320&h=180 (320x180)", "servedBy": "thumbnail-provider" },
+  "transcript": { "value": "[asset-1] A CAT ON A SOFA [5 words]",   "servedBy": "transcribe-provider" }
+}
+```
+
+You can also call any producer capability directly by its dotted name:
+
+```bash
+meshctl call media.caption '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+# -> {"assetId":"asset-1","caption":"A scene showing a cat on a sofa.","provider":"caption-provider"}
+```
+
+Inspect the published services and the view edges:
+
+```bash
+meshctl list --services   # media.caption / media.thumbnail / media.transcribe and their agents
+```
+
+### See graceful degradation (optional edge)
+
+Stop one OPTIONAL provider and call again — only that method degrades. Allow a
+few seconds for the consumer's next heartbeat to rebind:
+
+```bash
+meshctl stop transcribe-provider
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+# -> transcript: { "value": "(no transcript — provider offline)", "servedBy": "unavailable" }
+```
+
+### See the tool-boundary refusal (required edge)
+
+Stop the REQUIRED `caption-provider` and call again:
+
+```bash
+meshctl stop caption-provider
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+```
+
+The call is refused BEFORE the handler runs, with the structured error carried
+as JSON in the tool result:
+
+```json
+{ "error": "dependency_unavailable", "capability": "media.caption" }
+```
+
+Restart the providers to return to the healthy output above.
+
+## Cross-runtime interchangeability
+
+Because the capabilities (`media.caption` / `media.thumbnail` /
+`media.transcribe`) and their `assetId` / `text` / `width` parameters are
+identical across the Java, Python, and TypeScript examples, you can mix runtimes
+freely. For example, start the Java providers and this Python gateway:
+
+```bash
+# Java providers
+meshctl start examples/java/service-view/caption-provider
+meshctl start examples/java/service-view/thumbnail-provider
+meshctl start examples/java/service-view/transcribe-provider
+# Python gateway over them
+meshctl start examples/python/service-view/media-gateway/main.py
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+```
+
+## Documentation
+
+- Run `meshctl man decorators` for the decorator reference.
+- Run `meshctl man dependency-injection` for capability resolution and
+  availability semantics.

--- a/examples/python/service-view/caption-provider/.dockerignore
+++ b/examples/python/service-view/caption-provider/.dockerignore
@@ -1,0 +1,51 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Documentation
+docs/_build/
+*.md
+
+# Local files
+*.local
+.DS_Store

--- a/examples/python/service-view/caption-provider/Dockerfile
+++ b/examples/python/service-view/caption-provider/Dockerfile
@@ -1,0 +1,25 @@
+# Dockerfile for caption-provider MCP Mesh agent
+FROM mcpmesh/python-runtime:2.8.2
+
+WORKDIR /app
+
+# Switch to root to copy files (base image runs as non-root mcp-mesh user)
+USER root
+
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy agent source code and set permissions
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
+
+# Switch back to non-root user for security
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 8120
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["python"], so CMD only needs the script name
+CMD ["main.py"]

--- a/examples/python/service-view/caption-provider/README.md
+++ b/examples/python/service-view/caption-provider/README.md
@@ -1,0 +1,64 @@
+# caption-provider
+
+Provider A in the [`@mesh.service` service-view example](../README.md).
+
+## Overview
+
+A Python MCP Mesh agent. Publishes the `media.caption` capability via **producer sugar**:
+the `@mesh.service("media")` class exposes one public async method, so the mesh
+publishes it as the dotted capability `media.caption` — no per-method `@mesh.tool`.
+
+The `media.*` capability + its parameters match the Java and TypeScript
+providers exactly, so gateways in ANY runtime are interchangeable.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.11+
+- MCP Mesh SDK
+- FastMCP
+
+### Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+### Running the Agent
+
+```bash
+meshctl start main.py
+```
+
+The agent will start on port 8120 by default. Override with the
+`MCP_MESH_HTTP_PORT` environment variable or the `http_port` parameter in the
+`@mesh.agent` decorator.
+
+## Project Structure
+
+```text
+caption-provider/
+├── main.py            # agent bootstrap + @mesh.service("media") producer
+├── requirements.txt
+├── Dockerfile
+├── helm-values.yaml
+├── __init__.py
+└── __main__.py
+```
+
+## Docker
+
+```bash
+docker build -t caption-provider:latest .
+docker run -p 8120:8120 caption-provider:latest
+```
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- Run `meshctl man decorators` for the decorator reference
+
+## License
+
+MIT

--- a/examples/python/service-view/caption-provider/__init__.py
+++ b/examples/python/service-view/caption-provider/__init__.py
@@ -1,0 +1,1 @@
+"""CaptionProvider Agent - MCP Mesh agent."""

--- a/examples/python/service-view/caption-provider/__main__.py
+++ b/examples/python/service-view/caption-provider/__main__.py
@@ -1,3 +1,3 @@
-"""Entry point for `python -m caption_provider`."""
+"""Entry point for `python -m caption-provider` (run from examples/python/service-view/)."""
 
 from . import main  # noqa: F401 — importing `main` triggers the @mesh.agent decorator

--- a/examples/python/service-view/caption-provider/__main__.py
+++ b/examples/python/service-view/caption-provider/__main__.py
@@ -1,0 +1,3 @@
+"""Entry point for `python -m caption_provider`."""
+
+from . import main  # noqa: F401 — importing `main` triggers the @mesh.agent decorator

--- a/examples/python/service-view/caption-provider/helm-values.yaml
+++ b/examples/python/service-view/caption-provider/helm-values.yaml
@@ -1,0 +1,35 @@
+# Helm values for deploying caption-provider with mcp-mesh-agent chart
+# Usage: helm install caption-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/caption-provider
+  tag: "v1.0.0"  # Your image version. Override with: --set image.tag=v1.2.3
+  pullPolicy: IfNotPresent
+
+agent:
+  name: caption-provider
+  runtime: python
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"

--- a/examples/python/service-view/caption-provider/main.py
+++ b/examples/python/service-view/caption-provider/main.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""
+caption-provider - MCP Mesh Agent
+
+Publishes ONE slice of the shared ``media.*`` namespace via producer sugar
+(RFC #1280). A class decorated ``@mesh.service("media")`` publishes each public
+async method as a mesh tool under the capability ``media.<method>`` — so the
+``caption`` method below becomes the dotted capability ``media.caption``.
+
+Cross-runtime note: the parameter names (``assetId``, ``text``) match the Java
+and TypeScript providers exactly, so a gateway in ANY runtime can consume this
+provider — the capability + wire schema are identical across runtimes.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+# FastMCP server instance (hosts the agent's /mcp HTTP endpoint).
+app = FastMCP("Caption Provider Service")
+
+
+@mesh.service("media")
+class MediaCaptionService:
+    """Producer sugar: publishes ``media.caption`` (prefix + method name).
+
+    The ``"media"`` prefix is entirely user-chosen — nothing about it is
+    hard-coded in the mesh.
+    """
+
+    async def caption(self, assetId: str, text: str) -> dict:
+        """Generate a deterministic caption for a media asset."""
+        return {
+            "assetId": assetId,
+            "caption": f"A scene showing {text.strip().lower()}.",
+            "provider": "caption-provider",
+        }
+
+
+@mesh.agent(
+    name="caption-provider",
+    version="1.0.0",
+    description="Publishes media.caption into the shared media.* namespace",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "8120")),
+    enable_http=True,
+    auto_run=True,
+)
+class CaptionProvider:
+    """Agent bootstrap — the mesh processor discovers ``app`` and the
+    ``@mesh.service`` producer, then serves + registers ``media.caption``."""
+
+    pass

--- a/examples/python/service-view/caption-provider/requirements.txt
+++ b/examples/python/service-view/caption-provider/requirements.txt
@@ -1,0 +1,3 @@
+# caption-provider dependencies
+# Add your third-party dependencies here
+# Note: mcp-mesh is provided by the runtime environment (local venv or Docker base image)

--- a/examples/python/service-view/media-gateway/.dockerignore
+++ b/examples/python/service-view/media-gateway/.dockerignore
@@ -1,0 +1,51 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Documentation
+docs/_build/
+*.md
+
+# Local files
+*.local
+.DS_Store

--- a/examples/python/service-view/media-gateway/Dockerfile
+++ b/examples/python/service-view/media-gateway/Dockerfile
@@ -1,0 +1,25 @@
+# Dockerfile for media-gateway MCP Mesh agent
+FROM mcpmesh/python-runtime:2.8.2
+
+WORKDIR /app
+
+# Switch to root to copy files (base image runs as non-root mcp-mesh user)
+USER root
+
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy agent source code and set permissions
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
+
+# Switch back to non-root user for security
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 8123
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["python"], so CMD only needs the script name
+CMD ["main.py"]

--- a/examples/python/service-view/media-gateway/README.md
+++ b/examples/python/service-view/media-gateway/README.md
@@ -1,0 +1,87 @@
+# media-gateway
+
+The consumer in the [`@mesh.service` service-view example](../README.md).
+Declares one typed `MediaService` view aggregating three `media.*` capabilities
+and exposes a `process_media` tool that fans a request out across all three view
+methods — each served by a different provider agent.
+
+## Overview
+
+A Python MCP Mesh agent. `MediaService` is a consumer service view; it is
+injected as a `@mesh.tool` parameter (hidden from the MCP input schema):
+
+```python
+@mesh.service
+class MediaService:
+    @mesh.selector("media.caption", required=True)
+    async def caption(self, args: dict) -> dict: ...
+    @mesh.selector("media.thumbnail")
+    async def thumbnail(self, args: dict) -> dict: ...
+    @mesh.selector("media.transcribe")
+    async def transcribe(self, args: dict) -> dict: ...
+
+@mesh.tool(capability="process_media", tags=["media", "gateway"])
+async def process_media(assetId: str, text: str, media: MediaService = None) -> dict:
+    ...
+```
+
+`caption` is `required` (missing provider → structured `dependency_unavailable`
+refusal before the handler runs); `thumbnail`/`transcribe` are optional and
+raise `ToolError` when unresolved, which the handler catches for graceful
+degradation.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.11+
+- MCP Mesh SDK
+- FastMCP
+- The three providers running (`caption-provider`, `thumbnail-provider`,
+  `transcribe-provider`)
+
+### Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+### Running the Agent
+
+```bash
+meshctl start main.py
+```
+
+The agent will start on port 8123 by default. Then:
+
+```bash
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+```
+
+## Project Structure
+
+```text
+media-gateway/
+├── main.py            # MediaService view + process_media tool
+├── requirements.txt
+├── Dockerfile
+├── helm-values.yaml
+├── __init__.py
+└── __main__.py
+```
+
+## Docker
+
+```bash
+docker build -t media-gateway:latest .
+docker run -p 8123:8123 media-gateway:latest
+```
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- Run `meshctl man decorators` for the decorator reference
+
+## License
+
+MIT

--- a/examples/python/service-view/media-gateway/__init__.py
+++ b/examples/python/service-view/media-gateway/__init__.py
@@ -1,0 +1,1 @@
+"""MediaGateway Agent - MCP Mesh agent."""

--- a/examples/python/service-view/media-gateway/__main__.py
+++ b/examples/python/service-view/media-gateway/__main__.py
@@ -1,0 +1,3 @@
+"""Entry point for `python -m media_gateway`."""
+
+from . import main  # noqa: F401 — importing `main` triggers the @mesh.agent decorator

--- a/examples/python/service-view/media-gateway/__main__.py
+++ b/examples/python/service-view/media-gateway/__main__.py
@@ -1,3 +1,3 @@
-"""Entry point for `python -m media_gateway`."""
+"""Entry point for `python -m media-gateway` (run from examples/python/service-view/)."""
 
 from . import main  # noqa: F401 — importing `main` triggers the @mesh.agent decorator

--- a/examples/python/service-view/media-gateway/helm-values.yaml
+++ b/examples/python/service-view/media-gateway/helm-values.yaml
@@ -1,0 +1,35 @@
+# Helm values for deploying media-gateway with mcp-mesh-agent chart
+# Usage: helm install media-gateway oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/media-gateway
+  tag: "v1.0.0"  # Your image version. Override with: --set image.tag=v1.2.3
+  pullPolicy: IfNotPresent
+
+agent:
+  name: media-gateway
+  runtime: python
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"

--- a/examples/python/service-view/media-gateway/main.py
+++ b/examples/python/service-view/media-gateway/main.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+media-gateway - MCP Mesh Agent
+
+Aggregates three independent capabilities behind ONE typed service view
+(RFC #1280) and fans a single request out across them. Because each view method
+binds its own capability, the ``servedBy`` fields in the result name THREE
+different provider agents answering through one interface.
+
+Consumption style: the view is injected as a ``@mesh.tool`` PARAMETER (the
+Python form of RFC #1280). Each view method becomes a dependency edge on the
+``process_media`` tool. The ``caption`` method is ``required=True``, so the mesh
+runtime returns the structured ``dependency_unavailable`` refusal BEFORE the
+handler runs whenever caption has no provider; the optional ``thumbnail`` /
+``transcribe`` methods raise ``ToolError`` when unresolved, which the handler
+catches for graceful degradation.
+
+Cross-runtime: the ``media.*`` capabilities are identical across the Java,
+Python, and TypeScript examples, so this gateway can consume the providers from
+ANY runtime (e.g. a Python gateway over the Java providers) and vice versa.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+
+app = FastMCP("Media Gateway Service")
+
+
+@mesh.service
+class MediaService:
+    """Consumer service view: three capabilities behind one typed interface.
+
+    Each method is a selector stub (its body never runs); the framework injects
+    a facade whose methods delegate to each capability's own resolved proxy.
+    """
+
+    @mesh.selector("media.caption", required=True)
+    async def caption(self, args: dict) -> dict: ...
+
+    @mesh.selector("media.thumbnail")
+    async def thumbnail(self, args: dict) -> dict: ...
+
+    @mesh.selector("media.transcribe")
+    async def transcribe(self, args: dict) -> dict: ...
+
+
+def _entry(value: str, served_by: str) -> dict:
+    """One combined-result entry: the value plus the provider agent that served it."""
+    return {"value": value, "servedBy": served_by}
+
+
+async def _combine(media: MediaService, asset_id: str, text: str) -> dict:
+    """Run one asset through all three view methods and combine the results."""
+    result: dict = {"assetId": asset_id}
+
+    # REQUIRED edge — a missing provider is refused before this handler runs.
+    caption = await media.caption({"assetId": asset_id, "text": text})
+    result["caption"] = _entry(caption["caption"], caption["provider"])
+
+    # OPTIONAL edge — degrade gracefully if no thumbnail provider is present.
+    try:
+        thumb = await media.thumbnail({"assetId": asset_id, "width": 320})
+        result["thumbnail"] = _entry(f"{thumb['uri']} ({thumb['size']})", thumb["provider"])
+    except ToolError:
+        result["thumbnail"] = _entry("(no thumbnail — provider offline)", "unavailable")
+
+    # OPTIONAL edge — degrade gracefully if no transcribe provider is present.
+    try:
+        tx = await media.transcribe({"assetId": asset_id, "text": text})
+        result["transcript"] = _entry(
+            f"{tx['transcript']} [{tx['wordCount']} words]", tx["provider"]
+        )
+    except ToolError:
+        result["transcript"] = _entry("(no transcript — provider offline)", "unavailable")
+
+    return result
+
+
+@app.tool()
+@mesh.tool(
+    capability="process_media",
+    description="Runs an asset through caption, thumbnail and transcribe via one service view",
+    tags=["media", "gateway"],
+)
+async def process_media(assetId: str, text: str, media: MediaService = None) -> dict:
+    """Fan one media asset across the three view methods and combine results.
+
+    ``media`` is the injected service-view facade (hidden from the MCP input
+    schema); ``assetId`` and ``text`` are the tool's real inputs.
+    """
+    return await _combine(media, assetId, text)
+
+
+@mesh.agent(
+    name="media-gateway",
+    version="1.0.0",
+    description="Aggregates three media capabilities behind one typed service view",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "8123")),
+    enable_http=True,
+    auto_run=True,
+)
+class MediaGateway:
+    pass

--- a/examples/python/service-view/media-gateway/main.py
+++ b/examples/python/service-view/media-gateway/main.py
@@ -20,6 +20,7 @@ Python, and TypeScript examples, so this gateway can consume the providers from
 ANY runtime (e.g. a Python gateway over the Java providers) and vice versa.
 """
 
+import json
 import os
 
 import mesh
@@ -27,6 +28,22 @@ from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 
 app = FastMCP("Media Gateway Service")
+
+
+def _is_dependency_unavailable(err: ToolError) -> bool:
+    """True only for the structured ``dependency_unavailable`` refusal.
+
+    An unresolved OPTIONAL view edge raises ``ToolError`` whose message is the
+    JSON ``{"error": "dependency_unavailable", "capability": "..."}``. Inspect
+    the payload so we degrade ONLY on that shape — any other ToolError (a real
+    provider bug, a bad request) must propagate rather than be masked as
+    "provider offline".
+    """
+    try:
+        payload = json.loads(str(err))
+    except (ValueError, TypeError):
+        return False
+    return isinstance(payload, dict) and payload.get("error") == "dependency_unavailable"
 
 
 @mesh.service
@@ -60,20 +77,24 @@ async def _combine(media: MediaService, asset_id: str, text: str) -> dict:
     caption = await media.caption({"assetId": asset_id, "text": text})
     result["caption"] = _entry(caption["caption"], caption["provider"])
 
-    # OPTIONAL edge — degrade gracefully if no thumbnail provider is present.
+    # OPTIONAL edge — degrade gracefully ONLY on dependency_unavailable.
     try:
         thumb = await media.thumbnail({"assetId": asset_id, "width": 320})
         result["thumbnail"] = _entry(f"{thumb['uri']} ({thumb['size']})", thumb["provider"])
-    except ToolError:
+    except ToolError as e:
+        if not _is_dependency_unavailable(e):
+            raise
         result["thumbnail"] = _entry("(no thumbnail — provider offline)", "unavailable")
 
-    # OPTIONAL edge — degrade gracefully if no transcribe provider is present.
+    # OPTIONAL edge — degrade gracefully ONLY on dependency_unavailable.
     try:
         tx = await media.transcribe({"assetId": asset_id, "text": text})
         result["transcript"] = _entry(
             f"{tx['transcript']} [{tx['wordCount']} words]", tx["provider"]
         )
-    except ToolError:
+    except ToolError as e:
+        if not _is_dependency_unavailable(e):
+            raise
         result["transcript"] = _entry("(no transcript — provider offline)", "unavailable")
 
     return result

--- a/examples/python/service-view/media-gateway/requirements.txt
+++ b/examples/python/service-view/media-gateway/requirements.txt
@@ -1,0 +1,3 @@
+# media-gateway dependencies
+# Add your third-party dependencies here
+# Note: mcp-mesh is provided by the runtime environment (local venv or Docker base image)

--- a/examples/python/service-view/thumbnail-provider/.dockerignore
+++ b/examples/python/service-view/thumbnail-provider/.dockerignore
@@ -1,0 +1,51 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Documentation
+docs/_build/
+*.md
+
+# Local files
+*.local
+.DS_Store

--- a/examples/python/service-view/thumbnail-provider/Dockerfile
+++ b/examples/python/service-view/thumbnail-provider/Dockerfile
@@ -1,0 +1,25 @@
+# Dockerfile for thumbnail-provider MCP Mesh agent
+FROM mcpmesh/python-runtime:2.8.2
+
+WORKDIR /app
+
+# Switch to root to copy files (base image runs as non-root mcp-mesh user)
+USER root
+
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy agent source code and set permissions
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
+
+# Switch back to non-root user for security
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 8121
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["python"], so CMD only needs the script name
+CMD ["main.py"]

--- a/examples/python/service-view/thumbnail-provider/README.md
+++ b/examples/python/service-view/thumbnail-provider/README.md
@@ -1,0 +1,64 @@
+# thumbnail-provider
+
+Provider B (optional edge — stop it to see graceful degradation) in the [`@mesh.service` service-view example](../README.md).
+
+## Overview
+
+A Python MCP Mesh agent. Publishes the `media.thumbnail` capability via **producer sugar**:
+the `@mesh.service("media")` class exposes one public async method, so the mesh
+publishes it as the dotted capability `media.thumbnail` — no per-method `@mesh.tool`.
+
+The `media.*` capability + its parameters match the Java and TypeScript
+providers exactly, so gateways in ANY runtime are interchangeable.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.11+
+- MCP Mesh SDK
+- FastMCP
+
+### Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+### Running the Agent
+
+```bash
+meshctl start main.py
+```
+
+The agent will start on port 8121 by default. Override with the
+`MCP_MESH_HTTP_PORT` environment variable or the `http_port` parameter in the
+`@mesh.agent` decorator.
+
+## Project Structure
+
+```text
+thumbnail-provider/
+├── main.py            # agent bootstrap + @mesh.service("media") producer
+├── requirements.txt
+├── Dockerfile
+├── helm-values.yaml
+├── __init__.py
+└── __main__.py
+```
+
+## Docker
+
+```bash
+docker build -t thumbnail-provider:latest .
+docker run -p 8121:8121 thumbnail-provider:latest
+```
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- Run `meshctl man decorators` for the decorator reference
+
+## License
+
+MIT

--- a/examples/python/service-view/thumbnail-provider/__init__.py
+++ b/examples/python/service-view/thumbnail-provider/__init__.py
@@ -1,0 +1,1 @@
+"""ThumbnailProvider Agent - MCP Mesh agent."""

--- a/examples/python/service-view/thumbnail-provider/__main__.py
+++ b/examples/python/service-view/thumbnail-provider/__main__.py
@@ -1,0 +1,3 @@
+"""Entry point for `python -m thumbnail_provider`."""
+
+from . import main  # noqa: F401 — importing `main` triggers the @mesh.agent decorator

--- a/examples/python/service-view/thumbnail-provider/__main__.py
+++ b/examples/python/service-view/thumbnail-provider/__main__.py
@@ -1,3 +1,3 @@
-"""Entry point for `python -m thumbnail_provider`."""
+"""Entry point for `python -m thumbnail-provider` (run from examples/python/service-view/)."""
 
 from . import main  # noqa: F401 — importing `main` triggers the @mesh.agent decorator

--- a/examples/python/service-view/thumbnail-provider/helm-values.yaml
+++ b/examples/python/service-view/thumbnail-provider/helm-values.yaml
@@ -1,0 +1,35 @@
+# Helm values for deploying thumbnail-provider with mcp-mesh-agent chart
+# Usage: helm install thumbnail-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/thumbnail-provider
+  tag: "v1.0.0"  # Your image version. Override with: --set image.tag=v1.2.3
+  pullPolicy: IfNotPresent
+
+agent:
+  name: thumbnail-provider
+  runtime: python
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"

--- a/examples/python/service-view/thumbnail-provider/main.py
+++ b/examples/python/service-view/thumbnail-provider/main.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+thumbnail-provider - MCP Mesh Agent
+
+Publishes ``media.thumbnail`` via producer sugar (RFC #1280): a class decorated
+``@mesh.service("media")`` publishes its public ``thumbnail`` method as the
+dotted capability ``media.thumbnail`` — a second slice of the shared ``media.*``
+namespace, served by a DIFFERENT agent than caption/transcribe.
+
+Cross-runtime note: parameter names (``assetId``, ``width``) match the Java and
+TypeScript providers, so any-runtime gateways are interchangeable.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Thumbnail Provider Service")
+
+
+@mesh.service("media")
+class MediaThumbnailService:
+    """Producer sugar: publishes ``media.thumbnail``."""
+
+    async def thumbnail(self, assetId: str, width: int) -> dict:
+        """Generate a deterministic thumbnail descriptor for a media asset."""
+        w = width if width and width > 0 else 128
+        h = max(1, w * 9 // 16)
+        return {
+            "assetId": assetId,
+            "uri": f"thumb://{assetId}?w={w}&h={h}",
+            "size": f"{w}x{h}",
+            "provider": "thumbnail-provider",
+        }
+
+
+@mesh.agent(
+    name="thumbnail-provider",
+    version="1.0.0",
+    description="Publishes media.thumbnail into the shared media.* namespace",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "8121")),
+    enable_http=True,
+    auto_run=True,
+)
+class ThumbnailProvider:
+    pass

--- a/examples/python/service-view/thumbnail-provider/requirements.txt
+++ b/examples/python/service-view/thumbnail-provider/requirements.txt
@@ -1,0 +1,3 @@
+# thumbnail-provider dependencies
+# Add your third-party dependencies here
+# Note: mcp-mesh is provided by the runtime environment (local venv or Docker base image)

--- a/examples/python/service-view/transcribe-provider/.dockerignore
+++ b/examples/python/service-view/transcribe-provider/.dockerignore
@@ -1,0 +1,51 @@
+# Git
+.git
+.gitignore
+
+# Python
+__pycache__
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Documentation
+docs/_build/
+*.md
+
+# Local files
+*.local
+.DS_Store

--- a/examples/python/service-view/transcribe-provider/Dockerfile
+++ b/examples/python/service-view/transcribe-provider/Dockerfile
@@ -1,0 +1,25 @@
+# Dockerfile for transcribe-provider MCP Mesh agent
+FROM mcpmesh/python-runtime:2.8.2
+
+WORKDIR /app
+
+# Switch to root to copy files (base image runs as non-root mcp-mesh user)
+USER root
+
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy agent source code and set permissions
+COPY . .
+RUN chown -R mcp-mesh:mcp-mesh /app && chmod -R 755 /app
+
+# Switch back to non-root user for security
+USER mcp-mesh
+
+# Expose the agent port
+EXPOSE 8122
+
+# Run the agent
+# NOTE: Base image has ENTRYPOINT ["python"], so CMD only needs the script name
+CMD ["main.py"]

--- a/examples/python/service-view/transcribe-provider/README.md
+++ b/examples/python/service-view/transcribe-provider/README.md
@@ -1,0 +1,64 @@
+# transcribe-provider
+
+Provider C (optional edge) in the [`@mesh.service` service-view example](../README.md).
+
+## Overview
+
+A Python MCP Mesh agent. Publishes the `media.transcribe` capability via **producer sugar**:
+the `@mesh.service("media")` class exposes one public async method, so the mesh
+publishes it as the dotted capability `media.transcribe` — no per-method `@mesh.tool`.
+
+The `media.*` capability + its parameters match the Java and TypeScript
+providers exactly, so gateways in ANY runtime are interchangeable.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.11+
+- MCP Mesh SDK
+- FastMCP
+
+### Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+### Running the Agent
+
+```bash
+meshctl start main.py
+```
+
+The agent will start on port 8122 by default. Override with the
+`MCP_MESH_HTTP_PORT` environment variable or the `http_port` parameter in the
+`@mesh.agent` decorator.
+
+## Project Structure
+
+```text
+transcribe-provider/
+├── main.py            # agent bootstrap + @mesh.service("media") producer
+├── requirements.txt
+├── Dockerfile
+├── helm-values.yaml
+├── __init__.py
+└── __main__.py
+```
+
+## Docker
+
+```bash
+docker build -t transcribe-provider:latest .
+docker run -p 8122:8122 transcribe-provider:latest
+```
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- Run `meshctl man decorators` for the decorator reference
+
+## License
+
+MIT

--- a/examples/python/service-view/transcribe-provider/__init__.py
+++ b/examples/python/service-view/transcribe-provider/__init__.py
@@ -1,0 +1,1 @@
+"""TranscribeProvider Agent - MCP Mesh agent."""

--- a/examples/python/service-view/transcribe-provider/__main__.py
+++ b/examples/python/service-view/transcribe-provider/__main__.py
@@ -1,0 +1,3 @@
+"""Entry point for `python -m transcribe_provider`."""
+
+from . import main  # noqa: F401 — importing `main` triggers the @mesh.agent decorator

--- a/examples/python/service-view/transcribe-provider/__main__.py
+++ b/examples/python/service-view/transcribe-provider/__main__.py
@@ -1,3 +1,3 @@
-"""Entry point for `python -m transcribe_provider`."""
+"""Entry point for `python -m transcribe-provider` (run from examples/python/service-view/)."""
 
 from . import main  # noqa: F401 — importing `main` triggers the @mesh.agent decorator

--- a/examples/python/service-view/transcribe-provider/helm-values.yaml
+++ b/examples/python/service-view/transcribe-provider/helm-values.yaml
@@ -1,0 +1,35 @@
+# Helm values for deploying transcribe-provider with mcp-mesh-agent chart
+# Usage: helm install transcribe-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent -f helm-values.yaml
+# Check latest version: helm show chart oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent
+
+image:
+  repository: your-registry/transcribe-provider
+  tag: "v1.0.0"  # Your image version. Override with: --set image.tag=v1.2.3
+  pullPolicy: IfNotPresent
+
+agent:
+  name: transcribe-provider
+  runtime: python
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+mesh:
+  enabled: true
+  # Short name resolves in same namespace as core. For cross-namespace:
+  #   registry.host: mcp-core-mcp-mesh-registry.<core-namespace>.svc.cluster.local
+
+registry:
+  host: "mcp-core-mcp-mesh-registry"
+  port: "8000"
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"

--- a/examples/python/service-view/transcribe-provider/main.py
+++ b/examples/python/service-view/transcribe-provider/main.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+transcribe-provider - MCP Mesh Agent
+
+Publishes ``media.transcribe`` via producer sugar (RFC #1280): a class decorated
+``@mesh.service("media")`` publishes its public ``transcribe`` method as the
+dotted capability ``media.transcribe`` — the third slice of the shared
+``media.*`` namespace, served by its own agent.
+
+Cross-runtime note: parameter names (``assetId``, ``text``) match the Java and
+TypeScript providers, so any-runtime gateways are interchangeable.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Transcribe Provider Service")
+
+
+@mesh.service("media")
+class MediaTranscribeService:
+    """Producer sugar: publishes ``media.transcribe``."""
+
+    async def transcribe(self, assetId: str, text: str) -> dict:
+        """Generate a deterministic transcript for a media asset."""
+        stripped = text.strip()
+        word_count = len(stripped.split()) if stripped else 0
+        return {
+            "assetId": assetId,
+            "transcript": f"[{assetId}] {stripped.upper()}",
+            "wordCount": word_count,
+            "provider": "transcribe-provider",
+        }
+
+
+@mesh.agent(
+    name="transcribe-provider",
+    version="1.0.0",
+    description="Publishes media.transcribe into the shared media.* namespace",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "8122")),
+    enable_http=True,
+    auto_run=True,
+)
+class TranscribeProvider:
+    pass

--- a/examples/python/service-view/transcribe-provider/requirements.txt
+++ b/examples/python/service-view/transcribe-provider/requirements.txt
@@ -1,0 +1,3 @@
+# transcribe-provider dependencies
+# Add your third-party dependencies here
+# Note: mcp-mesh is provided by the runtime environment (local venv or Docker base image)

--- a/examples/typescript/service-view/README.md
+++ b/examples/typescript/service-view/README.md
@@ -1,0 +1,170 @@
+# Service View Example — `mesh.serviceView` / `agent.addService` (RFC #1280, TypeScript)
+
+**Three methods, three different provider agents, one typed interface.**
+
+This is the TypeScript sibling of
+[`examples/java/service-view`](../../java/service-view) and
+[`examples/python/service-view`](../../python/service-view). All three tell the
+same story with the **same `media.*` capabilities**, so the agents are
+**cross-runtime interchangeable** — a TypeScript gateway can consume the Java or
+Python providers, and vice versa.
+
+A service view aggregates several ordinary capability dependencies behind one
+typed facade. Each method binds a single capability, and calling it delegates to
+that capability's own resolved proxy — so different methods resolve to
+**different provider agents** and rebind independently as topology changes.
+
+## Agents
+
+| Agent                 | Port | Capability         | Role                                   |
+|-----------------------|------|--------------------|----------------------------------------|
+| `caption-provider`    | 8130 | `media.caption`    | Provider A — captions an asset         |
+| `thumbnail-provider`  | 8131 | `media.thumbnail`  | Provider B — thumbnails an asset       |
+| `transcribe-provider` | 8132 | `media.transcribe` | Provider C — transcribes an asset      |
+| `media-gateway`       | 8133 | `process_media`    | Consumer — one service view            |
+
+## Producer side: publish a service, not N tools
+
+Each provider calls `agent.addService("media", { ... })`, which publishes each
+entry as a mesh tool under the capability `media.<method>` — no per-method
+`addTool` needed.
+
+```ts
+agent.addService("media", {          // "media" prefix is user-chosen; nothing is hard-coded
+  caption: async (args: { assetId: string; text: string }) => ({   // → capability "media.caption"
+    assetId: args.assetId,
+    caption: `A scene showing ${args.text.trim().toLowerCase()}.`,
+    provider: "caption-provider",
+  }),
+});
+```
+
+- **Dotted capability names are first-class** across the stack — the
+  registry and the Java/Python/TypeScript runtimes all accept segment-wise names
+  like `media.caption`. The published capability is `prefix.<method>`.
+- **The prefix is yours.** All three agents use `"media"`, so together they
+  populate one namespace from three independent processes.
+- Entries are published **name-sorted**; the object form
+  (`{ execute, tags, version, parameters }`) lets a method carry custom metadata.
+
+## Consumer side: one typed view
+
+```ts
+const Media = mesh.serviceView({
+  methods: {
+    caption: { capability: "media.caption", required: true },
+    thumbnail: "media.thumbnail",
+    transcribe: "media.transcribe",
+  },
+});
+
+agent.addTool({
+  name: "process_media",
+  parameters: z.object({ assetId: z.string(), text: z.string() }),
+  dependencies: [Media],   // ONE slot, expands into three name-sorted edges
+  execute: async ({ assetId, text }, media: unknown) =>
+    combine(media as MeshServiceFacade<typeof Media>, assetId, text),
+});
+```
+
+The `serviceView` occupies one positional slot in `dependencies` but expands
+into a dependency edge per method. `caption` is `required`;
+`thumbnail`/`transcribe` are optional. The facade is injected at that slot.
+
+## What it demonstrates
+
+- **Per-method multi-agent resolution.** One `process_media` call fans out
+  across all three methods; the combined result's `servedBy` fields name three
+  different provider agents answering through one interface.
+- **Independent rebinding.** Stop `thumbnail-provider` and only that method's
+  edge goes away; the others keep resolving to their own agents.
+- **Two refusal behaviors:**
+  - a missing **required** `caption` provider → the tool returns the structured
+    `dependency_unavailable` refusal BEFORE the handler runs;
+  - a missing **optional** provider → the facade call throws, which the handler
+    catches and substitutes a fallback (graceful degradation).
+
+## Build
+
+Each agent is a standalone TypeScript project (mirrors the sibling TS examples):
+
+```bash
+cd examples/typescript/service-view/caption-provider
+npm install
+npm run build      # tsc — type-checks against the local @mcpmesh/sdk
+```
+
+## Run it locally
+
+`meshctl start` runs each agent (via `tsx`) and starts a local registry
+automatically if none is running. Use four terminals (or add `--detach`):
+
+```bash
+# Terminal 1 — provider A (also starts the local registry)
+meshctl start examples/typescript/service-view/caption-provider/index.ts
+
+# Terminal 2 — provider B
+meshctl start examples/typescript/service-view/thumbnail-provider/index.ts
+
+# Terminal 3 — provider C
+meshctl start examples/typescript/service-view/transcribe-provider/index.ts
+
+# Terminal 4 — the consumer/gateway
+meshctl start examples/typescript/service-view/media-gateway/index.ts
+```
+
+Once all four are healthy:
+
+```bash
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+```
+
+Expected output — one interface, three different serving agents:
+
+```json
+{
+  "assetId": "asset-1",
+  "caption":    { "value": "A scene showing a cat on a sofa.",     "servedBy": "caption-provider" },
+  "thumbnail":  { "value": "thumb://asset-1?w=320&h=180 (320x180)", "servedBy": "thumbnail-provider" },
+  "transcript": { "value": "[asset-1] A CAT ON A SOFA [5 words]",   "servedBy": "transcribe-provider" }
+}
+```
+
+Call a producer capability directly by its dotted name, and inspect the mesh:
+
+```bash
+meshctl call media.caption '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+meshctl list --services   # media.caption / media.thumbnail / media.transcribe and their agents
+```
+
+### See graceful degradation (optional edge)
+
+```bash
+meshctl stop transcribe-provider
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+# -> transcript: { "value": "(no transcript — provider offline)", "servedBy": "unavailable" }
+```
+
+### See the tool-boundary refusal (required edge)
+
+```bash
+meshctl stop caption-provider
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+# refused before the handler runs:
+# { "error": "dependency_unavailable", "capability": "media.caption" }
+```
+
+Restart the providers to return to the healthy output above.
+
+## Cross-runtime interchangeability
+
+The capabilities (`media.caption` / `media.thumbnail` / `media.transcribe`) and
+their `assetId` / `text` / `width` parameters are identical across the Java,
+Python, and TypeScript examples, so you can mix runtimes freely — e.g. run the
+Python providers and this TypeScript gateway, or vice versa.
+
+## Documentation
+
+- Run `meshctl man decorators` for the decorator reference.
+- Run `meshctl man dependency-injection` for capability resolution and
+  availability semantics.

--- a/examples/typescript/service-view/caption-provider/README.md
+++ b/examples/typescript/service-view/caption-provider/README.md
@@ -1,0 +1,48 @@
+# caption-provider
+
+Provider A in the [service-view example](../README.md).
+
+## Overview
+
+A TypeScript MCP Mesh agent. Publishes the `media.caption` capability via **producer
+sugar**: `agent.addService("media", { ... })` publishes one method as the dotted
+capability `media.caption` — no per-method `addTool`.
+
+The `media.*` capability + its parameters match the Java and Python providers
+exactly, so gateways in ANY runtime are interchangeable.
+
+## Setup
+
+```bash
+cd examples/typescript/service-view/caption-provider
+npm install
+```
+
+## Build (type-check)
+
+```bash
+npm run build      # tsc
+```
+
+## Run
+
+```bash
+npx tsx index.ts
+```
+
+Or with meshctl (starts a local registry automatically if none is running):
+
+```bash
+meshctl start examples/typescript/service-view/caption-provider/index.ts
+```
+
+The agent listens on port 8130.
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- Run `meshctl man decorators` for the decorator reference
+
+## License
+
+MIT

--- a/examples/typescript/service-view/caption-provider/README.md
+++ b/examples/typescript/service-view/caption-provider/README.md
@@ -13,24 +13,21 @@ exactly, so gateways in ANY runtime are interchangeable.
 
 ## Setup
 
+From the repo root, install this agent's dependencies:
+
 ```bash
-cd examples/typescript/service-view/caption-provider
-npm install
+npm --prefix examples/typescript/service-view/caption-provider install
 ```
 
 ## Build (type-check)
 
 ```bash
-npm run build      # tsc
+npm --prefix examples/typescript/service-view/caption-provider run build   # tsc
 ```
 
 ## Run
 
-```bash
-npx tsx index.ts
-```
-
-Or with meshctl (starts a local registry automatically if none is running):
+Start with meshctl (starts a local registry automatically if none is running):
 
 ```bash
 meshctl start examples/typescript/service-view/caption-provider/index.ts

--- a/examples/typescript/service-view/caption-provider/index.ts
+++ b/examples/typescript/service-view/caption-provider/index.ts
@@ -17,6 +17,7 @@
  */
 
 import { mesh, FastMCP } from "@mcpmesh/sdk";
+import { z } from "zod";
 
 const server = new FastMCP({
   name: "Caption Provider Service",
@@ -30,11 +31,23 @@ const agent = mesh(server, {
 });
 
 agent.addService("media", {
-  caption: async (args: { assetId: string; text: string }) => ({
-    assetId: args.assetId,
-    caption: `A scene showing ${args.text.trim().toLowerCase()}.`,
-    provider: "caption-provider",
-  }),
+  // Object form: a Zod schema documents + validates the tool's inputs at
+  // runtime (addService forwards `parameters` to the underlying addTool). The
+  // object-form execute types its args as `unknown`, so narrow after validation.
+  caption: {
+    parameters: z.object({
+      assetId: z.string().describe("Media asset identifier"),
+      text: z.string().describe("Source description text"),
+    }),
+    execute: async (args) => {
+      const { assetId, text } = args as { assetId: string; text: string };
+      return {
+        assetId,
+        caption: `A scene showing ${text.trim().toLowerCase()}.`,
+        provider: "caption-provider",
+      };
+    },
+  },
 });
 
 // The SDK auto-starts after module loading completes.

--- a/examples/typescript/service-view/caption-provider/index.ts
+++ b/examples/typescript/service-view/caption-provider/index.ts
@@ -1,0 +1,41 @@
+/**
+ * caption-provider — MCP Mesh agent (TypeScript).
+ *
+ * Publishes ONE slice of the shared `media.*` namespace via producer sugar
+ * (RFC #1280). `agent.addService("media", { caption })` publishes the `caption`
+ * entry as a mesh tool under the capability `media.caption` (prefix + method
+ * name). The `"media"` prefix is entirely user-chosen — nothing is hard-coded.
+ *
+ * Cross-runtime: the parameter names (`assetId`, `text`) and the `media.caption`
+ * capability match the Java and Python providers exactly, so a gateway in ANY
+ * runtime can consume this provider.
+ *
+ * Run:
+ *   cd examples/typescript/service-view/caption-provider
+ *   npm install
+ *   npx tsx index.ts
+ */
+
+import { mesh, FastMCP } from "@mcpmesh/sdk";
+
+const server = new FastMCP({
+  name: "Caption Provider Service",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "caption-provider",
+  httpPort: 8130,
+  description: "Publishes media.caption into the shared media.* namespace",
+});
+
+agent.addService("media", {
+  caption: async (args: { assetId: string; text: string }) => ({
+    assetId: args.assetId,
+    caption: `A scene showing ${args.text.trim().toLowerCase()}.`,
+    provider: "caption-provider",
+  }),
+});
+
+// The SDK auto-starts after module loading completes.
+console.log("caption-provider defined — publishes media.caption. Waiting for auto-start...");

--- a/examples/typescript/service-view/caption-provider/package-lock.json
+++ b/examples/typescript/service-view/caption-provider/package-lock.json
@@ -1,0 +1,2854 @@
+{
+  "name": "caption-provider-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "caption-provider-example",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mcpmesh/sdk": "file:../../../../src/runtime/typescript",
+        "fastmcp": "^3.34.0",
+        "zod": "^3.24.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "../../../../src/runtime/typescript": {
+      "name": "@mcpmesh/sdk",
+      "version": "2.8.2",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/google-vertex": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@mcpmesh/core": "file:../core/typescript",
+        "ai": "^6.0.0",
+        "fastmcp": "^4.3.2",
+        "handlebars": "^4.7.8",
+        "mcp-proxy": "6.4.4",
+        "undici": "^6.21.0",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.0",
+        "@types/express-v5": "npm:@types/express@^5.0.0",
+        "@types/node": "^22.0.0",
+        "express": "^4.18.0",
+        "express-v5": "npm:express@^5.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@mcpmesh/sdk": {
+      "resolved": "../../../../src/runtime/typescript",
+      "link": true
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastmcp": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.35.0.tgz",
+      "integrity": "sha512-bcyAaVa3Zw5f4xighGg6fNNgEzZoP6tX/O+ZfS2lIhbEULWe/zUWG533JyFEUOjZT7EB+tiZW1ot4eWKmYJ6DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.24.3",
+        "@standard-schema/spec": "^1.0.0",
+        "execa": "^9.6.1",
+        "file-type": "^21.1.1",
+        "fuse.js": "^7.1.0",
+        "hono": "^4.11.5",
+        "mcp-proxy": "^6.4.0",
+        "strict-event-emitter-types": "^2.0.0",
+        "undici": "^7.16.0",
+        "uri-templates": "^0.2.0",
+        "xsschema": "^0.4.3",
+        "yargs": "^18.0.0",
+        "zod": "^4.1.13",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "bin": {
+        "fastmcp": "dist/bin/fastmcp.js"
+      },
+      "peerDependencies": {
+        "jose": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fastmcp/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.2.tgz",
+      "integrity": "sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-readable-ids": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/human-readable-ids/-/human-readable-ids-1.0.4.tgz",
+      "integrity": "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==",
+      "license": "Apache2",
+      "dependencies": {
+        "knuth-shuffle": "^1.0.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/knuth-shuffle": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle/-/knuth-shuffle-1.0.8.tgz",
+      "integrity": "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/koa": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.1.tgz",
+      "integrity": "sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa-router": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-14.0.0.tgz",
+      "integrity": "sha512-Ue8f/PRsLLNm6b7y+eS6xkqvsG2xH11d2VB1HPcfdfW6p5736kCHf2pXaq8q9XPQ01x0Dk7V/P5Il9pe+tGTxA==",
+      "deprecated": "Please use @koa/router instead, starting from v9! ",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^8.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/koa/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/koa/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-proxy": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.5.2.tgz",
+      "integrity": "sha512-3sE9kedh81dqqpObzO0nUf8aAyGnzLVDVH97GCLL3fXCBOkXDWZBts63u0bM5lT1Q4FKZY0+E91dZ7Chb2ybsA==",
+      "license": "MIT",
+      "dependencies": {
+        "pipenet": "^1.3.0"
+      },
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.mjs"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pipenet": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.2.tgz",
+      "integrity": "sha512-mPPqygXr7ccwImeaa8zReY9GubH/1r+kBNfqPVfKREQ1s8bKE3XlOqBMONxJAW4d3ZBNGzP9AZp9Axnhi5uOyw==",
+      "dependencies": {
+        "axios": "^1.7.3",
+        "debug": "^4.3.6",
+        "human-readable-ids": "^1.0.4",
+        "koa": "^3.1.1",
+        "koa-router": "^14.0.0",
+        "pump": "^3.0.3",
+        "tldjs": "^2.3.2",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "pipenet": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tldjs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.2.tgz",
+      "integrity": "sha512-EORDwFMSZKrHPUVDhejCMDeAovRS5d8jZKiqALFiPp3cjKjEldPkxBY39ZSx3c45awz3RpKwJD1cCgGxEfy8/A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-templates": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
+      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
+      "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xsschema": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/xsschema/-/xsschema-0.4.4.tgz",
+      "integrity": "sha512-TMhbk8AhxO+YuDOn3rXBjGXQ+Vja3T13UPQkHx/FemhusaOzRfCSj2seykt0mdnFPsOtO9l3ANf4adcp+4NRGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@valibot/to-json-schema": "^1.0.0",
+        "arktype": "^2.1.20",
+        "effect": "^3.16.0",
+        "sury": "^10.0.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "sury": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/typescript/service-view/caption-provider/package.json
+++ b/examples/typescript/service-view/caption-provider/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "caption-provider-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Service-view producer sugar: publishes media.caption",
+  "scripts": {
+    "start": "tsx index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "file:../../../../src/runtime/typescript",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/typescript/service-view/caption-provider/tsconfig.json
+++ b/examples/typescript/service-view/caption-provider/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/typescript/service-view/media-gateway/README.md
+++ b/examples/typescript/service-view/media-gateway/README.md
@@ -34,29 +34,30 @@ throw when unresolved, which the handler catches for graceful degradation.
 
 ## Setup
 
+From the repo root, install this agent's dependencies:
+
 ```bash
-cd examples/typescript/service-view/media-gateway
-npm install
+npm --prefix examples/typescript/service-view/media-gateway install
 ```
 
 ## Build (type-check)
 
 ```bash
-npm run build      # tsc
+npm --prefix examples/typescript/service-view/media-gateway run build   # tsc
 ```
 
 ## Run
 
-```bash
-npx tsx index.ts
-# then, with the three providers running:
-meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
-```
-
-Or with meshctl (starts a local registry automatically if none is running):
+Start with meshctl (starts a local registry automatically if none is running):
 
 ```bash
 meshctl start examples/typescript/service-view/media-gateway/index.ts
+```
+
+Then, with the three providers running:
+
+```bash
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
 ```
 
 The agent listens on port 8133.

--- a/examples/typescript/service-view/media-gateway/README.md
+++ b/examples/typescript/service-view/media-gateway/README.md
@@ -1,0 +1,71 @@
+# media-gateway
+
+The consumer in the [service-view example](../README.md). Declares one typed
+service view aggregating three `media.*` capabilities and exposes a
+`process_media` tool that fans a request out across all three view methods —
+each served by a different provider agent.
+
+## Overview
+
+A TypeScript MCP Mesh agent. `mesh.serviceView(...)` sits in the tool's
+`dependencies` array and expands into three edges:
+
+```ts
+const Media = mesh.serviceView({
+  methods: {
+    caption: { capability: "media.caption", required: true },
+    thumbnail: "media.thumbnail",
+    transcribe: "media.transcribe",
+  },
+});
+
+agent.addTool({
+  name: "process_media",
+  parameters: z.object({ assetId: z.string(), text: z.string() }),
+  dependencies: [Media],
+  execute: async ({ assetId, text }, media: unknown) =>
+    combine(media as MeshServiceFacade<typeof Media>, assetId, text),
+});
+```
+
+`caption` is `required` (missing provider → structured `dependency_unavailable`
+refusal before the handler runs); `thumbnail`/`transcribe` are optional and
+throw when unresolved, which the handler catches for graceful degradation.
+
+## Setup
+
+```bash
+cd examples/typescript/service-view/media-gateway
+npm install
+```
+
+## Build (type-check)
+
+```bash
+npm run build      # tsc
+```
+
+## Run
+
+```bash
+npx tsx index.ts
+# then, with the three providers running:
+meshctl call process_media '{"assetId": "asset-1", "text": "a cat on a sofa"}'
+```
+
+Or with meshctl (starts a local registry automatically if none is running):
+
+```bash
+meshctl start examples/typescript/service-view/media-gateway/index.ts
+```
+
+The agent listens on port 8133.
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- Run `meshctl man decorators` for the decorator reference
+
+## License
+
+MIT

--- a/examples/typescript/service-view/media-gateway/index.ts
+++ b/examples/typescript/service-view/media-gateway/index.ts
@@ -1,0 +1,118 @@
+/**
+ * media-gateway — MCP Mesh agent (TypeScript).
+ *
+ * Aggregates three independent capabilities behind ONE typed service view
+ * (RFC #1280) and fans a single request out across them. Because each view
+ * method binds its own capability, the `servedBy` fields in the result name
+ * THREE different provider agents answering through one interface.
+ *
+ * Consumption style: `mesh.serviceView(...)` placed in a tool's `dependencies`
+ * array occupies one positional slot but expands into N dependency edges on the
+ * `process_media` tool. The `caption` method is `required`, so the mesh runtime
+ * returns the structured `dependency_unavailable` refusal BEFORE the handler
+ * runs whenever caption has no provider; the optional `thumbnail` / `transcribe`
+ * methods throw when unresolved, which the handler catches for graceful
+ * degradation.
+ *
+ * Cross-runtime: the `media.*` capabilities are identical across the Java,
+ * Python, and TypeScript examples, so this gateway can consume the providers
+ * from ANY runtime and vice versa.
+ *
+ * Run:
+ *   cd examples/typescript/service-view/media-gateway
+ *   npm install
+ *   npx tsx index.ts
+ */
+
+import { mesh, FastMCP, type MeshServiceFacade } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "Media Gateway Service",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "media-gateway",
+  httpPort: 8133,
+  description: "Aggregates three media capabilities behind one typed service view",
+});
+
+// One typed view aggregating three capabilities. caption is required; thumbnail
+// and transcribe are optional. Methods expand into edges NAME-SORTED.
+const Media = mesh.serviceView({
+  methods: {
+    caption: { capability: "media.caption", required: true },
+    thumbnail: "media.thumbnail",
+    transcribe: "media.transcribe",
+  },
+});
+
+type MediaFacade = MeshServiceFacade<typeof Media>;
+
+/** One combined-result entry: the value plus the provider agent that served it. */
+function entry(value: string, servedBy: string) {
+  return { value, servedBy };
+}
+
+/** Shared fan-out: run one asset through all three view methods and combine. */
+async function combine(media: MediaFacade, assetId: string, text: string) {
+  const result: Record<string, unknown> = { assetId };
+
+  // REQUIRED edge — a missing provider is refused before this handler runs.
+  const caption = (await media.caption({ assetId, text })) as {
+    caption: string;
+    provider: string;
+  };
+  result.caption = entry(caption.caption, caption.provider);
+
+  // OPTIONAL edge — degrade gracefully if no thumbnail provider is present.
+  try {
+    const thumb = (await media.thumbnail({ assetId, width: 320 })) as {
+      uri: string;
+      size: string;
+      provider: string;
+    };
+    result.thumbnail = entry(`${thumb.uri} (${thumb.size})`, thumb.provider);
+  } catch (e) {
+    // An unresolved OPTIONAL edge throws when called; anything else (provider
+    // bug, floor error) is a real failure and must propagate.
+    if (!(e instanceof TypeError)) throw e;
+    result.thumbnail = entry("(no thumbnail — provider offline)", "unavailable");
+  }
+
+  // OPTIONAL edge — degrade gracefully if no transcribe provider is present.
+  try {
+    const tx = (await media.transcribe({ assetId, text })) as {
+      transcript: string;
+      wordCount: number;
+      provider: string;
+    };
+    result.transcript = entry(`${tx.transcript} [${tx.wordCount} words]`, tx.provider);
+  } catch (e) {
+    if (!(e instanceof TypeError)) throw e;
+    result.transcript = entry("(no transcript — provider offline)", "unavailable");
+  }
+
+  return result;
+}
+
+agent.addTool({
+  name: "process_media",
+  capability: "process_media",
+  description: "Runs an asset through caption, thumbnail and transcribe via one service view",
+  tags: ["media", "gateway"],
+  parameters: z.object({
+    assetId: z.string().describe("Media asset identifier"),
+    text: z.string().describe("Source description / audio text"),
+  }),
+  dependencies: [Media],
+  // The view facade is injected at the [Media] slot. Its runtime shape is the
+  // MediaFacade, but the execute dep slot is typed McpMeshTool | MeshJob | null,
+  // so annotate `unknown` and narrow to the facade (same idiom as the SDK tests).
+  execute: async ({ assetId, text }, media: unknown) =>
+    combine(media as MediaFacade, assetId, text),
+});
+
+// The SDK auto-starts after module loading completes.
+console.log("media-gateway defined — process_media over one MediaService view. Waiting for auto-start...");

--- a/examples/typescript/service-view/media-gateway/package-lock.json
+++ b/examples/typescript/service-view/media-gateway/package-lock.json
@@ -1,0 +1,2854 @@
+{
+  "name": "media-gateway-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "media-gateway-example",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mcpmesh/sdk": "file:../../../../src/runtime/typescript",
+        "fastmcp": "^3.34.0",
+        "zod": "^3.24.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "../../../../src/runtime/typescript": {
+      "name": "@mcpmesh/sdk",
+      "version": "2.8.2",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/google-vertex": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@mcpmesh/core": "file:../core/typescript",
+        "ai": "^6.0.0",
+        "fastmcp": "^4.3.2",
+        "handlebars": "^4.7.8",
+        "mcp-proxy": "6.4.4",
+        "undici": "^6.21.0",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.0",
+        "@types/express-v5": "npm:@types/express@^5.0.0",
+        "@types/node": "^22.0.0",
+        "express": "^4.18.0",
+        "express-v5": "npm:express@^5.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@mcpmesh/sdk": {
+      "resolved": "../../../../src/runtime/typescript",
+      "link": true
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastmcp": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.35.0.tgz",
+      "integrity": "sha512-bcyAaVa3Zw5f4xighGg6fNNgEzZoP6tX/O+ZfS2lIhbEULWe/zUWG533JyFEUOjZT7EB+tiZW1ot4eWKmYJ6DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.24.3",
+        "@standard-schema/spec": "^1.0.0",
+        "execa": "^9.6.1",
+        "file-type": "^21.1.1",
+        "fuse.js": "^7.1.0",
+        "hono": "^4.11.5",
+        "mcp-proxy": "^6.4.0",
+        "strict-event-emitter-types": "^2.0.0",
+        "undici": "^7.16.0",
+        "uri-templates": "^0.2.0",
+        "xsschema": "^0.4.3",
+        "yargs": "^18.0.0",
+        "zod": "^4.1.13",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "bin": {
+        "fastmcp": "dist/bin/fastmcp.js"
+      },
+      "peerDependencies": {
+        "jose": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fastmcp/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.2.tgz",
+      "integrity": "sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-readable-ids": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/human-readable-ids/-/human-readable-ids-1.0.4.tgz",
+      "integrity": "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==",
+      "license": "Apache2",
+      "dependencies": {
+        "knuth-shuffle": "^1.0.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/knuth-shuffle": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle/-/knuth-shuffle-1.0.8.tgz",
+      "integrity": "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/koa": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.1.tgz",
+      "integrity": "sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa-router": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-14.0.0.tgz",
+      "integrity": "sha512-Ue8f/PRsLLNm6b7y+eS6xkqvsG2xH11d2VB1HPcfdfW6p5736kCHf2pXaq8q9XPQ01x0Dk7V/P5Il9pe+tGTxA==",
+      "deprecated": "Please use @koa/router instead, starting from v9! ",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^8.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/koa/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/koa/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-proxy": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.5.2.tgz",
+      "integrity": "sha512-3sE9kedh81dqqpObzO0nUf8aAyGnzLVDVH97GCLL3fXCBOkXDWZBts63u0bM5lT1Q4FKZY0+E91dZ7Chb2ybsA==",
+      "license": "MIT",
+      "dependencies": {
+        "pipenet": "^1.3.0"
+      },
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.mjs"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pipenet": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.2.tgz",
+      "integrity": "sha512-mPPqygXr7ccwImeaa8zReY9GubH/1r+kBNfqPVfKREQ1s8bKE3XlOqBMONxJAW4d3ZBNGzP9AZp9Axnhi5uOyw==",
+      "dependencies": {
+        "axios": "^1.7.3",
+        "debug": "^4.3.6",
+        "human-readable-ids": "^1.0.4",
+        "koa": "^3.1.1",
+        "koa-router": "^14.0.0",
+        "pump": "^3.0.3",
+        "tldjs": "^2.3.2",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "pipenet": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tldjs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.2.tgz",
+      "integrity": "sha512-EORDwFMSZKrHPUVDhejCMDeAovRS5d8jZKiqALFiPp3cjKjEldPkxBY39ZSx3c45awz3RpKwJD1cCgGxEfy8/A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-templates": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
+      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
+      "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xsschema": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/xsschema/-/xsschema-0.4.4.tgz",
+      "integrity": "sha512-TMhbk8AhxO+YuDOn3rXBjGXQ+Vja3T13UPQkHx/FemhusaOzRfCSj2seykt0mdnFPsOtO9l3ANf4adcp+4NRGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@valibot/to-json-schema": "^1.0.0",
+        "arktype": "^2.1.20",
+        "effect": "^3.16.0",
+        "sury": "^10.0.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "sury": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/typescript/service-view/media-gateway/package.json
+++ b/examples/typescript/service-view/media-gateway/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "media-gateway-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Service-view consumer: aggregates media.* behind one typed view",
+  "scripts": {
+    "start": "tsx index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "file:../../../../src/runtime/typescript",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/typescript/service-view/media-gateway/tsconfig.json
+++ b/examples/typescript/service-view/media-gateway/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/typescript/service-view/thumbnail-provider/README.md
+++ b/examples/typescript/service-view/thumbnail-provider/README.md
@@ -13,24 +13,21 @@ exactly, so gateways in ANY runtime are interchangeable.
 
 ## Setup
 
+From the repo root, install this agent's dependencies:
+
 ```bash
-cd examples/typescript/service-view/thumbnail-provider
-npm install
+npm --prefix examples/typescript/service-view/thumbnail-provider install
 ```
 
 ## Build (type-check)
 
 ```bash
-npm run build      # tsc
+npm --prefix examples/typescript/service-view/thumbnail-provider run build   # tsc
 ```
 
 ## Run
 
-```bash
-npx tsx index.ts
-```
-
-Or with meshctl (starts a local registry automatically if none is running):
+Start with meshctl (starts a local registry automatically if none is running):
 
 ```bash
 meshctl start examples/typescript/service-view/thumbnail-provider/index.ts

--- a/examples/typescript/service-view/thumbnail-provider/README.md
+++ b/examples/typescript/service-view/thumbnail-provider/README.md
@@ -1,0 +1,48 @@
+# thumbnail-provider
+
+Provider B (optional edge — stop it to see graceful degradation) in the [service-view example](../README.md).
+
+## Overview
+
+A TypeScript MCP Mesh agent. Publishes the `media.thumbnail` capability via **producer
+sugar**: `agent.addService("media", { ... })` publishes one method as the dotted
+capability `media.thumbnail` — no per-method `addTool`.
+
+The `media.*` capability + its parameters match the Java and Python providers
+exactly, so gateways in ANY runtime are interchangeable.
+
+## Setup
+
+```bash
+cd examples/typescript/service-view/thumbnail-provider
+npm install
+```
+
+## Build (type-check)
+
+```bash
+npm run build      # tsc
+```
+
+## Run
+
+```bash
+npx tsx index.ts
+```
+
+Or with meshctl (starts a local registry automatically if none is running):
+
+```bash
+meshctl start examples/typescript/service-view/thumbnail-provider/index.ts
+```
+
+The agent listens on port 8131.
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- Run `meshctl man decorators` for the decorator reference
+
+## License
+
+MIT

--- a/examples/typescript/service-view/thumbnail-provider/index.ts
+++ b/examples/typescript/service-view/thumbnail-provider/index.ts
@@ -16,6 +16,7 @@
  */
 
 import { mesh, FastMCP } from "@mcpmesh/sdk";
+import { z } from "zod";
 
 const server = new FastMCP({
   name: "Thumbnail Provider Service",
@@ -29,15 +30,25 @@ const agent = mesh(server, {
 });
 
 agent.addService("media", {
-  thumbnail: async (args: { assetId: string; width: number }) => {
-    const w = args.width && args.width > 0 ? args.width : 128;
-    const h = Math.max(1, Math.floor((w * 9) / 16));
-    return {
-      assetId: args.assetId,
-      uri: `thumb://${args.assetId}?w=${w}&h=${h}`,
-      size: `${w}x${h}`,
-      provider: "thumbnail-provider",
-    };
+  // Object form: a Zod schema documents + validates the tool's inputs at
+  // runtime (addService forwards `parameters` to the underlying addTool). The
+  // object-form execute types its args as `unknown`, so narrow after validation.
+  thumbnail: {
+    parameters: z.object({
+      assetId: z.string().describe("Media asset identifier"),
+      width: z.number().int().positive().describe("Requested thumbnail width in pixels"),
+    }),
+    execute: async (args) => {
+      const { assetId, width } = args as { assetId: string; width: number };
+      const w = width && width > 0 ? width : 128;
+      const h = Math.max(1, Math.floor((w * 9) / 16));
+      return {
+        assetId,
+        uri: `thumb://${assetId}?w=${w}&h=${h}`,
+        size: `${w}x${h}`,
+        provider: "thumbnail-provider",
+      };
+    },
   },
 });
 

--- a/examples/typescript/service-view/thumbnail-provider/index.ts
+++ b/examples/typescript/service-view/thumbnail-provider/index.ts
@@ -1,0 +1,45 @@
+/**
+ * thumbnail-provider — MCP Mesh agent (TypeScript).
+ *
+ * Publishes `media.thumbnail` via producer sugar (RFC #1280):
+ * `agent.addService("media", { thumbnail })` publishes the `thumbnail` entry as
+ * the dotted capability `media.thumbnail` — a second slice of the shared
+ * `media.*` namespace, served by a DIFFERENT agent than caption/transcribe.
+ *
+ * Cross-runtime: parameter names (`assetId`, `width`) and the capability match
+ * the Java and Python providers, so any-runtime gateways are interchangeable.
+ *
+ * Run:
+ *   cd examples/typescript/service-view/thumbnail-provider
+ *   npm install
+ *   npx tsx index.ts
+ */
+
+import { mesh, FastMCP } from "@mcpmesh/sdk";
+
+const server = new FastMCP({
+  name: "Thumbnail Provider Service",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "thumbnail-provider",
+  httpPort: 8131,
+  description: "Publishes media.thumbnail into the shared media.* namespace",
+});
+
+agent.addService("media", {
+  thumbnail: async (args: { assetId: string; width: number }) => {
+    const w = args.width && args.width > 0 ? args.width : 128;
+    const h = Math.max(1, Math.floor((w * 9) / 16));
+    return {
+      assetId: args.assetId,
+      uri: `thumb://${args.assetId}?w=${w}&h=${h}`,
+      size: `${w}x${h}`,
+      provider: "thumbnail-provider",
+    };
+  },
+});
+
+// The SDK auto-starts after module loading completes.
+console.log("thumbnail-provider defined — publishes media.thumbnail. Waiting for auto-start...");

--- a/examples/typescript/service-view/thumbnail-provider/package-lock.json
+++ b/examples/typescript/service-view/thumbnail-provider/package-lock.json
@@ -1,0 +1,2854 @@
+{
+  "name": "thumbnail-provider-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "thumbnail-provider-example",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mcpmesh/sdk": "file:../../../../src/runtime/typescript",
+        "fastmcp": "^3.34.0",
+        "zod": "^3.24.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "../../../../src/runtime/typescript": {
+      "name": "@mcpmesh/sdk",
+      "version": "2.8.2",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/google-vertex": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@mcpmesh/core": "file:../core/typescript",
+        "ai": "^6.0.0",
+        "fastmcp": "^4.3.2",
+        "handlebars": "^4.7.8",
+        "mcp-proxy": "6.4.4",
+        "undici": "^6.21.0",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.0",
+        "@types/express-v5": "npm:@types/express@^5.0.0",
+        "@types/node": "^22.0.0",
+        "express": "^4.18.0",
+        "express-v5": "npm:express@^5.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@mcpmesh/sdk": {
+      "resolved": "../../../../src/runtime/typescript",
+      "link": true
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastmcp": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.35.0.tgz",
+      "integrity": "sha512-bcyAaVa3Zw5f4xighGg6fNNgEzZoP6tX/O+ZfS2lIhbEULWe/zUWG533JyFEUOjZT7EB+tiZW1ot4eWKmYJ6DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.24.3",
+        "@standard-schema/spec": "^1.0.0",
+        "execa": "^9.6.1",
+        "file-type": "^21.1.1",
+        "fuse.js": "^7.1.0",
+        "hono": "^4.11.5",
+        "mcp-proxy": "^6.4.0",
+        "strict-event-emitter-types": "^2.0.0",
+        "undici": "^7.16.0",
+        "uri-templates": "^0.2.0",
+        "xsschema": "^0.4.3",
+        "yargs": "^18.0.0",
+        "zod": "^4.1.13",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "bin": {
+        "fastmcp": "dist/bin/fastmcp.js"
+      },
+      "peerDependencies": {
+        "jose": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fastmcp/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.2.tgz",
+      "integrity": "sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-readable-ids": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/human-readable-ids/-/human-readable-ids-1.0.4.tgz",
+      "integrity": "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==",
+      "license": "Apache2",
+      "dependencies": {
+        "knuth-shuffle": "^1.0.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/knuth-shuffle": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle/-/knuth-shuffle-1.0.8.tgz",
+      "integrity": "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/koa": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.1.tgz",
+      "integrity": "sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa-router": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-14.0.0.tgz",
+      "integrity": "sha512-Ue8f/PRsLLNm6b7y+eS6xkqvsG2xH11d2VB1HPcfdfW6p5736kCHf2pXaq8q9XPQ01x0Dk7V/P5Il9pe+tGTxA==",
+      "deprecated": "Please use @koa/router instead, starting from v9! ",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^8.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/koa/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/koa/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-proxy": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.5.2.tgz",
+      "integrity": "sha512-3sE9kedh81dqqpObzO0nUf8aAyGnzLVDVH97GCLL3fXCBOkXDWZBts63u0bM5lT1Q4FKZY0+E91dZ7Chb2ybsA==",
+      "license": "MIT",
+      "dependencies": {
+        "pipenet": "^1.3.0"
+      },
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.mjs"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pipenet": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.2.tgz",
+      "integrity": "sha512-mPPqygXr7ccwImeaa8zReY9GubH/1r+kBNfqPVfKREQ1s8bKE3XlOqBMONxJAW4d3ZBNGzP9AZp9Axnhi5uOyw==",
+      "dependencies": {
+        "axios": "^1.7.3",
+        "debug": "^4.3.6",
+        "human-readable-ids": "^1.0.4",
+        "koa": "^3.1.1",
+        "koa-router": "^14.0.0",
+        "pump": "^3.0.3",
+        "tldjs": "^2.3.2",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "pipenet": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tldjs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.2.tgz",
+      "integrity": "sha512-EORDwFMSZKrHPUVDhejCMDeAovRS5d8jZKiqALFiPp3cjKjEldPkxBY39ZSx3c45awz3RpKwJD1cCgGxEfy8/A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-templates": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
+      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
+      "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xsschema": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/xsschema/-/xsschema-0.4.4.tgz",
+      "integrity": "sha512-TMhbk8AhxO+YuDOn3rXBjGXQ+Vja3T13UPQkHx/FemhusaOzRfCSj2seykt0mdnFPsOtO9l3ANf4adcp+4NRGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@valibot/to-json-schema": "^1.0.0",
+        "arktype": "^2.1.20",
+        "effect": "^3.16.0",
+        "sury": "^10.0.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "sury": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/typescript/service-view/thumbnail-provider/package.json
+++ b/examples/typescript/service-view/thumbnail-provider/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "thumbnail-provider-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Service-view producer sugar: publishes media.thumbnail",
+  "scripts": {
+    "start": "tsx index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "file:../../../../src/runtime/typescript",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/typescript/service-view/thumbnail-provider/tsconfig.json
+++ b/examples/typescript/service-view/thumbnail-provider/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/typescript/service-view/transcribe-provider/README.md
+++ b/examples/typescript/service-view/transcribe-provider/README.md
@@ -1,0 +1,48 @@
+# transcribe-provider
+
+Provider C (optional edge) in the [service-view example](../README.md).
+
+## Overview
+
+A TypeScript MCP Mesh agent. Publishes the `media.transcribe` capability via **producer
+sugar**: `agent.addService("media", { ... })` publishes one method as the dotted
+capability `media.transcribe` — no per-method `addTool`.
+
+The `media.*` capability + its parameters match the Java and Python providers
+exactly, so gateways in ANY runtime are interchangeable.
+
+## Setup
+
+```bash
+cd examples/typescript/service-view/transcribe-provider
+npm install
+```
+
+## Build (type-check)
+
+```bash
+npm run build      # tsc
+```
+
+## Run
+
+```bash
+npx tsx index.ts
+```
+
+Or with meshctl (starts a local registry automatically if none is running):
+
+```bash
+meshctl start examples/typescript/service-view/transcribe-provider/index.ts
+```
+
+The agent listens on port 8132.
+
+## Documentation
+
+- [MCP Mesh Documentation](https://github.com/dhyansraj/mcp-mesh)
+- Run `meshctl man decorators` for the decorator reference
+
+## License
+
+MIT

--- a/examples/typescript/service-view/transcribe-provider/README.md
+++ b/examples/typescript/service-view/transcribe-provider/README.md
@@ -13,24 +13,21 @@ exactly, so gateways in ANY runtime are interchangeable.
 
 ## Setup
 
+From the repo root, install this agent's dependencies:
+
 ```bash
-cd examples/typescript/service-view/transcribe-provider
-npm install
+npm --prefix examples/typescript/service-view/transcribe-provider install
 ```
 
 ## Build (type-check)
 
 ```bash
-npm run build      # tsc
+npm --prefix examples/typescript/service-view/transcribe-provider run build   # tsc
 ```
 
 ## Run
 
-```bash
-npx tsx index.ts
-```
-
-Or with meshctl (starts a local registry automatically if none is running):
+Start with meshctl (starts a local registry automatically if none is running):
 
 ```bash
 meshctl start examples/typescript/service-view/transcribe-provider/index.ts

--- a/examples/typescript/service-view/transcribe-provider/index.ts
+++ b/examples/typescript/service-view/transcribe-provider/index.ts
@@ -16,6 +16,7 @@
  */
 
 import { mesh, FastMCP } from "@mcpmesh/sdk";
+import { z } from "zod";
 
 const server = new FastMCP({
   name: "Transcribe Provider Service",
@@ -29,15 +30,25 @@ const agent = mesh(server, {
 });
 
 agent.addService("media", {
-  transcribe: async (args: { assetId: string; text: string }) => {
-    const stripped = args.text.trim();
-    const wordCount = stripped ? stripped.split(/\s+/).length : 0;
-    return {
-      assetId: args.assetId,
-      transcript: `[${args.assetId}] ${stripped.toUpperCase()}`,
-      wordCount,
-      provider: "transcribe-provider",
-    };
+  // Object form: a Zod schema documents + validates the tool's inputs at
+  // runtime (addService forwards `parameters` to the underlying addTool). The
+  // object-form execute types its args as `unknown`, so narrow after validation.
+  transcribe: {
+    parameters: z.object({
+      assetId: z.string().describe("Media asset identifier"),
+      text: z.string().describe("Source audio text"),
+    }),
+    execute: async (args) => {
+      const { assetId, text } = args as { assetId: string; text: string };
+      const stripped = text.trim();
+      const wordCount = stripped ? stripped.split(/\s+/).length : 0;
+      return {
+        assetId,
+        transcript: `[${assetId}] ${stripped.toUpperCase()}`,
+        wordCount,
+        provider: "transcribe-provider",
+      };
+    },
   },
 });
 

--- a/examples/typescript/service-view/transcribe-provider/index.ts
+++ b/examples/typescript/service-view/transcribe-provider/index.ts
@@ -1,0 +1,45 @@
+/**
+ * transcribe-provider — MCP Mesh agent (TypeScript).
+ *
+ * Publishes `media.transcribe` via producer sugar (RFC #1280):
+ * `agent.addService("media", { transcribe })` publishes the `transcribe` entry
+ * as the dotted capability `media.transcribe` — the third slice of the shared
+ * `media.*` namespace, served by its own agent.
+ *
+ * Cross-runtime: parameter names (`assetId`, `text`) and the capability match
+ * the Java and Python providers, so any-runtime gateways are interchangeable.
+ *
+ * Run:
+ *   cd examples/typescript/service-view/transcribe-provider
+ *   npm install
+ *   npx tsx index.ts
+ */
+
+import { mesh, FastMCP } from "@mcpmesh/sdk";
+
+const server = new FastMCP({
+  name: "Transcribe Provider Service",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "transcribe-provider",
+  httpPort: 8132,
+  description: "Publishes media.transcribe into the shared media.* namespace",
+});
+
+agent.addService("media", {
+  transcribe: async (args: { assetId: string; text: string }) => {
+    const stripped = args.text.trim();
+    const wordCount = stripped ? stripped.split(/\s+/).length : 0;
+    return {
+      assetId: args.assetId,
+      transcript: `[${args.assetId}] ${stripped.toUpperCase()}`,
+      wordCount,
+      provider: "transcribe-provider",
+    };
+  },
+});
+
+// The SDK auto-starts after module loading completes.
+console.log("transcribe-provider defined — publishes media.transcribe. Waiting for auto-start...");

--- a/examples/typescript/service-view/transcribe-provider/package-lock.json
+++ b/examples/typescript/service-view/transcribe-provider/package-lock.json
@@ -1,0 +1,2854 @@
+{
+  "name": "transcribe-provider-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "transcribe-provider-example",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mcpmesh/sdk": "file:../../../../src/runtime/typescript",
+        "fastmcp": "^3.34.0",
+        "zod": "^3.24.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "../../../../src/runtime/typescript": {
+      "name": "@mcpmesh/sdk",
+      "version": "2.8.2",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/google-vertex": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@mcpmesh/core": "file:../core/typescript",
+        "ai": "^6.0.0",
+        "fastmcp": "^4.3.2",
+        "handlebars": "^4.7.8",
+        "mcp-proxy": "6.4.4",
+        "undici": "^6.21.0",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.0",
+        "@types/express-v5": "npm:@types/express@^5.0.0",
+        "@types/node": "^22.0.0",
+        "express": "^4.18.0",
+        "express-v5": "npm:express@^5.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@mcpmesh/sdk": {
+      "resolved": "../../../../src/runtime/typescript",
+      "link": true
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastmcp": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.35.0.tgz",
+      "integrity": "sha512-bcyAaVa3Zw5f4xighGg6fNNgEzZoP6tX/O+ZfS2lIhbEULWe/zUWG533JyFEUOjZT7EB+tiZW1ot4eWKmYJ6DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.24.3",
+        "@standard-schema/spec": "^1.0.0",
+        "execa": "^9.6.1",
+        "file-type": "^21.1.1",
+        "fuse.js": "^7.1.0",
+        "hono": "^4.11.5",
+        "mcp-proxy": "^6.4.0",
+        "strict-event-emitter-types": "^2.0.0",
+        "undici": "^7.16.0",
+        "uri-templates": "^0.2.0",
+        "xsschema": "^0.4.3",
+        "yargs": "^18.0.0",
+        "zod": "^4.1.13",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "bin": {
+        "fastmcp": "dist/bin/fastmcp.js"
+      },
+      "peerDependencies": {
+        "jose": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fastmcp/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.2.tgz",
+      "integrity": "sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-readable-ids": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/human-readable-ids/-/human-readable-ids-1.0.4.tgz",
+      "integrity": "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==",
+      "license": "Apache2",
+      "dependencies": {
+        "knuth-shuffle": "^1.0.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/knuth-shuffle": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle/-/knuth-shuffle-1.0.8.tgz",
+      "integrity": "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/koa": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.1.tgz",
+      "integrity": "sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa-router": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-14.0.0.tgz",
+      "integrity": "sha512-Ue8f/PRsLLNm6b7y+eS6xkqvsG2xH11d2VB1HPcfdfW6p5736kCHf2pXaq8q9XPQ01x0Dk7V/P5Il9pe+tGTxA==",
+      "deprecated": "Please use @koa/router instead, starting from v9! ",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^8.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/koa/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/koa/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-proxy": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.5.2.tgz",
+      "integrity": "sha512-3sE9kedh81dqqpObzO0nUf8aAyGnzLVDVH97GCLL3fXCBOkXDWZBts63u0bM5lT1Q4FKZY0+E91dZ7Chb2ybsA==",
+      "license": "MIT",
+      "dependencies": {
+        "pipenet": "^1.3.0"
+      },
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.mjs"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pipenet": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.2.tgz",
+      "integrity": "sha512-mPPqygXr7ccwImeaa8zReY9GubH/1r+kBNfqPVfKREQ1s8bKE3XlOqBMONxJAW4d3ZBNGzP9AZp9Axnhi5uOyw==",
+      "dependencies": {
+        "axios": "^1.7.3",
+        "debug": "^4.3.6",
+        "human-readable-ids": "^1.0.4",
+        "koa": "^3.1.1",
+        "koa-router": "^14.0.0",
+        "pump": "^3.0.3",
+        "tldjs": "^2.3.2",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "pipenet": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tldjs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.2.tgz",
+      "integrity": "sha512-EORDwFMSZKrHPUVDhejCMDeAovRS5d8jZKiqALFiPp3cjKjEldPkxBY39ZSx3c45awz3RpKwJD1cCgGxEfy8/A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-templates": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
+      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
+      "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xsschema": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/xsschema/-/xsschema-0.4.4.tgz",
+      "integrity": "sha512-TMhbk8AhxO+YuDOn3rXBjGXQ+Vja3T13UPQkHx/FemhusaOzRfCSj2seykt0mdnFPsOtO9l3ANf4adcp+4NRGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@valibot/to-json-schema": "^1.0.0",
+        "arktype": "^2.1.20",
+        "effect": "^3.16.0",
+        "sury": "^10.0.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "sury": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/typescript/service-view/transcribe-provider/package.json
+++ b/examples/typescript/service-view/transcribe-provider/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "transcribe-provider-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Service-view producer sugar: publishes media.transcribe",
+  "scripts": {
+    "start": "tsx index.ts",
+    "build": "tsc"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "file:../../../../src/runtime/typescript",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/typescript/service-view/transcribe-provider/tsconfig.json
+++ b/examples/typescript/service-view/transcribe-provider/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/core/cli/man/content/decorators.md
+++ b/src/core/cli/man/content/decorators.md
@@ -118,6 +118,36 @@ async def hr_report(employee_lookup: mesh.McpMeshTool = None): ...
 
 Producer tools can opt out of strict schema verdicts via `output_schema_strict=False`. See `meshctl man schema-matching` for verdict tiers and policy. See `meshctl man dependency-injection` for the full filter pipeline.
 
+## @mesh.service
+
+Aggregates capabilities behind a typed view, or — with a prefix — publishes a class's methods as tools (RFC #1280).
+
+**Consumer view** — a class of `async` `@mesh.selector` stubs, injected as a `@mesh.tool` parameter:
+
+```python
+@mesh.service                       # or @mesh.service(min_available=2)
+class MediaService:
+    @mesh.selector("media.caption", required=True)
+    async def caption(self, args: dict) -> dict: ...
+    @mesh.selector("media.thumbnail")
+    async def thumbnail(self, args: dict) -> dict: ...
+
+@mesh.tool(capability="process_media")
+async def process_media(req: dict, media: MediaService = None):
+    return await media.caption({"text": req["text"]})
+```
+
+**Producer** — a prefixed class whose real methods publish as `prefix.<method>`:
+
+```python
+@mesh.service("media")              # publishes media.caption, media.thumbnail
+class MediaTools:
+    async def caption(self, args: dict) -> dict: ...
+    async def thumbnail(self, args: dict) -> dict: ...
+```
+
+Each view method is an ordinary dependency edge and each producer method an ordinary tool — both show as `N` entries in `meshctl list`. `required` view edges get the pre-invoke `dependency_unavailable` refusal; `min_available` (consumer-only) adds a floor. For the full semantics see `meshctl man dependency-injection`.
+
 ## @mesh.llm
 
 Enables LLM-powered tools with automatic tool discovery.

--- a/src/core/cli/man/content/decorators_typescript.md
+++ b/src/core/cli/man/content/decorators_typescript.md
@@ -134,6 +134,40 @@ agent.addTool({
 
 See `meshctl man schema-matching` for modes, the cross-language convention table, and verdict tiers. See `meshctl man dependency-injection --typescript` for the full filter pipeline.
 
+## mesh.serviceView() / agent.addService()
+
+Service views aggregate capabilities behind one typed facade, or publish a group of tools under a dotted prefix (RFC #1280).
+
+**Consumer** — one `dependencies` entry expanding to N edges, injected as a facade argument:
+
+```ts
+const Media = mesh.serviceView({
+  methods: {
+    caption: { capability: "media.caption", required: true },
+    thumbnail: "media.thumbnail",
+  },
+});
+
+agent.addTool({
+  name: "process_media",
+  dependencies: [Media],
+  execute: async (args, media) =>
+    // dep params are inferred; cast the view slot to type its methods
+    (media as MeshServiceFacade<typeof Media>).caption({ text: args.text }),
+});
+```
+
+**Producer** — publish methods as `prefix.<method>` tools:
+
+```ts
+agent.addService("media", {
+  caption: async (args) => ({ caption: `a scene: ${args.text}` }),
+  thumbnail: async (args) => ({ uri: `thumb://${args.id}` }),
+});
+```
+
+`required` view edges get the pre-invoke `dependency_unavailable` refusal (a `UserError`); `minAvailable` (consumer-only) adds a floor; a view forces inline execution and is rejected in `mesh.route(...)` / `mesh.a2a.mount(...)`. For the full semantics see `meshctl man dependency-injection --typescript`.
+
 ## mesh.llm()
 
 Creates an LLM-powered tool with automatic tool discovery.

--- a/src/core/cli/man/content/dependency-injection.md
+++ b/src/core/cli/man/content/dependency-injection.md
@@ -257,6 +257,61 @@ The agents/capabilities API carries two derived fields per capability:
 
 The capability stays visible in the registry, UI, and `meshctl` (availability is distinct from presence), so the reason chain is a diagnostic upgrade, not a disappearance.
 
+## Service Views (RFC #1280)
+
+A **service view** aggregates several capability dependencies behind one typed class. Decorate a class with `@mesh.service`; every public method is an **`async` stub** carrying `@mesh.selector("cap", ...)` that binds one capability. Pass the view class as a `@mesh.tool` parameter (detected by type, like `MeshJob`) and the framework injects a facade whose methods each delegate to their capability's own resolved proxy — so different methods can resolve to different provider agents and rebind independently.
+
+```python
+@mesh.service                       # or @mesh.service(min_available=2)
+class MediaService:
+    @mesh.selector("media.caption", required=True, tags=["+fast"])
+    async def caption(self, args: dict) -> dict: ...
+    @mesh.selector("media.thumbnail")
+    async def thumbnail(self, args: dict) -> dict: ...
+    @mesh.selector("media.transcribe")
+    async def transcribe(self, args: dict) -> dict: ...
+
+
+@app.tool()
+@mesh.tool(capability="process_media", dependencies=["audit_log"])
+async def process_media(
+    req: dict,
+    audit: mesh.McpMeshTool = None,
+    media: MediaService = None,
+):
+    caption = await media.caption({"text": req["text"]})   # dict → the target tool's named args
+    try:
+        thumb = await media.thumbnail({"asset_id": req["id"]})
+    except ToolError:                                       # optional method unresolved
+        thumb = None
+    return {"caption": caption, "thumbnail": thumb}
+```
+
+A facade call takes one `dict` that becomes the target tool's named arguments, and accepts a `headers=` kwarg for header propagation. Each view method expands into an ordinary dependency edge appended **after** the tool's explicit `dependencies` — name-sorted within a view, in parameter order across multiple views — so a view over N capabilities shows as **N dependencies** in `meshctl list`. Capability names are dot-namespaced (see the naming rules in `meshctl man capabilities`).
+
+- Every method must be `async def` with `@mesh.selector`; a **sync** stub or a selector-less public method **boot-fails** (make helpers private with a leading underscore).
+- A `required=True` method joins the tool's pre-invoke guard: an unresolved required edge makes the tool return the structured `dependency_unavailable` refusal before the handler runs (direct and claim paths). An unresolved **optional** method raises `ToolError` (`fastmcp.exceptions.ToolError`) carrying that same `dependency_unavailable` payload on its own call only — catch it to degrade gracefully.
+- `@mesh.service(min_available=N)` adds a consumer-local floor: below `N` resolved methods every facade call raises `mesh.MeshServiceUnavailableError` (settle-aware). Default `0` = no floor.
+- **Testing:** passing your own facade object for the view parameter skips the pre-invoke refusal and settle wait for that view — mock the facade directly in unit tests.
+- Views are a **tool-parameter** surface only: a view in `@mesh.route` boot-fails, and an undecorated subclass of a view is not a view (decorate the class directly).
+
+### Publishing a service (producer side)
+
+Give `@mesh.service` a **prefix** and the class becomes a producer: each public method (a real `async` implementation) publishes as an ordinary tool with capability `prefix.<method>`.
+
+```python
+@mesh.service("media")              # publishes media.caption, media.thumbnail
+class MediaTools:
+    async def caption(self, args: dict) -> dict:
+        return {"caption": f"a scene: {args['text']}"}
+    async def thumbnail(self, args: dict) -> dict:
+        return {"uri": f"thumb://{args['asset_id']}"}
+```
+
+- Methods publish **name-sorted** under dotted tool names; underscore-prefixed methods are skipped.
+- A method carrying its own `@mesh.tool` **wins** (keeps its declared capability/tags/version).
+- The class must be **zero-arg constructible** (instantiated once at decoration time to publish bound methods); the `prefix` is segment-validated against the dotted-capability grammar. A `@mesh.selector` inside a prefixed class is a **mixed-roles boot-fail**, and `min_available` is consumer-only.
+
 ## Proxy Configuration
 
 Per-dependency proxy options (timeout, retry, streaming, session affinity, auth, custom headers, etc.) are configured via `dependency_kwargs`. See `meshctl man proxies` for the full options table.

--- a/src/core/cli/man/content/dependency-injection.md
+++ b/src/core/cli/man/content/dependency-injection.md
@@ -282,7 +282,10 @@ async def process_media(
     caption = await media.caption({"text": req["text"]})   # dict → the target tool's named args
     try:
         thumb = await media.thumbnail({"asset_id": req["id"]})
-    except ToolError:                                       # optional method unresolved
+    except ToolError as e:
+        # swallow ONLY the unresolved-optional refusal, not provider-side errors
+        if "dependency_unavailable" not in str(e):
+            raise
         thumb = None
     return {"caption": caption, "thumbnail": thumb}
 ```

--- a/src/core/cli/man/content/dependency-injection_typescript.md
+++ b/src/core/cli/man/content/dependency-injection_typescript.md
@@ -287,6 +287,61 @@ The agents/capabilities API carries two derived fields per capability:
 
 The capability stays visible in the registry, UI, and `meshctl` (availability is distinct from presence), so the reason chain is a diagnostic upgrade, not a disappearance.
 
+## Service Views (RFC #1280)
+
+A **service view** aggregates several capability dependencies behind one typed facade. `mesh.serviceView({ methods })` returns a branded value you place as **one** entry in a tool's `dependencies` array; it expands into N ordinary edges (one per method, name-sorted) and the framework injects a single facade argument. Each method delegates to its own resolved proxy, so different methods can bind different provider agents and rebind independently.
+
+```ts
+const Media = mesh.serviceView({
+  methods: {
+    caption: { capability: "media.caption", required: true, tags: ["+fast"] },
+    thumbnail: "media.thumbnail",
+    transcribe: "media.transcribe",
+  },
+  // minAvailable: 2,
+});
+
+agent.addTool({
+  name: "process_media",
+  dependencies: ["audit_log", Media],
+  execute: async (args, auditLog, media) => {
+    // dep params are inferred; cast the view slot to type its methods
+    const svc = media as MeshServiceFacade<typeof Media>;
+    const caption = await svc.caption({ text: args.text });
+    let thumb: unknown = null;
+    try {
+      thumb = await svc.thumbnail({ id: args.id });
+    } catch (e) {
+      if (!(e instanceof TypeError)) throw e;               // optional method unresolved
+    }
+    return { caption, thumb };
+  },
+});
+```
+
+The view slot expands **in place** (name-sorted), so its edges keep contiguous indices and a view over N capabilities shows as **N dependencies** in `meshctl list`. A method spec is a capability string or an object (`capability`, `tags`, `version`, `required`, `expectedSchema`, `matchMode`). Leave the `execute` dependency params un-annotated (they're inferred) and cast the view slot at point of use — `const svc = view as MeshServiceFacade<typeof View>` — to type its method keys; a direct parameter annotation doesn't compile under `strictFunctionTypes`. Capability names are dot-namespaced (see the naming rules in `meshctl man capabilities`).
+
+- A `required` method joins the tool's pre-invoke guard: an unresolved required edge makes the tool refuse with a `UserError` carrying the structured `dependency_unavailable` payload before the handler runs (direct and claim paths). An unresolved **optional** method rejects with a `TypeError` (the null-proxy passthrough) on its own call only.
+- `minAvailable` adds a consumer-local floor: below it every facade call throws `MeshServiceUnavailableError` (settle-aware).
+- A view **forces inline execution** — per-tool worker isolation is disabled for a view-bearing tool, with a warning logged at registration when `MCP_MESH_TOOL_WORKERS>1`.
+- Views are a **tool-parameter** surface only: a `mesh.serviceView(...)` in `mesh.route(...)` or `mesh.a2a.mount(...)` dependencies is rejected.
+
+### Publishing a service (producer side)
+
+`agent.addService("prefix", { ... })` publishes each entry as an ordinary tool with capability `prefix.<method>` (name-sorted). An entry is a bare `execute` function or an object carrying `execute` plus `addTool` passthrough (`tags`, `description`, …); `name`/`capability` are derived and must not be supplied.
+
+```ts
+agent.addService("media", {
+  caption: async (args) => ({ caption: `a scene: ${args.text}` }),
+  thumbnail: {
+    execute: async (args) => ({ uri: `thumb://${args.id}` }),
+    tags: ["fast"],
+  },
+});
+```
+
+The `prefix` is segment-validated against the dotted-capability grammar — the SDK's only capability-name check, mirroring the registry contract. A derived name that collides with an existing tool throws.
+
 ## Proxy Configuration
 
 Configure proxy behavior via `dependencyKwargs` — an array indexed by dependency position (aligned with `dependencies`):

--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -167,6 +167,7 @@ def _make_stream_wrapper(
     log: logging.Logger,
     settle_keys: Optional[list] = None,
     settle_params: Optional[list] = None,
+    view_slots: Optional[list] = None,
 ) -> Callable:
     """Build a wrapper that drives an async-iterator tool over MCP progress.
 
@@ -216,6 +217,7 @@ def _make_stream_wrapper(
             stream_wrapper._mesh_injected_deps,
             get_dependency_fn,
             log,
+            view_slots=view_slots,
         )
 
         original = func._mesh_original_func
@@ -293,6 +295,7 @@ def _build_clean_signature(func: Any) -> inspect.Signature | None:
         _get_original_func,
         analyze_mesh_job_signature,
         get_mesh_agent_parameter_names,
+        get_service_view_parameter_names,
     )
 
     # Respect explicit ``__signature__`` overrides. Decorators (e.g.
@@ -323,6 +326,13 @@ def _build_clean_signature(func: Any) -> inspect.Signature | None:
     mj = analyze_mesh_job_signature(original)
     if mj.mesh_job_param_name:
         injectable_names.add(mj.mesh_job_param_name)
+
+    # RFC #1280: a @mesh.service consumer-view parameter is framework-injected
+    # (a facade), so hide it from FastMCP's tools/list schema too.
+    try:
+        injectable_names.update(get_service_view_parameter_names(original))
+    except Exception:  # noqa: BLE001 - never block clean-signature on view introspection
+        pass
 
     if not injectable_names:
         return None
@@ -541,6 +551,20 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
         # propagate per the resolver contract.
         pass
 
+    # RFC #1280: @mesh.service consumer-view parameters are a NEW type-detected
+    # slot kind (a facade), NOT positional McpMeshTool targets. Exclude them so
+    # the untyped single-parameter heuristic never mistakes a lone view param
+    # for an injection target and so the "no McpMeshTool params" diagnostics
+    # aren't skewed. Injection into view slots is handled separately in the
+    # facade block of ``_prepare_injection_kwargs``.
+    view_positions: set[int] = set()
+    try:
+        from .signature_analyzer import get_service_view_positions
+
+        view_positions = set(get_service_view_positions(func))
+    except Exception:  # noqa: BLE001
+        pass
+
     # Strict-mode decoration-time promotion of the "eligible slots will
     # remain None" diagnostic, checked UP FRONT so every branch below —
     # including the early returns for single-MeshJob-param and
@@ -586,8 +610,10 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
 
     # Single parameter rule: inject regardless of typing. Only applies when
     # no params are hidden — a hidden single param is framework-bound by the
-    # hiding decorator itself, never an injection target.
-    if param_count == 1 and not has_hidden_params:
+    # hiding decorator itself, never an injection target — and when the lone
+    # param is not a @mesh.service view (RFC #1280: views are facade slots,
+    # never untyped single-parameter injection targets).
+    if param_count == 1 and not has_hidden_params and not view_positions:
         if not mesh_positions:
             if has_mesh_job_param:
                 # The single parameter is a MeshJob — the unified injection
@@ -688,6 +714,7 @@ def _prepare_injection_kwargs(
     injected_deps_array: list,
     get_dependency_fn: Callable[[str], Any | None],
     log: logging.Logger,
+    view_slots: Optional[list] = None,
 ) -> tuple[dict, int]:
     """Prepare kwargs with injected dependencies and LLM agent.
 
@@ -949,6 +976,34 @@ def _prepare_injection_kwargs(
             llm_agent = getattr(func, "_mesh_llm_agent", None)
             final_kwargs[llm_param] = llm_agent
             log.debug(f"{tp}🤖 LLM_INJECTION: Injected {llm_param}={llm_agent}")
+
+    # RFC #1280: inject a facade for each @mesh.service consumer-view parameter.
+    # Additive slot kind — the view-method deps live in ``injected_deps_array``
+    # at the appended indices recorded on each view slot, read by the facade at
+    # CALL time so rebinding via update_dependency is picked up transparently.
+    # A caller-supplied non-None value (mock contract) is left untouched.
+    if view_slots:
+        func_id = f"{func.__module__}.{func.__qualname__}"
+        for v in view_slots:
+            pname = v["param_name"]
+            if pname in final_kwargs and final_kwargs.get(pname) is not None:
+                continue
+            from .service_view import MeshServiceFacade
+
+            final_kwargs[pname] = MeshServiceFacade(
+                view_name=v["view_name"],
+                min_available=v["min_available"],
+                methods=v["methods"],
+                func_id=func_id,
+                injected_deps_array=injected_deps_array,
+                get_dependency_fn=get_dependency_fn,
+            )
+            injected_count += 1
+            log.debug(
+                f"{tp}🧩 VIEW_INJECTION: Injected facade for view "
+                f"{v['view_name']!r} into param {pname!r} "
+                f"({len(v['methods'])} method edge(s))"
+            )
 
     return final_kwargs, injected_count
 
@@ -1286,6 +1341,7 @@ class DependencyInjector:
         dependencies: list[str],
         route_required_caps: Optional[list[Optional[str]]] = None,
         tool_required_caps: Optional[list[Optional[str]]] = None,
+        view_slots: Optional[list] = None,
     ) -> Callable:
         """
         Create in-place dependency injection by modifying the original function.
@@ -1331,8 +1387,24 @@ class DependencyInjector:
         # every call (mirrors the claim dispatcher's mesh_job_dep_index skip).
         _tool_required_caps: list[Optional[str]] = list(tool_required_caps or [])
 
-        # Use new smart injection strategy
-        mesh_positions = analyze_injection_strategy(func, dependencies)
+        # RFC #1280: ``dependencies`` is the FULL edge list — explicit deps
+        # first, then each @mesh.service view's method edges (name-sorted)
+        # appended AFTER. The positional McpMeshTool/MeshJob pairing concerns
+        # ONLY the explicit prefix; view-method edges have no parameter of
+        # their own (a facade fans them out). Everything else keyed by
+        # dep_index (``_mesh_injected_deps`` sizing, the dependency mapping,
+        # settle keys, update_dependency, the required-refusal caps) spans the
+        # full list unchanged — so this is purely additive: a function with no
+        # view slots computes exactly as before.
+        _view_slots: list = list(view_slots or [])
+        _n_view_methods = sum(len(v["methods"]) for v in _view_slots)
+        _n_explicit = len(dependencies) - _n_view_methods
+
+        # Use new smart injection strategy — over the EXPLICIT prefix only, so
+        # the McpMeshTool positional pairing + diagnostics stay identical to
+        # the pre-view behaviour (view edges never pair with a McpMeshTool
+        # parameter).
+        mesh_positions = analyze_injection_strategy(func, dependencies[:_n_explicit])
 
         # Track which dependencies this function needs (using composite keys)
         for dep_index, dep in enumerate(dependencies):
@@ -1406,6 +1478,18 @@ class DependencyInjector:
                 settle_keys[_i] = f"{func_id}:dep_{_i}"
                 if _pos < len(_settle_param_names):
                     settle_params[_i] = _settle_param_names[_pos]
+        # RFC #1280: view-method edges are settle-covered too (item 2 + the
+        # floor's settle-aware wait). Map each edge's settle_params entry to the
+        # view's PARAMETER NAME so the documented mock contract works: a caller
+        # that supplies a fake facade for the view param skips both the settle
+        # wait and the required-edge pre-invoke refusal for ALL that view's
+        # edges (mirrors the McpMeshTool per-slot mock skip).
+        for _v in _view_slots:
+            for _m in _v["methods"]:
+                _di = _m["dep_index"]
+                if 0 <= _di < len(dependencies):
+                    settle_keys[_di] = f"{func_id}:dep_{_di}"
+                    settle_params[_di] = _v["param_name"]
         _settle_state = get_settle_state()
         for _key in settle_keys:
             if _key is not None:
@@ -1423,10 +1507,11 @@ class DependencyInjector:
                 _tool_required_caps[_mj_dep_index] = None
         _has_tool_required = any(c is not None for c in _tool_required_caps)
 
-        # If no mesh positions to inject AND no MeshJob slot, fall back to
-        # the minimal tracking wrapper. With a MeshJob slot we route to the
-        # full path so the auto-injection block at line ~439 can fire.
-        if not mesh_positions and not has_mesh_job_param:
+        # If no mesh positions to inject AND no MeshJob slot AND no service-view
+        # slot, fall back to the minimal tracking wrapper. With a MeshJob slot
+        # or a @mesh.service view we route to the full path so the auto-injection
+        # / facade blocks in ``_prepare_injection_kwargs`` can fire.
+        if not mesh_positions and not has_mesh_job_param and not _view_slots:
             logger.debug(
                 f"🔧 No injection positions for {func.__name__}, creating minimal wrapper for tracking"
             )
@@ -1648,6 +1733,7 @@ class DependencyInjector:
                 wrapper_logger,
                 settle_keys=settle_keys,
                 settle_params=settle_params,
+                view_slots=_view_slots,
             )
         elif need_async_wrapper:
 
@@ -1678,6 +1764,7 @@ class DependencyInjector:
                     dependency_wrapper._mesh_injected_deps,
                     self.get_dependency,
                     wrapper_logger,
+                    view_slots=_view_slots,
                 )
 
                 # Issue #1249 perimeter (shared helper; runs after settle).
@@ -1748,6 +1835,7 @@ class DependencyInjector:
                     dependency_wrapper._mesh_injected_deps,
                     self.get_dependency,
                     wrapper_logger,
+                    view_slots=_view_slots,
                 )
 
                 # Issue #1249 perimeter (shared helper; sync route variant).

--- a/src/runtime/python/_mcp_mesh/engine/service_view.py
+++ b/src/runtime/python/_mcp_mesh/engine/service_view.py
@@ -1,0 +1,193 @@
+"""
+RFC #1280 service-view facade (Python runtime, engine side).
+
+A ``MeshServiceFacade`` is the object injected for a ``@mesh.service`` consumer
+view parameter on a ``@mesh.tool``. Each method call delegates to the
+per-capability proxy read from the wrapper's stable ``_mesh_injected_deps``
+array AT CALL TIME — so a slot rebinding via ``update_dependency`` (topology
+change) is picked up transparently.
+
+* Unresolved OPTIONAL method → ``ToolError`` carrying the same
+  ``{"error":"dependency_unavailable","capability":<cap>}`` envelope the
+  #1273 pre-invoke refusal uses, naming the capability.
+* ``min_available`` floor (consumer-local): when fewer than the floor of the
+  view's methods resolve, EVERY facade call raises
+  ``MeshServiceUnavailableError`` — settle-grace-aware (waits out the
+  per-capability settle keys within the remaining budget before the
+  authoritative recount), mirroring the Java runtime's ``enforceFloor``.
+"""
+
+import asyncio
+import inspect
+import json
+import logging
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class MeshServiceFacade:
+    """Injected facade for a ``@mesh.service`` consumer-view parameter."""
+
+    def __init__(
+        self,
+        *,
+        view_name: str,
+        min_available: int,
+        methods: list,
+        func_id: str,
+        injected_deps_array: list,
+        get_dependency_fn: Callable[[str], Any | None],
+    ) -> None:
+        # ``methods``: list of dicts {method_name, capability, dep_index}.
+        self._view_name = view_name
+        self._min_available = min_available
+        self._methods = methods
+        self._method_by_name = {m["method_name"]: m for m in methods}
+        self._func_id = func_id
+        self._injected = injected_deps_array
+        self._get_dep = get_dependency_fn
+
+    # -- slot resolution ----------------------------------------------------
+
+    def _resolve(self, dep_index: int) -> Any | None:
+        """Read the live proxy for a method's slot (array first, injector
+        composite-key fallback) — same lookup the injection path uses."""
+        proxy = None
+        if dep_index < len(self._injected):
+            proxy = self._injected[dep_index]
+        if proxy is None:
+            proxy = self._get_dep(f"{self._func_id}:dep_{dep_index}")
+        return proxy
+
+    def _count_available(self) -> int:
+        return sum(1 for m in self._methods if self._resolve(m["dep_index"]) is not None)
+
+    # -- floor --------------------------------------------------------------
+
+    async def _enforce_floor(self) -> None:
+        if self._min_available <= 0:
+            return
+        from .settle import get_settle_state
+
+        # Count FIRST — a floored view whose floor is already satisfied never
+        # waits, so an unresolvable method next to enough resolved ones can
+        # never park the call for the whole budget.
+        available = self._count_available()
+        if available >= self._min_available:
+            return
+
+        state = get_settle_state()
+        # Settle-aware wait: race ALL currently-unresolved edges concurrently
+        # (wake on ANY resolution, not serially per edge), recount, and loop
+        # until the floor is met or the budget is spent. A serial per-edge wait
+        # would burn the whole budget on one unresolvable edge before ever
+        # seeing a sibling resolve.
+        while (
+            available < self._min_available
+            and not state.is_settled()
+            and state.remaining() > 0
+        ):
+            pending = [
+                m for m in self._methods if self._resolve(m["dep_index"]) is None
+            ]
+            if not pending:
+                break
+            tasks = [
+                asyncio.ensure_future(
+                    state.wait_for_async(
+                        f"{self._func_id}:dep_{m['dep_index']}",
+                        m["capability"],
+                        logger,
+                    )
+                )
+                for m in pending
+            ]
+            try:
+                await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            finally:
+                for t in tasks:
+                    if not t.done():
+                        t.cancel()
+                # Let cancellations run wait_for_async's finally cleanup.
+                await asyncio.gather(*tasks, return_exceptions=True)
+            available = self._count_available()
+
+        if available < self._min_available:
+            from mesh._service import MeshServiceUnavailableError
+
+            logger.info(
+                "service view %s below floor: methods_available=%d/%d (min_available=%d)",
+                self._view_name,
+                available,
+                len(self._methods),
+                self._min_available,
+            )
+            raise MeshServiceUnavailableError(
+                self._view_name, available, len(self._methods), self._min_available
+            )
+
+    # -- delegation ---------------------------------------------------------
+
+    def __getattr__(self, name: str):
+        # __getattr__ only fires for names not found normally, so real
+        # attributes/methods above are never shadowed.
+        method_by_name = self.__dict__.get("_method_by_name", {})
+        m = method_by_name.get(name)
+        if m is None:
+            raise AttributeError(
+                f"'{type(self).__name__}' for view "
+                f"'{self.__dict__.get('_view_name')}' has no method '{name}'"
+            )
+
+        capability = m["capability"]
+        method_name = m["method_name"]
+        view_name = self._view_name
+
+        async def _call(args: Optional[dict] = None, **kwargs):
+            await self._enforce_floor()
+            proxy = self._resolve(m["dep_index"])
+            if proxy is None:
+                from fastmcp.exceptions import ToolError
+
+                raise ToolError(
+                    json.dumps(
+                        {
+                            "error": "dependency_unavailable",
+                            "capability": capability,
+                        }
+                    )
+                )
+
+            # Convention: the injected mesh proxies take tool arguments as
+            # KEYWORDS, not a positional dict — UnifiedMCPProxy.__call__ ignores
+            # *args and sends only **kwargs upstream (as named tool params, the
+            # Java/uc37 wire form), and SelfDependencyProxy accepts **kwargs
+            # only. So the owner-idiom single dict arg is spread into kwargs.
+            # ``headers`` (if supplied) rides in kwargs and the HTTP proxy pops
+            # it, mirroring how existing consumers call injected proxies.
+            call_kwargs: dict = {}
+            if args is not None:
+                if not isinstance(args, dict):
+                    raise TypeError(
+                        f"service view {view_name}.{method_name}: the positional "
+                        f"argument must be a dict of tool parameters, got "
+                        f"{type(args).__name__}"
+                    )
+                call_kwargs.update(args)
+            call_kwargs.update(kwargs)
+
+            result = proxy(**call_kwargs)
+            if inspect.isawaitable(result):
+                result = await result
+            return result
+
+        _call.__name__ = name
+        return _call
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        try:
+            counts = f"{self._count_available()}/{len(self._methods)}"
+        except Exception:
+            counts = f"?/{len(self._methods)}"
+        return f"MeshServiceFacade[{self._view_name}, {counts} available]"

--- a/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
+++ b/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
@@ -118,6 +118,133 @@ def _is_mesh_job_type(param_type: Any) -> bool:
     return False
 
 
+def _service_view_meta(param_type: Any) -> Any:
+    """Return the ``ServiceViewMeta`` for a ``@mesh.service`` consumer-view
+    class (RFC #1280), unwrapping ``Optional[View]`` / ``View | None``, or
+    ``None`` if the type is not a service view.
+
+    Detection keys purely on the marker attribute stamped by ``@mesh.service``
+    (``SERVICE_VIEW_ATTR``, imported lazily from ``mesh._service`` — the marker
+    name only, never the decorator machinery, avoiding an import cycle).
+    Producer classes are NOT views (they publish tools and carry no marker), so
+    they are never detected here.
+    """
+    from mesh._service import SERVICE_VIEW_ATTR
+
+    candidates = [param_type]
+    if hasattr(param_type, "__args__"):
+        candidates.extend(param_type.__args__)
+    for candidate in candidates:
+        if inspect.isclass(candidate):
+            # DIRECT annotation only (``__dict__``, not ``getattr`` which walks
+            # the MRO): an UNDECORATED subclass of a view is NOT itself a view —
+            # inheriting the parent's marker would resolve the subclass's own
+            # selectors to the PARENT's bindings (wrong methods, wrong name in
+            # errors). Mirrors Java's direct-annotation scanning rule. A
+            # subclass that WANTS to be a view re-applies @mesh.service (its own
+            # marker then lands in its __dict__).
+            meta = candidate.__dict__.get(SERVICE_VIEW_ATTR)
+            if meta is not None:
+                return meta
+    return None
+
+
+def _is_service_view_type(param_type: Any) -> bool:
+    """Whether a type is a ``@mesh.service`` consumer view (RFC #1280)."""
+    return _service_view_meta(param_type) is not None
+
+
+def analyze_service_view_params(func: Any) -> list:
+    """Classify a function's ``@mesh.service`` consumer-view parameters.
+
+    Returns a list of ``(position, name, ServiceViewMeta)`` tuples in
+    declaration order — the parameter-order half of the RFC #1280 view-edge
+    layout (methods are name-sorted within each view by ``@mesh.service``).
+    A view parameter is a NEW type-detected slot kind (the MeshJob precedent),
+    orthogonal to the McpMeshTool/MeshJob positional namespace.
+    """
+    func = _get_original_func(func)
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return []
+
+    try:
+        type_hints = get_type_hints(func)
+    except Exception:
+        # get_type_hints is all-or-nothing: one unresolvable annotation (e.g. a
+        # TYPE_CHECKING-only import under ``from __future__ import annotations``)
+        # breaks it for the WHOLE function — including ordinary view-free tools.
+        # Fall back to per-parameter resolution so a resolvable view isn't
+        # silently lost, and warn ONLY when a view is actually recovered (never
+        # for a view-free function whose hints happen to fail elsewhere).
+        return _recover_view_params_per_param(func, sig)
+
+    result: list = []
+    for i, param_name in enumerate(sig.parameters.keys()):
+        if param_name not in type_hints:
+            continue
+        meta = _service_view_meta(type_hints[param_name])
+        if meta is not None:
+            result.append((i, param_name, meta))
+    return result
+
+
+def _recover_view_params_per_param(func: Any, sig: inspect.Signature) -> list:
+    """Best-effort per-parameter view detection when function-wide
+    :func:`get_type_hints` fails.
+
+    Resolves each parameter's annotation individually against the function's
+    module globals, so a view whose class IS importable survives a sibling
+    parameter's unresolvable annotation. Emits a single WARNING **only when a
+    view is recovered here** — that both names the ``from __future__`` cause AND
+    stays silent for ordinary view-free tools (whose hints fail for unrelated
+    reasons), satisfying RFC #1280's "don't spam" scoping.
+    """
+    import sys
+
+    module = getattr(func, "__module__", None)
+    globalns = getattr(sys.modules.get(module), "__dict__", {}) if module else {}
+
+    result: list = []
+    for i, (param_name, param) in enumerate(sig.parameters.items()):
+        raw = param.annotation
+        if raw is inspect.Parameter.empty:
+            continue
+        if isinstance(raw, str):
+            try:
+                resolved = eval(raw, globalns)  # noqa: S307 - module-scoped, best-effort
+            except Exception:
+                continue
+        else:
+            resolved = raw
+        meta = _service_view_meta(resolved)
+        if meta is not None:
+            result.append((i, param_name, meta))
+
+    if result:
+        logger.warning(
+            "analyze_service_view_params: function '%s' has @mesh.service view "
+            "parameter(s) %s but function-wide type-hint resolution failed "
+            "(recovered per-parameter). If this module uses "
+            "`from __future__ import annotations`, ensure every annotated type "
+            "is importable at module scope so the view is reliably detected.",
+            getattr(func, "__qualname__", getattr(func, "__name__", "?")),
+            [name for _pos, name, _meta in result],
+        )
+    return result
+
+
+def get_service_view_positions(func: Any) -> list[int]:
+    """Signature positions (0-indexed) of ``@mesh.service`` view parameters."""
+    return [pos for pos, _name, _meta in analyze_service_view_params(func)]
+
+
+def get_service_view_parameter_names(func: Any) -> list[str]:
+    """Parameter names of ``@mesh.service`` view parameters."""
+    return [name for _pos, name, _meta in analyze_service_view_params(func)]
+
+
 def _scan_params(
     func: Any,
     predicate: Callable[[Any], bool],
@@ -374,7 +501,22 @@ def validate_mesh_dependencies(func: Any, dependencies: list[dict]) -> tuple[boo
     if resolution is not None and resolution.mesh_job_param_name is not None:
         job_slots = 1
 
-    expected = len(mesh_positions) + job_slots
+    # RFC #1280: each @mesh.service view parameter expands to N dependency
+    # edges (one per selector method), appended AFTER the explicit deps. Those
+    # edges have no McpMeshTool/MeshJob parameter of their own, so the count
+    # must add them or the tool would be dropped from the heartbeat.
+    view_method_slots = 0
+    try:
+        for _pos, _name, _meta in analyze_service_view_params(func):
+            view_method_slots += len(_meta.bindings)
+    except Exception as e:  # noqa: BLE001 - never block validation on view introspection
+        logger.debug(
+            "validate_mesh_dependencies: service-view analysis skipped for %s: %s",
+            getattr(func, "__name__", "?"),
+            e,
+        )
+
+    expected = len(mesh_positions) + job_slots + view_method_slots
     if len(dependencies) != expected:
         # Name each typed slot (declaration order) so the message shows the
         # exact dep→param pairing positional binding uses, plus the fix.
@@ -401,8 +543,9 @@ def validate_mesh_dependencies(func: Any, dependencies: list[dict]) -> tuple[boo
 
         message = (
             f"Function {func.__name__} has "
-            f"{pluralize(len(mesh_positions), 'McpMeshTool parameter')} and "
-            f"{pluralize(job_slots, 'MeshJob slot')} "
+            f"{pluralize(len(mesh_positions), 'McpMeshTool parameter')}, "
+            f"{pluralize(job_slots, 'MeshJob slot')} and "
+            f"{pluralize(view_method_slots, 'service-view method edge')} "
             f"but {pluralize(len(dependencies), 'dependency', 'dependencies')} "
             f"declared. "
             f"Each typed slot needs a corresponding dependency. "

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/__init__.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/__init__.py
@@ -16,6 +16,7 @@ from .jobs_cancel_route import JobsCancelRouteStep
 from .jobs_claim_workers import JobsClaimWorkersStep
 from .jobs_helper_tools import JobsHelperToolsStep
 from .media_store_validation import MediaStoreValidationStep
+from .service_view_serving import ServiceViewProducerServingStep
 from .startup_orchestrator import (MeshOrchestrator,
                                    clear_debounce_coordinator,
                                    get_debounce_coordinator,
@@ -35,6 +36,7 @@ __all__ = [
     "JobsHelperToolsStep",
     "MediaStoreValidationStep",
     "MeshOrchestrator",
+    "ServiceViewProducerServingStep",
     "StartupPipeline",
     "clear_debounce_coordinator",
     "get_global_orchestrator",

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/service_view_serving.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/service_view_serving.py
@@ -1,0 +1,133 @@
+"""Attach ``@mesh.service`` producer-sugar tools to the SERVED FastMCP server(s)
+(RFC #1280).
+
+An ordinary mesh tool is served because the user stacks ``@app.tool()`` (which
+registers the callable on their FastMCP instance) alongside ``@mesh.tool()``
+(which registers it in the DecoratorRegistry for the heartbeat/wire). Producer
+sugar (``@mesh.service("prefix")``) applies ``@mesh.tool`` programmatically and
+the user never touches the FastMCP server, so without this step the published
+tools land in the DecoratorRegistry (→ heartbeat advertises ``prefix.method``)
+but NOT on the served FastMCP instance — ``tools/list`` omits them and
+``tools/call prefix.method`` returns "Unknown tool" (registration/serving
+split-brain).
+
+This step runs AFTER :class:`FastMCPServerDiscoveryStep` (so the servers exist)
+and BEFORE :class:`FastAPIServerSetupStep` (so the mounted app advertises them),
+exactly like :class:`JobsHelperToolsStep`. It registers every DI wrapper flagged
+``_mesh_service_served_name`` (set by ``mesh._service._mark_for_serving`` for
+both the sugar and tool-wins paths) on each discovered server, keyed by the
+dotted capability — idempotent, no registry required.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..shared import PipelineResult, PipelineStatus, PipelineStep
+
+logger = logging.getLogger(__name__)
+
+
+async def _existing_tool_names(server: Any) -> set:
+    """Names of tools already registered on ``server``.
+
+    Prefers FastMCP's public async ``list_tools()`` surface (the installed
+    version exposes no *sync* tool-listing API — ``list_tools`` / ``get_tool``
+    are all coroutines). Falls back to the private ``local_provider._components``
+    map only if the public call is unavailable / raises, so a FastMCP internals
+    change can't break the idempotency guard.
+    """
+    try:
+        tools = await server.list_tools()
+        return {getattr(t, "name", None) for t in tools}
+    except Exception:
+        local_provider = getattr(server, "local_provider", None)
+        components = getattr(local_provider, "_components", None)
+        if not isinstance(components, dict):
+            return set()
+        return {
+            getattr(comp, "name", None)
+            for key, comp in components.items()
+            if str(key).startswith("tool:")
+        }
+
+
+def _collect_served_tools() -> dict[str, tuple[Any, str]]:
+    """Map ``served_name -> (callable, description)`` for every producer-sugar /
+    tool-wins wrapper flagged for serving in the DecoratorRegistry."""
+    from ...engine.decorator_registry import DecoratorRegistry
+
+    out: dict[str, tuple[Any, str]] = {}
+    for _name, decorated in DecoratorRegistry.get_mesh_tools().items():
+        fn = decorated.function
+        served_name = getattr(fn, "_mesh_service_served_name", None)
+        if served_name is None:
+            continue
+        description = (decorated.metadata or {}).get("description") or ""
+        out[served_name] = (fn, description)
+    return out
+
+
+class ServiceViewProducerServingStep(PipelineStep):
+    """Register ``@mesh.service`` producer-sugar tools on each discovered FastMCP
+    server so they appear in ``tools/list`` and answer ``tools/call``."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="service-view-producer-serving",
+            required=False,  # Best-effort: must not block startup.
+            description=(
+                "Attach @mesh.service producer-sugar tools to the served "
+                "FastMCP server(s)"
+            ),
+        )
+
+    async def execute(self, context: dict[str, Any]) -> PipelineResult:
+        result = PipelineResult(message="Service-view producer serving")
+
+        served = _collect_served_tools()
+        if not served:
+            result.status = PipelineStatus.SKIPPED
+            result.message = "No @mesh.service producer-sugar tools to serve"
+            return result
+
+        servers = context.get("fastmcp_servers", {}) or {}
+        if not servers:
+            result.status = PipelineStatus.SKIPPED
+            result.message = (
+                "@mesh.service producer tools not served: no FastMCP servers "
+                "discovered (a producer class needs a FastMCP server to serve "
+                "its published tools)"
+            )
+            self.logger.warning("⚠️ %s", result.message)
+            return result
+
+        total = 0
+        for server_key, server in servers.items():
+            existing = await _existing_tool_names(server)
+            for name, (fn, description) in served.items():
+                if name in existing:
+                    continue
+                try:
+                    server.tool(name=name, description=description)(fn)
+                    total += 1
+                    self.logger.debug(
+                        "service-view serving: registered %s on FastMCP server %r",
+                        name,
+                        server_key,
+                    )
+                except Exception as e:
+                    self.logger.warning(
+                        "service-view serving: failed to register %s on %r: %s",
+                        name,
+                        server_key,
+                        e,
+                    )
+
+        result.message = (
+            f"Registered {total} @mesh.service producer tool(s) across "
+            f"{len(servers)} FastMCP server(s)"
+        )
+        self.logger.info("🧩 %s", result.message)
+        return result

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_pipeline.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_pipeline.py
@@ -14,7 +14,7 @@ from . import (ConfigurationStep, DecoratorCollectionStep,
                FastMCPServerDiscoveryStep, HeartbeatLoopStep,
                HeartbeatPreparationStep, JobsCancelRouteStep,
                JobsClaimWorkersStep, JobsHelperToolsStep,
-               MediaStoreValidationStep)
+               MediaStoreValidationStep, ServiceViewProducerServingStep)
 from .server_discovery import ServerDiscoveryStep
 
 logger = logging.getLogger(__name__)
@@ -62,6 +62,10 @@ class StartupPipeline(MeshPipeline):
             # Phase 1 MeshJob: register helper tools on the FastMCP server
             # BEFORE FastAPIServerSetup mounts it (so they appear in /tools/list).
             JobsHelperToolsStep(),
+            # RFC #1280: attach @mesh.service producer-sugar tools to the served
+            # FastMCP server(s) — same late-bind timing as the job helpers, so
+            # sugar-published tools appear in /tools/list and answer tools/call.
+            ServiceViewProducerServingStep(),
             HeartbeatPreparationStep(),  # Prepare heartbeat payload structure (can now access FastMCP schemas)
             ServerDiscoveryStep(),  # Discover existing uvicorn servers from immediate startup
             HeartbeatLoopStep(),  # Setup background heartbeat config (handles no registry gracefully)

--- a/src/runtime/python/mesh/__init__.py
+++ b/src/runtime/python/mesh/__init__.py
@@ -137,6 +137,18 @@ def __getattr__(name):
         from ._a2a_consumer import A2AJobCanceled
 
         return A2AJobCanceled
+    elif name == "service":
+        from ._service import service
+
+        return service
+    elif name == "selector":
+        from ._service import selector
+
+        return selector
+    elif name == "MeshServiceUnavailableError":
+        from ._service import MeshServiceUnavailableError
+
+        return MeshServiceUnavailableError
     elif name == "llm":
         return decorators.llm
     elif name == "llm_provider":

--- a/src/runtime/python/mesh/_service.py
+++ b/src/runtime/python/mesh/_service.py
@@ -1,0 +1,532 @@
+"""
+RFC #1280 service views — Python runtime.
+
+Two related roles depending on the decorated class (mirrors the Java
+``@McpMeshService`` contract; uc37 is the cross-runtime seam):
+
+CONSUMER VIEW (no prefix) — a typed aggregation of ordinary capability
+dependencies. Every public method carries ``@mesh.selector(...)`` and is a
+stub whose body is never executed; the framework injects a facade whose
+methods delegate to each capability's own resolved proxy::
+
+    @mesh.service                       # or @mesh.service(min_available=2)
+    class MediaService:
+        @mesh.selector("media.caption", required=True, tags=["+fast"])
+        async def caption(self, args: dict) -> dict: ...
+        @mesh.selector("media.thumbnail")
+        async def thumbnail(self, args: dict) -> dict: ...
+
+    @mesh.tool(capability="process", dependencies=["audit_log"])
+    async def process(req: dict, audit: mesh.McpMeshTool = None,
+                      media: MediaService = None):
+        cap = await media.caption({"text": req["text"]})
+
+PRODUCER SUGAR (prefix argument) — each public method of the class becomes an
+ordinary mesh tool with capability ``prefix.<method>``, published through the
+existing ``@mesh.tool`` machinery::
+
+    @mesh.service("media")              # publishes media.caption, media.thumbnail
+    class MediaTools:
+        async def caption(self, args: dict) -> dict:
+            return {...}
+
+Disambiguation: a prefix present → producer (methods must be real
+implementations; any ``@mesh.selector`` inside → boot-fail "mixed roles"); no
+prefix → consumer view (every public method must carry ``@mesh.selector``).
+``min_available`` is only valid on a consumer view.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Marker attribute stamped on a consumer-view class. Detection (in
+# signature_analyzer) keys on this attribute so the engine never imports this
+# public module.
+SERVICE_VIEW_ATTR = "_mesh_service_view"
+
+# Marker attribute stamped on a method by @mesh.selector.
+SELECTOR_ATTR = "_mesh_selector"
+
+
+class MeshServiceUnavailableError(Exception):
+    """Raised when a service view is below its declared ``min_available`` floor.
+
+    When fewer than ``min_available`` of the view's methods currently resolve
+    to a provider, EVERY facade call raises this instead of delegating — a
+    consumer-local circuit breaker with no wire effect. Carries the view name
+    and the current/required availability counts so the failure is actionable.
+    Mirrors Java's ``MeshServiceUnavailableException``.
+    """
+
+    def __init__(
+        self,
+        service: str,
+        methods_available: int,
+        methods_total: int,
+        min_available: int,
+    ) -> None:
+        super().__init__(
+            f"Mesh service view unavailable ({service}): "
+            f"{methods_available}/{methods_total} method(s) resolved, "
+            f"below the declared min_available={min_available} floor"
+        )
+        self.service = service
+        self.methods_available = methods_available
+        self.methods_total = methods_total
+        self.min_available = min_available
+
+
+@dataclass(frozen=True)
+class ServiceMethodBinding:
+    """A single validated view method → capability binding (name-sorted)."""
+
+    method_name: str
+    capability: str
+    tags: list = field(default_factory=list)
+    version: Optional[str] = None
+    required: bool = False
+    expected_type: Any = None
+    match_mode: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ServiceViewMeta:
+    """Metadata for a discovered consumer-view class."""
+
+    name: str
+    min_available: int
+    bindings: list  # list[ServiceMethodBinding], sorted by method_name
+
+
+def _validate_capability_segmented(capability: str, context: str) -> None:
+    """Reuse the pydantic ``AgentCapability`` name validator (RFC #1280 v3
+    dotted rule) so views/producers accept exactly what the registry does —
+    no duplicated regex.
+    """
+    from pydantic import ValidationError
+
+    from _mcp_mesh.shared.support_types import AgentCapability
+
+    try:
+        AgentCapability(name=capability)
+    except ValidationError as e:
+        raise ValueError(f"{context}: invalid capability name '{capability}' — {e}") from None
+
+
+def selector(
+    capability: Optional[str] = None,
+    *,
+    tags: Optional[list] = None,
+    version: Optional[str] = None,
+    required: bool = False,
+    expected_type: Any = None,
+    match_mode: Optional[str] = None,
+):
+    """Bind a service-view method to a single capability (RFC #1280).
+
+    Same keys as a ``@mesh.tool`` dependency dict. ``expected_type`` /
+    ``match_mode`` opt into schema-aware matching exactly like a dict dep.
+    """
+    if capability is not None and not isinstance(capability, str):
+        raise ValueError("@mesh.selector capability must be a string")
+    if tags is not None and not isinstance(tags, list):
+        raise ValueError("@mesh.selector tags must be a list")
+    if version is not None and not isinstance(version, str):
+        raise ValueError("@mesh.selector version must be a string")
+    if not isinstance(required, bool):
+        raise ValueError("@mesh.selector required must be a boolean")
+    if match_mode is not None and match_mode not in ("subset", "strict"):
+        raise ValueError("@mesh.selector match_mode must be 'subset' or 'strict'")
+
+    def decorator(fn):
+        setattr(
+            fn,
+            SELECTOR_ATTR,
+            {
+                "capability": capability,
+                "tags": list(tags or []),
+                "version": version,
+                "required": required,
+                "expected_type": expected_type,
+                "match_mode": match_mode,
+            },
+        )
+        return fn
+
+    return decorator
+
+
+def binding_to_dependency_dict(b: ServiceMethodBinding) -> dict:
+    """Convert a view-method binding into a ``@mesh.tool`` dependency dict.
+
+    Mirrors the dict-dependency handling in ``@mesh.tool`` (expected_type →
+    expected_schema_raw, default match_mode "subset") so a view edge is
+    indistinguishable from a hand-written dependency once expanded.
+    """
+    dep: dict = {"capability": b.capability, "tags": list(b.tags or [])}
+    if b.version is not None:
+        dep["version"] = b.version
+    if b.required:
+        dep["required"] = True
+    if b.expected_type is not None:
+        mm = b.match_mode or "subset"
+        if isinstance(b.expected_type, dict):
+            dep["expected_schema_raw"] = b.expected_type
+        else:
+            from _mcp_mesh.utils.fastmcp_schema_extractor import FastMCPSchemaExtractor
+
+            schema = FastMCPSchemaExtractor.extract_type_schema(b.expected_type)
+            if schema is not None:
+                dep["expected_schema_raw"] = schema
+        dep["match_mode"] = mm
+    elif b.match_mode is not None:
+        dep["match_mode"] = b.match_mode
+    return dep
+
+
+def _public_methods(cls) -> list:
+    """Public instance methods declared on the class, in name-sorted order.
+
+    Underscore-prefixed methods are skipped; ``object`` methods are excluded.
+    """
+    import inspect
+
+    names = []
+    for name, member in inspect.getmembers(cls, predicate=inspect.isfunction):
+        if name.startswith("_"):
+            continue
+        if getattr(object, name, None) is not None:
+            continue
+        names.append(name)
+    return sorted(names)
+
+
+def _build_consumer_view(cls, min_available: int):
+    """Validate a consumer-view class and stamp its metadata."""
+    if not isinstance(min_available, int) or isinstance(min_available, bool):
+        raise ValueError("@mesh.service min_available must be an integer")
+    if min_available < 0:
+        raise ValueError(
+            f"@mesh.service view '{cls.__name__}': min_available must be >= 0 "
+            f"(got {min_available})"
+        )
+
+    method_names = _public_methods(cls)
+    bindings: list = []
+    for name in method_names:
+        member = getattr(cls, name)
+        sel = getattr(member, SELECTOR_ATTR, None)
+        if sel is None:
+            raise ValueError(
+                f"@mesh.service view '{cls.__name__}': public method '{name}' "
+                f"has no @mesh.selector — every method of a consumer view must "
+                f"bind a capability with @mesh.selector (or make it private "
+                f"with a leading underscore)."
+            )
+        # Facade methods are async (they delegate to async proxies). A sync
+        # stub would return an un-awaited coroutine and silently break — fail
+        # loudly at decoration instead.
+        import asyncio as _asyncio
+
+        if not _asyncio.iscoroutinefunction(member):
+            raise ValueError(
+                f"@mesh.service view '{cls.__name__}': selector method '{name}' "
+                f"must be `async def` — service-view facade methods are async "
+                f"(they delegate to async mesh proxies). Mark it `async def`."
+            )
+        capability = sel.get("capability")
+        if not capability or not str(capability).strip():
+            raise ValueError(
+                f"@mesh.service view '{cls.__name__}': method '{name}' has "
+                f"@mesh.selector with a blank capability."
+            )
+        _validate_capability_segmented(
+            capability, f"@mesh.service view '{cls.__name__}' method '{name}'"
+        )
+        bindings.append(
+            ServiceMethodBinding(
+                method_name=name,
+                capability=capability,
+                tags=sel.get("tags", []),
+                version=sel.get("version"),
+                required=bool(sel.get("required", False)),
+                expected_type=sel.get("expected_type"),
+                match_mode=sel.get("match_mode"),
+            )
+        )
+
+    if min_available > len(bindings):
+        raise ValueError(
+            f"@mesh.service view '{cls.__name__}': min_available={min_available} "
+            f"exceeds the number of selector-bound methods ({len(bindings)}) — "
+            f"the floor can never be satisfied."
+        )
+
+    if not bindings:
+        logger.warning(
+            f"@mesh.service view '{cls.__name__}' declares no selector methods — "
+            f"the injected facade is a no-op view."
+        )
+
+    setattr(
+        cls,
+        SERVICE_VIEW_ATTR,
+        ServiceViewMeta(
+            name=cls.__name__,
+            min_available=min_available,
+            bindings=bindings,
+        ),
+    )
+
+    # Make the view type appear optional/nullable in MCP schemas so FastMCP
+    # hides a view-typed tool parameter (mirrors McpMeshTool / MeshJob). The
+    # DI wrapper also strips it from __signature__, but the schema marker is
+    # the belt-and-suspenders that matches the other injectables.
+    _attach_pydantic_schema(cls)
+    return cls
+
+
+def _attach_pydantic_schema(cls) -> None:
+    try:
+        from pydantic_core import core_schema
+    except ImportError:
+        # Fallback when pydantic-core is unavailable — mirror the dict form
+        # McpMeshTool / MeshJob use so FastMCP still treats the view param as
+        # optional/nullable rather than rejecting it.
+        def __get_pydantic_core_schema_fallback__(cls_, source_type, handler):  # noqa: N807
+            return {
+                "type": "default",
+                "schema": {"type": "nullable", "schema": {"type": "any"}},
+                "default": None,
+            }
+
+        cls.__get_pydantic_core_schema__ = classmethod(
+            __get_pydantic_core_schema_fallback__
+        )
+        return
+
+    def __get_pydantic_core_schema__(cls_, source_type, handler):  # noqa: N807
+        return core_schema.with_default_schema(
+            core_schema.nullable_schema(core_schema.any_schema()),
+            default=None,
+        )
+
+    cls.__get_pydantic_core_schema__ = classmethod(__get_pydantic_core_schema__)
+
+
+def _build_producer(cls, prefix: str, min_available: int):
+    """Publish each public method of a prefixed class as a mesh tool."""
+    if min_available:
+        raise ValueError(
+            f"@mesh.service producer '{cls.__name__}': min_available is only "
+            f"valid on a consumer view (no prefix), not on a producer class."
+        )
+    if not prefix or not str(prefix).strip():
+        raise ValueError(
+            f"@mesh.service producer '{cls.__name__}': prefix must not be blank."
+        )
+    _validate_capability_segmented(prefix, f"@mesh.service producer '{cls.__name__}' prefix")
+
+    method_names = _public_methods(cls)
+
+    # Mixed-roles guard: a producer method must be a real implementation, not
+    # a selector stub.
+    for name in method_names:
+        if getattr(getattr(cls, name), SELECTOR_ATTR, None) is not None:
+            raise ValueError(
+                f"@mesh.service producer '{cls.__name__}' (prefix '{prefix}'): "
+                f"method '{name}' carries @mesh.selector — a prefixed class is a "
+                f"producer (methods are implementations), not a consumer view. "
+                f"Remove the prefix to make it a view, or remove @mesh.selector."
+            )
+
+    from . import decorators
+
+    # Instantiate ONCE at decoration time (bound methods are what get
+    # published). Producers must be zero-arg constructible; surface a
+    # constructor failure with a message naming @mesh.service and the class
+    # rather than a bare traceback from deep in the decorator.
+    try:
+        instance = cls()
+    except Exception as e:
+        raise ValueError(
+            f"@mesh.service producer '{cls.__name__}' (prefix '{prefix}'): "
+            f"failed to instantiate the class — producer classes must be "
+            f"zero-arg constructible (the sugar instantiates once at "
+            f"decoration time to publish bound methods). Constructor raised: "
+            f"{e!r}"
+        ) from e
+
+    for name in method_names:
+        member = getattr(cls, name)
+        own_meta = getattr(member, "_mesh_tool_metadata", None)
+        bound = getattr(instance, name)
+        if own_meta is not None:
+            # A method carrying its own @mesh.tool WINS: it keeps its declared
+            # capability (NOT the prefix sugar). But that @mesh.tool ran on the
+            # UNBOUND method during class-body evaluation, so `self` leaked into
+            # the FastMCP schema and it registered under the bare method name.
+            # Re-publish the BOUND method with the user's original metadata so
+            # `self` is gone and the registry key is unique per capability.
+            _republish_tool_wins(name, bound, own_meta, cls)
+            continue
+
+        capability = f"{prefix}.{name}"
+        _validate_capability_segmented(
+            capability, f"@mesh.service producer '{cls.__name__}' method '{name}'"
+        )
+        published = _wrap_bound(bound)
+        # Unique, deterministic, cross-runtime-consistent identity: the dotted
+        # capability itself (Java sugar uses the capability as the tool name;
+        # FastMCP accepts dots). DecoratorRegistry keys on __name__, so two
+        # producer classes sharing a method name (get/list/status) no longer
+        # silently clobber each other.
+        published.__name__ = capability
+        published.__qualname__ = capability
+        wrapper = decorators.tool(capability=capability)(published)
+        _mark_for_serving(wrapper, capability)
+
+    return cls
+
+
+def _mark_for_serving(wrapper, capability: str) -> None:
+    """Flag a sugar/tool-wins-published wrapper so the startup pipeline attaches
+    it to the SERVED FastMCP server.
+
+    Unlike an ordinary tool (where the user stacks ``@app.tool()`` +
+    ``@mesh.tool()`` — the former SERVES, the latter WIRES), producer sugar
+    applies ``@mesh.tool`` programmatically and the user never touches the
+    FastMCP server. The DI wrapper lands in DecoratorRegistry (→ heartbeat/wire)
+    but NOT on the served FastMCP instance, so tools/list wouldn't show it and
+    tools/call would 'Unknown tool'. ``ServiceViewProducerServingStep`` reads
+    this marker after FastMCP discovery and registers the wrapper on the server
+    — the same late-bind pattern the MeshJob helper tools use.
+    """
+    try:
+        wrapper._mesh_service_served_name = capability
+    except (AttributeError, TypeError):
+        logger.debug(
+            "@mesh.service: could not mark '%s' for FastMCP serving", capability
+        )
+
+
+def _wrap_bound(bound):
+    """Wrap a bound method in a plain function @mesh.tool can decorate.
+
+    Bound methods are read-only (no attribute assignment); the wrapper gives a
+    clean module-level-style callable. ``functools.wraps`` preserves
+    ``__annotations__`` / ``__doc__`` / ``__wrapped__`` so signature analysis
+    (``self`` already excluded on the bound method) and schema extraction
+    resolve exactly as for a hand-written tool.
+    """
+    import functools
+    import inspect
+
+    if inspect.isasyncgenfunction(bound):
+        # Streaming producer method (``async def ... -> Stream[str]: yield``).
+        # The wrapper MUST itself be an async-generator function so the stream
+        # detection (``inspect.isasyncgenfunction``) and dispatch treat it as a
+        # stream directly, rather than relying on the wraps-carried annotation +
+        # the stream wrapper's non-asyncgen fallback.
+        @functools.wraps(bound)
+        async def published(*args, __bound=bound, **kwargs):
+            async for _item in __bound(*args, **kwargs):
+                yield _item
+
+    elif inspect.iscoroutinefunction(bound):
+
+        @functools.wraps(bound)
+        async def published(*args, __bound=bound, **kwargs):
+            return await __bound(*args, **kwargs)
+
+    else:
+
+        @functools.wraps(bound)
+        def published(*args, __bound=bound, **kwargs):
+            return __bound(*args, **kwargs)
+
+    return published
+
+
+def _republish_tool_wins(method_name: str, bound, own_meta: dict, cls) -> None:
+    """Re-publish a tool-wins producer method as its BOUND form.
+
+    The user's ``@mesh.tool`` decorated the unbound method (``self`` in the
+    signature, registered under the bare name). Reconstruct the exact
+    ``@mesh.tool`` call from the stored metadata onto the bound method so the
+    schema has no ``self`` and the registry key is unique per capability.
+    """
+    from . import decorators
+
+    capability = own_meta.get("capability")
+    # Drop the stale unbound registration (keyed by the bare method __name__).
+    from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+    DecoratorRegistry.unregister_mesh_tool(method_name)
+
+    published = _wrap_bound(bound)
+    # Unique identity: the user's own capability if set, else the bare name.
+    published.__name__ = capability or method_name
+    published.__qualname__ = published.__name__
+
+    # Reconstruct the tool() call from the standard fields; forward any extra
+    # metadata (vendor kwargs) verbatim. ``retry_on`` is stored as a tuple
+    # (``()`` when unset) but tool() rejects a non-None retry_on with task=False
+    # — normalize empty → None.
+    _standard = {
+        "capability",
+        "tags",
+        "version",
+        "dependencies",
+        "description",
+        "output_schema_strict",
+        "task",
+        "retry_on",
+    }
+    extra = {
+        k: v
+        for k, v in own_meta.items()
+        if k not in _standard and k not in ("stream_type", "function_name")
+    }
+    retry_on = own_meta.get("retry_on") or None
+    wrapper = decorators.tool(
+        capability=capability,
+        tags=own_meta.get("tags"),
+        version=own_meta.get("version", "1.0.0"),
+        dependencies=own_meta.get("dependencies"),
+        description=own_meta.get("description"),
+        output_schema_strict=own_meta.get("output_schema_strict", True),
+        task=own_meta.get("task", False),
+        retry_on=retry_on,
+        **extra,
+    )(published)
+    _mark_for_serving(wrapper, published.__name__)
+
+
+def service(arg=None, *, min_available: int = 0):
+    """RFC #1280 ``@mesh.service`` — consumer view or producer sugar.
+
+    Forms::
+
+        @mesh.service                    # consumer view
+        @mesh.service()                  # consumer view
+        @mesh.service(min_available=2)   # consumer view with availability floor
+        @mesh.service("media")           # producer sugar (publishes media.<method>)
+    """
+    # Bare @mesh.service (class passed directly) → consumer view.
+    if isinstance(arg, type):
+        return _build_consumer_view(arg, min_available)
+
+    prefix = arg  # str (producer) or None (consumer view)
+
+    def decorator(cls):
+        if not isinstance(cls, type):
+            raise ValueError("@mesh.service must decorate a class")
+        if prefix is not None:
+            return _build_producer(cls, prefix, min_available)
+        return _build_consumer_view(cls, min_available)
+
+    return decorator

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -1165,6 +1165,89 @@ def tool(
         else:
             validated_dependencies = []
 
+        # RFC #1280: expand @mesh.service consumer-view parameters into
+        # dependency edges appended AFTER the explicit deps — parameter order
+        # across views, methods name-sorted WITHIN each view. The resulting
+        # edges are indistinguishable from hand-written deps on the wire; the
+        # ``view_slots`` descriptor tells the injector which appended indices
+        # belong to which view facade.
+        from _mcp_mesh.engine.signature_analyzer import (
+            analyze_mesh_job_signature,
+            analyze_service_view_params,
+            get_mesh_agent_positions,
+        )
+
+        from ._service import binding_to_dependency_dict
+
+        _view_params = analyze_service_view_params(target)
+
+        # RFC #1280 layout invariant: view edges are appended AFTER the explicit
+        # deps and are fanned out by a facade — they must NEVER be consumed by a
+        # positional McpMeshTool/MeshJob slot. That only holds if the explicit
+        # deps EXACTLY cover the explicit typed slots. A misdeclaration (e.g. a
+        # MeshJob param with no matching dependency) would otherwise silently
+        # steal the first view edge as its submitter/proxy target. Fail loudly
+        # with a precise message when views are present.
+        if _view_params:
+            _n_explicit = len(validated_dependencies)
+            _n_mesh = len(get_mesh_agent_positions(target))
+            _mj = analyze_mesh_job_signature(target)
+            _n_job = 1 if _mj.mesh_job_param_name else 0
+            _explicit_typed = _n_mesh + _n_job
+            if _n_explicit != _explicit_typed:
+                raise ValueError(
+                    f"@mesh.tool '{getattr(target, '__name__', '?')}': "
+                    f"{_n_explicit} explicit dependenc(ies) declared but the "
+                    f"signature has {_explicit_typed} explicit typed slot(s) "
+                    f"({_n_mesh} McpMeshTool + {_n_job} MeshJob) BEFORE the "
+                    f"@mesh.service view parameter(s). View edges are appended "
+                    f"after the explicit deps and fanned out by the facade — "
+                    f"they must not be positionally consumed. Fix: declare "
+                    f"exactly one dependency per explicit McpMeshTool/MeshJob "
+                    f"parameter (the view parameters take none)."
+                )
+
+        view_slots: list = []
+        for _vpos, _vname, _vmeta in _view_params:
+            _base = len(validated_dependencies)
+            _methods = []
+            for _rank, _binding in enumerate(_vmeta.bindings):
+                _dep_index = _base + _rank
+                validated_dependencies.append(binding_to_dependency_dict(_binding))
+                _methods.append(
+                    {
+                        "method_name": _binding.method_name,
+                        "capability": _binding.capability,
+                        "dep_index": _dep_index,
+                    }
+                )
+            view_slots.append(
+                {
+                    "param_name": _vname,
+                    "position": _vpos,
+                    "view_name": _vmeta.name,
+                    "min_available": _vmeta.min_available,
+                    "methods": _methods,
+                }
+            )
+
+        # A @mesh.service facade is async (its methods return coroutines), so a
+        # SYNC tool consuming a view could not await them — fail loudly at
+        # decoration rather than surface an un-awaited-coroutine bug at runtime.
+        # Async-generator (streaming) tools are async and allowed.
+        import inspect as _inspect
+
+        if view_slots and not (
+            asyncio.iscoroutinefunction(target)
+            or _inspect.isasyncgenfunction(target)
+        ):
+            _vnames = [v["param_name"] for v in view_slots]
+            raise ValueError(
+                f"@mesh.tool '{getattr(target, '__name__', '?')}': @mesh.service "
+                f"view parameter(s) {_vnames} require an `async def` tool — "
+                f"service-view facade methods are async. Mark the tool async."
+            )
+
         # Build tool metadata
         metadata = {
             "capability": capability,
@@ -1242,7 +1325,10 @@ def tool(
 
             injector = get_global_injector()
             wrapped = injector.create_injection_wrapper(
-                target, dependency_names, tool_required_caps=tool_required_caps
+                target,
+                dependency_names,
+                tool_required_caps=tool_required_caps,
+                view_slots=view_slots,
             )
 
             # Log the wrapper function pointer
@@ -1689,6 +1775,22 @@ def route(
     """
 
     def decorator(target: T) -> T:
+        # RFC #1280: @mesh.service views in @mesh.route are OUT OF SCOPE this
+        # round — fail loudly at decoration time rather than silently ignoring
+        # the parameter (which would inject nothing and surface as an
+        # AttributeError on first use). Views are supported on @mesh.tool.
+        from _mcp_mesh.engine.signature_analyzer import analyze_service_view_params
+
+        _route_views = analyze_service_view_params(target)
+        if _route_views:
+            _names = [name for _pos, name, _meta in _route_views]
+            raise ValueError(
+                f"@mesh.route '{getattr(target, '__name__', '?')}': @mesh.service "
+                f"view parameter(s) {_names} are not supported on routes "
+                f"(RFC #1280 views are @mesh.tool-only this round). Use "
+                f"McpMeshTool parameters with dependencies=[...] instead."
+            )
+
         # Validate and process dependencies (reuse logic from tool decorator)
         if dependencies is not None:
             if not isinstance(dependencies, list):

--- a/src/runtime/python/tests/unit/test_1273_direct_invoke_required.py
+++ b/src/runtime/python/tests/unit/test_1273_direct_invoke_required.py
@@ -170,7 +170,14 @@ class TestToolRequiredCapsWiring:
 
         real = DependencyInjector.create_injection_wrapper
 
-        def spy(self, func, dependencies, route_required_caps=None, tool_required_caps=None):
+        def spy(
+            self,
+            func,
+            dependencies,
+            route_required_caps=None,
+            tool_required_caps=None,
+            view_slots=None,
+        ):
             seen["tool_required_caps"] = tool_required_caps
             return real(
                 self,
@@ -178,6 +185,7 @@ class TestToolRequiredCapsWiring:
                 dependencies,
                 route_required_caps=route_required_caps,
                 tool_required_caps=tool_required_caps,
+                view_slots=view_slots,
             )
 
         with patch.object(DependencyInjector, "create_injection_wrapper", spy):
@@ -199,7 +207,14 @@ class TestToolRequiredCapsWiring:
 
         real = DependencyInjector.create_injection_wrapper
 
-        def spy(self, func, dependencies, route_required_caps=None, tool_required_caps=None):
+        def spy(
+            self,
+            func,
+            dependencies,
+            route_required_caps=None,
+            tool_required_caps=None,
+            view_slots=None,
+        ):
             seen["tool_required_caps"] = tool_required_caps
             return real(
                 self,
@@ -207,6 +222,7 @@ class TestToolRequiredCapsWiring:
                 dependencies,
                 route_required_caps=route_required_caps,
                 tool_required_caps=tool_required_caps,
+                view_slots=view_slots,
             )
 
         with patch.object(DependencyInjector, "create_injection_wrapper", spy):

--- a/src/runtime/python/tests/unit/test_1280_service_view.py
+++ b/src/runtime/python/tests/unit/test_1280_service_view.py
@@ -1,0 +1,1080 @@
+"""
+Unit tests for RFC #1280 service views — Python runtime.
+
+Python ships the CONSUMER VIEW (tool-parameter form) + PRODUCER SUGAR. These
+tests are the Python instance of the cross-runtime seam (uc37 is the
+integration contract; the Java runtime is the reference).
+
+CRITICAL: facade delegation is tested against the EXACT shapes of the real
+injected proxies — ``UnifiedMCPProxy.__call__(*args, **kwargs)`` ignores
+positionals and sends only kwargs upstream, and ``SelfDependencyProxy`` accepts
+kwargs only. A fake that accepts a positional dict would mask the wire bug, so
+the fakes below mirror the real signatures deliberately.
+
+Layout contract asserted throughout: explicit deps FIRST, then each view's
+method edges appended in parameter order, methods SORTED BY NAME within a view.
+"""
+
+import asyncio
+import json
+import os
+import time
+
+import mesh
+import pytest
+from fastmcp.exceptions import ToolError
+
+from _mcp_mesh.engine import settle
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+from _mcp_mesh.engine.signature_analyzer import (
+    analyze_service_view_params,
+    validate_mesh_dependencies,
+)
+from mesh import MeshJob, MeshServiceUnavailableError
+from mesh.types import McpMeshTool
+
+
+def _clear():
+    DecoratorRegistry.clear_all()
+    from _mcp_mesh.pipeline.mcp_startup import clear_debounce_coordinator
+
+    clear_debounce_coordinator()
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    """Fresh registry + settled (no grace) settle state per test."""
+    _clear()
+    os.environ["MCP_MESH_SETTLE_TIMEOUT"] = "0"
+    settle._reset_settle_state_for_tests()
+    yield
+    os.environ.pop("MCP_MESH_SETTLE_TIMEOUT", None)
+    settle._reset_settle_state_for_tests()
+    _clear()
+
+
+# ---------------------------------------------------------------------------
+# Real-shaped proxy fakes — DO NOT accept a positional dict, on purpose.
+# ---------------------------------------------------------------------------
+
+
+class FakeUnifiedProxy:
+    """Mirrors ``UnifiedMCPProxy.__call__(*args, **kwargs)``: ignores *args
+    entirely (so a positional dict would be silently dropped → empty upstream),
+    pops ``headers``, records the kwargs it would send as tool arguments."""
+
+    def __init__(self, name):
+        self.name = name
+        self.received = None
+        self.received_headers = None
+
+    async def __call__(self, *args, **kwargs):
+        self.received_headers = kwargs.pop("headers", None)
+        self.received = dict(kwargs)
+        return {"served": self.name, "args": dict(kwargs)}
+
+
+class FakeSelfProxy:
+    """Mirrors ``SelfDependencyProxy.__call__(**kwargs)``: kwargs only —
+    a positional argument raises TypeError."""
+
+    def __init__(self, name):
+        self.name = name
+        self.received = None
+
+    async def __call__(self, **kwargs):
+        self.received = dict(kwargs)
+        return {"served": self.name, "args": dict(kwargs)}
+
+
+# ---------------------------------------------------------------------------
+# Module-scope views (consumer views only stamp metadata — no registration).
+# ---------------------------------------------------------------------------
+
+
+@mesh.service
+class MediaService:
+    @mesh.selector("media.caption", required=True, tags=["+fast"])
+    async def caption(self, args: dict) -> dict: ...
+
+    @mesh.selector("media.thumbnail")
+    async def thumbnail(self, args: dict) -> dict: ...
+
+
+@mesh.service
+class OptionalView:
+    @mesh.selector("opt.alpha")
+    async def alpha(self, args: dict) -> dict: ...
+
+    @mesh.selector("opt.bravo")
+    async def bravo(self, args: dict) -> dict: ...
+
+
+# ===========================================================================
+# Detection + expansion order
+# ===========================================================================
+
+
+class TestViewDetectionAndExpansion:
+    def test_analyze_detects_view_param(self):
+        async def tool(req: dict, media: MediaService = None):
+            pass
+
+        views = analyze_service_view_params(tool)
+        assert len(views) == 1
+        pos, name, meta = views[0]
+        assert (pos, name) == (1, "media")
+        assert [b.method_name for b in meta.bindings] == ["caption", "thumbnail"]
+        assert [b.capability for b in meta.bindings] == [
+            "media.caption",
+            "media.thumbnail",
+        ]
+
+    def test_explicit_deps_first_then_view_methods_name_sorted(self):
+        @mesh.tool(capability="process", dependencies=["audit_log"])
+        async def process(
+            req: dict, audit: McpMeshTool = None, media: MediaService = None
+        ):
+            return None
+
+        caps = [d["capability"] for d in process._mesh_tool_metadata["dependencies"]]
+        assert caps == ["audit_log", "media.caption", "media.thumbnail"]
+        req = {
+            d["capability"]: d.get("required")
+            for d in process._mesh_tool_metadata["dependencies"]
+        }
+        assert req["media.caption"] is True
+        assert req.get("media.thumbnail") in (None, False)
+        assert len(process._mesh_injected_deps) == 3
+
+    def test_multi_view_param_order_then_name_sorted_within_each(self):
+        @mesh.tool(capability="multi")
+        async def multi(
+            req: dict, media: MediaService = None, opt: OptionalView = None
+        ):
+            return None
+
+        caps = [d["capability"] for d in multi._mesh_tool_metadata["dependencies"]]
+        assert caps == [
+            "media.caption",
+            "media.thumbnail",
+            "opt.alpha",
+            "opt.bravo",
+        ]
+
+    def test_explicit_dep_before_two_views(self):
+        @mesh.tool(capability="mixed", dependencies=["audit_log"])
+        async def mixed(
+            audit: McpMeshTool = None,
+            media: MediaService = None,
+            opt: OptionalView = None,
+        ):
+            return None
+
+        caps = [d["capability"] for d in mixed._mesh_tool_metadata["dependencies"]]
+        assert caps == [
+            "audit_log",
+            "media.caption",
+            "media.thumbnail",
+            "opt.alpha",
+            "opt.bravo",
+        ]
+
+    def test_view_param_hidden_from_fastmcp_signature(self):
+        import inspect
+
+        @mesh.tool(capability="hide", dependencies=["audit_log"])
+        async def hide(
+            req: dict, audit: McpMeshTool = None, media: MediaService = None
+        ):
+            return None
+
+        params = list(inspect.signature(hide).parameters.keys())
+        assert params == ["req"]
+
+    def test_optional_view_annotation_detected(self):
+        from typing import Optional
+
+        async def tool(req: dict, media: Optional[MediaService] = None):
+            pass
+
+        views = analyze_service_view_params(tool)
+        assert len(views) == 1
+        assert views[0][1] == "media"
+
+    def test_meshjob_plus_view_layout(self):
+        @mesh.tool(capability="combo", dependencies=["the_job"])
+        async def combo(user: str, the_job: MeshJob = None, view: OptionalView = None):
+            return None
+
+        caps = [d["capability"] for d in combo._mesh_tool_metadata["dependencies"]]
+        assert caps == ["the_job", "opt.alpha", "opt.bravo"]
+        assert len(combo._mesh_injected_deps) == 3
+
+    def test_hint_failure_view_free_function_no_warning(self, caplog):
+        """A view-free function whose get_type_hints fails (unresolvable
+        annotation) must NOT emit the @mesh.service view warning."""
+        import logging
+
+        async def tool(x: "TotallyMissingType"):  # noqa: F821
+            pass
+
+        with caplog.at_level(logging.WARNING, logger="_mcp_mesh.engine.signature_analyzer"):
+            views = analyze_service_view_params(tool)
+        assert views == []
+        assert not any(
+            "@mesh.service" in r.message or "view parameter" in r.message
+            for r in caplog.records
+        )
+
+    def test_hint_failure_recovers_view_and_warns(self, caplog):
+        """When get_type_hints fails on a sibling annotation, a resolvable view
+        parameter is still recovered per-parameter — and warns (naming it)."""
+        import logging
+
+        async def tool(bad: "TotallyMissingType", view: OptionalView = None):  # noqa: F821
+            pass
+
+        with caplog.at_level(logging.WARNING, logger="_mcp_mesh.engine.signature_analyzer"):
+            views = analyze_service_view_params(tool)
+        # View recovered despite the sibling's unresolvable annotation.
+        assert [name for _pos, name, _meta in views] == ["view"]
+        assert any("view" in r.message and "recovered" in r.message.lower()
+                   for r in caplog.records)
+
+
+# ===========================================================================
+# Dependency accounting
+# ===========================================================================
+
+
+class TestDependencyAccounting:
+    def test_validate_counts_view_edges(self):
+        async def tool(req: dict, media: MediaService = None):
+            pass
+
+        ok, msg = validate_mesh_dependencies(
+            tool, [{"capability": "media.caption"}, {"capability": "media.thumbnail"}]
+        )
+        assert ok, msg
+
+    def test_validate_counts_explicit_plus_view(self):
+        async def tool(
+            req: dict, audit: McpMeshTool = None, media: MediaService = None
+        ):
+            pass
+
+        deps = [
+            {"capability": "audit_log"},
+            {"capability": "media.caption"},
+            {"capability": "media.thumbnail"},
+        ]
+        ok, msg = validate_mesh_dependencies(tool, deps)
+        assert ok, msg
+
+    def test_validate_mismatch_when_view_edges_missing(self):
+        async def tool(req: dict, media: MediaService = None):
+            pass
+
+        ok, msg = validate_mesh_dependencies(tool, [{"capability": "media.caption"}])
+        assert not ok
+        assert "service-view method edge" in msg
+
+    def test_settle_keys_registered_for_view_edges(self):
+        @mesh.tool(capability="settle_reg", dependencies=["audit_log"])
+        async def settle_reg(
+            req: dict, audit: McpMeshTool = None, media: MediaService = None
+        ):
+            return None
+
+        declared = settle.get_settle_state()._declared
+        func_id = (
+            f"{settle_reg._mesh_original_func.__module__}."
+            f"{settle_reg._mesh_original_func.__qualname__}"
+        )
+        assert f"{func_id}:dep_0" in declared
+        assert f"{func_id}:dep_1" in declared
+        assert f"{func_id}:dep_2" in declared
+
+    def test_meshjob_without_matching_dep_raises_clear_error(self):
+        with pytest.raises(ValueError) as exc:
+
+            @mesh.tool(capability="bad_combo")  # no dependencies for the_job
+            async def bad_combo(
+                user: str, the_job: MeshJob = None, view: OptionalView = None
+            ):
+                return None
+
+        msg = str(exc.value)
+        assert "explicit typed slot" in msg
+        assert "MeshJob" in msg
+
+
+# ===========================================================================
+# Facade delegation — REAL proxy shapes
+# ===========================================================================
+
+
+class TestFacadeDelegation:
+    def test_delegates_named_params_through_unified_proxy_shape(self):
+        """Owner-idiom positional dict must be SPREAD into kwargs — a proxy
+        that ignores *args (like UnifiedMCPProxy) must still receive the args."""
+
+        @mesh.tool(capability="deleg_unified")
+        async def deleg(media: OptionalView = None):
+            return {
+                "a": await media.alpha({"x": 1, "y": 2}),
+                "b": await media.bravo({"z": 3}),
+            }
+
+        alpha_proxy = FakeUnifiedProxy("alpha")
+        bravo_proxy = FakeUnifiedProxy("bravo")
+        deleg._mesh_update_dependency(0, alpha_proxy)  # opt.alpha
+        deleg._mesh_update_dependency(1, bravo_proxy)  # opt.bravo
+
+        out = asyncio.run(deleg())
+        assert alpha_proxy.received == {"x": 1, "y": 2}
+        assert bravo_proxy.received == {"z": 3}
+        assert out["a"]["served"] == "alpha"
+        assert out["b"]["served"] == "bravo"
+
+    def test_delegates_through_self_dependency_proxy_shape(self):
+        @mesh.tool(capability="deleg_self")
+        async def deleg(media: OptionalView = None):
+            return await media.alpha({"k": "v"})
+
+        proxy = FakeSelfProxy("self_alpha")
+        deleg._mesh_update_dependency(0, proxy)
+        deleg._mesh_update_dependency(1, FakeSelfProxy("b"))
+
+        out = asyncio.run(deleg())
+        assert proxy.received == {"k": "v"}
+        assert out["served"] == "self_alpha"
+
+    def test_no_arg_method_call(self):
+        @mesh.service
+        class NoArgView:
+            @mesh.selector("na.ping")
+            async def ping(self) -> dict: ...
+
+        @mesh.tool(capability="noarg")
+        async def noarg(view: NoArgView = None):
+            return await view.ping()
+
+        proxy = FakeUnifiedProxy("ping")
+        noarg._mesh_update_dependency(0, proxy)
+        out = asyncio.run(noarg())
+        assert proxy.received == {}
+        assert out["served"] == "ping"
+
+    def test_headers_thread_through_kwargs(self):
+        @mesh.tool(capability="hdr")
+        async def hdr(media: OptionalView = None):
+            return await media.alpha({"x": 1}, headers={"x-audit-id": "abc"})
+
+        proxy = FakeUnifiedProxy("alpha")
+        hdr._mesh_update_dependency(0, proxy)
+        hdr._mesh_update_dependency(1, FakeUnifiedProxy("b"))
+        asyncio.run(hdr())
+        assert proxy.received == {"x": 1}
+        assert proxy.received_headers == {"x-audit-id": "abc"}
+
+    def test_offset_delegation_with_explicit_dep(self):
+        @mesh.tool(capability="offset", dependencies=["audit_log"])
+        async def offset(audit: McpMeshTool = None, media: OptionalView = None):
+            return {
+                "audit": audit is not None,
+                "a": await media.alpha({"n": 1}),
+            }
+
+        offset._mesh_update_dependency(0, FakeUnifiedProxy("audit"))  # audit_log
+        alpha_proxy = FakeUnifiedProxy("alpha")
+        offset._mesh_update_dependency(1, alpha_proxy)  # opt.alpha
+        offset._mesh_update_dependency(2, FakeUnifiedProxy("bravo"))  # opt.bravo
+
+        out = asyncio.run(offset())
+        assert out["audit"] is True
+        assert alpha_proxy.received == {"n": 1}
+        assert out["a"]["served"] == "alpha"
+
+    def test_rebinding_picked_up_at_call_time(self):
+        @mesh.tool(capability="rebind")
+        async def rebind(media: OptionalView = None):
+            return await media.alpha({"n": 1})
+
+        rebind._mesh_update_dependency(0, FakeUnifiedProxy("first"))
+        rebind._mesh_update_dependency(1, FakeUnifiedProxy("b"))
+        assert asyncio.run(rebind())["served"] == "first"
+
+        rebind._mesh_update_dependency(0, FakeUnifiedProxy("second"))
+        assert asyncio.run(rebind())["served"] == "second"
+
+    def test_unresolved_optional_method_raises_naming_capability(self):
+        @mesh.tool(capability="opt_unresolved")
+        async def opt_unresolved(media: OptionalView = None):
+            return await media.bravo({"z": 1})
+
+        opt_unresolved._mesh_update_dependency(0, FakeUnifiedProxy("alpha"))
+        with pytest.raises(ToolError) as exc:
+            asyncio.run(opt_unresolved())
+        assert json.loads(str(exc.value)) == {
+            "error": "dependency_unavailable",
+            "capability": "opt.bravo",
+        }
+
+    def test_unknown_method_raises_attribute_error(self):
+        @mesh.tool(capability="unknown_method")
+        async def unknown_method(media: OptionalView = None):
+            return await media.nonexistent({})
+
+        unknown_method._mesh_update_dependency(0, FakeUnifiedProxy("a"))
+        unknown_method._mesh_update_dependency(1, FakeUnifiedProxy("b"))
+        with pytest.raises(AttributeError):
+            asyncio.run(unknown_method())
+
+    def test_non_dict_positional_raises_typeerror(self):
+        @mesh.tool(capability="baddict")
+        async def baddict(media: OptionalView = None):
+            return await media.alpha("not-a-dict")
+
+        baddict._mesh_update_dependency(0, FakeUnifiedProxy("a"))
+        baddict._mesh_update_dependency(1, FakeUnifiedProxy("b"))
+        with pytest.raises(TypeError):
+            asyncio.run(baddict())
+
+
+# ===========================================================================
+# Required view edge → pre-invoke refusal + mock contract
+# ===========================================================================
+
+
+class TestRequiredViewEdgeRefusal:
+    def test_required_view_method_unresolved_refuses_before_handler(self):
+        called = []
+
+        @mesh.tool(capability="req_view")
+        async def req_view(media: MediaService = None):
+            called.append(True)
+            return await media.caption({"t": "x"})
+
+        with pytest.raises(ToolError) as exc:
+            asyncio.run(req_view())
+        assert json.loads(str(exc.value)) == {
+            "error": "dependency_unavailable",
+            "capability": "media.caption",
+        }
+        assert called == []
+
+    def test_required_view_method_available_runs_handler(self):
+        called = []
+
+        @mesh.tool(capability="req_view_ok")
+        async def req_view_ok(media: MediaService = None):
+            called.append(True)
+            return await media.caption({"t": "y"})
+
+        proxy = FakeUnifiedProxy("caption")
+        req_view_ok._mesh_update_dependency(0, proxy)  # media.caption (required)
+        out = asyncio.run(req_view_ok())
+        assert called == [True]
+        assert proxy.received == {"t": "y"}
+
+    def test_mock_contract_supplied_facade_skips_refusal(self):
+        """A caller that supplies a fake facade for the view param skips the
+        required-edge pre-invoke refusal for ALL that view's edges."""
+        called = []
+
+        class FakeFacade:
+            async def caption(self, args=None, **kw):
+                return {"mocked": True}
+
+        @mesh.tool(capability="mock_view")
+        async def mock_view(media: MediaService = None):
+            called.append(True)
+            return await media.caption({"t": "z"})
+
+        out = asyncio.run(mock_view(media=FakeFacade()))
+        assert called == [True]
+        assert out == {"mocked": True}
+
+
+# ===========================================================================
+# min_available floor
+# ===========================================================================
+
+
+@mesh.service(min_available=2)
+class FlooredView:
+    @mesh.selector("floor.alpha")
+    async def alpha(self, args: dict) -> dict: ...
+
+    @mesh.selector("floor.bravo")
+    async def bravo(self, args: dict) -> dict: ...
+
+
+class TestMinAvailableFloor:
+    def test_below_floor_raises_service_unavailable_with_counts(self):
+        @mesh.tool(capability="floored")
+        async def floored(view: FlooredView = None):
+            return await view.alpha({})
+
+        floored._mesh_update_dependency(0, FakeUnifiedProxy("a"))  # only 1 of 2
+        with pytest.raises(MeshServiceUnavailableError) as exc:
+            asyncio.run(floored())
+        err = exc.value
+        assert err.service == "FlooredView"
+        assert err.methods_available == 1
+        assert err.methods_total == 2
+        assert err.min_available == 2
+
+    def test_floor_satisfied_delegates(self):
+        @mesh.tool(capability="floor_ok")
+        async def floor_ok(view: FlooredView = None):
+            return await view.alpha({"q": 1})
+
+        alpha_p = FakeUnifiedProxy("alpha")
+        floor_ok._mesh_update_dependency(0, alpha_p)
+        floor_ok._mesh_update_dependency(1, FakeUnifiedProxy("bravo"))
+        out = asyncio.run(floor_ok())
+        assert out["served"] == "alpha"
+        assert alpha_p.received == {"q": 1}
+
+    def test_floor_already_satisfied_no_wait(self, monkeypatch):
+        """_enforce_floor counts FIRST: floor=1 with one resolved + one
+        unresolvable must not park on the unresolvable edge. Tested against the
+        facade directly to isolate it from the wrapper-level settle grace."""
+        from _mcp_mesh.engine.service_view import MeshServiceFacade
+
+        monkeypatch.setenv("MCP_MESH_SETTLE_TIMEOUT", "5")
+        settle._reset_settle_state_for_tests()
+        state = settle.get_settle_state()
+        state.register_declared("t.OneFloor:dep_0")
+        state.register_declared("t.OneFloor:dep_1")  # never resolves
+
+        injected = [FakeUnifiedProxy("alpha"), None]
+        facade = MeshServiceFacade(
+            view_name="OneFloor",
+            min_available=1,
+            methods=[
+                {"method_name": "alpha", "capability": "of.alpha", "dep_index": 0},
+                {"method_name": "bravo", "capability": "of.bravo", "dep_index": 1},
+            ],
+            func_id="t.OneFloor",
+            injected_deps_array=injected,
+            get_dependency_fn=lambda k: None,
+        )
+
+        start = time.monotonic()
+        asyncio.run(facade._enforce_floor())  # already satisfied → returns fast
+        elapsed = time.monotonic() - start
+        assert elapsed < 1.0
+        settle._reset_settle_state_for_tests()
+
+    def test_floor_cross_edge_wake(self, monkeypatch):
+        """Below floor while settling → wake on ANY edge resolving (race, not
+        serial), recount, proceed early. Tested against the facade directly."""
+        from _mcp_mesh.engine.service_view import MeshServiceFacade
+
+        monkeypatch.setenv("MCP_MESH_SETTLE_TIMEOUT", "5")
+        settle._reset_settle_state_for_tests()
+        state = settle.get_settle_state()
+        state.register_declared("t.Wake:dep_0")
+        state.register_declared("t.Wake:dep_1")
+
+        injected = [None, None]
+        facade = MeshServiceFacade(
+            view_name="Wake",
+            min_available=1,
+            methods=[
+                {"method_name": "alpha", "capability": "wf.alpha", "dep_index": 0},
+                {"method_name": "bravo", "capability": "wf.bravo", "dep_index": 1},
+            ],
+            func_id="t.Wake",
+            injected_deps_array=injected,
+            get_dependency_fn=lambda k: None,
+        )
+
+        async def scenario():
+            async def resolve_soon():
+                await asyncio.sleep(0.1)
+                injected[0] = FakeUnifiedProxy("alpha")  # only ONE resolves
+                settle.get_settle_state().mark_resolved("t.Wake:dep_0")
+
+            task = asyncio.create_task(resolve_soon())
+            start = time.monotonic()
+            await facade._enforce_floor()  # below floor → races, wakes on alpha
+            elapsed = time.monotonic() - start
+            await task
+            return elapsed
+
+        elapsed = asyncio.run(scenario())
+        assert elapsed < 2.0  # woke early on the alpha resolution, not full 5s
+        settle._reset_settle_state_for_tests()
+
+
+# ===========================================================================
+# Producer sugar
+# ===========================================================================
+
+
+class TestProducerSugar:
+    def test_publishes_prefixed_capabilities(self):
+        @mesh.service("media")
+        class MediaTools:
+            async def caption(self, args: dict) -> dict:
+                return {"cap": "caption"}
+
+            async def thumbnail(self, args: dict) -> dict:
+                return {"cap": "thumbnail"}
+
+        tools = DecoratorRegistry.get_mesh_tools()
+        caps = sorted(
+            t.metadata.get("capability")
+            for t in tools.values()
+            if (t.metadata.get("capability") or "").startswith("media.")
+        )
+        assert caps == ["media.caption", "media.thumbnail"]
+
+    def test_published_tool_registered_under_dotted_name(self):
+        @mesh.service("svc")
+        class SvcTools:
+            async def alpha(self, args: dict) -> dict:
+                return {}
+
+        assert "svc.alpha" in DecoratorRegistry.get_mesh_tools()
+
+    def test_two_producers_same_method_name_both_registered(self):
+        @mesh.service("svca")
+        class A:
+            async def get(self, args: dict) -> dict:
+                return {"from": "a"}
+
+        @mesh.service("svcb")
+        class B:
+            async def get(self, args: dict) -> dict:
+                return {"from": "b"}
+
+        tools = DecoratorRegistry.get_mesh_tools()
+        caps = sorted(
+            t.metadata.get("capability")
+            for t in tools.values()
+            if (t.metadata.get("capability") or "").startswith("svc")
+        )
+        assert "svca.get" in caps
+        assert "svcb.get" in caps
+
+    def test_underscore_methods_skipped(self):
+        @mesh.service("svc")
+        class WithHelper:
+            async def visible(self, args: dict) -> dict:
+                return {}
+
+            def _helper(self):
+                return 1
+
+        tools = DecoratorRegistry.get_mesh_tools()
+        caps = sorted(
+            t.metadata.get("capability")
+            for t in tools.values()
+            if (t.metadata.get("capability") or "").startswith("svc.")
+        )
+        assert caps == ["svc.visible"]
+
+    def test_auto_published_invocation_no_self_in_schema(self):
+        import inspect
+
+        @mesh.service("inv")
+        class InvTools:
+            async def caption(self, args: dict) -> dict:
+                return {"cap": "caption", "got": args}
+
+        fn = DecoratorRegistry.get_mesh_tools()["inv.caption"].function
+        assert "self" not in inspect.signature(fn).parameters
+        out = asyncio.run(fn(args={"k": 1}))
+        assert out == {"cap": "caption", "got": {"k": 1}}
+
+    def test_method_with_own_mesh_tool_wins_no_double_publish(self):
+        @mesh.service("prod")
+        class ProdTools:
+            @mesh.tool(capability="custom_cap")
+            async def special(self, args: dict) -> dict:
+                return {"special": True, "got": args}
+
+            async def plain(self, args: dict) -> dict:
+                return {}
+
+        all_caps = sorted(
+            t.metadata.get("capability")
+            for t in DecoratorRegistry.get_mesh_tools().values()
+            if t.metadata.get("capability")
+        )
+        assert "custom_cap" in all_caps
+        assert "prod.special" not in all_caps
+        assert "prod.plain" in all_caps
+
+    def test_tool_wins_bound_invocation_no_self_in_schema(self):
+        import inspect
+
+        @mesh.service("prod2")
+        class ProdTools2:
+            @mesh.tool(capability="custom_cap2")
+            async def special(self, args: dict) -> dict:
+                return {"special": True, "got": args}
+
+        fn = DecoratorRegistry.get_mesh_tools()["custom_cap2"].function
+        assert "self" not in inspect.signature(fn).parameters
+        out = asyncio.run(fn(args={"n": 2}))
+        assert out == {"special": True, "got": {"n": 2}}
+
+    def test_invalid_prefix_raises_reusing_validator(self):
+        with pytest.raises(ValueError) as exc:
+
+            @mesh.service("1bad")
+            class Bad:
+                async def m(self, args: dict) -> dict:
+                    return {}
+
+        assert "capability" in str(exc.value).lower()
+
+    def test_blank_prefix_raises(self):
+        with pytest.raises(ValueError):
+
+            @mesh.service("")
+            class Blank:
+                async def m(self, args: dict) -> dict:
+                    return {}
+
+    def test_producer_min_available_raises(self):
+        with pytest.raises(ValueError) as exc:
+
+            @mesh.service("p", min_available=1)
+            class P:
+                async def m(self, args: dict) -> dict:
+                    return {}
+
+        assert "min_available" in str(exc.value)
+
+    def test_producer_constructor_error_named_clearly(self):
+        with pytest.raises(ValueError) as exc:
+
+            @mesh.service("ctor")
+            class NeedsArg:
+                def __init__(self, required_arg):
+                    self.x = required_arg
+
+                async def m(self, args: dict) -> dict:
+                    return {}
+
+        msg = str(exc.value)
+        assert "@mesh.service" in msg
+        assert "NeedsArg" in msg
+        assert "zero-arg" in msg
+
+
+# ===========================================================================
+# Validation boot-fails (item 7)
+# ===========================================================================
+
+
+class TestValidationBootFails:
+    def test_view_public_method_without_selector_raises(self):
+        with pytest.raises(ValueError) as exc:
+
+            @mesh.service
+            class BadView:
+                @mesh.selector("x.y")
+                async def good(self, args: dict) -> dict: ...
+
+                async def missing(self, args: dict) -> dict: ...
+
+        assert "selector" in str(exc.value).lower()
+
+    def test_sync_selector_stub_raises(self):
+        with pytest.raises(ValueError) as exc:
+
+            @mesh.service
+            class SyncStub:
+                @mesh.selector("x.y")
+                def sync_method(self, args: dict) -> dict: ...
+
+        assert "async" in str(exc.value).lower()
+
+    def test_sync_tool_consuming_view_raises(self):
+        with pytest.raises(ValueError) as exc:
+
+            @mesh.tool(capability="sync_consumer")
+            def sync_consumer(media: MediaService = None):
+                return None
+
+        assert "async" in str(exc.value).lower()
+
+    def test_producer_with_selector_raises_mixed_roles(self):
+        with pytest.raises(ValueError) as exc:
+
+            @mesh.service("mixed")
+            class Mixed:
+                @mesh.selector("a.b")
+                async def m(self, args: dict) -> dict: ...
+
+        msg = str(exc.value).lower()
+        assert "producer" in msg or "selector" in msg
+
+    def test_blank_capability_in_selector_raises(self):
+        with pytest.raises(ValueError) as exc:
+
+            @mesh.service
+            class BlankCap:
+                @mesh.selector("")
+                async def m(self, args: dict) -> dict: ...
+
+        assert "blank" in str(exc.value).lower() or "capability" in str(exc.value).lower()
+
+    def test_min_available_exceeds_method_count_raises(self):
+        with pytest.raises(ValueError) as exc:
+
+            @mesh.service(min_available=3)
+            class TooHigh:
+                @mesh.selector("a.b")
+                async def a(self, args: dict) -> dict: ...
+
+                @mesh.selector("c.d")
+                async def b(self, args: dict) -> dict: ...
+
+        assert "min_available" in str(exc.value)
+
+    def test_negative_min_available_raises(self):
+        with pytest.raises(ValueError):
+
+            @mesh.service(min_available=-1)
+            class Neg:
+                @mesh.selector("a.b")
+                async def a(self, args: dict) -> dict: ...
+
+
+# ===========================================================================
+# View inheritance (item 5)
+# ===========================================================================
+
+
+class TestViewInheritance:
+    def test_decorated_subclass_is_own_view(self):
+        @mesh.service
+        class Base:
+            @mesh.selector("base.a")
+            async def a(self, args: dict) -> dict: ...
+
+        @mesh.service
+        class Child(Base):
+            @mesh.selector("child.b")
+            async def b(self, args: dict) -> dict: ...
+
+        async def tool(view: Child = None):
+            pass
+
+        views = analyze_service_view_params(tool)
+        assert len(views) == 1
+        meta = views[0][2]
+        assert meta.name == "Child"
+        assert sorted(bnd.capability for bnd in meta.bindings) == [
+            "base.a",
+            "child.b",
+        ]
+
+    def test_undecorated_subclass_is_not_a_view(self):
+        @mesh.service
+        class Parent:
+            @mesh.selector("p.a")
+            async def a(self, args: dict) -> dict: ...
+
+        class PlainChild(Parent):  # NOT decorated
+            pass
+
+        async def tool(view: PlainChild = None):
+            pass
+
+        assert analyze_service_view_params(tool) == []
+
+        @mesh.tool(capability="undecorated_child")
+        async def undecorated_child(view: PlainChild = None):
+            return None
+
+        assert undecorated_child._mesh_tool_metadata["dependencies"] == []
+
+
+# ===========================================================================
+# Stream tool + view (item 10)
+# ===========================================================================
+
+
+class TestStreamToolView:
+    def test_stream_tool_with_view_injects_facade(self):
+        @mesh.tool(capability="stream_view")
+        async def stream_view(view: OptionalView = None) -> mesh.Stream[str]:
+            res = await view.alpha({"x": 1})
+            yield res["served"]
+
+        proxy = FakeUnifiedProxy("alpha")
+        stream_view._mesh_update_dependency(0, proxy)
+        stream_view._mesh_update_dependency(1, FakeUnifiedProxy("b"))
+
+        result = asyncio.run(stream_view())
+        assert result == "alpha"
+        assert proxy.received == {"x": 1}
+
+
+# ===========================================================================
+# Producer serving — tools land on the SERVED FastMCP server (not just wire)
+# ===========================================================================
+
+
+def _server_tool_names(server) -> set:
+    lp = server.local_provider
+    return {
+        getattr(comp, "name", key)
+        for key, comp in lp._components.items()
+        if str(key).startswith("tool:")
+    }
+
+
+class TestProducerServing:
+    def _run_serving_step(self, server):
+        from _mcp_mesh.pipeline.mcp_startup import ServiceViewProducerServingStep
+
+        step = ServiceViewProducerServingStep()
+        ctx = {"fastmcp_servers": {"__main__.app": server}}
+        return asyncio.run(step.execute(ctx))
+
+    def test_sugar_tools_registered_on_fastmcp_server(self):
+        from fastmcp import FastMCP
+
+        @mesh.service("pysvc")
+        class PySvc:
+            async def alpha(self, args: dict) -> dict:
+                return {"cap": "pysvc.alpha"}
+
+            async def bravo(self, args: dict) -> dict:
+                return {"cap": "pysvc.bravo"}
+
+        server = FastMCP("test-producer")
+        # Before the step: NOT on the served instance (only in DecoratorRegistry).
+        assert "pysvc.alpha" not in _server_tool_names(server)
+
+        self._run_serving_step(server)
+
+        names = _server_tool_names(server)
+        assert "pysvc.alpha" in names
+        assert "pysvc.bravo" in names
+
+    def test_tool_wins_registered_on_fastmcp_server(self):
+        from fastmcp import FastMCP
+
+        @mesh.service("pw")
+        class PwTools:
+            @mesh.tool(capability="pw_custom")
+            async def special(self, args: dict) -> dict:
+                return {"special": True}
+
+            async def plain(self, args: dict) -> dict:
+                return {"plain": True}
+
+        server = FastMCP("test-toolwins")
+        self._run_serving_step(server)
+
+        names = _server_tool_names(server)
+        # tool-wins served under its own capability; plain under the prefix.
+        assert "pw_custom" in names
+        assert "pw.plain" in names
+
+    def test_serving_is_idempotent(self):
+        from fastmcp import FastMCP
+
+        @mesh.service("idem")
+        class IdemTools:
+            async def alpha(self, args: dict) -> dict:
+                return {}
+
+        server = FastMCP("test-idem")
+        self._run_serving_step(server)
+        # Running again must not raise / double-register.
+        self._run_serving_step(server)
+        names = [n for n in _server_tool_names(server) if n == "idem.alpha"]
+        assert names == ["idem.alpha"]
+
+    def test_step_skips_when_no_servers(self):
+        from _mcp_mesh.pipeline.mcp_startup import ServiceViewProducerServingStep
+        from _mcp_mesh.pipeline.shared import PipelineStatus
+
+        @mesh.service("noserver")
+        class NoServer:
+            async def alpha(self, args: dict) -> dict:
+                return {}
+
+        step = ServiceViewProducerServingStep()
+        res = asyncio.run(step.execute({"fastmcp_servers": {}}))
+        assert res.status == PipelineStatus.SKIPPED
+
+    def test_streaming_producer_method_served_as_stream(self):
+        """A streaming producer method (async-gen → Stream[str]) is published as
+        a real streaming tool and served."""
+        import inspect
+
+        from fastmcp import FastMCP
+
+        @mesh.service("strm")
+        class StrmTools:
+            async def ticker(self, args: dict) -> mesh.Stream[str]:
+                yield "a"
+                yield "b"
+
+        tools = DecoratorRegistry.get_mesh_tools()
+        decorated = tools["strm.ticker"]
+        # Stream detection fired directly (not via the wraps/annotation fallback):
+        # the published wrapper is itself an async-generator function.
+        assert decorated.metadata.get("stream_type") == "text"
+        assert inspect.isasyncgenfunction(decorated.function._mesh_original_func)
+
+        # Served on the FastMCP instance.
+        server = FastMCP("strm-server")
+        self._run_serving_step(server)
+        assert "strm.ticker" in _server_tool_names(server)
+
+        # Invoking the served wrapper accumulates the streamed chunks.
+        out = asyncio.run(decorated.function(args={}))
+        assert out == "ab"
+
+
+# ===========================================================================
+# @mesh.route views out of scope
+# ===========================================================================
+
+
+class TestRouteViewBootFail:
+    def test_view_param_in_route_raises(self):
+        with pytest.raises(ValueError) as exc:
+
+            @mesh.route(dependencies=["audit_log"])
+            async def handler(audit: McpMeshTool = None, media: MediaService = None):
+                return {}
+
+        assert "view" in str(exc.value).lower()
+
+
+# ===========================================================================
+# Public API surface
+# ===========================================================================
+
+
+class TestPublicSurface:
+    def test_service_selector_importable(self):
+        assert callable(mesh.service)
+        assert callable(mesh.selector)
+
+    def test_exception_importable_and_shaped(self):
+        err = MeshServiceUnavailableError("V", 1, 3, 2)
+        assert err.service == "V"
+        assert err.methods_available == 1
+        assert err.methods_total == 3
+        assert err.min_available == 2
+
+    def test_view_class_has_pydantic_schema_marker(self):
+        assert hasattr(MediaService, "__get_pydantic_core_schema__")

--- a/src/runtime/typescript/src/__tests__/service-view-types.spec.ts
+++ b/src/runtime/typescript/src/__tests__/service-view-types.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Strict-mode COMPILE test for the documented service-view consumer idiom
+ * (RFC #1280). The failure mode this guards against: "docs show code that
+ * doesn't compile." The project's `tsc --noEmit` (strict) type-checks this file,
+ * so if the documented idiom in service-view.ts's `MeshServiceFacade` JSDoc ever
+ * stops compiling, the build breaks here.
+ *
+ * The idiom functions below are never INVOKED (they'd construct a real
+ * MeshAgent); they exist purely so the compiler checks their bodies. Vitest runs
+ * the trivial assertion so this counts as a spec.
+ */
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { mesh, type MeshServiceFacade, type McpMeshTool } from "../index.js";
+
+// ── The canonical documented idiom, verbatim: un-annotated params + a cast on
+// the view slot at point of use. Must compile under strictFunctionTypes. ──────
+function _documentedConsumerIdiom(): void {
+  const server = {} as unknown as import("fastmcp").FastMCP;
+  const agent = mesh(server, { name: "example", httpPort: 0 });
+
+  const Media = mesh.serviceView({
+    methods: {
+      caption: { capability: "media.caption", required: true, tags: ["+fast"] },
+      thumbnail: "media.thumbnail",
+    },
+    minAvailable: 1,
+  });
+
+  agent.addTool({
+    name: "process",
+    parameters: z.object({ text: z.string() }),
+    dependencies: ["audit_log", Media],
+    execute: async (args, auditLog, media) => {
+      const svc = media as MeshServiceFacade<typeof Media>;
+      // Both spec method keys are typed on the facade, callable with the
+      // McpMeshTool signature (args?, options?) => Promise<unknown>.
+      const cap = await svc.caption({ text: args.text });
+      await svc.thumbnail();
+      // Ordinary McpMeshTool deps are consumed with the same cast idiom.
+      const audit = auditLog as McpMeshTool | null;
+      if (audit) await audit({ event: "captioned" });
+      return cap;
+    },
+  });
+}
+
+// ── Producer sugar idiom, verbatim. ──────────────────────────────────────────
+function _documentedProducerIdiom(): void {
+  const server = {} as unknown as import("fastmcp").FastMCP;
+  const agent = mesh(server, { name: "producer", httpPort: 0 });
+
+  agent.addService("media", {
+    caption: async (args: { text: string }) => ({ caption: args.text }),
+    thumbnail: {
+      execute: async (args: { assetId: string }) => ({ url: args.assetId }),
+      tags: ["fast"],
+      description: "thumbnail",
+    },
+  });
+}
+
+// ── The facade type maps each method key to a callable (compile-time only). ───
+type _MediaFacade = MeshServiceFacade<
+  ReturnType<
+    typeof mesh.serviceView<{ methods: { caption: "media.caption" } }>
+  >
+>;
+const _facadeMethodIsCallable: _MediaFacade["caption"] = async () => undefined;
+
+describe("service-view documented idiom compiles under strict", () => {
+  it("type-checks the consumer + producer idioms (compile-only)", () => {
+    expect(typeof _documentedConsumerIdiom).toBe("function");
+    expect(typeof _documentedProducerIdiom).toBe("function");
+    expect(typeof _facadeMethodIsCallable).toBe("function");
+  });
+});

--- a/src/runtime/typescript/src/__tests__/service-view.spec.ts
+++ b/src/runtime/typescript/src/__tests__/service-view.spec.ts
@@ -549,11 +549,84 @@ describe("minAvailable floor", () => {
     // A bounded wait actually occurred (never a fixed sleep once settled).
     expect(settle.waitCount).toBeGreaterThan(before);
   });
+
+  it("flapped (ratchet-resolved then unavailable) edges do NOT busy-spin below floor", async () => {
+    // Regression: an edge resolved once (settle ratchet) then flapped to a null
+    // proxy can never re-fire its waiter. If every pending edge is in that
+    // state, waitForAny returns immediately — the old enforceFloor loop would
+    // spin hot until the window expired. The fix breaks to the final throw the
+    // instant no WAKEABLE edge remains.
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    process.env.MCP_MESH_SETTLE_TIMEOUT = "30";
+    resetSettleStateForTests();
+    const View = serviceView({
+      methods: { a: "svc.a", b: "svc.b" },
+      minAvailable: 1,
+    });
+    const { edges, slots } = (
+      await import("../service-view.js")
+    ).expandDependencies([View], "flap_tool");
+    const settle = getSettleState();
+    settle.registerDeclared("flap_tool:dep_0");
+    settle.registerDeclared("flap_tool:dep_1");
+    // A third, never-resolving declared key keeps the agent UNSETTLED so the
+    // enforceFloor loop's `!isSettled()` guard stays true (the spin precondition).
+    settle.registerDeclared("other_tool:dep_0");
+
+    // Ratchet BOTH view edges (resolved-at-least-once) then flap them to null.
+    for (const e of [0, 1]) {
+      injectEdge(agent, "flap_tool", e, async () => "x");
+      settle.markResolved(`flap_tool:dep_${e}`);
+      removeEdge(agent, "flap_tool", e);
+    }
+    expect(settle.isResolved("flap_tool:dep_0")).toBe(true);
+    expect(settle.isResolved("flap_tool:dep_1")).toBe(true);
+    expect(settle.isSettled()).toBe(false); // window still open
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const depsArray = (agent as any)._buildDepSlots(
+      "flap_tool",
+      slots,
+      edges,
+      undefined,
+      settle,
+    );
+    const facade = depsArray[0] as Record<string, () => Promise<unknown>>;
+
+    const waitAnySpy = vi.spyOn(settle, "waitForAny");
+    let err: unknown;
+    try {
+      await facade.a();
+    } catch (e) {
+      err = e;
+    }
+    // Threw promptly with the floor error — no wakeable edge, so waitForAny was
+    // never entered and the window is still open (proof it did NOT spin to
+    // expiry; a spin would have latched isSettled() true).
+    expect(err).toBeInstanceOf(MeshServiceUnavailableError);
+    expect((err as MeshServiceUnavailableError).available).toBe(0);
+    expect((err as MeshServiceUnavailableError).total).toBe(2);
+    expect((err as MeshServiceUnavailableError).floor).toBe(1);
+    expect(waitAnySpy).not.toHaveBeenCalled();
+    expect(settle.isSettled()).toBe(false);
+    waitAnySpy.mockRestore();
+  });
 });
 
 describe("serviceView validation (throws at construction)", () => {
   it("empty methods map", () => {
     expect(() => serviceView({ methods: {} })).toThrow(/at least one method/);
+  });
+  it("methods array (numeric keys) is rejected as a non-object map", () => {
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      serviceView({ methods: [] as any }),
+    ).toThrow(/must be an object mapping method names/);
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      serviceView({ methods: ["svc.a"] as any }),
+    ).toThrow(/must be an object mapping method names/);
   });
   it("blank capability", () => {
     expect(() => serviceView({ methods: { a: "" } })).toThrow(/blank capability/);

--- a/src/runtime/typescript/src/__tests__/service-view.spec.ts
+++ b/src/runtime/typescript/src/__tests__/service-view.spec.ts
@@ -1,0 +1,1021 @@
+/**
+ * Service views (RFC #1280) — TypeScript runtime.
+ *
+ * Cross-runtime contract (mirrors the Java uc37 suite):
+ *
+ *  - CONSUMER VIEW: a `mesh.serviceView(...)` entry in a tool's `dependencies`
+ *    array occupies ONE positional slot but expands into N ordinary edges (one
+ *    per method, NAME-SORTED, in-place). The framework injects a facade at that
+ *    slot; each facade method delegates to its edge's own resolved proxy and
+ *    rebinds independently. The flat edge array is what ships / settles /
+ *    resolves — zero wire change; a view-free tool is byte-identical.
+ *
+ *  - PRODUCER SUGAR: `agent.addService("prefix", { ... })` publishes each entry
+ *    (name-sorted) as an ordinary tool with capability `prefix.<method>`.
+ *
+ * Covers: expansion order (explicit + view + explicit; multi-view; name-sort),
+ * settle keys per edge, payload carries N edges with required flags, facade
+ * delegation + rebinding, required refusal (direct + job flavors), the
+ * minAvailable floor (below/at, settle-aware wait), unresolved optional method
+ * error, all validation throws, producer addService, and serviceView-in-route.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { z } from "zod";
+import { UserError } from "fastmcp";
+
+// Mock only makeJobController (wraps a napi handle hitting the registry). The
+// REAL readJobHeaders runs so the job-dispatch classification path is exercised.
+const h = vi.hoisted(() => {
+  const releaseLeaseMock = vi.fn(async () => {});
+  const failMock = vi.fn(async () => {});
+  const makeJobControllerMock = vi.fn(() => ({
+    releaseLease: releaseLeaseMock,
+    fail: failMock,
+  }));
+  return { releaseLeaseMock, failMock, makeJobControllerMock };
+});
+
+vi.mock("../inbound-job-dispatch.js", async (importActual) => {
+  const actual = await importActual<typeof import("../inbound-job-dispatch.js")>();
+  return {
+    ...actual,
+    makeJobController:
+      h.makeJobControllerMock as unknown as typeof actual.makeJobController,
+  };
+});
+
+import { MeshAgent } from "../agent.js";
+import { RouteRegistry, route } from "../route.js";
+import { mount as a2aMount } from "../a2a/producer/index.js";
+import { ClaimDispatcher } from "../claim-dispatcher.js";
+import { MeshJobSubmitter } from "../mesh-job-submitter.js";
+import { normalizeSchemaWithPolicy } from "../schema-normalize.js";
+import {
+  serviceView,
+  isServiceView,
+  assertNoServiceViewDeps,
+  MeshServiceUnavailableError,
+} from "../service-view.js";
+import {
+  getSettleState,
+  resetSettleStateForTests,
+} from "../settle.js";
+
+function makeFastMCPStub() {
+  return {
+    addTool: vi.fn(),
+    start: vi.fn(),
+    getApp: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+let autoStartSpy: ReturnType<typeof vi.spyOn> | null = null;
+let warnSpy: ReturnType<typeof vi.spyOn> | null = null;
+const savedEnv: Record<string, string | undefined> = {};
+let agentCounter = 0;
+
+beforeEach(() => {
+  h.releaseLeaseMock.mockClear();
+  h.makeJobControllerMock.mockClear();
+  autoStartSpy = vi
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .spyOn(MeshAgent.prototype as any, "_autoStart")
+    .mockImplementation(async () => {
+      /* no-op */
+    });
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    /* swallow */
+  });
+  savedEnv.MCP_MESH_SETTLE_TIMEOUT = process.env.MCP_MESH_SETTLE_TIMEOUT;
+  savedEnv.MCP_MESH_TOOL_ISOLATION = process.env.MCP_MESH_TOOL_ISOLATION;
+  process.env.MCP_MESH_TOOL_ISOLATION = "false";
+  // Settle immediately by default so an unresolved edge is genuinely unresolved.
+  // Floor-wait tests override with a positive budget.
+  process.env.MCP_MESH_SETTLE_TIMEOUT = "0";
+  resetSettleStateForTests();
+  RouteRegistry.reset();
+});
+
+afterEach(() => {
+  autoStartSpy?.mockRestore();
+  autoStartSpy = null;
+  warnSpy?.mockRestore();
+  warnSpy = null;
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetSettleStateForTests();
+  RouteRegistry.reset();
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function newAgent(fastmcp: any): MeshAgent {
+  return new MeshAgent(fastmcp, {
+    name: `view-agent-${agentCounter++}`,
+    httpPort: 0,
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function captureExecute(fastmcp: any, idx = 0): (args: unknown) => Promise<string> {
+  return fastmcp.addTool.mock.calls[idx][0].execute as (
+    args: unknown,
+  ) => Promise<string>;
+}
+
+/** Inject a fake callable proxy at a tool's flat edge slot. */
+function injectEdge(
+  agent: MeshAgent,
+  toolName: string,
+  edgeIndex: number,
+  impl: (args?: Record<string, unknown>, options?: unknown) => Promise<unknown>,
+): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (agent as any).resolvedDeps.set(`${toolName}:dep_${edgeIndex}`, impl);
+}
+
+function removeEdge(agent: MeshAgent, toolName: string, edgeIndex: number): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (agent as any).resolvedDeps.delete(`${toolName}:dep_${edgeIndex}`);
+}
+
+/** Read the flat normalized-edge array the tool ships to the registry. */
+function edgesOf(
+  agent: MeshAgent,
+  toolName: string,
+): Array<{ capability: string; required?: boolean; tags: unknown }> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (agent as any).tools.get(toolName).dependencies;
+}
+
+describe("serviceView() factory + brand", () => {
+  it("brands the returned value", () => {
+    const v = serviceView({ methods: { a: "cap.a" } });
+    expect(isServiceView(v)).toBe(true);
+    expect(isServiceView({ methods: {} })).toBe(false);
+    expect(isServiceView("cap.a")).toBe(false);
+    expect(isServiceView(null)).toBe(false);
+  });
+});
+
+describe("expansion order + slot layout", () => {
+  it("explicit + view + explicit: edges expand in-place, view = one facade slot", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const Media = serviceView({
+      // Declared out of order to prove name-sorting.
+      methods: { thumbnail: "media.thumbnail", caption: "media.caption" },
+    });
+    const seen: unknown[] = [];
+    agent.addTool({
+      name: "process",
+      parameters: z.object({}),
+      dependencies: ["audit_log", Media, "metrics"],
+      execute: async (
+        _args: unknown,
+        audit: unknown,
+        media: unknown,
+        metrics: unknown,
+      ) => {
+        seen.push(audit, media, metrics);
+        return "ok";
+      },
+    });
+
+    // Flat edges: audit(0), caption(1), thumbnail(2), metrics(3) — view methods
+    // NAME-SORTED and expanded in-place at the view's array position.
+    expect(edgesOf(agent, "process").map((d) => d.capability)).toEqual([
+      "audit_log",
+      "media.caption",
+      "media.thumbnail",
+      "metrics",
+    ]);
+
+    // Wire up the two explicit deps + both view edges.
+    injectEdge(agent, "process", 0, async () => "audit-proxy");
+    injectEdge(agent, "process", 1, async (a) => ({ cap: "caption", a }));
+    injectEdge(agent, "process", 2, async (a) => ({ cap: "thumbnail", a }));
+    injectEdge(agent, "process", 3, async () => "metrics-proxy");
+
+    await captureExecute(fastmcp)({});
+    const [audit, media, metrics] = seen as [
+      (a?: Record<string, unknown>) => Promise<unknown>,
+      Record<string, (a?: Record<string, unknown>) => Promise<unknown>>,
+      (a?: Record<string, unknown>) => Promise<unknown>,
+    ];
+
+    // Explicit slots receive their own proxies; the view slot is a facade.
+    expect(await audit()).toBe("audit-proxy");
+    expect(await metrics()).toBe("metrics-proxy");
+    expect(typeof media.caption).toBe("function");
+    expect(typeof media.thumbnail).toBe("function");
+    expect(await media.caption({ text: "hi" })).toEqual({
+      cap: "caption",
+      a: { text: "hi" },
+    });
+    expect(await media.thumbnail({ id: "x" })).toEqual({
+      cap: "thumbnail",
+      a: { id: "x" },
+    });
+  });
+
+  it("multiple views expand into disjoint contiguous edge ranges", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const ViewA = serviceView({ methods: { b: "svc.b", a: "svc.a" } });
+    const ViewB = serviceView({ methods: { c: "svc.c" } });
+    const seen: unknown[] = [];
+    agent.addTool({
+      name: "multi",
+      parameters: z.object({}),
+      dependencies: [ViewA, ViewB],
+      execute: async (_args: unknown, va: unknown, vb: unknown) => {
+        seen.push(va, vb);
+        return "ok";
+      },
+    });
+
+    expect(edgesOf(agent, "multi").map((d) => d.capability)).toEqual([
+      "svc.a", // ViewA edge 0
+      "svc.b", // ViewA edge 1
+      "svc.c", // ViewB edge 2
+    ]);
+
+    injectEdge(agent, "multi", 0, async () => "A.a");
+    injectEdge(agent, "multi", 1, async () => "A.b");
+    injectEdge(agent, "multi", 2, async () => "B.c");
+
+    await captureExecute(fastmcp)({});
+    const [va, vb] = seen as [
+      Record<string, () => Promise<unknown>>,
+      Record<string, () => Promise<unknown>>,
+    ];
+    expect(Object.keys(va).sort()).toEqual(["a", "b"]);
+    expect(Object.keys(vb)).toEqual(["c"]);
+    expect(await va.a()).toBe("A.a");
+    expect(await va.b()).toBe("A.b");
+    expect(await vb.c()).toBe("B.c");
+  });
+
+  it("view-free tool is byte-identical (slot index === edge index)", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    agent.addTool({
+      name: "plain",
+      parameters: z.object({}),
+      dependencies: ["a", { capability: "b", required: true }],
+      execute: async () => "ok",
+    });
+    const edges = edgesOf(agent, "plain");
+    expect(edges.map((d) => d.capability)).toEqual(["a", "b"]);
+    expect(edges[1].required).toBe(true);
+  });
+});
+
+describe("wire payload + settle keys", () => {
+  it("payload carries N edges with per-method required flags", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({
+      methods: {
+        caption: { capability: "media.caption", required: true, tags: ["+fast"] },
+        thumbnail: "media.thumbnail",
+      },
+    });
+    agent.addTool({
+      name: "gen",
+      parameters: z.object({}),
+      dependencies: [View],
+      execute: async () => "ok",
+    });
+    const edges = edgesOf(agent, "gen");
+    expect(edges.map((d) => d.capability)).toEqual([
+      "media.caption",
+      "media.thumbnail",
+    ]);
+    // required=true only on the caption edge; thumbnail stays soft (undefined).
+    expect(edges[0].required).toBe(true);
+    expect(edges[1].required).toBeUndefined();
+    expect(edges[0].tags).toEqual(["+fast"]);
+  });
+
+  it("registers a settle key per edge (agent settles only when ALL resolve)", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({ methods: { a: "svc.a", b: "svc.b" } });
+    process.env.MCP_MESH_SETTLE_TIMEOUT = "30";
+    resetSettleStateForTests();
+    agent.addTool({
+      name: "svt",
+      parameters: z.object({}),
+      dependencies: [View],
+      execute: async () => "ok",
+    });
+    const settle = getSettleState();
+    expect(settle.isSettled()).toBe(false);
+    // Resolve edge 0 only → still unsettled (edge 1 pending).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).handleDependencyAvailable(
+      "svc.a",
+      "http://localhost:19999",
+      "fn",
+      "prov",
+      "svt",
+      0,
+    );
+    expect(settle.isSettled()).toBe(false);
+    // Resolve edge 1 → last declared key → eager latch flips.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).handleDependencyAvailable(
+      "svc.b",
+      "http://localhost:19999",
+      "fn",
+      "prov",
+      "svt",
+      1,
+    );
+    expect(settle.isSettled()).toBe(true);
+  });
+});
+
+describe("facade delegation + rebinding", () => {
+  it("reads the CURRENT per-edge proxy at call time (rebinding-free)", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({ methods: { chat: "llm.chat" } });
+    const seen: unknown[] = [];
+    agent.addTool({
+      name: "talk",
+      parameters: z.object({}),
+      dependencies: [View],
+      execute: async (_a: unknown, v: unknown) => {
+        seen.push(v);
+        return "ok";
+      },
+    });
+    injectEdge(agent, "talk", 0, async () => "provider-1");
+    await captureExecute(fastmcp)({});
+    const facade = seen[0] as Record<string, () => Promise<unknown>>;
+    expect(await facade.chat()).toBe("provider-1");
+
+    // Simulate a rebind: dependency_available swaps the edge proxy.
+    injectEdge(agent, "talk", 0, async () => "provider-2");
+    expect(await facade.chat()).toBe("provider-2");
+
+    // Simulate dependency_unavailable: the edge is dropped → optional call
+    // throws the null-proxy shape (TypeError).
+    removeEdge(agent, "talk", 0);
+    await expect(facade.chat()).rejects.toBeInstanceOf(TypeError);
+  });
+});
+
+describe("required=true view method refusal", () => {
+  it("direct tools/call refuses with dependency_unavailable", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({
+      methods: { caption: { capability: "media.caption", required: true } },
+    });
+    const ran: unknown[] = [];
+    agent.addTool({
+      name: "req_direct",
+      parameters: z.object({}),
+      dependencies: [View],
+      execute: async () => {
+        ran.push(true);
+        return "ran";
+      },
+    });
+    let thrown: unknown;
+    try {
+      await captureExecute(fastmcp)({});
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(UserError);
+    expect(JSON.parse((thrown as Error).message)).toEqual({
+      error: "dependency_unavailable",
+      capability: "media.caption",
+    });
+    expect(ran).toHaveLength(0);
+    expect(h.releaseLeaseMock).not.toHaveBeenCalled();
+  });
+
+  it("inbound JOB dispatch releases the lease (never throws)", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({
+      methods: { render: { capability: "media.render", required: true } },
+    });
+    const ran: unknown[] = [];
+    agent.addTool({
+      name: "req_job",
+      task: true,
+      parameters: z.object({}),
+      dependencies: [View],
+      execute: async () => {
+        ran.push(true);
+        return "ran";
+      },
+    });
+    const result = await captureExecute(fastmcp)({
+      _mesh_headers: { "x-mesh-job-id": "job-9", "x-mesh-claim-epoch": "2" },
+    });
+    expect(result).toBe("");
+    expect(ran).toHaveLength(0);
+    expect(h.makeJobControllerMock).toHaveBeenCalledTimes(1);
+    const ctorArgs = h.makeJobControllerMock.mock.calls[0] as unknown as unknown[];
+    expect(ctorArgs[0]).toBe("job-9");
+    expect(ctorArgs[3]).toBe(2);
+    expect(h.releaseLeaseMock).toHaveBeenCalledTimes(1);
+    const releaseArgs = h.releaseLeaseMock.mock.calls[0] as unknown as unknown[];
+    expect(String(releaseArgs[0])).toContain("media.render");
+  });
+
+  it("required view edge does not refuse once resolved", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({
+      methods: { caption: { capability: "media.caption", required: true } },
+    });
+    agent.addTool({
+      name: "req_ok",
+      parameters: z.object({}),
+      dependencies: [View],
+      execute: async (_a: unknown, v: unknown) => {
+        const facade = v as Record<string, () => Promise<unknown>>;
+        return (await facade.caption()) as string;
+      },
+    });
+    injectEdge(agent, "req_ok", 0, async () => "captioned");
+    // String results pass through unchanged (wrappedExecute returns strings as-is).
+    expect(await captureExecute(fastmcp)({})).toBe("captioned");
+  });
+});
+
+describe("minAvailable floor", () => {
+  it("at floor → delegates; below floor (settled) → MeshServiceUnavailableError", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({
+      methods: { a: "svc.a", b: "svc.b" },
+      minAvailable: 1,
+      name: "MyView",
+    });
+    const seen: unknown[] = [];
+    agent.addTool({
+      name: "floortool",
+      parameters: z.object({}),
+      dependencies: [View],
+      execute: async (_a: unknown, v: unknown) => {
+        seen.push(v);
+        return "ok";
+      },
+    });
+    // Resolve one of two methods → floor (1) satisfied.
+    injectEdge(agent, "floortool", 0, async () => "A");
+    await captureExecute(fastmcp)({});
+    const facade = seen[0] as Record<string, () => Promise<unknown>>;
+    // The resolved method delegates; the unresolved-but-floor-satisfied method
+    // throws the null-proxy shape (optional edge) rather than the floor error.
+    expect(await facade.a()).toBe("A");
+    await expect(facade.b()).rejects.toBeInstanceOf(TypeError);
+
+    // Drop below the floor (settled → no wait) → every call throws the floor error.
+    removeEdge(agent, "floortool", 0);
+    let err: unknown;
+    try {
+      await facade.a();
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(MeshServiceUnavailableError);
+    const mse = err as MeshServiceUnavailableError;
+    expect(mse.service).toBe("MyView");
+    expect(mse.available).toBe(0);
+    expect(mse.total).toBe(2);
+    expect(mse.floor).toBe(1);
+  });
+
+  it("below floor: waking on a CROSS edge (resolve b while blocked) returns promptly", async () => {
+    // The old serial enforceFloor awaited each pending edge in name order, so a
+    // call would block on edge 'a' even after edge 'b' resolved and satisfied
+    // the floor. The race-based enforceFloor wakes on ANY pending edge.
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    process.env.MCP_MESH_SETTLE_TIMEOUT = "30";
+    resetSettleStateForTests();
+    const View = serviceView({
+      methods: { a: "svc.a", b: "svc.b" },
+      minAvailable: 1,
+    });
+    // Build the facade directly so the tool's own settle-wait doesn't interfere.
+    const { edges, slots } = (
+      await import("../service-view.js")
+    ).expandDependencies([View], "wait_tool");
+    const settle = getSettleState();
+    slots.forEach((s) => {
+      if (s.kind === "view") {
+        for (const m of s.methods) {
+          settle.registerDeclared(`wait_tool:dep_${m.edgeIndex}`);
+        }
+      }
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const depsArray = (agent as any)._buildDepSlots(
+      "wait_tool",
+      slots,
+      edges,
+      undefined,
+      settle,
+    );
+    const facade = depsArray[0] as Record<string, () => Promise<unknown>>;
+    expect(settle.isSettled()).toBe(false);
+
+    // Call method 'b' while BELOW the floor (0 resolved). enforceFloor races
+    // BOTH pending edges. Resolving 'b' (edge 1) — a DIFFERENT key than 'a'
+    // which sorts first — must wake the wait and delegate promptly.
+    const before = settle.waitCount;
+    const p = facade.b();
+    // Let enforceFloor register its waiters before we resolve.
+    await new Promise((r) => setImmediate(r));
+    injectEdge(agent, "wait_tool", 1, async () => "B");
+    settle.markResolved("wait_tool:dep_1");
+    // Floor satisfied by edge 'b' → the call delegates to 'b' without waiting
+    // for the still-pending 'a' or the full 30s window.
+    expect(await p).toBe("B");
+    // A bounded wait actually occurred (never a fixed sleep once settled).
+    expect(settle.waitCount).toBeGreaterThan(before);
+  });
+});
+
+describe("serviceView validation (throws at construction)", () => {
+  it("empty methods map", () => {
+    expect(() => serviceView({ methods: {} })).toThrow(/at least one method/);
+  });
+  it("blank capability", () => {
+    expect(() => serviceView({ methods: { a: "" } })).toThrow(/blank capability/);
+    expect(() =>
+      serviceView({ methods: { a: { capability: "   " } } }),
+    ).toThrow(/blank capability/);
+  });
+  it("minAvailable < 0", () => {
+    expect(() =>
+      serviceView({ methods: { a: "svc.a" }, minAvailable: -1 }),
+    ).toThrow(/minAvailable must be an integer >= 0/);
+  });
+  it("minAvailable > method count", () => {
+    expect(() =>
+      serviceView({ methods: { a: "svc.a" }, minAvailable: 2 }),
+    ).toThrow(/exceeds the number of methods/);
+  });
+});
+
+describe("addTool validation (views)", () => {
+  it("meshJobDepIndex pointing at a view slot throws", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({ methods: { a: "svc.a" } });
+    expect(() =>
+      agent.addTool({
+        name: "bad_mj",
+        parameters: z.object({}),
+        dependencies: [View],
+        meshJobDepIndex: 0,
+        execute: async () => "ok",
+      }),
+    ).toThrow(/points at a mesh.serviceView slot/);
+  });
+
+  it("a producer-shaped object (no capability) in dependencies throws", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    expect(() =>
+      agent.addTool({
+        name: "bad_dep",
+        parameters: z.object({}),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        dependencies: [{ execute: async () => "x" } as any],
+        execute: async () => "ok",
+      }),
+    ).toThrow(/without a 'capability'/);
+  });
+});
+
+describe("serviceView rejected on non-facade surfaces", () => {
+  it("shared guard rejects a view for any surface label", () => {
+    const View = serviceView({ methods: { a: "svc.a" } });
+    expect(() => assertNoServiceViewDeps([View], "mesh.route")).toThrow(
+      /mesh.route does not support mesh.serviceView/,
+    );
+    expect(() => assertNoServiceViewDeps(["ok", View], "mesh.a2a.mount")).toThrow(
+      /mesh.a2a.mount does not support mesh.serviceView/,
+    );
+    // No views → no throw.
+    expect(() => assertNoServiceViewDeps(["a", { capability: "b" }], "x")).not.toThrow();
+  });
+
+  it("mesh.route rejects a view in route deps", () => {
+    const View = serviceView({ methods: { a: "svc.a" } });
+    expect(() =>
+      route(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        [View as any],
+        async () => {
+          /* noop */
+        },
+      ),
+    ).toThrow(/does not support mesh.serviceView/);
+  });
+
+  it("mesh.a2a.mount rejects a view in surface deps", () => {
+    const View = serviceView({ methods: { a: "svc.a" } });
+    expect(() =>
+      a2aMount(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        {} as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { path: "/a2a", skillId: "s", dependencies: [View] } as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (async () => ({})) as any,
+      ),
+    ).toThrow(/mesh.a2a.mount does not support mesh.serviceView/);
+  });
+});
+
+describe("view-bound worker isolation", () => {
+  it("warns at registration that isolation is force-disabled when the env is set", () => {
+    process.env.MCP_MESH_TOOL_ISOLATION = "true"; // override the beforeEach "false"
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({ methods: { a: "svc.a" } });
+    agent.addTool({
+      name: "isotool",
+      parameters: z.object({}),
+      dependencies: [View],
+      execute: async () => "ok",
+    });
+    const warned = warnSpy!.mock.calls
+      .map((c) => String(c[0]))
+      .some(
+        (m) =>
+          m.includes("isotool") &&
+          m.includes("serviceView facade") &&
+          m.includes("isolation is disabled"),
+      );
+    expect(warned).toBe(true);
+  });
+
+  it("does NOT warn when isolation is off (the default here)", () => {
+    // beforeEach pins MCP_MESH_TOOL_ISOLATION="false".
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({ methods: { a: "svc.a" } });
+    agent.addTool({
+      name: "noiso",
+      parameters: z.object({}),
+      dependencies: [View],
+      execute: async () => "ok",
+    });
+    const warned = warnSpy!.mock.calls
+      .map((c) => String(c[0]))
+      .some((m) => m.includes("noiso") && m.includes("serviceView facade"));
+    expect(warned).toBe(false);
+  });
+});
+
+describe("dependencyKwargs slot→edge remap", () => {
+  it("a slot AFTER a view shifts correctly (view kwargs applied to each edge)", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({ methods: { a: "svc.a", b: "svc.b" } });
+    agent.addTool({
+      name: "kwt",
+      parameters: z.object({}),
+      dependencies: ["dep", View, "dep2"],
+      dependencyKwargs: [{ timeout: 10 }, { timeout: 20 }, { timeout: 30 }],
+      execute: async () => "ok",
+    });
+    // Slots: dep(k0), View(k1 → both edges), dep2(k2). Edge kwargs:
+    // [dep=10, svc.a=20, svc.b=20, dep2=30].
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const kwargs = (agent as any).tools.get("kwt").dependencyKwargs;
+    expect(kwargs.map((k: { timeout: number }) => k.timeout)).toEqual([
+      10, 20, 20, 30,
+    ]);
+  });
+
+  it("view-free tools pass dependencyKwargs through unchanged", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const kw = [{ timeout: 5 }, { timeout: 6 }];
+    agent.addTool({
+      name: "kwplain",
+      parameters: z.object({}),
+      dependencies: ["a", "b"],
+      dependencyKwargs: kw,
+      execute: async () => "ok",
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((agent as any).tools.get("kwplain").dependencyKwargs).toBe(kw);
+  });
+});
+
+describe("claim path with a required view edge (#1268 gate)", () => {
+  it("requiredProbe reports the unresolved required view method; released via dispatcher", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({
+      methods: { render: { capability: "media.render", required: true } },
+    });
+    const ran: unknown[] = [];
+    agent.addTool({
+      name: "renderjob",
+      capability: "renderjob",
+      task: true,
+      parameters: z.object({}),
+      dependencies: [View],
+      execute: async () => {
+        ran.push(true);
+        return "ran";
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const th = (agent as any)._taskHandlers.get("renderjob") as {
+      handler: (p: Record<string, unknown>, c: unknown) => Promise<unknown>;
+      requiredProbe?: () => string | null;
+    };
+    expect(th.requiredProbe).toBeDefined();
+    // The required VIEW method edge feeds the claim gate.
+    expect(th.requiredProbe!()).toBe("media.render");
+
+    // Drive the dispatcher's pre-invoke guard: an unresolved required edge
+    // releases the lease and never runs the handler.
+    const dispatcher = new ClaimDispatcher(
+      "renderjob",
+      "inst-1",
+      "http://registry:8000",
+      th.handler as never,
+      undefined,
+      th.requiredProbe,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (dispatcher as any)._dispatch({ id: "job-1", submitted_payload: {} });
+    expect(h.releaseLeaseMock).toHaveBeenCalledTimes(1);
+    expect(h.failMock).not.toHaveBeenCalled();
+    expect(ran).toHaveLength(0);
+
+    // Once the required view edge resolves, the probe clears.
+    injectEdge(agent, "renderjob", 0, async () => "rendered");
+    expect(th.requiredProbe!()).toBeNull();
+  });
+});
+
+describe("view + meshJobDepIndex (job slot AFTER the view)", () => {
+  it("edge-shift math: submitter at the job slot, facade at the view slot", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    process.env.MCP_MESH_SETTLE_TIMEOUT = "30";
+    resetSettleStateForTests();
+    const View = serviceView({ methods: { a: "svc.a", b: "svc.b" } });
+    const seen: unknown[] = [];
+    agent.addTool({
+      name: "mjv",
+      parameters: z.object({}),
+      // Authored slots: [View(slot 0), "jobcap"(slot 1)].
+      dependencies: [View, "jobcap"],
+      meshJobDepIndex: 1, // the jobcap slot (edge index 2 after the view's 2 edges)
+      execute: async (_a: unknown, view: unknown, job: unknown) => {
+        seen.push(view, job);
+        return "ok";
+      },
+    });
+    // Flat edges: svc.a(0), svc.b(1), jobcap(2).
+    expect(edgesOf(agent, "mjv").map((d) => d.capability)).toEqual([
+      "svc.a",
+      "svc.b",
+      "jobcap",
+    ]);
+
+    // Settle keys skip the MeshJob EDGE (index 2): resolving the two view edges
+    // is sufficient to settle (proving meshJobEdgeIndex shifted past the view).
+    const settle = getSettleState();
+    expect(settle.isSettled()).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).handleDependencyAvailable("svc.a", "http://x", "fn", "p", "mjv", 0);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).handleDependencyAvailable("svc.b", "http://x", "fn", "p", "mjv", 1);
+    expect(settle.isSettled()).toBe(true);
+
+    await captureExecute(fastmcp)({});
+    const [view, job] = seen as [
+      Record<string, () => Promise<unknown>>,
+      MeshJobSubmitter,
+    ];
+    expect(Object.keys(view).sort()).toEqual(["a", "b"]);
+    expect(job).toBeInstanceOf(MeshJobSubmitter);
+    // The submitter targets the capability at the shifted edge (jobcap).
+    expect(job.capability).toBe("jobcap");
+  });
+});
+
+describe("#1231 unwired-slot warning for view edges", () => {
+  it("warns once when a view method edge is null after settling", async () => {
+    process.env.MCP_MESH_SETTLE_TIMEOUT = "0"; // settled immediately
+    resetSettleStateForTests();
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({ methods: { caption: "media.caption" } });
+    agent.addTool({
+      name: "unwired",
+      parameters: z.object({}),
+      dependencies: [View],
+      execute: async () => "ok",
+    });
+    // Build the facade (unresolved edge, settled) → warn once.
+    await captureExecute(fastmcp)({});
+    const warned = warnSpy!.mock.calls
+      .map((c) => String(c[0]))
+      .filter(
+        (m) =>
+          m.includes("service view") &&
+          m.includes("caption") &&
+          m.includes("media.caption") &&
+          m.includes("still null after settling"),
+      );
+    expect(warned.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("view method schema matching (#547 parity)", () => {
+  it("expectedSchema on a view method lands on the edge and yields canonical/hash", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({
+      methods: {
+        caption: {
+          capability: "media.caption",
+          expectedSchema: z.object({ caption: z.string() }),
+          matchMode: "strict",
+        },
+      },
+    });
+    agent.addTool({
+      name: "schematool",
+      parameters: z.object({}),
+      dependencies: [View],
+      execute: async () => "ok",
+    });
+    const edge = edgesOf(agent, "schematool")[0] as unknown as {
+      capability: string;
+      expectedSchemaRaw?: object;
+      matchMode?: string;
+    };
+    expect(edge.capability).toBe("media.caption");
+    expect(edge.expectedSchemaRaw).toBeDefined();
+    expect(edge.matchMode).toBe("strict");
+    // The payload builder feeds expectedSchemaRaw through this exact call to
+    // derive expectedSchemaCanonical/hash (agent.ts startHeartbeat).
+    const r = normalizeSchemaWithPolicy(
+      edge.expectedSchemaRaw!,
+      "dependency on 'media.caption'",
+      false,
+      true,
+    );
+    expect(r.canonicalJson).toBeTruthy();
+    expect(r.hash).toBeTruthy();
+  });
+});
+
+describe("addService producer sugar", () => {
+  it("publishes N tools name-sorted with capability prefix.method", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    agent.addService("media", {
+      // Out of order to prove name-sorting.
+      thumbnail: async () => ({ url: "u" }),
+      caption: async (args: { text: string }) => ({ caption: args.text }),
+    });
+    // Registered in NAME-SORTED order: caption, then thumbnail.
+    const names = fastmcp.addTool.mock.calls.map(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (c: any[]) => c[0].name,
+    );
+    expect(names).toEqual(["media.caption", "media.thumbnail"]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((agent as any).tools.get("media.caption").capability).toBe(
+      "media.caption",
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((agent as any).tools.get("media.thumbnail").capability).toBe(
+      "media.thumbnail",
+    );
+  });
+
+  it("object form carries addTool passthrough (tags/version/description)", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    agent.addService("svc", {
+      m: {
+        execute: async () => "ok",
+        tags: ["fast"],
+        version: "2.1.0",
+        description: "does m",
+        parameters: z.object({ x: z.number() }),
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const meta = (agent as any).tools.get("svc.m");
+    expect(meta.tags).toEqual(["fast"]);
+    expect(meta.version).toBe("2.1.0");
+    expect(meta.description).toBe("does m");
+  });
+
+  it("function shorthand works and runs through the wrapped execute", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    agent.addService("svc", {
+      echo: async (args: { v: string }) => ({ echoed: args.v }),
+    });
+    const execute = captureExecute(fastmcp);
+    expect(await execute({ v: "hi" })).toBe(JSON.stringify({ echoed: "hi" }));
+  });
+
+  it("rejects an invalid prefix", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    expect(() =>
+      agent.addService("1bad", { m: async () => "x" }),
+    ).toThrow(/not a valid capability name/);
+    expect(() =>
+      agent.addService("", { m: async () => "x" }),
+    ).toThrow(/non-empty capability prefix/);
+  });
+
+  it("rejects a method whose derived capability is invalid", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    expect(() =>
+      agent.addService("svc", { "bad name": async () => "x" }),
+    ).toThrow(/is not a valid capability name/);
+  });
+
+  it("rejects a serviceView passed as a producer method", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    const View = serviceView({ methods: { a: "svc.a" } });
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      agent.addService("svc", { a: View as any }),
+    ).toThrow(/is a mesh.serviceView/);
+  });
+
+  it("rejects a method that is neither a function nor an execute object", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      agent.addService("svc", { a: { tags: ["x"] } as any }),
+    ).toThrow(/must be an execute function/);
+  });
+
+  it("accepts dotted prefixes (segment-wise grammar)", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    agent.addService("acme.media", { caption: async () => "c" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((agent as any).tools.get("acme.media.caption").capability).toBe(
+      "acme.media.caption",
+    );
+  });
+
+  it("is atomic: an invalid method mid-map registers NOTHING (item 7)", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    expect(() =>
+      agent.addService("svc", {
+        good: async () => "ok",
+        "bad name": async () => "x", // invalid derived capability
+      }),
+    ).toThrow(/is not a valid capability name/);
+    // 'svc.good' must NOT have been registered — validation runs before any addTool.
+    expect(fastmcp.addTool).not.toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((agent as any).tools.has("svc.good")).toBe(false);
+  });
+
+  it("throws when a derived capability collides with an existing tool (item 9)", () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = newAgent(fastmcp);
+    agent.addTool({
+      name: "svc.caption",
+      parameters: z.object({}),
+      execute: async () => "existing",
+    });
+    expect(() =>
+      agent.addService("svc", { caption: async () => "new" }),
+    ).toThrow(/already registered/);
+  });
+});

--- a/src/runtime/typescript/src/a2a/producer/mount.ts
+++ b/src/runtime/typescript/src/a2a/producer/mount.ts
@@ -37,6 +37,7 @@ import { resolveConfig } from "@mcpmesh/core";
 import type { AgentConfig } from "../../types.js";
 import { RouteRegistry } from "../../route.js";
 import { normalizeDependency } from "../../proxy.js";
+import { assertNoServiceViewDeps } from "../../service-view.js";
 import { getApiRuntime } from "../../api-runtime.js";
 import { MeshJobSubmitter } from "../../mesh-job-submitter.js";
 
@@ -234,6 +235,9 @@ export function mount<D extends A2ADependencies = A2ADependencies>(
   }
 
   const dependencies = config.dependencies ?? [];
+  // RFC #1280: like mesh.route, the A2A producer surface has no tool-parameter
+  // facade form — reject a serviceView rather than shipping a nameless edge.
+  assertNoServiceViewDeps(dependencies, "mesh.a2a.mount");
   const normalizedDeps = dependencies.map(normalizeDependency);
 
   // ── Register dependencies via RouteRegistry (DDDI) ───────────────────

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -1588,10 +1588,20 @@ export class MeshAgent {
         !settleState.isSettled() &&
         settleState.remainingMs() > 0
       ) {
+        // Only edges that can still fire a settle WAKE are worth waiting on: a
+        // key already in the settle ratchet (resolved at least once) will never
+        // re-fire its waiter, so if such an edge has since flapped to a null
+        // proxy `waitForAny` would filter it out and return immediately — a hot
+        // busy-loop until the window expires. Excluding ratchet-resolved keys
+        // here means `pending` empties and we break to the final recount/throw
+        // the instant no wakeable edge remains (no spin).
         const pending: PendingSettleDep[] = [];
         for (const m of slot.methods) {
           const key = `${toolName}:dep_${m.edgeIndex}`;
-          if ((this.resolvedDeps.get(key) ?? null) === null) {
+          if (
+            (this.resolvedDeps.get(key) ?? null) === null &&
+            !settleState.isResolved(key)
+          ) {
             pending.push({ depKey: key, capability: edges[m.edgeIndex].capability });
           }
         }

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -30,8 +30,19 @@ import type {
   ToolMeta,
   McpMeshTool,
   NormalizedDependency,
+  DependencyKwargs,
   LlmProviderConfig,
 } from "./types.js";
+import {
+  expandDependencies,
+  isServiceView,
+  MeshServiceUnavailableError,
+  CAPABILITY_NAME_PATTERN,
+  defaultProducerParams,
+  type DepSlot,
+  type MeshServiceFacadeMethod,
+  type ServiceProducerMethod,
+} from "./service-view.js";
 import {
   resolveConfig,
   generateAgentIdSuffix,
@@ -41,7 +52,7 @@ import {
   NEXT_EVENT_BACKOFF_CAP_MS,
 } from "./config.js";
 import { enrichSchemaWithMediaTypes } from "./media-param.js";
-import { createProxy, normalizeDependency, runWithTraceContext, runWithPropagatedHeaders, PROXY_DISPATCH_META } from "./proxy.js";
+import { createProxy, runWithTraceContext, runWithPropagatedHeaders, PROXY_DISPATCH_META } from "./proxy.js";
 import {
   readJobHeaders,
   runWithJobContext,
@@ -582,11 +593,43 @@ export class MeshAgent {
       return this;
     }
 
-    // Normalize dependencies
-    const normalizedDeps: NormalizedDependency[] = (def.dependencies ?? []).map(
-      normalizeDependency
+    // Normalize dependencies. RFC #1280: a `mesh.serviceView(...)` entry
+    // occupies ONE positional slot but expands into N ordinary edges (name-
+    // sorted, in-place). `normalizedDeps` is the FLAT edge array — the wire
+    // payload, settle keys, resolution events, and resolvedDeps all index it
+    // exactly as before; `depSlots` maps each positional execute slot to its
+    // edge (a `dep`) or edge-range (a `view`). For a view-free tool the edges
+    // are byte-identical to `deps.map(normalizeDependency)` and
+    // `depSlots[i].edgeIndex === i` — zero behavior change.
+    const { edges: normalizedDeps, slots: depSlots } = expandDependencies(
+      def.dependencies ?? [],
+      toolName,
     );
     const depEndpoints = normalizedDeps.map((d) => d.capability);
+
+    // Phase 1 MeshJob substrate: meshJobDepIndex is an index into the AUTHORED
+    // dependencies array (i.e. a positional slot). It must point at an ordinary
+    // dependency slot, never a service-view slot (a view has no single edge to
+    // swap for a submitter).
+    if (def.meshJobDepIndex !== undefined) {
+      const slot = depSlots[def.meshJobDepIndex];
+      if (slot && slot.kind === "view") {
+        throw new Error(
+          `addTool({ meshJobDepIndex: ${def.meshJobDepIndex} }) for tool ` +
+            `'${toolName}' points at a mesh.serviceView slot — a MeshJob ` +
+            `submitter can only replace an ordinary dependency slot.`,
+        );
+      }
+    }
+
+    // The flat edge index of the MeshJob submitter slot (if any). Used by the
+    // edge-indexed skip logic below (settle declaration/wait, required guard).
+    // For a view-free tool this equals `def.meshJobDepIndex` (slot index ===
+    // edge index), so those loops are byte-identical to before.
+    const meshJobEdgeIndex =
+      def.meshJobDepIndex === undefined
+        ? undefined
+        : (depSlots[def.meshJobDepIndex] as { edgeIndex: number }).edgeIndex;
 
     // Settling-window grace (#1193): declare this tool's proxy deps with the
     // process-wide settle state so the agent-level "all declared deps
@@ -594,7 +637,7 @@ export class MeshAgent {
     // submitter is constructed locally, not resolved by an event.
     const settleState = getSettleState();
     normalizedDeps.forEach((_dep, depIndex) => {
-      if (depIndex !== def.meshJobDepIndex) {
+      if (depIndex !== meshJobEdgeIndex) {
         settleState.registerDeclared(`${toolName}:dep_${depIndex}`);
       }
     });
@@ -631,6 +674,20 @@ export class MeshAgent {
           `Set 'task: true' explicitly if you intend a producer.`,
       );
     }
+    // RFC #1280: same force-disable + non-silent warning for view-bound tools.
+    // A serviceView facade wraps live closures over resolvedDeps and has no
+    // PROXY_DISPATCH_META, so it can't cross the worker_threads boundary — the
+    // wrapper runs view-bound tools inline. Warn once (like the job-bound case)
+    // so users who opted into MCP_MESH_TOOL_ISOLATION know it does not apply.
+    const isViewBoundForLog = depSlots.some((s) => s.kind === "view");
+    if (isViewBoundForLog && isolationEnvSet) {
+      console.warn(
+        `[mesh-tool] '${toolName}' injects a mesh.serviceView facade; worker ` +
+          `isolation is disabled for view-bound tools (facades wrap live ` +
+          `closures over resolved dependencies that don't cross worker ` +
+          `boundaries).`,
+      );
+    }
 
     // Create wrapper that injects dependencies positionally and handles tracing
     const wrappedExecute = async (
@@ -646,7 +703,7 @@ export class MeshAgent {
         normalizedDeps.forEach((dep, depIndex) => {
           const depKey = `${toolName}:dep_${depIndex}`;
           if (
-            depIndex !== meshJobDepIndex &&
+            depIndex !== meshJobEdgeIndex &&
             !this.resolvedDeps.has(depKey)
           ) {
             pendingSettle.push({ depKey, capability: dep.capability });
@@ -657,19 +714,29 @@ export class MeshAgent {
         }
       }
 
-      // Build positional deps array using composite keys (toolName:dep_index)
-      // Phase 1 MeshJob substrate (consumer-side): if meshJobDepIndex is
-      // set, swap the McpMeshTool proxy at that slot for a
-      // MeshJobSubmitter targeting that dep's capability. We bind the
-      // submitter to the live registryUrl/agentId so it can submit
-      // jobs without needing access to the agent instance.
+      // Build positional deps array (one entry per authored slot). A view slot
+      // yields a facade; the MeshJob slot yields a MeshJobSubmitter; every other
+      // slot yields resolvedDeps.get(...) ?? null.
       const depsArray = this._buildDepSlots(
         toolName,
+        depSlots,
         normalizedDeps,
         meshJobDepIndex,
         settleState,
       );
-      const injectedCount = depsArray.filter((d) => d !== null).length;
+      // Trace metric: count resolved EDGES, not slots — a view slot always
+      // yields a non-null facade, so counting slots would inflate the numerator
+      // against the edge-based dependency total. Excludes the MeshJob submitter
+      // edge (built locally, never a resolved proxy) and adds it back as one
+      // injected slot so a view-free tool's count is byte-identical to before.
+      let injectedCount = 0;
+      for (let e = 0; e < normalizedDeps.length; e++) {
+        if (e === meshJobEdgeIndex) continue;
+        if ((this.resolvedDeps.get(`${toolName}:dep_${e}`) ?? null) !== null) {
+          injectedCount++;
+        }
+      }
+      if (meshJobDepIndex !== undefined) injectedCount++;
 
       // Issue #1273: detect a required dependency slot that is still
       // unresolved AFTER the settle wait above (depsArray was built
@@ -678,13 +745,17 @@ export class MeshAgent {
       // direct tools/call refuses, an inbound JOB dispatch releases the
       // lease. Optional deps keep null-passthrough; the MeshJob submitter
       // slot is skipped (built locally, never a resolved proxy).
+      // Evaluate per-EDGE against resolvedDeps (not per-slot against depsArray):
+      // a view slot collapses N edges into one non-null facade, so a required
+      // view-method edge must be checked on the flat edge state. For a view-free
+      // tool this is equivalent to the old `depsArray[depIndex] == null` test.
       let missingRequiredCap: string | null = null;
       for (let depIndex = 0; depIndex < normalizedDeps.length; depIndex++) {
         const dep = normalizedDeps[depIndex];
         if (
           dep.required === true &&
-          depIndex !== meshJobDepIndex &&
-          depsArray[depIndex] == null
+          depIndex !== meshJobEdgeIndex &&
+          (this.resolvedDeps.get(`${toolName}:dep_${depIndex}`) ?? null) == null
         ) {
           missingRequiredCap = dep.capability;
           break;
@@ -835,9 +906,15 @@ export class MeshAgent {
       // cached client + connection pool intact across calls.
       const isA2aBound = a2aClient !== null;
       const isJobBound = isTaskTool || meshJobDepIndex !== undefined;
+      // RFC #1280: a service-view facade wraps live closures over resolvedDeps
+      // and cannot be serialised across the worker_threads boundary (it has no
+      // PROXY_DISPATCH_META). Force inline execution for view-bound tools, like
+      // job-bound and A2A-bound tools.
+      const isViewBound = depSlots.some((s) => s.kind === "view");
       const isolationEnabled =
         !isJobBound &&
         !isA2aBound &&
+        !isViewBound &&
         (process.env.MCP_MESH_TOOL_ISOLATION ?? "true").toLowerCase() !== "false";
 
       try {
@@ -1044,7 +1121,7 @@ export class MeshAgent {
           normalizedDeps.forEach((dep, depIndex) => {
             const depKey = `${toolName}:dep_${depIndex}`;
             if (
-              depIndex !== meshJobDepIndex &&
+              depIndex !== meshJobEdgeIndex &&
               !this.resolvedDeps.has(depKey)
             ) {
               pendingSettle.push({ depKey, capability: dep.capability });
@@ -1056,6 +1133,7 @@ export class MeshAgent {
         }
         const liveDeps = this._buildDepSlots(
           toolName,
+          depSlots,
           normalizedDeps,
           meshJobDepIndex,
           settleState,
@@ -1081,7 +1159,7 @@ export class MeshAgent {
       // covers both an absent key and an explicit null slot.
       const requiredSlots: Array<[number, string]> = [];
       normalizedDeps.forEach((dep, depIndex) => {
-        if (dep.required && depIndex !== meshJobDepIndex) {
+        if (dep.required && depIndex !== meshJobEdgeIndex) {
           requiredSlots.push([depIndex, dep.capability]);
         }
       });
@@ -1111,6 +1189,30 @@ export class MeshAgent {
     if (def.outputSchema) {
       outputSchemaRaw = this.convertZodToJsonSchema(def.outputSchema);
     }
+
+    // dependencyKwargs is authored per positional SLOT but consumed per flat
+    // EDGE (handleDependencyAvailable reads meta.dependencyKwargs[depIndex] with
+    // the event's edge index). For a view-free tool slot index === edge index,
+    // so pass it through unchanged (byte-identical). When a view slot is present,
+    // remap each slot's kwargs onto its edge(s) — a view's single kwargs entry
+    // applies to each of its method edges.
+    let edgeDependencyKwargs = def.dependencyKwargs;
+    if (def.dependencyKwargs && depSlots.some((s) => s.kind === "view")) {
+      const remapped: (DependencyKwargs | undefined)[] = new Array(
+        normalizedDeps.length,
+      );
+      depSlots.forEach((slot, slotIndex) => {
+        const kw = def.dependencyKwargs?.[slotIndex];
+        if (slot.kind === "dep") {
+          remapped[slot.edgeIndex] = kw;
+        } else {
+          for (const m of slot.methods) {
+            remapped[m.edgeIndex] = kw;
+          }
+        }
+      });
+      edgeDependencyKwargs = remapped as DependencyKwargs[];
+    }
     this.tools.set(toolName, {
       capability: def.capability ?? toolName,
       version: def.version ?? "1.0.0",
@@ -1121,7 +1223,7 @@ export class MeshAgent {
       // Issue #547 Phase 4: per-tool override (default true = current behavior).
       outputSchemaStrict: def.outputSchemaStrict !== false,
       dependencies: normalizedDeps,
-      dependencyKwargs: def.dependencyKwargs,
+      dependencyKwargs: edgeDependencyKwargs,
       // Phase 1 MeshJob substrate: stamp producer's long-running flag
       // so the heartbeat pipeline ships it to the registry. Consumers
       // read this to decide between job semantics and a regular
@@ -1138,6 +1240,132 @@ export class MeshAgent {
         def.a2aConfig !== undefined ? this.config.name : undefined,
     });
 
+    return this;
+  }
+
+  /**
+   * RFC #1280 producer sugar: publish each entry of `methods` as an ordinary
+   * mesh tool with capability `prefix.<method>`, routed through the SAME
+   * `addTool` machinery (schemas, heartbeat, DI, duplicate handling all fall
+   * out). Entries are registered NAME-SORTED for deterministic registration.
+   *
+   * Each entry is either a bare execute function (shorthand) or an object
+   * `{ execute, parameters?, tags?, version?, description?, dependencies?, ... }`
+   * carrying any `addTool` passthrough (but NOT `name`/`capability` — those are
+   * derived). A method with no `parameters` gets a permissive passthrough schema.
+   *
+   * The prefix AND every derived capability are validated against the segment-
+   * wise dotted grammar (kept in lockstep with the Go registry validator —
+   * src/core/registry/validation.go). This is the ONLY place the SDK validates a
+   * capability name (it validates only the names it SYNTHESIZES); hand-written
+   * capabilities remain the registry's authority.
+   *
+   * @example
+   * ```typescript
+   * agent.addService("media", {
+   *   caption: async (args) => ({ caption: `...${args.text}` }),
+   *   thumbnail: { execute: async (args) => ({ url: "..." }), tags: ["fast"] },
+   * });
+   * // → tools/capabilities "media.caption" and "media.thumbnail"
+   * ```
+   */
+  addService(
+    prefix: string,
+    methods: Record<string, ServiceProducerMethod>,
+  ): this {
+    if (typeof prefix !== "string" || prefix.trim() === "") {
+      throw new Error(
+        "addService: a non-empty capability prefix is required " +
+          '(e.g. addService("media", { ... })).',
+      );
+    }
+    if (!CAPABILITY_NAME_PATTERN.test(prefix)) {
+      throw new Error(
+        `addService: prefix '${prefix}' is not a valid capability name — each ` +
+          `dot-separated segment must start with a letter and contain only ` +
+          `letters, digits, '_' or '-' (cross-ref src/core/registry/validation.go).`,
+      );
+    }
+    if (methods == null || typeof methods !== "object") {
+      throw new Error(
+        `addService("${prefix}", ...): methods must be an object mapping ` +
+          `method names to producer functions/definitions.`,
+      );
+    }
+    const names = Object.keys(methods).sort();
+    if (names.length === 0) {
+      throw new Error(
+        `addService("${prefix}", ...): at least one method is required.`,
+      );
+    }
+
+    // Pass 1 — validate EVERY derived name/entry before registering any tool so
+    // an invalid method mid-map is atomic (registers nothing). Also rejects a
+    // derived capability that collides with an already-registered tool (scoped
+    // to addService: addTool's own last-wins behavior for hand-written tools is
+    // unchanged).
+    const prepared: Array<{
+      capability: string;
+      def: import("./service-view.js").ServiceProducerMethodObject;
+    }> = [];
+    for (const method of names) {
+      const capability = `${prefix}.${method}`;
+      // Validate the FULL derived capability, not just the prefix: a method
+      // name may contain characters ('$', unicode, ...) the grammar rejects.
+      if (!CAPABILITY_NAME_PATTERN.test(capability)) {
+        throw new Error(
+          `addService("${prefix}", ...): method '${method}' derives capability ` +
+            `'${capability}', which is not a valid capability name (each ` +
+            `dot-separated segment must start with a letter and contain only ` +
+            `letters, digits, '_' or '-'). Rename the method.`,
+        );
+      }
+      if (this.tools.has(capability)) {
+        throw new Error(
+          `addService("${prefix}", ...): method '${method}' derives tool/` +
+            `capability '${capability}', which is already registered. Rename ` +
+            `the method or the conflicting tool.`,
+        );
+      }
+      const entry = methods[method];
+      // Guard: a service-view value here is the consumer surface used in the
+      // wrong role (producer). Fail loud.
+      if (isServiceView(entry)) {
+        throw new Error(
+          `addService("${prefix}", ...): method '${method}' is a ` +
+            `mesh.serviceView(...) — that is a CONSUMER view, not a producer ` +
+            `method. Provide an execute function or { execute, ... } object.`,
+        );
+      }
+      let def: import("./service-view.js").ServiceProducerMethodObject;
+      if (typeof entry === "function") {
+        def = { execute: entry as MeshToolDef["execute"] };
+      } else if (
+        entry != null &&
+        typeof entry === "object" &&
+        typeof (entry as { execute?: unknown }).execute === "function"
+      ) {
+        def = entry as import("./service-view.js").ServiceProducerMethodObject;
+      } else {
+        throw new Error(
+          `addService("${prefix}", ...): method '${method}' must be an execute ` +
+            `function or an object with an execute function.`,
+        );
+      }
+      prepared.push({ capability, def });
+    }
+
+    // Pass 2 — register through the existing addTool machinery. Derived name ===
+    // derived capability for deterministic uniqueness.
+    for (const { capability, def } of prepared) {
+      this.addTool({
+        ...(def as object),
+        name: capability,
+        capability,
+        parameters: def.parameters ?? defaultProducerParams(),
+        execute: def.execute,
+      } as MeshToolDef);
+    }
     return this;
   }
 
@@ -1252,36 +1480,46 @@ export class MeshAgent {
    * Build the positional dependency-slot array for one tool call, shared by
    * BOTH the inbound HTTP wrapper (wrappedExecute) and the claim-dispatch
    * path (the ClaimHandler for task:true tools). Centralising this keeps the
-   * two slot-assembly sites identical:
+   * two slot-assembly sites identical. One entry per AUTHORED slot:
+   *   - a service-view slot (RFC #1280) → a facade over its method edges
    *   - the MeshJob slot (meshJobDepIndex) → a freshly-bound MeshJobSubmitter
-   *   - every other slot → resolvedDeps.get(`${toolName}:dep_${index}`) ?? null
+   *   - every other slot → resolvedDeps.get(`${toolName}:dep_${edgeIndex}`) ?? null
+   *
+   * `depSlots` carries the slot→edge mapping (a `dep` slot owns one edge; a
+   * `view` slot owns a contiguous edge range). `edges` is the flat edge array;
+   * a slot's proxy/capability is read via its edge index.
    *
    * #1231: a typed dep slot can resolve at the registry yet never receive an
    * injected proxy, leaving the parameter null. Once the settle latch has
    * flipped (during settling the proxy may still land), warn ONCE per
    * tool+slot — the array is rebuilt per call, so a per-call warning would
-   * spam. The warn-once dedupe keys on `${toolName}:dep_${index}` via the
+   * spam. The warn-once dedupe keys on `${toolName}:dep_${edgeIndex}` via the
    * module-level `_unwiredSlotWarned` Set, so a tool exercised via BOTH the
    * inbound and claim paths warns at most once total.
    */
   private _buildDepSlots(
     toolName: string,
-    normalizedDeps: NormalizedDependency[],
+    depSlots: DepSlot[],
+    edges: NormalizedDependency[],
     meshJobDepIndex: number | undefined,
     settleState: SettleState,
-  ): (McpMeshTool | MeshJobSubmitter | null)[] {
-    return normalizedDeps.map((dep, depIndex) => {
-      if (depIndex === meshJobDepIndex) {
+  ): (McpMeshTool | MeshJobSubmitter | Record<string, MeshServiceFacadeMethod> | null)[] {
+    return depSlots.map((slot, slotIndex) => {
+      if (slot.kind === "view") {
+        return this._buildServiceViewFacade(toolName, slot, edges, settleState);
+      }
+      const edgeIndex = slot.edgeIndex;
+      if (slotIndex === meshJobDepIndex) {
         // Build the submitter lazily per call so we always pick up the
         // current registryUrl (test harnesses sometimes mutate it between
         // calls).
         return new MeshJobSubmitter(
-          dep.capability,
+          edges[edgeIndex].capability,
           this.agentId,
           this.config.registryUrl,
         );
       }
-      const slotKey = `${toolName}:dep_${depIndex}`;
+      const slotKey = `${toolName}:dep_${edgeIndex}`;
       const proxy = this.resolvedDeps.get(slotKey) ?? null;
       // #1231: a declared typed dep slot that is still null AFTER settling
       // never received an injected proxy. Warn ONCE per tool+slot. Note this
@@ -1291,15 +1529,116 @@ export class MeshAgent {
         if (!_unwiredSlotWarned.has(slotKey)) {
           _unwiredSlotWarned.add(slotKey);
           console.warn(
-            `[mesh-tool] dependency '${dep.capability}' on '${toolName}' ` +
-              `is still null after settling — no proxy was injected into ` +
-              `positional slot ${depIndex}. Fix: ensure the provider for ` +
-              `'${dep.capability}' is registered and reachable.`,
+            `[mesh-tool] dependency '${edges[edgeIndex].capability}' on ` +
+              `'${toolName}' is still null after settling — no proxy was ` +
+              `injected into positional slot ${slotIndex}. Fix: ensure the ` +
+              `provider for '${edges[edgeIndex].capability}' is registered ` +
+              `and reachable.`,
           );
         }
       }
       return proxy;
     });
+  }
+
+  /**
+   * RFC #1280: build the facade injected at a service-view slot. Each facade
+   * method reads its edge's CURRENT proxy from `resolvedDeps` at call time —
+   * rebinding-free: a `dependency_available`/`unavailable` event swapping the
+   * per-edge proxy is observed on the next call without rebuilding the facade.
+   *
+   * The `minAvailable` floor is enforced BEFORE delegation on every call: below
+   * the floor during the settling window (#1193) the method performs the same
+   * bounded, capability-keyed wait the injected-proxy path uses, recounts, then
+   * throws {@link MeshServiceUnavailableError}. An unresolved OPTIONAL method
+   * edge throws a `TypeError` — the same failure shape a directly-injected
+   * unresolved `McpMeshTool` (a null proxy) produces when called.
+   */
+  private _buildServiceViewFacade(
+    toolName: string,
+    slot: Extract<DepSlot, { kind: "view" }>,
+    edges: NormalizedDependency[],
+    settleState: SettleState,
+  ): Record<string, MeshServiceFacadeMethod> {
+    const total = slot.methods.length;
+    const floor = slot.minAvailable;
+    const viewName = slot.name;
+
+    const countAvailable = (): number => {
+      let n = 0;
+      for (const m of slot.methods) {
+        if ((this.resolvedDeps.get(`${toolName}:dep_${m.edgeIndex}`) ?? null) !== null) {
+          n++;
+        }
+      }
+      return n;
+    };
+
+    const enforceFloor = async (): Promise<void> => {
+      if (floor <= 0) return;
+      let available = countAvailable();
+      // Below the floor during the settling window: perform a bounded wait that
+      // RACES all of the view's still-pending edges (wake on ANY resolution),
+      // recounts, and breaks the moment the floor is met — so a call gated on
+      // the floor wakes when ANY qualifying edge lands, never sleeping the full
+      // window on a still-pending sibling key. Once settled the waits are
+      // no-ops and the floor fails fast.
+      while (
+        available < floor &&
+        !settleState.isSettled() &&
+        settleState.remainingMs() > 0
+      ) {
+        const pending: PendingSettleDep[] = [];
+        for (const m of slot.methods) {
+          const key = `${toolName}:dep_${m.edgeIndex}`;
+          if ((this.resolvedDeps.get(key) ?? null) === null) {
+            pending.push({ depKey: key, capability: edges[m.edgeIndex].capability });
+          }
+        }
+        if (pending.length === 0) break;
+        await settleState.waitForAny(pending);
+        available = countAvailable();
+      }
+      if (available < floor) {
+        throw new MeshServiceUnavailableError(viewName, available, total, floor);
+      }
+    };
+
+    const facade: Record<string, MeshServiceFacadeMethod> = {};
+    for (const m of slot.methods) {
+      const key = `${toolName}:dep_${m.edgeIndex}`;
+      const capability = edges[m.edgeIndex].capability;
+      // #1231 parity for view edges: a method edge that resolved at the registry
+      // yet never received an injected proxy stays null after settling. Warn
+      // ONCE per tool+edge (facade is rebuilt per call), naming the view method
+      // and capability so the diagnostic matches the slot-dep warning.
+      if ((this.resolvedDeps.get(key) ?? null) === null && settleState.isSettled()) {
+        if (!_unwiredSlotWarned.has(key)) {
+          _unwiredSlotWarned.add(key);
+          console.warn(
+            `[mesh-tool] service view '${viewName}' method '${m.method}' ` +
+              `(capability '${capability}') on '${toolName}' is still null ` +
+              `after settling — no proxy was injected. Fix: ensure the provider ` +
+              `for '${capability}' is registered and reachable.`,
+          );
+        }
+      }
+      facade[m.method] = async (args, options) => {
+        await enforceFloor();
+        const proxy = this.resolvedDeps.get(key) ?? null;
+        if (proxy === null) {
+          // Mirror the failure shape of calling an unresolved McpMeshTool
+          // (a null proxy) directly — a TypeError.
+          throw new TypeError(
+            `service view '${viewName}' method '${m.method}' (capability ` +
+              `'${capability}') is unavailable — the dependency did not ` +
+              `resolve (unresolved optional edge).`,
+          );
+        }
+        return proxy(args, options);
+      };
+    }
+    return facade;
   }
 
   private _getOrBuildA2AClient(config: A2AClientConfig): A2AClient {

--- a/src/runtime/typescript/src/index.ts
+++ b/src/runtime/typescript/src/index.ts
@@ -52,6 +52,7 @@
 
 import { mesh as meshFn, MeshAgent } from "./agent.js";
 import { route, routeWithConfig } from "./route.js";
+import { serviceView } from "./service-view.js";
 import { bindToExpress } from "./api-runtime.js";
 import { llm } from "./llm.js";
 import { llmProvider } from "./llm-provider.js";
@@ -118,6 +119,8 @@ interface MeshNamespace {
   llm: typeof llm;
   /** Create a zero-code LLM provider tool */
   llmProvider: typeof llmProvider;
+  /** Create a consumer service view (RFC #1280) for a tool dependency slot */
+  serviceView: typeof serviceView;
   /** Pipe an AsyncIterable<string> to an Express response as text/event-stream */
   sseStream: typeof sseStream;
   /** A2A v1.0 producer surface (issue #933). */
@@ -142,6 +145,7 @@ const mesh: MeshNamespace = Object.assign(meshFn, {
   bind: bindToExpress,
   llm,
   llmProvider,
+  serviceView,
   sseStream,
   a2a,
   jobs,
@@ -190,6 +194,22 @@ export {
   type MeshRouteConfig,
   type RouteMetadata,
 } from "./route.js";
+
+// Service views (RFC #1280) — consumer view factory + producer sugar surface.
+export {
+  serviceView,
+  isServiceView,
+  MeshServiceUnavailableError,
+  SERVICE_VIEW_BRAND,
+  CAPABILITY_NAME_PATTERN,
+  type ServiceView,
+  type ServiceViewSpec,
+  type ServiceViewMethodSpec,
+  type MeshServiceFacade,
+  type MeshServiceFacadeMethod,
+  type ServiceProducerMethod,
+  type ServiceProducerMethodObject,
+} from "./service-view.js";
 
 // Proxy utilities (for advanced use)
 export { createProxy, normalizeDependency, getCurrentPropagatedHeaders, callingJob, type CallingJob, extractContent, streamMcpTool, type MultiContentResult } from "./proxy.js";

--- a/src/runtime/typescript/src/route.ts
+++ b/src/runtime/typescript/src/route.ts
@@ -32,6 +32,7 @@
 import type { Request, Response, NextFunction, RequestHandler } from "express";
 import type { DependencySpec, McpMeshTool, DependencyKwargs, TagSpec } from "./types.js";
 import { normalizeDependency, runWithPropagatedHeaders, runWithTraceContext } from "./proxy.js";
+import { assertNoServiceViewDeps } from "./service-view.js";
 import { getApiRuntime, introspectExpressRoutes } from "./api-runtime.js";
 import { getSettleState, type PendingSettleDep } from "./settle.js";
 import {
@@ -369,6 +370,11 @@ export function route(
   options?: { dependencyKwargs?: DependencyKwargs[] }
 ): RequestHandler {
   const registry = RouteRegistry.getInstance();
+
+  // RFC #1280: service views are a tool-parameter surface only. A view in
+  // mesh.route deps is out of scope — reject rather than shipping a malformed
+  // `capability: undefined` edge.
+  assertNoServiceViewDeps(dependencies, "mesh.route");
 
   // We don't know the method/path yet since this is called before app.get/post/etc
   // So we'll register with placeholder and update when the middleware is called

--- a/src/runtime/typescript/src/service-view.ts
+++ b/src/runtime/typescript/src/service-view.ts
@@ -218,7 +218,8 @@ export function serviceView<S extends ServiceViewSpec>(spec: S): ServiceView<S> 
     spec == null ||
     typeof spec !== "object" ||
     typeof spec.methods !== "object" ||
-    spec.methods === null
+    spec.methods === null ||
+    Array.isArray(spec.methods)
   ) {
     throw new Error(
       "mesh.serviceView: `methods` must be an object mapping method names to " +

--- a/src/runtime/typescript/src/service-view.ts
+++ b/src/runtime/typescript/src/service-view.ts
@@ -1,0 +1,410 @@
+/**
+ * Service views (RFC #1280) for the TypeScript SDK.
+ *
+ * Two related roles, mirroring the Java runtime (`@McpMeshService`) so the
+ * cross-runtime contract (integration suite uc37) holds identically:
+ *
+ *   1. CONSUMER VIEW — `mesh.serviceView({ methods, minAvailable? })` produces a
+ *      branded object that occupies ONE positional dependency slot in a tool's
+ *      `dependencies` array but expands into N ordinary dependency edges (one per
+ *      method, SORTED BY NAME for deterministic registration). At call time the
+ *      framework injects a facade whose methods delegate to each edge's own
+ *      resolved proxy — so different methods may bind different provider agents
+ *      and rebind independently as topology changes. There are NO wire or
+ *      registry changes: every method is an ordinary dependency edge.
+ *
+ *   2. PRODUCER SUGAR — `agent.addService("prefix", { ... })` publishes each
+ *      entry (name-sorted) as an ordinary mesh tool with capability
+ *      `prefix.<method>` through the existing `addTool` machinery.
+ *
+ * A service view is purely consumer-local: there is no group versioning and no
+ * interface-level availability summary. The optional `minAvailable` floor is a
+ * consumer-local circuit breaker with no wire effect.
+ */
+
+import { z } from "zod";
+import type {
+  DependencySpec,
+  NormalizedDependency,
+  TagSpec,
+  MeshToolDef,
+} from "./types.js";
+import { normalizeDependency } from "./proxy.js";
+
+/**
+ * Reject any {@link ServiceView} in a dependency list for a surface that does
+ * NOT support the tool-parameter facade form (mesh.route, mesh.a2a.mount). A
+ * view there would normalize to a `capability: undefined` edge — a settle key
+ * that never resolves plus a nameless dependency shipped to the registry.
+ * Shared by every such call site so the error message + policy stay identical.
+ */
+export function assertNoServiceViewDeps(
+  deps: ReadonlyArray<unknown>,
+  surface: string,
+): void {
+  for (const dep of deps) {
+    if (isServiceView(dep)) {
+      throw new Error(
+        `${surface} does not support mesh.serviceView(...) dependencies ` +
+          `(RFC #1280 service views are a tool-parameter surface). Declare the ` +
+          `individual capability deps directly, or use a service view inside ` +
+          `agent.addTool(...).`,
+      );
+    }
+  }
+}
+
+/**
+ * Segment-wise dotted capability-name grammar. Kept in lockstep with the Go
+ * registry validator's `capabilityNamePattern`
+ * (src/core/registry/validation.go: `^[a-zA-Z][a-zA-Z0-9_-]*(\.[a-zA-Z][a-zA-Z0-9_-]*)*$`)
+ * and the Python/Java runtimes. Applied ONLY to the derived capability names
+ * `agent.addService` synthesizes — the SDK deliberately does NOT add a general
+ * capability-validation layer elsewhere (the registry remains the single
+ * authority for hand-written capability names).
+ */
+export const CAPABILITY_NAME_PATTERN =
+  /^[a-zA-Z][a-zA-Z0-9_-]*(\.[a-zA-Z][a-zA-Z0-9_-]*)*$/;
+
+/**
+ * Brand symbol marking a `mesh.serviceView(...)` result so the dependency
+ * expander can detect a view slot structurally (config-over-reflection, the
+ * same precedent as `meshJobDepIndex`). `Symbol.for` keeps the brand stable
+ * across duplicate module instances.
+ */
+export const SERVICE_VIEW_BRAND: unique symbol = Symbol.for(
+  "@mcpmesh/sdk/service-view",
+);
+
+/** A single view method — a capability string shorthand or a full selector. */
+export type ServiceViewMethodSpec =
+  | string
+  | {
+      /** Capability this method binds. */
+      capability: string;
+      /** Tags for filtering (supports OR alternatives via nested arrays). */
+      tags?: TagSpec[];
+      /** Version constraint (e.g. ">=2.0.0"). */
+      version?: string;
+      /** Issue #1249 opt-in strictness for this edge (default soft-fail). */
+      required?: boolean;
+      /**
+       * Issue #547: optional Zod schema describing the expected provider
+       * response for this method edge (parity with Java `@Selector` schema
+       * matching). Passed through `normalizeDependency` exactly like an ordinary
+       * object dependency, so the registry filters providers by canonical hash.
+       */
+      expectedSchema?: z.ZodType<unknown>;
+      /** Issue #547: schema match mode (defaults to "subset" when expectedSchema set). */
+      matchMode?: "subset" | "strict";
+    };
+
+/**
+ * A consumer service-view specification. `methods` maps facade method names to
+ * their capability binding; the injected facade exposes exactly these keys.
+ */
+export interface ServiceViewSpec {
+  /** Facade method name → capability binding. At least one entry required. */
+  methods: Record<string, ServiceViewMethodSpec>;
+  /**
+   * Optional availability floor. When fewer than `minAvailable` of the view's
+   * methods currently resolve, EVERY facade call throws
+   * {@link MeshServiceUnavailableError} — a consumer-local circuit breaker with
+   * no wire effect. Default 0 = no floor (each method soft/hard-fails per its
+   * own `required` flag).
+   */
+  minAvailable?: number;
+  /** Optional label surfaced in floor-breach errors and logs. */
+  name?: string;
+}
+
+/**
+ * A single facade method. Signature mirrors {@link import("./types.js").McpMeshTool}'s
+ * callable form so a view method is a drop-in for a directly-injected proxy.
+ */
+export type MeshServiceFacadeMethod = (
+  args?: Record<string, unknown>,
+  options?: { headers?: Record<string, string> },
+) => Promise<unknown>;
+
+/**
+ * The injected facade type inferred from a {@link ServiceView} (or a bare
+ * {@link ServiceViewSpec}). Each spec method key becomes a callable facade
+ * method.
+ *
+ * **How to type the view slot in `execute`:** leave the positional parameters
+ * un-annotated (they infer as the injected `McpMeshTool | MeshJob | null`
+ * union) and narrow the view slot with a cast at point of use. A direct
+ * parameter annotation (`media: MeshServiceFacade<typeof Media>`) does NOT
+ * compile under `strictFunctionTypes`: `execute`'s dependency parameters are
+ * checked contravariantly, so any type narrower than the full injected union —
+ * including a plain `McpMeshTool | null` — is rejected. This is why the cast
+ * idiom is the canonical form (it also matches how ordinary `McpMeshTool` deps
+ * are consumed):
+ *
+ * ```ts
+ * import { mesh, type MeshServiceFacade } from "@mcpmesh/sdk";
+ *
+ * const Media = mesh.serviceView({ methods: { caption: "media.caption" } });
+ *
+ * agent.addTool({
+ *   name: "process",
+ *   parameters: z.object({ text: z.string() }),
+ *   dependencies: ["audit_log", Media],
+ *   execute: async (args, auditLog, media) => {
+ *     const svc = media as MeshServiceFacade<typeof Media>;
+ *     return await svc.caption({ text: args.text });
+ *   },
+ * });
+ * ```
+ */
+export type MeshServiceFacade<V> = V extends ServiceView<infer S>
+  ? { [K in keyof S["methods"]]: MeshServiceFacadeMethod }
+  : V extends ServiceViewSpec
+    ? { [K in keyof V["methods"]]: MeshServiceFacadeMethod }
+    : never;
+
+/**
+ * A branded service-view value produced by {@link serviceView}. Placed in a
+ * tool's `dependencies` array where it occupies one positional slot.
+ */
+export interface ServiceView<S extends ServiceViewSpec = ServiceViewSpec> {
+  readonly [SERVICE_VIEW_BRAND]: true;
+  readonly spec: S;
+}
+
+/** Structural brand check — true for a `mesh.serviceView(...)` result. */
+export function isServiceView(value: unknown): value is ServiceView {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Record<PropertyKey, unknown>)[SERVICE_VIEW_BRAND] === true
+  );
+}
+
+/**
+ * Thrown by every facade call when a view is below its declared
+ * {@link ServiceViewSpec.minAvailable} floor. Carries the view label plus the
+ * current/total/floor counts so the failure is actionable. Mirrors Java's
+ * `MeshServiceUnavailableException`.
+ */
+export class MeshServiceUnavailableError extends Error {
+  readonly name = "MeshServiceUnavailableError";
+
+  constructor(
+    /** View label (spec.name or a derived owner:slot label). */
+    public readonly service: string,
+    /** View methods currently resolving to a provider. */
+    public readonly available: number,
+    /** Total dependency-bound view methods. */
+    public readonly total: number,
+    /** The declared availability floor. */
+    public readonly floor: number,
+  ) {
+    super(
+      `Mesh service view unavailable (${service}): ${available}/${total} ` +
+        `method(s) resolved, below the declared minAvailable=${floor} floor`,
+    );
+  }
+}
+
+/**
+ * Construct a consumer service view. Validates the spec at construction time
+ * (empty methods map; blank capability; out-of-range `minAvailable`) so misuse
+ * fails loud before the agent talks to the registry.
+ */
+export function serviceView<S extends ServiceViewSpec>(spec: S): ServiceView<S> {
+  if (
+    spec == null ||
+    typeof spec !== "object" ||
+    typeof spec.methods !== "object" ||
+    spec.methods === null
+  ) {
+    throw new Error(
+      "mesh.serviceView: `methods` must be an object mapping method names to " +
+        "capabilities.",
+    );
+  }
+  const keys = Object.keys(spec.methods);
+  if (keys.length === 0) {
+    throw new Error(
+      "mesh.serviceView: `methods` must declare at least one method (got an " +
+        "empty methods map).",
+    );
+  }
+  for (const key of keys) {
+    const m = spec.methods[key];
+    const capability = typeof m === "string" ? m : m?.capability;
+    if (typeof capability !== "string" || capability.trim() === "") {
+      throw new Error(
+        `mesh.serviceView: method '${key}' has a blank capability.`,
+      );
+    }
+  }
+  const min = spec.minAvailable;
+  if (min !== undefined) {
+    if (!Number.isInteger(min) || min < 0) {
+      throw new Error(
+        `mesh.serviceView: minAvailable must be an integer >= 0 (got ${min}).`,
+      );
+    }
+    if (min > keys.length) {
+      throw new Error(
+        `mesh.serviceView: minAvailable=${min} exceeds the number of methods ` +
+          `(${keys.length}) — the floor can never be satisfied.`,
+      );
+    }
+  }
+  return {
+    [SERVICE_VIEW_BRAND]: true,
+    spec,
+  } as ServiceView<S>;
+}
+
+/** One view method's flat-edge placement within the expanded dependency list. */
+export interface ViewMethodEdge {
+  /** Facade method name (spec key). */
+  method: string;
+  /** Index into the flat edge array (settle-key / resolvedDeps / wire index). */
+  edgeIndex: number;
+}
+
+/**
+ * One positional dependency slot after expansion. A `dep` slot maps to exactly
+ * one edge; a `view` slot collapses N edges into a single facade argument. The
+ * disjoint edge ranges are tracked here (mirrors Java's index-range mapping).
+ */
+export type DepSlot =
+  | { kind: "dep"; edgeIndex: number }
+  | {
+      kind: "view";
+      name: string;
+      minAvailable: number;
+      methods: ViewMethodEdge[];
+    };
+
+/** Result of expanding a mixed `(DependencySpec | ServiceView)[]` list. */
+export interface ExpandedDeps {
+  /**
+   * Flat dependency edges in wire/settle/resolve order. This is what ships to
+   * the registry, what settle keys index (`owner:dep_<edgeIndex>`), what
+   * `dependency_available` events address, and what `resolvedDeps` keys — one
+   * entry per edge, view methods expanded IN-PLACE at the view's array position
+   * in NAME-SORTED order.
+   */
+  edges: NormalizedDependency[];
+  /**
+   * Positional execute slots (one per authored `dependencies` entry). A view
+   * entry is ONE slot spanning a contiguous edge range; a non-view entry is one
+   * slot mapping to one edge. For a view-free list `slots[i].edgeIndex === i`.
+   */
+  slots: DepSlot[];
+}
+
+function normalizeViewMethod(m: ServiceViewMethodSpec): NormalizedDependency {
+  if (typeof m === "string") {
+    return normalizeDependency(m);
+  }
+  return normalizeDependency({
+    capability: m.capability,
+    tags: m.tags,
+    version: m.version,
+    required: m.required,
+    expectedSchema: m.expectedSchema,
+    matchMode: m.matchMode,
+  });
+}
+
+/**
+ * Expand a tool's authored dependency list (a mix of {@link DependencySpec} and
+ * {@link ServiceView}) into the flat edge array + the positional slot layout.
+ *
+ * Layout contract (identical to the Java runtime — see uc37):
+ *   - non-view entries keep their exact slot↔edge pairing;
+ *   - a view entry contributes ONE slot at its array position but N edges,
+ *     expanded IN-PLACE (name-sorted) so the flat edge indices stay contiguous
+ *     and every downstream index consumer (settle keys, wire payload,
+ *     resolution events, required guard) sees ordinary edges.
+ *
+ * For a view-free list this returns `edges` byte-identical to
+ * `deps.map(normalizeDependency)` and `slots[i] = { kind: "dep", edgeIndex: i }`
+ * — zero behavior change.
+ */
+export function expandDependencies(
+  deps: ReadonlyArray<DependencySpec | ServiceView>,
+  ownerLabel: string,
+): ExpandedDeps {
+  const edges: NormalizedDependency[] = [];
+  const slots: DepSlot[] = [];
+
+  deps.forEach((entry, slotIndex) => {
+    if (isServiceView(entry)) {
+      const spec = entry.spec;
+      // Object key order is insertion-based; MUST sort by name for a
+      // deterministic edge layout across runtimes.
+      const methodNames = Object.keys(spec.methods).sort();
+      const methods: ViewMethodEdge[] = [];
+      for (const method of methodNames) {
+        const edgeIndex = edges.length;
+        edges.push(normalizeViewMethod(spec.methods[method]));
+        methods.push({ method, edgeIndex });
+      }
+      slots.push({
+        kind: "view",
+        name: spec.name ?? `${ownerLabel}:view${slotIndex}`,
+        minAvailable: spec.minAvailable ?? 0,
+        methods,
+      });
+      return;
+    }
+
+    // Guard: an object without a `capability` in a dependencies array is almost
+    // certainly a producer-method object placed where a view/dep was expected
+    // (or a malformed spec). Fail loud rather than shipping a `capability:
+    // undefined` edge.
+    if (
+      typeof entry === "object" &&
+      entry !== null &&
+      typeof (entry as { capability?: unknown }).capability !== "string"
+    ) {
+      throw new Error(
+        `${ownerLabel}: dependency #${slotIndex} is an object without a ` +
+          `'capability' — expected a DependencySpec (string or { capability }) ` +
+          `or a mesh.serviceView(...). If this is a producer method, register ` +
+          `it with agent.addService(...).`,
+      );
+    }
+
+    const edgeIndex = edges.length;
+    edges.push(normalizeDependency(entry as DependencySpec));
+    slots.push({ kind: "dep", edgeIndex });
+  });
+
+  return { edges, slots };
+}
+
+/**
+ * A producer method for `agent.addService`. Either a bare execute function
+ * (shorthand) or an object carrying `execute` plus any `addTool` passthrough
+ * (tags/version/description/parameters/dependencies/...). `name` and
+ * `capability` are DERIVED (`prefix.<method>`) and must not be supplied.
+ */
+export type ServiceProducerMethod =
+  | ((...args: never[]) => Promise<unknown> | unknown)
+  | ServiceProducerMethodObject;
+
+/** Object form of a {@link ServiceProducerMethod}. */
+export type ServiceProducerMethodObject = Omit<
+  Partial<MeshToolDef>,
+  "name" | "capability" | "execute" | "parameters"
+> & {
+  /** Method implementation (positional deps injected after args, as usual). */
+  execute: MeshToolDef["execute"];
+  /** Optional Zod input schema. Defaults to a permissive passthrough object. */
+  parameters?: z.ZodType;
+};
+
+/** Permissive default schema for producer methods that declare no `parameters`. */
+export function defaultProducerParams(): z.ZodType {
+  return z.object({}).passthrough();
+}

--- a/src/runtime/typescript/src/settle.ts
+++ b/src/runtime/typescript/src/settle.ts
@@ -243,31 +243,39 @@ export class SettleState {
   }
 
   /**
-   * Wait until `depKey` resolves or the remaining settle budget elapses.
-   * Event-driven: the dependency's resolution promise is raced against a
-   * timer bounded by the remaining window — never a fixed sleep.
+   * Shared wait plumbing for {@link waitFor} / {@link waitForAny}: log the
+   * settle cadence for each capability (INFO first time, DEBUG after), bump the
+   * diagnostic `waitCount`, and race every `depKeys` resolution waiter against
+   * ONE budget timer bounded by `remaining` — never a fixed sleep. Callers apply
+   * their own resolved-state filtering + early-return BEFORE calling this, so
+   * `depKeys` are the genuinely-still-pending keys and `remaining > 0`.
+   *
+   * On timeout the caller simply proceeds — the unresolved dep injects null
+   * exactly as today; the existing unresolved-dep handling covers the
+   * diagnostic (no double-logging here).
    */
-  async waitFor(depKey: string, capability: string): Promise<void> {
-    const remaining = this.remainingMs();
-    if (remaining <= 0 || this.resolved.has(depKey)) {
-      return;
-    }
-    const waiter = this.waiterFor(depKey);
+  private async raceWaiters(
+    depKeys: readonly string[],
+    capabilities: readonly string[],
+    remaining: number,
+  ): Promise<void> {
     const remainingSecs = (remaining / 1000).toFixed(1);
-    const message = `waiting up to ${remainingSecs}s for dependency '${capability}' to settle`;
-    if (!this.loggedWaits.has(capability)) {
-      // One INFO line per capability per process; later waits at DEBUG
-      // (matches the Python/Java log cadence).
-      this.loggedWaits.add(capability);
-      console.log(message);
-    } else {
-      console.debug(message);
+    for (const capability of capabilities) {
+      const message = `waiting up to ${remainingSecs}s for dependency '${capability}' to settle`;
+      if (!this.loggedWaits.has(capability)) {
+        // One INFO line per capability per process; later waits at DEBUG
+        // (matches the Python/Java log cadence).
+        this.loggedWaits.add(capability);
+        console.log(message);
+      } else {
+        console.debug(message);
+      }
     }
     this.waitCount++;
     let timer: NodeJS.Timeout | undefined;
     try {
       await Promise.race([
-        waiter.promise,
+        ...depKeys.map((k) => this.waiterFor(k).promise),
         new Promise<void>((resolve) => {
           timer = setTimeout(resolve, remaining);
           // Never keep the process alive just for a settle timer.
@@ -279,9 +287,19 @@ export class SettleState {
         clearTimeout(timer);
       }
     }
-    // On timeout we simply proceed — the unresolved dep injects null
-    // exactly as today; the existing unresolved-dep handling covers the
-    // diagnostic (no double-logging here).
+  }
+
+  /**
+   * Wait until `depKey` resolves or the remaining settle budget elapses.
+   * Event-driven: the dependency's resolution promise is raced against a
+   * timer bounded by the remaining window — never a fixed sleep.
+   */
+  async waitFor(depKey: string, capability: string): Promise<void> {
+    const remaining = this.remainingMs();
+    if (remaining <= 0 || this.resolved.has(depKey)) {
+      return;
+    }
+    await this.raceWaiters([depKey], [capability], remaining);
   }
 
   /**
@@ -309,31 +327,11 @@ export class SettleState {
     if (remaining <= 0 || unresolved.length === 0) {
       return;
     }
-    const remainingSecs = (remaining / 1000).toFixed(1);
-    for (const { capability } of unresolved) {
-      const message = `waiting up to ${remainingSecs}s for dependency '${capability}' to settle`;
-      if (!this.loggedWaits.has(capability)) {
-        this.loggedWaits.add(capability);
-        console.log(message);
-      } else {
-        console.debug(message);
-      }
-    }
-    this.waitCount++;
-    let timer: NodeJS.Timeout | undefined;
-    try {
-      await Promise.race([
-        ...unresolved.map((p) => this.waiterFor(p.depKey).promise),
-        new Promise<void>((resolve) => {
-          timer = setTimeout(resolve, remaining);
-          timer.unref?.();
-        }),
-      ]);
-    } finally {
-      if (timer !== undefined) {
-        clearTimeout(timer);
-      }
-    }
+    await this.raceWaiters(
+      unresolved.map((p) => p.depKey),
+      unresolved.map((p) => p.capability),
+      remaining,
+    );
   }
 }
 

--- a/src/runtime/typescript/src/settle.ts
+++ b/src/runtime/typescript/src/settle.ts
@@ -294,6 +294,47 @@ export class SettleState {
       await this.waitFor(depKey, capability);
     }
   }
+
+  /**
+   * Wait until ANY of `pending` resolves or the remaining settle budget
+   * elapses. Unlike {@link awaitPending} (which blocks on each key in turn),
+   * this races every pending key's resolution promise against ONE budget timer,
+   * so a caller gated on a floor wakes the moment ANY qualifying dependency
+   * lands — never sleeping on an already-satisfied floor because it happened to
+   * be awaiting a still-pending sibling key (RFC #1280 minAvailable).
+   */
+  async waitForAny(pending: PendingSettleDep[]): Promise<void> {
+    const remaining = this.remainingMs();
+    const unresolved = pending.filter((p) => !this.resolved.has(p.depKey));
+    if (remaining <= 0 || unresolved.length === 0) {
+      return;
+    }
+    const remainingSecs = (remaining / 1000).toFixed(1);
+    for (const { capability } of unresolved) {
+      const message = `waiting up to ${remainingSecs}s for dependency '${capability}' to settle`;
+      if (!this.loggedWaits.has(capability)) {
+        this.loggedWaits.add(capability);
+        console.log(message);
+      } else {
+        console.debug(message);
+      }
+    }
+    this.waitCount++;
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        ...unresolved.map((p) => this.waiterFor(p.depKey).promise),
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, remaining);
+          timer.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+    }
+  }
 }
 
 let settleState = new SettleState();

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import { z } from "zod";
+import type { ServiceView } from "./service-view.js";
 
 /**
  * Metadata for media-typed tool parameters.
@@ -511,6 +512,11 @@ export interface MeshToolDef<T extends z.ZodType = z.ZodType> {
    * Dependencies required by this tool.
    * Injected positionally as McpMeshTool params after args.
    *
+   * A `mesh.serviceView(...)` entry (RFC #1280) occupies ONE positional slot but
+   * expands into N ordinary dependency edges (one per method, name-sorted); the
+   * framework injects a facade at that slot whose methods delegate to each edge's
+   * own resolved proxy.
+   *
    * @example
    * ```typescript
    * dependencies: ["time-service", "calculator"],
@@ -521,7 +527,7 @@ export interface MeshToolDef<T extends z.ZodType = z.ZodType> {
    * ) => { ... }
    * ```
    */
-  dependencies?: DependencySpec[];
+  dependencies?: (DependencySpec | ServiceView)[];
   /**
    * Per-dependency configuration indexed by position.
    * Array index corresponds to dependencies array position.

--- a/tests/integration/suites/uc37_service_view_java/artifacts/py-svc-producer
+++ b/tests/integration/suites/uc37_service_view_java/artifacts/py-svc-producer
@@ -1,0 +1,1 @@
+../fixtures/py-svc-producer

--- a/tests/integration/suites/uc37_service_view_java/artifacts/py-view-consumer
+++ b/tests/integration/suites/uc37_service_view_java/artifacts/py-view-consumer
@@ -1,0 +1,1 @@
+../fixtures/py-view-consumer

--- a/tests/integration/suites/uc37_service_view_java/artifacts/ts-svc-producer
+++ b/tests/integration/suites/uc37_service_view_java/artifacts/ts-svc-producer
@@ -1,0 +1,1 @@
+../fixtures/ts-svc-producer

--- a/tests/integration/suites/uc37_service_view_java/artifacts/ts-view-consumer
+++ b/tests/integration/suites/uc37_service_view_java/artifacts/ts-view-consumer
@@ -1,0 +1,1 @@
+../fixtures/ts-view-consumer

--- a/tests/integration/suites/uc37_service_view_java/fixtures/py-svc-producer/main.py
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/py-svc-producer/main.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""uc37 py-svc-producer — PYTHON producer sugar (RFC #1280 phase 3, tc12).
+
+``@mesh.service("pysvc")`` publishes each public method as a DOTTED
+capability (pysvc.alpha, pysvc.bravo) through the normal ``@mesh.tool``
+machinery — the Python twin of java-view-producer's
+``@McpMeshService("svc")`` and ts-svc-producer's ``addService("tssvc")``.
+
+Payloads are self-identifying (agent + capability) so tc12's direct
+``meshctl call pysvc.<m>`` assertions prove serving + routing, not just
+registration. Methods are deliberately no-arg (mirrors the other producers)
+so ``'{}'`` calls work.
+
+NOTE: no ``@app.tool`` anywhere by design — the sugar must publish AND serve
+on its own. If pysvc.* shows in the registry but ``tools/call`` answers
+"Unknown tool", that is the SDK gap tc12 exists to surface (sugar registered
+the capability for the wire but not on the served FastMCP instance).
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Py Svc Producer (uc37)")
+
+
+@mesh.service("pysvc")
+class PySvcTools:
+    """Publishes pysvc.alpha and pysvc.bravo — nothing else."""
+
+    async def alpha(self) -> dict:
+        return {"agent": "py-svc-producer", "cap": "pysvc.alpha", "msg": "hello-from-pysvc-alpha"}
+
+    async def bravo(self) -> dict:
+        return {"agent": "py-svc-producer", "cap": "pysvc.bravo", "msg": "hello-from-pysvc-bravo"}
+
+
+@mesh.agent(
+    name="py-svc-producer",
+    version="1.0.0",
+    description="uc37 Python producer of pysvc.* dotted capabilities via @mesh.service sugar",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9302")),
+    enable_http=True,
+    auto_run=True,
+)
+class PySvcProducer:
+    pass

--- a/tests/integration/suites/uc37_service_view_java/fixtures/py-svc-producer/requirements.txt
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/py-svc-producer/requirements.txt
@@ -1,0 +1,1 @@
+# uc37 py-svc-producer deps. mesh + fastmcp come from the runtime image.

--- a/tests/integration/suites/uc37_service_view_java/fixtures/py-view-consumer/main.py
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/py-view-consumer/main.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""uc37 py-view-consumer — PYTHON service view consuming the JAVA producer
+(RFC #1280 cross-runtime seam, tc10).
+
+The ``SvcView`` view binds the dotted svc.* capabilities published by
+java-view-producer's ``@McpMeshService("svc")`` sugar. ``bravo`` carries
+``required=True``: because a Python view is a TOOL-PARAMETER surface, its
+edges are ordinary tool dependency slots, so the required edge participates
+in the issue #1273 pre-invoke guard — calling ``py_view_report`` while
+svc.bravo is unresolved is refused with the structured
+``{"error":"dependency_unavailable","capability":"svc.bravo"}`` ToolError
+BEFORE the handler runs (envelope parity with the Java tool-param path,
+tc06).
+
+The report tool mirrors the suite's flat shape: ``<method>_agent`` /
+``<method>_cap`` on success, ``<method>_error`` / ``<method>_error_message``
+on failure.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Py View Consumer (uc37)")
+
+
+@mesh.service
+class SvcView:
+    """Consumer view over the Java producer's dotted svc.* capabilities."""
+
+    @mesh.selector("svc.alpha")
+    async def alpha(self) -> dict: ...
+
+    @mesh.selector("svc.bravo", required=True)
+    async def bravo(self) -> dict: ...
+
+
+@app.tool()
+@mesh.tool(
+    capability="py_view_report",
+    description="Call both SvcView methods (Java svc.* producer) and report which agent served each",
+)
+async def py_view_report(view: SvcView = None) -> dict:
+    out: dict = {}
+    for name in ("alpha", "bravo"):
+        try:
+            payload = await getattr(view, name)()
+            out[f"{name}_agent"] = payload.get("agent")
+            out[f"{name}_cap"] = payload.get("cap")
+        except Exception as e:  # noqa: BLE001 — the report IS the observation surface
+            out[f"{name}_error"] = type(e).__name__
+            out[f"{name}_error_message"] = str(e)
+    return out
+
+
+@mesh.agent(
+    name="py-view-consumer",
+    version="1.0.0",
+    description="uc37 Python consumer of the Java svc.* producer via a @mesh.service view",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9301")),
+    enable_http=True,
+    auto_run=True,
+)
+class PyViewConsumer:
+    pass

--- a/tests/integration/suites/uc37_service_view_java/fixtures/py-view-consumer/requirements.txt
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/py-view-consumer/requirements.txt
@@ -1,0 +1,1 @@
+# uc37 py-view-consumer deps. mesh + fastmcp come from the runtime image.

--- a/tests/integration/suites/uc37_service_view_java/fixtures/ts-svc-producer/package.json
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/ts-svc-producer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ts-svc-producer",
+  "version": "1.0.0",
+  "description": "uc37 TypeScript producer sugar publishing tssvc.* dotted capabilities (RFC #1280)",
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^2.8.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc37_service_view_java/fixtures/ts-svc-producer/src/index.ts
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/ts-svc-producer/src/index.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env npx tsx
+/**
+ * ts-svc-producer — TYPESCRIPT producer sugar (RFC #1280 phase 3, uc37 tc12).
+ *
+ * `agent.addService("tssvc", {...})` publishes each entry (name-sorted) as an
+ * ordinary mesh tool with a DOTTED capability (tssvc.alpha, tssvc.bravo)
+ * through the existing addTool machinery — the TS twin of
+ * java-view-producer's `@McpMeshService("svc")` and py-svc-producer's
+ * `@mesh.service("pysvc")`.
+ *
+ * Payloads are self-identifying (agent + capability) so tc12's direct
+ * `meshctl call tssvc.<m>` assertions prove serving + routing, not just
+ * registration. Methods take no meaningful args (permissive default schema)
+ * so `'{}'` calls work.
+ */
+
+import { FastMCP, mesh } from "@mcpmesh/sdk";
+
+const server = new FastMCP({
+  name: "TsSvcProducer Service",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "ts-svc-producer",
+  httpPort: 9402,
+});
+
+agent.addService("tssvc", {
+  alpha: async () =>
+    JSON.stringify({
+      agent: "ts-svc-producer",
+      cap: "tssvc.alpha",
+      msg: "hello-from-tssvc-alpha",
+    }),
+  bravo: async () =>
+    JSON.stringify({
+      agent: "ts-svc-producer",
+      cap: "tssvc.bravo",
+      msg: "hello-from-tssvc-bravo",
+    }),
+});
+
+console.log("ts-svc-producer agent defined. Waiting for auto-start...");

--- a/tests/integration/suites/uc37_service_view_java/fixtures/ts-svc-producer/tsconfig.json
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/ts-svc-producer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc37_service_view_java/fixtures/ts-view-consumer/package.json
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/ts-view-consumer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ts-view-consumer",
+  "version": "1.0.0",
+  "description": "uc37 TypeScript service-view consumer of the Java svc.* producer (RFC #1280)",
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^2.8.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc37_service_view_java/fixtures/ts-view-consumer/src/index.ts
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/ts-view-consumer/src/index.ts
@@ -1,0 +1,74 @@
+#!/usr/bin/env npx tsx
+/**
+ * ts-view-consumer — TYPESCRIPT service view consuming the JAVA producer
+ * (RFC #1280 cross-runtime seam, uc37 tc11).
+ *
+ * `mesh.serviceView(...)` occupies ONE dependencies slot but expands into two
+ * ordinary edges (name-sorted) binding java-view-producer's dotted svc.*
+ * capabilities. `bravo` is required=true: a TS view is a TOOL-PARAMETER
+ * surface, so the edge is an ordinary tool dependency slot and participates
+ * in the issue #1273 pre-invoke guard — calling `ts_view_report` while
+ * svc.bravo is unresolved is refused with the structured
+ * `{"error":"dependency_unavailable","capability":"svc.bravo"}` result
+ * BEFORE execute runs (envelope parity with the Java/Python tool-param
+ * paths, tc06/tc10).
+ *
+ * The report mirrors the suite's flat shape: `<method>_agent`/`<method>_cap`
+ * on success, `<method>_error`/`<method>_error_message` on failure.
+ */
+
+import { FastMCP, mesh, type MeshServiceFacade } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "TsViewConsumer Service",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "ts-view-consumer",
+  httpPort: 9401,
+});
+
+const SvcView = mesh.serviceView({
+  name: "SvcView",
+  methods: {
+    alpha: "svc.alpha",
+    bravo: { capability: "svc.bravo", required: true },
+  },
+});
+
+agent.addTool({
+  name: "ts_view_report",
+  capability: "ts_view_report",
+  description:
+    "Call both SvcView methods (Java svc.* producer) and report which agent served each",
+  dependencies: [SvcView],
+  parameters: z.object({}),
+  execute: async (
+    _args,
+    viewDep: unknown = null, // Positional: dependencies[0] (ONE slot, two edges)
+  ) => {
+    // The SDK's execute dep union is (McpMeshTool | MeshJob | null); facades
+    // arrive through the same positional slot, so type via cast — the same
+    // pattern the SDK's own service-view spec uses.
+    const view = viewDep as MeshServiceFacade<typeof SvcView> | null;
+    const out: Record<string, unknown> = {};
+    if (!view) {
+      return JSON.stringify({ error: "view not injected" });
+    }
+    for (const name of ["alpha", "bravo"] as const) {
+      try {
+        const payload = (await view[name]({})) as Record<string, unknown> | null;
+        out[`${name}_agent`] = payload?.agent;
+        out[`${name}_cap`] = payload?.cap;
+      } catch (e) {
+        out[`${name}_error`] = e instanceof Error ? e.name : "unknown";
+        out[`${name}_error_message`] = e instanceof Error ? e.message : String(e);
+      }
+    }
+    return JSON.stringify(out);
+  },
+});
+
+console.log("ts-view-consumer agent defined. Waiting for auto-start...");

--- a/tests/integration/suites/uc37_service_view_java/fixtures/ts-view-consumer/tsconfig.json
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/ts-view-consumer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc37_service_view_java/tc10_py_view_consumer/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc10_py_view_consumer/test.yaml
@@ -117,8 +117,13 @@ test:
 
   # Guarantee 2: the structured pre-invoke refusal from the PYTHON tool.
   # Poll until the guard fires (the consumer's heartbeat must first drop the
-  # slot; the interim window may surface a handler-level bravo_error report —
-  # only the structured body counts as the verdict).
+  # slot; the interim window may surface a handler-level bravo_error report).
+  # The loop exit REQUIRES the structural refusal shape — isError==true (a
+  # handler-level report is a SUCCESS result carrying the error text, so
+  # tokens alone could exit on a transient) — plus the body: parsed
+  # `.error == "dependency_unavailable" and .capability == "svc.bravo"` when
+  # content[0].text is pure JSON, with raw-token matching as the fallback for
+  # a FastMCP-wrapped ToolError text.
   - name: "Wait for the structured dependency_unavailable refusal"
     handler: shell
     workdir: /workspace
@@ -126,11 +131,16 @@ test:
       RESP=""
       for i in $(seq 1 60); do
         RESP=$(meshctl call py_view_report '{}' --raw 2>&1 || true)
-        if echo "$RESP" | grep -q 'dependency_unavailable' && echo "$RESP" | grep -q 'svc.bravo'; then
-          echo "PY_REFUSAL_STRUCTURED=1 after ~$((i*2))s"
-          [ "$(echo "$RESP" | jq -r '.isError == true' 2>/dev/null)" = "true" ] && echo "PY_REFUSAL_ISERROR=1"
-          echo "$RESP"
-          exit 0
+        ISERR=$(echo "$RESP" | jq -r '.isError == true' 2>/dev/null || echo "")
+        BODY=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .error == "dependency_unavailable" and .capability == "svc.bravo"' 2>/dev/null || echo "")
+        if [ "$ISERR" = "true" ]; then
+          if [ "$BODY" = "true" ] || { echo "$RESP" | grep -q 'dependency_unavailable' && echo "$RESP" | grep -q 'svc.bravo'; }; then
+            echo "PY_REFUSAL_STRUCTURED=1 after ~$((i*2))s"
+            echo "PY_REFUSAL_ISERROR=1"
+            [ "$BODY" = "true" ] && echo "PY_REFUSAL_BODY_PARSED=1"
+            echo "$RESP"
+            exit 0
+          fi
         fi
         sleep 2
       done

--- a/tests/integration/suites/uc37_service_view_java/tc10_py_view_consumer/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc10_py_view_consumer/test.yaml
@@ -1,0 +1,193 @@
+# tc10_py_view_consumer — RFC #1280 cross-runtime consumer parity (PYTHON):
+# a @mesh.service view in a PYTHON consumer binds the DOTTED svc.*
+# capabilities published by the JAVA producer's @McpMeshService("svc") sugar,
+# and the required-edge refusal envelope is byte-compatible with the Java
+# tool-param path (tc06).
+#
+# Topology: java-view-producer (svc.alpha + svc.bravo) + py-view-consumer
+# whose SvcView binds both (bravo required=True) and whose py_view_report
+# @mesh.tool takes the view as a TOOL PARAMETER.
+#
+# Design guarantees under test:
+#   1. Cross-runtime binding: both view methods answer FROM THE JAVA AGENT —
+#      the report pairs alpha->java-view-producer/svc.alpha and
+#      bravo->java-view-producer/svc.bravo (anchored key:value pairs).
+#   2. Refusal parity: kill java-view-producer -> invoking py_view_report is
+#      REFUSED pre-invoke with the structured
+#      {"error":"dependency_unavailable","capability":"svc.bravo"} ToolError
+#      (isError=true) — a Python view is a tool-parameter surface, so its
+#      required edges are ordinary tool dependency slots under the #1273
+#      guard, exactly like Java's view_tool_param. A report carrying
+#      bravo_error instead would mean the handler ran with a dead REQUIRED
+#      proxy. (The refusal body rides the ToolError message text; judged
+#      structurally — isError via jq, body tokens via grep — since FastMCP
+#      may wrap the text.)
+#   3. Organic recovery: restart the producer -> the report binds again with
+#      no consumer restart.
+#
+# Timing: transitions ride the default health debounce (~15-25s) plus one
+# consumer heartbeat — polled with deadlines. No dependency-resolution waits
+# (issue #1193): the baseline call rides the settle window. TC timeout =
+# cold-cache step-budget sum: copy 120 + maven 600 + pip 120 + starts 2x120
+# + registration 260 + baseline poll 200 + kill 120 + refusal poll 140 +
+# restart 120 + recovery poll 190 = 2110, rounded up with slack to 2400.
+
+name: "Service views cross-runtime: Python @mesh.service view over the Java svc.* producer"
+description: "py-view-consumer's SvcView binds svc.alpha/svc.bravo from java-view-producer; kill producer: structured dependency_unavailable refusal (svc.bravo required) from the PYTHON tool; restart: recovers"
+tags:
+  - integration
+  - python
+  - java
+  - registry
+  - service-view
+  - rfc-1280
+  - required-deps
+  - availability
+  - slow
+timeout: 2400
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/java-view-producer /workspace/
+      cp -rL /uc-artifacts/py-view-consumer /workspace/
+
+  - name: "Install producer Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-view-producer
+    timeout: 600
+
+  - name: "Install py-view-consumer deps"
+    handler: pip-install
+    path: /workspace/py-view-consumer
+
+  - name: "Start java-view-producer (port 9202)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-producer --env MCP_MESH_HTTP_PORT=9202 -d
+
+  - name: "Start py-view-consumer (port 9301)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start py-view-consumer/main.py --env MCP_MESH_HTTP_PORT=9301 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193): 240s deadline covers the cold JVM start.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "java-view-producer py-view-consumer"
+
+  # Baseline: both methods served by the JAVA agent with dotted caps.
+  # ENVELOPE: parse via `.content[0].text | fromjson` (portable across the
+  # Python/Java tool envelopes), equality inside the jq filter; anchored
+  # key:value pairing so cross-wired edges cannot pass.
+  - name: "Wait for cross-runtime report (baseline)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 90); do
+        RESP=$(meshctl call py_view_report '{}' --raw 2>&1 || true)
+        A=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .alpha_agent == "java-view-producer" and .alpha_cap == "svc.alpha"' 2>/dev/null || echo "")
+        B=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .bravo_agent == "java-view-producer" and .bravo_cap == "svc.bravo"' 2>/dev/null || echo "")
+        if [ "$A" = "true" ] && [ "$B" = "true" ]; then
+          echo "PY_VIEW_BOUND=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: py_view_report never reported both svc.* methods served by java-view-producer within 180s"
+      echo "last response: $RESP"
+      meshctl logs py-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: py_baseline
+    timeout: 200
+
+  - name: "Kill java-view-producer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop java-view-producer
+    capture: kill_producer
+
+  # Guarantee 2: the structured pre-invoke refusal from the PYTHON tool.
+  # Poll until the guard fires (the consumer's heartbeat must first drop the
+  # slot; the interim window may surface a handler-level bravo_error report —
+  # only the structured body counts as the verdict).
+  - name: "Wait for the structured dependency_unavailable refusal"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 60); do
+        RESP=$(meshctl call py_view_report '{}' --raw 2>&1 || true)
+        if echo "$RESP" | grep -q 'dependency_unavailable' && echo "$RESP" | grep -q 'svc.bravo'; then
+          echo "PY_REFUSAL_STRUCTURED=1 after ~$((i*2))s"
+          [ "$(echo "$RESP" | jq -r '.isError == true' 2>/dev/null)" = "true" ] && echo "PY_REFUSAL_ISERROR=1"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: the structured dependency_unavailable refusal never appeared within 120s"
+      echo "last response: $RESP"
+      meshctl logs py-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: py_refusal
+    timeout: 140
+
+  - name: "Restart java-view-producer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-producer --env MCP_MESH_HTTP_PORT=9202 -d
+
+  # Guarantee 3: organic recovery — no consumer restart. Long deadline: the
+  # producer is a cold-restart JVM.
+  - name: "Wait for cross-runtime report recovery"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 85); do
+        RESP=$(meshctl call py_view_report '{}' --raw 2>&1 || true)
+        RECOVERED=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .bravo_agent == "java-view-producer"' 2>/dev/null || echo "")
+        if [ "$RECOVERED" = "true" ]; then
+          echo "PY_VIEW_RECOVERED=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: py_view_report never recovered within 170s of restarting the producer"
+      echo "last response: $RESP"
+      meshctl logs py-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: py_recovery
+    timeout: 190
+
+assertions:
+  # Guarantee 1: cross-runtime per-method binding (anchored pairs verified
+  # in-shell; markers are the verdicts)
+  - expr: "${captured.py_baseline} contains 'PY_VIEW_BOUND=1'"
+    message: "both Python view methods must be served by the JAVA producer with the correct dotted capability payloads (svc.alpha / svc.bravo)"
+  - expr: "${captured.py_baseline} not contains '_error'"
+    message: "no view method may degrade at baseline (producer up)"
+
+  # Guarantee 2: refusal parity with the Java tool-param path (tc06)
+  - expr: "${captured.py_refusal} contains 'PY_REFUSAL_STRUCTURED=1'"
+    message: "the PYTHON tool must refuse with the structured contract (dependency_unavailable naming svc.bravo) — a bravo_error report would mean the handler ran with a dead REQUIRED proxy"
+  - expr: "${captured.py_refusal} contains 'PY_REFUSAL_ISERROR=1'"
+    message: "the refusal must be an isError=true tool result, not a successful report"
+
+  # Guarantee 3: organic recovery
+  - expr: "${captured.py_recovery} contains 'PY_VIEW_RECOVERED=1'"
+    message: "the report must bind again after the producer restarts, with no consumer restart"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc37_service_view_java/tc11_ts_view_consumer/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc11_ts_view_consumer/test.yaml
@@ -1,0 +1,193 @@
+# tc11_ts_view_consumer — RFC #1280 cross-runtime consumer parity
+# (TYPESCRIPT): a mesh.serviceView(...) in a TS consumer binds the DOTTED
+# svc.* capabilities published by the JAVA producer's @McpMeshService("svc")
+# sugar, and the required-edge refusal envelope matches the Java/Python
+# tool-param paths (tc06/tc10).
+#
+# Topology: java-view-producer (svc.alpha + svc.bravo) + ts-view-consumer
+# whose serviceView occupies ONE dependencies slot (two name-sorted edges,
+# bravo required=true) fanned out to the ts_view_report execute's facade arg.
+#
+# Design guarantees under test:
+#   1. Cross-runtime binding: both facade methods answer FROM THE JAVA AGENT
+#      — the report pairs alpha->java-view-producer/svc.alpha and
+#      bravo->java-view-producer/svc.bravo (anchored key:value pairs).
+#   2. Refusal parity: kill java-view-producer -> invoking ts_view_report is
+#      REFUSED pre-invoke with the structured
+#      {"error":"dependency_unavailable","capability":"svc.bravo"} result
+#      (isError=true) — a TS view expands into ordinary tool dependency
+#      slots, so its required edges sit under the same #1273 guard as
+#      hand-written deps. A report carrying bravo_error instead would mean
+#      execute ran with a dead REQUIRED proxy. (Body tokens judged
+#      structurally on the raw envelope — grep — with isError via jq; the TS
+#      error text shape is not a contract.)
+#   3. Organic recovery: restart the producer -> the report binds again with
+#      no consumer restart.
+#
+# Timing: transitions ride the default health debounce (~15-25s) plus one
+# consumer heartbeat — polled with deadlines. No dependency-resolution waits
+# (issue #1193): the baseline call rides the settle window. TC timeout =
+# cold-cache step-budget sum: copy 120 + maven 600 + npm 600 + starts 2x120
+# + registration 260 + baseline poll 200 + kill 120 + refusal poll 140 +
+# restart 120 + recovery poll 190 = 2590, rounded up with slack to 2800.
+
+name: "Service views cross-runtime: TypeScript mesh.serviceView over the Java svc.* producer"
+description: "ts-view-consumer's serviceView binds svc.alpha/svc.bravo from java-view-producer; kill producer: structured dependency_unavailable refusal (svc.bravo required) from the TS tool; restart: recovers"
+tags:
+  - integration
+  - typescript
+  - java
+  - registry
+  - service-view
+  - rfc-1280
+  - required-deps
+  - availability
+  - slow
+timeout: 2800
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/java-view-producer /workspace/
+      cp -rL /uc-artifacts/ts-view-consumer /workspace/
+
+  - name: "Install producer Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-view-producer
+    timeout: 600
+
+  - name: "Install ts-view-consumer deps"
+    handler: npm-install
+    path: /workspace/ts-view-consumer
+    timeout: 600
+
+  - name: "Start java-view-producer (port 9202)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-producer --env MCP_MESH_HTTP_PORT=9202 -d
+
+  - name: "Start ts-view-consumer (port 9401)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start ts-view-consumer/src/index.ts --env MCP_MESH_HTTP_PORT=9401 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+
+  # Liveness only (issue #1193): 240s deadline covers the cold JVM start.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "java-view-producer ts-view-consumer"
+
+  # Baseline: both methods served by the JAVA agent with dotted caps.
+  # ENVELOPE: the TS tool returns JSON.stringify(...) so content[0].text
+  # parses with the portable `.content[0].text | fromjson` idiom; equality
+  # inside the jq filter; anchored key:value pairing.
+  - name: "Wait for cross-runtime report (baseline)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 90); do
+        RESP=$(meshctl call ts_view_report '{}' --raw 2>&1 || true)
+        A=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .alpha_agent == "java-view-producer" and .alpha_cap == "svc.alpha"' 2>/dev/null || echo "")
+        B=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .bravo_agent == "java-view-producer" and .bravo_cap == "svc.bravo"' 2>/dev/null || echo "")
+        if [ "$A" = "true" ] && [ "$B" = "true" ]; then
+          echo "TS_VIEW_BOUND=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: ts_view_report never reported both svc.* methods served by java-view-producer within 180s"
+      echo "last response: $RESP"
+      meshctl logs ts-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: ts_baseline
+    timeout: 200
+
+  - name: "Kill java-view-producer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl stop java-view-producer
+    capture: kill_producer
+
+  # Guarantee 2: the structured pre-invoke refusal from the TS tool. Poll
+  # until the guard fires (the consumer's heartbeat must first drop the
+  # slot; the interim window may surface a handler-level bravo_error report
+  # — only the structured body counts as the verdict).
+  - name: "Wait for the structured dependency_unavailable refusal"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 60); do
+        RESP=$(meshctl call ts_view_report '{}' --raw 2>&1 || true)
+        if echo "$RESP" | grep -q 'dependency_unavailable' && echo "$RESP" | grep -q 'svc.bravo'; then
+          echo "TS_REFUSAL_STRUCTURED=1 after ~$((i*2))s"
+          [ "$(echo "$RESP" | jq -r '.isError == true' 2>/dev/null)" = "true" ] && echo "TS_REFUSAL_ISERROR=1"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: the structured dependency_unavailable refusal never appeared within 120s"
+      echo "last response: $RESP"
+      meshctl logs ts-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: ts_refusal
+    timeout: 140
+
+  - name: "Restart java-view-producer"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-producer --env MCP_MESH_HTTP_PORT=9202 -d
+
+  # Guarantee 3: organic recovery — no consumer restart. Long deadline: the
+  # producer is a cold-restart JVM.
+  - name: "Wait for cross-runtime report recovery"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 85); do
+        RESP=$(meshctl call ts_view_report '{}' --raw 2>&1 || true)
+        RECOVERED=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .bravo_agent == "java-view-producer"' 2>/dev/null || echo "")
+        if [ "$RECOVERED" = "true" ]; then
+          echo "TS_VIEW_RECOVERED=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: ts_view_report never recovered within 170s of restarting the producer"
+      echo "last response: $RESP"
+      meshctl logs ts-view-consumer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: ts_recovery
+    timeout: 190
+
+assertions:
+  # Guarantee 1: cross-runtime per-method binding (anchored pairs verified
+  # in-shell; markers are the verdicts)
+  - expr: "${captured.ts_baseline} contains 'TS_VIEW_BOUND=1'"
+    message: "both TS facade methods must be served by the JAVA producer with the correct dotted capability payloads (svc.alpha / svc.bravo)"
+  - expr: "${captured.ts_baseline} not contains '_error'"
+    message: "no view method may degrade at baseline (producer up)"
+
+  # Guarantee 2: refusal parity with the Java/Python tool-param paths
+  - expr: "${captured.ts_refusal} contains 'TS_REFUSAL_STRUCTURED=1'"
+    message: "the TS tool must refuse with the structured contract (dependency_unavailable naming svc.bravo) — a bravo_error report would mean execute ran with a dead REQUIRED proxy"
+  - expr: "${captured.ts_refusal} contains 'TS_REFUSAL_ISERROR=1'"
+    message: "the refusal must be an isError=true tool result, not a successful report"
+
+  # Guarantee 3: organic recovery
+  - expr: "${captured.ts_recovery} contains 'TS_VIEW_RECOVERED=1'"
+    message: "the report must bind again after the producer restarts, with no consumer restart"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc37_service_view_java/tc11_ts_view_consumer/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc11_ts_view_consumer/test.yaml
@@ -117,8 +117,13 @@ test:
 
   # Guarantee 2: the structured pre-invoke refusal from the TS tool. Poll
   # until the guard fires (the consumer's heartbeat must first drop the
-  # slot; the interim window may surface a handler-level bravo_error report
-  # — only the structured body counts as the verdict).
+  # slot; the interim window may surface a handler-level bravo_error
+  # report). The loop exit REQUIRES the structural refusal shape —
+  # isError==true (a handler-level report is a SUCCESS result carrying the
+  # error text, so tokens alone could exit on a transient) — plus the body:
+  # parsed `.error == "dependency_unavailable" and .capability ==
+  # "svc.bravo"` when content[0].text is pure JSON, with raw-token matching
+  # as the fallback for a wrapped error text.
   - name: "Wait for the structured dependency_unavailable refusal"
     handler: shell
     workdir: /workspace
@@ -126,11 +131,16 @@ test:
       RESP=""
       for i in $(seq 1 60); do
         RESP=$(meshctl call ts_view_report '{}' --raw 2>&1 || true)
-        if echo "$RESP" | grep -q 'dependency_unavailable' && echo "$RESP" | grep -q 'svc.bravo'; then
-          echo "TS_REFUSAL_STRUCTURED=1 after ~$((i*2))s"
-          [ "$(echo "$RESP" | jq -r '.isError == true' 2>/dev/null)" = "true" ] && echo "TS_REFUSAL_ISERROR=1"
-          echo "$RESP"
-          exit 0
+        ISERR=$(echo "$RESP" | jq -r '.isError == true' 2>/dev/null || echo "")
+        BODY=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .error == "dependency_unavailable" and .capability == "svc.bravo"' 2>/dev/null || echo "")
+        if [ "$ISERR" = "true" ]; then
+          if [ "$BODY" = "true" ] || { echo "$RESP" | grep -q 'dependency_unavailable' && echo "$RESP" | grep -q 'svc.bravo'; }; then
+            echo "TS_REFUSAL_STRUCTURED=1 after ~$((i*2))s"
+            echo "TS_REFUSAL_ISERROR=1"
+            [ "$BODY" = "true" ] && echo "TS_REFUSAL_BODY_PARSED=1"
+            echo "$RESP"
+            exit 0
+          fi
         fi
         sleep 2
       done

--- a/tests/integration/suites/uc37_service_view_java/tc12_cross_producer_sugar/test.yaml
+++ b/tests/integration/suites/uc37_service_view_java/tc12_cross_producer_sugar/test.yaml
@@ -1,0 +1,213 @@
+# tc12_cross_producer_sugar — RFC #1280 producer parity across ALL THREE
+# runtimes: Java @McpMeshService("svc"), Python @mesh.service("pysvc") and
+# TypeScript agent.addService("tssvc") each publish two DOTTED capabilities,
+# and one grouped `meshctl list --services` view shows all three services.
+#
+# Topology: java-view-producer + py-svc-producer + ts-svc-producer. No
+# consumer agent — the assertions are registry- and meshctl-driven on
+# purpose (the java-view-consumer fixture is deliberately NOT extended
+# again; consumer parity is tc10/tc11).
+#
+# Design guarantees under test:
+#   1. VALIDATOR E2E (py/ts): the registry accepts the Python- and TS-
+#      originated dotted registrations — both producers register healthy
+#      with pysvc.alpha/pysvc.bravo and tssvc.alpha/tssvc.bravo in their
+#      capability lists (the Java twin is tc08's subject).
+#   2. Dotted names through the CLI call path, per runtime:
+#      `meshctl call pysvc.alpha` and `meshctl call tssvc.alpha` reach the
+#      sugar-published tools and return self-identifying payloads. This is
+#      SERVING, not just registration: a "tools/call → Unknown tool" here
+#      with the capability registry-visible means the runtime's sugar
+#      published the capability to the wire but never registered the tool on
+#      the served MCP instance (registration/serving split-brain).
+#   3. Display closure: `meshctl list --services --json` groups all THREE
+#      services (svc, pysvc, tssvc), each with exactly its two methods —
+#      three runtimes producing, one grouped view.
+#
+# Timing: registration waits are liveness-only (issue #1193); no dependency
+# edges exist in this TC at all. TC timeout = cold-cache step-budget sum:
+# copy 120 + maven 600 + pip 120 + npm 600 + starts 3x120 + registration 260
+# + /agents capture 120 + py call poll 200 + ts call poll 200 + services
+# gate poll 140 + services capture 120 = 3200, rounded up with slack to 3400.
+
+name: "Service views producer parity: Java+Python+TS dotted producer sugar in one grouped view"
+description: "svc.* (Java), pysvc.* (Python) and tssvc.* (TS) all register (validator e2e), answer direct meshctl calls, and group into three services in meshctl list --services"
+tags:
+  - integration
+  - java
+  - python
+  - typescript
+  - registry
+  - service-view
+  - rfc-1280
+  - meshctl
+  - slow
+timeout: 3400
+
+pre_run:
+  - routine: global.setup_for_python_agent
+  - routine: global.setup_for_typescript_agent
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/java-view-producer /workspace/
+      cp -rL /uc-artifacts/py-svc-producer /workspace/
+      cp -rL /uc-artifacts/ts-svc-producer /workspace/
+
+  - name: "Install Java producer Maven dependencies"
+    handler: maven-install
+    path: /workspace/java-view-producer
+    timeout: 600
+
+  - name: "Install py-svc-producer deps"
+    handler: pip-install
+    path: /workspace/py-svc-producer
+
+  - name: "Install ts-svc-producer deps"
+    handler: npm-install
+    path: /workspace/ts-svc-producer
+    timeout: 600
+
+  - name: "Start java-view-producer (port 9202)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start /workspace/java-view-producer --env MCP_MESH_HTTP_PORT=9202 -d
+
+  - name: "Start py-svc-producer (port 9302)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start py-svc-producer/main.py --env MCP_MESH_HTTP_PORT=9302 -d
+
+  - name: "Start ts-svc-producer (port 9402)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start ts-svc-producer/src/index.ts --env MCP_MESH_HTTP_PORT=9402 -d
+
+  # Liveness only (issue #1193): 240s deadline covers the cold JVM start.
+  # All three APPEARING is already half of guarantee 1 — a validator
+  # rejection keeps the whole registration out.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "java-view-producer py-svc-producer ts-svc-producer"
+
+  # Pure-JSON snapshot for the registration assertions (guarantee 1).
+  - name: "Capture /agents snapshot"
+    handler: shell
+    workdir: /workspace
+    command: curl -s http://localhost:8000/agents
+    capture: agents_snapshot
+
+  # Guarantee 2a: the PYTHON sugar tool answers a direct dotted call.
+  # ENVELOPE: portable `.content[0].text | fromjson`, equality inside jq.
+  - name: "Wait for direct dotted call (meshctl call pysvc.alpha)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 90); do
+        RESP=$(meshctl call pysvc.alpha '{}' --raw 2>&1 || true)
+        OK=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .agent == "py-svc-producer" and .cap == "pysvc.alpha"' 2>/dev/null || echo "")
+        if [ "$OK" = "true" ]; then
+          echo "PYSVC_DIRECT_CALL_OK=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: meshctl call pysvc.alpha never answered with the producer payload within 180s"
+      echo "If the response says 'Unknown tool' while pysvc.alpha is in the registry, the"
+      echo "Python producer sugar published the capability to the wire but never registered"
+      echo "the tool on the served FastMCP instance (registration/serving split-brain)."
+      echo "last response: $RESP"
+      meshctl logs py-svc-producer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: pysvc_direct_call
+    timeout: 200
+
+  # Guarantee 2b: the TS sugar tool answers a direct dotted call.
+  - name: "Wait for direct dotted call (meshctl call tssvc.alpha)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      RESP=""
+      for i in $(seq 1 90); do
+        RESP=$(meshctl call tssvc.alpha '{}' --raw 2>&1 || true)
+        OK=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .agent == "ts-svc-producer" and .cap == "tssvc.alpha"' 2>/dev/null || echo "")
+        if [ "$OK" = "true" ]; then
+          echo "TSSVC_DIRECT_CALL_OK=1 after ~$((i*2))s"
+          echo "$RESP"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: meshctl call tssvc.alpha never answered with the producer payload within 180s"
+      echo "last response: $RESP"
+      meshctl logs ts-svc-producer 2>/dev/null | tail -40 || true
+      exit 1
+    capture: tssvc_direct_call
+    timeout: 200
+
+  # Guarantee 3 gate: all three services visible in the grouped view.
+  - name: "Wait for all three services in the grouped view"
+    handler: shell
+    workdir: /workspace
+    command: |
+      N=""
+      for i in $(seq 1 60); do
+        N=$(meshctl list --services --json 2>/dev/null | jq -r '[.services[] | select(.service == "svc" or .service == "pysvc" or .service == "tssvc")] | length' 2>/dev/null || echo "")
+        if [ "$N" = "3" ]; then
+          echo "THREE_SERVICES_GROUPED=1 after ~$((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: the grouped view never showed all three services within 120s (last count=$N)"
+      meshctl list --services --json 2>/dev/null || true
+      exit 1
+    capture: wait_three_services
+    timeout: 140
+
+  # Pure-JSON capture: the display contract.
+  - name: "Capture --services --json"
+    handler: shell
+    workdir: /workspace
+    command: meshctl list --services --json
+    capture: services_json
+
+assertions:
+  # IDIOM: equality lives INSIDE the jq filter so the interpolation yields a
+  # bare true/false; no '}' in interpolation bodies.
+
+  # Guarantee 1: py/ts dotted registrations accepted by the registry
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"py-svc-producer\") | .status == \"healthy\")} == 'true'"
+    message: "py-svc-producer must register HEALTHY with its dotted capabilities (Python-side validator e2e)"
+  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"py-svc-producer\") | .capabilities[] | select(.name == \"pysvc.alpha\" or .name == \"pysvc.bravo\")] | length == 2)} == 'true'"
+    message: "the Python producer's capability list must carry BOTH dotted names (pysvc.alpha, pysvc.bravo)"
+  - expr: "${jq:captured.agents_snapshot:(.agents[] | select(.name == \"ts-svc-producer\") | .status == \"healthy\")} == 'true'"
+    message: "ts-svc-producer must register HEALTHY with its dotted capabilities (TS-side validator e2e)"
+  - expr: "${jq:captured.agents_snapshot:([.agents[] | select(.name == \"ts-svc-producer\") | .capabilities[] | select(.name == \"tssvc.alpha\" or .name == \"tssvc.bravo\")] | length == 2)} == 'true'"
+    message: "the TS producer's capability list must carry BOTH dotted names (tssvc.alpha, tssvc.bravo)"
+
+  # Guarantee 2: dotted serving per runtime (not just registration)
+  - expr: "${captured.pysvc_direct_call} contains 'PYSVC_DIRECT_CALL_OK=1'"
+    message: "meshctl call pysvc.alpha must reach the Python sugar-published tool and return its self-identifying payload — registry-visible + 'Unknown tool' means the sugar never registered the tool on the served MCP instance"
+  - expr: "${captured.tssvc_direct_call} contains 'TSSVC_DIRECT_CALL_OK=1'"
+    message: "meshctl call tssvc.alpha must reach the TS sugar-published tool and return its self-identifying payload"
+
+  # Guarantee 3: one grouped view over three runtimes
+  - expr: "${captured.wait_three_services} contains 'THREE_SERVICES_GROUPED=1'"
+    message: "meshctl list --services must group all three services (svc, pysvc, tssvc)"
+  - expr: "${jq:captured.services_json:([.services[] | select(.service == \"svc\") | .methods[]] | length == 2)} == 'true'"
+    message: "service 'svc' (Java) must carry exactly its two methods in the grouped view"
+  - expr: "${jq:captured.services_json:([.services[] | select(.service == \"pysvc\") | .methods[]] | length == 2)} == 'true'"
+    message: "service 'pysvc' (Python) must carry exactly its two methods in the grouped view"
+  - expr: "${jq:captured.services_json:([.services[] | select(.service == \"tssvc\") | .methods[]] | length == 2)} == 'true'"
+    message: "service 'tssvc' (TypeScript) must carry exactly its two methods in the grouped view"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

The final item of RFC #1280: service-view consumer declaration idioms and producer sugar for Python and TypeScript, completing three-runtime parity for the whole feature.

**Python**
- Consumer: `@mesh.service` class of `@mesh.selector("cap", required=, tags=, version=)` async method stubs; a view-typed `@mesh.tool` parameter is a type-detected slot (MeshJob precedent — strictly additive to the positional-injection machinery, zero behavior change for existing signatures). Facade call shape `await view.method({...})` (dict → named tool arguments; `headers=` supported). Edges append after explicit deps, name-sorted per view; required edges ride the existing pre-invoke `dependency_unavailable` refusal; `min_available` floor → `MeshServiceUnavailableError`, settle-grace-aware and racing all pending edges; the mock contract is preserved (a supplied fake facade skips refusal/settle); direct-decoration rule for subclasses; views in `@mesh.route` boot-fail.
- Producer: `@mesh.service("prefix")` publishes public async methods (name-sorted) as `prefix.<method>` with dotted tool names; `@mesh.tool`-on-method wins (re-published bound); streaming methods supported via an explicit async-generator branch; zero-arg constructible; prefix segment-validated (reusing the runtime validator). A new pipeline serving step (`ServiceViewProducerServingStep`, JobsHelper pattern) registers sugar tools on the served FastMCP instance — closing the registered-but-not-served split-brain an integration fixture surfaced empirically before any cluster run.

**TypeScript**
- Consumer: `mesh.serviceView({methods, minAvailable?})` — a Symbol-branded object occupying ONE `dependencies` entry; method edges expand in-place name-sorted in the flat edge array while the slot array collapses the range into one facade argument (provably byte-identical layout for view-free tools). Per-method `expectedSchema`/`matchMode`; required edges refuse pre-invoke on direct and claim paths; floor races all pending settle keys; views force inline execution (worker-isolation disable warned); rejected in `mesh.route` and `mesh.a2a.mount`. Facade typing via the cast idiom (`media as MeshServiceFacade<typeof Media>`) — the direct parameter annotation cannot compile under `strictFunctionTypes` (contravariance, pre-existing); a strict compile test pins the documented idiom verbatim.
- Producer: `agent.addService("prefix", {method: fn | {execute, ...}})` — name-sorted, atomic validation, duplicate-name throw, and the SDK's first capability-name validation (segment regex mirroring the registry contract, scoped to derived names only).

**Cross-runtime proof** — uc37 grows to 12 TCs, validated 12/12 on k8s:
- tc10/tc11: Python and TS view consumers bind the Java producer's dotted capabilities, with **byte-identical structured refusal envelopes** across all three runtimes on required-edge outage, and organic recovery.
- tc12: Python and TS producer sugar register **and serve** dotted capabilities (direct `meshctl call pysvc.alpha` / `tssvc.alpha`), and one `meshctl list --services` view groups services produced by Java, Python, and TypeScript simultaneously.

**Examples & docs**: `examples/{python,typescript}/service-view` mirror the Java example with identical `media.*` capabilities — the three examples' providers and consumers are cross-runtime interchangeable (documented). Eight Python/TS doc surfaces (DI + decorators/functions, man + mkdocs) with every behavioral claim verified against source.

## Review Notes

- Two zero-context review rounds per runtime plus a final checklist round; all findings fixed. The two notable HIGHs (both masked by convenient test fakes, both now guarded by real-shaped tests): the Python facade passed args positionally to a proxy that only reads kwargs (production calls would have sent `{}`), and producer tools registered under bare method names (two producers sharing `get`/`status` silently clobbered each other — now keyed by the dotted capability, consistent with Java/TS).
- The Python serving split-brain was found empirically by the integration author before any cluster run and fixed at the SDK (per the fix-the-SDK-not-the-test rule); tc12's direct-call leg is the standing tripwire.
- Known pre-existing behavior noted, unchanged: importing `FastMCP` directly from `"fastmcp"` in TS consumer projects hits duplicate class identity — the supported idiom is the `@mcpmesh/sdk` re-export.

## Test plan

- [x] Python unit suite 1365/1365; TS suite 1079/1079 + strict typecheck both configs
- [x] src-tests 12/12 (image rebuild with both runtimes)
- [x] `tsuite run --suite-path tests/integration --uc uc37_service_view_java` — 12/12 on k8s incl. the three new cross-runtime TCs
- [x] Examples: py_compile all Python, `tsc --noEmit` strict all four TS agents
- [x] `go build ./src/core/cli/...` + mkdocs strict green

Closes #1291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “service view” support for both consumers (typed facades aggregating multiple capabilities) and producers (publishing grouped tools under dotted names), including required/optional handling and consumer-side availability floors.
  * Updated runtime behavior to expand service-view dependencies into flat edges for consistent invocation and availability tracking.
  * Added new Python and TypeScript service-view example agents (caption, thumbnail, transcription, media-gateway) and cross-runtime interoperability fixtures.

* **Documentation**
  * Added/expanded guides covering service views, selector bindings, `required` semantics, `minAvailable`, and producer publishing rules, plus full example READMEs.

* **Tests**
  * Added unit and TypeScript compile-time checks, plus integration tests validating cross-runtime refusal and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->