### PR TITLE
feat(jobs): resume_cursor opt-in — durable recvEvent resume across all runtimes (#1277 wave 2)

### DIFF
--- a/src/runtime/core/include/mcp_mesh_core.h
+++ b/src/runtime/core/include/mcp_mesh_core.h
@@ -777,6 +777,35 @@ int32_t mesh_job_controller_new_with_epoch(const char *job_id,
                                            int64_t claim_epoch,
                                            struct JobControllerHandle **out_handle);
 
+// Construct a [`JobController`] that resumes from a persisted per-filter
+// receive cursor (issue #1277). Mirrors
+// [`mesh_job_controller_new_with_epoch`] but additionally seeds the
+// controller's `recv_event` cursors from `recv_cursor_json` so a reclaimed
+// job resumes instead of replaying its event log from seq 0. Used by the
+// Java SDK's claim dispatch path only when the tool opted into resume
+// (`@MeshTool(resumeCursor = true)`); the default replay-from-0 path stays
+// on [`mesh_job_controller_new_with_epoch`].
+//
+// The C ABI has no map type, so the cursor map rides as a JSON string:
+// `recv_cursor_json` must encode a JSON object `{"<filter-key>": <seq:int>,
+// ...}` (parsed into `HashMap<String, i64>`). A NULL or empty/blank
+// `recv_cursor_json` ⇒ no seed (identical to
+// [`mesh_job_controller_new_with_epoch`]). Malformed JSON, a non-object
+// shape, or a non-integer value returns -1 with the last-error slot set.
+//
+// Additive: a separate entry point rather than a new parameter on the
+// existing constructors, so current C/Java callers keep their signatures.
+//
+// # Safety
+// Same contract as [`mesh_job_controller_new`]. `recv_cursor_json` may be
+// NULL; when non-NULL it must be valid null-terminated UTF-8.
+int32_t mesh_job_controller_new_with_resume(const char *job_id,
+                                            const char *instance_id,
+                                            const char *registry_url,
+                                            int64_t claim_epoch,
+                                            const char *recv_cursor_json,
+                                            struct JobControllerHandle **out_handle);
+
 // Enqueue a progress update. Coalesces with any prior pending progress
 // for this job — only the latest survives the next batch flush.
 //

--- a/src/runtime/core/src/claim_worker.rs
+++ b/src/runtime/core/src/claim_worker.rs
@@ -96,6 +96,12 @@ pub struct ClaimWorkerConfig {
     /// Backoff ceiling. Doubles up from `backoff_min` on consecutive
     /// empty / errored claim cycles, capped at this value.
     pub backoff_max: Duration,
+    /// Whether reclaimed jobs resume from their persisted per-filter
+    /// `recv_cursor` (issue #1277) instead of replaying the event log from
+    /// seq 0. Default `false` ⇒ replay-from-0 (byte-identical to prior
+    /// behavior). This is the Rust-native gate; the per-language SDKs gate
+    /// resume in their own dispatchers via the binding constructors.
+    pub resume_cursor: bool,
 }
 
 impl ClaimWorkerConfig {
@@ -108,6 +114,7 @@ impl ClaimWorkerConfig {
             max_concurrent: 4,
             backoff_min: Duration::from_millis(200),
             backoff_max: Duration::from_secs(5),
+            resume_cursor: false,
         }
     }
 }
@@ -254,17 +261,24 @@ async fn run_loop(
                     // claim so the controller fences its deltas + executor
                     // reads (issue #1252). `None` (old registry) degrades to
                     // legacy owner-only behavior.
-                    // `None` initial_cursors: this wave does NOT resume from the
-                    // persisted recv_cursor — the controller replays from seq 0
-                    // as before. Runtime resume gating (passing
-                    // `claimed.recv_cursor`) is a later wave (issue #1277).
+                    //
+                    // Resume gating (issue #1277): seed the controller from the
+                    // persisted per-filter `recv_cursor` ONLY when this worker
+                    // opted into resume (`cfg.resume_cursor`). Default `false`
+                    // ⇒ `None` ⇒ replay-from-0, byte-identical to prior
+                    // behavior.
+                    let initial_cursors = if cfg.resume_cursor {
+                        claimed.recv_cursor.clone()
+                    } else {
+                        None
+                    };
                     let controller = JobController::new_with_epoch(
                         claimed.id.clone(),
                         cfg.instance_id.clone(),
                         claimed.claim_epoch,
                         backend.clone(),
                         queue.clone(),
-                        None,
+                        initial_cursors,
                     );
                     let dispatcher_clone = dispatcher.clone();
                     let job_id_for_log = claimed.id.clone();

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -34,6 +34,7 @@
 
 #![cfg(feature = "ffi")]
 
+use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_void};
 use std::ptr;
@@ -250,7 +251,7 @@ pub unsafe extern "C" fn mesh_job_controller_new(
 ) -> i32 {
     // Legacy owner-only path (no claim epoch). See
     // `mesh_job_controller_new_with_epoch` for the fenced claim path.
-    mesh_job_controller_new_impl(job_id, instance_id, registry_url, None, out_handle)
+    mesh_job_controller_new_impl(job_id, instance_id, registry_url, None, None, out_handle)
 }
 
 /// Construct a [`JobController`] carrying the claim generation the registry
@@ -274,10 +275,74 @@ pub unsafe extern "C" fn mesh_job_controller_new_with_epoch(
     out_handle: *mut *mut JobControllerHandle,
 ) -> i32 {
     let epoch = if claim_epoch < 0 { None } else { Some(claim_epoch) };
-    mesh_job_controller_new_impl(job_id, instance_id, registry_url, epoch, out_handle)
+    mesh_job_controller_new_impl(job_id, instance_id, registry_url, epoch, None, out_handle)
 }
 
-/// Shared body for the two `mesh_job_controller_new*` entry points.
+/// Construct a [`JobController`] that resumes from a persisted per-filter
+/// receive cursor (issue #1277). Mirrors
+/// [`mesh_job_controller_new_with_epoch`] but additionally seeds the
+/// controller's `recv_event` cursors from `recv_cursor_json` so a reclaimed
+/// job resumes instead of replaying its event log from seq 0. Used by the
+/// Java SDK's claim dispatch path only when the tool opted into resume
+/// (`@MeshTool(resumeCursor = true)`); the default replay-from-0 path stays
+/// on [`mesh_job_controller_new_with_epoch`].
+///
+/// The C ABI has no map type, so the cursor map rides as a JSON string:
+/// `recv_cursor_json` must encode a JSON object `{"<filter-key>": <seq:int>,
+/// ...}` (parsed into `HashMap<String, i64>`). A NULL or empty/blank
+/// `recv_cursor_json` ⇒ no seed (identical to
+/// [`mesh_job_controller_new_with_epoch`]). Malformed JSON, a non-object
+/// shape, or a non-integer value returns -1 with the last-error slot set.
+///
+/// Additive: a separate entry point rather than a new parameter on the
+/// existing constructors, so current C/Java callers keep their signatures.
+///
+/// # Safety
+/// Same contract as [`mesh_job_controller_new`]. `recv_cursor_json` may be
+/// NULL; when non-NULL it must be valid null-terminated UTF-8.
+#[no_mangle]
+pub unsafe extern "C" fn mesh_job_controller_new_with_resume(
+    job_id: *const c_char,
+    instance_id: *const c_char,
+    registry_url: *const c_char,
+    claim_epoch: i64,
+    recv_cursor_json: *const c_char,
+    out_handle: *mut *mut JobControllerHandle,
+) -> i32 {
+    let epoch = if claim_epoch < 0 { None } else { Some(claim_epoch) };
+    // NULL / blank ⇒ no seed (replay-from-0). Otherwise parse the JSON object
+    // into the cursor map; surface parse failures as -1 rather than silently
+    // dropping the seed so a caller bug is visible.
+    let initial_cursors: Option<HashMap<String, i64>> =
+        match opt_cstr(recv_cursor_json, "recv_cursor_json") {
+            Ok(None) => None,
+            Ok(Some(s)) if s.trim().is_empty() => None,
+            Ok(Some(s)) => match serde_json::from_str::<HashMap<String, i64>>(s) {
+                Ok(map) => {
+                    if map.is_empty() {
+                        None
+                    } else {
+                        Some(map)
+                    }
+                }
+                Err(e) => {
+                    set_last_error(format!("invalid recv_cursor_json: {}", e));
+                    return -1;
+                }
+            },
+            Err(()) => return -1,
+        };
+    mesh_job_controller_new_impl(
+        job_id,
+        instance_id,
+        registry_url,
+        epoch,
+        initial_cursors,
+        out_handle,
+    )
+}
+
+/// Shared body for the `mesh_job_controller_new*` entry points.
 ///
 /// # Safety
 /// See [`mesh_job_controller_new`].
