### PR TITLE
feat(di): typed supersession signal for fenced downstream writes

### DIFF
--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -556,6 +556,84 @@ a caller on an older SDK, and — critically — inside a handler that was
 not here); the epoch is `null` for a push-mode inbound job. Reading them is
 purely additive and read-only.
 
+**Typed supersession signal.** Stamping the caller's epoch lets a provider
+*dedupe* a superseded write after the fact. When the provider is a **state
+authority** that must *reject* the stale write outright, it compares the
+caller's epoch against its own live/expected epoch and raises a typed error.
+The framework does **not** auto-detect supersession — the app owns the "is
+this caller stale?" decision (it holds the authoritative epoch); the
+framework only carries the typed signal end to end. The provider raises
+`mesh.SupersededError` (Python), throws `MeshSupersededError` (TypeScript,
+package root), or throws `MeshSupersededException` (Java, `io.mcpmesh.types`):
+
+<!-- markdownlint-disable MD046 -->
+=== "Python"
+
+    ```python
+    import mesh
+
+    @app.tool()
+    @mesh.tool(capability="record_charge")
+    async def record_charge(order_id: str, amount: float) -> dict:
+        caller = mesh.calling_job()          # CallingJob(job_id, claim_epoch) | None
+        live = await ledger.live_epoch(order_id)   # the app's authoritative epoch
+        if caller and caller.claim_epoch is not None and caller.claim_epoch < live:
+            raise mesh.SupersededError(f"stale epoch {caller.claim_epoch}")
+        await ledger.upsert(key=order_id, amount=amount)
+        return {"order_id": order_id}
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { callingJob, MeshSupersededError } from "@mcpmesh/sdk";
+
+    // inside agent.addTool({ ..., execute: async ({ order_id, amount }) => {
+    const caller = callingJob();          // { jobId, claimEpoch } | null
+    const live = await ledger.liveEpoch(order_id);
+    if (caller && caller.claimEpoch != null && caller.claimEpoch < live) {
+      throw new MeshSupersededError(`stale epoch ${caller.claimEpoch}`);
+    }
+    await ledger.upsert({ key: order_id, amount });
+    return { order_id };
+    ```
+
+=== "Java"
+
+    ```java
+    import io.mcpmesh.spring.MeshCallContext;
+    import io.mcpmesh.spring.MeshCallContext.CallingJob;
+    import io.mcpmesh.types.MeshSupersededException;
+
+    @MeshTool(capability = "record_charge")
+    public Map<String, Object> recordCharge(
+        @Param("order_id") String orderId,
+        @Param("amount") double amount) {
+      CallingJob caller = MeshCallContext.callingJob();   // never null; fields nullable
+      long live = ledger.liveEpoch(orderId);
+      if (caller.isPresent() && caller.claimEpoch() != null && caller.claimEpoch() < live) {
+        throw new MeshSupersededException("stale epoch " + caller.claimEpoch());
+      }
+      ledger.upsert(orderId, amount);
+      return Map.of("order_id", orderId);
+    }
+    ```
+<!-- markdownlint-enable MD046 -->
+
+The signal crosses the wire as a reserved `{"error":"claim_superseded"}` app
+envelope — the same `claim_superseded` vocabulary the registry uses to fence
+job writes. On the **calling** side the injected mesh proxy recognizes that
+envelope and re-raises the same typed error, so a superseded executor unwinds
+with **one** catch (`except mesh.SupersededError` / `if (e instanceof
+MeshSupersededError)` / `catch (MeshSupersededException e)`) instead of
+string-matching an error marker after every mutating call. It is distinct
+from a generic tool failure and from the `dependency_unavailable` refusal (an
+unresolved required dep) — it means specifically *you are running under a
+superseded claim*. It does **not** change delivery: jobs remain
+**at-least-once** and a fenced re-execution still runs under the new claim;
+the typed signal only lets the stale attempt bow out on its first rejected
+write rather than every downstream provider re-checking a string marker.
+
 The **agent runtime** is a thin client. On the producer side, it
 maintains a claim queue per `task=true` capability (`UPDATE jobs SET
 owner_instance_id = $self WHERE capability = $cap AND status =

--- a/examples/jobs-java/README.md
+++ b/examples/jobs-java/README.md
@@ -177,6 +177,50 @@ not double-applied. Two rules the handler must honor to opt in safely:
 Drive it exactly like the base task, targeting the `resumable_event_task`
 capability instead.
 
+## Typed supersession signal (`MeshSupersededException`, issue #1278)
+
+`superseded-provider-java/` + `superseded-consumer-java/` port the calling-job
+fencing pattern to Java. A `task = true` writer job makes mutating downstream
+calls; when it is superseded, the provider fences its writes and the consumer
+unwinds with ONE `catch (MeshSupersededException)`.
+
+Three moving parts:
+
+1. **Calling-job identity is the decision input (#1263).** A `task = true`
+   handler runs *as* a job, so every outbound mesh call carries its identity on
+   the `x-mesh-calling-*` headers. The provider reads it with
+   `MeshCallContext.callingJob()` → `CallingJob(jobId, claimEpoch)`.
+2. **The app decides supersession; the framework does not.** `applyWrite`
+   remembers the highest `claimEpoch` accepted per `jobId` and rejects any call
+   whose epoch is lower.
+3. **The typed error is the one-catch unwind (#1278).** The provider rejects
+   with `throw new MeshSupersededException(detail)` — on the wire the reserved
+   `{"error":"claim_superseded","detail":...}` envelope. The caller's injected
+   proxy re-throws `MeshSupersededException`, so the consumer wraps its whole
+   write batch in ONE `catch (MeshSupersededException e)` instead of
+   string-matching the marker after every call.
+
+Distinct from `dependency_unavailable` (#1273): that means "capability
+unreachable"; supersession means "you personally are stale". Both are typed so
+the contract (the reserved envelope), not the error string, drives
+classification.
+
+```bash
+# Build the SDK first if you haven't: (cd src/runtime/java && mvn install -DskipTests)
+
+# Terminal 2 — provider (port 9124)
+cd examples/jobs-java/superseded-provider-java
+MCP_MESH_REGISTRY_URL=http://localhost:8000 mvn spring-boot:run
+
+# Terminal 3 — consumer (port 9125)
+cd examples/jobs-java/superseded-consumer-java
+MCP_MESH_REGISTRY_URL=http://localhost:8000 mvn spring-boot:run
+```
+
+Then `meshctl call superseded-consumer-java run_writer --arg count=3`. See the
+Python tree's README (`../jobs/README.md#typed-supersession-signal-supersedederror-issue-1278`)
+for the full conceptual treatment.
+
 ## What's NOT in v2.2 yet
 
 - Idempotency keys for retries (future).

--- a/examples/jobs-java/README.md
+++ b/examples/jobs-java/README.md
@@ -217,7 +217,7 @@ cd examples/jobs-java/superseded-consumer-java
 MCP_MESH_REGISTRY_URL=http://localhost:8000 mvn spring-boot:run
 ```
 
-Then `meshctl call superseded-consumer-java run_writer --arg count=3`. See the
+Then `meshctl call superseded-consumer-java run_writer '{"count": 3}'`. See the
 Python tree's README (`../jobs/README.md#typed-supersession-signal-supersedederror-issue-1278`)
 for the full conceptual treatment.
 

--- a/examples/jobs-java/superseded-consumer-java/pom.xml
+++ b/examples/jobs-java/superseded-consumer-java/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>superseded-consumer-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Supersession Writer Job (Java)</name>
+    <description>Issue #1278 example — task=true writer that unwinds superseded writes with one catch</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.8.2</mcp-mesh.version>
+    </properties>
+
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.supersededconsumer.SupersededConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/jobs-java/superseded-consumer-java/pom.xml
+++ b/examples/jobs-java/superseded-consumer-java/pom.xml
@@ -25,8 +25,8 @@
     </properties>
 
     <!--
-      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
-      published to Maven Central. Build them first via:
+      Depends on local mcp-mesh-* artifacts which carry the typed supersession
+      surfaces (#1278) and are not published to Maven Central. Build them first via:
           cd src/runtime/java && mvn install -DskipTests
       Maven and IDEs then resolve them from your local ~/.m2/repository.
     -->

--- a/examples/jobs-java/superseded-consumer-java/src/main/java/com/example/supersededconsumer/SupersededConsumerApplication.java
+++ b/examples/jobs-java/superseded-consumer-java/src/main/java/com/example/supersededconsumer/SupersededConsumerApplication.java
@@ -1,0 +1,139 @@
+package com.example.supersededconsumer;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+import io.mcpmesh.types.McpMeshTool;
+import io.mcpmesh.types.MeshSupersededException;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Typed supersession signal (issue #1278) — Java Consumer: a job executor whose
+ * mutating writes unwind with ONE {@code catch (MeshSupersededException)}.
+ *
+ * <p>This is the consumer half of the fencing pattern. {@code runWriter} is a
+ * {@code task = true} handler — it executes AS a job, so it runs under a
+ * {@code claimEpoch}. Every outbound mesh call it makes (here to the provider's
+ * {@code apply_write}) automatically carries this job's identity on the
+ * propagated headers, so the provider can fence it via
+ * {@code MeshCallContext.callingJob()} without the executor threading
+ * {@code jobId} / {@code claimEpoch} through each payload.
+ *
+ * <p>The point of #1278 is the UNWIND. A job executor makes many mutating
+ * downstream calls; if this executor has been superseded (a newer claim of the
+ * same job is now authoritative) it must stop and bail — cleanly, from wherever
+ * it is in the batch. Because a superseded write re-throws the TYPED
+ * {@link MeshSupersededException}, the whole batch is wrapped in ONE
+ * {@code catch}:
+ * <pre>{@code
+ * try {
+ *     for (String entry : entries) {
+ *         applyWrite.call(Map.of("entry", entry));   // any of these may be fenced
+ *     }
+ * } catch (MeshSupersededException e) {
+ *     return Map.of("status", "superseded", "detail", e.getDetail());  // one unwind
+ * }
+ * }</pre>
+ *
+ * <p>Contrast the OLD pattern this REPLACES — inspecting every call's result and
+ * string-matching the marker after each one:
+ * <pre>{@code
+ * for (String entry : entries) {
+ *     Map<String, Object> r = applyWrite.call(Map.of("entry", entry));
+ *     // brittle: re-check the shape/marker on EVERY call site
+ *     if ("claim_superseded".equals(r.get("error"))) return supersededResult();
+ * }
+ * }</pre>
+ *
+ * <p>Note this is DISTINCT from {@code dependency_unavailable} (issue #1273):
+ * that says "the capability isn't reachable"; supersession says "you personally
+ * are stale, a newer you is authoritative". Both are typed so the CONTRACT (the
+ * reserved envelope), not the error string, drives classification.
+ *
+ * <p>Run after the provider is up:
+ * <pre>
+ * MCP_MESH_REGISTRY_URL=http://localhost:8000 mvn spring-boot:run
+ * </pre>
+ */
+@MeshAgent(
+    name = "superseded-consumer-java",
+    version = "1.0.0",
+    description = "Issue #1278 consumer (Java) — a task=true writer job that "
+        + "unwinds mutating writes with one catch (MeshSupersededException)",
+    port = 9125
+)
+@SpringBootApplication
+public class SupersededConsumerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SupersededConsumerApplication.class, args);
+    }
+
+    @MeshTool(
+        capability = "run_writer",
+        // task = true: this handler is dispatched AS a job (claimed from the
+        // registry), so it runs under a claimEpoch that the mesh stamps onto
+        // the calling-job headers of the applyWrite.call below.
+        task = true,
+        description = "Run a batch of ledger writes as a job. If this executor "
+            + "is superseded mid-batch, unwind cleanly with one "
+            + "catch (MeshSupersededException).",
+        // Regular McpMeshTool dependency on the provider's mutating capability.
+        // (A dependency, NOT a MeshJobSubmitter — apply_write is a plain tool.)
+        dependencies = @Selector(capability = "apply_write")
+    )
+    public Map<String, Object> runWriter(
+            @Param(value = "count", required = false) Integer count,
+            // Injected by type: the apply_write McpMeshTool proxy.
+            McpMeshTool<Map<String, Object>> applyWrite,
+            // Injected by type: the controller for THIS job (its own identity /
+            // claimEpoch live here; the provider sees it via callingJob()).
+            MeshJob job) {
+
+        if (applyWrite == null) {
+            Map<String, Object> err = new LinkedHashMap<>();
+            err.put("error", "apply_write not injected — check that the "
+                + "superseded-provider-java is registered");
+            return err;
+        }
+
+        int n = (count == null) ? 3 : count;
+        List<String> written = new ArrayList<>();
+        try {
+            for (int i = 0; i < n; i++) {
+                String entry = "line-" + i;
+                // Any of these calls may be fenced by the provider. If this
+                // executor has been superseded, the provider throws
+                // MeshSupersededException; the injected proxy recognizes the
+                // reserved envelope and re-throws MeshSupersededException here
+                // — so we do NOT inspect each result for a marker.
+                applyWrite.call(Map.of("entry", entry));
+                written.add(entry);
+            }
+        } catch (MeshSupersededException e) {
+            // ONE unwind for the whole batch. A newer claim of this job is
+            // authoritative — stop writing and hand back what we managed before
+            // being fenced. No rollback needed: the provider already rejected
+            // the stale write, so the ledger reflects only the authoritative
+            // executor.
+            Map<String, Object> out = new LinkedHashMap<>();
+            out.put("status", "superseded");
+            out.put("written_before_fence", written);
+            out.put("detail", e.getDetail());
+            return out;
+        }
+
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("status", "completed");
+        out.put("written", written);
+        return out;
+    }
+}

--- a/examples/jobs-java/superseded-provider-java/pom.xml
+++ b/examples/jobs-java/superseded-provider-java/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>superseded-provider-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Supersession Write Authority (Java)</name>
+    <description>Issue #1278 example — provider that fences superseded executors via calling-job epoch</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.8.2</mcp-mesh.version>
+    </properties>
+
+    <!--
+      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
+      published to Maven Central. Build them first via:
+          cd src/runtime/java && mvn install -DskipTests
+      Maven and IDEs then resolve them from your local ~/.m2/repository.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.supersededprovider.SupersededProviderApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/jobs-java/superseded-provider-java/pom.xml
+++ b/examples/jobs-java/superseded-provider-java/pom.xml
@@ -25,8 +25,8 @@
     </properties>
 
     <!--
