### PR TITLE
chore(examples,tests): python -m entrypoint docstrings + warm-cache timeout convention (#1293 items 3-4)

### DIFF
--- a/examples/required-dependency/python/data-provider/__main__.py
+++ b/examples/required-dependency/python/data-provider/__main__.py
@@ -1,3 +1,3 @@
-"""Entry point for `python -m data_provider`."""
+"""Entry point for `python -m data-provider` (run from examples/required-dependency/python/)."""
 
 from . import main  # noqa: F401 — importing `main` triggers the @mesh.agent decorator

--- a/examples/required-dependency/python/report-consumer/__main__.py
+++ b/examples/required-dependency/python/report-consumer/__main__.py
@@ -1,3 +1,3 @@
-"""Entry point for `python -m report_consumer`."""
+"""Entry point for `python -m report-consumer` (run from examples/required-dependency/python/)."""
 
 from . import main  # noqa: F401 — importing `main` triggers the @mesh.agent decorator

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -170,6 +170,25 @@ post_run:
   - routine: global.cleanup_workspace
 ```
 
+## Timeout budgets & the shared build cache
+
+Per-TC `timeout` values assume the shared maven/npm build cache is **warm**:
+the suite/runner populates it once, and per-TC workspaces reuse it. Timeouts
+are sized for the warm case plus slack — NOT a cold-cache sum of step budgets.
+This is the suite's actual, working convention: most existing TCs run at
+120–420s with one or two `maven-install`/`npm-install` steps whose individual
+step budgets alone would exceed the TC timeout on a cold cache.
+
+When writing new TCs:
+
+- Size the `timeout` for the warm case with reasonable slack. Do NOT budget a
+  full cold `maven-install`/`npm-install` (~600s each) unless the TC can
+  genuinely run first on a cold cache.
+- A few of the newest TCs (uc37 tc08–tc12) carry explicit cold-cache
+  step-budget arithmetic in their header comments as extra headroom. That is
+  acceptable defensive slack, not the required norm — don't sweep existing
+  timeouts up to match, and don't feel obliged to replicate the arithmetic.
+
 ## Test Results
 
 Results are stored in `results.db` (SQLite). View recent runs:


### PR DESCRIPTION
Second of the #1293 follow-up batch — hygiene. **References #1293; does not close it** (items 5–7 remain).

## Item 3 — `required-dependency` example `python -m` docstrings

`report-consumer/__main__.py` and `data-provider/__main__.py` documented `python -m report_consumer` / `python -m data_provider`, but the package directories are hyphenated — the underscore forms fail (`No module named …`) while `python -m report-consumer` / `python -m data-provider` resolve and boot the runtime (verified). Corrected the docstrings to the hyphenated importable form with the cwd note, matching the `examples/python/service-view` convention. Docstrings only — no directory or import changes.

## Item 4 — warm-cache timeout convention (re-scoped)

Filed as a timeout sweep, but investigation showed the premise doesn't hold suite-wide: ~50+ existing TCs run at 120–420s with one or two install steps whose *individual* cold budgets alone exceed the TC timeout, and they pass because the shared maven/npm build cache is warmed once and reused across per-TC workspaces. That warm-cache reliance is the suite's actual, working convention — inflating every timeout to a cold-cache sum would be wrong. Per owner decision, item 4 became a documentation task:

- Added a "Timeout budgets & the shared build cache" section to `tests/integration/README.md` (in the existing authoring guidance).
- States the warm-cache assumption, guidance for sizing new-TC timeouts (don't budget a full cold ~600s install unless genuinely first-on-cold), and frames the newest TCs' explicit cold-cache arithmetic (uc37 tc08–tc12) as acceptable defensive slack — with an anti-sweep warning so nobody "fixes" the 50+ existing timeouts upward.
- **No `test.yaml` timeout was changed** (verified: diff is docstrings + 19 README lines only).

## Test plan

- [x] `python -m report-consumer` / `python -m data-provider` boot the runtime from `examples/required-dependency/python/`; underscore forms fail as before
- [x] `git diff` confirms zero `timeout:` changes under `tests/integration/suites/`

Part of #1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the correct commands and working-directory context for running the Python example modules.
  * Added guidance for integration test timeout budgets, including how they relate to the shared build cache and how to size new test timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->