@@ -286,6 +351,7 @@ unsafe fn mesh_job_controller_new_impl(
     instance_id: *const c_char,
     registry_url: *const c_char,
     claim_epoch: Option<i64>,
+    initial_cursors: Option<HashMap<String, i64>>,
     out_handle: *mut *mut JobControllerHandle,
 ) -> i32 {
     take_last_error();
@@ -311,15 +377,16 @@ unsafe fn mesh_job_controller_new_impl(
     };
 
     let queue = new_coalescing_queue();
+    // `initial_cursors=None` (default) ⇒ replay-from-0. Seeded via
+    // `mesh_job_controller_new_with_resume` when the Java SDK opts into resume
+    // (issue #1277).
     let inner = JobController::new_with_epoch(
         job_id,
         instance_id.clone(),
         claim_epoch,
         backend.clone(),
         queue.clone(),
-        // No seeded resume cursor at this binding surface (issue #1277 runtime
-        // resume gating is a later wave).
-        None,
+        initial_cursors,
     );
 
     // Spawn the batching tick inside the FFI tokio runtime so mid-flight

--- a/src/runtime/core/src/jobs_napi.rs
+++ b/src/runtime/core/src/jobs_napi.rs
@@ -27,6 +27,7 @@
 
 #![cfg(feature = "typescript")]
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -160,21 +161,25 @@ impl JsJobController {
         instance_id: String,
         registry_url: String,
         claim_epoch: Option<i64>,
+        initial_cursors: Option<HashMap<String, i64>>,
     ) -> Result<Self> {
         let backend = backend_from_url(&registry_url)?;
         let queue = new_coalescing_queue();
         // `claim_epoch=None` (push-mode inbound job / old registry) ⇒ legacy
         // owner-only behavior; on the claim path the SDK passes the epoch
         // from the `/jobs/claim` response so this execution is fenced (#1252).
+        //
+        // `initial_cursors=None` (default) ⇒ replay-from-0. When the SDK opts
+        // into resume (`mesh.tool({ resumeCursor: true })`) it passes the
+        // persisted per-filter `recv_cursor` map from the claim response so the
+        // reclaimed controller resumes instead of replaying (issue #1277).
         let inner = JobController::new_with_epoch(
             job_id,
             instance_id.clone(),
             claim_epoch,
             backend.clone(),
             queue.clone(),
-            // No seeded resume cursor at this binding surface (issue #1277
-            // runtime resume gating is a later wave).
-            None,
+            initial_cursors,
         );
         // Spawn the batching tick inside napi-rs's shared Tokio runtime so
         // mid-flight progress deltas actually reach the registry. The

--- a/src/runtime/core/src/jobs_py.rs
+++ b/src/runtime/core/src/jobs_py.rs
@@ -16,6 +16,7 @@
 
 #![cfg(feature = "python")]
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -163,12 +164,13 @@ impl PyJobController {
     /// configured cadence (default 2s); the tick is torn down with a final
     /// flush when the controller is dropped.
     #[new]
-    #[pyo3(signature = (job_id, instance_id, registry_url, claim_epoch=None))]
+    #[pyo3(signature = (job_id, instance_id, registry_url, claim_epoch=None, initial_cursors=None))]
     fn new(
         job_id: String,
         instance_id: String,
         registry_url: &str,
         claim_epoch: Option<i64>,
+        initial_cursors: Option<HashMap<String, i64>>,
     ) -> PyResult<Self> {
         let backend = backend_from_url(registry_url)?;
         let queue = new_coalescing_queue();
@@ -176,15 +178,18 @@ impl PyJobController {
         // predates epochs) ⇒ legacy owner-only behavior. On the claim path
         // the SDK passes the epoch from the `/jobs/claim` response so this
         // execution is fenced (issue #1252).
+        //
+        // `initial_cursors=None` (default) ⇒ replay-from-0. When the SDK opts
+        // into resume (`@mesh.tool(resume_cursor=True)`) it passes the
+        // persisted per-filter `recv_cursor` map from the claim response so the
+        // reclaimed controller resumes instead of replaying (issue #1277).
         let inner = JobController::new_with_epoch(
             job_id,
             instance_id.clone(),
             claim_epoch,
             backend.clone(),
             queue.clone(),
-            // No seeded resume cursor at this binding surface (issue #1277
-            // runtime resume gating is a later wave).
-            None,
+            initial_cursors,
         );
         // Spawn the batching tick on the shared PyO3 Tokio runtime so
         // mid-flight progress deltas actually reach the registry. We

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
@@ -506,6 +506,39 @@ public interface MeshCore {
                                            long claimEpoch, PointerByReference outHandle);
 
     /**
+     * Construct a JobController that resumes from a persisted per-filter
+     * receive cursor (issue #1277). Mirrors
+     * {@link #mesh_job_controller_new_with_epoch} but additionally seeds the
+     * controller's {@code recv_event} cursors from {@code recvCursorJson} so a
+     * reclaimed job resumes instead of replaying its event log from seq 0.
+     * Used by the Java SDK's claim dispatch path only when the tool opted into
+     * resume ({@code @MeshTool(resumeCursor = true)}).
+     *
+     * <p>The C ABI has no map type, so the cursor map rides as a JSON string:
+     * {@code recvCursorJson} must encode a JSON object
+     * {@code {"<filter-key>": <seq:int>, ...}}. A {@code null} or blank /
+     * empty-object {@code recvCursorJson} ⇒ no seed (identical to
+     * {@link #mesh_job_controller_new_with_epoch}). A {@code claimEpoch < 0}
+     * is treated as "no epoch". Malformed JSON, a non-object shape, or a
+     * non-integer value returns -1 with the last-error slot set.
+     *
+     * <p>Additive: a separate entry point rather than a new parameter on the
+     * existing constructors, so current callers keep their signatures.
+     *
+     * @param jobId          Job UUID this controller is bound to
+     * @param instanceId     Instance ID submitting deltas to the registry
+     * @param registryUrl    Registry base URL
+     * @param claimEpoch     Claim generation ({@code < 0} ⇒ no epoch)
+     * @param recvCursorJson JSON object of per-filter seqs, or {@code null} /
+     *                       blank / empty-object for "no seed"
+     * @param outHandle      Out-param: receives the opaque handle on success
+     * @return 0 on success, -1 on error (see mesh_last_error)
+     */
+    int mesh_job_controller_new_with_resume(String jobId, String instanceId, String registryUrl,
+                                            long claimEpoch, String recvCursorJson,
+                                            PointerByReference outHandle);
+
+    /**
      * Enqueue a progress update. Coalesces with any prior pending progress
      * for this job — only the latest survives the next batch flush.
      *

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobController.java
@@ -124,6 +124,127 @@ public final class JobController implements MeshJob, AutoCloseable {
         return new JobController(core, handle, jobId);
     }
 
+    /**
+     * Open a controller that RESUMES its {@link #recvEvent} cursor from a
+     * persisted per-filter cursor map (issue #1277), rather than replaying
+     * the event log from seq 0. Used by the claim dispatch path when the
+     * producing tool opted in via {@code @MeshTool(resumeCursor = true)} and
+     * the registry supplied a {@code recv_cursor} for the claim.
+     *
+     * <p>The cursor map is serialized to the FFI's JSON-object string shape
+     * ({@code {"<filter-key>": <seq:int>, ...}}) via the SDK's shared Jackson
+     * mapper and passed to the native
+     * {@code mesh_job_controller_new_with_resume} entry point. A {@code null},
+     * empty, or non-integer-valued cursor serializes to {@code null} ⇒ the
+     * native side seeds nothing ⇒ replay-from-0 (never throws for a bad
+     * cursor — the resume is a best-effort optimization).
+     *
+     * @param jobId       Server-assigned job UUID
+     * @param instanceId  This agent's instance ID
+     * @param registryUrl Registry base URL
+     * @param claimEpoch  Claim generation from {@code /jobs/claim}, or
+     *                    {@code null} for legacy owner-only fencing
+     * @param recvCursor  Per-filter receive cursor to seed from (the claim's
+     *                    {@code recv_cursor}); may be {@code null}/empty
+     * @return A new controller seeded from {@code recvCursor}; caller MUST
+     *         {@link #close} when done
+     * @throws MeshException if the native handle cannot be allocated
+     * @see #open(String, String, String, Long)
+     */
+    public static JobController openWithResume(String jobId, String instanceId, String registryUrl,
+                                               Long claimEpoch, Map<String, ?> recvCursor) {
+        if (jobId == null || jobId.isEmpty()) {
+            throw new IllegalArgumentException("jobId is required");
+        }
+        if (instanceId == null || instanceId.isEmpty()) {
+            throw new IllegalArgumentException("instanceId is required");
+        }
+        if (registryUrl == null || registryUrl.isEmpty()) {
+            throw new IllegalArgumentException("registryUrl is required");
+        }
+        // Serialize the cursor to the FFI JSON-object shape. A bad/empty
+        // cursor yields null (no seed) — a resume cursor is a best-effort
+        // optimization, never a reason to fail the job.
+        String recvCursorJson = serializeRecvCursor(recvCursor);
+        // The C ABI has no null int; a negative epoch means "no epoch".
+        long epoch = claimEpoch != null ? claimEpoch : -1L;
+        MeshCore core = MeshCore.load();
+        PointerByReference out = new PointerByReference();
+        int rc = core.mesh_job_controller_new_with_resume(
+            jobId, instanceId, registryUrl, epoch, recvCursorJson, out);
+        if (rc != 0) {
+            throw new MeshException("mesh_job_controller_new_with_resume failed: " + lastError(core));
+        }
+        Pointer handle = out.getValue();
+        if (handle == null) {
+            throw new MeshException("mesh_job_controller_new_with_resume returned null handle");
+        }
+        return new JobController(core, handle, jobId);
+    }
+
+    /**
+     * Serialize a per-filter receive cursor map to the FFI's JSON-object
+     * string ({@code {"key": seq, ...}}).
+     *
+     * <p>Value contract (identical across the Python/TS/Java runtimes): keep
+     * only entries whose value is a <em>non-negative integer</em>; drop every
+     * other key. Integral boxes (Integer/Long/Short/Byte) with value {@code >=
+     * 0} survive; fractional {@code Double}/{@code Float} are REJECTED (never
+     * {@code longValue()}-truncated), and negatives are dropped. Returns
+     * {@code null} for a null/empty cursor, a cursor with no surviving entry,
+     * or any serialization failure — the caller passes that {@code null}
+     * straight through to the native "no seed" path (resume is a best-effort
+     * optimization; a bad cursor degrades to replay-from-0, never throws).
+     */
+    static String serializeRecvCursor(Map<String, ?> recvCursor) {
+        if (recvCursor == null || recvCursor.isEmpty()) {
+            return null;
+        }
+        try {
+            java.util.Map<String, Long> normalized = new java.util.LinkedHashMap<>();
+            for (Map.Entry<String, ?> e : recvCursor.entrySet()) {
+                if (e.getKey() == null) {
+                    continue;
+                }
+                Long seq = nonNegativeInteger(e.getValue());
+                if (seq != null) {
+                    normalized.put(e.getKey(), seq);
+                }
+            }
+            if (normalized.isEmpty()) {
+                return null;
+            }
+            return MAPPER.writeValueAsString(normalized);
+        } catch (Exception e) {
+            log.warn("Failed to serialize recv_cursor for job resume; replaying from seq 0: {}",
+                e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Coerce a cursor value to a non-negative {@code Long}, or {@code null} if
+     * it is not a non-negative integer. Accepts only integral boxed types
+     * ({@code Integer}/{@code Long}/{@code Short}/{@code Byte}); rejects
+     * fractional {@code Double}/{@code Float} (no truncation) and any negative.
+     */
+    private static Long nonNegativeInteger(Object value) {
+        long seq;
+        if (value instanceof Long l) {
+            seq = l;
+        } else if (value instanceof Integer i) {
+            seq = i;
+        } else if (value instanceof Short s) {
+            seq = s;
+        } else if (value instanceof Byte b) {
+            seq = b;
+        } else {
+            // Double / Float / BigDecimal / String / anything else → reject.
+            return null;
+        }
+        return seq >= 0 ? seq : null;
+    }
+
     /** The job ID this controller is bound to. */
     public String jobId() {
         return jobId;

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshTool.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshTool.java
@@ -180,6 +180,37 @@ public @interface MeshTool {
     boolean task() default false;
 
     /**
+     * Issue #1277: opt in to <b>cursor resume</b> for a reclaimed job.
+     *
+     * <p>By default a job that is reclaimed by a peer replica (owner change,
+     * lease expiry, drain) gets a fresh {@link JobController} whose
+     * {@link JobController#recvEvent(java.util.List, java.time.Duration)}
+     * cursor starts at seq 0 — the handler <em>replays</em> the whole event
+     * log from the beginning. When {@code resumeCursor = true}, the dispatcher
+     * seeds the reclaimed controller from the {@code recv_cursor} the registry
+     * persisted for the claim, so {@code recvEvent} resumes from the last
+     * consumed sequence instead of replaying.
+     *
+     * <p>Constraints (validated at registration via
+     * {@link io.mcpmesh.spring.MeshToolBeanPostProcessor}):
+     * <ul>
+     *   <li>requires {@code task = true} — non-task tools have no controller,
+     *       so a resume cursor has no meaning;
+     *   <li>the handler MUST consume events strictly sequentially per filter.
+     *       A handler that prefetches (reads ahead of the work it has actually
+     *       committed) MUST NOT enable this — on resume it would skip the
+     *       prefetched-but-unprocessed events. Replay-from-0 (the default) is
+     *       the safe choice for such handlers.
+     * </ul>
+     *
+     * <p>Default {@code false} preserves the replay-from-0 semantics.
+     *
+     * @return {@code true} to resume {@code recvEvent} from the persisted
+     *         cursor on reclaim; {@code false} (default) to replay from seq 0.
+     */
+    boolean resumeCursor() default false;
+
+    /**
      * Issue #895: per-tool retry-eligible exception whitelist.
      *
      * <p>When a {@code task = true} handler raises a {@link Throwable} whose

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/JobControllerResumeCursorTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/JobControllerResumeCursorTest.java
@@ -1,0 +1,111 @@
+package io.mcpmesh;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the WAVE 2c cursor-resume serialization seam (issue #1277) —
+ * {@link JobController#serializeRecvCursor(Map)}. This is the exact JSON-object
+ * string handed to the native {@code mesh_job_controller_new_with_resume} entry
+ * point, so it stays below the FFI boundary (no live registry / native handle
+ * needed — the full resume round-trip is a Wave-3 integration UC).
+ *
+ * <p>Contract: a well-formed cursor becomes {@code {"key": seq, ...}}; a
+ * null/empty/non-integer cursor becomes {@code null} (native "no seed" ⇒
+ * replay-from-0). Serialization never throws — resume is best-effort, a bad
+ * cursor silently degrades to replay-from-0.
+ */
+class JobControllerResumeCursorTest {
+
+    @Test
+    void serializeRecvCursor_buildsJsonObjectOfSeqs() {
+        Map<String, Object> cursor = new LinkedHashMap<>();
+        cursor.put("answer", 3);
+        cursor.put("signal", 7L);
+        String json = JobController.serializeRecvCursor(cursor);
+        assertNotNull(json);
+        // Order-preserving LinkedHashMap → deterministic JSON.
+        assertEquals("{\"answer\":3,\"signal\":7}", json);
+    }
+
+    @Test
+    void serializeRecvCursor_singleKey() {
+        String json = JobController.serializeRecvCursor(Map.of("answer", 42));
+        assertEquals("{\"answer\":42}", json);
+    }
+
+    @Test
+    void serializeRecvCursor_nullOrEmpty_returnsNull() {
+        assertNull(JobController.serializeRecvCursor(null),
+            "null cursor ⇒ no seed (replay-from-0)");
+        assertNull(JobController.serializeRecvCursor(Map.of()),
+            "empty cursor ⇒ no seed (replay-from-0)");
+    }
+
+    @Test
+    void serializeRecvCursor_nonIntegerValues_filteredOut() {
+        Map<String, Object> cursor = new LinkedHashMap<>();
+        cursor.put("answer", 5);
+        cursor.put("bogus", "not-a-number");
+        cursor.put("nullish", null);
+        String json = JobController.serializeRecvCursor(cursor);
+        // Only the integer-valued entry survives.
+        assertEquals("{\"answer\":5}", json);
+    }
+
+    @Test
+    void serializeRecvCursor_allNonInteger_returnsNull() {
+        Map<String, Object> cursor = new LinkedHashMap<>();
+        cursor.put("a", "x");
+        cursor.put("b", null);
+        assertNull(JobController.serializeRecvCursor(cursor),
+            "a cursor with no integer seqs ⇒ no seed (replay-from-0)");
+    }
+
+    @Test
+    void serializeRecvCursor_mixedMap_keepsOnlyNonNegativeIntegers() {
+        // Shared cross-runtime mixed-map contract (Python/TS/Java identical):
+        // only "a":4 survives — negatives, fractions, and non-numbers drop.
+        Map<String, Object> cursor = new LinkedHashMap<>();
+        cursor.put("a", 4);        // non-negative int  → keep
+        cursor.put("b", -1);       // negative int      → drop
+        cursor.put("c", 2.5d);     // fractional Double → drop (NO truncation)
+        cursor.put("d", "x");      // non-number        → drop
+        String json = JobController.serializeRecvCursor(cursor);
+        assertEquals("{\"a\":4}", json);
+    }
+
+    @Test
+    void serializeRecvCursor_fractionalNotTruncated() {
+        // A lone fractional value must NOT longValue()-truncate to 2 — it is
+        // rejected, leaving no surviving entry ⇒ null (replay-from-0).
+        assertNull(JobController.serializeRecvCursor(Map.of("work", 2.5d)),
+            "fractional Double must be rejected, never truncated");
+    }
+
+    @Test
+    void serializeRecvCursor_negativeDropped() {
+        assertNull(JobController.serializeRecvCursor(Map.of("work", -1)),
+            "negative seq ⇒ dropped ⇒ no seed");
+    }
+
+    @Test
+    void serializeRecvCursor_zeroIsKept() {
+        assertEquals("{\"work\":0}", JobController.serializeRecvCursor(Map.of("work", 0)));
+    }
+
+    @Test
+    void openWithResume_validatesRequiredArgs() {
+        Map<String, Object> cursor = Map.of("answer", 1);
+        assertThrows(IllegalArgumentException.class,
+            () -> JobController.openWithResume(null, "inst", "http://x", null, cursor));
+        assertThrows(IllegalArgumentException.class,
+            () -> JobController.openWithResume("job", "", "http://x", null, cursor));
+        assertThrows(IllegalArgumentException.class,
+            () -> JobController.openWithResume("job", "inst", null, null, cursor));
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ClaimDispatcher.java
@@ -108,6 +108,17 @@ public final class ClaimDispatcher implements AutoCloseable {
     private final Class<? extends Throwable>[] retryOn;
 
     /**
+     * Issue #1277: cursor-resume opt-in read from the producer's
+     * {@code @MeshTool(resumeCursor=...)}. When true AND the claim carries a
+     * non-empty {@code recv_cursor}, the dispatcher opens the controller via
+     * {@link JobController#openWithResume} so {@code recvEvent} resumes from
+     * the persisted per-filter cursor instead of replaying from seq 0. When
+     * false (default) or the claim has no cursor, the plain replay-from-0
+     * {@link JobController#open} path is used.
+     */
+    private final boolean resumeCursor;
+
+    /**
      * Issue #1268 pre-claim gate: returns the capability of a currently
      * unresolved {@code required} dependency (naming the reason a claim is
      * skipped), or {@code null} when the tool is clear to claim. Consulted
@@ -154,22 +165,34 @@ public final class ClaimDispatcher implements AutoCloseable {
         this(capability, instanceId, registryUrl, handler, retryOn, null);
     }
 
+    public ClaimDispatcher(String capability, String instanceId, String registryUrl,
+                           ClaimHandler handler, Class<? extends Throwable>[] retryOn,
+                           java.util.function.Supplier<String> claimBlockedReason) {
+        this(capability, instanceId, registryUrl, handler, retryOn, claimBlockedReason, false);
+    }
+
     /**
-     * Construct a dispatcher with an explicit {@code retryOn} whitelist AND a
-     * pre-claim gate (issue #1268). Before each {@code /jobs/claim} poll the
-     * loop consults {@code claimBlockedReason}; a non-null result names an
-     * unresolved {@code required} dependency and the poll is skipped (the job
-     * stays queued registry-side with no attempt burn) until the dep resolves.
+     * Construct a dispatcher with an explicit {@code retryOn} whitelist, a
+     * pre-claim gate (issue #1268), and the cursor-resume opt-in (issue
+     * #1277). Before each {@code /jobs/claim} poll the loop consults
+     * {@code claimBlockedReason}; a non-null result names an unresolved
+     * {@code required} dependency and the poll is skipped (the job stays
+     * queued registry-side with no attempt burn) until the dep resolves.
      *
      * @param retryOn            Per-tool retry-eligible exception classes (may
      *                           be null/empty for "no retry-eligible exceptions").
      * @param claimBlockedReason Supplier returning the capability of an
      *                           unresolved required dependency, or {@code null}
      *                           when clear to claim. Null ⇒ "always ready".
+     * @param resumeCursor       When true, a claim carrying a non-empty
+     *                           {@code recv_cursor} opens the controller in
+     *                           resume mode ({@code recvEvent} continues from
+     *                           the persisted cursor); false ⇒ replay-from-0.
      */
     public ClaimDispatcher(String capability, String instanceId, String registryUrl,
                            ClaimHandler handler, Class<? extends Throwable>[] retryOn,
-                           java.util.function.Supplier<String> claimBlockedReason) {
+                           java.util.function.Supplier<String> claimBlockedReason,
+                           boolean resumeCursor) {
         if (capability == null || capability.isEmpty()) {
             throw new IllegalArgumentException("capability is required");
         }
@@ -188,6 +211,7 @@ public final class ClaimDispatcher implements AutoCloseable {
         this.handler = handler;
         this.retryOn = retryOn != null ? retryOn : EMPTY_RETRY_ON;
         this.claimBlockedReason = claimBlockedReason != null ? claimBlockedReason : () -> null;
+        this.resumeCursor = resumeCursor;
         this.loopExecutor = Executors.newSingleThreadExecutor(named("mesh-claim-loop-" + capability));
         this.dispatchExecutor = Executors.newFixedThreadPool(MAX_CONCURRENT_DISPATCHES,
             named("mesh-claim-dispatch-" + capability));
@@ -497,7 +521,10 @@ public final class ClaimDispatcher implements AutoCloseable {
 
         JobController controller;
         try {
-            controller = JobController.open(jobId, instanceId, registryUrl, claimEpoch);
+            // Issue #1277: resume the recvEvent cursor from the claim's
+            // persisted recv_cursor when the tool opted in AND the registry
+            // supplied a non-empty cursor; else replay-from-0 (the default).
+            controller = openController(jobId, claimEpoch, claimed.get("recv_cursor"));
         } catch (Exception e) {
             log.warn("[mesh-claim] failed to construct controller for job={}: {}", jobId, e.getMessage());
             // Best-effort: tell the registry we failed so the row doesn't
@@ -558,6 +585,29 @@ public final class ClaimDispatcher implements AutoCloseable {
         } finally {
             controller.close();
         }
+    }
+
+    /**
+     * Issue #1277 gate: choose the controller-open path for a claimed job.
+     * When this dispatcher's tool opted into {@code resumeCursor} AND the
+     * claim carried a non-empty {@code recv_cursor} map, open in resume mode
+     * so {@code recvEvent} continues from the persisted per-filter cursor;
+     * otherwise the plain replay-from-0 path. A malformed / empty / absent
+     * cursor degrades to plain open — resume is a best-effort optimization
+     * and never fails the dispatch. Package-private so the gate logic is
+     * unit-testable at the {@link JobController} boundary without a live
+     * native.
+     *
+     * @param recvCursorRaw the claim's {@code recv_cursor} value (a
+     *                      {@code Map<String, Number>} or null)
+     */
+    JobController openController(String jobId, Long claimEpoch, Object recvCursorRaw) {
+        if (resumeCursor && recvCursorRaw instanceof Map<?, ?> cursor && !cursor.isEmpty()) {
+            @SuppressWarnings("unchecked")
+            Map<String, ?> typed = (Map<String, ?>) cursor;
+            return JobController.openWithResume(jobId, instanceId, registryUrl, claimEpoch, typed);
+        }
+        return JobController.open(jobId, instanceId, registryUrl, claimEpoch);
     }
 
     private void runHandler(Map<String, Object> payload, JobController controller) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
@@ -178,6 +178,9 @@ public final class JobsRuntimeManager implements SmartLifecycle {
             // queued registry-side with no attempt burn and self-heals on a
             // later poll — the pre-invoke guard in invokeForClaim is the
             // safety net for the narrow window the two clocks leave open.
+            // Issue #1277: thread the @MeshTool(resumeCursor=...) opt-in so a
+            // reclaimed job seeds its recvEvent cursor from the persisted
+            // recv_cursor instead of replaying from seq 0.
             ClaimDispatcher dispatcher = new ClaimDispatcher(
                 meta.capability(),
                 instanceId,
@@ -185,12 +188,13 @@ public final class JobsRuntimeManager implements SmartLifecycle {
                 (payload, controller) -> wrapper.invokeForClaim(
                     payload, controller, deadlineFromJobContext()),
                 meta.retryOn(),
-                wrapper::firstUnresolvedRequiredDependency
+                wrapper::firstUnresolvedRequiredDependency,
+                meta.resumeCursor()
             );
             dispatcher.start();
             dispatchers.put(meta.capability(), dispatcher);
-            log.info("MeshJob producer wired: capability={} (wrapper={}, dispatcher started, retryOn={})",
-                meta.capability(), wrapper.getFuncId(), meta.retryOn().length);
+            log.info("MeshJob producer wired: capability={} (wrapper={}, dispatcher started, retryOn={}, resumeCursor={})",
+                meta.capability(), wrapper.getFuncId(), meta.retryOn().length, meta.resumeCursor());
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolBeanPostProcessor.java
@@ -156,6 +156,15 @@ public class MeshToolBeanPostProcessor implements BeanPostProcessor, Ordered {
                     "remove retryOn or set task = true.");
             }
 
+            // Issue #1277: resumeCursor requires task=true (no controller
+            // without it, so a resume cursor has no meaning).
+            if (annotation.resumeCursor() && !annotation.task()) {
+                throw new IllegalStateException(
+                    "@MeshTool(resumeCursor = true) on '" + targetClass.getName() +
+                    "#" + method.getName() + "' requires task = true; " +
+                    "remove resumeCursor or set task = true.");
+            }
+
             // RFC #1280 phase 2 (item 7b): analyze @McpMeshService view params
             // ONCE and hand the result to both the registry and the wrapper.
             List<McpMeshServiceToolSupport.ViewParamInfo> viewParams =

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolRegistry.java
@@ -83,6 +83,10 @@ public class MeshToolRegistry {
             // task=true` before this call, so we only need to capture it
             // here for downstream dispatch wiring.
             annotation.retryOn(),
+            // Issue #1277: cursor-resume opt-in. Validated (requires
+            // task=true) in the bean post-processor before this call;
+            // captured here to thread into the ClaimDispatcher.
+            annotation.resumeCursor(),
             bean,
             method
         );
@@ -575,6 +579,11 @@ public class MeshToolRegistry {
      * per-tool exception whitelist that triggers release-and-retry instead of
      * fail() when a {@code task=true} handler raises. Always non-null (defaults
      * to a zero-length array).
+     *
+     * <p>{@code resumeCursor} mirrors {@link MeshTool#resumeCursor()} (issue
+     * #1277) — when true, a reclaimed job's controller resumes its
+     * {@code recvEvent} cursor from the persisted {@code recv_cursor} instead
+     * of replaying from seq 0. Defaults to false.
      */
     public record ToolMetadata(
         String capability,
@@ -587,6 +596,7 @@ public class MeshToolRegistry {
         boolean outputSchemaStrict,
         boolean task,
         Class<? extends Throwable>[] retryOn,
+        boolean resumeCursor,
         Object bean,
         Method method
     ) {
@@ -604,7 +614,7 @@ public class MeshToolRegistry {
                 Object bean,
                 Method method) {
             this(capability, description, version, tags, dependencies, inputSchema,
-                outputType, outputSchemaStrict, false, EMPTY_RETRY_ON, bean, method);
+                outputType, outputSchemaStrict, false, EMPTY_RETRY_ON, false, bean, method);
         }
 
         // Backward-compatible 11-arg constructor for callers that adopted
@@ -622,7 +632,26 @@ public class MeshToolRegistry {
                 Object bean,
                 Method method) {
             this(capability, description, version, tags, dependencies, inputSchema,
-                outputType, outputSchemaStrict, task, EMPTY_RETRY_ON, bean, method);
+                outputType, outputSchemaStrict, task, EMPTY_RETRY_ON, false, bean, method);
+        }
+
+        // Backward-compatible 12-arg constructor for callers that adopted the
+        // issue #895 retryOn field but predate the issue #1277 resumeCursor flag.
+        public ToolMetadata(
+                String capability,
+                String description,
+                String version,
+                List<String> tags,
+                List<DependencyInfo> dependencies,
+                Map<String, Object> inputSchema,
+                Class<?> outputType,
+                boolean outputSchemaStrict,
+                boolean task,
+                Class<? extends Throwable>[] retryOn,
+                Object bean,
+                Method method) {
+            this(capability, description, version, tags, dependencies, inputSchema,
+                outputType, outputSchemaStrict, task, retryOn, false, bean, method);
         }
 
         @SuppressWarnings("unchecked")

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/ClaimDispatcherTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/ClaimDispatcherTest.java
@@ -1,17 +1,27 @@
 package io.mcpmesh.spring;
 
+import io.mcpmesh.JobController;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 
 /**
  * Unit tests for {@link ClaimDispatcher}. Spins up a {@link MockWebServer}
@@ -209,6 +219,92 @@ class ClaimDispatcherTest {
         d.stop(0);
         assertNotNull(req, "dispatcher must poll /jobs/claim once the gate opens");
         assertEquals("/jobs/claim", req.getPath());
+    }
+
+    // ---- Issue #1277: cursor-resume gate -----------------------------------
+    //
+    // The gate decision (which JobController.open* to call) is unit-tested at
+    // the JobController static boundary via Mockito mockStatic, so no live
+    // native handle / registry is needed — the real resume round-trip is the
+    // Wave-3 integration UC. `openController(...)` is the package-private seam
+    // dispatch() delegates to.
+
+    private static ClaimDispatcher dispatcher(boolean resumeCursor) {
+        return new ClaimDispatcher(
+            "test_cap", "instance-1", "http://registry:8000",
+            (payload, controller) -> null,
+            null, null, resumeCursor);
+    }
+
+    @Test
+    void openController_resumeOn_withCursor_opensWithResume() {
+        ClaimDispatcher d = dispatcher(true);
+        Map<String, Object> recvCursor = Map.of("answer", 3);
+        try (MockedStatic<JobController> mocked = mockStatic(JobController.class)) {
+            JobController stub = mock(JobController.class);
+            mocked.when(() -> JobController.openWithResume(
+                    eq("job-1"), eq("instance-1"), anyString(), eq(7L), any()))
+                .thenReturn(stub);
+
+            JobController result = d.openController("job-1", 7L, recvCursor);
+
+            assertSame(stub, result);
+            // Resume-open called with the claim's recv_cursor map...
+            mocked.verify(() -> JobController.openWithResume(
+                eq("job-1"), eq("instance-1"), anyString(), eq(7L),
+                argThat(m -> m != null
+                    && ((Number) ((Map<?, ?>) m).get("answer")).intValue() == 3)));
+            // ...and the plain replay-from-0 path NOT called. The exact JSON
+            // cursor shape ({"answer":3}) handed to the native layer is
+            // asserted at the SDK serialization seam
+            // (JobControllerResumeCursorTest).
+            mocked.verify(() -> JobController.open(
+                anyString(), anyString(), anyString(), any()), never());
+        }
+        d.stop(0);
+    }
+
+    @Test
+    void openController_resumeOff_withCursor_opensPlain() {
+        ClaimDispatcher d = dispatcher(false);
+        Map<String, Object> recvCursor = Map.of("answer", 3);
+        try (MockedStatic<JobController> mocked = mockStatic(JobController.class)) {
+            JobController stub = mock(JobController.class);
+            mocked.when(() -> JobController.open(
+                    eq("job-1"), eq("instance-1"), anyString(), eq(7L)))
+                .thenReturn(stub);
+
+            JobController result = d.openController("job-1", 7L, recvCursor);
+
+            assertSame(stub, result);
+            // Default (resumeCursor=false) → plain open even though a cursor
+            // is present; resume-open must NOT be called.
+            mocked.verify(() -> JobController.open(
+                eq("job-1"), eq("instance-1"), anyString(), eq(7L)));
+            mocked.verify(() -> JobController.openWithResume(
+                anyString(), anyString(), anyString(), any(), any()), never());
+        }
+        d.stop(0);
+    }
+
+    @Test
+    void openController_resumeOn_noCursor_opensPlain() {
+        ClaimDispatcher d = dispatcher(true);
+        try (MockedStatic<JobController> mocked = mockStatic(JobController.class)) {
+            JobController stub = mock(JobController.class);
+            mocked.when(() -> JobController.open(
+                    eq("job-1"), eq("instance-1"), anyString(), eq(7L)))
+                .thenReturn(stub);
+
+            // null cursor → plain open.
+            assertSame(stub, d.openController("job-1", 7L, null));
+            // empty-map cursor → plain open.
+            assertSame(stub, d.openController("job-1", 7L, Map.of()));
+
+            mocked.verify(() -> JobController.openWithResume(
+                anyString(), anyString(), anyString(), any(), any()), never());
+        }
+        d.stop(0);
     }
 
     @Test

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolResumeCursorValidationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolResumeCursorValidationTest.java
@@ -1,0 +1,97 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1277 (WAVE 2c): {@code @MeshTool(resumeCursor = true)} requires
+ * {@code task = true} — a non-task tool has no {@link io.mcpmesh.JobController},
+ * so a resume cursor has no meaning. The
+ * {@link MeshToolBeanPostProcessor} fails fast at startup otherwise (mirrors
+ * the issue #895 {@code retryOn requires task=true} guard).
+ */
+@DisplayName("@MeshTool(resumeCursor) — startup validation (issue #1277)")
+class MeshToolResumeCursorValidationTest {
+
+    // ── Fixtures ────────────────────────────────────────────────────────────
+
+    /** Illegal: resumeCursor without task. */
+    public static class ResumeWithoutTaskBean {
+        @MeshTool(capability = "bad_resume", resumeCursor = true)
+        public String bad(@Param("x") String x) {
+            return x;
+        }
+    }
+
+    /** Legal: resumeCursor with task=true. */
+    public static class ResumeWithTaskBean {
+        @MeshTool(capability = "good_resume", task = true, resumeCursor = true)
+        public String good(@Param("x") String x, MeshJob job) {
+            return x;
+        }
+    }
+
+    /** Baseline: no resumeCursor opt-in. */
+    public static class PlainBean {
+        @MeshTool(capability = "plain")
+        public String plain(@Param("x") String x) {
+            return x;
+        }
+    }
+
+    // ── Helper ──────────────────────────────────────────────────────────────
+
+    private static MeshToolBeanPostProcessor processor(MeshToolRegistry registry) {
+        return new MeshToolBeanPostProcessor(
+            registry,
+            new MeshToolWrapperRegistry(new McpMeshToolProxyFactory()),
+            JsonMapper.builder().build());
+    }
+
+    // ── Tests ───────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("resumeCursor=true without task=true → boot error naming the constraint")
+    void resumeCursorWithoutTaskFailsFast() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () ->
+            processor(registry).postProcessAfterInitialization(
+                new ResumeWithoutTaskBean(), "bad"));
+        assertTrue(ex.getMessage().contains("resumeCursor"),
+            "error must name resumeCursor. Got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("task = true"),
+            "error must state the task=true requirement. Got: " + ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("resumeCursor=true with task=true → accepted, flag captured on metadata")
+    void resumeCursorWithTaskAccepted() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        assertDoesNotThrow(() ->
+            processor(registry).postProcessAfterInitialization(
+                new ResumeWithTaskBean(), "good"));
+        MeshToolRegistry.ToolMetadata meta = registry.getTool("good_resume");
+        assertNotNull(meta);
+        assertTrue(meta.task());
+        assertTrue(meta.resumeCursor(),
+            "resumeCursor opt-in must be threaded onto the tool metadata");
+    }
+
+    @Test
+    @DisplayName("no resumeCursor opt-in → defaults to false")
+    void plainToolDefaultsResumeCursorFalse() {
+        MeshToolRegistry registry = new MeshToolRegistry();
+        assertDoesNotThrow(() ->
+            processor(registry).postProcessAfterInitialization(
+                new PlainBean(), "plain"));
+        MeshToolRegistry.ToolMetadata meta = registry.getTool("plain");
+        assertNotNull(meta);
+        assertFalse(meta.resumeCursor(), "resumeCursor must default to false");
+    }
+}

--- a/src/runtime/python/_mcp_mesh/engine/claim_dispatcher.py
+++ b/src/runtime/python/_mcp_mesh/engine/claim_dispatcher.py
@@ -336,6 +336,25 @@ class PythonClaimDispatcher:
             claim_epoch = _valid_claim_epoch(claimed.get("claim_epoch"))
             if claim_epoch is not None:
                 merged["x-mesh-claim-epoch"] = str(claim_epoch)
+            # Seed the persisted per-filter receive cursor (issue #1277) so a
+            # tool that opted into resume (`@mesh.tool(resume_cursor=True)`)
+            # resumes its recv_event consumption instead of replaying from
+            # seq 0. Unlike the scalar headers above, recv_cursor is a MAP —
+            # it rides the same contextvar channel as a JSON string. Absent /
+            # empty ⇒ no header (replay-from-0, unchanged). The gate that
+            # decides whether to actually seed the controller lives in
+            # job_dispatch (keyed on the tool's resume_cursor opt-in).
+            recv_cursor = claimed.get("recv_cursor")
+            if isinstance(recv_cursor, dict) and recv_cursor:
+                try:
+                    merged["x-mesh-recv-cursor"] = json.dumps(recv_cursor)
+                except (TypeError, ValueError) as e:
+                    logger.debug(
+                        "claim_dispatcher: could not serialize recv_cursor "
+                        "%r (%s); dispatching without resume cursor",
+                        recv_cursor,
+                        e,
+                    )
             TraceContext.set_propagated_headers(merged)
         except Exception as e:
             logger.debug(

--- a/src/runtime/python/_mcp_mesh/engine/job_dispatch.py
+++ b/src/runtime/python/_mcp_mesh/engine/job_dispatch.py
@@ -32,6 +32,7 @@ can call into it without re-implementing the contract.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 from typing import Any, Awaitable, Callable, Optional
@@ -58,33 +59,40 @@ _HDR_TIMEOUT = "x-mesh-timeout"
 # Claim generation minted by the registry on POST /jobs/claim (issue #1252).
 # Seeded by the claim dispatcher; absent on the push-mode inbound path.
 _HDR_CLAIM_EPOCH = "x-mesh-claim-epoch"
+# Persisted per-filter receive cursor (issue #1277). Seeded by the claim
+# dispatcher as a JSON-serialized ``dict[str, int]``; absent on the push-mode
+# inbound path and whenever the reclaimed row had no prior consumption.
+_HDR_RECV_CURSOR = "x-mesh-recv-cursor"
 
 
-def _read_job_headers() -> tuple[Optional[str], Optional[float], Optional[int]]:
-    """Pull ``X-Mesh-Job-Id`` / ``X-Mesh-Timeout`` / ``X-Mesh-Claim-Epoch``
-    from the propagated-headers contextvar populated by the MCP session
-    middleware (or seeded by the claim dispatcher).
+def _read_job_headers() -> (
+    tuple[Optional[str], Optional[float], Optional[int], Optional[dict]]
+):
+    """Pull ``X-Mesh-Job-Id`` / ``X-Mesh-Timeout`` / ``X-Mesh-Claim-Epoch`` /
+    ``X-Mesh-Recv-Cursor`` from the propagated-headers contextvar populated by
+    the MCP session middleware (or seeded by the claim dispatcher).
 
-    Returns ``(job_id, deadline_secs_remaining, claim_epoch)`` — any may be
-    ``None``. ``claim_epoch`` is present only on the claim path; a push-mode
-    inbound job leaves it ``None`` (legacy owner-only fencing).
+    Returns ``(job_id, deadline_secs_remaining, claim_epoch, recv_cursor)`` —
+    any may be ``None``. ``claim_epoch`` and ``recv_cursor`` are present only
+    on the claim path; a push-mode inbound job leaves them ``None`` (legacy
+    owner-only fencing, replay-from-0).
 
     Defensive: never raises. If the trace-context module is somehow not
-    importable (test harness with stubs), returns ``(None, None, None)``.
+    importable (test harness with stubs), returns ``(None, None, None, None)``.
     """
     try:
         from ..tracing.context import TraceContext
     except Exception:
-        return None, None, None
+        return None, None, None, None
 
     headers = TraceContext.get_propagated_headers() or {}
     if not headers:
-        return None, None, None
+        return None, None, None, None
 
     # Header dict is lowercased by the middleware before storing.
     job_id = headers.get(_HDR_JOB_ID)
     if not job_id:
-        return None, None, None
+        return None, None, None, None
 
     timeout_raw = headers.get(_HDR_TIMEOUT)
     deadline_secs: Optional[float] = None
@@ -117,7 +125,54 @@ def _read_job_headers() -> tuple[Optional[str], Optional[float], Optional[int]]:
                 claim_epoch_raw,
             )
             claim_epoch = None
-    return job_id, deadline_secs, claim_epoch
+
+    # The recv cursor rides as a JSON string (it is a MAP, unlike the scalar
+    # headers above). Absent / blank ⇒ None (replay-from-0). Malformed or a
+    # non-object shape ⇒ None + a warning; never crash the handler over a bad
+    # cursor — the worst case is a replay, which is already the default.
+    #
+    # Value contract (identical across the Python/TS/Java runtimes): keep only
+    # entries whose value is a NON-NEGATIVE INTEGER; drop every other key.
+    # This is a hard requirement here, not just hygiene: the surviving map is
+    # handed to PyO3's ``Option[HashMap[str, i64]]`` extraction at controller
+    # construction, which THROWS on a str / float value — and that throw would
+    # drop us to a plain call with NO controller (strictly worse than a clean
+    # replay-from-0 with a working controller). Filtering to clean ints here
+    # guarantees construction never throws on a bad registry cursor. A Python
+    # ``bool`` is an ``int`` subclass but a seq is never a bool, so exclude it.
+    recv_cursor_raw = headers.get(_HDR_RECV_CURSOR)
+    recv_cursor: Optional[dict] = None
+    if recv_cursor_raw is not None and recv_cursor_raw.strip() != "":
+        try:
+            parsed_cursor = json.loads(recv_cursor_raw)
+            if isinstance(parsed_cursor, dict):
+                filtered = {
+                    k: v
+                    for k, v in parsed_cursor.items()
+                    if isinstance(v, int)
+                    and not isinstance(v, bool)
+                    and v >= 0
+                }
+                # Empty after filtering (nothing survived) ⇒ None ⇒ replay-from-0
+                # with a working controller, never a lost controller.
+                recv_cursor = filtered or None
+            else:
+                logger.warning(
+                    "job_dispatch: ignoring %s header — expected a JSON "
+                    "object, got %r",
+                    _HDR_RECV_CURSOR,
+                    parsed_cursor,
+                )
+        except (TypeError, ValueError) as e:
+            logger.warning(
+                "job_dispatch: ignoring malformed %s header value %r (%s)",
+                _HDR_RECV_CURSOR,
+                recv_cursor_raw,
+                e,
+            )
+            recv_cursor = None
+
+    return job_id, deadline_secs, claim_epoch, recv_cursor
 
 
 def _resolve_runtime_identity() -> tuple[Optional[str], Optional[str]]:
@@ -219,6 +274,20 @@ def get_retry_on(func: Any) -> tuple:
     return ()
 
 
+def get_resume_cursor(func: Any) -> bool:
+    """Return the ``resume_cursor`` opt-in flag stamped by
+    ``@mesh.tool(resume_cursor=True)`` (issue #1277).
+
+    Defaults to ``False`` when the metadata is missing or the kwarg was not
+    set — preserving the default replay-from-0 behaviour for tools that don't
+    opt into resume.
+    """
+    meta = _read_tool_metadata(func)
+    if meta is None:
+        return False
+    return bool(meta.get("resume_cursor"))
+
+
 def get_mesh_job_param_name(func: Any) -> Optional[str]:
     """Return the function's ``MeshJob`` parameter name, or ``None`` if
     the function does not declare one.
@@ -271,7 +340,7 @@ async def maybe_dispatch_as_job(
     if not is_task_tool(func):
         return await invoke(final_kwargs)
 
-    job_id, deadline_secs, claim_epoch = _read_job_headers()
+    job_id, deadline_secs, claim_epoch, recv_cursor = _read_job_headers()
     mesh_job_param = get_mesh_job_param_name(func)
 
     # Ensure the MeshJob param defaults to ``None`` — this is what the
@@ -320,7 +389,24 @@ async def maybe_dispatch_as_job(
     try:
         # Pass the claim generation (when present) so the controller fences
         # its deltas + executor reads; None ⇒ legacy owner-only (issue #1252).
-        controller = PyJobController(job_id, instance_id, registry_url, claim_epoch)
+        #
+        # Resume gating (issue #1277): seed the controller from the persisted
+        # per-filter recv_cursor ONLY when the tool opted in
+        # (`@mesh.tool(resume_cursor=True)`) AND a cursor actually rode the
+        # header. Otherwise construct with no seed (replay-from-0, unchanged) —
+        # this is the single Python gate for resume.
+        if get_resume_cursor(func) and recv_cursor:
+            controller = PyJobController(
+                job_id,
+                instance_id,
+                registry_url,
+                claim_epoch,
+                initial_cursors=recv_cursor,
+            )
+        else:
+            controller = PyJobController(
+                job_id, instance_id, registry_url, claim_epoch
+            )
     except Exception as e:
         logger.warning(
             "job_dispatch: failed to construct JobController for job=%s "

--- a/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
+++ b/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
@@ -682,6 +682,16 @@ class UnifiedMCPProxy:
         current_trace = TraceContext.get_current()
         merged_headers: dict[str, str] = dict(TraceContext.get_propagated_headers())
 
+        # Issue #1277: the persisted recv-cursor is CLAIM-LOCAL — it is read
+        # once by job_dispatch (from the contextvar, before this outbound call)
+        # to seed the handler's controller, and is meaningless (and wasteful —
+        # it's a serialized map) downstream. Unlike x-mesh-job-id /
+        # x-mesh-claim-epoch (which propagate intentionally for calling-job
+        # identity, #1263), scrub ONLY this key from the outbound base. The
+        # inbound claim→handler seed is unaffected — that read already happened
+        # against the contextvar, not this outbound copy.
+        merged_headers.pop("x-mesh-recv-cursor", None)
+
         if self.custom_headers:
             for k, v in self.custom_headers.items():
                 if matches_propagate_header(k):

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -897,6 +897,7 @@ def tool(
     output_schema_strict: bool = True,
     task: bool = False,
     retry_on: tuple[type[BaseException], ...] | None = None,
+    resume_cursor: bool = False,
     **kwargs: Any,
 ) -> Callable[[T], T]:
     """
@@ -971,6 +972,16 @@ def tool(
             row instead of honouring the cancel. Stick to ``Exception``
             subclasses representing transient I/O / availability faults
             (``OSError``, ``ConnectionError``, custom transient types).
+        resume_cursor: When True, a reclaimed run of this tool resumes its
+            per-filter event consumption from the persisted ``recv_cursor``
+            (issue #1277) instead of replaying its event log from seq 0.
+            Opt-in: default ``False`` preserves replay-from-0 (byte-identical
+            to prior behaviour). Only opt in when the handler's ``recv_event``
+            consumption is strictly sequential-per-filter — a prefetching or
+            concurrent consumer must NOT set this, or it will skip events on
+            resume. Only meaningful for ``task=True`` tools; a ``True`` value
+            on a non-task tool raises at decoration time (there is no job
+            controller to seed).
         **kwargs: Additional metadata
 
     Returns:
@@ -1034,6 +1045,18 @@ def tool(
             raise ValueError(
                 "retry_on is only valid with task=True; remove retry_on or "
                 "set task=True"
+            )
+
+        # Validate resume_cursor (issue #1277): opt-in resume-from-persisted-
+        # cursor. Must be a bool and, like retry_on, is only meaningful for
+        # task=True tools — a non-task tool has no job controller to seed.
+        # Fail loud at decoration time rather than silently ignore the kwarg.
+        if not isinstance(resume_cursor, bool):
+            raise ValueError("resume_cursor must be a boolean")
+        if resume_cursor and not task:
+            raise ValueError(
+                "resume_cursor is only valid with task=True; remove "
+                "resume_cursor or set task=True"
             )
 
         # Validate optional parameters
@@ -1271,6 +1294,11 @@ def tool(
             # resets owner_instance_id and a peer replica re-claims within
             # ~5s. Empty tuple = previous behaviour (every raise → fail).
             "retry_on": validated_retry_on,
+            # Issue #1277: opt-in resume-from-persisted-cursor. When True, the
+            # claim dispatch path seeds the reclaimed JobController from the
+            # persisted per-filter recv_cursor so recv_event resumes instead of
+            # replaying from seq 0. Default False = replay-from-0.
+            "resume_cursor": resume_cursor,
             **kwargs,
         }
 

--- a/src/runtime/python/tests/unit/test_1277_resume_cursor.py
+++ b/src/runtime/python/tests/unit/test_1277_resume_cursor.py
@@ -1,0 +1,443 @@
+"""Issue #1277 — resume_cursor opt-in (Python reference implementation).
+
+Covers the three moving parts of the Python surface:
+
+1. Decorator opt-in: ``@mesh.tool(resume_cursor=True)`` stamps metadata,
+   requires ``task=True``, defaults ``False``, must be a bool.
+2. Cursor propagation: the claim dispatcher serializes ``recv_cursor`` onto
+   the ``x-mesh-recv-cursor`` header (JSON); ``_read_job_headers`` round-trips
+   it back to a dict; absent / malformed → ``None`` (never crashes).
+3. The single gate: ``maybe_dispatch_as_job`` seeds the controller from the
+   parsed cursor ONLY when the tool opted in AND a cursor is present.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+import mesh
+import pytest
+
+
+# ===========================================================================
+# 1. Decorator opt-in surface
+# ===========================================================================
+
+
+class TestResumeCursorDecorator:
+    def test_resume_cursor_true_on_task_tool_sets_metadata(self):
+        @mesh.tool(capability="resumable", task=True, resume_cursor=True)
+        async def handler():
+            pass
+
+        meta = handler._mesh_tool_metadata
+        assert meta["resume_cursor"] is True
+        assert meta["task"] is True
+
+    def test_resume_cursor_default_false(self):
+        @mesh.tool(capability="replayer", task=True)
+        async def handler():
+            pass
+
+        assert handler._mesh_tool_metadata["resume_cursor"] is False
+
+    def test_resume_cursor_on_non_task_tool_raises(self):
+        with pytest.raises(ValueError, match="resume_cursor is only valid with task=True"):
+
+            @mesh.tool(capability="bad", resume_cursor=True)
+            async def handler():
+                pass
+
+    def test_resume_cursor_non_bool_raises(self):
+        with pytest.raises(ValueError, match="resume_cursor must be a boolean"):
+
+            @mesh.tool(capability="bad_type", task=True, resume_cursor="yes")
+            async def handler():
+                pass
+
+
+class TestGetResumeCursor:
+    def test_reads_flag_true(self):
+        from _mcp_mesh.engine.job_dispatch import get_resume_cursor
+
+        async def fn():
+            pass
+
+        fn._mesh_tool_metadata = {"task": True, "resume_cursor": True}
+        assert get_resume_cursor(fn) is True
+
+    def test_defaults_false_when_absent(self):
+        from _mcp_mesh.engine.job_dispatch import get_resume_cursor
+
+        async def fn():
+            pass
+
+        fn._mesh_tool_metadata = {"task": True}
+        assert get_resume_cursor(fn) is False
+
+    def test_defaults_false_when_no_metadata(self):
+        from _mcp_mesh.engine.job_dispatch import get_resume_cursor
+
+        async def fn():
+            pass
+
+        assert get_resume_cursor(fn) is False
+
+    def test_follows_wrapped_original(self):
+        from _mcp_mesh.engine.job_dispatch import get_resume_cursor
+
+        async def original():
+            pass
+
+        original._mesh_tool_metadata = {"task": True, "resume_cursor": True}
+
+        async def wrapper():
+            pass
+
+        wrapper._mesh_original_func = original
+        assert get_resume_cursor(wrapper) is True
+
+
+# ===========================================================================
+# 2a. _read_job_headers round-trip
+# ===========================================================================
+
+
+class TestReadJobHeadersRecvCursor:
+    def _read_with(self, headers):
+        from _mcp_mesh.engine.job_dispatch import _read_job_headers
+        from _mcp_mesh.tracing.context import TraceContext
+
+        TraceContext.set_propagated_headers(headers)
+        try:
+            return _read_job_headers()
+        finally:
+            TraceContext.set_propagated_headers({})
+
+    def test_parses_recv_cursor_to_dict(self):
+        cursor = {"work": 7, "answer": 3}
+        _jid, _dl, _ep, recv = self._read_with(
+            {"x-mesh-job-id": "j1", "x-mesh-recv-cursor": json.dumps(cursor)}
+        )
+        assert recv == cursor
+
+    def test_absent_recv_cursor_is_none(self):
+        _jid, _dl, _ep, recv = self._read_with({"x-mesh-job-id": "j1"})
+        assert recv is None
+
+    def test_blank_recv_cursor_is_none(self):
+        _jid, _dl, _ep, recv = self._read_with(
+            {"x-mesh-job-id": "j1", "x-mesh-recv-cursor": "   "}
+        )
+        assert recv is None
+
+    def test_malformed_recv_cursor_is_none_no_crash(self):
+        _jid, _dl, _ep, recv = self._read_with(
+            {"x-mesh-job-id": "j1", "x-mesh-recv-cursor": "{not json"}
+        )
+        assert recv is None
+
+    def test_non_object_recv_cursor_is_none(self):
+        # Valid JSON but not an object (a list) → None, no crash.
+        _jid, _dl, _ep, recv = self._read_with(
+            {"x-mesh-job-id": "j1", "x-mesh-recv-cursor": "[1, 2, 3]"}
+        )
+        assert recv is None
+
+    def test_string_value_dropped_empty_map_is_none(self):
+        # A registry cursor whose value is a string is NOT a valid seq — it
+        # would throw at PyO3 extraction. Filtered out → empty → None (so the
+        # controller is still constructed, replay-from-0).
+        _jid, _dl, _ep, recv = self._read_with(
+            {"x-mesh-job-id": "j1", "x-mesh-recv-cursor": '{"work": "5"}'}
+        )
+        assert recv is None
+
+    def test_fractional_value_dropped_empty_map_is_none(self):
+        _jid, _dl, _ep, recv = self._read_with(
+            {"x-mesh-job-id": "j1", "x-mesh-recv-cursor": '{"work": 2.5}'}
+        )
+        assert recv is None
+
+    def test_negative_value_dropped(self):
+        _jid, _dl, _ep, recv = self._read_with(
+            {"x-mesh-job-id": "j1", "x-mesh-recv-cursor": '{"work": -1}'}
+        )
+        assert recv is None
+
+    def test_bool_value_dropped(self):
+        # JSON true/false parse to Python bool (an int subclass) but a seq is
+        # never a bool — must be dropped.
+        _jid, _dl, _ep, recv = self._read_with(
+            {"x-mesh-job-id": "j1", "x-mesh-recv-cursor": '{"work": true}'}
+        )
+        assert recv is None
+
+    def test_mixed_map_keeps_only_non_negative_ints(self):
+        # The shared cross-runtime mixed-map: only "a":4 survives.
+        _jid, _dl, _ep, recv = self._read_with(
+            {
+                "x-mesh-job-id": "j1",
+                "x-mesh-recv-cursor": '{"a": 4, "b": -1, "c": 2.5, "d": "x"}',
+            }
+        )
+        assert recv == {"a": 4}
+
+    def test_zero_is_kept(self):
+        _jid, _dl, _ep, recv = self._read_with(
+            {"x-mesh-job-id": "j1", "x-mesh-recv-cursor": '{"work": 0}'}
+        )
+        assert recv == {"work": 0}
+
+
+# ===========================================================================
+# 2b. Claim dispatcher sets the header from claimed.recv_cursor
+# ===========================================================================
+
+
+class TestDispatchSetsRecvCursorHeader:
+    def _make_dispatcher(self, handler):
+        from _mcp_mesh.engine.claim_dispatcher import PythonClaimDispatcher
+
+        return PythonClaimDispatcher(
+            capability="cap",
+            instance_id="inst",
+            registry_url="http://registry:8000",
+            handler=handler,
+            func_id="mod.fn",
+            required_deps=[],
+        )
+
+    @pytest.mark.asyncio
+    async def test_dispatch_serializes_recv_cursor_header(self):
+        from _mcp_mesh.tracing.context import TraceContext
+
+        seen: dict = {}
+
+        async def handler(**kwargs):
+            seen["headers"] = dict(TraceContext.get_propagated_headers())
+
+        d = self._make_dispatcher(handler)
+        cursor = {"work": 4, "signal": 1}
+        try:
+            await d._dispatch(
+                {
+                    "id": "job-1",
+                    "submitted_payload": {},
+                    "claim_epoch": 2,
+                    "recv_cursor": cursor,
+                }
+            )
+        finally:
+            TraceContext.set_propagated_headers({})
+
+        assert "x-mesh-recv-cursor" in seen["headers"]
+        assert json.loads(seen["headers"]["x-mesh-recv-cursor"]) == cursor
+
+    @pytest.mark.asyncio
+    async def test_dispatch_without_recv_cursor_sets_no_header(self):
+        from _mcp_mesh.tracing.context import TraceContext
+
+        seen: dict = {}
+
+        async def handler(**kwargs):
+            seen["headers"] = dict(TraceContext.get_propagated_headers())
+
+        d = self._make_dispatcher(handler)
+        try:
+            await d._dispatch(
+                {"id": "job-2", "submitted_payload": {}, "claim_epoch": 2}
+            )
+        finally:
+            TraceContext.set_propagated_headers({})
+
+        assert "x-mesh-recv-cursor" not in seen["headers"]
+
+    @pytest.mark.asyncio
+    async def test_dispatch_empty_recv_cursor_sets_no_header(self):
+        from _mcp_mesh.tracing.context import TraceContext
+
+        seen: dict = {}
+
+        async def handler(**kwargs):
+            seen["headers"] = dict(TraceContext.get_propagated_headers())
+
+        d = self._make_dispatcher(handler)
+        try:
+            await d._dispatch(
+                {
+                    "id": "job-3",
+                    "submitted_payload": {},
+                    "recv_cursor": {},
+                }
+            )
+        finally:
+            TraceContext.set_propagated_headers({})
+
+        assert "x-mesh-recv-cursor" not in seen["headers"]
+
+
+# ===========================================================================
+# 3. The single gate in maybe_dispatch_as_job
+# ===========================================================================
+
+
+# Module-level fixture: get_type_hints resolves annotations against module
+# globals, so the MeshJob-slotted function must live at module scope.
+from mesh import MeshJob as _MeshJob  # noqa: E402
+
+
+async def _task_fixture(user: str, job: _MeshJob = None):
+    pass
+
+
+class TestResumeGate:
+    async def _run_gate(self, monkeypatch, *, resume_cursor, header_cursor):
+        from _mcp_mesh.engine.job_dispatch import maybe_dispatch_as_job
+        from _mcp_mesh.tracing.context import TraceContext
+
+        fn = _task_fixture
+        fn._mesh_tool_metadata = {"task": True, "resume_cursor": resume_cursor}
+
+        headers = {"x-mesh-job-id": "job-1", "x-mesh-claim-epoch": "5"}
+        if header_cursor is not None:
+            headers["x-mesh-recv-cursor"] = json.dumps(header_cursor)
+        TraceContext.set_propagated_headers(headers)
+        monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
+        monkeypatch.setenv("MCP_MESH_AGENT_ID", "agent-1")
+
+        seen: dict = {}
+
+        async def invoke(_kw):
+            return "ok"
+
+        class _FakeController:
+            def __init__(
+                self,
+                job_id,
+                instance_id,
+                registry_url,
+                claim_epoch=None,
+                initial_cursors=None,
+            ):
+                seen["initial_cursors"] = initial_cursors
+                # Record whether the kwarg was passed at all (sentinel is the
+                # default; the gate must NOT pass it on the replay path).
+                seen["kwargs_seen"] = True
+
+        async def _passthrough(job_id, deadline, awaitable, claim_epoch=None):
+            return await awaitable
+
+        try:
+            with mock.patch(
+                "mcp_mesh_core.JobController", _FakeController, create=True
+            ), mock.patch(
+                "mcp_mesh_core.with_job_async", _passthrough, create=True
+            ):
+                await maybe_dispatch_as_job(fn, invoke, {"user": "alice"})
+        finally:
+            TraceContext.set_propagated_headers({})
+        return seen
+
+    @pytest.mark.asyncio
+    async def test_opted_in_with_cursor_seeds_controller(self, monkeypatch):
+        cursor = {"work": 9}
+        seen = await self._run_gate(
+            monkeypatch, resume_cursor=True, header_cursor=cursor
+        )
+        assert seen["initial_cursors"] == cursor
+
+    @pytest.mark.asyncio
+    async def test_off_with_cursor_present_does_not_seed(self, monkeypatch):
+        # resume_cursor OFF but the header IS present → must NOT seed.
+        seen = await self._run_gate(
+            monkeypatch, resume_cursor=False, header_cursor={"work": 9}
+        )
+        assert seen["initial_cursors"] is None
+
+    @pytest.mark.asyncio
+    async def test_opted_in_no_cursor_does_not_seed(self, monkeypatch):
+        # resume_cursor ON but no cursor rode the header → no seed.
+        seen = await self._run_gate(
+            monkeypatch, resume_cursor=True, header_cursor=None
+        )
+        assert seen["initial_cursors"] is None
+
+    @pytest.mark.asyncio
+    async def test_opted_in_bad_value_cursor_still_constructs_controller(
+        self, monkeypatch
+    ):
+        # A registry cursor with a non-integer value must NOT drop us to a
+        # plain call with no controller (that would break a resume handler
+        # calling recv_event). The controller IS constructed, seeded with
+        # None (filtered empty) → clean replay-from-0.
+        seen = await self._run_gate(
+            monkeypatch, resume_cursor=True, header_cursor={"work": "5"}
+        )
+        assert seen.get("kwargs_seen") is True, "controller must be constructed"
+        assert seen["initial_cursors"] is None
+
+    @pytest.mark.asyncio
+    async def test_opted_in_mixed_map_seeds_filtered(self, monkeypatch):
+        seen = await self._run_gate(
+            monkeypatch,
+            resume_cursor=True,
+            header_cursor={"a": 4, "b": -1, "c": 2.5, "d": "x"},
+        )
+        assert seen["initial_cursors"] == {"a": 4}
+
+
+# ===========================================================================
+# 4. Outbound header hygiene: x-mesh-recv-cursor is claim-LOCAL, must not leak
+# ===========================================================================
+
+
+class TestOutboundScrub:
+    """The recv-cursor is read once (claim→handler seed) from the contextvar;
+    it must NOT ride outbound downstream calls. The dispatch job/epoch pair
+    (which DO propagate for calling-job identity) are unaffected."""
+
+    def teardown_method(self):
+        from _mcp_mesh.tracing.context import TraceContext
+
+        TraceContext.set_propagated_headers({})
+
+    def _merged(self):
+        from _mcp_mesh.engine.unified_mcp_proxy import UnifiedMCPProxy
+
+        proxy = UnifiedMCPProxy("http://downstream:8000", "some_tool")
+        _args, merged = proxy._inject_trace_into_args({}, None)
+        return merged
+
+    def test_recv_cursor_scrubbed_from_outbound(self):
+        from _mcp_mesh.tracing.context import TraceContext
+
+        TraceContext.set_propagated_headers(
+            {
+                "x-mesh-job-id": "job-1",
+                "x-mesh-claim-epoch": "3",
+                "x-mesh-recv-cursor": json.dumps({"work": 5}),
+            }
+        )
+        merged = self._merged()
+        assert "x-mesh-recv-cursor" not in merged
+
+    def test_seed_still_readable_from_contextvar_after_scrub(self):
+        # The inbound seed reads the cursor from the contextvar directly (before
+        # any outbound call); the outbound scrub copies the contextvar, so the
+        # source contextvar — and thus the seed path — is untouched.
+        from _mcp_mesh.engine.job_dispatch import _read_job_headers
+        from _mcp_mesh.tracing.context import TraceContext
+
+        TraceContext.set_propagated_headers(
+            {
+                "x-mesh-job-id": "job-1",
+                "x-mesh-recv-cursor": json.dumps({"work": 5}),
+            }
+        )
+        merged = self._merged()
+        assert "x-mesh-recv-cursor" not in merged
+        # Contextvar still carries the cursor for the claim→handler read.
+        _jid, _dl, _ep, recv = _read_job_headers()
+        assert recv == {"work": 5}

--- a/src/runtime/typescript/src/__tests__/agent-add-tool.spec.ts
+++ b/src/runtime/typescript/src/__tests__/agent-add-tool.spec.ts
@@ -643,3 +643,61 @@ describe("addTool — #925 wrappedExecute return shape (no structuredContent)", 
     });
   });
 });
+
+describe("addTool — resumeCursor validation (issue #1277)", () => {
+  function newAgent(): MeshAgent {
+    return new MeshAgent(makeFastMCPStub(), {
+      name: "test-agent",
+      httpPort: 0,
+    });
+  }
+
+  it("rejects resumeCursor: true without task: true", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "resume-no-task",
+        parameters: z.object({}),
+        resumeCursor: true,
+        execute: async () => "x",
+      }),
+    ).toThrow(/resumeCursor is only valid with task: true/);
+  });
+
+  it("accepts resumeCursor: true with task: true", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "resume-with-task",
+        task: true,
+        parameters: z.object({}),
+        resumeCursor: true,
+        execute: async () => "x",
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts resumeCursor: false with a synchronous tool (default posture)", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "resume-false-sync",
+        parameters: z.object({}),
+        resumeCursor: false,
+        execute: async () => "x",
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts task: true tools that omit resumeCursor (no change to default)", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "task-no-resume",
+        task: true,
+        parameters: z.object({}),
+        execute: async () => "x",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/runtime/typescript/src/__tests__/claim-dispatcher-resume-cursor.test.ts
+++ b/src/runtime/typescript/src/__tests__/claim-dispatcher-resume-cursor.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Issue #1277 (Wave 2b): TypeScript `resumeCursor` opt-in gate.
+ *
+ * The claim dispatcher seeds a reclaimed `JobController` from the claim
+ * response's persisted `recv_cursor` map ONLY when the tool opted in
+ * (`resumeCursor: true`) AND the registry returned a usable, non-empty
+ * cursor. Otherwise it passes `undefined` ⇒ replay-from-0 (the Wave 1/2a
+ * default posture).
+ *
+ * These tests exercise the GATE by spying on `makeJobController` — no live
+ * native controller is needed. We assert the dispatcher forwards the claimed
+ * `recv_cursor` as the 5th (`initialCursors`) constructor arg when opted in,
+ * and `undefined` when the flag is off or the cursor is absent/malformed.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Capture makeJobController call args per-test. The controller shape only
+// needs the methods `_dispatch` touches on the happy path (none, since
+// runWithJobContext is a pass-through and the handler resolves).
+//
+// `vi.hoisted` so the spy exists when the (hoisted) vi.mock factory runs.
+const { makeJobControllerMock } = vi.hoisted(() => ({
+  makeJobControllerMock: vi.fn((..._args: unknown[]) => ({
+    releaseLease: vi.fn(async () => {}),
+    fail: vi.fn(async () => {}),
+    isTerminal: vi.fn(async () => false),
+    complete: vi.fn(async () => {}),
+  })),
+}));
+
+vi.mock("../inbound-job-dispatch.js", () => ({
+  makeJobController: makeJobControllerMock,
+  // Pass-through: run the thunk so the handler executes.
+  runWithJobContext: vi.fn(
+    async (
+      _jobId: string | null,
+      _dl: number | null,
+      _controller: unknown,
+      invoke: () => Promise<unknown>,
+    ) => invoke(),
+  ),
+}));
+
+vi.mock("../proxy.js", () => ({
+  runWithPropagatedHeaders: (_headers: unknown, fn: () => unknown) => fn(),
+}));
+
+import { ClaimDispatcher, normalizeRecvCursor } from "../claim-dispatcher.js";
+
+function makeDispatcher(resumeCursor?: boolean): ClaimDispatcher {
+  return new ClaimDispatcher(
+    "test_cap",
+    "test-instance",
+    "http://registry:8000",
+    async () => "ok",
+    undefined,
+    undefined,
+    resumeCursor,
+  );
+}
+
+// The 5th positional arg to makeJobController is `initialCursors`.
+function initialCursorsArg(): unknown {
+  expect(makeJobControllerMock).toHaveBeenCalledTimes(1);
+  return makeJobControllerMock.mock.calls[0][4];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resumeCursor gate (issue #1277)", () => {
+  it("resumeCursor:true + recv_cursor present → seeds initialCursors", async () => {
+    const d = makeDispatcher(true);
+    const cursor = { "default": 7, "answers": 3 };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (d as any)._dispatch({
+      id: "job-1",
+      submitted_payload: {},
+      recv_cursor: cursor,
+    });
+
+    expect(initialCursorsArg()).toEqual(cursor);
+  });
+
+  it("resumeCursor:false (default) + recv_cursor present → no initialCursors", async () => {
+    const d = makeDispatcher(false);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (d as any)._dispatch({
+      id: "job-2",
+      submitted_payload: {},
+      recv_cursor: { "default": 5 },
+    });
+
+    expect(initialCursorsArg()).toBeUndefined();
+  });
+
+  it("resumeCursor default undefined + recv_cursor present → no initialCursors", async () => {
+    const d = makeDispatcher(); // flag omitted entirely
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (d as any)._dispatch({
+      id: "job-2b",
+      submitted_payload: {},
+      recv_cursor: { "default": 5 },
+    });
+
+    expect(initialCursorsArg()).toBeUndefined();
+  });
+
+  it("resumeCursor:true + no recv_cursor → no initialCursors (replay-from-0)", async () => {
+    const d = makeDispatcher(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (d as any)._dispatch({ id: "job-3", submitted_payload: {} });
+
+    expect(initialCursorsArg()).toBeUndefined();
+  });
+
+  it("resumeCursor:true + empty recv_cursor {} → no initialCursors", async () => {
+    const d = makeDispatcher(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (d as any)._dispatch({
+      id: "job-4",
+      submitted_payload: {},
+      recv_cursor: {},
+    });
+
+    expect(initialCursorsArg()).toBeUndefined();
+  });
+
+  it("resumeCursor:true + malformed recv_cursor → treated as absent, never throws", async () => {
+    const d = makeDispatcher(true);
+
+    // Non-object cursor value; the gate must degrade to replay, not throw.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (d as any)._dispatch({
+      id: "job-5",
+      submitted_payload: {},
+      recv_cursor: "not-an-object",
+    });
+
+    expect(initialCursorsArg()).toBeUndefined();
+  });
+
+  it("resumeCursor:true + partially-junk recv_cursor → keeps only valid seqs", async () => {
+    const d = makeDispatcher(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (d as any)._dispatch({
+      id: "job-6",
+      submitted_payload: {},
+      recv_cursor: { good: 4, negative: -1, frac: 2.5, str: "x", nul: null },
+    });
+
+    expect(initialCursorsArg()).toEqual({ good: 4 });
+  });
+});
+
+describe("normalizeRecvCursor (fail-safe helper)", () => {
+  it("returns undefined for absent / null / non-object / array inputs", () => {
+    expect(normalizeRecvCursor(undefined)).toBeUndefined();
+    expect(normalizeRecvCursor(null)).toBeUndefined();
+    expect(normalizeRecvCursor("nope")).toBeUndefined();
+    expect(normalizeRecvCursor(42)).toBeUndefined();
+    expect(normalizeRecvCursor([1, 2, 3])).toBeUndefined();
+  });
+
+  it("returns undefined for empty or all-invalid maps", () => {
+    expect(normalizeRecvCursor({})).toBeUndefined();
+    expect(normalizeRecvCursor({ a: -1, b: 1.5, c: "x" })).toBeUndefined();
+  });
+
+  it("keeps only non-negative integer seqs", () => {
+    expect(normalizeRecvCursor({ a: 0, b: 9, c: -2, d: 3.3 })).toEqual({
+      a: 0,
+      b: 9,
+    });
+  });
+
+  it("shared cross-runtime mixed-map → only {a:4} survives", () => {
+    // Identical mix asserted in the Python and Java suites: a non-negative
+    // int survives; negative, fractional, and non-number values are dropped.
+    expect(normalizeRecvCursor({ a: 4, b: -1, c: 2.5, d: "x" })).toEqual({
+      a: 4,
+    });
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -291,6 +291,13 @@ export class MeshAgent {
       handler: ClaimHandler;
       retryOn?: ReadonlyArray<new (...args: unknown[]) => Error>;
       requiredProbe?: () => string | null;
+      /**
+       * Issue #1277: opt-in durable-cursor resume. When true, the
+       * ClaimDispatcher seeds the reclaimed controller from the claim
+       * response's `recv_cursor` so `recvEvent` resumes instead of
+       * replaying from seq 0. Default false/undefined (replay-from-0).
+       */
+      resumeCursor?: boolean;
     }
   > = new Map();
   /**
@@ -535,6 +542,18 @@ export class MeshAgent {
       }
     }
 
+    // Issue #1277: validate resumeCursor at registration so misuse fails loud
+    // before the agent talks to the registry. Mirrors the retryOn check:
+    // resumeCursor requires task: true — only job-bound handlers have a
+    // controller (and a per-filter recvEvent cursor) to resume, so the flag
+    // is meaningless for synchronous tools.
+    if (def.resumeCursor === true && def.task !== true) {
+      throw new Error(
+        `addTool({ resumeCursor }) for tool '${toolName}': resumeCursor is ` +
+          `only valid with task: true; remove resumeCursor or set task: true.`,
+      );
+    }
+
     // Issue #917: validate a2aConfig at registration time so misuse fails
     // loud BEFORE the agent talks to the registry. Match the Python
     // `mesh.a2a_consumer` and Java `@A2AConsumer` startup-time checks.
@@ -671,6 +690,10 @@ export class MeshAgent {
     // registered in this.taskHandlers). Captured here so the closure
     // sees a stable reference even if def is mutated post-registration.
     const retryOn = def.retryOn;
+    // Issue #1277: per-tool durable-cursor resume opt-in. Captured here so
+    // the ClaimHandler registration below carries it into the dispatcher
+    // (which seeds the reclaimed controller from the claim's recv_cursor).
+    const resumeCursor = def.resumeCursor === true;
 
     // Phase 1 MeshJob substrate: when a job-bound tool exists AND the
     // user explicitly opted into worker isolation via env, log a single
@@ -1196,7 +1219,12 @@ export class MeshAgent {
               return null;
             }
           : undefined;
-      this._taskHandlers.set(capability, { handler, retryOn, requiredProbe });
+      this._taskHandlers.set(capability, {
+        handler,
+        retryOn,
+        requiredProbe,
+        resumeCursor,
+      });
     }
 
     // Store mesh metadata with JSON Schema for LLM tool resolution
@@ -1913,6 +1941,7 @@ export class MeshAgent {
         entry.handler,
         entry.retryOn,
         entry.requiredProbe,
+        entry.resumeCursor,
       );
       dispatcher.start();
       this._claimDispatchers.push(dispatcher);

--- a/src/runtime/typescript/src/claim-dispatcher.ts
+++ b/src/runtime/typescript/src/claim-dispatcher.ts
@@ -55,6 +55,39 @@ const _STOP_DRAIN_TIMEOUT_MS = 30_000;
 const _STOP_BUDGET_GRACE_MS = 10_000;
 
 /**
+ * Issue #1277: validate + normalize a claim response's `recv_cursor` into a
+ * `Record<string, number>` suitable for seeding a reclaimed `JobController`.
+ *
+ * The claim response is read untyped, so `recv_cursor` may be absent, null, a
+ * non-object, or an object with junk values. This coerces it to a clean map of
+ * `{ <filter-key>: <seq> }` where every seq is a non-negative integer, and
+ * returns `undefined` when there is nothing usable to resume from. Callers pass
+ * the result straight to `makeJobController` — `undefined` ⇒ replay-from-0.
+ *
+ * Fail-safe by contract: never throws. A malformed/empty cursor is treated as
+ * absent (replay), matching the "opting in never breaks a job that has no
+ * persisted cursor" guarantee.
+ */
+export function normalizeRecvCursor(
+  raw: unknown,
+): Record<string, number> | undefined {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+  const out: Record<string, number> = {};
+  let count = 0;
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (
+      typeof value === "number" &&
+      Number.isInteger(value) &&
+      value >= 0
+    ) {
+      out[key] = value;
+      count += 1;
+    }
+  }
+  return count > 0 ? out : undefined;
+}
+
+/**
  * Handler signature: the user's `task=true` execute function as
  * registered via `agent.addTool({ task: true, execute: ... })`. The
  * dispatcher invokes it with the claimed payload as args + the
@@ -98,6 +131,15 @@ export class ClaimDispatcher {
    * `undefined` (no required deps) disables the gate entirely.
    */
   private readonly requiredProbe?: () => string | null;
+  /**
+   * Issue #1277: durable-cursor resume opt-in for this capability's tool.
+   * When true AND the claim response carries a non-empty `recv_cursor` map,
+   * `_dispatch` seeds the reclaimed `JobController` from that map so a
+   * handler blocked in `recvEvent` resumes at the next unconsumed seq instead
+   * of replaying the event log from 0. Default false ⇒ replay-from-0 (the
+   * Wave 1/2a posture — resume gated OFF for TS).
+   */
+  private readonly resumeCursor: boolean;
   /**
    * Transition-edge state for the required-dep gate (issue #1268): the
    * capability we're currently gated on, or `null` when the gate is open.
@@ -152,6 +194,7 @@ export class ClaimDispatcher {
     handler: ClaimHandler,
     retryOn?: ReadonlyArray<new (...args: unknown[]) => Error>,
     requiredProbe?: () => string | null,
+    resumeCursor?: boolean,
   ) {
     this.capability = capability;
     this.instanceId = instanceId;
@@ -159,6 +202,7 @@ export class ClaimDispatcher {
     this.handler = handler;
     this.retryOn = retryOn;
     this.requiredProbe = requiredProbe;
+    this.resumeCursor = resumeCursor === true;
   }
 
   /** Spawn the polling loop. Idempotent. */
@@ -425,6 +469,17 @@ export class ClaimDispatcher {
         ? rawEpoch
         : null;
 
+    // Issue #1277: durable-cursor resume gate. Seed the reclaimed controller
+    // from the claim's persisted per-filter `recv_cursor` ONLY when this tool
+    // opted in (`resumeCursor: true`) AND the registry returned a usable,
+    // non-empty cursor map. Otherwise pass `undefined` ⇒ replay-from-0 (the
+    // default, and the only path when resume is off / cursor absent / cursor
+    // malformed). Fail-safe: never throw here — a bad cursor degrades to
+    // replay, it does not fail the dispatch.
+    const initialCursors = this.resumeCursor
+      ? normalizeRecvCursor(claimed.recv_cursor)
+      : undefined;
+
     let controller: JobController;
     try {
       controller = makeJobController(
@@ -432,6 +487,7 @@ export class ClaimDispatcher {
         this.instanceId,
         this.registryUrl,
         claimEpoch,
+        initialCursors,
       );
     } catch (err) {
       console.warn(

--- a/src/runtime/typescript/src/inbound-job-dispatch.ts
+++ b/src/runtime/typescript/src/inbound-job-dispatch.ts
@@ -331,15 +331,23 @@ export function makeJobController(
   instanceId: string,
   registryUrl: string,
   claimEpoch?: number | null,
+  initialCursors?: Record<string, number> | null,
 ): JobController {
   // `claimEpoch` undefined/null (push-mode inbound job / old registry) ⇒
   // legacy owner-only fencing; on the claim path the dispatcher passes the
   // epoch from the /jobs/claim response so this execution is fenced (#1252).
+  //
+  // `initialCursors` undefined/null (default; push-mode inbound job, or a
+  // claim without resumeCursor opt-in) ⇒ replay-from-0. When the claim
+  // dispatcher opts in (issue #1277) it forwards the claim's per-filter
+  // `recv_cursor` map so the reclaimed controller resumes `recvEvent` at the
+  // next unconsumed seq instead of replaying the event log.
   return new JobController(
     jobId,
     instanceId,
     registryUrl,
     claimEpoch ?? undefined,
+    initialCursors ?? undefined,
   );
 }
 

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -509,6 +509,30 @@ export interface MeshToolDef<T extends z.ZodType = z.ZodType> {
    */
   retryOn?: Array<new (...args: unknown[]) => Error>;
   /**
+   * Issue #1277: opt into durable `recvEvent` cursor resume on re-claim.
+   *
+   * By default a re-claimed `task: true` job builds a fresh `JobController`
+   * that replays this job's event log from seq 0 — a handler blocked in
+   * `job.recvEvent(...)` would re-observe events it already consumed before
+   * the previous owner crashed. When `true`, the claim dispatcher seeds the
+   * reclaimed controller from the persisted per-filter `recv_cursor` map the
+   * registry returns on the `/jobs/claim` response, so `recvEvent` resumes at
+   * the next unconsumed seq instead of replaying.
+   *
+   * Constraints (validated at `addTool` time):
+   *
+   *   - requires `task: true` (only job-bound handlers have a controller /
+   *     an event cursor to resume; the flag is meaningless for synchronous
+   *     tools).
+   *
+   * Fail-safe: if the claim response carries no `recv_cursor` (old registry,
+   * first claim) the controller still replays from 0 — opting in never breaks
+   * a job that has no persisted cursor.
+   *
+   * Default: `false`/`undefined` (replay-from-0, existing behaviour).
+   */
+  resumeCursor?: boolean;
+  /**
    * Dependencies required by this tool.
    * Injected positionally as McpMeshTool params after args.
    *


### PR DESCRIPTION
Wave 2 of #1277 — turns on durable `recvEvent` resume. **References #1277; does not close it** (user docs + a reclaim-resume integration UC are wave 3).

## What this does

Wave 1 (merged) built the persist + seed core with resume gated off. Wave 2 adds the `resume_cursor` tool opt-in and wires it to the seed: when a `task` tool opts in **and** the claim response carries a usable `recv_cursor`, the reclaimed `JobController` is seeded from it so `recvEvent` resumes at the next unconsumed seq instead of replaying from 0. **Default stays replay-from-0** — opting in is the only thing that changes behavior.

## Design (identical semantics in all three runtimes)

- **Bindings widened** so the SDK can pass the persisted cursor map: `PyJobController(..., initial_cursors=None)`; `JsJobController` trailing `initialCursors?`; a new FFI `mesh_job_controller_new_with_resume(..., recv_cursor_json)` (legacy entry points unchanged, pass `None`); `claim_worker` gains a `resume_cursor` config (default false, Rust-native path unchanged).
- **Opt-in, gated on `task=true`**: `@mesh.tool(resume_cursor=True)` / `MeshToolDef.resumeCursor` / `@MeshTool(resumeCursor=true)`. A non-task tool errors at declaration in every runtime.
- **Gate**: seed only when opted in AND a non-empty `recv_cursor` is present; otherwise replay-from-0.
- **Python propagation**: its claim→handler hop can't carry a *map* on the scalar-header path, so the cursor rides an `x-mesh-recv-cursor` JSON header on the trace contextvar — and is scrubbed from **outbound** propagation (it's claim-local; the `x-mesh-job-id`/`x-mesh-claim-epoch` calling-job-identity headers are untouched).
- **Fail-safe + parity**: all three cursor normalizers accept **only** non-negative-integer values, drop everything else, treat an empty result as no-seed (with a working controller), and never throw in the dispatch path. Proven identical: `{a:4, b:-1, c:2.5, d:"x"} → {a:4}` in Python, TS, and Java.

## Review notes

Zero-context review of all three runtimes together: **0 BLOCKER, no skip/data-loss path** — the gate is correct everywhere and no runtime can produce a too-high seed. The fixes applied were fail-safe parity divergences (Python wasn't value-validating → a bad value lost the controller; Java truncated fractions / kept negatives) converged to one contract, plus the outbound-header scrub.

Behavioral contract (documented in code; user-facing docs are wave 3): durable resume requires **sequential-per-filter** consumption — a handler that prefetches or consumes a filter's events concurrently must not opt in.

## Test plan

- [x] Rust `cargo test --lib` 489; `cargo check --workspace --all-targets` clean (cdylib link step is the known pyo3 `extension-module` environmental non-issue)
- [x] Python full unit suite (29 resume-cursor tests: gate ×4, value-filter, mixed-map, malformed-value-still-builds-controller, outbound scrub)
- [x] TS `npm test` 1101; typecheck clean both variants
- [x] Java `mvn test` — SDK 108/0; the one starter failure (`springConfigBeanProxyDivergesFromTarget`, a #1141 CGLIB-proxy test in a different module) is a pre-existing suite-ordering flake that passes in isolation — unrelated to this change
- [ ] Real native resume end-to-end is proven by the wave-3 integration UC (the committed `.node`/`.so`/JNI artifacts predate wave 2a; unit tests mock at the controller boundary)

Part of #1277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