### PR TITLE
feat(ts,docs): capability-name validation at addTool + FastMCP import idiom (#1293 items 6-7)

### DIFF
--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -97,8 +97,7 @@ and [`examples/jobs-java/`](https://github.com/dhyansraj/mcp-mesh/tree/main/exam
 === "TypeScript"
 
     ```typescript
-    import { FastMCP } from "fastmcp";
-    import { mesh, type MeshJob } from "@mcpmesh/sdk";
+    import { FastMCP, mesh, type MeshJob } from "@mcpmesh/sdk";
     import { z } from "zod";
 
     const server = new FastMCP({ name: "Long Task Provider (TS)", version: "1.0.0" });

--- a/docs/typescript/dependency-injection.md
+++ b/docs/typescript/dependency-injection.md
@@ -356,8 +356,7 @@ execute: async (
 ## Complete Example
 
 ```typescript
-import { FastMCP } from "fastmcp";
-import { mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 const server = new FastMCP({ name: "Report Service", version: "1.0.0" });

--- a/docs/typescript/examples.md
+++ b/docs/typescript/examples.md
@@ -27,8 +27,7 @@ The TypeScript SDK works well with Vitest for unit testing:
 ```typescript
 // src/index.test.ts
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { FastMCP } from "fastmcp";
-import { mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 describe("Calculator Agent", () => {

--- a/docs/typescript/llm/index.md
+++ b/docs/typescript/llm/index.md
@@ -31,8 +31,7 @@ export OPENAI_API_KEY=sk-...
 ## mesh.llm() Function
 
 ```typescript
-import { FastMCP } from "fastmcp";
-import { mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 const server = new FastMCP({ name: "Smart Assistant", version: "1.0.0" });

--- a/docs/typescript/mesh-functions.md
+++ b/docs/typescript/mesh-functions.md
@@ -27,8 +27,7 @@ MCP Mesh provides core functions that transform regular TypeScript functions int
 Creates a MeshAgent that wraps a FastMCP server with mesh capabilities.
 
 ```typescript
-import { FastMCP } from "fastmcp";
-import { mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh } from "@mcpmesh/sdk";
 
 const server = new FastMCP({
   name: "My Service",
@@ -45,6 +44,8 @@ const agent = mesh(server, {
   heartbeatInterval: 30,        // Heartbeat interval in seconds
 });
 ```
+
+> **Import `FastMCP` from `@mcpmesh/sdk`**, which re-exports it — not directly from `"fastmcp"`. A direct `"fastmcp"` import can trigger duplicate class-identity type errors under `tsc` against the SDK's own bundled copy.
 
 ## agent.addTool()
 
@@ -223,8 +224,7 @@ export MCP_MESH_REGISTRY_URL=http://registry:8000
 ## Complete Example
 
 ```typescript
-import { FastMCP } from "fastmcp";
-import { mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 const server = new FastMCP({

--- a/src/core/cli/man/content/decorators_typescript.md
+++ b/src/core/cli/man/content/decorators_typescript.md
@@ -20,8 +20,7 @@ MCP Mesh provides core functions that transform regular TypeScript functions int
 Creates a MeshAgent that wraps a FastMCP server with mesh capabilities.
 
 ```typescript
-import { FastMCP } from "fastmcp";
-import { mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh } from "@mcpmesh/sdk";
 
 const server = new FastMCP({
   name: "My Service",
@@ -38,6 +37,8 @@ const agent = mesh(server, {
   heartbeatInterval: 30,        // Heartbeat interval in seconds
 });
 ```
+
+> **Import `FastMCP` from `@mcpmesh/sdk`**, which re-exports it — not directly from `"fastmcp"`. A direct `"fastmcp"` import can trigger duplicate class-identity type errors under `tsc` against the SDK's own bundled copy.
 
 ## agent.addTool()
 
@@ -308,8 +309,7 @@ export MCP_MESH_REGISTRY_URL=http://registry:8000
 ## Complete Example
 
 ```typescript
-import { FastMCP } from "fastmcp";
-import { mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 const server = new FastMCP({

--- a/src/core/cli/man/content/dependency-injection_typescript.md
+++ b/src/core/cli/man/content/dependency-injection_typescript.md
@@ -419,8 +419,7 @@ execute: async (
 ## Complete Example
 
 ```typescript
-import { FastMCP } from "fastmcp";
-import { mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 const server = new FastMCP({ name: "Report Service", version: "1.0.0" });

--- a/src/core/cli/man/content/jobs_typescript.md
+++ b/src/core/cli/man/content/jobs_typescript.md
@@ -39,8 +39,7 @@ no behavior change for non-job tools.
 ## Producer: `task: true`
 
 ```typescript
-import { FastMCP } from "fastmcp";
-import { mesh, type MeshJob } from "@mcpmesh/sdk";
+import { FastMCP, mesh, type MeshJob } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 const server = new FastMCP({
@@ -112,8 +111,7 @@ agent.addTool({
 ## Consumer: `MeshJob`-typed dependency
 
 ```typescript
-import { FastMCP } from "fastmcp";
-import { mesh, type MeshJob } from "@mcpmesh/sdk";
+import { FastMCP, mesh, type MeshJob } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 const server = new FastMCP({

--- a/src/core/cli/man/content/llm_typescript.md
+++ b/src/core/cli/man/content/llm_typescript.md
@@ -23,8 +23,7 @@ export OPENAI_API_KEY=sk-...
 ## mesh.llm() Function
 
 ```typescript
-import { FastMCP } from "fastmcp";
-import { mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 const server = new FastMCP({ name: "Smart Assistant", version: "1.0.0" });

--- a/src/core/cli/man/content/proxies_typescript.md
+++ b/src/core/cli/man/content/proxies_typescript.md
@@ -221,8 +221,7 @@ Agents communicate directly - no proxy server:
 ## Complete Example
 
 ```typescript
-import { FastMCP } from "fastmcp";
-import { mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 const server = new FastMCP({ name: "Data Processor", version: "1.0.0" });

--- a/src/core/cli/man/content/tags_typescript.md
+++ b/src/core/cli/man/content/tags_typescript.md
@@ -177,8 +177,7 @@ agent.addTool({
 ## Complete Example
 
 ```typescript
-import { FastMCP } from "fastmcp";
-import { mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 const server = new FastMCP({ name: "Weather Consumer", version: "1.0.0" });

--- a/src/core/cli/man/content/testing_typescript.md
+++ b/src/core/cli/man/content/testing_typescript.md
@@ -19,8 +19,7 @@ The TypeScript SDK works well with Vitest for unit testing:
 ```typescript
 // src/index.test.ts
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { FastMCP } from "fastmcp";
-import { mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 describe("Calculator Agent", () => {

--- a/src/runtime/typescript/src/__tests__/agent-add-tool.spec.ts
+++ b/src/runtime/typescript/src/__tests__/agent-add-tool.spec.ts
@@ -157,6 +157,84 @@ describe("addTool — meshJobParamIndex validation", () => {
   });
 });
 
+// =============================================================================
+// #1293 item 6 — produced-capability name validation parity at addTool.
+// The Go registry (src/core/registry/validation.go) and Python
+// (support_types.py validate_capability_name) validate a PRODUCED capability
+// against the segment-wise dotted grammar. addTool now validates the same
+// value (capability ?? name) locally, so a bad hand-written capability throws
+// at registration instead of failing remotely as a registry 400.
+// =============================================================================
+
+describe("addTool — produced capability name validation (#1293 item 6)", () => {
+  function newAgent(): MeshAgent {
+    return new MeshAgent(makeFastMCPStub(), {
+      name: "test-agent-capname",
+      httpPort: 0,
+    });
+  }
+
+  it("rejects an explicit capability with a space", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "bad-cap",
+        capability: "Bad Name",
+        parameters: z.object({}),
+        execute: async () => "x",
+      }),
+    ).toThrow(/'Bad Name' is not a valid capability name/);
+  });
+
+  it("rejects a tool name used as capability that starts with a digit", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "1bad",
+        parameters: z.object({}),
+        execute: async () => "x",
+      }),
+    ).toThrow(/'1bad' is not a valid capability name/);
+  });
+
+  it("accepts a valid dotted capability (media.caption)", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "caption",
+        capability: "media.caption",
+        parameters: z.object({}),
+        execute: async () => "x",
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts an existing flat name/capability (greet-lucky)", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "greet_with_lucky_number",
+        capability: "greet-lucky",
+        parameters: z.object({}),
+        execute: async () => "x",
+      }),
+    ).not.toThrow();
+  });
+
+  it("does NOT reject an unusual DEPENDENCY capability (dependency validation unchanged)", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "consumer",
+        capability: "consumer",
+        parameters: z.object({}),
+        dependencies: [{ capability: "weird cap$name" }],
+        execute: async () => "x",
+      }),
+    ).not.toThrow();
+  });
+});
+
 describe("addTool — meshJobDepIndex validation", () => {
   function newAgent(): MeshAgent {
     return new MeshAgent(makeFastMCPStub(), {

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -384,6 +384,25 @@ export class MeshAgent {
     const toolName = def.name;
     const execute = def.execute;
 
+    // Issue #1293 item 6: validate the PRODUCED capability name — the value
+    // published to the registry (def.capability ?? toolName) — against the
+    // segment-wise dotted grammar, closing the parity gap with the Go registry
+    // (src/core/registry/validation.go) and the Python runtime
+    // (support_types.py validate_capability_name). Only the produced capability
+    // is checked; dependency capability names are deliberately left unvalidated
+    // (they are unvalidated in the Go registry and every runtime), so checking
+    // them here would be stricter than the contract, not parity. Reuses the
+    // same CAPABILITY_NAME_PATTERN that addService applies to synthesized names.
+    const producedCapability = def.capability ?? toolName;
+    if (!CAPABILITY_NAME_PATTERN.test(producedCapability)) {
+      throw new Error(
+        `addTool: capability '${producedCapability}' is not a valid capability ` +
+          `name — each dot-separated segment must start with a letter and ` +
+          `contain only letters, digits, underscores, and hyphens ` +
+          `(cross-ref src/core/registry/validation.go).`,
+      );
+    }
+
     // Phase 1 MeshJob substrate: validate `task: true` requires an
     // async function. Long-running tools need a Promise-based control
     // flow so the dispatch wrapper (Phase B) can await
@@ -1256,9 +1275,10 @@ export class MeshAgent {
    *
    * The prefix AND every derived capability are validated against the segment-
    * wise dotted grammar (kept in lockstep with the Go registry validator —
-   * src/core/registry/validation.go). This is the ONLY place the SDK validates a
-   * capability name (it validates only the names it SYNTHESIZES); hand-written
-   * capabilities remain the registry's authority.
+   * src/core/registry/validation.go). addTool applies the same grammar to its
+   * produced capability (#1293 item 6), so both surfaces validate a PRODUCED
+   * capability name before it reaches the registry; dependency capability names
+   * remain the registry's authority.
    *
    * @example
    * ```typescript

--- a/src/runtime/typescript/src/index.ts
+++ b/src/runtime/typescript/src/index.ts
@@ -5,8 +5,7 @@
  *
  * @example MCP Agent (fastmcp)
  * ```typescript
- * import { FastMCP } from "fastmcp";
- * import { mesh } from "@mcpmesh/sdk";
+ * import { FastMCP, mesh } from "@mcpmesh/sdk";
  * import { z } from "zod";
  *
  * const server = new FastMCP({ name: "Calculator", version: "1.0.0" });

--- a/src/runtime/typescript/src/llm-provider.ts
+++ b/src/runtime/typescript/src/llm-provider.ts
@@ -6,8 +6,7 @@
  *
  * @example
  * ```typescript
- * import { FastMCP } from "fastmcp";
- * import { mesh } from "@mcpmesh/sdk";
+ * import { FastMCP, mesh } from "@mcpmesh/sdk";
  *
  * const server = new FastMCP({ name: "Claude Provider", version: "1.0.0" });
  *
@@ -514,8 +513,7 @@ type MeshLlmRequestInput = z.infer<typeof MeshLlmRequestSchema>;
  *
  * @example
  * ```typescript
- * import { FastMCP } from "fastmcp";
- * import { mesh } from "@mcpmesh/sdk";
+ * import { FastMCP, mesh } from "@mcpmesh/sdk";
  *
  * const server = new FastMCP({ name: "Claude Provider", version: "1.0.0" });
  *

--- a/src/runtime/typescript/src/llm.ts
+++ b/src/runtime/typescript/src/llm.ts
@@ -6,8 +6,7 @@
  *
  * @example
  * ```typescript
- * import { FastMCP } from "fastmcp";
- * import { mesh } from "@mcpmesh/sdk";
+ * import { FastMCP, mesh } from "@mcpmesh/sdk";
  * import { z } from "zod";
  *
  * const server = new FastMCP({ name: "Smart Assistant", version: "1.0.0" });

--- a/src/runtime/typescript/src/service-view.ts
+++ b/src/runtime/typescript/src/service-view.ts
@@ -58,10 +58,11 @@ export function assertNoServiceViewDeps(
  * Segment-wise dotted capability-name grammar. Kept in lockstep with the Go
  * registry validator's `capabilityNamePattern`
  * (src/core/registry/validation.go: `^[a-zA-Z][a-zA-Z0-9_-]*(\.[a-zA-Z][a-zA-Z0-9_-]*)*$`)
- * and the Python/Java runtimes. Applied ONLY to the derived capability names
- * `agent.addService` synthesizes — the SDK deliberately does NOT add a general
- * capability-validation layer elsewhere (the registry remains the single
- * authority for hand-written capability names).
+ * and the Python/Java runtimes. Applied to the PRODUCED capability names of
+ * `agent.addService` (the derived `prefix.method`) and `agent.addTool`
+ * (`capability ?? name`, #1293 item 6) — both validate before the name reaches
+ * the registry. Dependency capability names are deliberately left unvalidated
+ * (the registry remains their single authority).
  */
 export const CAPABILITY_NAME_PATTERN =
   /^[a-zA-Z][a-zA-Z0-9_-]*(\.[a-zA-Z][a-zA-Z0-9_-]*)*$/;


### PR DESCRIPTION
Third of the #1293 follow-up batch — the TypeScript pair. **References #1293; does not close it** (item 5, meshui vitest, is the final PR).

## Item 6 — capability-name validation parity at `addTool`

Go (`src/core/registry/validation.go`) and Python validate a **produced** capability name against the segment-wise dotted grammar; TypeScript validated only the names `addService` synthesizes, so a hand-written `agent.addTool({ capability: "bad name" })` (or a tool `name` used as the capability) sailed through and failed remotely as a registry 400. `addTool` now validates the produced capability (`def.capability ?? toolName`) against the existing shared `CAPABILITY_NAME_PATTERN`, throwing at registration with a message cross-referencing `validation.go`. This is TS's first general capability-name check, at parity with Go/Python (which validate produced names, not consumed dependency names — dependency capabilities stay unvalidated everywhere, deliberately).

**Breakage check: none** — every produced capability across the TS runtime, its tests/fixtures, and `examples/typescript` already satisfies the grammar.

## Item 7 — FastMCP import idiom

Importing `FastMCP` directly from `"fastmcp"` in a consumer project hits duplicate class-identity errors under tsc against the SDK's bundled copy; the working idiom is the `@mcpmesh/sdk` re-export. The SDK's own doc-comment examples taught the broken form. Fixed:
- SDK-authored doc comments (`index.ts`, `llm.ts`, `llm-provider.ts`) → `@mcpmesh/sdk`.
- All 13 user-facing doc/man examples across `docs/` and `src/core/cli/man/content/` swept to `@mcpmesh/sdk`; a setup note added on the mesh-functions surface.
- Functional/type imports (`import type … from "fastmcp"`, `import { UserError } …`) and the `export { FastMCP } from "fastmcp"` re-export are unchanged.
- **Zero user-facing `from "fastmcp"` examples remain** (verified by grep).

## Test plan

- [x] TS suite 1086/1086 (+5 new item-6 tests); typecheck clean on both tsconfig variants
- [x] `go build ./src/core/cli/...` (embedded man content); `mkdocs build` exits 0 (the `--strict` abort is a pre-existing, unrelated pages-not-in-nav warning)
- [x] `grep 'from "fastmcp"' docs/ src/core/cli/man/content/` → 0

Part of #1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