-      Depends on local mcp-mesh-* artifacts at version 1.4.1+ which are not
-      published to Maven Central. Build them first via:
+      Depends on local mcp-mesh-* artifacts which carry the typed supersession
+      surfaces (#1278) and are not published to Maven Central. Build them first via:
           cd src/runtime/java && mvn install -DskipTests
       Maven and IDEs then resolve them from your local ~/.m2/repository.
     -->

--- a/examples/jobs-java/superseded-provider-java/src/main/java/com/example/supersededprovider/SupersededProviderApplication.java
+++ b/examples/jobs-java/superseded-provider-java/src/main/java/com/example/supersededprovider/SupersededProviderApplication.java
@@ -101,7 +101,7 @@ public class SupersededProviderApplication {
             row.put("entry", entry);
             row.put("byEpoch", null);
             ledger.add(row);
-            return result(false, null);
+            return result(null);
         }
 
         long callerEpoch = cj.claimEpoch();
@@ -124,14 +124,13 @@ public class SupersededProviderApplication {
         row.put("entry", entry);
         row.put("byEpoch", callerEpoch);
         ledger.add(row);
-        return result(false, callerEpoch);
+        return result(callerEpoch);
     }
 
-    private Map<String, Object> result(boolean fenced, Long acceptedEpoch) {
+    private Map<String, Object> result(Long acceptedEpoch) {
         Map<String, Object> out = new LinkedHashMap<>();
         out.put("applied", true);
         out.put("ledger_size", ledger.size());
-        out.put("fenced", fenced);
         if (acceptedEpoch != null) {
             out.put("accepted_epoch", acceptedEpoch);
         }

--- a/examples/jobs-java/superseded-provider-java/src/main/java/com/example/supersededprovider/SupersededProviderApplication.java
+++ b/examples/jobs-java/superseded-provider-java/src/main/java/com/example/supersededprovider/SupersededProviderApplication.java
@@ -1,0 +1,140 @@
+package com.example.supersededprovider;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.spring.MeshCallContext;
+import io.mcpmesh.types.MeshSupersededException;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Typed supersession signal (issue #1278) — Java Provider: a write authority
+ * that fences stale-executor writes.
+ *
+ * <p>This is the provider half of the calling-job fencing pattern. A state
+ * authority (here an in-memory ledger) accepts mutating writes from job
+ * executors. When a job is re-claimed after a crash/reclaim, a NEWER executor
+ * runs under a HIGHER {@code claimEpoch}; the OLD executor may still be
+ * mid-flight and try to write. Those stale writes must be rejected so the newer
+ * executor owns the outcome.
+ *
+ * <p>Two mesh surfaces make this a few lines:
+ * <pre>{@code
+ * // 1. Read WHO called me (issue #1263 — the calling job's identity).
+ * var cj = MeshCallContext.callingJob();     // fields nullable
+ *
+ * // 2. Reject a superseded caller with the TYPED signal (issue #1278).
+ * throw new MeshSupersededException(detail);
+ * }</pre>
+ *
+ * <p>The framework does NOT auto-detect supersession — the APP decides. The
+ * mesh only propagates the calling job's identity and provides the typed
+ * exception plus its emit/recognize plumbing. Here the "is superseded" rule is
+ * deliberately simple and deterministic for teaching: the authority remembers
+ * the highest {@code claimEpoch} it has seen per calling {@code jobId} and
+ * rejects any call whose epoch is lower — i.e. "an older executor is trying to
+ * write after a newer one already has".
+ *
+ * <p>{@link MeshSupersededException} crosses the wire as the reserved app
+ * envelope {@code {"error":"claim_superseded"}} (plus an optional
+ * {@code "detail"}). The calling side's injected proxy recognizes that envelope
+ * and re-throws {@code MeshSupersededException} — so the CONSUMER unwinds with
+ * ONE {@code catch (MeshSupersededException e)} (see
+ * {@code ../superseded-consumer-java}) instead of string-matching a marker
+ * after every call.
+ *
+ * <p>Run:
+ * <pre>
+ * MCP_MESH_REGISTRY_URL=http://localhost:8000 mvn spring-boot:run
+ * </pre>
+ */
+@MeshAgent(
+    name = "superseded-provider-java",
+    version = "1.0.0",
+    description = "Issue #1278 provider (Java) — write authority that fences "
+        + "superseded executors via calling-job epoch + typed MeshSupersededException",
+    port = 9124
+)
+@SpringBootApplication
+public class SupersededProviderApplication {
+
+    // Highest claimEpoch this authority has accepted a write under, per calling
+    // jobId. This is the APP's supersession state — the framework does not keep
+    // it. A ConcurrentHashMap because inbound tool calls may be served on
+    // different request threads; a multi-replica authority would keep this in a
+    // shared store (Redis, a DB version column, ...).
+    private final Map<String, Long> latestEpochByJob = new ConcurrentHashMap<>();
+
+    // The in-memory "ledger" we are protecting from stale writes.
+    private final List<Map<String, Object>> ledger = new ArrayList<>();
+
+    public static void main(String[] args) {
+        SpringApplication.run(SupersededProviderApplication.class, args);
+    }
+
+    @MeshTool(
+        capability = "apply_write",
+        description = "Apply a mutating write to the ledger, fencing out writes "
+            + "from a superseded (older-epoch) executor. Demonstrates "
+            + "calling-job fencing with the typed MeshSupersededException."
+    )
+    public synchronized Map<String, Object> applyWrite(@Param("entry") String entry) {
+        // The mutating payload (`entry`) is an ordinary tool argument. The
+        // caller's IDENTITY is NOT in the payload — it rides the propagated
+        // headers the mesh seeds on outbound calls made from within a job
+        // execution context, and we read it back via MeshCallContext.
+        MeshCallContext.CallingJob cj = MeshCallContext.callingJob();
+
+        // No calling-job identity → a regular (non-job) call, or a caller on an
+        // old SDK that does not propagate identity. Nothing to fence against;
+        // apply the write. (Fencing is defense-in-depth — soft-fail-open when
+        // identity is absent.)
+        if (!cj.isPresent() || cj.claimEpoch() == null) {
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("entry", entry);
+            row.put("byEpoch", null);
+            ledger.add(row);
+            return result(false, null);
+        }
+
+        long callerEpoch = cj.claimEpoch();
+        long seen = latestEpochByJob.getOrDefault(cj.jobId(), -1L);
+
+        if (callerEpoch < seen) {
+            // APP DECISION: a newer executor (epoch `seen`) has already written
+            // for this job, so this older executor's write is stale. Throw the
+            // typed signal — it serializes to the reserved
+            // {"error":"claim_superseded","detail":...} envelope, and the
+            // caller's injected proxy re-throws MeshSupersededException.
+            String detail = "job " + cj.jobId() + ": calling epoch " + callerEpoch
+                + " < latest accepted epoch " + seen;
+            throw new MeshSupersededException(detail);
+        }
+
+        // Caller is current (>= highest seen). Record its epoch and apply.
+        latestEpochByJob.put(cj.jobId(), Math.max(seen, callerEpoch));
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("entry", entry);
+        row.put("byEpoch", callerEpoch);
+        ledger.add(row);
+        return result(false, callerEpoch);
+    }
+
+    private Map<String, Object> result(boolean fenced, Long acceptedEpoch) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("applied", true);
+        out.put("ledger_size", ledger.size());
+        out.put("fenced", fenced);
+        if (acceptedEpoch != null) {
+            out.put("accepted_epoch", acceptedEpoch);
+        }
+        return out;
+    }
+}

--- a/examples/jobs-ts/README.md
+++ b/examples/jobs-ts/README.md
@@ -211,7 +211,7 @@ cd examples/jobs-ts/superseded-consumer-ts && npm install
 MCP_MESH_REGISTRY_URL=http://localhost:8000 npx tsx src/index.ts
 ```
 
-Then `meshctl call superseded-consumer-ts run_writer --arg count=3`. See the
+Then `meshctl call superseded-consumer-ts run_writer '{"count": 3}'`. See the
 Python tree's README (`../jobs/README.md#typed-supersession-signal-supersedederror-issue-1278`)
 for the full conceptual treatment.
 

--- a/examples/jobs-ts/README.md
+++ b/examples/jobs-ts/README.md
@@ -174,6 +174,47 @@ double-applied. Two rules the handler must honor to opt in safely:
 Drive it exactly like the base task, targeting the `resumable_event_task`
 capability instead.
 
+## Typed supersession signal (`MeshSupersededError`, issue #1278)
+
+`superseded-provider-ts/` + `superseded-consumer-ts/` port the calling-job
+fencing pattern to TypeScript. A `task: true` writer job makes mutating
+downstream calls; when it is superseded, the provider fences its writes and the
+consumer unwinds with ONE `instanceof MeshSupersededError`.
+
+Three moving parts:
+
+1. **Calling-job identity is the decision input (#1263).** A `task: true`
+   handler runs *as* a job, so every outbound mesh call carries its identity on
+   the `x-mesh-calling-*` headers. The provider reads it with `callingJob()` →
+   `CallingJob { jobId, claimEpoch }`.
+2. **The app decides supersession; the framework does not.** `apply_write`
+   remembers the highest `claimEpoch` accepted per `jobId` and rejects any call
+   whose epoch is lower.
+3. **The typed error is the one-catch unwind (#1278).** The provider rejects
+   with `throw new MeshSupersededError(detail)` — on the wire the reserved
+   `{"error":"claim_superseded","detail":...}` envelope. The caller's injected
+   proxy re-throws `MeshSupersededError`, so the consumer wraps its whole write
+   batch in ONE `catch (e) { if (e instanceof MeshSupersededError) ... }`
+   instead of string-matching the marker after every call.
+
+Distinct from `dependency_unavailable` (#1273): that means "capability
+unreachable"; supersession means "you personally are stale". Both are typed
+`UserError` subclasses so the contract, not the string, drives classification.
+
+```bash
+# Terminal 2 — provider (port 9114)
+cd examples/jobs-ts/superseded-provider-ts && npm install
+MCP_MESH_REGISTRY_URL=http://localhost:8000 npx tsx src/index.ts
+
+# Terminal 3 — consumer (port 9115)
+cd examples/jobs-ts/superseded-consumer-ts && npm install
+MCP_MESH_REGISTRY_URL=http://localhost:8000 npx tsx src/index.ts
+```
+
+Then `meshctl call superseded-consumer-ts run_writer --arg count=3`. See the
+Python tree's README (`../jobs/README.md#typed-supersession-signal-supersedederror-issue-1278`)
+for the full conceptual treatment.
+
 ## What's NOT in v2.2 yet
 
 - Idempotency keys for retries (future).

--- a/examples/jobs-ts/superseded-consumer-ts/package-lock.json
+++ b/examples/jobs-ts/superseded-consumer-ts/package-lock.json
@@ -1,0 +1,2870 @@
+{
+  "name": "superseded-consumer-ts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "superseded-consumer-ts",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mcpmesh/core": "file:../../../src/runtime/core/typescript",
+        "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+        "fastmcp": "^3.34.0",
+        "zod": "^3.24.2"
+      },
+      "devDependencies": {
+        "@types/node": "^22.18.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "../../../src/runtime/core/typescript": {
+      "name": "@mcpmesh/core",
+      "version": "2.8.2",
+      "license": "MIT",
+      "devDependencies": {
+        "@napi-rs/cli": "^3.5.1"
+      }
+    },
+    "../../../src/runtime/typescript": {
+      "name": "@mcpmesh/sdk",
+      "version": "2.8.2",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/google-vertex": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@mcpmesh/core": "file:../core/typescript",
+        "ai": "^6.0.0",
+        "fastmcp": "^4.3.2",
+        "handlebars": "^4.7.8",
+        "mcp-proxy": "6.4.4",
+        "undici": "^6.21.0",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.0",
+        "@types/express-v5": "npm:@types/express@^5.0.0",
+        "@types/node": "^22.0.0",
+        "express": "^4.18.0",
+        "express-v5": "npm:express@^5.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@mcpmesh/core": {
+      "resolved": "../../../src/runtime/core/typescript",
+      "link": true
+    },
+    "node_modules/@mcpmesh/sdk": {
+      "resolved": "../../../src/runtime/typescript",
+      "link": true
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastmcp": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.35.0.tgz",
+      "integrity": "sha512-bcyAaVa3Zw5f4xighGg6fNNgEzZoP6tX/O+ZfS2lIhbEULWe/zUWG533JyFEUOjZT7EB+tiZW1ot4eWKmYJ6DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.24.3",
+        "@standard-schema/spec": "^1.0.0",
+        "execa": "^9.6.1",
+        "file-type": "^21.1.1",
+        "fuse.js": "^7.1.0",
+        "hono": "^4.11.5",
+        "mcp-proxy": "^6.4.0",
+        "strict-event-emitter-types": "^2.0.0",
+        "undici": "^7.16.0",
+        "uri-templates": "^0.2.0",
+        "xsschema": "^0.4.3",
+        "yargs": "^18.0.0",
+        "zod": "^4.1.13",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "bin": {
+        "fastmcp": "dist/bin/fastmcp.js"
+      },
+      "peerDependencies": {
+        "jose": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fastmcp/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.2.tgz",
+      "integrity": "sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.28",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
+      "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-readable-ids": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/human-readable-ids/-/human-readable-ids-1.0.4.tgz",
+      "integrity": "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==",
+      "license": "Apache2",
+      "dependencies": {
+        "knuth-shuffle": "^1.0.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/knuth-shuffle": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle/-/knuth-shuffle-1.0.8.tgz",
+      "integrity": "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/koa": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.1.tgz",
+      "integrity": "sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa-router": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-14.0.0.tgz",
+      "integrity": "sha512-Ue8f/PRsLLNm6b7y+eS6xkqvsG2xH11d2VB1HPcfdfW6p5736kCHf2pXaq8q9XPQ01x0Dk7V/P5Il9pe+tGTxA==",
+      "deprecated": "Please use @koa/router instead, starting from v9! ",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^8.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/koa/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/koa/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-proxy": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.5.2.tgz",
+      "integrity": "sha512-3sE9kedh81dqqpObzO0nUf8aAyGnzLVDVH97GCLL3fXCBOkXDWZBts63u0bM5lT1Q4FKZY0+E91dZ7Chb2ybsA==",
+      "license": "MIT",
+      "dependencies": {
+        "pipenet": "^1.3.0"
+      },
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.mjs"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pipenet": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.2.tgz",
+      "integrity": "sha512-mPPqygXr7ccwImeaa8zReY9GubH/1r+kBNfqPVfKREQ1s8bKE3XlOqBMONxJAW4d3ZBNGzP9AZp9Axnhi5uOyw==",
+      "dependencies": {
+        "axios": "^1.7.3",
+        "debug": "^4.3.6",
+        "human-readable-ids": "^1.0.4",
+        "koa": "^3.1.1",
+        "koa-router": "^14.0.0",
+        "pump": "^3.0.3",
+        "tldjs": "^2.3.2",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "pipenet": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tldjs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.2.tgz",
+      "integrity": "sha512-EORDwFMSZKrHPUVDhejCMDeAovRS5d8jZKiqALFiPp3cjKjEldPkxBY39ZSx3c45awz3RpKwJD1cCgGxEfy8/A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-templates": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
+      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
+      "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xsschema": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/xsschema/-/xsschema-0.4.4.tgz",
+      "integrity": "sha512-TMhbk8AhxO+YuDOn3rXBjGXQ+Vja3T13UPQkHx/FemhusaOzRfCSj2seykt0mdnFPsOtO9l3ANf4adcp+4NRGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@valibot/to-json-schema": "^1.0.0",
+        "arktype": "^2.1.20",
+        "effect": "^3.16.0",
+        "sury": "^10.0.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "sury": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/jobs-ts/superseded-consumer-ts/package.json
+++ b/examples/jobs-ts/superseded-consumer-ts/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "superseded-consumer-ts",
+  "version": "1.0.0",
+  "description": "MCP Mesh — TypeScript issue #1278 supersession consumer example",
+  "type": "module",
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/core": "file:../../../src/runtime/core/typescript",
+    "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/jobs-ts/superseded-consumer-ts/src/index.ts
+++ b/examples/jobs-ts/superseded-consumer-ts/src/index.ts
@@ -1,0 +1,132 @@
+/**
+ * Typed supersession signal (issue #1278) — TS Consumer: a job executor whose
+ * mutating writes unwind with ONE `instanceof MeshSupersededError`.
+ *
+ * This is the consumer half of the fencing pattern. `run_writer` is a
+ * `task: true` handler — it executes AS a job, so it runs under a `claimEpoch`.
+ * Every outbound mesh call it makes (here to the provider's `apply_write`)
+ * automatically carries this job's identity on the propagated headers, so the
+ * provider can fence it via `callingJob()` without the executor threading
+ * `jobId` / `claimEpoch` through each payload.
+ *
+ * The point of #1278 is the UNWIND. A job executor makes many mutating
+ * downstream calls; if this executor has been superseded (a newer claim of the
+ * same job is now authoritative) it must stop and bail — cleanly, from wherever
+ * it is in the batch. Because a superseded write re-throws the TYPED
+ * `MeshSupersededError`, the whole batch is wrapped in ONE `catch`:
+ *
+ *     try {
+ *       for (const entry of entries) {
+ *         await applyWrite({ entry });        // any of these may be fenced
+ *       }
+ *     } catch (e) {
+ *       if (e instanceof MeshSupersededError) {
+ *         return { status: "superseded", detail: e.detail };   // one unwind
+ *       }
+ *       throw e;
+ *     }
+ *
+ * Contrast the OLD pattern this REPLACES — inspecting every call's result and
+ * string-matching the marker after each one:
+ *
+ *     for (const entry of entries) {
+ *       const result = await applyWrite({ entry });
+ *       // brittle: re-check the shape/marker on EVERY call site
+ *       if (result?.error === "claim_superseded") return { status: "superseded" };
+ *     }
+ *
+ * Note this is DISTINCT from `dependency_unavailable` (issue #1273): that says
+ * "the capability isn't reachable"; supersession says "you personally are
+ * stale, a newer you is authoritative". Both are typed so the CONTRACT (the
+ * reserved envelope), not the error string, drives classification.
+ *
+ * Run after the provider is up:
+ *     MCP_MESH_REGISTRY_URL=http://localhost:8000 npx tsx src/index.ts
+ */
+import { FastMCP } from "fastmcp";
+import {
+  mesh,
+  type MeshJob,
+  type McpMeshTool,
+  MeshSupersededError,
+} from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "Superseded Writer Job (TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "superseded-consumer-ts",
+  httpPort: 9115,
+  description:
+    "Issue #1278 consumer (TS) — a task=true writer job that unwinds mutating " +
+    "writes with one instanceof MeshSupersededError",
+});
+
+agent.addTool({
+  name: "run_writer",
+  capability: "run_writer",
+  // task: true — this handler is dispatched AS a job (claimed from the
+  // registry), so it runs under a claimEpoch that the mesh stamps onto the
+  // calling-job headers of the applyWrite call below.
+  task: true,
+  // Regular McpMeshTool dependency on the provider's mutating capability.
+  // (A dependency, NOT a MeshJob submitter — apply_write is a plain tool.)
+  dependencies: [{ capability: "apply_write" }],
+  // Injection order: pos 0 is `args`, dep[0] (applyWrite) lands at pos 1, and
+  // the MeshJob controller is spliced at meshJobParamIndex 2. So the execute
+  // signature is (args, applyWrite, job).
+  meshJobParamIndex: 2,
+  description:
+    "Run a batch of ledger writes as a job. If this executor is superseded " +
+    "mid-batch, unwind cleanly with one instanceof MeshSupersededError.",
+  parameters: z.object({
+    count: z.number().int().default(3),
+  }),
+  execute: async (
+    { count },
+    applyWrite: McpMeshTool | null = null,
+    _job: MeshJob | null = null,
+  ) => {
+    if (!applyWrite) {
+      return {
+        error:
+          "apply_write not injected — check that the superseded-provider-ts " +
+          "is registered",
+      };
+    }
+
+    const written: string[] = [];
+    try {
+      for (let i = 0; i < count; i++) {
+        const entry = `line-${i}`;
+        // Any of these calls may be fenced by the provider. If this executor
+        // has been superseded, the provider throws MeshSupersededError; the
+        // injected proxy recognizes the reserved envelope and re-throws
+        // MeshSupersededError here — so we do NOT inspect each result for a
+        // marker.
+        await applyWrite({ entry });
+        written.push(entry);
+      }
+    } catch (e) {
+      if (e instanceof MeshSupersededError) {
+        // ONE unwind for the whole batch. A newer claim of this job is
+        // authoritative — stop writing and hand back what we managed before
+        // being fenced. No rollback needed: the provider already rejected the
+        // stale write, so the ledger reflects only the authoritative executor.
+        return {
+          status: "superseded",
+          written_before_fence: written,
+          detail: e.detail,
+        };
+      }
+      throw e;
+    }
+
+    return { status: "completed", written };
+  },
+});
+
+console.log("superseded-consumer-ts agent defined. Waiting for auto-start...");

--- a/examples/jobs-ts/superseded-consumer-ts/tsconfig.json
+++ b/examples/jobs-ts/superseded-consumer-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/jobs-ts/superseded-provider-ts/package-lock.json
+++ b/examples/jobs-ts/superseded-provider-ts/package-lock.json
@@ -1,0 +1,2870 @@
+{
+  "name": "superseded-provider-ts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "superseded-provider-ts",
+      "version": "1.0.0",
+      "dependencies": {
+        "@mcpmesh/core": "file:../../../src/runtime/core/typescript",
+        "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+        "fastmcp": "^3.34.0",
+        "zod": "^3.24.2"
+      },
+      "devDependencies": {
+        "@types/node": "^22.18.0",
+        "tsx": "^4.0.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "../../../src/runtime/core/typescript": {
+      "name": "@mcpmesh/core",
+      "version": "2.8.2",
+      "license": "MIT",
+      "devDependencies": {
+        "@napi-rs/cli": "^3.5.1"
+      }
+    },
+    "../../../src/runtime/typescript": {
+      "name": "@mcpmesh/sdk",
+      "version": "2.8.2",
+      "license": "MIT",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/google-vertex": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@mcpmesh/core": "file:../core/typescript",
+        "ai": "^6.0.0",
+        "fastmcp": "^4.3.2",
+        "handlebars": "^4.7.8",
+        "mcp-proxy": "6.4.4",
+        "undici": "^6.21.0",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.0",
+        "@types/express-v5": "npm:@types/express@^5.0.0",
+        "@types/node": "^22.0.0",
+        "express": "^4.18.0",
+        "express-v5": "npm:express@^5.0.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@mcpmesh/core": {
+      "resolved": "../../../src/runtime/core/typescript",
+      "link": true
+    },
+    "node_modules/@mcpmesh/sdk": {
+      "resolved": "../../../src/runtime/typescript",
+      "link": true
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastmcp": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/fastmcp/-/fastmcp-3.35.0.tgz",
+      "integrity": "sha512-bcyAaVa3Zw5f4xighGg6fNNgEzZoP6tX/O+ZfS2lIhbEULWe/zUWG533JyFEUOjZT7EB+tiZW1ot4eWKmYJ6DA==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.24.3",
+        "@standard-schema/spec": "^1.0.0",
+        "execa": "^9.6.1",
+        "file-type": "^21.1.1",
+        "fuse.js": "^7.1.0",
+        "hono": "^4.11.5",
+        "mcp-proxy": "^6.4.0",
+        "strict-event-emitter-types": "^2.0.0",
+        "undici": "^7.16.0",
+        "uri-templates": "^0.2.0",
+        "xsschema": "^0.4.3",
+        "yargs": "^18.0.0",
+        "zod": "^4.1.13",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "bin": {
+        "fastmcp": "dist/bin/fastmcp.js"
+      },
+      "peerDependencies": {
+        "jose": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fastmcp/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.4.2.tgz",
+      "integrity": "sha512-LVbzjD4WA6UP5B1UnP8wuaXJiLnqMdM/E4fiJXTJ5haJ5b/MBNsK29h2fm6swEoQaVQjvYFWKLE2RanyZIoRVQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.28",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
+      "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-readable-ids": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/human-readable-ids/-/human-readable-ids-1.0.4.tgz",
+      "integrity": "sha512-h1zwThTims8A/SpqFGWyTx+jG1+WRMJaEeZgbtPGrIpj2AZjsOgy8Y+iNzJ0yAyN669Q6F02EK66WMWcst+2FA==",
+      "license": "Apache2",
+      "dependencies": {
+        "knuth-shuffle": "^1.0.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/knuth-shuffle": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/knuth-shuffle/-/knuth-shuffle-1.0.8.tgz",
+      "integrity": "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ==",
+      "license": "(MIT OR Apache-2.0)"
+    },
+    "node_modules/koa": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-3.2.1.tgz",
+      "integrity": "sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.8",
+        "content-disposition": "~1.0.1",
+        "content-type": "^1.0.5",
+        "cookies": "~0.9.1",
+        "delegates": "^1.0.0",
+        "destroy": "^1.2.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.5.0",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "mime-types": "^3.0.1",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "license": "MIT"
+    },
+    "node_modules/koa-router": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-14.0.0.tgz",
+      "integrity": "sha512-Ue8f/PRsLLNm6b7y+eS6xkqvsG2xH11d2VB1HPcfdfW6p5736kCHf2pXaq8q9XPQ01x0Dk7V/P5Il9pe+tGTxA==",
+      "deprecated": "Please use @koa/router instead, starting from v9! ",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "http-errors": "^2.0.0",
+        "koa-compose": "^4.1.0",
+        "path-to-regexp": "^8.2.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/koa/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/accepts/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/koa/node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-proxy": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/mcp-proxy/-/mcp-proxy-6.5.2.tgz",
+      "integrity": "sha512-3sE9kedh81dqqpObzO0nUf8aAyGnzLVDVH97GCLL3fXCBOkXDWZBts63u0bM5lT1Q4FKZY0+E91dZ7Chb2ybsA==",
+      "license": "MIT",
+      "dependencies": {
+        "pipenet": "^1.3.0"
+      },
+      "bin": {
+        "mcp-proxy": "dist/bin/mcp-proxy.mjs"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pipenet": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/pipenet/-/pipenet-1.4.2.tgz",
+      "integrity": "sha512-mPPqygXr7ccwImeaa8zReY9GubH/1r+kBNfqPVfKREQ1s8bKE3XlOqBMONxJAW4d3ZBNGzP9AZp9Axnhi5uOyw==",
+      "dependencies": {
+        "axios": "^1.7.3",
+        "debug": "^4.3.6",
+        "human-readable-ids": "^1.0.4",
+        "koa": "^3.1.1",
+        "koa-router": "^14.0.0",
+        "pump": "^3.0.3",
+        "tldjs": "^2.3.2",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "pipenet": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA==",
+      "license": "ISC"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tldjs": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-2.3.2.tgz",
+      "integrity": "sha512-EORDwFMSZKrHPUVDhejCMDeAovRS5d8jZKiqALFiPp3cjKjEldPkxBY39ZSx3c45awz3RpKwJD1cCgGxEfy8/A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-templates": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uri-templates/-/uri-templates-0.2.0.tgz",
+      "integrity": "sha512-EWkjYEN0L6KOfEoOH6Wj4ghQqU7eBZMJqRHQnxQAq+dSEzRPClkWjf8557HkWQXF6BrAUoLSAyy9i3RVTliaNg==",
+      "license": "http://geraintluff.github.io/tv4/LICENSE.txt"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xsschema": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/xsschema/-/xsschema-0.4.4.tgz",
+      "integrity": "sha512-TMhbk8AhxO+YuDOn3rXBjGXQ+Vja3T13UPQkHx/FemhusaOzRfCSj2seykt0mdnFPsOtO9l3ANf4adcp+4NRGw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@valibot/to-json-schema": "^1.0.0",
+        "arktype": "^2.1.20",
+        "effect": "^3.16.0",
+        "sury": "^10.0.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "sury": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/jobs-ts/superseded-provider-ts/package.json
+++ b/examples/jobs-ts/superseded-provider-ts/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "superseded-provider-ts",
+  "version": "1.0.0",
+  "description": "MCP Mesh — TypeScript issue #1278 supersession provider example",
+  "type": "module",
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/core": "file:../../../src/runtime/core/typescript",
+    "@mcpmesh/sdk": "file:../../../src/runtime/typescript",
+    "fastmcp": "^3.34.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/jobs-ts/superseded-provider-ts/src/index.ts
+++ b/examples/jobs-ts/superseded-provider-ts/src/index.ts
@@ -1,0 +1,117 @@
+/**
+ * Typed supersession signal (issue #1278) — TS Provider: a write authority
+ * that fences stale-executor writes.
+ *
+ * This is the provider half of the calling-job fencing pattern. A state
+ * authority (here an in-memory ledger) accepts mutating writes from job
+ * executors. When a job is re-claimed after a crash/reclaim, a NEWER executor
+ * runs under a HIGHER `claimEpoch`; the OLD executor may still be mid-flight
+ * and try to write. Those stale writes must be rejected so the newer executor
+ * owns the outcome.
+ *
+ * Two mesh surfaces make this a few lines:
+ *
+ *     // 1. Read WHO called me (issue #1263 — the calling job's identity).
+ *     const cj = callingJob();          // -> CallingJob | null
+ *
+ *     // 2. Reject a superseded caller with the TYPED signal (issue #1278).
+ *     throw new MeshSupersededError(detail);
+ *
+ * The framework does NOT auto-detect supersession — the APP decides. The mesh
+ * only propagates the calling job's identity and provides the typed error plus
+ * its emit/recognize plumbing. Here the "is superseded" rule is deliberately
+ * simple and deterministic for teaching: the authority remembers the highest
+ * `claimEpoch` it has seen per calling `jobId` and rejects any call whose epoch
+ * is lower — i.e. "an older executor is trying to write after a newer one
+ * already has".
+ *
+ * `MeshSupersededError` crosses the wire as the reserved app envelope
+ * `{"error":"claim_superseded"}` (plus an optional `"detail"`). The calling
+ * side's injected proxy recognizes that envelope and re-throws
+ * `MeshSupersededError` — so the CONSUMER unwinds with ONE
+ * `if (e instanceof MeshSupersededError)` (see
+ * `../superseded-consumer-ts/src/index.ts`) instead of string-matching a
+ * marker after every call.
+ *
+ * Run:
+ *     MCP_MESH_REGISTRY_URL=http://localhost:8000 npx tsx src/index.ts
+ */
+import { FastMCP } from "fastmcp";
+import { mesh, callingJob, MeshSupersededError } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "Superseded Write Authority (TS)",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "superseded-provider-ts",
+  httpPort: 9114,
+  description:
+    "Issue #1278 provider (TS) — write authority that fences superseded " +
+    "executors via calling-job epoch + typed MeshSupersededError",
+});
+
+// Highest claimEpoch this authority has accepted a write under, per calling
+// jobId. This is the APP's supersession state — the framework does not keep
+// it. A single-process server touches this from one event loop, so a plain
+// Map is safe here; a multi-replica authority would keep it in a shared store.
+const latestEpochByJob = new Map<string, number>();
+
+// The in-memory "ledger" we are protecting from stale writes.
+const ledger: Array<{ entry: string; byEpoch: number | null }> = [];
+
+agent.addTool({
+  name: "apply_write",
+  capability: "apply_write",
+  description:
+    "Apply a mutating write to the ledger, fencing out writes from a " +
+    "superseded (older-epoch) executor. Demonstrates calling-job fencing " +
+    "with the typed MeshSupersededError.",
+  parameters: z.object({
+    entry: z.string(),
+  }),
+  execute: async ({ entry }) => {
+    // The mutating payload (`entry`) is an ordinary tool argument. The
+    // caller's IDENTITY is NOT in the payload — it rides the propagated
+    // headers the mesh seeds on outbound calls made from within a job
+    // execution context, and we read it back with callingJob().
+    const cj = callingJob();
+
+    // No calling-job identity → a regular (non-job) call, or a caller on an
+    // old SDK that does not propagate identity. Nothing to fence against;
+    // apply the write. (Fencing is defense-in-depth — soft-fail-open when
+    // identity is absent.)
+    if (!cj || cj.claimEpoch == null) {
+      ledger.push({ entry, byEpoch: null });
+      return { applied: true, ledger_size: ledger.length, fenced: false };
+    }
+
+    const seen = latestEpochByJob.get(cj.jobId) ?? -1;
+
+    if (cj.claimEpoch < seen) {
+      // APP DECISION: a newer executor (epoch `seen`) has already written for
+      // this job, so this older executor's write is stale. Reject with the
+      // typed signal — this serializes to the reserved
+      // {"error":"claim_superseded","detail":...} envelope, and the caller's
+      // injected proxy re-throws MeshSupersededError on its side.
+      const detail =
+        `job ${cj.jobId}: calling epoch ${cj.claimEpoch} < ` +
+        `latest accepted epoch ${seen}`;
+      throw new MeshSupersededError(detail);
+    }
+
+    // Caller is current (>= highest seen). Record its epoch and apply.
+    latestEpochByJob.set(cj.jobId, Math.max(seen, cj.claimEpoch));
+    ledger.push({ entry, byEpoch: cj.claimEpoch });
+    return {
+      applied: true,
+      ledger_size: ledger.length,
+      accepted_epoch: cj.claimEpoch,
+      fenced: false,
+    };
+  },
+});
+
+console.log("superseded-provider-ts agent defined. Waiting for auto-start...");

--- a/examples/jobs-ts/superseded-provider-ts/tsconfig.json
+++ b/examples/jobs-ts/superseded-provider-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/jobs/README.md
+++ b/examples/jobs/README.md
@@ -168,6 +168,91 @@ not double-applied. Two rules the handler must honor to opt in safely:
 Drive it exactly like the base task, targeting the `resumable_event_task`
 capability instead.
 
+## Typed supersession signal (`SupersededError`, issue #1278)
+
+`superseded-provider/` + `superseded-consumer/` demonstrate how a job
+executor's mutating downstream writes are fenced when the executor has been
+superseded — and how the caller unwinds cleanly with ONE `except`.
+
+### The problem
+
+When a job is re-claimed (crash, reclaim, drain), a NEWER executor runs under a
+HIGHER `claim_epoch`. The OLD executor may still be mid-flight and try to write.
+Those stale writes must be rejected so the newer executor owns the outcome.
+
+### The pattern (three moving parts)
+
+1. **Calling-job identity is the decision input (#1263).** A `task=True`
+   handler runs *as* a job, so every outbound mesh call it makes carries its
+   identity on dedicated headers (`x-mesh-calling-job-id` /
+   `x-mesh-calling-claim-epoch`). The provider reads it back with
+   `mesh.calling_job()` → `CallingJob(job_id, claim_epoch)` — no need to thread
+   identity through each payload.
+
+2. **The app decides supersession; the framework does not.** The provider owns
+   the "is this caller stale?" rule. In `apply_write` the authority remembers
+   the highest `claim_epoch` it has accepted per `job_id` and rejects any call
+   whose epoch is lower — a deterministic "an older executor is writing after a
+   newer one already has" test. A real authority might consult the registry, a
+   lease table, or a monotonic version column instead.
+
+3. **The typed error is the one-catch unwind (#1278).** The provider rejects
+   with `raise mesh.SupersededError(detail)`. On the wire that is the reserved
+   app envelope `{"error":"claim_superseded","detail":...}`. The caller's
+   injected proxy recognizes that envelope and re-raises `mesh.SupersededError`
+   on the calling side — so the consumer wraps its whole write batch in ONE
+   `except mesh.SupersededError` instead of string-matching the marker after
+   every call:
+
+   ```python
+   try:
+       for entry in entries:
+           await apply_write(entry=entry)   # any call may be fenced
+   except mesh.SupersededError as e:
+       return {"status": "superseded", "detail": e.detail}   # one unwind
+   ```
+
+   The OLD pattern this replaces re-checked `result.get("error") ==
+   "claim_superseded"` at every call site — brittle and easy to forget.
+
+### Distinct from `dependency_unavailable` (#1273)
+
+`dependency_unavailable` means "the capability isn't reachable"; supersession
+means "you personally are stale — a newer you is authoritative". Both are typed
+so the CONTRACT (the reserved envelope), not the error string, drives
+classification; both raise a `ToolError` subclass, so `except ToolError` still
+catches either.
+
+### Quick start
+
+```bash
+# Terminal 1 — registry
+./bin/mcp-mesh-registry > /tmp/registry.log 2>&1 &
+
+# Terminal 2 — provider (port 9104)
+MCP_MESH_REGISTRY_URL=http://localhost:8000 \
+  python3 examples/jobs/superseded-provider/main.py
+
+# Terminal 3 — consumer (port 9105)
+MCP_MESH_REGISTRY_URL=http://localhost:8000 \
+  python3 examples/jobs/superseded-consumer/main.py
+```
+
+Kick off a writer job:
+
+```bash
+meshctl call superseded-consumer run_writer --arg count=3
+```
+
+A single, uncontested run returns `{"status": "completed", ...}` — the
+authority sees a monotonic epoch and accepts every write. The fence fires when
+a LOWER-epoch executor writes after a higher one has been recorded for the same
+`job_id` (the reclaim scenario): the provider raises `SupersededError`, the
+consumer catches it once, and returns `{"status": "superseded", ...}`.
+
+The TypeScript (`../jobs-ts/`) and Java (`../jobs-java/`) trees carry the same
+pair with `MeshSupersededError` / `MeshSupersededException`.
+
 ## What's NOT in v2.2 yet
 
 - Idempotency keys for retries (future).

--- a/examples/jobs/README.md
+++ b/examples/jobs/README.md
@@ -241,7 +241,7 @@ MCP_MESH_REGISTRY_URL=http://localhost:8000 \
 Kick off a writer job:
 
 ```bash
-meshctl call superseded-consumer run_writer --arg count=3
+meshctl call superseded-consumer run_writer '{"count": 3}'
 ```
 
 A single, uncontested run returns `{"status": "completed", ...}` — the

--- a/examples/jobs/superseded-consumer/main.py
+++ b/examples/jobs/superseded-consumer/main.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Typed supersession signal (issue #1278) — Consumer: a job executor whose
+mutating writes unwind with ONE ``except mesh.SupersededError``.
+
+This is the consumer half of the fencing pattern. ``run_writer`` is a
+``task=True`` handler — it executes AS a job, so it runs under a
+``claim_epoch``. Every outbound mesh call it makes (here to the provider's
+``apply_write``) automatically carries this job's identity on the propagated
+headers, so the provider can fence it via ``mesh.calling_job()`` without the
+executor threading ``job_id`` / ``claim_epoch`` through each payload.
+
+The point of #1278 is the UNWIND. A job executor makes many mutating downstream
+calls; if this executor has been superseded (a newer claim of the same job is
+now authoritative) it must stop and bail — cleanly, from wherever it is in the
+batch. Because a superseded write re-raises the TYPED ``mesh.SupersededError``,
+the whole batch is wrapped in ONE ``except``:
+
+    try:
+        for entry in entries:
+            await apply_write(entry=entry)   # any of these may be fenced
+    except mesh.SupersededError as e:
+        return {"status": "superseded", "detail": e.detail}   # one unwind
+
+Contrast the OLD pattern this REPLACES — inspecting every call's result and
+string-matching the marker after each one::
+
+    for entry in entries:
+        result = await apply_write(entry=entry)
+        # brittle: re-check the shape/marker on EVERY call site
+        if isinstance(result, dict) and result.get("error") == "claim_superseded":
+            return {"status": "superseded"}   # repeated at every call site
+
+Note this is DISTINCT from ``dependency_unavailable`` (issue #1273): that says
+"the capability isn't reachable"; supersession says "you personally are stale,
+a newer you is authoritative". Both are typed so the CONTRACT (the reserved
+envelope), not the error string, drives classification.
+
+Run after the provider is up:
+    MCP_MESH_REGISTRY_URL=http://localhost:8000 python3 main.py
+"""
+
+import logging
+
+import mesh
+from fastmcp import FastMCP
+from mesh import MeshJob
+
+log = logging.getLogger("superseded-consumer")
+app = FastMCP("Superseded Writer Job")
+
+
+@app.tool()
+@mesh.tool(
+    capability="run_writer",
+    # task=True: this handler is dispatched AS a job (claimed from the
+    # registry), so it runs under a claim_epoch that the mesh stamps onto the
+    # calling-job headers of the apply_write call below.
+    task=True,
+    # Regular McpMeshTool dependency on the provider's mutating capability.
+    # (A dependency, NOT a MeshJob submitter — apply_write is a plain tool.)
+    dependencies=["apply_write"],
+    description=(
+        "Run a batch of ledger writes as a job. If this executor is "
+        "superseded mid-batch, unwind cleanly with one except SupersededError."
+    ),
+)
+async def run_writer(
+    count: int = 3,
+    # Injected by name-match: the apply_write McpMeshTool proxy.
+    apply_write: mesh.McpMeshTool = None,
+    # Injected by type: the controller for THIS job (its own identity /
+    # claim_epoch live here; the provider sees it via calling_job()).
+    job: MeshJob = None,
+) -> dict:
+    """Write ``count`` ledger entries, bailing cleanly if superseded."""
+    if apply_write is None:
+        return {
+            "error": "apply_write not injected — check that the "
+            "superseded-provider is registered"
+        }
+
+    written: list[str] = []
+    try:
+        for i in range(count):
+            entry = f"line-{i}"
+            # Any of these calls may be fenced by the provider. If this
+            # executor has been superseded, the provider raises
+            # SupersededError; the injected proxy recognizes the reserved
+            # envelope and re-raises mesh.SupersededError here — so we do NOT
+            # inspect each result for a marker.
+            await apply_write(entry=entry)
+            written.append(entry)
+            if job is not None:
+                await job.update_progress(
+                    (i + 1) / max(count, 1), f"wrote {i + 1}/{count}"
+                )
+    except mesh.SupersededError as e:
+        # ONE unwind for the whole batch. A newer claim of this job is
+        # authoritative — stop writing and hand back what we managed before
+        # being fenced. No rollback needed: the provider already rejected the
+        # stale write, so the ledger reflects only the authoritative executor.
+        log.warning("superseded mid-batch after %d writes: %s", len(written), e.detail)
+        return {
+            "status": "superseded",
+            "written_before_fence": written,
+            "detail": e.detail,
+        }
+
+    return {"status": "completed", "written": written}
+
+
+@mesh.agent(
+    name="superseded-consumer",
+    version="1.0.0",
+    description=(
+        "Issue #1278 consumer — a task=True writer job that unwinds mutating "
+        "writes with one except mesh.SupersededError"
+    ),
+    http_port=9105,
+    enable_http=True,
+    auto_run=True,
+)
+class SupersededConsumer:
+    """Hosts the ``run_writer`` capability."""
+
+    pass

--- a/examples/jobs/superseded-provider/main.py
+++ b/examples/jobs/superseded-provider/main.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Typed supersession signal (issue #1278) — Provider: a write authority that
+fences stale-executor writes.
+
+This is the provider half of the calling-job fencing pattern. A state
+authority (here an in-memory ledger) accepts mutating writes from job
+executors. When a job is re-claimed after a crash/reclaim, a NEWER executor
+runs under a HIGHER ``claim_epoch``; the OLD executor may still be mid-flight
+and try to write. Those stale writes must be rejected so the newer executor
+owns the outcome.
+
+Two mesh surfaces make this a few lines:
+
+    # 1. Read WHO called me (issue #1263 — the calling job's identity).
+    cj = mesh.calling_job()          # -> CallingJob(job_id, claim_epoch) | None
+
+    # 2. Reject a superseded caller with the TYPED signal (issue #1278).
+    raise mesh.SupersededError(detail)
+
+The framework does NOT auto-detect supersession — the APP decides. The mesh
+only propagates the calling job's identity and provides the typed error plus
+its emit/recognize plumbing. Here the "is superseded" rule is deliberately
+simple and deterministic for teaching: the authority remembers the highest
+``claim_epoch`` it has seen per calling ``job_id`` and rejects any call whose
+epoch is lower — i.e. "an older executor is trying to write after a newer one
+already has". A real authority might instead consult the registry, a lease
+table, or a monotonic version column.
+
+``mesh.SupersededError`` crosses the wire as the reserved app envelope
+``{"error":"claim_superseded"}`` (plus an optional ``"detail"``). The calling
+side's injected proxy recognizes that envelope and re-raises
+``mesh.SupersededError`` — so the CONSUMER unwinds with ONE
+``except mesh.SupersededError`` (see ``../superseded-consumer/main.py``)
+instead of string-matching a marker after every call.
+
+Run:
+    MCP_MESH_REGISTRY_URL=http://localhost:8000 python3 main.py
+"""
+
+import logging
+from typing import Any
+
+import mesh
+from fastmcp import FastMCP
+
+log = logging.getLogger("superseded-provider")
+app = FastMCP("Superseded Write Authority")
+
+# Highest claim_epoch this authority has accepted a write under, per calling
+# job_id. This is the APP's supersession state — the framework does not keep
+# it. A single-process async server touches this from one event loop, so a
+# plain dict is safe here; a multi-replica authority would keep it in a shared
+# store (Redis, a DB version column, ...).
+_latest_epoch_by_job: dict[str, int] = {}
+
+# The in-memory "ledger" we are protecting from stale writes.
+_ledger: list[dict[str, Any]] = []
+
+
+@app.tool()
+@mesh.tool(
+    capability="apply_write",
+    description=(
+        "Apply a mutating write to the ledger, fencing out writes from a "
+        "superseded (older-epoch) executor. Demonstrates calling-job fencing "
+        "with the typed SupersededError."
+    ),
+)
+async def apply_write(entry: str) -> dict[str, Any]:
+    """Append ``entry`` to the ledger — unless the caller is superseded.
+
+    The mutating payload (``entry``) is an ordinary tool argument. The caller's
+    IDENTITY is NOT in the payload — it rides the propagated headers the mesh
+    seeds on outbound calls made from within a job execution context, and we
+    read it back with ``mesh.calling_job()``.
+    """
+    cj = mesh.calling_job()
+
+    # No calling-job identity → a regular (non-job) tools/call, or a caller on
+    # an old SDK that does not propagate identity. Nothing to fence against;
+    # apply the write. (Fencing is defense-in-depth, never a hard requirement
+    # to make progress — soft-fail-open when identity is absent.)
+    if cj is None or cj.claim_epoch is None:
+        log.info("apply_write from non-job/unidentified caller — applying")
+        _ledger.append({"entry": entry, "by_epoch": None})
+        return {"applied": True, "ledger_size": len(_ledger), "fenced": False}
+
+    seen = _latest_epoch_by_job.get(cj.job_id, -1)
+
+    if cj.claim_epoch < seen:
+        # APP DECISION: a newer executor (epoch ``seen``) has already written
+        # for this job, so this older executor's write is stale. Reject with
+        # the typed signal — this serializes to the reserved
+        # {"error":"claim_superseded","detail":...} envelope, and the caller's
+        # injected proxy re-raises mesh.SupersededError on its side.
+        detail = (
+            f"job {cj.job_id}: calling epoch {cj.claim_epoch} < "
+            f"latest accepted epoch {seen}"
+        )
+        log.warning("fencing superseded write: %s", detail)
+        raise mesh.SupersededError(detail)
+
+    # Caller is current (>= highest seen). Record its epoch and apply.
+    _latest_epoch_by_job[cj.job_id] = max(seen, cj.claim_epoch)
+    _ledger.append({"entry": entry, "by_epoch": cj.claim_epoch})
+    log.info(
+        "applied write for job %s at epoch %s (ledger_size=%d)",
+        cj.job_id,
+        cj.claim_epoch,
+        len(_ledger),
+    )
+    return {
+        "applied": True,
+        "ledger_size": len(_ledger),
+        "accepted_epoch": cj.claim_epoch,
+        "fenced": False,
+    }
+
+
+@mesh.agent(
+    name="superseded-provider",
+    version="1.0.0",
+    description=(
+        "Issue #1278 provider — write authority that fences superseded "
+        "executors via calling-job epoch + typed SupersededError"
+    ),
+    http_port=9104,
+    enable_http=True,
+    auto_run=True,
+)
+class SupersededProvider:
+    """Hosts the ``apply_write`` capability."""
+
+    pass

--- a/src/core/cli/man/content/jobs.md
+++ b/src/core/cli/man/content/jobs.md
@@ -617,6 +617,56 @@ additive and read-only — reading it has no effect on the call. This is the
 provider-side dual of `current_job()`: `current_job()` answers "what job am I
 executing *as*", `calling_job()` answers "what job *invoked* me".
 
+## Typed supersession signal
+
+Stamping the caller's epoch (above) lets a provider *dedupe* a superseded
+write after the fact. When the provider is a **state authority** that must
+*reject* the stale write outright, it compares the caller's epoch against
+its own live/expected epoch and raises a typed error. The framework does
+**not** auto-detect supersession — the app owns the "is this caller stale?"
+decision (it holds the authoritative epoch); the framework only carries the
+typed signal end to end.
+
+The provider raises `mesh.SupersededError`:
+
+```python
+import mesh
+
+@app.tool()
+@mesh.tool(capability="record_charge")
+async def record_charge(order_id: str, amount: float) -> dict:
+    caller = mesh.calling_job()          # CallingJob(job_id, claim_epoch) | None
+    live = await ledger.live_epoch(order_id)   # the app's authoritative epoch
+    if caller and caller.claim_epoch is not None and caller.claim_epoch < live:
+        # Stale executor — reject instead of applying the write.
+        raise mesh.SupersededError(f"stale epoch {caller.claim_epoch}")
+    await ledger.upsert(key=order_id, amount=amount)
+    return {"order_id": order_id}
+```
+
+The signal crosses the wire as a reserved `{"error":"claim_superseded"}`
+app envelope — the same `claim_superseded` vocabulary the registry uses to
+fence job writes. On the **calling** side, the injected mesh proxy
+recognizes that envelope and re-raises the same typed error, so a superseded
+executor unwinds with **one** catch instead of string-matching an error
+marker after every mutating call:
+
+```python
+try:
+    await record_charge(order_id=oid, amount=42.0)   # injected mesh dependency
+    await settle_ledger(order_id=oid)
+except mesh.SupersededError:
+    return                                            # superseded — unwind cleanly
+```
+
+`SupersededError` is distinct from a generic tool failure and from the
+`dependency_unavailable` refusal (an unresolved required dep, `meshctl man
+dependency-injection`) — it means specifically *you are running under a
+superseded claim*. It does **not** change delivery: jobs remain
+**at-least-once** and a fenced re-execution still runs under the new claim;
+the typed signal only lets the stale attempt bow out on its first rejected
+write rather than every downstream provider re-checking a string marker.
+
 ## Out-of-band inspection
 
 Three SDK-managed helper tools are auto-registered on every mesh

--- a/src/core/cli/man/content/jobs_java.md
+++ b/src/core/cli/man/content/jobs_java.md
@@ -808,6 +808,64 @@ it has no effect on the call. This is the provider-side dual of
 `JobContext.current()`: `JobContext.current()` answers "what job am I
 executing *as*", `callingJob()` answers "what job *invoked* me".
 
+## Typed supersession signal
+
+Stamping the caller's epoch (above) lets a provider *dedupe* a superseded
+write after the fact. When the provider is a **state authority** that must
+*reject* the stale write outright, it compares the caller's epoch against
+its own live/expected epoch and throws a typed exception. The framework does
+**not** auto-detect supersession — the app owns the "is this caller stale?"
+decision (it holds the authoritative epoch); the framework only carries the
+typed signal end to end.
+
+The provider throws `MeshSupersededException` (package `io.mcpmesh.types`):
+
+```java
+import io.mcpmesh.spring.MeshCallContext;
+import io.mcpmesh.spring.MeshCallContext.CallingJob;
+import io.mcpmesh.types.MeshSupersededException;
+
+@MeshTool(capability = "record_charge")
+public Map<String, Object> recordCharge(
+    @Param("order_id") String orderId,
+    @Param("amount") double amount) {
+  CallingJob caller = MeshCallContext.callingJob();   // never null; fields nullable
+  long live = ledger.liveEpoch(orderId);              // the app's authoritative epoch
+  if (caller.isPresent() && caller.claimEpoch() != null && caller.claimEpoch() < live) {
+    // Stale executor — reject instead of applying the write.
+    throw new MeshSupersededException("stale epoch " + caller.claimEpoch());
+  }
+  ledger.upsert(orderId, amount);
+  return Map.of("order_id", orderId);
+}
+```
+
+The signal crosses the wire as a reserved `{"error":"claim_superseded"}`
+app envelope — the same `claim_superseded` vocabulary the registry uses to
+fence job writes. On the **calling** side, the injected mesh proxy
+recognizes that envelope and re-throws the same typed exception, so a
+superseded executor unwinds with **one** catch instead of string-matching an
+error marker after every mutating call:
+
+```java
+import io.mcpmesh.types.MeshSupersededException;
+
+try {
+  recordCharge(orderId, 42.0);   // injected mesh dependency
+  settleLedger(orderId);
+} catch (MeshSupersededException e) {
+  return;                        // superseded — unwind cleanly
+}
+```
+
+`MeshSupersededException` is distinct from a generic tool failure and from
+the `dependency_unavailable` refusal (an unresolved required dep, `meshctl
+man dependency-injection --java`) — it means specifically *you are running
+under a superseded claim*. It does **not** change delivery: jobs remain
+**at-least-once** and a fenced re-execution still runs under the new claim;
+the typed signal only lets the stale attempt bow out on its first rejected
+write rather than every downstream provider re-checking a string marker.
+
 ## Out-of-band inspection
 
 Three SDK-managed helper tools are auto-registered on every mesh

--- a/src/core/cli/man/content/jobs_typescript.md
+++ b/src/core/cli/man/content/jobs_typescript.md
@@ -670,6 +670,65 @@ and read-only — reading it has no effect on the call. This is the
 provider-side dual of `currentJob()`: `currentJob()` answers "what job am I
 executing *as*", `callingJob()` answers "what job *invoked* me".
 
+## Typed supersession signal
+
+Stamping the caller's epoch (above) lets a provider *dedupe* a superseded
+write after the fact. When the provider is a **state authority** that must
+*reject* the stale write outright, it compares the caller's epoch against
+its own live/expected epoch and throws a typed error. The framework does
+**not** auto-detect supersession — the app owns the "is this caller stale?"
+decision (it holds the authoritative epoch); the framework only carries the
+typed signal end to end.
+
+The provider throws `MeshSupersededError` (exported from the package root):
+
+```typescript
+import { callingJob, MeshSupersededError } from "@mcpmesh/sdk";
+
+agent.addTool({
+  name: "record_charge",
+  capability: "record_charge",
+  parameters: z.object({ order_id: z.string(), amount: z.number() }),
+  execute: async ({ order_id, amount }) => {
+    const caller = callingJob();          // { jobId, claimEpoch } | null
+    const live = await ledger.liveEpoch(order_id);   // the app's authoritative epoch
+    if (caller && caller.claimEpoch != null && caller.claimEpoch < live) {
+      // Stale executor — reject instead of applying the write.
+      throw new MeshSupersededError(`stale epoch ${caller.claimEpoch}`);
+    }
+    await ledger.upsert({ key: order_id, amount });
+    return { order_id };
+  },
+});
+```
+
+The signal crosses the wire as a reserved `{"error":"claim_superseded"}`
+app envelope — the same `claim_superseded` vocabulary the registry uses to
+fence job writes. On the **calling** side, the injected mesh proxy
+recognizes that envelope and re-throws the same typed error, so a superseded
+executor unwinds with **one** catch instead of string-matching an error
+marker after every mutating call:
+
+```typescript
+import { MeshSupersededError } from "@mcpmesh/sdk";
+
+try {
+  await recordCharge({ order_id, amount: 42 });   // injected mesh dependency
+  await settleLedger({ order_id });
+} catch (e) {
+  if (e instanceof MeshSupersededError) return;   // superseded — unwind cleanly
+  throw e;
+}
+```
+
+`MeshSupersededError` is distinct from a generic tool failure and from the
+`dependency_unavailable` refusal (an unresolved required dep, `meshctl man
+dependency-injection --typescript`) — it means specifically *you are running
+under a superseded claim*. It does **not** change delivery: jobs remain
+**at-least-once** and a fenced re-execution still runs under the new claim;
+the typed signal only lets the stale attempt bow out on its first rejected
+write rather than every downstream provider re-checking a string marker.
+
 ## Out-of-band inspection
 
 Three SDK-managed helper tools are auto-registered on every mesh

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshSupersededException.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshSupersededException.java
@@ -1,0 +1,109 @@
+package io.mcpmesh.types;
+
+import io.mcpmesh.core.MeshObjectMappers;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Thrown by a provider tool to reject a call from a SUPERSEDED executor
+ * (issue #1278).
+ *
+ * <p>A provider decides supersession itself — the framework does NOT
+ * auto-detect it. The app compares the calling job's claim generation
+ * (obtained via {@code MeshCallContext.callingJob()}, issue #1263) against its
+ * own live epoch and throws this from the {@code @MeshTool} handler when the
+ * caller is stale:
+ *
+ * <pre>{@code
+ * var cj = MeshCallContext.callingJob();
+ * if (cj != null && cj.claimEpoch() != null && cj.claimEpoch() < myLiveEpoch) {
+ *     throw new MeshSupersededException("stale epoch " + cj.claimEpoch());
+ * }
+ * }</pre>
+ *
+ * <p>The signal crosses the wire as the reserved {@code isError} app envelope
+ * {@code {"error":"claim_superseded"}} (plus an OPTIONAL {@code "detail"}
+ * string — omitted, not null, when absent). The calling side's injected proxy
+ * recognizes that envelope and re-throws {@code MeshSupersededException}, so a
+ * superseded caller unwinds with a single {@code catch}
+ * ({@code catch (MeshSupersededException e)}) instead of string-matching
+ * {@code claim_superseded} after every mutating call. This is the exact
+ * parallel of the {@code dependency_unavailable} refusal (issue #1273): the
+ * contract (the reserved envelope), not the carrier, drives classification.
+ *
+ * <p>The marker string {@code "claim_superseded"} is the SAME canonical marker
+ * the job path already uses on the wire (Go {@code ent_service_jobs.go} /
+ * Rust {@code CLAIM_SUPERSEDED_REASON}), reused verbatim so a superseded signal
+ * is one string end-to-end.
+ */
+public class MeshSupersededException extends RuntimeException {
+
+    /**
+     * Reserved marker for the supersession envelope — the canonical
+     * {@code claim_superseded} string reused verbatim from the job path.
+     */
+    public static final String CLAIM_SUPERSEDED_MARKER = "claim_superseded";
+
+    private static final ObjectMapper MAPPER = MeshObjectMappers.create();
+
+    private final String detail;
+
+    /**
+     * Create the supersession signal with an optional human-readable detail.
+     *
+     * @param detail why the caller is superseded, or {@code null} when none —
+     *               omitted entirely from the wire envelope when null
+     */
+    public MeshSupersededException(String detail) {
+        super(detail == null ? "Caller superseded" : "Caller superseded: " + detail);
+        this.detail = detail;
+    }
+
+    /**
+     * The optional detail carried by the signal, or {@code null} when none.
+     *
+     * @return the detail string, or {@code null}
+     */
+    public String getDetail() {
+        return detail;
+    }
+
+    /**
+     * Return a {@code MeshSupersededException} if {@code errorText} is the
+     * reserved supersession envelope, else {@code null}.
+     *
+     * <p>Defensive parse for the consumer recognize path: a non-JSON body, a
+     * JSON body that is not an object, or one whose {@code error} field is not
+     * exactly {@link #CLAIM_SUPERSEDED_MARKER} all return {@code null} so the
+     * caller falls through to its existing generic error handling. Only the
+     * exact reserved marker is classified — a {@code dependency_unavailable}
+     * (or any other) envelope is left alone. A non-string {@code detail} is
+     * treated as absent.
+     *
+     * @param errorText the {@code isError} tool-result text to classify
+     * @return the typed signal, or {@code null} when not the reserved envelope
+     */
+    public static MeshSupersededException fromEnvelope(String errorText) {
+        if (errorText == null) {
+            return null;
+        }
+        JsonNode node;
+        try {
+            node = MAPPER.readTree(errorText);
+        } catch (Exception e) {
+            return null;
+        }
+        if (node == null || !node.isObject()) {
+            return null;
+        }
+        JsonNode error = node.get("error");
+        if (error == null || !error.isTextual()
+                || !CLAIM_SUPERSEDED_MARKER.equals(error.asText())) {
+            return null;
+        }
+        JsonNode detailNode = node.get("detail");
+        String detail = (detailNode != null && detailNode.isTextual())
+            ? detailNode.asText() : null;
+        return new MeshSupersededException(detail);
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/types/MeshSupersededExceptionTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/types/MeshSupersededExceptionTest.java
@@ -1,0 +1,86 @@
+package io.mcpmesh.types;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1278 — typed supersession signal.
+ *
+ * <p>Covers the pure (no-FFI, no-HTTP) contract of {@link MeshSupersededException}:
+ * the reserved marker string, the optional {@code detail} accessor, and the
+ * defensive {@link MeshSupersededException#fromEnvelope} recognize parse — the
+ * exact byte-shape and classification the consumer proxies rely on. Mirrors the
+ * Python reference's {@code parse_superseded_envelope} unit tests.
+ */
+class MeshSupersededExceptionTest {
+
+    @Test
+    void marker_isTheCanonicalClaimSupersededString() {
+        // Reused verbatim from the job path (Go ent_service_jobs.go / Rust
+        // CLAIM_SUPERSEDED_REASON) — one string end-to-end.
+        assertEquals("claim_superseded", MeshSupersededException.CLAIM_SUPERSEDED_MARKER);
+    }
+
+    @Test
+    void detailAccessor_carriesDetail_orNull() {
+        assertEquals("stale", new MeshSupersededException("stale").getDetail());
+        assertNull(new MeshSupersededException(null).getDetail());
+    }
+
+    // ---- fromEnvelope: recognizes the reserved envelope ---------------------
+
+    @Test
+    void fromEnvelope_noDetail_recognized_detailNull() {
+        MeshSupersededException e =
+            MeshSupersededException.fromEnvelope("{\"error\":\"claim_superseded\"}");
+        assertNotNull(e, "the reserved envelope must be recognized");
+        assertNull(e.getDetail(), "an absent detail must surface as null");
+    }
+
+    @Test
+    void fromEnvelope_withDetail_recognized_detailCarried() {
+        MeshSupersededException e = MeshSupersededException.fromEnvelope(
+            "{\"error\":\"claim_superseded\",\"detail\":\"stale\"}");
+        assertNotNull(e);
+        assertEquals("stale", e.getDetail(),
+            "the detail string must be carried onto the typed signal");
+    }
+
+    // ---- fromEnvelope: defensive fall-through -------------------------------
+
+    @Test
+    void fromEnvelope_nonJson_returnsNull() {
+        assertNull(MeshSupersededException.fromEnvelope("not json"),
+            "a non-JSON body must fall through to generic handling");
+    }
+
+    @Test
+    void fromEnvelope_null_returnsNull() {
+        assertNull(MeshSupersededException.fromEnvelope(null));
+    }
+
+    @Test
+    void fromEnvelope_jsonButNotObject_returnsNull() {
+        // A bare JSON string "claim_superseded" is valid JSON but NOT an object.
+        assertNull(MeshSupersededException.fromEnvelope("\"claim_superseded\""),
+            "a non-object JSON body must not be classified");
+        assertNull(MeshSupersededException.fromEnvelope("[\"claim_superseded\"]"));
+    }
+
+    @Test
+    void fromEnvelope_wrongMarker_returnsNull() {
+        // dependency_unavailable (issue #1273) must NOT be misclassified.
+        assertNull(MeshSupersededException.fromEnvelope(
+            "{\"error\":\"dependency_unavailable\",\"capability\":\"lookup\"}"),
+            "a dependency_unavailable envelope must be left alone");
+    }
+
+    @Test
+    void fromEnvelope_nonStringDetail_treatedAsAbsent() {
+        MeshSupersededException e = MeshSupersededException.fromEnvelope(
+            "{\"error\":\"claim_superseded\",\"detail\":42}");
+        assertNotNull(e, "the marker still classifies even with a bad detail");
+        assertNull(e.getDetail(), "a non-string detail must be treated as absent");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
@@ -9,6 +9,7 @@ import io.mcpmesh.core.MeshCoreBridge;
 import io.mcpmesh.core.MeshObjectMappers;
 import io.mcpmesh.spring.tracing.TraceContext;
 import io.mcpmesh.spring.tracing.TraceInfo;
+import io.mcpmesh.types.MeshSupersededException;
 import io.mcpmesh.types.MeshToolCallException;
 import okhttp3.*;
 import org.slf4j.Logger;
@@ -675,6 +676,17 @@ public class McpHttpClient {
                     // Check if the tool call returned an error
                     if (result.has("isError") && result.get("isError").asBoolean()) {
                         String errorText = textContent != null ? textContent : "Unknown tool error";
+                        // Issue #1278: recognize the reserved
+                        // {"error":"claim_superseded"} envelope and re-throw the
+                        // typed signal so a superseded caller unwinds with one
+                        // catch. Only the exact reserved marker is reclassified —
+                        // a generic isError (or dependency_unavailable) still
+                        // throws MeshToolCallException below.
+                        MeshSupersededException superseded =
+                            MeshSupersededException.fromEnvelope(errorText);
+                        if (superseded != null) {
+                            throw superseded;
+                        }
                         throw new MeshToolCallException(functionName, functionName, errorText);
                     }
 
@@ -704,6 +716,12 @@ public class McpHttpClient {
                 return null;
             }
         } catch (MeshToolCallException e) {
+            throw e;
+        } catch (MeshSupersededException e) {
+            // Issue #1278: the reserved supersession signal must reach the
+            // calling handler untouched — the generic catch below would
+            // otherwise re-wrap it into MeshToolCallException and defeat the
+            // one-catch unwind.
             throw e;
         } catch (IOException e) {
             throw new MeshToolCallException(functionName, functionName, e);
@@ -1265,6 +1283,18 @@ public class McpHttpClient {
                         ? errorNode.get("message").asText()
                         : errorNode.toString();
                     upstreamError = new MeshToolCallException(functionName, functionName, em);
+                } else {
+                    // Issue #1278: a stream ending with the reserved tool-level
+                    // {"error":"claim_superseded"} envelope must surface the typed
+                    // signal (via subscriber.onError) rather than be swallowed as a
+                    // clean end-of-stream. Narrowly scoped to the reserved marker —
+                    // surfacing GENERIC tool-level isError on streams is a separate
+                    // pre-existing gap and intentionally left unchanged here.
+                    MeshSupersededException superseded =
+                        supersededFromStreamResult(msg.get("result"));
+                    if (superseded != null) {
+                        upstreamError = superseded;
+                    }
                 }
                 // Final result content is intentionally NOT delivered — matches the
                 // documented contract for streaming consumers.
@@ -1273,6 +1303,29 @@ public class McpHttpClient {
 
             return false;
         }
+    }
+
+    /**
+     * Return a {@link MeshSupersededException} if a stream's final tool result
+     * carries the reserved {@code {"error":"claim_superseded"}} envelope
+     * (issue #1278), else {@code null}. Defensive: a missing/false
+     * {@code isError}, an empty/non-text content block, or any non-reserved
+     * envelope all return {@code null} so the stream ends normally.
+     */
+    private static MeshSupersededException supersededFromStreamResult(JsonNode result) {
+        if (result == null || !result.has("isError") || !result.get("isError").asBoolean()) {
+            return null;
+        }
+        JsonNode content = result.get("content");
+        if (content == null || !content.isArray() || content.size() == 0) {
+            return null;
+        }
+        JsonNode first = content.get(0);
+        JsonNode textNode = first != null ? first.get("text") : null;
+        if (textNode == null || !textNode.isTextual()) {
+            return null;
+        }
+        return MeshSupersededException.fromEnvelope(textNode.asText());
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -16,6 +16,7 @@ import io.mcpmesh.spring.tracing.TraceContext;
 import io.mcpmesh.spring.tracing.TraceInfo;
 import io.mcpmesh.types.McpMeshTool;
 import io.mcpmesh.types.MeshLlmAgent;
+import io.mcpmesh.types.MeshSupersededException;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
 import io.modelcontextprotocol.spec.McpSchema.TextContent;
 import org.slf4j.Logger;
@@ -718,6 +719,33 @@ public class MeshToolWrapper implements McpToolHandler {
     }
 
     /**
+     * Build the reserved {@code claim_superseded} tool result (issue #1278) for
+     * a provider handler that threw {@link MeshSupersededException} to reject a
+     * superseded caller. Same carrier as {@link #dependencyUnavailableResult}:
+     * an {@code isError=true} {@link CallToolResult} whose single
+     * {@link TextContent} carries {@code {"error":"claim_superseded"}} (plus a
+     * {@code "detail"} key when supplied — OMITTED, not null, when absent), so
+     * the calling side's proxy classifies it by contract and re-throws the
+     * typed signal rather than treating it as a generic app failure.
+     */
+    private CallToolResult supersededResult(String detail) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("error", MeshSupersededException.CLAIM_SUPERSEDED_MARKER);
+        if (detail != null) {
+            body.put("detail", detail);
+        }
+        String json;
+        try {
+            json = objectMapper.writeValueAsString(body);
+        } catch (Exception e) {
+            // Trivial map — serialization never realistically fails; fall back
+            // to the no-detail envelope so the reserved contract stays valid.
+            json = "{\"error\":\"claim_superseded\"}";
+        }
+        return new CallToolResult(List.of(new TextContent(json)), true, null, null);
+    }
+
+    /**
      * Best-effort lease release for the inbound job-dispatch required-dependency
      * guard (issue #1273). Opens the controller via {@code opener}, releases the
      * lease, and closes it — swallowing ANY failure (from {@code open()} OR
@@ -1097,6 +1125,16 @@ public class MeshToolWrapper implements McpToolHandler {
         } catch (InvocationTargetException e) {
             // Unwrap to get the actual exception
             Throwable cause = e.getCause();
+            // Issue #1278: a provider handler rejects a superseded caller by
+            // throwing MeshSupersededException. Convert it — BEFORE the generic
+            // exception rethrow — into the reserved {"error":"claim_superseded"}
+            // isError result (same carrier as dependency_unavailable) so the
+            // calling side classifies it by contract and re-throws the typed
+            // signal. App-driven: the handler decided supersession via
+            // MeshCallContext.callingJob(); the framework never auto-detects.
+            if (cause instanceof MeshSupersededException mse) {
+                return supersededResult(mse.getDetail());
+            }
             log.error("Tool execution failed for {}: {}", funcId, cause.getMessage(), cause);
             if (cause instanceof Exception) {
                 throw (Exception) cause;
@@ -1109,7 +1147,14 @@ public class MeshToolWrapper implements McpToolHandler {
 
         // Handle async results (CompletableFuture) — bounded by the inbound
         // X-Mesh-Timeout budget when present (issue #1164 MED-5).
-        result = awaitIfFuture(result, deadlineSecs);
+        try {
+            result = awaitIfFuture(result, deadlineSecs);
+        } catch (MeshSupersededException mse) {
+            // Async handler: the returned future completed exceptionally with
+            // the supersession signal (awaitIfFuture unwrapped the
+            // ExecutionException). Same reserved-envelope conversion (#1278).
+            return supersededResult(mse.getDetail());
+        }
 
         return result;
     }
@@ -1641,12 +1686,25 @@ public class MeshToolWrapper implements McpToolHandler {
             result = method.invoke(bean, fullArgs);
         } catch (InvocationTargetException e) {
             Throwable cause = e.getCause();
+            // Issue #1278: a superseded-caller rejection must emit the reserved
+            // {"error":"claim_superseded"} envelope on the job-dispatch path too
+            // (task providers are the primary supersession scenario). Python/TS
+            // convert at the transport-independent fastmcp layer; Java converts
+            // at the wrapper, so mirror the non-job branch here.
+            if (cause instanceof MeshSupersededException mse) {
+                return supersededResult(mse.getDetail());
+            }
             if (cause instanceof Exception ex) throw ex;
             throw new RuntimeException(cause);
         } catch (IllegalAccessException e) {
             throw new RuntimeException("Method access denied: " + e.getMessage(), e);
         }
-        result = awaitIfFuture(result, deadlineSecs);
+        try {
+            result = awaitIfFuture(result, deadlineSecs);
+        } catch (MeshSupersededException mse) {
+            // Async handler completed exceptionally with the supersession signal.
+            return supersededResult(mse.getDetail());
+        }
         return result;
     }
 
@@ -1656,6 +1714,15 @@ public class MeshToolWrapper implements McpToolHandler {
             result = method.invoke(bean, fullArgs);
         } catch (InvocationTargetException e) {
             Throwable cause = e.getCause();
+            // Issue #1278: a superseded-caller rejection emits the reserved
+            // {"error":"claim_superseded"} envelope regardless of dispatch path.
+            // Return it BEFORE the retryOn/fail handling and WITHOUT
+            // auto-completing — mirrors Python, where SupersededError propagates
+            // past _run_and_autocomplete (no complete()/fail()) and the fastmcp
+            // layer converts it; the registry sweep is the row's backstop.
+            if (cause instanceof MeshSupersededException mse) {
+                return supersededResult(mse.getDetail());
+            }
             // Issue #895: retryOn-aware exception handling. Mirrors Python
             // `_run_and_autocomplete` (job_dispatch.py:336-386) and TS
             // `runWithJobContext` (inbound-job-dispatch.ts:160-225):
@@ -1706,6 +1773,11 @@ public class MeshToolWrapper implements McpToolHandler {
                 // release the lease.
                 Throwable cause = e.getCause();
                 if (cause == null) cause = e;
+                // Issue #1278: async supersession signal — same reserved-envelope
+                // conversion, before the retryOn/fail handling (no auto-complete).
+                if (cause instanceof MeshSupersededException mse) {
+                    return supersededResult(mse.getDetail());
+                }
                 if (handleRetryOrFail(controller, cause)) {
                     return null;
                 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ToolInvoker.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/ToolInvoker.java
@@ -2,6 +2,7 @@ package io.mcpmesh.spring;
 
 import io.mcpmesh.types.McpMeshTool;
 import io.mcpmesh.types.MeshLlmAgent.ToolInfo;
+import io.mcpmesh.types.MeshSupersededException;
 import io.mcpmesh.types.MeshToolCallException;
 import io.mcpmesh.types.MeshToolUnavailableException;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
@@ -185,6 +186,17 @@ public class ToolInvoker {
                 if (result instanceof CallToolResult ctr
                         && Boolean.TRUE.equals(ctr.isError())) {
                     String errorText = firstTextContent(ctr);
+                    // Issue #1278: a self/local/LLM dependency can also emit the
+                    // reserved {"error":"claim_superseded"} envelope — recognize
+                    // it and re-throw the typed signal (mirrors McpHttpClient).
+                    // A generic isError (or dependency_unavailable) still throws
+                    // MeshToolCallException below.
+                    MeshSupersededException superseded =
+                        MeshSupersededException.fromEnvelope(errorText);
+                    if (superseded != null) {
+                        span.withError(superseded);
+                        throw superseded;
+                    }
                     MeshToolCallException ex = new MeshToolCallException(
                         capability, handler.getMethodName(), errorText);
                     span.withError(ex);
@@ -195,6 +207,11 @@ public class ToolInvoker {
             } catch (MeshToolCallException e) {
                 // Already the caller-facing type (isError translation above) —
                 // don't double-wrap.
+                throw e;
+            } catch (MeshSupersededException e) {
+                // Issue #1278: the reserved supersession signal must reach the
+                // calling handler untouched — never re-wrap into
+                // MeshToolCallException.
                 throw e;
             } catch (Exception e) {
                 span.withError(e);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpHttpClientStreamTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpHttpClientStreamTest.java
@@ -1,5 +1,6 @@
 package io.mcpmesh.spring;
 
+import io.mcpmesh.types.MeshSupersededException;
 import io.mcpmesh.types.MeshToolCallException;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -90,6 +91,15 @@ class McpHttpClientStreamTest {
     private String finalErrorEvent(long requestId, String message) {
         String body = "{\"jsonrpc\":\"2.0\",\"id\":" + requestId
             + ",\"error\":{\"code\":-32000,\"message\":\"" + message + "\"}}";
+        return sseEvent(body);
+    }
+
+    /** Final tool result with isError=true whose text block is {@code envelope}. */
+    private String finalIsErrorResultEvent(long requestId, String envelope) {
+        String escaped = envelope.replace("\"", "\\\"");
+        String body = "{\"jsonrpc\":\"2.0\",\"id\":" + requestId
+            + ",\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"" + escaped
+            + "\"}],\"isError\":true}}";
         return sseEvent(body);
     }
 
@@ -263,6 +273,66 @@ class McpHttpClientStreamTest {
             () -> collect(client.streamTool(endpoint, "tool", null, null)));
         assertTrue(ex.getMessage().contains("tool blew up"),
             "Expected exception to include error message, got: " + ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("#1278: a stream ending with the reserved claim_superseded envelope surfaces MeshSupersededException")
+    void onSupersededEnvelope_surfacesTypedSignal() {
+        server.setDispatcher(new okhttp3.mockwebserver.Dispatcher() {
+            @Override
+            public MockResponse dispatch(RecordedRequest request) {
+                String body = request.getBody().readUtf8();
+                try {
+                    JsonNode bodyJson = mapper.readTree(body);
+                    String token = bodyJson.get("params").get("_meta").get("progressToken").asText();
+                    long id = bodyJson.get("id").asLong();
+                    String sse = progressEvent(token, 1, "partial")
+                               + finalIsErrorResultEvent(id,
+                                   "{\"error\":\"claim_superseded\",\"detail\":\"stale\"}");
+                    return new MockResponse()
+                        .setBody(sse)
+                        .setHeader("Content-Type", "text/event-stream");
+                } catch (Exception e) {
+                    return new MockResponse().setResponseCode(500);
+                }
+            }
+        });
+
+        String endpoint = server.url("/").toString();
+        MeshSupersededException ex = assertThrows(MeshSupersededException.class,
+            () -> collect(client.streamTool(endpoint, "tool", null, null)),
+            "the reserved envelope ending a stream must surface as the typed signal");
+        assertEquals("stale", ex.getDetail());
+    }
+
+    @Test
+    @DisplayName("#1278: a GENERIC tool-level isError ending a stream stays a clean end-of-stream (pre-existing behavior, unchanged)")
+    void onGenericIsError_stillCleanEndOfStream() throws Exception {
+        server.setDispatcher(new okhttp3.mockwebserver.Dispatcher() {
+            @Override
+            public MockResponse dispatch(RecordedRequest request) {
+                String body = request.getBody().readUtf8();
+                try {
+                    JsonNode bodyJson = mapper.readTree(body);
+                    String token = bodyJson.get("params").get("_meta").get("progressToken").asText();
+                    long id = bodyJson.get("id").asLong();
+                    String sse = progressEvent(token, 1, "kept")
+                               + finalIsErrorResultEvent(id, "boom: generic tool error");
+                    return new MockResponse()
+                        .setBody(sse)
+                        .setHeader("Content-Type", "text/event-stream");
+                } catch (Exception e) {
+                    return new MockResponse().setResponseCode(500);
+                }
+            }
+        });
+
+        String endpoint = server.url("/").toString();
+        // Narrow scope: only the reserved envelope is surfaced. A generic
+        // tool-level isError remains a clean end-of-stream (the broader
+        // streaming-isError gap is pre-existing and intentionally untouched).
+        List<String> chunks = collect(client.streamTool(endpoint, "tool", null, null));
+        assertEquals(List.of("kept"), chunks);
     }
 
     @Test

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpHttpClientSupersededTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/McpHttpClientSupersededTest.java
@@ -1,0 +1,113 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.types.MeshSupersededException;
+import io.mcpmesh.types.MeshToolCallException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.*;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1278 — consumer recognize + swallow point ({@link McpHttpClient}).
+ *
+ * <p>The injected remote proxy classifies an {@code isError} tool result: the
+ * reserved {@code {"error":"claim_superseded"}} envelope is re-thrown as the
+ * typed {@link MeshSupersededException} (carrying detail), while a generic
+ * isError — or the sibling {@code dependency_unavailable} envelope (#1273) —
+ * still throws {@link MeshToolCallException}. Critically, the thrown typed
+ * signal must reach the caller UNTOUCHED: the method's outer
+ * {@code catch (Exception)} must not re-wrap it back into MeshToolCallException.
+ */
+@DisplayName("McpHttpClient supersession recognize (#1278)")
+class McpHttpClientSupersededTest {
+
+    private MockWebServer server;
+    private McpHttpClient client;
+
+    @BeforeAll
+    static void initTlsConfig() throws Exception {
+        // Pre-seed MeshTlsConfig.cached to avoid a native FFI call during tests.
+        Constructor<MeshTlsConfig> ctor = MeshTlsConfig.class.getDeclaredConstructor(
+            boolean.class, String.class, String.class, String.class, String.class);
+        ctor.setAccessible(true);
+        MeshTlsConfig disabled = ctor.newInstance(false, "off", null, null, null);
+
+        Field cachedField = MeshTlsConfig.class.getDeclaredField("cached");
+        cachedField.setAccessible(true);
+        cachedField.set(null, disabled);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        client = new McpHttpClient();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+        server.shutdown();
+    }
+
+    /** Enqueue a JSON-RPC isError result whose single text block is {@code envelope}. */
+    private void enqueueError(String envelope) {
+        String escaped = envelope.replace("\"", "\\\"");
+        String body = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[{\"type\":\"text\","
+            + "\"text\":\"" + escaped + "\"}],\"isError\":true}}";
+        server.enqueue(new MockResponse()
+            .setBody(body)
+            .setHeader("Content-Type", "application/json"));
+    }
+
+    @Test
+    void reservedEnvelopeWithDetail_throwsTypedSignal_untouched() {
+        enqueueError("{\"error\":\"claim_superseded\",\"detail\":\"stale\"}");
+        String endpoint = server.url("/").toString();
+
+        // The swallow-point assertion: the CAUGHT exception is the typed signal
+        // itself — NOT a MeshToolCallException wrapping it.
+        MeshSupersededException e = assertThrows(MeshSupersededException.class,
+            () -> client.callTool(endpoint, "mutate", Map.of()),
+            "the reserved envelope must surface as the typed signal, not re-wrapped");
+        assertEquals("stale", e.getDetail(), "the detail must be carried to the caller");
+    }
+
+    @Test
+    void reservedEnvelopeNoDetail_throwsTypedSignal_detailNull() {
+        enqueueError("{\"error\":\"claim_superseded\"}");
+        String endpoint = server.url("/").toString();
+
+        MeshSupersededException e = assertThrows(MeshSupersededException.class,
+            () -> client.callTool(endpoint, "mutate", Map.of()));
+        assertNull(e.getDetail());
+    }
+
+    @Test
+    void dependencyUnavailableEnvelope_stillThrowsMeshToolCallException() {
+        // #1273 sibling envelope must NOT be misclassified as supersession.
+        enqueueError("{\"error\":\"dependency_unavailable\",\"capability\":\"lookup\"}");
+        String endpoint = server.url("/").toString();
+
+        assertThrows(MeshToolCallException.class,
+            () -> client.callTool(endpoint, "mutate", Map.of()),
+            "dependency_unavailable must remain a MeshToolCallException");
+    }
+
+    @Test
+    void genericErrorText_stillThrowsMeshToolCallException() {
+        enqueueError("boom: something went wrong");
+        String endpoint = server.url("/").toString();
+
+        assertThrows(MeshToolCallException.class,
+            () -> client.callTool(endpoint, "mutate", Map.of()),
+            "a generic isError must remain a MeshToolCallException");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperSupersededTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperSupersededTest.java
@@ -1,0 +1,150 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.Param;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.spring.tracing.TraceContext;
+import io.mcpmesh.types.MeshSupersededException;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1278 — provider emit: a handler that rejects a superseded caller by
+ * throwing {@link MeshSupersededException} produces the reserved
+ * {@code {"error":"claim_superseded"}} {@code isError} tool result (same carrier
+ * as the {@code dependency_unavailable} refusal), with {@code detail} present
+ * only when supplied. Mirrors {@link MeshToolWrapperRequiredDepGuardTest}.
+ */
+class MeshToolWrapperSupersededTest {
+
+    /** Provider that throws the supersession signal (app-decided). */
+    public static class SupersedingBean {
+        @MeshTool(capability = "mutate")
+        public Object mutate(@Param("detail") String detail) {
+            // The app decides supersession (e.g. via MeshCallContext.callingJob());
+            // an empty/absent detail exercises the no-detail envelope.
+            throw new MeshSupersededException(
+                (detail == null || detail.isEmpty()) ? null : detail);
+        }
+
+        @MeshTool(capability = "mutate_async")
+        public CompletableFuture<Object> mutateAsync(@Param("detail") String detail) {
+            // Async handler: the future completes exceptionally with the signal.
+            CompletableFuture<Object> f = new CompletableFuture<>();
+            f.completeExceptionally(new MeshSupersededException(
+                (detail == null || detail.isEmpty()) ? null : detail));
+            return f;
+        }
+    }
+
+    private static MeshToolWrapper wrapperFor(String methodName) throws Exception {
+        SupersedingBean bean = new SupersedingBean();
+        Method m = SupersedingBean.class.getMethod(methodName, String.class);
+        return new MeshToolWrapper(
+            "SupersedingBean." + methodName,
+            m.getAnnotation(MeshTool.class).capability(),
+            "test",
+            bean,
+            m,
+            List.of(),
+            JsonMapper.builder().build());
+    }
+
+    private static String textOf(Object result) {
+        assertInstanceOf(CallToolResult.class, result,
+            "the supersession refusal must be a structured tool result");
+        CallToolResult ctr = (CallToolResult) result;
+        assertEquals(Boolean.TRUE, ctr.isError(),
+            "the refusal must be an isError result (contract-classified, not app success)");
+        return ((TextContent) ctr.content().get(0)).text();
+    }
+
+    @Test
+    void handlerThrows_withDetail_emitsReservedEnvelopeWithDetail() throws Exception {
+        MeshToolWrapper wrapper = wrapperFor("mutate");
+
+        Object result = wrapper.invoke(Map.of("detail", "d"));
+
+        assertEquals("{\"error\":\"claim_superseded\",\"detail\":\"d\"}", textOf(result),
+            "the envelope must carry the detail key when supplied");
+    }
+
+    @Test
+    void handlerThrows_noDetail_emitsReservedEnvelope_detailOmitted() throws Exception {
+        MeshToolWrapper wrapper = wrapperFor("mutate");
+
+        Object result = wrapper.invoke(Map.of("detail", ""));
+
+        assertEquals("{\"error\":\"claim_superseded\"}", textOf(result),
+            "the detail key must be OMITTED (not null) when absent");
+    }
+
+    @Test
+    void asyncHandlerThrows_withDetail_emitsReservedEnvelopeWithDetail() throws Exception {
+        MeshToolWrapper wrapper = wrapperFor("mutateAsync");
+
+        Object result = wrapper.invoke(Map.of("detail", "async-stale"));
+
+        assertEquals("{\"error\":\"claim_superseded\",\"detail\":\"async-stale\"}", textOf(result),
+            "an async handler's supersession signal must emit the same reserved envelope");
+    }
+
+    @Test
+    void asyncHandlerThrows_noDetail_emitsReservedEnvelope_detailOmitted() throws Exception {
+        MeshToolWrapper wrapper = wrapperFor("mutateAsync");
+
+        Object result = wrapper.invoke(Map.of("detail", ""));
+
+        assertEquals("{\"error\":\"claim_superseded\"}", textOf(result));
+    }
+
+    // ---- job-dispatch path (issue #1278 review gap 1) -----------------------
+
+    /** task=true provider (the PRIMARY supersession scenario) with a MeshJob slot. */
+    public static class SupersedingJobBean {
+        @MeshTool(capability = "job_mutate", task = true)
+        public Object jobMutate(@Param("detail") String detail, MeshJob job) {
+            // A dispatched job provider inspects MeshCallContext.callingJob() and
+            // rejects a superseded caller. Modeled here by throwing directly.
+            throw new MeshSupersededException(
+                (detail == null || detail.isEmpty()) ? null : detail);
+        }
+    }
+
+    @AfterEach
+    void reset() {
+        MeshSettleState.resetForTests();
+        TraceContext.clearPropagatedHeaders();
+    }
+
+    @Test
+    void jobDispatch_handlerThrows_emitsReservedEnvelope() throws Exception {
+        // A task=true tool invoked WITH an X-Mesh-Job-Id header routes through
+        // dispatchAsJob → invokeNoController (instanceId/registryUrl are NOT wired,
+        // so canInjectController is false). The supersession signal must STILL
+        // emit the reserved envelope — the job-dispatch invocation paths convert
+        // it exactly like the non-job branch.
+        MeshSettleState.resetForTests(); // settled — no grace window
+        SupersedingJobBean bean = new SupersedingJobBean();
+        Method m = SupersedingJobBean.class.getMethod("jobMutate", String.class, MeshJob.class);
+        MeshToolWrapper wrapper = new MeshToolWrapper(
+            "SupersedingJobBean.jobMutate", "job_mutate", "test", bean, m,
+            List.of(), JsonMapper.builder().build(), true);
+
+        TraceContext.setPropagatedHeaders(Map.of("x-mesh-job-id", "job-xyz"));
+        Object result = wrapper.invoke(Map.of("detail", "job-stale"));
+
+        assertEquals("{\"error\":\"claim_superseded\",\"detail\":\"job-stale\"}", textOf(result),
+            "a superseded rejection on the job-dispatch path must emit the reserved envelope");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/ToolInvokerSupersededTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/ToolInvokerSupersededTest.java
@@ -1,0 +1,80 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.types.MeshSupersededException;
+import io.mcpmesh.types.MeshToolCallException;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #1278 — consumer recognize + swallow point for the LOCAL /
+ * self-dependency / LLM path ({@link ToolInvoker#invokeLocal}). Mirrors
+ * {@link ToolInvokerLocalRefusalTest}: a handler that RETURNS the reserved
+ * {@code claim_superseded} isError envelope must surface to the local caller as
+ * the typed {@link MeshSupersededException} (not re-wrapped by the outer
+ * {@code catch}), while a generic isError — or {@code dependency_unavailable} —
+ * still surfaces as {@link MeshToolCallException}.
+ */
+class ToolInvokerSupersededTest {
+
+    private static CallToolResult errorResult(String envelope) {
+        return new CallToolResult(List.of(new TextContent(envelope)), true, null, null);
+    }
+
+    private static ToolInvoker invokerReturning(CallToolResult result) throws Exception {
+        MeshToolWrapperRegistry registry = mock(MeshToolWrapperRegistry.class);
+        McpToolHandler handler = mock(McpToolHandler.class);
+        when(handler.getFuncId()).thenReturn("Bean.mutate");
+        when(handler.getMethodName()).thenReturn("mutate");
+        when(handler.invoke(Map.of())).thenReturn(result);
+        when(registry.getHandlerByCapability("mutate")).thenReturn(handler);
+        return new ToolInvoker(null, registry, "agent-1");
+    }
+
+    @Test
+    void reservedEnvelopeWithDetail_throwsTypedSignal_untouched() throws Exception {
+        ToolInvoker invoker = invokerReturning(
+            errorResult("{\"error\":\"claim_superseded\",\"detail\":\"stale\"}"));
+
+        // Swallow-point: the caught exception is the typed signal, NOT a
+        // MeshToolCallException wrapping it.
+        MeshSupersededException e = assertThrows(MeshSupersededException.class,
+            () -> invoker.invokeLocal("mutate", Map.of()));
+        assertEquals("stale", e.getDetail());
+    }
+
+    @Test
+    void reservedEnvelopeNoDetail_throwsTypedSignal_detailNull() throws Exception {
+        ToolInvoker invoker = invokerReturning(
+            errorResult("{\"error\":\"claim_superseded\"}"));
+
+        MeshSupersededException e = assertThrows(MeshSupersededException.class,
+            () -> invoker.invokeLocal("mutate", Map.of()));
+        assertNull(e.getDetail());
+    }
+
+    @Test
+    void dependencyUnavailableEnvelope_stillThrowsMeshToolCallException() throws Exception {
+        ToolInvoker invoker = invokerReturning(
+            errorResult("{\"error\":\"dependency_unavailable\",\"capability\":\"lookup\"}"));
+
+        assertThrows(MeshToolCallException.class,
+            () -> invoker.invokeLocal("mutate", Map.of()),
+            "dependency_unavailable must not be misclassified as supersession");
+    }
+
+    @Test
+    void genericErrorText_stillThrowsMeshToolCallException() throws Exception {
+        ToolInvoker invoker = invokerReturning(errorResult("boom"));
+
+        assertThrows(MeshToolCallException.class,
+            () -> invoker.invokeLocal("mutate", Map.of()));
+    }
+}

--- a/src/runtime/python/_mcp_mesh/engine/superseded.py
+++ b/src/runtime/python/_mcp_mesh/engine/superseded.py
@@ -1,0 +1,88 @@
+"""Typed supersession signal (issue #1278).
+
+A provider tool that detects it is being called by a SUPERSEDED executor —
+the app compares the calling job's epoch via :func:`mesh.calling_job`
+(issue #1263) against its own live epoch — rejects the call by raising
+:class:`SupersededError`. That crosses the wire as the reserved app envelope
+``{"error":"claim_superseded"}`` (plus an optional ``"detail"`` string), and
+the CALLING side's injected ``McpMeshTool`` proxy recognizes the envelope and
+re-raises :class:`SupersededError`. A superseded caller then unwinds with one
+``except mesh.SupersededError`` instead of string-matching ``claim_superseded``
+after every mutating call.
+
+The framework does NOT auto-detect supersession — the app decides (full
+control); the framework provides the typed class plus the emit/recognize
+plumbing. This is the structural parallel of the ``dependency_unavailable``
+refusal (issue #1273): both raise a ``ToolError`` whose message is a reserved
+JSON envelope, so the contract (not the carrier) drives classification.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from fastmcp.exceptions import ToolError
+
+# Reserved marker string for the supersession envelope. This is the SAME
+# canonical marker the job path already uses on the wire (Rust
+# ``task_backend.rs`` ``CLAIM_SUPERSEDED_REASON`` / Go
+# ``ent_service_jobs.go``), reused verbatim so a superseded signal is one
+# string end-to-end.
+CLAIM_SUPERSEDED_MARKER = "claim_superseded"
+
+
+class SupersededError(ToolError):
+    """Raised by a provider tool to reject a call from a superseded executor.
+
+    Subclasses fastmcp's :class:`~fastmcp.exceptions.ToolError` — the same
+    error primitive the ``dependency_unavailable`` refusal uses — so raising it
+    from a ``@mesh.tool`` handler auto-emits an ``isError`` tool result whose
+    text is the reserved envelope, through the EXISTING fastmcp ToolError path
+    (no provider wrapper change needed).
+
+    The serialized message (``str(err)``) is
+    ``{"error":"claim_superseded","detail":<detail>}`` — the ``detail`` key is
+    omitted entirely when no detail is supplied.
+
+    Provider usage::
+
+        cj = mesh.calling_job()
+        if cj and cj.claim_epoch is not None and cj.claim_epoch < my_live_epoch:
+            raise mesh.SupersededError(f"stale epoch {cj.claim_epoch}")
+
+    ``except mesh.SupersededError`` is the specific catch this enables; because
+    it IS a ToolError, ``except ToolError`` still catches it too.
+    """
+
+    def __init__(self, detail: Optional[str] = None):
+        self.detail = detail
+        envelope: dict[str, Any] = {"error": CLAIM_SUPERSEDED_MARKER}
+        if detail is not None:
+            envelope["detail"] = detail
+        # Compact separators → byte-identical to the TS/Java emit and the
+        # compact job-path marker (no whitespace after ',' / ':').
+        super().__init__(json.dumps(envelope, separators=(",", ":")))
+
+
+def parse_superseded_envelope(error_text: str) -> Optional[SupersededError]:
+    """Return a :class:`SupersededError` if ``error_text`` is the reserved
+    supersession envelope, else ``None``.
+
+    Defensive parse for the consumer recognize path: a non-JSON body, a JSON
+    body that is not an object, or one whose ``error`` field is not exactly the
+    reserved marker all return ``None`` so the caller falls through to its
+    existing generic error handling. Only the exact reserved marker is
+    classified — a ``dependency_unavailable`` (or any other) envelope is left
+    alone.
+    """
+    try:
+        payload = json.loads(error_text)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("error") != CLAIM_SUPERSEDED_MARKER:
+        return None
+    detail = payload.get("detail")
+    return SupersededError(detail if isinstance(detail, str) else None)

--- a/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
+++ b/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
@@ -24,6 +24,9 @@ from ..shared.logging_config import (
 from ..shared.sse_parser import SSEParser
 from ..tracing.context import TraceContext
 from ..tracing.utils import generate_span_id
+from fastmcp.exceptions import ToolError
+
+from .superseded import SupersededError, parse_superseded_envelope
 
 logger = logging.getLogger(__name__)
 
@@ -799,6 +802,12 @@ class UnifiedMCPProxy:
                 # HTTP direct path (PRIMARY) — pooled httpx client, no MCP session overhead
                 result = await self._http_call(name, args_with_trace)
                 return result
+            except SupersededError:
+                # Issue #1278: a superseded refusal from the PRIMARY transport is
+                # an application response, not a transport failure — propagate it
+                # typed WITHOUT falling back to the FastMCP client (which would
+                # invoke the provider a SECOND time). Specific-before-generic.
+                raise
             except Exception as e:
                 error_msg = str(e)
                 # Don't fallback on application-level errors — the remote tool responded
@@ -825,6 +834,11 @@ class UnifiedMCPProxy:
                             f"{tp}✅ FastMCP fallback successful: {name} in {duration_ms}ms → {format_result_summary(converted_result)}"
                         )
                         return converted_result
+                except SupersededError:
+                    # Issue #1278: if the fallback path itself surfaces the typed
+                    # supersession signal, propagate it untouched rather than
+                    # rewrapping into a generic RuntimeError.
+                    raise
                 except Exception as fallback_error:
                     raise RuntimeError(
                         f"Tool call to '{name}' failed: HTTP={e}, FastMCP={fallback_error}"
@@ -848,6 +862,15 @@ class UnifiedMCPProxy:
                             error_text = item.text
                             break
                 self.logger.error(f"Remote tool returned error: {error_text}")
+                # Typed supersession signal (issue #1278): a provider that
+                # rejected this call as coming from a superseded executor emits
+                # the reserved ``{"error":"claim_superseded"}`` envelope. Re-
+                # raise it as the typed SupersededError so the caller unwinds
+                # with one ``except mesh.SupersededError``. Defensive parse —
+                # a non-superseded isError falls through to the generic error.
+                superseded = parse_superseded_envelope(error_text)
+                if superseded is not None:
+                    raise superseded
                 raise RuntimeError(f"Remote tool call failed: {error_text}")
 
             # Handle CallToolResult objects
@@ -909,6 +932,10 @@ class UnifiedMCPProxy:
                     return str(mcp_result)
 
         except RuntimeError:
+            raise
+        except SupersededError:
+            # Issue #1278: the typed supersession signal must propagate — it is
+            # a recognized error, not a conversion failure to swallow.
             raise
         except Exception as e:
             self.logger.warning(
@@ -1343,6 +1370,13 @@ class UnifiedMCPProxy:
                         error_text = item["text"]
                         break
                 self.logger.error(f"❌ Remote tool error: {error_text}")
+                # Typed supersession signal (issue #1278) — HTTP-fallback twin
+                # of the FastMCP recognize above. Re-raise the reserved
+                # ``claim_superseded`` envelope as SupersededError; defensive
+                # parse falls through to the generic error otherwise.
+                superseded = parse_superseded_envelope(error_text)
+                if superseded is not None:
+                    raise superseded
                 raise RuntimeError(f"Tool call error: {error_text}")
 
             # Calculate performance metrics
@@ -1366,6 +1400,13 @@ class UnifiedMCPProxy:
             raise RuntimeError(
                 f"HTTP error {e.response.status_code}: {e.response.text[:200]}"
             )
+        except SupersededError:
+            # Issue #1278: the typed supersession signal recognized above must
+            # re-raise UNTOUCHED — the generic rewrap below would turn it into a
+            # "HTTP call failed" RuntimeError that _call_remote_tool then treats
+            # as a transport failure and retries via the FastMCP fallback
+            # (double-invoking the provider). Specific-before-generic ordering.
+            raise
         except Exception as e:
             self.logger.error(f"❌ HTTP call failed: {type(e).__name__}: {e}")
             raise RuntimeError(f"HTTP call failed: {e}")
@@ -1488,7 +1529,22 @@ class UnifiedMCPProxy:
                         pass
                     final_result = None
                 else:
-                    final_result = await call_task
+                    try:
+                        final_result = await call_task
+                    except ToolError as e:
+                        # Issue #1278: a superseded streaming producer surfaces
+                        # here as a fastmcp ToolError whose message is the
+                        # reserved ``claim_superseded`` envelope. Re-raise it
+                        # typed so streaming callers get the same one-catch
+                        # (``except mesh.SupersededError``) contract as the
+                        # unary path. Already-typed or non-superseded ToolErrors
+                        # propagate unchanged.
+                        if isinstance(e, SupersededError):
+                            raise
+                        superseded = parse_superseded_envelope(str(e))
+                        if superseded is not None:
+                            raise superseded from e
+                        raise
 
                 # If the producer was non-streaming and no progress chunks
                 # arrived, extract text from the final CallToolResult and yield

--- a/src/runtime/python/mesh/__init__.py
+++ b/src/runtime/python/mesh/__init__.py
@@ -231,6 +231,13 @@ def __getattr__(name):
         from _mcp_mesh.engine.job_context import CallingJob
 
         return CallingJob
+    elif name == "SupersededError":
+        # Issue #1278: typed supersession signal. A provider raises this to
+        # reject a call from a superseded executor; the calling side's injected
+        # proxy re-raises it on recognizing the reserved envelope.
+        from _mcp_mesh.engine.superseded import SupersededError
+
+        return SupersededError
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 

--- a/src/runtime/python/tests/unit/test_1278_superseded_signal.py
+++ b/src/runtime/python/tests/unit/test_1278_superseded_signal.py
@@ -1,0 +1,351 @@
+"""Unit tests for issue #1278: typed supersession signal.
+
+A provider tool that detects it is being called by a SUPERSEDED executor (the
+app compares the calling job's epoch via ``mesh.calling_job()`` — issue #1263)
+rejects the call by raising a typed ``mesh.SupersededError``. That crosses the
+wire as the reserved ``{"error":"claim_superseded"}`` app envelope (plus an
+optional ``"detail"``), and the CALLING side's injected ``McpMeshTool`` proxy
+recognizes the envelope and re-raises ``mesh.SupersededError`` — so a superseded
+caller unwinds with one ``except mesh.SupersededError`` instead of
+string-matching ``claim_superseded`` after every mutating call.
+
+Structural parallel of the ``dependency_unavailable`` refusal (issue #1273):
+both raise a ``ToolError`` whose message is a reserved JSON envelope, so the
+contract (not the carrier) drives classification. Mirrors
+``test_1273_direct_invoke_required.py``.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import mesh
+import pytest
+from _mcp_mesh.engine.superseded import (
+    CLAIM_SUPERSEDED_MARKER,
+    SupersededError,
+    parse_superseded_envelope,
+)
+from _mcp_mesh.engine.unified_mcp_proxy import UnifiedMCPProxy
+from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+
+
+class _FakeContent:
+    def __init__(self, text):
+        self.text = text
+
+
+class _FakeErrorResult:
+    """Minimal stand-in for a FastMCP ``CallToolResult`` with ``isError``."""
+
+    def __init__(self, text):
+        self.isError = True
+        self.content = [_FakeContent(text)]
+
+
+class TestSupersededErrorClass:
+    def test_marker_matches_job_path_string(self):
+        # The reserved marker is the SAME canonical string the job path uses on
+        # the wire (Rust task_backend.rs CLAIM_SUPERSEDED_REASON / Go).
+        assert CLAIM_SUPERSEDED_MARKER == "claim_superseded"
+
+    def test_is_toolerror_subclass(self):
+        assert issubclass(SupersededError, ToolError)
+        assert isinstance(SupersededError("x"), ToolError)
+
+    def test_serialized_envelope_with_detail(self):
+        err = SupersededError("stale epoch 3")
+        assert json.loads(str(err)) == {
+            "error": "claim_superseded",
+            "detail": "stale epoch 3",
+        }
+        assert err.detail == "stale epoch 3"
+
+    def test_serialized_envelope_omits_detail_when_none(self):
+        err = SupersededError()
+        # detail key omitted entirely (not a null) when no detail supplied.
+        assert json.loads(str(err)) == {"error": "claim_superseded"}
+        assert err.detail is None
+
+    def test_public_export_is_same_class(self):
+        assert mesh.SupersededError is SupersededError
+
+
+class TestProviderEmit:
+    """Raising ``mesh.SupersededError`` from a real @mesh tool auto-emits an
+    isError tool result carrying the reserved envelope — through the EXISTING
+    fastmcp ToolError path, no provider wrapper change."""
+
+    def test_raise_produces_iserror_reserved_envelope(self):
+        srv = FastMCP(name="provider")
+
+        @srv.tool()
+        def mutate():
+            raise mesh.SupersededError("stale epoch 3")
+
+        async def go():
+            async with Client(srv) as c:
+                return await c.call_tool("mutate", {}, raise_on_error=False)
+
+        res = asyncio.run(go())
+        assert res.is_error
+        assert json.loads(res.content[0].text) == {
+            "error": "claim_superseded",
+            "detail": "stale epoch 3",
+        }
+
+    def test_raise_without_detail_emits_envelope_without_detail(self):
+        srv = FastMCP(name="provider")
+
+        @srv.tool()
+        def mutate():
+            raise mesh.SupersededError()
+
+        async def go():
+            async with Client(srv) as c:
+                return await c.call_tool("mutate", {}, raise_on_error=False)
+
+        res = asyncio.run(go())
+        assert res.is_error
+        assert json.loads(res.content[0].text) == {"error": "claim_superseded"}
+
+
+class TestParseSupersededEnvelope:
+    """The shared recognizer both proxy sites delegate to."""
+
+    def test_recognizes_marker(self):
+        err = parse_superseded_envelope('{"error":"claim_superseded"}')
+        assert isinstance(err, SupersededError)
+        assert err.detail is None
+
+    def test_carries_detail(self):
+        err = parse_superseded_envelope('{"error":"claim_superseded","detail":"x"}')
+        assert isinstance(err, SupersededError)
+        assert err.detail == "x"
+
+    def test_non_json_falls_through(self):
+        assert parse_superseded_envelope("boom, plain text error") is None
+
+    def test_dependency_unavailable_not_misclassified(self):
+        # A sibling reserved envelope must NOT trip the supersession recognizer.
+        assert (
+            parse_superseded_envelope(
+                '{"error":"dependency_unavailable","capability":"lookup"}'
+            )
+            is None
+        )
+
+    def test_json_non_object_falls_through(self):
+        assert parse_superseded_envelope('"claim_superseded"') is None
+        assert parse_superseded_envelope("[1,2,3]") is None
+
+    def test_non_string_detail_dropped(self):
+        err = parse_superseded_envelope('{"error":"claim_superseded","detail":42}')
+        assert isinstance(err, SupersededError)
+        assert err.detail is None
+
+
+class TestConsumerRecognizeMainPath:
+    """The injected-proxy FastMCP error path (``_convert_mcp_result_to_python``,
+    unified_mcp_proxy.py :843): an isError remote result carrying the reserved
+    envelope re-raises ``mesh.SupersededError`` instead of the generic
+    RuntimeError."""
+
+    def _proxy(self):
+        return UnifiedMCPProxy("http://provider:8080", "mutate")
+
+    def test_superseded_iserror_raises_typed_error(self):
+        proxy = self._proxy()
+        result = _FakeErrorResult('{"error":"claim_superseded"}')
+        with pytest.raises(SupersededError) as excinfo:
+            proxy._convert_mcp_result_to_python(result)
+        assert excinfo.value.detail is None
+
+    def test_superseded_iserror_carries_detail(self):
+        proxy = self._proxy()
+        result = _FakeErrorResult('{"error":"claim_superseded","detail":"stale"}')
+        with pytest.raises(SupersededError) as excinfo:
+            proxy._convert_mcp_result_to_python(result)
+        assert excinfo.value.detail == "stale"
+
+    def test_non_superseded_iserror_raises_generic_runtime_error(self):
+        proxy = self._proxy()
+        result = _FakeErrorResult("some ordinary tool failure")
+        with pytest.raises(RuntimeError) as excinfo:
+            proxy._convert_mcp_result_to_python(result)
+        assert not isinstance(excinfo.value, SupersededError)
+        assert "Remote tool call failed" in str(excinfo.value)
+
+    def test_dependency_unavailable_iserror_stays_generic(self):
+        # SupersededError does NOT swallow a sibling reserved envelope.
+        proxy = self._proxy()
+        result = _FakeErrorResult(
+            '{"error":"dependency_unavailable","capability":"lookup"}'
+        )
+        with pytest.raises(RuntimeError) as excinfo:
+            proxy._convert_mcp_result_to_python(result)
+        assert not isinstance(excinfo.value, SupersededError)
+
+
+class _FakeHttpResponse:
+    def __init__(self, text):
+        self.text = text
+        self.status_code = 200
+        self.headers = {}
+
+    def raise_for_status(self):
+        return None
+
+
+class _FakeHttpxClient:
+    """Records how many times the PRIMARY transport actually POSTs."""
+
+    def __init__(self, text):
+        self._text = text
+        self.post_calls = 0
+
+    async def post(self, url, content=None, headers=None, timeout=None):
+        self.post_calls += 1
+        return _FakeHttpResponse(self._text)
+
+
+def _rpc_iserror_envelope(detail=None):
+    envelope = {"error": "claim_superseded"}
+    if detail is not None:
+        envelope["detail"] = detail
+    return json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "isError": True,
+                "content": [
+                    {"type": "text", "text": json.dumps(envelope)}
+                ],
+            },
+        }
+    )
+
+
+class TestPrimaryTransportEndToEnd:
+    """The LIVE path: ``call_tool`` → ``_http_call`` (PRIMARY transport). This
+    is the site the direct-``_convert_mcp_result_to_python`` tests could not
+    reach — before the guard fix, ``_http_call`` rewrapped the SupersededError
+    into a generic ``RuntimeError('HTTP call failed')`` which ``call_tool``
+    misread as a transport failure and RETRIED via the FastMCP fallback,
+    invoking the provider a SECOND time and losing the typed error.
+    """
+
+    def test_primary_superseded_typed_and_single_invoke(self):
+        proxy = UnifiedMCPProxy("http://provider:8080", "mutate")
+        fake_client = _FakeHttpxClient(_rpc_iserror_envelope("stale epoch 3"))
+        fastmcp_factory = AsyncMock()  # the FALLBACK path — must NOT be entered
+
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy._get_httpx_client_sync",
+            return_value=fake_client,
+        ), patch.object(
+            proxy, "_get_or_create_fastmcp_client", fastmcp_factory
+        ):
+            with pytest.raises(SupersededError) as excinfo:
+                asyncio.run(proxy.call_tool("mutate", {}))
+
+        # (a) typed error reaches the caller — NOT a generic RuntimeError
+        assert excinfo.value.detail == "stale epoch 3"
+        # (b) provider invoked exactly ONCE — no fallback double-invoke
+        assert fake_client.post_calls == 1
+        fastmcp_factory.assert_not_called()
+
+    def test_primary_generic_iserror_still_raises_runtime_error(self):
+        # A non-superseded application error is still surfaced as before, and
+        # (per the existing "Tool call error" guard) does not trigger fallback.
+        proxy = UnifiedMCPProxy("http://provider:8080", "mutate")
+        rpc = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "isError": True,
+                    "content": [{"type": "text", "text": "ordinary failure"}],
+                },
+            }
+        )
+        fake_client = _FakeHttpxClient(rpc)
+        fastmcp_factory = AsyncMock()
+
+        with patch(
+            "_mcp_mesh.engine.unified_mcp_proxy._get_httpx_client_sync",
+            return_value=fake_client,
+        ), patch.object(
+            proxy, "_get_or_create_fastmcp_client", fastmcp_factory
+        ):
+            with pytest.raises(RuntimeError) as excinfo:
+                asyncio.run(proxy.call_tool("mutate", {}))
+
+        assert not isinstance(excinfo.value, SupersededError)
+        assert fake_client.post_calls == 1
+        fastmcp_factory.assert_not_called()
+
+
+class TestStreamSupersession:
+    """A superseded STREAMING producer surfaces via ``await call_task`` as a
+    fastmcp ToolError whose message is the reserved envelope; ``stream()``
+    re-raises it typed so streaming callers get the same one-catch contract."""
+
+    def test_stream_superseded_raises_typed(self):
+        srv = FastMCP(name="stream-provider")
+
+        @srv.tool()
+        def produce():  # non-streaming producer that refuses as superseded
+            raise mesh.SupersededError("stale stream epoch")
+
+        proxy = UnifiedMCPProxy(
+            "http://provider:8080", "produce", {"stream_type": "text"}
+        )
+
+        client_cm = Client(srv)
+
+        async def fake_factory(*args, **kwargs):
+            return client_cm
+
+        async def drive():
+            chunks = []
+            async for chunk in proxy.stream("produce"):
+                chunks.append(chunk)
+            return chunks
+
+        with patch.object(
+            proxy, "_get_or_create_fastmcp_client", side_effect=fake_factory
+        ):
+            with pytest.raises(SupersededError) as excinfo:
+                asyncio.run(drive())
+
+        assert excinfo.value.detail == "stale stream epoch"
+
+    def test_stream_generic_toolerror_propagates_unchanged(self):
+        srv = FastMCP(name="stream-provider")
+
+        @srv.tool()
+        def produce():
+            raise ToolError("ordinary stream failure")
+
+        proxy = UnifiedMCPProxy(
+            "http://provider:8080", "produce", {"stream_type": "text"}
+        )
+        client_cm = Client(srv)
+
+        async def fake_factory(*args, **kwargs):
+            return client_cm
+
+        async def drive():
+            async for _ in proxy.stream("produce"):
+                pass
+
+        with patch.object(
+            proxy, "_get_or_create_fastmcp_client", side_effect=fake_factory
+        ):
+            with pytest.raises(ToolError) as excinfo:
+                asyncio.run(drive())
+
+        assert not isinstance(excinfo.value, SupersededError)

--- a/src/runtime/typescript/src/__tests__/superseded-signal.spec.ts
+++ b/src/runtime/typescript/src/__tests__/superseded-signal.spec.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for issue #1278: typed supersession signal (TypeScript half).
+ *
+ * A provider tool that detects it is being called by a SUPERSEDED executor (the
+ * app compares the calling job's epoch via `callingJob()` — issue #1263)
+ * rejects the call by throwing a typed `MeshSupersededError`. That crosses the
+ * wire as the reserved `{"error":"claim_superseded"}` app envelope (plus an
+ * optional `"detail"`), and the CALLING side's injected proxy recognizes the
+ * envelope and re-throws `MeshSupersededError` — so a superseded caller unwinds
+ * with one `instanceof MeshSupersededError` instead of string-matching
+ * `claim_superseded` after every mutating call.
+ *
+ * Structural parallel of the `dependency_unavailable` refusal (issue #1273):
+ * both throw a `UserError` whose message is a reserved JSON envelope, so the
+ * contract (not the carrier) drives classification. Mirrors
+ * direct-invoke-required.spec.ts + proxy-tool-error.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { UserError } from "fastmcp";
+import {
+  MeshSupersededError,
+  CLAIM_SUPERSEDED_MARKER,
+  parseSupersededEnvelope,
+} from "../superseded.js";
+import { callMcpTool, DEFAULT_CALL_OPTIONS } from "../proxy.js";
+
+vi.mock("@mcpmesh/core", () => ({
+  generateTraceId: () => "trace-mock",
+  generateSpanId: () => "span-mock",
+  injectTraceContext: (argsJson: string) => argsJson,
+  publishSpan: vi.fn(async () => false),
+  parseSseResponse: (s: string) => s,
+  parseSseResponseToObject: (s: string) => JSON.parse(s),
+  awaitJobCancel: vi.fn(() => new Promise<void>(() => {})),
+  matchesPropagateHeader: () => false,
+}));
+
+vi.mock("../http-pool.js", () => ({
+  getDispatcher: () => undefined,
+}));
+
+describe("MeshSupersededError class (#1278)", () => {
+  it("uses the SAME canonical marker as the job path", () => {
+    // The reserved marker is the SAME string the job path uses on the wire
+    // (Rust task_backend.rs CLAIM_SUPERSEDED_REASON / Go).
+    expect(CLAIM_SUPERSEDED_MARKER).toBe("claim_superseded");
+  });
+
+  it("is a UserError subclass (so `instanceof UserError` still catches it)", () => {
+    const err = new MeshSupersededError("x");
+    expect(err).toBeInstanceOf(UserError);
+    expect(err).toBeInstanceOf(MeshSupersededError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("MeshSupersededError");
+  });
+
+  it("serializes the reserved envelope WITH detail", () => {
+    // fastmcp maps a thrown UserError to {content:[{text: error.message}],
+    // isError:true} (verified in fastmcp dist: `if (error instanceof
+    // UserError) return {content:[{text: error.message}], isError:true}`), so
+    // err.message IS the isError tool-result text a provider auto-emits.
+    const err = new MeshSupersededError("stale epoch 3");
+    expect(JSON.parse(err.message)).toEqual({
+      error: "claim_superseded",
+      detail: "stale epoch 3",
+    });
+    expect(err.detail).toBe("stale epoch 3");
+  });
+
+  it("OMITS the detail key entirely when no detail is supplied", () => {
+    const err = new MeshSupersededError();
+    expect(JSON.parse(err.message)).toEqual({ error: "claim_superseded" });
+    expect(err.detail).toBeUndefined();
+  });
+});
+
+describe("parseSupersededEnvelope recognizer (#1278)", () => {
+  it("recognizes the bare marker (no detail)", () => {
+    const err = parseSupersededEnvelope('{"error":"claim_superseded"}');
+    expect(err).toBeInstanceOf(MeshSupersededError);
+    expect(err?.detail).toBeUndefined();
+  });
+
+  it("carries a string detail through", () => {
+    const err = parseSupersededEnvelope(
+      '{"error":"claim_superseded","detail":"stale"}',
+    );
+    expect(err).toBeInstanceOf(MeshSupersededError);
+    expect(err?.detail).toBe("stale");
+  });
+
+  it("returns null for non-JSON text", () => {
+    expect(parseSupersededEnvelope("boom, plain text error")).toBeNull();
+  });
+
+  it("returns null for JSON that is not a plain object", () => {
+    expect(parseSupersededEnvelope('"claim_superseded"')).toBeNull();
+    expect(parseSupersededEnvelope("[1,2,3]")).toBeNull();
+    expect(parseSupersededEnvelope("null")).toBeNull();
+  });
+
+  it("does NOT misclassify a sibling dependency_unavailable envelope", () => {
+    expect(
+      parseSupersededEnvelope(
+        '{"error":"dependency_unavailable","capability":"lookup"}',
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for a generic error object", () => {
+    expect(parseSupersededEnvelope('{"error":"boom"}')).toBeNull();
+  });
+
+  it("drops a non-string detail (marker still recognized)", () => {
+    const err = parseSupersededEnvelope(
+      '{"error":"claim_superseded","detail":42}',
+    );
+    expect(err).toBeInstanceOf(MeshSupersededError);
+    expect(err?.detail).toBeUndefined();
+  });
+});
+
+// --- Consumer recognize path: driven end-to-end through callMcpTool, whose
+// injected-proxy error path re-throws the typed error. Mirrors
+// proxy-tool-error.test.ts fixtures. ---
+
+const ENDPOINT = "http://producer.local:9000";
+const TOOL = "mutate";
+const CAPABILITY = "mutator";
+
+function jsonResponse(envelope: object): Response {
+  const body = JSON.stringify({ jsonrpc: "2.0", id: "x", ...envelope });
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => body,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+  } as unknown as Response;
+}
+
+function sseResponse(envelopes: object[]): Response {
+  const encoder = new TextEncoder();
+  const blocks = envelopes.map(
+    (e) =>
+      `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: "x", ...e })}\n\n`,
+  );
+  let i = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < blocks.length) {
+        controller.enqueue(encoder.encode(blocks[i]));
+        i += 1;
+      } else {
+        controller.close();
+      }
+    },
+  });
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    body: stream,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "text/event-stream" : null,
+    },
+  } as unknown as Response;
+}
+
+/** An isError CallToolResult carrying `text` in its single content item. */
+function isErrorResult(text: string): object {
+  return { isError: true, content: [{ type: "text", text }] };
+}
+
+async function callAndCatch(makeResponse: () => Response): Promise<unknown> {
+  const fetchMock = vi.fn(async () => makeResponse());
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  try {
+    await callMcpTool(ENDPOINT, TOOL, { a: 1 }, DEFAULT_CALL_OPTIONS, CAPABILITY);
+    return { caught: null, fetchMock };
+  } catch (err) {
+    return { caught: err, fetchMock };
+  }
+}
+
+describe("consumer recognize path — JSON transport (#1278)", () => {
+  let originalFetch: typeof fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("re-throws the TYPED MeshSupersededError for the reserved envelope (with detail)", async () => {
+    const { caught } = (await callAndCatch(() =>
+      jsonResponse({
+        result: isErrorResult('{"error":"claim_superseded","detail":"stale"}'),
+      }),
+    )) as { caught: unknown };
+    // The swallow-point: the retry loop / post-loop `throw lastError` must NOT
+    // re-wrap it into a generic `MCP tool error: …` Error.
+    expect(caught).toBeInstanceOf(MeshSupersededError);
+    expect((caught as MeshSupersededError).detail).toBe("stale");
+  });
+
+  it("re-throws MeshSupersededError for the bare marker (no detail)", async () => {
+    const { caught } = (await callAndCatch(() =>
+      jsonResponse({ result: isErrorResult('{"error":"claim_superseded"}') }),
+    )) as { caught: unknown };
+    expect(caught).toBeInstanceOf(MeshSupersededError);
+    expect((caught as MeshSupersededError).detail).toBeUndefined();
+  });
+
+  it("does NOT retry a superseded rejection (deliberate provider refusal)", async () => {
+    const { caught, fetchMock } = (await callAndCatch(() =>
+      jsonResponse({ result: isErrorResult('{"error":"claim_superseded"}') }),
+    )) as { caught: unknown; fetchMock: ReturnType<typeof vi.fn> };
+    expect(caught).toBeInstanceOf(MeshSupersededError);
+    // maxAttempts defaults > 1; the guard re-throws untouched, one fetch only.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still throws a GENERIC Error for an ordinary isError result", async () => {
+    const { caught } = (await callAndCatch(() =>
+      jsonResponse({ result: isErrorResult("some ordinary tool failure") }),
+    )) as { caught: unknown };
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(MeshSupersededError);
+    expect((caught as Error).message).toContain("MCP tool error");
+  });
+
+  it("leaves a sibling dependency_unavailable envelope GENERIC", async () => {
+    const { caught } = (await callAndCatch(() =>
+      jsonResponse({
+        result: isErrorResult(
+          '{"error":"dependency_unavailable","capability":"lookup"}',
+        ),
+      }),
+    )) as { caught: unknown };
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(MeshSupersededError);
+  });
+});
+
+describe("consumer recognize path — SSE transport (#1278)", () => {
+  let originalFetch: typeof fetch;
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("re-throws the TYPED MeshSupersededError over SSE (transport-symmetric)", async () => {
+    const { caught } = (await callAndCatch(() =>
+      sseResponse([
+        {
+          result: isErrorResult(
+            '{"error":"claim_superseded","detail":"stale"}',
+          ),
+        },
+      ]),
+    )) as { caught: unknown };
+    expect(caught).toBeInstanceOf(MeshSupersededError);
+    expect((caught as MeshSupersededError).detail).toBe("stale");
+  });
+
+  it("still throws a generic Error for an ordinary isError result over SSE", async () => {
+    const { caught } = (await callAndCatch(() =>
+      sseResponse([{ result: isErrorResult("boom: division by zero") }]),
+    )) as { caught: unknown };
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught).not.toBeInstanceOf(MeshSupersededError);
+  });
+});

--- a/src/runtime/typescript/src/__tests__/worker-error-serde.spec.ts
+++ b/src/runtime/typescript/src/__tests__/worker-error-serde.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Issue #1278: UserError identity must survive the tool worker boundary.
+ *
+ * Under default tool isolation (MCP_MESH_TOOL_ISOLATION=true) a tool body runs
+ * in a worker thread. A `UserError` (or subclass such as `MeshSupersededError`)
+ * thrown there is postMessage'd to the main thread via structured clone, which
+ * drops the prototype. Before the fix the pool rebuilt a plain `Error`, so
+ * fastmcp's `instanceof UserError` failed and it emitted the GENERIC branch —
+ * prefixing the message `Tool '<name>' execution failed: ...` and corrupting
+ * the reserved JSON envelope.
+ *
+ * These tests exercise the matched serialize/deserialize pair, pushing the
+ * serialized shape through a real `structuredClone` (exactly what postMessage
+ * does) so the round-trip proves the `UserError` prototype is reconstructed and
+ * that generic errors are unaffected.
+ */
+import { describe, it, expect } from "vitest";
+import { UserError } from "fastmcp";
+import {
+  serializeError,
+  deserializeError,
+} from "../worker-error-serde.js";
+import { MeshSupersededError } from "../superseded.js";
+
+/** Mimic the worker hop: serialize → structured-clone (postMessage) → deserialize. */
+function roundTrip(err: unknown): Error {
+  return deserializeError(structuredClone(serializeError(err)));
+}
+
+/**
+ * Reproduce fastmcp's exact error-branch discriminator
+ * (chunk-LWU5CQGW.js:1199-1216) so we can assert the user-visible wire text
+ * without booting a full FastMCP HTTP server.
+ */
+function fastmcpErrorText(error: unknown, toolName = "some_tool"): string {
+  if (error instanceof UserError) {
+    return error.message; // clean branch
+  }
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  return `Tool '${toolName}' execution failed: ${errorMessage}`; // generic branch
+}
+
+describe("worker-error-serde — UserError identity (issue #1278)", () => {
+  it("a UserError round-trips to an instanceof UserError with the exact message", () => {
+    const original = new UserError("plain user message");
+    const revived = roundTrip(original);
+
+    expect(revived).toBeInstanceOf(UserError);
+    expect(revived.message).toBe("plain user message");
+  });
+
+  it("a MeshSupersededError round-trips as UserError with an intact reserved envelope", () => {
+    const original = new MeshSupersededError("stale epoch 3");
+    const revived = roundTrip(original);
+
+    // Identity survives → fastmcp emits the clean branch.
+    expect(revived).toBeInstanceOf(UserError);
+    // Message preserved EXACTLY — the reserved JSON must survive verbatim.
+    expect(revived.message).toBe(original.message);
+    const parsed = JSON.parse(revived.message);
+    expect(parsed).toEqual({ error: "claim_superseded", detail: "stale epoch 3" });
+    // Diagnostic name restored.
+    expect(revived.name).toBe("MeshSupersededError");
+  });
+
+  it("MeshSupersededError with no detail round-trips to the marker-only envelope", () => {
+    const revived = roundTrip(new MeshSupersededError());
+    expect(revived).toBeInstanceOf(UserError);
+    expect(JSON.parse(revived.message)).toEqual({ error: "claim_superseded" });
+  });
+
+  it("fastmcp emits the CLEAN envelope (no prefix) for a round-tripped MeshSupersededError", () => {
+    const revived = roundTrip(new MeshSupersededError("stale epoch 3"));
+    const text = fastmcpErrorText(revived, "reject_superseded");
+
+    // The fix: no `Tool '...' execution failed:` prefix; text is valid JSON.
+    expect(text).not.toMatch(/execution failed:/);
+    expect(JSON.parse(text)).toEqual({
+      error: "claim_superseded",
+      detail: "stale epoch 3",
+    });
+  });
+
+  it("carries structured-cloneable UserError extras", () => {
+    const original = new UserError("with extras", { reason: "quota", limit: 5 });
+    const revived = roundTrip(original) as UserError;
+
+    expect(revived).toBeInstanceOf(UserError);
+    expect(revived.extras).toEqual({ reason: "quota", limit: 5 });
+  });
+
+  it("drops non-cloneable extras but keeps message + UserError identity", () => {
+    // A function is not structured-cloneable; it must not break the hop.
+    const original = new UserError("keep me", {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fn: (() => 1) as any,
+    });
+    const revived = roundTrip(original) as UserError;
+
+    expect(revived).toBeInstanceOf(UserError);
+    expect(revived.message).toBe("keep me");
+    expect(revived.extras).toBeUndefined();
+  });
+});
+
+describe("worker-error-serde — generic errors unaffected", () => {
+  it("a plain Error round-trips to a plain Error, NOT a UserError", () => {
+    const revived = roundTrip(new Error("boom"));
+
+    expect(revived).toBeInstanceOf(Error);
+    expect(revived).not.toBeInstanceOf(UserError);
+    expect(revived.message).toBe("boom");
+  });
+
+  it("a plain Error takes fastmcp's GENERIC (prefixed) branch", () => {
+    const revived = roundTrip(new Error("boom"));
+    expect(fastmcpErrorText(revived, "calc")).toBe(
+      "Tool 'calc' execution failed: boom",
+    );
+  });
+
+  it("a TypeError subclass round-trips as a non-UserError, preserving name", () => {
+    const revived = roundTrip(new TypeError("bad type"));
+
+    expect(revived).not.toBeInstanceOf(UserError);
+    expect(revived.name).toBe("TypeError");
+    expect(revived.message).toBe("bad type");
+  });
+
+  it("preserves error code and a nested cause chain", () => {
+    const cause = new Error("root");
+    (cause as Error & { code?: string }).code = "ECONN";
+    const top = new Error("wrapper", { cause });
+    const revived = roundTrip(top) as Error & {
+      cause?: Error & { code?: string };
+    };
+
+    expect(revived.message).toBe("wrapper");
+    expect(revived.cause).toBeInstanceOf(Error);
+    expect(revived.cause!.message).toBe("root");
+    expect(revived.cause!.code).toBe("ECONN");
+  });
+
+  it("a non-Error throw (string) serializes and revives as a plain Error", () => {
+    const revived = roundTrip("just a string");
+    expect(revived).not.toBeInstanceOf(UserError);
+    expect(revived.message).toBe("just a string");
+  });
+});

--- a/src/runtime/typescript/src/index.ts
+++ b/src/runtime/typescript/src/index.ts
@@ -312,6 +312,15 @@ export {
   ProviderUnavailableError,
 } from "./errors.js";
 
+// Typed supersession signal (issue #1278): a provider throws
+// MeshSupersededError to reject a superseded caller; the injected proxy
+// re-throws it on the calling side.
+export {
+  MeshSupersededError,
+  CLAIM_SUPERSEDED_MARKER,
+  parseSupersededEnvelope,
+} from "./superseded.js";
+
 // SSE utilities
 export { parseSSEResponse, isSSEResponse, parseSSEStream } from "./sse.js";
 export { sseStream } from "./sse-stream.js";

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -20,6 +20,10 @@ import { getDispatcher } from "./http-pool.js";
 import { currentJob } from "./job-context.js";
 import { awaitJobCancel } from "@mcpmesh/core";
 import { createDebug } from "./debug.js";
+import {
+  MeshSupersededError,
+  parseSupersededEnvelope,
+} from "./superseded.js";
 
 const debugProxy = createDebug("proxy");
 
@@ -580,6 +584,17 @@ export async function callMcpTool(
       // re-wrap it instead of returning the error text as a successful result.
       const toolErrMsg = toolErrorMessage(result.result);
       if (toolErrMsg !== null) {
+        // Typed supersession signal (issue #1278): a provider that rejected
+        // this call as coming from a superseded executor emits the reserved
+        // `{"error":"claim_superseded"}` envelope. Re-throw it as the typed
+        // MeshSupersededError so the caller unwinds with one
+        // `instanceof MeshSupersededError`. Defensive parse — a
+        // non-superseded isError (e.g. dependency_unavailable) falls through
+        // to the generic error below.
+        const superseded = parseSupersededEnvelope(toolErrMsg);
+        if (superseded !== null) {
+          throw superseded;
+        }
         throw new Error(`MCP tool error: ${toolErrMsg}`);
       }
 
@@ -590,6 +605,17 @@ export async function callMcpTool(
       return content;
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
+
+      // Typed supersession signal (issue #1278): a MeshSupersededError is a
+      // deliberate provider rejection, not a transient failure — re-throw it
+      // untouched (like ProxyTimeoutError below) so it (a) is NOT retried and
+      // (b) reaches the caller as the typed error rather than being swept into
+      // the post-loop generic `throw lastError`. Guards the retry loop from
+      // swallowing/re-wrapping the classified error.
+      if (lastError instanceof MeshSupersededError) {
+        publishProxySpan(traceCtx, spanId, startTime, toolName, capability, endpoint, false, lastError.message, "error", requestBytes, lastResponseBytes, attempt + 1);
+        throw lastError;
+      }
 
       // Don't retry on abort (timeout)
       if (isTimeoutError(lastError)) {
@@ -786,6 +812,13 @@ export async function* streamMcpTool(
         // and must not look like a clean end-of-stream.
         const streamToolErrMsg = toolErrorMessage(msg.result);
         if (streamToolErrMsg !== null) {
+          // Typed supersession signal (issue #1278): mirror callMcpTool's
+          // JSON path — a producer that rejected a superseded caller ends the
+          // stream with the reserved envelope; re-throw the typed error.
+          const superseded = parseSupersededEnvelope(streamToolErrMsg);
+          if (superseded !== null) {
+            throw superseded;
+          }
           throw new Error(`MCP tool error: ${streamToolErrMsg}`);
         }
         // result arrived — done; do NOT yield the buffered final result
@@ -1051,6 +1084,14 @@ async function readSSEResponseToContent(response: Response): Promise<unknown> {
     if (event && typeof event === "object" && "result" in event) {
       const toolErrMsg = toolErrorMessage(jsonRpcEvent.result);
       if (toolErrMsg !== null) {
+        // Typed supersession signal (issue #1278): mirror the JSON path so
+        // the SSE transport can't classify a superseded rejection differently.
+        // The throw propagates out through callMcpTool's retry loop, whose
+        // MeshSupersededError guard re-throws it untouched (no retry).
+        const superseded = parseSupersededEnvelope(toolErrMsg);
+        if (superseded !== null) {
+          throw superseded;
+        }
         throw new Error(`MCP tool error: ${toolErrMsg}`);
       }
       sawResult = true;

--- a/src/runtime/typescript/src/superseded.ts
+++ b/src/runtime/typescript/src/superseded.ts
@@ -1,0 +1,108 @@
+/**
+ * Typed supersession signal (issue #1278).
+ *
+ * A provider tool that detects it is being called by a SUPERSEDED executor —
+ * the app compares the calling job's epoch via {@link callingJob} (issue
+ * #1263) against its own live epoch — rejects the call by throwing
+ * {@link MeshSupersededError}. That crosses the wire as the reserved app
+ * envelope `{"error":"claim_superseded"}` (plus an optional `"detail"`
+ * string), and the CALLING side's injected proxy recognizes the envelope and
+ * re-throws {@link MeshSupersededError}. A superseded caller then unwinds with
+ * one `catch (e) { if (e instanceof MeshSupersededError) ... }` instead of
+ * string-matching `claim_superseded` after every mutating call.
+ *
+ * The framework does NOT auto-detect supersession — the app decides (full
+ * control); the framework provides the typed class plus the emit/recognize
+ * plumbing. This is the structural parallel of the `dependency_unavailable`
+ * refusal (issue #1273): both throw a `UserError` whose message is a reserved
+ * JSON envelope, so the contract (not the carrier) drives classification.
+ */
+
+import { UserError } from "fastmcp";
+
+/**
+ * Reserved marker string for the supersession envelope. This is the SAME
+ * canonical marker the job path already uses on the wire (Rust
+ * `task_backend.rs` `CLAIM_SUPERSEDED_REASON` / Go `ent_service_jobs.go`),
+ * reused verbatim so a superseded signal is one string end-to-end.
+ */
+export const CLAIM_SUPERSEDED_MARKER = "claim_superseded";
+
+/**
+ * Thrown by a provider tool to reject a call from a superseded executor.
+ *
+ * Extends fastmcp's {@link UserError} — the same error primitive the
+ * `dependency_unavailable` refusal uses (agent.ts) — so throwing it from a
+ * `@mesh.tool` handler auto-emits an `isError` tool result whose text is the
+ * reserved envelope, through the EXISTING fastmcp UserError path (fastmcp maps
+ * a thrown `UserError` to `{content:[{text: error.message}], isError:true}`,
+ * so no provider wrapper change is needed).
+ *
+ * The serialized message (`err.message`) is
+ * `{"error":"claim_superseded","detail":<detail>}` — the `detail` key is
+ * omitted entirely when no detail is supplied.
+ *
+ * Provider usage:
+ * ```ts
+ * const cj = callingJob();
+ * if (cj && cj.claimEpoch != null && cj.claimEpoch < myLiveEpoch) {
+ *   throw new MeshSupersededError(`stale epoch ${cj.claimEpoch}`);
+ * }
+ * ```
+ *
+ * `if (e instanceof MeshSupersededError)` is the specific catch this enables;
+ * because it IS a `UserError`, `if (e instanceof UserError)` still catches it
+ * too.
+ */
+export class MeshSupersededError extends UserError {
+  readonly detail?: string;
+
+  constructor(detail?: string) {
+    const envelope: { error: string; detail?: string } = {
+      error: CLAIM_SUPERSEDED_MARKER,
+    };
+    if (detail !== undefined) {
+      envelope.detail = detail;
+    }
+    super(JSON.stringify(envelope));
+    this.name = "MeshSupersededError";
+    this.detail = detail;
+  }
+}
+
+/**
+ * Return a {@link MeshSupersededError} if `text` is the reserved supersession
+ * envelope, else `null`.
+ *
+ * Defensive parse for the consumer recognize path: a non-JSON body, a JSON
+ * body that is not a plain object, or one whose `error` field is not exactly
+ * the reserved marker all return `null` so the caller falls through to its
+ * existing generic error handling. Only the exact reserved marker is
+ * classified — a `dependency_unavailable` (or any other) envelope is left
+ * alone.
+ */
+export function parseSupersededEnvelope(
+  text: string,
+): MeshSupersededError | null {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (
+    payload === null ||
+    typeof payload !== "object" ||
+    Array.isArray(payload)
+  ) {
+    return null;
+  }
+  const obj = payload as Record<string, unknown>;
+  if (obj.error !== CLAIM_SUPERSEDED_MARKER) {
+    return null;
+  }
+  const detail = obj.detail;
+  return new MeshSupersededError(
+    typeof detail === "string" ? detail : undefined,
+  );
+}

--- a/src/runtime/typescript/src/tool-worker-entry.ts
+++ b/src/runtime/typescript/src/tool-worker-entry.ts
@@ -21,6 +21,7 @@
 import { parentPort, workerData, isMainThread } from "node:worker_threads";
 import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
+import { serializeError } from "./worker-error-serde.js";
 
 if (isMainThread) {
   throw new Error("tool-worker-entry.js must be loaded inside a worker thread");
@@ -107,25 +108,6 @@ async function bootstrap(): Promise<void> {
   });
 
   parentPort!.postMessage({ kind: "ready" });
-}
-
-interface SerializedError {
-  name: string;
-  message: string;
-  stack?: string;
-  code?: string | number;
-  cause?: SerializedError;
-}
-
-function serializeError(err: unknown): SerializedError {
-  if (!(err instanceof Error)) {
-    return { name: "Error", message: String(err) };
-  }
-  const out: SerializedError = { name: err.name, message: err.message, stack: err.stack };
-  const errAny = err as Error & { code?: string | number; cause?: unknown };
-  if (errAny.code !== undefined) out.code = errAny.code;
-  if (errAny.cause !== undefined) out.cause = serializeError(errAny.cause);
-  return out;
 }
 
 interface CallMessage {

--- a/src/runtime/typescript/src/tool-worker-pool.ts
+++ b/src/runtime/typescript/src/tool-worker-pool.ts
@@ -22,6 +22,7 @@ import { fileURLToPath } from "node:url";
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
+import { deserializeError } from "./worker-error-serde.js";
 
 export interface DepConfig {
   endpoint: string;
@@ -51,26 +52,6 @@ let _initialized = false;
 let _nextIdx = 0;
 let _msgId = 0;
 let _shutdownRegistered = false;
-
-interface SerializedError {
-  name?: string;
-  message?: string;
-  stack?: string;
-  code?: string | number;
-  cause?: SerializedError;
-}
-
-function deserializeError(serialized: SerializedError | undefined | null): Error {
-  const err = new Error(serialized?.message ?? "worker error") as Error & {
-    code?: string | number;
-    cause?: Error;
-  };
-  if (serialized?.name) err.name = serialized.name;
-  if (serialized?.stack) err.stack = serialized.stack;
-  if (serialized?.code !== undefined) err.code = serialized.code;
-  if (serialized?.cause !== undefined) err.cause = deserializeError(serialized.cause);
-  return err;
-}
 
 function _resolvePoolSize(): number {
   const envVal = process.env.MCP_MESH_TOOL_WORKERS;

--- a/src/runtime/typescript/src/worker-error-serde.ts
+++ b/src/runtime/typescript/src/worker-error-serde.ts
@@ -1,0 +1,110 @@
+/**
+ * Shared error (de)serialization for the tool worker boundary.
+ *
+ * `worker_threads` postMessage uses the structured-clone algorithm, which does
+ * NOT preserve an Error subclass's prototype: a `UserError` (or any subclass)
+ * thrown inside a worker arrives on the main thread as a plain object. If we
+ * naively rebuild it as `new Error(message)`, the main-thread `instanceof
+ * UserError` check in fastmcp fails, and fastmcp emits its GENERIC error branch
+ * — prefixing the message with `Tool '<name>' execution failed: ...`. That
+ * prefix corrupts reserved JSON envelopes (issue #1278's `claim_superseded`,
+ * issue #1273's `dependency_unavailable`) so the consumer's `JSON.parse` fails.
+ *
+ * These two functions are the matched halves of ONE wire contract and MUST stay
+ * in sync, so they live together here (worker side calls {@link serializeError},
+ * main-thread pool calls {@link deserializeError}). Keeping them co-located also
+ * makes the round-trip unit-testable from the main thread — `tool-worker-entry`
+ * throws at import time when loaded outside a worker, so its copy could not be
+ * exercised directly.
+ */
+import { UserError } from "fastmcp";
+
+export interface SerializedError {
+  name?: string;
+  message?: string;
+  stack?: string;
+  code?: string | number;
+  cause?: SerializedError;
+  /**
+   * Issue #1278: set when the source error was a fastmcp `UserError` (or a
+   * subclass such as `MeshSupersededError`). The main-thread deserializer uses
+   * this to reconstruct a real `UserError` so `instanceof UserError` survives
+   * the worker hop and fastmcp emits the clean `content:[{text: message}]`
+   * envelope instead of the generic `Tool '...' execution failed:` branch.
+   */
+  isUserError?: boolean;
+  /**
+   * Issue #1278: `UserError.extras`, carried only when structured-cloneable so
+   * a non-cloneable extras can never break the postMessage that carries the
+   * (always cloneable) reserved-envelope message.
+   */
+  extras?: unknown;
+}
+
+/**
+ * Flatten an Error (or arbitrary throw) into a structured-clone-safe shape for
+ * postMessage. Preserves `name`, walks `cause`, and — issue #1278 — flags
+ * `UserError` identity so the main thread can rebuild a real `UserError`.
+ */
+export function serializeError(err: unknown): SerializedError {
+  if (!(err instanceof Error)) {
+    return { name: "Error", message: String(err) };
+  }
+  const out: SerializedError = {
+    name: err.name,
+    message: err.message,
+    stack: err.stack,
+  };
+  const errAny = err as Error & { code?: string | number; cause?: unknown };
+  if (errAny.code !== undefined) out.code = errAny.code;
+  if (errAny.cause !== undefined) out.cause = serializeError(errAny.cause);
+  // Issue #1278: preserve UserError identity across the worker boundary.
+  if (err instanceof UserError) {
+    out.isUserError = true;
+    const extras = (err as UserError).extras;
+    if (extras !== undefined) {
+      // Only carry extras if it survives structured clone — a non-cloneable
+      // extras must NOT break the postMessage that carries the (always
+      // cloneable) reserved-envelope message.
+      try {
+        structuredClone(extras);
+        out.extras = extras;
+      } catch {
+        /* drop non-cloneable extras; message still crosses intact */
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Rebuild an Error on the main thread from its {@link SerializedError} shape.
+ *
+ * Issue #1278: when `isUserError` is set, reconstruct a real fastmcp
+ * `UserError` (the SAME class the fastmcp tool handler and agent.ts use) so
+ * `instanceof UserError` holds and fastmcp emits the clean envelope. The
+ * `message` is preserved EXACTLY — the reserved JSON envelope must survive
+ * verbatim. `name` is restored afterwards for diagnostics (fastmcp's clean
+ * branch keys off `message`/`extras`, not `name`). A non-UserError rebuilds as
+ * a plain `Error` and takes fastmcp's generic branch, unchanged.
+ */
+export function deserializeError(
+  serialized: SerializedError | undefined | null,
+): Error {
+  const message = serialized?.message ?? "worker error";
+  const err = (
+    serialized?.isUserError
+      ? new UserError(
+          message,
+          serialized.extras as ConstructorParameters<typeof UserError>[1],
+        )
+      : new Error(message)
+  ) as Error & { code?: string | number; cause?: Error };
+  if (serialized?.name) err.name = serialized.name;
+  if (serialized?.stack) err.stack = serialized.stack;
+  if (serialized?.code !== undefined) err.code = serialized.code;
+  if (serialized?.cause !== undefined) {
+    err.cause = deserializeError(serialized.cause);
+  }
+  return err;
+}

--- a/tests/integration/suites/uc38_superseded_signal/artifacts/java-signal-consumer
+++ b/tests/integration/suites/uc38_superseded_signal/artifacts/java-signal-consumer
@@ -1,0 +1,1 @@
+../fixtures/java-signal-consumer

--- a/tests/integration/suites/uc38_superseded_signal/artifacts/java-signal-provider
+++ b/tests/integration/suites/uc38_superseded_signal/artifacts/java-signal-provider
@@ -1,0 +1,1 @@
+../fixtures/java-signal-provider

--- a/tests/integration/suites/uc38_superseded_signal/artifacts/py-signal-consumer
+++ b/tests/integration/suites/uc38_superseded_signal/artifacts/py-signal-consumer
@@ -1,0 +1,1 @@
+../fixtures/py-signal-consumer

--- a/tests/integration/suites/uc38_superseded_signal/artifacts/py-signal-provider
+++ b/tests/integration/suites/uc38_superseded_signal/artifacts/py-signal-provider
@@ -1,0 +1,1 @@
+../fixtures/py-signal-provider

--- a/tests/integration/suites/uc38_superseded_signal/artifacts/ts-signal-consumer
+++ b/tests/integration/suites/uc38_superseded_signal/artifacts/ts-signal-consumer
@@ -1,0 +1,1 @@
+../fixtures/ts-signal-consumer

--- a/tests/integration/suites/uc38_superseded_signal/artifacts/ts-signal-provider
+++ b/tests/integration/suites/uc38_superseded_signal/artifacts/ts-signal-provider
@@ -1,0 +1,1 @@
+../fixtures/ts-signal-provider

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-consumer/pom.xml
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-consumer/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  uc38 java-signal-consumer — RECOGNIZES the typed supersession signal (#1278).
+
+  Skeleton cloned from uc23_meshjob_java/fixtures/long-task-consumer-java, then
+  stripped to two probe tools that call the provider through an INJECTED
+  McpMeshTool dependency and classify the outcome. Proves the consumer-side
+  recognize path (ToolInvoker / McpHttpClient re-throw of the reserved envelope)
+  over the REAL JNI/HTTP transport.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>java-signal-consumer</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>uc38 Signal Consumer (Java)</name>
+    <description>uc38 consumer that recognizes the typed supersession signal (issue #1278).</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.8.2</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.signalconsumer.SignalConsumerApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-consumer/src/main/java/com/example/signalconsumer/SignalConsumerApplication.java
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-consumer/src/main/java/com/example/signalconsumer/SignalConsumerApplication.java
@@ -1,0 +1,100 @@
+package com.example.signalconsumer;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Selector;
+import io.mcpmesh.types.McpMeshTool;
+import io.mcpmesh.types.MeshSupersededException;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * uc38 java-signal-consumer — RECOGNIZES the typed supersession signal (#1278).
+ *
+ * <p>The Java counterpart of py-signal-consumer / ts-signal-consumer. Each
+ * probe tool calls the provider through an INJECTED {@link McpMeshTool} proxy
+ * (the real JNI/HTTP transport) and classifies the outcome:
+ *
+ * <ul>
+ *   <li>{@code probeSuperseded} calls reject-superseded. The injected proxy
+ *       must recognize the reserved claim_superseded envelope and re-throw the
+ *       typed {@link MeshSupersededException}, so {@code catch
+ *       (MeshSupersededException e)} fires and it reports outcome=superseded.
+ *       That marker is reachable ONLY via the typed catch — a raw body or a
+ *       generic error would land in the generic branch.</li>
+ *   <li>{@code probeGeneric} calls reject-generic (the control). The plain
+ *       error is NOT the reserved envelope, so the proxy must NOT re-throw
+ *       MeshSupersededException; the handler falls through to the generic
+ *       branch (outcome=generic).</li>
+ * </ul>
+ *
+ * <p>The catch order matters: {@link MeshSupersededException} extends
+ * {@code RuntimeException}, so the specific catch is listed first. Each probe
+ * returns a {@code Map} so the caller parses it uniformly via
+ * {@code content[0].text | fromjson}.
+ *
+ * <p>Tool names are the camelCase method names (mesh's Java convention):
+ * {@code probeSuperseded}, {@code probeGeneric}.
+ */
+@MeshAgent(
+    name = "java-signal-consumer",
+    version = "1.0.0",
+    description = "uc38 consumer that recognizes the typed supersession signal (issue #1278).",
+    port = 9206
+)
+@SpringBootApplication
+public class SignalConsumerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SignalConsumerApplication.class, args);
+    }
+
+    @MeshTool(
+        capability = "probe-superseded",
+        description = "Calls reject-superseded via injected proxy and classifies it",
+        dependencies = @Selector(capability = "reject-superseded")
+    )
+    public Map<String, Object> probeSuperseded(McpMeshTool dep) {
+        return classify(dep);
+    }
+
+    @MeshTool(
+        capability = "probe-generic",
+        description = "Control: calls reject-generic via injected proxy and classifies it",
+        dependencies = @Selector(capability = "reject-generic")
+    )
+    public Map<String, Object> probeGeneric(McpMeshTool dep) {
+        return classify(dep);
+    }
+
+    /**
+     * Call the injected provider proxy and classify the failure. Reachable
+     * outcomes: {@code no_dep} (dependency unresolved), {@code no_error} (the
+     * provider unexpectedly succeeded), {@code superseded} (the typed exception
+     * was re-thrown by the recognize path), {@code generic} (any other error).
+     */
+    private Map<String, Object> classify(McpMeshTool dep) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        if (dep == null) {
+            out.put("outcome", "no_dep");
+            return out;
+        }
+        try {
+            dep.call();
+            out.put("outcome", "no_error");
+        } catch (MeshSupersededException e) {
+            // Reachable ONLY when the injected proxy recognized the reserved
+            // claim_superseded envelope and re-threw the typed exception.
+            out.put("outcome", "superseded");
+            out.put("detail", e.getDetail());
+        } catch (Exception e) {
+            // A generic error MUST land here — never misclassified as superseded.
+            out.put("outcome", "generic");
+            out.put("error_type", e.getClass().getSimpleName());
+        }
+        return out;
+    }
+}

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-consumer/src/main/resources/application.properties
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-consumer/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# Tomcat port for the Spring Boot HTTP server. Mesh's @MeshAgent(port=) is the
+# value advertised to the registry — it must match the actual Tomcat port so
+# the registry can route MCP calls to us.
+server.port=9206
+mesh.agent.port=9206

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-provider/pom.xml
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-provider/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  uc38 java-signal-provider — emits the typed supersession signal (issue #1278).
+
+  Skeleton cloned from uc23_meshjob_java/fixtures/long-task-provider-java, then
+  stripped to the minimal superseded scenario. Java's emit is DIFFERENT from the
+  Python/TS fastmcp auto-serialize path: a thrown MeshSupersededException is
+  caught by the MeshToolWrapper and turned into the reserved
+  {"error":"claim_superseded"} isError envelope. This fixture drives that
+  wrapper-catch emit over the REAL JNI/HTTP transport (not a mocked boundary).
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>java-signal-provider</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>uc38 Signal Provider (Java)</name>
+    <description>uc38 provider that emits the typed supersession signal (issue #1278).</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.6</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <mcp-mesh.version>2.8.2</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.signalprovider.SignalProviderApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-provider/src/main/java/com/example/signalprovider/SignalProviderApplication.java
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-provider/src/main/java/com/example/signalprovider/SignalProviderApplication.java
@@ -1,0 +1,88 @@
+package com.example.signalprovider;
+
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.types.MeshSupersededException;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * uc38 java-signal-provider — emits the typed supersession signal (issue #1278).
+ *
+ * <p>The Java counterpart of py-signal-provider / ts-signal-provider. Java's
+ * emit is DIFFERENT from the Python/TS fastmcp auto-serialize path: a thrown
+ * {@link MeshSupersededException} is caught by the framework's MeshToolWrapper
+ * and turned into the reserved {@code {"error":"claim_superseded"}} isError
+ * envelope. This fixture proves that wrapper-catch emit crosses the REAL
+ * JNI/HTTP transport and is recognized by a consumer's injected proxy.
+ *
+ * <p>These are PLAIN (synchronous) {@code @MeshTool}s, not {@code task=true}
+ * job tools: the round-trip under test is a consumer's injected-proxy call that
+ * catches the exception inline, which requires a synchronous throw — a task
+ * tool would dispatch as an async job and never hand the caller an exception to
+ * catch. No epoch dance: the app logic is out of scope; reject-superseded
+ * rejects UNCONDITIONALLY.
+ *
+ * <p>Tool names are the camelCase method names (mesh's Java convention, e.g.
+ * uc02 {@code greet}/{@code getInfo}): {@code rejectSuperseded},
+ * {@code rejectGeneric}, {@code getRejectCount}.
+ */
+@MeshAgent(
+    name = "java-signal-provider",
+    version = "1.0.0",
+    description = "uc38 provider that emits the typed supersession signal (issue #1278).",
+    port = 9205
+)
+@SpringBootApplication
+public class SignalProviderApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SignalProviderApplication.class, args);
+    }
+
+    // In-process invocation counter. Only rejectSuperseded increments it; a
+    // double-invoke on the real transport (a fallback-transport retry) would
+    // push this past 1.
+    private static final AtomicInteger REJECT_SUPERSEDED_CALLS = new AtomicInteger(0);
+
+    /**
+     * Unconditionally rejects the caller as superseded. Counts the REAL
+     * provider-side invocation, then throws the typed exception — the framework
+     * wrapper emits the reserved claim_superseded envelope.
+     */
+    @MeshTool(
+        capability = "reject-superseded",
+        description = "Unconditionally rejects the caller as superseded (issue #1278)"
+    )
+    public Map<String, Object> rejectSuperseded() {
+        REJECT_SUPERSEDED_CALLS.incrementAndGet();
+        throw new MeshSupersededException("stale epoch: caller superseded");
+    }
+
+    /**
+     * Control: fails with a plain (non-envelope) error. The caller must
+     * classify this as generic, proving the recognize path is envelope-exact.
+     */
+    @MeshTool(
+        capability = "reject-generic",
+        description = "Control: fails with a generic (non-superseded) error"
+    )
+    public Map<String, Object> rejectGeneric() {
+        throw new RuntimeException("generic-provider-failure: this is NOT a supersession");
+    }
+
+    /** Reports how many times reject-superseded actually ran in this process. */
+    @MeshTool(
+        capability = "superseded-call-count",
+        description = "Reports how many times reject-superseded was invoked"
+    )
+    public Map<String, Object> getRejectCount() {
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("count", REJECT_SUPERSEDED_CALLS.get());
+        return out;
+    }
+}

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-provider/src/main/resources/application.properties
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-provider/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# Tomcat port for the Spring Boot HTTP server. Mesh's @MeshAgent(port=) is the
+# value advertised to the registry — it must match the actual Tomcat port so
+# consumer agents can route MCP calls to us.
+server.port=9205
+mesh.agent.port=9205

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/py-signal-consumer/main.py
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/py-signal-consumer/main.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""uc38 py-signal-consumer — RECOGNIZES the typed supersession signal (#1278).
+
+This consumer proves the RECOGNIZE half over the REAL transport. Each probe
+tool calls the provider through an INJECTED ``mesh.McpMeshTool`` proxy (the
+primary HTTP transport path — the one whose recognize was found DEAD because
+the unit tests mocked the converter boundary) and classifies the outcome:
+
+  * probe_superseded calls reject-superseded. The provider's reserved envelope
+    must be recognized by the injected proxy and re-raised as the typed
+    ``mesh.SupersededError`` — so this handler's ``except mesh.SupersededError``
+    fires and it reports ``outcome=superseded``. That marker is ONLY reachable
+    if the typed error was raised; a string body or a generic error would land
+    in the generic branch instead.
+
+  * probe_generic calls reject-generic (the control). The provider's plain
+    error is NOT the reserved envelope, so the proxy must NOT re-raise
+    ``SupersededError`` — this handler falls through to the generic branch and
+    reports ``outcome=generic``. This is the negative control that proves an
+    arbitrary failure is never misclassified as supersession.
+
+The ``except`` order matters: ``SupersededError`` IS a ``ToolError`` IS an
+``Exception``, so the specific catch is listed first. Every probe returns a
+JSON STRING so the caller parses it uniformly via ``content[0].text | fromjson``
+(structuredContent is Python-only; the text envelope is portable).
+"""
+
+import json
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("SignalConsumer Service")
+
+
+@app.tool()
+@mesh.tool(
+    capability="probe-superseded",
+    description="Calls reject-superseded via injected proxy and classifies it",
+    dependencies=[{"capability": "reject-superseded"}],
+)
+async def probe_superseded(dep: mesh.McpMeshTool = None) -> str:
+    if dep is None:
+        return json.dumps({"outcome": "no_dep"})
+    try:
+        await dep()
+        return json.dumps({"outcome": "no_error"})
+    except mesh.SupersededError as e:
+        # Reachable ONLY when the injected proxy recognized the reserved
+        # claim_superseded envelope and re-raised the typed error.
+        return json.dumps({"outcome": "superseded", "detail": e.detail})
+    except Exception as e:  # noqa: BLE001 — deliberately broad control branch
+        return json.dumps({"outcome": "generic", "error_type": type(e).__name__})
+
+
+@app.tool()
+@mesh.tool(
+    capability="probe-generic",
+    description="Control: calls reject-generic via injected proxy and classifies it",
+    dependencies=[{"capability": "reject-generic"}],
+)
+async def probe_generic(dep: mesh.McpMeshTool = None) -> str:
+    if dep is None:
+        return json.dumps({"outcome": "no_dep"})
+    try:
+        await dep()
+        return json.dumps({"outcome": "no_error"})
+    except mesh.SupersededError as e:
+        return json.dumps({"outcome": "superseded", "detail": e.detail})
+    except Exception as e:  # noqa: BLE001 — a generic error MUST land here
+        return json.dumps({"outcome": "generic", "error_type": type(e).__name__})
+
+
+@mesh.agent(
+    name="py-signal-consumer",
+    version="1.0.0",
+    description="uc38 consumer that recognizes the typed supersession signal",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9202")),
+    enable_http=True,
+    auto_run=True,
+)
+class SignalConsumer:
+    pass

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/py-signal-consumer/requirements.txt
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/py-signal-consumer/requirements.txt
@@ -1,0 +1,1 @@
+# uc38 py-signal-consumer deps. mesh + fastmcp come from the runtime image.

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/py-signal-provider/main.py
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/py-signal-provider/main.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""uc38 py-signal-provider — emits the typed supersession signal (issue #1278).
+
+This provider proves the EMIT half of the emit->wire->recognize plumbing over
+the REAL HTTP transport (not the mocked converter boundary the unit tests
+exercised). Three capabilities:
+
+  * reject-superseded — UNCONDITIONALLY rejects every call by raising
+    ``mesh.SupersededError``. That subclasses fastmcp's ``ToolError``, so the
+    existing tool-error path emits an ``isError`` result whose text is the
+    reserved envelope ``{"error":"claim_superseded","detail":...}``. This is the
+    signal that must cross the wire and be RECOGNIZED by the caller's injected
+    proxy. It increments an in-process counter BEFORE raising so the caller side
+    can assert the provider was invoked EXACTLY ONCE (the Python real-transport
+    bug double-invoked via a fallback transport).
+
+  * reject-generic — the CONTROL. Raises a plain ``ToolError`` whose message is
+    NOT the reserved envelope. The caller's recognize path must classify this as
+    a GENERIC failure, never as supersession.
+
+  * superseded-call-count — reports how many times reject-superseded actually
+    ran in this process, so the caller can prove single-invoke.
+
+The provider rejects unconditionally on purpose: this TC proves the framework
+plumbing, NOT the epoch-supersession app logic (that is app-owned and covered
+by the example). The real calling-job-epoch dance is deliberately absent.
+"""
+
+import json
+import os
+
+import mesh
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+
+app = FastMCP("SignalProvider Service")
+
+# In-process invocation counter. Only reject_superseded increments it; a
+# double-invoke on the real transport would push this to 2.
+_calls = {"reject_superseded": 0}
+
+
+@app.tool()
+@mesh.tool(
+    capability="reject-superseded",
+    description="Unconditionally rejects the caller as superseded (issue #1278)",
+)
+async def reject_superseded() -> str:
+    # Count the REAL provider-side invocation, then reject. A caller that
+    # recognizes the typed signal sees this exactly once.
+    _calls["reject_superseded"] += 1
+    raise mesh.SupersededError("stale epoch: caller superseded")
+
+
+@app.tool()
+@mesh.tool(
+    capability="reject-generic",
+    description="Control: fails with a generic (non-superseded) error",
+)
+async def reject_generic() -> str:
+    # A plain ToolError whose message is NOT the reserved envelope. The caller
+    # must classify this as generic, proving the recognize path is envelope-
+    # exact and does not misclassify arbitrary failures as supersession.
+    raise ToolError("generic-provider-failure: this is NOT a supersession")
+
+
+@app.tool()
+@mesh.tool(
+    capability="superseded-call-count",
+    description="Reports how many times reject-superseded was invoked",
+)
+async def get_reject_count() -> str:
+    return json.dumps({"count": _calls["reject_superseded"]})
+
+
+@mesh.agent(
+    name="py-signal-provider",
+    version="1.0.0",
+    description="uc38 provider that emits the typed supersession signal",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9201")),
+    enable_http=True,
+    auto_run=True,
+)
+class SignalProvider:
+    pass

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/py-signal-provider/requirements.txt
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/py-signal-provider/requirements.txt
@@ -1,0 +1,1 @@
+# uc38 py-signal-provider deps. mesh + fastmcp come from the runtime image.

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-consumer/package.json
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-consumer/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ts-signal-consumer",
+  "version": "1.0.0",
+  "description": "uc38 consumer that recognizes the typed supersession signal (issue #1278)",
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^2.8.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-consumer/src/index.ts
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-consumer/src/index.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env npx tsx
+/**
+ * uc38 ts-signal-consumer — RECOGNIZES the typed supersession signal (#1278).
+ *
+ * The TypeScript counterpart of py-signal-consumer. Each probe tool calls the
+ * provider through an INJECTED McpMeshTool proxy (the real napi/HTTP transport)
+ * and classifies the outcome:
+ *
+ *   - probe_superseded calls reject-superseded. The injected proxy must
+ *     recognize the reserved claim_superseded envelope and re-throw the typed
+ *     MeshSupersededError, so `e instanceof MeshSupersededError` is true and the
+ *     handler reports outcome=superseded. That marker is ONLY reachable if the
+ *     typed error was raised.
+ *   - probe_generic calls reject-generic (the control). The plain error is NOT
+ *     the reserved envelope, so the proxy must NOT re-throw MeshSupersededError;
+ *     the handler falls through to the generic branch (outcome=generic).
+ *
+ * Every probe returns a JSON STRING so the caller parses it uniformly via
+ * `content[0].text | fromjson`.
+ */
+
+import { FastMCP, mesh, McpMeshTool, MeshSupersededError } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "TsSignalConsumer Service",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "ts-signal-consumer",
+  httpPort: Number(process.env.MCP_MESH_HTTP_PORT ?? "9204"),
+});
+
+agent.addTool({
+  name: "probe_superseded",
+  capability: "probe-superseded",
+  description: "Calls reject-superseded via injected proxy and classifies it",
+  dependencies: ["reject-superseded"],
+  parameters: z.object({}),
+  execute: async (_args, dep: McpMeshTool | null = null) => {
+    if (!dep) {
+      return JSON.stringify({ outcome: "no_dep" });
+    }
+    try {
+      await dep({});
+      return JSON.stringify({ outcome: "no_error" });
+    } catch (e) {
+      if (e instanceof MeshSupersededError) {
+        // Reachable ONLY when the injected proxy recognized the reserved
+        // claim_superseded envelope and re-threw the typed error.
+        return JSON.stringify({ outcome: "superseded", detail: e.detail });
+      }
+      return JSON.stringify({
+        outcome: "generic",
+        error_type: e instanceof Error ? e.name : typeof e,
+      });
+    }
+  },
+});
+
+agent.addTool({
+  name: "probe_generic",
+  capability: "probe-generic",
+  description: "Control: calls reject-generic via injected proxy and classifies it",
+  dependencies: ["reject-generic"],
+  parameters: z.object({}),
+  execute: async (_args, dep: McpMeshTool | null = null) => {
+    if (!dep) {
+      return JSON.stringify({ outcome: "no_dep" });
+    }
+    try {
+      await dep({});
+      return JSON.stringify({ outcome: "no_error" });
+    } catch (e) {
+      if (e instanceof MeshSupersededError) {
+        return JSON.stringify({ outcome: "superseded", detail: e.detail });
+      }
+      // A generic error MUST land here.
+      return JSON.stringify({
+        outcome: "generic",
+        error_type: e instanceof Error ? e.name : typeof e,
+      });
+    }
+  },
+});
+
+console.log("ts-signal-consumer agent defined. Waiting for auto-start...");

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-consumer/tsconfig.json
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-consumer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/package.json
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ts-signal-provider",
+  "version": "1.0.0",
+  "description": "uc38 provider that emits the typed supersession signal (issue #1278)",
+  "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^2.8.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.18.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/package.json
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/package.json
@@ -12,7 +12,8 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^2.8.2"
+    "@mcpmesh/sdk": "^2.8.2",
+    "fastmcp": "^4.3.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/src/index.ts
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/src/index.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env npx tsx
+/**
+ * uc38 ts-signal-provider — emits the typed supersession signal (issue #1278).
+ *
+ * The TypeScript counterpart of py-signal-provider: it proves the EMIT half of
+ * the emit->wire->recognize plumbing over the REAL napi/HTTP transport. Three
+ * capabilities:
+ *
+ *   - reject-superseded: UNCONDITIONALLY throws MeshSupersededError. It extends
+ *     fastmcp's UserError, so the existing tool-error path emits an isError
+ *     result whose text is the reserved envelope
+ *     {"error":"claim_superseded","detail":...}. Increments an in-process
+ *     counter BEFORE throwing so the caller can assert single-invoke.
+ *   - reject-generic: the CONTROL — throws a plain UserError whose message is
+ *     NOT the reserved envelope.
+ *   - superseded-call-count: reports how many times reject-superseded ran.
+ *
+ * Rejects unconditionally on purpose: this proves the framework plumbing, not
+ * the epoch-supersession app logic.
+ */
+
+import { FastMCP, mesh, MeshSupersededError } from "@mcpmesh/sdk";
+import { UserError } from "fastmcp";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "TsSignalProvider Service",
+  version: "1.0.0",
+});
+
+const agent = mesh(server, {
+  name: "ts-signal-provider",
+  httpPort: Number(process.env.MCP_MESH_HTTP_PORT ?? "9203"),
+});
+
+// In-process invocation counter. A double-invoke on the real transport would
+// push this past 1.
+let rejectSupersededCalls = 0;
+
+agent.addTool({
+  name: "reject_superseded",
+  capability: "reject-superseded",
+  description: "Unconditionally rejects the caller as superseded (issue #1278)",
+  parameters: z.object({}),
+  execute: async () => {
+    rejectSupersededCalls += 1;
+    throw new MeshSupersededError("stale epoch: caller superseded");
+  },
+});
+
+agent.addTool({
+  name: "reject_generic",
+  capability: "reject-generic",
+  description: "Control: fails with a generic (non-superseded) error",
+  parameters: z.object({}),
+  execute: async () => {
+    // Plain UserError whose message is NOT the reserved envelope.
+    throw new UserError("generic-provider-failure: this is NOT a supersession");
+  },
+});
+
+agent.addTool({
+  name: "get_reject_count",
+  capability: "superseded-call-count",
+  description: "Reports how many times reject-superseded was invoked",
+  parameters: z.object({}),
+  execute: async () => {
+    return JSON.stringify({ count: rejectSupersededCalls });
+  },
+});
+
+console.log("ts-signal-provider agent defined. Waiting for auto-start...");

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/tsconfig.json
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc38_superseded_signal/tc01_python_typed_superseded_roundtrip/test.yaml
+++ b/tests/integration/suites/uc38_superseded_signal/tc01_python_typed_superseded_roundtrip/test.yaml
@@ -1,0 +1,136 @@
+# tc01 — typed supersession signal round-trips over the REAL HTTP transport
+# (issue #1278, Python — the reference runtime whose primary-transport recognize
+# was found DEAD because the unit tests mocked the converter boundary).
+#
+# Topology (2 Python agents, all injected calls over real HTTP):
+#   py-signal-consumer --injected proxy--> py-signal-provider
+#
+# What this proves (the emit->wire->recognize plumbing, NOT the epoch app logic):
+#   1. EMIT + RECOGNIZE: the provider raises mesh.SupersededError; it crosses the
+#      wire as the reserved {"error":"claim_superseded"} isError envelope; the
+#      consumer's INJECTED McpMeshTool proxy recognizes it and re-raises the
+#      typed error, so probe_superseded reports outcome=superseded. That marker
+#      is reachable ONLY via `except mesh.SupersededError` — a raw string body or
+#      a generic error would land in the generic branch instead.
+#   2. SINGLE-INVOKE: the provider counts each real invocation of
+#      reject-superseded. After ONE consumer probe the count must be exactly 1 —
+#      the Python real-transport bug double-invoked via a fallback transport, so
+#      count==2 would surface it.
+#   3. NEGATIVE CONTROL: probe_generic calls a provider tool that raises a plain
+#      (non-envelope) error. It must report outcome=generic, never superseded —
+#      proving the recognize path is envelope-exact and does not misclassify an
+#      arbitrary failure as supersession.
+#
+# Timing: liveness-only registration wait (issue #1193); the consumer's settle
+# window (MCP_MESH_SETTLE_TIMEOUT=60) covers dependency resolution — NO
+# dep-resolution sleeps. Timeout budget is sized for the WARM build cache:
+# step-budget arithmetic below is cold-cache headroom, not the warm sum.
+#   pip-install x2 (~10s warm) + 2 agent starts (~10s) + register poll
+#   (~10s typical, shared routine's deadline is longer) + settle-covered calls
+#   (~15s) ≈ 45s warm; 300s gives generous slack without budgeting the
+#   cold-cache worst case.
+
+name: "Typed supersession signal round-trips over real HTTP (Python)"
+description: "Provider raises mesh.SupersededError; consumer's injected proxy recognizes the reserved claim_superseded envelope (outcome=superseded), provider invoked exactly once, and a generic provider error is NOT misclassified (outcome=generic)"
+tags:
+  - integration
+  - python
+  - tools
+  - superseded
+  - issue-1278
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/py-signal-provider /workspace/
+      cp -rL /uc-artifacts/py-signal-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: pip-install
+    path: /workspace/py-signal-provider
+
+  - name: "Install consumer deps"
+    handler: pip-install
+    path: /workspace/py-signal-consumer
+
+  # Start provider first. No registration wait before the consumer: the
+  # consumer's settle window covers dependency arrival order.
+  - name: "Start provider (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start py-signal-provider/main.py --env MCP_MESH_HTTP_PORT=9201 -d
+    capture: start_provider
+
+  - name: "Start consumer (port 9202)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start py-signal-consumer/main.py --env MCP_MESH_HTTP_PORT=9202 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+    capture: start_consumer
+
+  # Liveness only (issue #1193): both agents must APPEAR in the registry.
+  # Dependency resolution is covered by the settle window on the calls below.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "py-signal-provider py-signal-consumer"
+
+  # (1) EMIT + RECOGNIZE. meshctl call returns the MCP CallToolResult JSON; the
+  # probe returns a JSON string, parsed uniformly via content[0].text | fromjson.
+  - name: "Probe: consumer calls reject-superseded via injected proxy"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call probe_superseded '{}' 2>/dev/null
+    capture: probe_superseded
+    timeout: 90
+
+  # (2) SINGLE-INVOKE. Read the provider's real invocation counter.
+  - name: "Read provider invocation count"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call get_reject_count '{}' 2>/dev/null
+    capture: reject_count
+    timeout: 60
+
+  # (3) NEGATIVE CONTROL. Same consumer, a provider tool that fails generically.
+  - name: "Control: consumer calls reject-generic via injected proxy"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call probe_generic '{}' 2>/dev/null
+    capture: probe_generic
+    timeout: 90
+
+assertions:
+  # IDIOM: equality lives INSIDE the jq filter so the interpolation yields a bare
+  # true/false (no '}' in the interpolation body); the envelope is parsed via the
+  # portable content[0].text | fromjson (structuredContent is Python-only).
+
+  # (1) The typed signal was recognized over the real transport.
+  - expr: "${jq:captured.probe_superseded:(.content[0].text | fromjson | .outcome == \"superseded\")} == 'true'"
+    message: "consumer's injected proxy must recognize the reserved claim_superseded envelope and re-raise the typed error (outcome=superseded) — a raw body or generic error would report 'generic'"
+  - expr: "${jq:captured.probe_superseded:(.content[0].text | fromjson | .outcome == \"generic\")} == 'false'"
+    message: "probe_superseded must NOT fall into the generic branch — that would mean the real-transport recognize is dead (the exact primary-path bug this UC exists to catch)"
+  # The optional detail round-tripped through the envelope too.
+  - expr: "${jq:captured.probe_superseded:(.content[0].text | fromjson | .detail | contains(\"stale epoch\"))} == 'true'"
+    message: "the SupersededError detail must round-trip through the wire envelope"
+
+  # (2) The provider was invoked EXACTLY ONCE (no fallback-transport double-invoke).
+  - expr: "${jq:captured.reject_count:(.content[0].text | fromjson | .count == 1)} == 'true'"
+    message: "reject-superseded must be invoked exactly once — count==2 means the caller double-invoked via a fallback transport (the Python real-transport regression)"
+
+  # (3) A generic provider error is NOT misclassified as superseded.
+  - expr: "${jq:captured.probe_generic:(.content[0].text | fromjson | .outcome == \"generic\")} == 'true'"
+    message: "a plain (non-envelope) provider error must classify as generic"
+  - expr: "${jq:captured.probe_generic:(.content[0].text | fromjson | .outcome == \"superseded\")} == 'false'"
+    message: "a generic provider error must NEVER be misclassified as superseded — the recognize path must be envelope-exact"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: meshctl stop 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc38_superseded_signal/tc02_typescript_typed_superseded_roundtrip/test.yaml
+++ b/tests/integration/suites/uc38_superseded_signal/tc02_typescript_typed_superseded_roundtrip/test.yaml
@@ -1,0 +1,137 @@
+# tc02 — typed supersession signal round-trips over the REAL napi/HTTP transport
+# (issue #1278, TypeScript). Ports the Python tc01 pattern to prove the TS
+# proxy's recognize path over the real transport, not the mocked boundary.
+#
+# Topology (2 TS agents, all injected calls over real HTTP):
+#   ts-signal-consumer --injected proxy--> ts-signal-provider
+#
+# What this proves (identical to tc01, TypeScript carrier):
+#   1. EMIT + RECOGNIZE: the provider throws MeshSupersededError; it crosses the
+#      wire as the reserved {"error":"claim_superseded"} isError envelope; the
+#      consumer's injected proxy recognizes it and re-throws the typed error, so
+#      probe_superseded reports outcome=superseded (reachable ONLY via
+#      `e instanceof MeshSupersededError`).
+#   2. SINGLE-INVOKE: after ONE consumer probe the provider's reject-superseded
+#      counter must be exactly 1. The provider is pinned to a single tool-worker
+#      (MCP_MESH_TOOL_WORKERS=1, isolation still ON) so the module-level counter
+#      is shared across the body and the count tool — see the provider start step.
+#   3. NEGATIVE CONTROL: probe_generic (a provider tool throwing a plain
+#      UserError) must report outcome=generic, never superseded.
+#
+# Timing: liveness-only registration wait (issue #1193); the consumer's settle
+# window (MCP_MESH_SETTLE_TIMEOUT=60) covers dependency resolution — NO
+# dep-resolution sleeps. Timeout budget sized for the WARM npm cache:
+#   npm-install x2 (~20s warm) + 2 agent starts (~15s) + register poll (<=90s
+#   deadline, ~15s typical) + settle-covered calls (~15s) ≈ 65s warm; 300s gives
+#   generous slack without budgeting the cold-cache worst case.
+
+name: "Typed supersession signal round-trips over real HTTP (TypeScript)"
+description: "Provider throws MeshSupersededError; consumer's injected proxy recognizes the reserved claim_superseded envelope (outcome=superseded), provider invoked exactly once, and a generic provider error is NOT misclassified (outcome=generic)"
+tags:
+  - integration
+  - typescript
+  - tools
+  - superseded
+  - issue-1278
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_typescript_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/ts-signal-provider /workspace/
+      cp -rL /uc-artifacts/ts-signal-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: npm-install
+    path: /workspace/ts-signal-provider
+
+  - name: "Install consumer deps"
+    handler: npm-install
+    path: /workspace/ts-signal-consumer
+
+  # Start provider first. No registration wait before the consumer: the
+  # consumer's settle window covers dependency arrival order.
+  # MCP_MESH_TOOL_WORKERS=1 pins the provider to a SINGLE tool-isolation worker.
+  # Tool isolation stays ON (the default — the worker_threads boundary is still
+  # crossed, which is exactly the path the reserved envelope must survive), but
+  # with one worker BOTH reject_superseded and get_reject_count run in the same
+  # worker, so the module-level counter is shared and the count==1 single-invoke
+  # assertion is observable. Under the default multi-worker pool the counter is
+  # per-worker: get_reject_count could read a different worker's copy (0) than
+  # the one that ran the body — not a wire double-invoke, just an unobservable
+  # counter — so we pin the pool rather than trust cross-worker module state.
+  - name: "Start provider (port 9203, single tool worker)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start ts-signal-provider/src/index.ts --env MCP_MESH_HTTP_PORT=9203 --env MCP_MESH_TOOL_WORKERS=1 -d
+    capture: start_provider
+
+  - name: "Start consumer (port 9204)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start ts-signal-consumer/src/index.ts --env MCP_MESH_HTTP_PORT=9204 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+    capture: start_consumer
+
+  # Liveness only (issue #1193): both agents must APPEAR in the registry.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "ts-signal-provider ts-signal-consumer"
+
+  # (1) EMIT + RECOGNIZE.
+  - name: "Probe: consumer calls reject-superseded via injected proxy"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call probe_superseded '{}' 2>/dev/null
+    capture: probe_superseded
+    timeout: 90
+
+  # (2) SINGLE-INVOKE.
+  - name: "Read provider invocation count"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call get_reject_count '{}' 2>/dev/null
+    capture: reject_count
+    timeout: 60
+
+  # (3) NEGATIVE CONTROL.
+  - name: "Control: consumer calls reject-generic via injected proxy"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call probe_generic '{}' 2>/dev/null
+    capture: probe_generic
+    timeout: 90
+
+assertions:
+  # IDIOM: equality INSIDE the jq filter (bare true/false out, no '}' in the
+  # interpolation body); envelope parsed via the portable content[0].text |
+  # fromjson.
+
+  # (1) The typed signal was recognized over the real transport.
+  - expr: "${jq:captured.probe_superseded:(.content[0].text | fromjson | .outcome == \"superseded\")} == 'true'"
+    message: "consumer's injected proxy must recognize the reserved claim_superseded envelope and re-throw the typed error (outcome=superseded)"
+  - expr: "${jq:captured.probe_superseded:(.content[0].text | fromjson | .outcome == \"generic\")} == 'false'"
+    message: "probe_superseded must NOT fall into the generic branch — that would mean the real-transport recognize is dead"
+  - expr: "${jq:captured.probe_superseded:(.content[0].text | fromjson | .detail | contains(\"stale epoch\"))} == 'true'"
+    message: "the MeshSupersededError detail must round-trip through the wire envelope"
+
+  # (2) The provider was invoked EXACTLY ONCE.
+  - expr: "${jq:captured.reject_count:(.content[0].text | fromjson | .count == 1)} == 'true'"
+    message: "reject-superseded must be invoked exactly once — count==2 means a fallback-transport double-invoke"
+
+  # (3) A generic provider error is NOT misclassified as superseded.
+  - expr: "${jq:captured.probe_generic:(.content[0].text | fromjson | .outcome == \"generic\")} == 'true'"
+    message: "a plain (non-envelope) provider error must classify as generic"
+  - expr: "${jq:captured.probe_generic:(.content[0].text | fromjson | .outcome == \"superseded\")} == 'false'"
+    message: "a generic provider error must NEVER be misclassified as superseded — the recognize path must be envelope-exact"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: meshctl stop 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc38_superseded_signal/tc03_java_typed_superseded_roundtrip/test.yaml
+++ b/tests/integration/suites/uc38_superseded_signal/tc03_java_typed_superseded_roundtrip/test.yaml
@@ -1,0 +1,171 @@
+# tc03 — typed supersession signal round-trips over the REAL JNI/HTTP transport
+# (issue #1278, Java). Modeled 1:1 on tc01 (Python), with uc23's Java build /
+# cold-start / budget conventions.
+#
+# Why Java gets its own real-transport TC even though the recognize "looks
+# wired": Java's EMIT path is DIFFERENT from Python/TS. Python/TS let fastmcp
+# auto-serialize a thrown error into the isError result; Java instead relies on
+# the framework MeshToolWrapper CATCHING MeshSupersededException and building the
+# reserved {"error":"claim_superseded"} envelope by hand. That wrapper-catch
+# emit (plus the ToolInvoker/McpHttpClient recognize on the consumer side) is
+# exactly the surface a mocked-boundary unit test cannot vouch for — this TC
+# drives it end-to-end over real HTTP.
+#
+# Topology (2 Java Spring Boot agents, all injected calls over real HTTP):
+#   java-signal-consumer --injected McpMeshTool proxy--> java-signal-provider
+#
+# What this proves (identical shape to tc01/tc02, Java carrier):
+#   1. EMIT + RECOGNIZE: provider throws MeshSupersededException; the wrapper
+#      emits the reserved envelope; the consumer's injected proxy recognizes it
+#      and re-throws the typed exception, so probeSuperseded reports
+#      outcome=superseded (reachable ONLY via catch (MeshSupersededException)).
+#   2. SINGLE-INVOKE: after ONE consumer probe the provider's reject-superseded
+#      counter must be exactly 1 (count==2 ⇒ fallback-transport double-invoke).
+#   3. NEGATIVE CONTROL: probeGeneric (a provider tool throwing a plain
+#      RuntimeException) must report outcome=generic, never superseded.
+#
+# NOTE (tool names): mesh's Java runtime derives the MCP tool name from the
+# camelCase METHOD name (e.g. uc02 greet/getInfo), so the calls below use
+# probeSuperseded / probeGeneric / getRejectCount. The ASSERTION shape is
+# identical to tc01/tc02; only the call names differ.
+#
+# Timing: liveness-only registration wait (issue #1193) plus a provider
+# status==healthy gate (Java Spring Boot cold-start is ~30s — the uc23 idiom);
+# the consumer's settle window (MCP_MESH_SETTLE_TIMEOUT=60) covers dependency
+# resolution — NO dep-resolution sleeps. Timeout budget sized for the WARM maven
+# cache, mirroring uc23's two-Java-agent TCs (360s there); the per-step
+# maven-install budgets (600s) are cold-cache step caps, not the warm sum:
+#   maven-install x2 (~30s warm) + 2 Spring Boot cold starts (~30s each) +
+#   health/register polls (~15s) + settle-covered calls (~10s) ≈ 145s warm; 420s
+#   gives generous slack for the double JVM boot without budgeting cold cache.
+
+name: "Typed supersession signal round-trips over real HTTP (Java)"
+description: "Provider throws MeshSupersededException (wrapper-catch emit); consumer's injected proxy recognizes the reserved claim_superseded envelope (outcome=superseded), provider invoked exactly once, and a generic provider error is NOT misclassified (outcome=generic)"
+tags:
+  - integration
+  - java
+  - tools
+  - superseded
+  - issue-1278
+  - slow
+timeout: 420
+
+pre_run:
+  - routine: global.setup_for_java_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/java-signal-provider /workspace/
+      cp -rL /uc-artifacts/java-signal-consumer /workspace/
+
+  - name: "Install provider deps"
+    handler: maven-install
+    path: /workspace/java-signal-provider
+    timeout: 600
+
+  - name: "Install consumer deps"
+    handler: maven-install
+    path: /workspace/java-signal-consumer
+    timeout: 600
+
+  # Start provider first. No registration wait before the consumer: the
+  # consumer's settle window covers dependency arrival order.
+  - name: "Start provider (port 9205)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start java-signal-provider --env MCP_MESH_HTTP_PORT=9205 -d
+    capture: start_provider
+
+  # Java Spring Boot cold-start is ~30s. Poll /agents until the provider is
+  # healthy so the consumer's first probe has a live target (uc23 idiom).
+  - name: "Wait for Java provider to be healthy"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 60); do
+        STATUS=$(curl -s http://localhost:8000/agents | jq -r \
+          '.agents[] | select(.name=="java-signal-provider") | .status' 2>/dev/null)
+        if [ "$STATUS" = "healthy" ]; then
+          echo "provider healthy after ${i}x2s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "ERROR: provider not healthy within 120s (last status='$STATUS')"
+      meshctl logs java-signal-provider 2>&1 | tail -80 || true
+      exit 1
+    capture: provider_healthy
+    timeout: 150
+
+  - name: "Start consumer (port 9206)"
+    handler: shell
+    workdir: /workspace
+    command: meshctl start java-signal-consumer --env MCP_MESH_HTTP_PORT=9206 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+    capture: start_consumer
+
+  # Liveness only (issue #1193): both agents must APPEAR in the registry.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "java-signal-provider java-signal-consumer"
+
+  # (1) EMIT + RECOGNIZE. meshctl call returns the MCP CallToolResult JSON; the
+  # probe returns a Map, parsed uniformly via content[0].text | fromjson.
+  - name: "Probe: consumer calls reject-superseded via injected proxy"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call probeSuperseded '{}' 2>/dev/null
+    capture: probe_superseded
+    timeout: 90
+
+  # (2) SINGLE-INVOKE. Read the provider's real invocation counter.
+  - name: "Read provider invocation count"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call getRejectCount '{}' 2>/dev/null
+    capture: reject_count
+    timeout: 60
+
+  # (3) NEGATIVE CONTROL. Same consumer, a provider tool that fails generically.
+  - name: "Control: consumer calls reject-generic via injected proxy"
+    handler: shell
+    workdir: /workspace
+    command: meshctl call probeGeneric '{}' 2>/dev/null
+    capture: probe_generic
+    timeout: 90
+
+assertions:
+  # IDIOM: equality lives INSIDE the jq filter so the interpolation yields a bare
+  # true/false (no '}' in the interpolation body); the envelope is parsed via the
+  # portable content[0].text | fromjson (structuredContent is Python-only).
+
+  # Gate: the Java provider came up healthy before the probes.
+  - expr: "${captured.provider_healthy} contains 'provider healthy'"
+    message: "the Java provider must reach status=healthy before the consumer probes it"
+
+  # (1) The typed signal was recognized over the real transport.
+  - expr: "${jq:captured.probe_superseded:(.content[0].text | fromjson | .outcome == \"superseded\")} == 'true'"
+    message: "consumer's injected proxy must recognize the reserved claim_superseded envelope and re-throw the typed exception (outcome=superseded) — a raw body or generic error would report 'generic'"
+  - expr: "${jq:captured.probe_superseded:(.content[0].text | fromjson | .outcome == \"generic\")} == 'false'"
+    message: "probeSuperseded must NOT fall into the generic branch — that would mean Java's wrapper-catch emit or the recognize path is dead on the real transport"
+  - expr: "${jq:captured.probe_superseded:(.content[0].text | fromjson | .detail | contains(\"stale epoch\"))} == 'true'"
+    message: "the MeshSupersededException detail must round-trip through the wire envelope"
+
+  # (2) The provider was invoked EXACTLY ONCE (no fallback-transport double-invoke).
+  - expr: "${jq:captured.reject_count:(.content[0].text | fromjson | .count == 1)} == 'true'"
+    message: "reject-superseded must be invoked exactly once — count==2 means the caller double-invoked via a fallback transport"
+
+  # (3) A generic provider error is NOT misclassified as superseded.
+  - expr: "${jq:captured.probe_generic:(.content[0].text | fromjson | .outcome == \"generic\")} == 'true'"
+    message: "a plain (non-envelope) provider error must classify as generic"
+  - expr: "${jq:captured.probe_generic:(.content[0].text | fromjson | .outcome == \"superseded\")} == 'false'"
+    message: "a generic provider error must NEVER be misclassified as superseded — the recognize path must be envelope-exact"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: meshctl stop 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Gap

#1263 gives providers the calling-job identity to fence stale-executor writes — but a rejected caller had no typed signal. Apps had to string-match `{"error":"claim_superseded"}` in the app envelope after *every* mutating call to unwind, threading a helper through ~10 call sites.

## What this adds

A standard, typed rejection surface so a superseded executor unwinds with **one catch** instead of per-call string checks. Purely additive — apps keep full control of what counts as superseded (decided via `calling_job()` from #1263); the framework does **not** auto-detect.

### Contract
- Provider raises a typed error → framework emits the reserved app envelope `{"error":"claim_superseded"[, "detail":…]}` (compact JSON, byte-identical across runtimes; `detail` omitted when absent).
- The injected proxy on the caller side **structurally parses** that envelope (JSON parse + exact `error ==` check, never substring) and re-raises a typed error, distinct from a generic tool failure.
- Reuses the existing `claim_superseded` vocabulary from the job path — **no Rust / registry / wire changes.**

### Per-runtime surface
| Runtime | Provider raises | Caller receives |
|---|---|---|
| Python | `mesh.SupersededError` | `mesh.SupersededError` |
| TypeScript | `MeshSupersededError` (extends `UserError`) | `MeshSupersededError` |
| Java | `MeshSupersededException` | `MeshSupersededException` |

Recognition covers buffered, streaming/SSE, and local/self-dependency paths in every runtime. Java's `MeshToolWrapper` converts on both the plain-tool and job-dispatch branches.

## Two transport-path bugs the real-transport UC caught (unit tests missed both)

The unit tests drove the converter boundary directly and all passed — the integration UC exercising real natives is what surfaced these:

1. **Python double-invoke (HIGH):** the recognize on the primary `_http_call` transport was dead — the typed raise was swallowed by the outer `except Exception`, fell through to the FastMCP fallback, and **double-invoked the tool.** Guarded the superseded raise ahead of the generic except on all three primary sites; regression proven by removing/restoring the guards.
2. **TS `UserError` identity loss across the worker boundary (general fix):** tool isolation (`worker_threads`, on by default) flattened custom `Error` subclasses crossing the boundary, so `instanceof UserError` failed on the main thread and fastmcp prefixed the message, corrupting the reserved envelope. Extracted shared `worker-error-serde.ts` that preserves `UserError` identity + extras across the boundary. **This fixes *any* `UserError` thrown from an isolated tool body**, not just this feature — a latent correctness bug independent of #1278.

## Validation
- **src-tests: 12/12** — rebuilds `tsuite-mesh:local` with the TS SDK change baked in.
- **integration `uc38_superseded_signal`: 3/3 on real natives (k8s)** — Python, TS, and Java each round-trip the typed signal; controls classify as generic (no misclassification); single-invoke holds under isolation (`count == 1`). New per-runtime unit suites for the proxy recognizers and the worker-error serde as well.

## Docs & examples
`meshctl man` job pages (all three language variants) + `docs/concepts/jobs.md` gain a "Typed supersession signal" section after calling-job identity. New `superseded-provider` / `superseded-consumer` examples in all three runtimes demonstrate the fence-then-one-catch pattern.

Closes #1278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed supersession handling across Python, TypeScript, and Java so stale job attempts now return a consistent typed error instead of a generic failure.
  * Added new provider/consumer examples for batch write fencing and one-catch unwind behavior.
* **Documentation**
  * Expanded job documentation with typed supersession guidance, usage examples, and quick-start commands.
* **Tests**
  * Added unit and integration coverage to verify typed error propagation, transport behavior, and single-invocation fencing across runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->