### PR TITLE
fix(java): structuredContent parity + docs(jobs): parked-vs-compute-bound lease gaps

### DIFF
--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -501,6 +501,19 @@ periodic progress to keep the lease renewed. Set `total_deadline` if you
 want a hard total-runtime bound across all attempts, or to opt out of the
 registry-wide stale ceiling entirely.
 
+**Parked vs. compute-bound gaps.** Which kind of gap the handler is
+sitting in decides whether the lease renews on its own:
+
+- **Parked gap** — blocked inside `recv_event` awaiting the next event.
+  The lease renews **automatically**: the poll *is* the renewal, so no
+  keepalive is needed.
+- **Compute-bound gap** — a long synchronous stretch between event gates
+  (an LLM request, a large local transform). **Nothing renews the lease**
+  during this window. Either emit a periodic `update_progress` keepalive,
+  or size `max_duration` to cover the longest compute-bound gap. A blanket
+  `max_duration` multiplier "to be safe" is the wrong fix — it papers over
+  the specific silent stretch instead of covering it.
+
 `MCP_MESH_JOB_STALE_TIMEOUT` is a **reap ceiling, not the lease window** —
 it caps total runtime from submission but does not size or extend the
 per-attempt lease. The lease window is derived per-job from `max_duration`

--- a/src/core/cli/man/content/jobs.md
+++ b/src/core/cli/man/content/jobs.md
@@ -507,6 +507,19 @@ periodic `update_progress` to keep the lease renewed. Set
 `total_deadline` if you want a hard total-runtime bound across all
 attempts, or to opt out of the registry-wide stale ceiling entirely.
 
+**Parked vs. compute-bound gaps.** Which kind of gap the handler is
+sitting in decides whether the lease renews on its own:
+
+- **Parked gap** — blocked inside `recv_event` awaiting the next event.
+  The lease renews **automatically**: the poll *is* the renewal, so no
+  keepalive is needed.
+- **Compute-bound gap** — a long synchronous stretch between event gates
+  (an LLM request, a large local transform). **Nothing renews the lease**
+  during this window. Either emit a periodic `update_progress` keepalive,
+  or size `max_duration` to cover the longest compute-bound gap. A blanket
+  `max_duration` multiplier "to be safe" is the wrong fix — it papers over
+  the specific silent stretch instead of covering it.
+
 ## Claim gating on unavailable capabilities
 
 A claim worker never pulls a job for a capability whose `required`

--- a/src/core/cli/man/content/jobs_java.md
+++ b/src/core/cli/man/content/jobs_java.md
@@ -695,6 +695,19 @@ periodic `updateProgress` to keep the lease renewed. Set `totalDeadline`
 if you want a hard total-runtime bound across all attempts, or to opt out
 of the registry-wide stale ceiling entirely.
 
+**Parked vs. compute-bound gaps.** Which kind of gap the handler is
+sitting in decides whether the lease renews on its own:
+
+- **Parked gap** — blocked inside `recvEvent` awaiting the next event.
+  The lease renews **automatically**: the poll *is* the renewal, so no
+  keepalive is needed.
+- **Compute-bound gap** — a long synchronous stretch between event gates
+  (an LLM request, a large local transform). **Nothing renews the lease**
+  during this window. Either emit a periodic `updateProgress` keepalive,
+  or size `maxDuration` to cover the longest compute-bound gap. A blanket
+  `maxDuration` multiplier "to be safe" is the wrong fix — it papers over
+  the specific silent stretch instead of covering it.
+
 ## Claim gating on unavailable capabilities
 
 A claim worker never pulls a job for a capability whose `required`

--- a/src/core/cli/man/content/jobs_typescript.md
+++ b/src/core/cli/man/content/jobs_typescript.md
@@ -558,6 +558,19 @@ periodic `updateProgress` to keep the lease renewed. Set `totalDeadline`
 if you want a hard total-runtime bound across all attempts, or to opt out
 of the registry-wide stale ceiling entirely.
 
+**Parked vs. compute-bound gaps.** Which kind of gap the handler is
+sitting in decides whether the lease renews on its own:
+
+- **Parked gap** — blocked inside `recvEvent` awaiting the next event.
+  The lease renews **automatically**: the poll *is* the renewal, so no
+  keepalive is needed.
+- **Compute-bound gap** — a long synchronous stretch between event gates
+  (an LLM request, a large local transform). **Nothing renews the lease**
+  during this window. Either emit a periodic `updateProgress` keepalive,
+  or size `maxDuration` to cover the longest compute-bound gap. A blanket
+  `maxDuration` multiplier "to be safe" is the wrong fix — it papers over
+  the specific silent stretch instead of covering it.
+
 ## Claim gating on unavailable capabilities
 
 A claim worker never pulls a job for a capability whose `required`

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshMcpServerConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshMcpServerConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -53,6 +54,17 @@ public class MeshMcpServerConfiguration {
     private static final Logger log = LoggerFactory.getLogger(MeshMcpServerConfiguration.class);
 
     private static final String MCP_ENDPOINT = "/mcp";
+
+    /**
+     * FastMCP's {@code wrap_result} marker (issue #1250/#1251), carried in the
+     * CallToolResult {@code meta} field — which the MCP SDK serializes on the
+     * wire as {@code _meta}. Signals that {@code structuredContent} is a
+     * {@code {"result": <value>}} envelope wrapping a non-object return, so a
+     * consumer unwraps the single {@code "result"} key. Byte-identical to the
+     * Python provider's {@code {"fastmcp": {"wrap_result": True}}}.
+     */
+    private static final Map<String, Object> WRAP_RESULT_META =
+        Map.of("fastmcp", Map.of("wrap_result", true));
 
     // MCP SDK 1.1.0 uses Jackson 3 (tools.jackson)
     private final tools.jackson.databind.json.JsonMapper mcpJsonMapper;
@@ -168,6 +180,61 @@ public class MeshMcpServerConfiguration {
     }
 
     /**
+     * Build the {@code structuredContent} for a serialized tool return,
+     * mirroring FastMCP / the Python provider (issue #1282, honoring the
+     * #1250/#1251 empty-return contract):
+     * <ul>
+     *   <li>object-shaped return (a {@code Map} or POJO serializing to a JSON
+     *       object) → the object itself, as a {@code Map}, with NO wrap marker;</li>
+     *   <li>every non-object return (list/array, scalar number/boolean, string,
+     *       {@code null}) → wrapped as {@code {"result": <value>}}, paired with
+     *       the {@link #WRAP_RESULT_META} marker (set by the caller).</li>
+     * </ul>
+     *
+     * <p>This produces exactly the emission the Python provider's
+     * empty-collection test asserts: {@code []} → {@code {"result": []}} +
+     * marker, {@code {}} → {@code {}} (no marker), {@code ""} →
+     * {@code {"result": ""}} + marker, {@code null} → {@code {"result": null}}
+     * + marker. Shared so any future structured-output path emits identically
+     * rather than forking.
+     */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> buildStructuredContent(Object result) {
+        if (isObjectShaped(result)) {
+            return mcpJsonMapper.convertValue(result, Map.class);
+        }
+        Map<String, Object> wrapped = new LinkedHashMap<>();
+        wrapped.put("result", result);
+        return wrapped;
+    }
+
+    /**
+     * Whether a tool return is object-shaped — i.e. serializes to a JSON object
+     * ({@code {...}}) rather than an array, scalar, string, or null. Object
+     * returns become {@code structuredContent} directly; everything else is
+     * wrapped in a {@code {"result": X}} envelope with the wrap marker, matching
+     * FastMCP.
+     */
+    private boolean isObjectShaped(Object result) {
+        if (result == null) {
+            return false;
+        }
+        if (result instanceof Map) {
+            return true;
+        }
+        if (result instanceof Iterable
+                || result instanceof CharSequence
+                || result instanceof Number
+                || result instanceof Boolean
+                || result.getClass().isArray()) {
+            return false;
+        }
+        // POJO / other: let Jackson decide by the serialized JSON shape.
+        tools.jackson.databind.JsonNode node = mcpJsonMapper.valueToTree(result);
+        return node != null && node.isObject();
+    }
+
+    /**
      * Create a JsonSchema from a schema map.
      */
     @SuppressWarnings("unchecked")
@@ -228,12 +295,20 @@ public class MeshMcpServerConfiguration {
                 resultJson = mcpJsonMapper.writeValueAsString(result);
             }
 
-            // Return as text content
+            // Return as text content, ADDITIONALLY populating structuredContent
+            // (issue #1282) so spec-compliant MCP clients — and future
+            // structured-first consumers — see the same structured value the
+            // Python provider emits via FastMCP. The text block
+            // (content[0].text = resultJson) is UNCHANGED: mesh consumers
+            // recover text-first (#1250/#1251), so the cross-runtime round-trip
+            // stays byte-identical regardless of this additive field.
+            Object structuredContent = buildStructuredContent(result);
+            Map<String, Object> meta = isObjectShaped(result) ? null : WRAP_RESULT_META;
             return new CallToolResult(
                 List.of(new TextContent(resultJson)),
                 false,  // isError
-                null,   // structuredContent
-                null    // meta
+                structuredContent,
+                meta
             );
 
         } catch (Exception e) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshMcpServerConfigurationStructuredContentTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshMcpServerConfigurationStructuredContentTest.java
@@ -1,0 +1,217 @@
+package io.mcpmesh.spring;
+
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Provider-side unit tests for {@code tools/call} {@code structuredContent}
+ * emission parity (issue #1282), mirroring the Python provider's #1250/#1251
+ * empty-return contract.
+ *
+ * <p>The Java provider now populates {@code structuredContent} (and the
+ * {@code fastmcp.wrap_result} marker in {@code _meta}) for object-shaped and
+ * non-object returns using the SAME rules FastMCP applies:
+ * <ul>
+ *   <li>object-shaped (Map/POJO) → {@code structuredContent} = the object, no
+ *       marker;</li>
+ *   <li>non-object (list, scalar, string, null) → {@code {"result": X}} + the
+ *       wrap marker.</li>
+ * </ul>
+ *
+ * <p>Critically, {@code content[0].text} is UNCHANGED in every case — mesh
+ * consumers recover text-first, so the cross-runtime round-trip is preserved
+ * and {@code structuredContent} is purely additive.
+ */
+@DisplayName("MeshMcpServerConfiguration structuredContent emission (#1282)")
+class MeshMcpServerConfigurationStructuredContentTest {
+
+    private static final Map<String, Object> WRAP_MARKER =
+        Map.of("fastmcp", Map.of("wrap_result", true));
+
+    /** Minimal handler that returns a fixed value from {@code invoke}. */
+    private static final class FixedHandler implements McpToolHandler {
+        private final Object value;
+
+        FixedHandler(Object value) {
+            this.value = value;
+        }
+
+        @Override public String getFuncId() { return "test.fixed"; }
+        @Override public String getCapability() { return "fixed"; }
+        @Override public String getMethodName() { return "fixed"; }
+        @Override public String getDescription() { return "fixed"; }
+        @Override public Map<String, Object> getInputSchema() { return Map.of("type", "object"); }
+        @Override public Object invoke(Map<String, Object> mcpArgs) { return value; }
+        @Override public int getDependencyCount() { return 0; }
+        @Override public int getLlmAgentCount() { return 0; }
+    }
+
+    private CallToolResult call(Object returnValue) throws Exception {
+        MeshMcpServerConfiguration config = new MeshMcpServerConfiguration();
+        Method m = MeshMcpServerConfiguration.class.getDeclaredMethod(
+            "handleToolCall", McpToolHandler.class, Map.class);
+        m.setAccessible(true);
+        return (CallToolResult) m.invoke(config, new FixedHandler(returnValue), Map.of());
+    }
+
+    private String text(CallToolResult r) {
+        assertEquals(1, r.content().size(), "expected exactly one content block");
+        return ((TextContent) r.content().get(0)).text();
+    }
+
+    // ----- object-shaped returns: structuredContent = object, no marker -----
+
+    @Test
+    @DisplayName("Map return → structuredContent is the object, no wrap marker")
+    void mapReturn() throws Exception {
+        Map<String, Object> obj = new LinkedHashMap<>();
+        obj.put("a", 1);
+        obj.put("b", "two");
+        CallToolResult r = call(obj);
+
+        assertEquals("{\"a\":1,\"b\":\"two\"}", text(r));
+        assertEquals(obj, r.structuredContent());
+        assertNull(r.meta(), "object-shaped return must not carry the wrap marker");
+        assertFalse(r.isError());
+    }
+
+    @Test
+    @DisplayName("Empty map {} → structuredContent {}, no marker (#1251)")
+    void emptyMapReturn() throws Exception {
+        CallToolResult r = call(new LinkedHashMap<String, Object>());
+
+        assertEquals("{}", text(r));
+        assertEquals(Map.of(), r.structuredContent());
+        assertNull(r.meta());
+    }
+
+    // ----- non-object returns: {"result": X} + wrap marker -----
+
+    @Test
+    @DisplayName("Empty list [] → structuredContent {\"result\": []} + marker (#1250)")
+    void emptyListReturn() throws Exception {
+        CallToolResult r = call(new ArrayList<Integer>());
+
+        assertEquals("[]", text(r));
+        Map<String, Object> expected = new LinkedHashMap<>();
+        expected.put("result", List.of());
+        assertEquals(expected, r.structuredContent());
+        assertEquals(WRAP_MARKER, r.meta());
+    }
+
+    @Test
+    @DisplayName("Non-empty list → structuredContent {\"result\": [...]} + marker")
+    void nonEmptyListReturn() throws Exception {
+        CallToolResult r = call(Arrays.asList(1, 2, 3));
+
+        assertEquals("[1,2,3]", text(r));
+        Map<String, Object> expected = new LinkedHashMap<>();
+        expected.put("result", Arrays.asList(1, 2, 3));
+        assertEquals(expected, r.structuredContent());
+        assertEquals(WRAP_MARKER, r.meta());
+    }
+
+    @Test
+    @DisplayName("Empty string \"\" → structuredContent {\"result\": \"\"} + marker (#1251)")
+    void emptyStringReturn() throws Exception {
+        CallToolResult r = call("");
+
+        assertEquals("", text(r));
+        Map<String, Object> expected = new LinkedHashMap<>();
+        expected.put("result", "");
+        assertEquals(expected, r.structuredContent());
+        assertEquals(WRAP_MARKER, r.meta());
+    }
+
+    @Test
+    @DisplayName("Plain string → text is the raw string, structuredContent wraps it")
+    void plainStringReturn() throws Exception {
+        CallToolResult r = call("hello");
+
+        assertEquals("hello", text(r));
+        Map<String, Object> expected = new LinkedHashMap<>();
+        expected.put("result", "hello");
+        assertEquals(expected, r.structuredContent());
+        assertEquals(WRAP_MARKER, r.meta());
+    }
+
+    @Test
+    @DisplayName("Scalar number → structuredContent {\"result\": 42} + marker")
+    void scalarNumberReturn() throws Exception {
+        CallToolResult r = call(42);
+
+        assertEquals("42", text(r));
+        Map<String, Object> expected = new LinkedHashMap<>();
+        expected.put("result", 42);
+        assertEquals(expected, r.structuredContent());
+        assertEquals(WRAP_MARKER, r.meta());
+    }
+
+    @Test
+    @DisplayName("Boolean → structuredContent {\"result\": true} + marker")
+    void scalarBooleanReturn() throws Exception {
+        CallToolResult r = call(true);
+
+        assertEquals("true", text(r));
+        Map<String, Object> expected = new LinkedHashMap<>();
+        expected.put("result", true);
+        assertEquals(expected, r.structuredContent());
+        assertEquals(WRAP_MARKER, r.meta());
+    }
+
+    @Test
+    @DisplayName("null → text is \"null\", structuredContent {\"result\": null} + marker")
+    void nullReturn() throws Exception {
+        CallToolResult r = call(null);
+
+        assertEquals("null", text(r));
+        Map<String, Object> expected = new LinkedHashMap<>();
+        expected.put("result", null);
+        assertEquals(expected, r.structuredContent());
+        assertEquals(WRAP_MARKER, r.meta());
+    }
+
+    // ----- POJO is object-shaped -----
+
+    public static final class Point {
+        public int x;
+        public int y;
+        public Point(int x, int y) { this.x = x; this.y = y; }
+    }
+
+    @Test
+    @DisplayName("POJO return → structuredContent is the object map, no marker")
+    void pojoReturn() throws Exception {
+        CallToolResult r = call(new Point(3, 4));
+
+        assertEquals("{\"x\":3,\"y\":4}", text(r));
+        Map<String, Object> expected = new LinkedHashMap<>();
+        expected.put("x", 3);
+        expected.put("y", 4);
+        assertEquals(expected, r.structuredContent());
+        assertNull(r.meta());
+    }
+
+    // ----- text block is never mutated: the #1250/#1251 round-trip anchor -----
+
+    @Test
+    @DisplayName("content[0].text is unchanged across every return shape")
+    void textBlockUnchanged() throws Exception {
+        assertEquals("[]", text(call(new ArrayList<>())));
+        assertEquals("{}", text(call(new LinkedHashMap<>())));
+        assertEquals("", text(call("")));
+        assertEquals("null", text(call(null)));
+        assertEquals("{\"a\":1}", text(call(Map.of("a", 1))));
+    }
+}


### PR DESCRIPTION
Two small, independent follow-ups in the jobs / cross-runtime lane. Disjoint surfaces (Java runtime vs docs).

## `Closes #1282` — Java `tools/call` populates `structuredContent`

Java tool responses passed `null` for `structuredContent`, shipping object-shaped returns only inside `content[0].text` (an escaped JSON string), while the Python (FastMCP) runtime *also* emits `structuredContent`. Plain/spec-compliant MCP clients and generic envelope tooling therefore saw runtime-dependent shapes from Java.

`handleToolCall()` now **additively** populates `structuredContent`, mirroring FastMCP's rules incl. the #1250/#1251 empty-return contract, via a shared `buildStructuredContent()` helper:
- object-shaped (Map/POJO) → the object as a Map, **no** wrap marker;
- non-object (list/array/scalar/string/null) → `{"result": X}` + the `{"fastmcp":{"wrap_result":true}}` marker in `meta` (serialized on the wire as `_meta`), byte-identical to the Python provider.

**Strictly additive — `content[0].text` is unchanged.** All three runtimes' proxies recover **text-first** and only read `structuredContent` when the content array is *empty*; the Java provider always emits a non-empty text block, so mesh-internal Java↔{Py,TS,Java} round-trips (incl. `[]`/`{}`/`""`/`null`) stay byte-identical. `LlmProviderToolWrapper`'s structured path flows through the same `handleToolCall`, so it shares the helper rather than forking; error and Content-passthrough branches correctly stay `null` (Python doesn't structure those either).

> **TS parity is out of scope and not regressed.** The issue's premise that TypeScript also emits `structuredContent` is stale — TS *removed* it in #917 (FastMCP TS's strict zod schema rejects the field) and re-enablement is tracked in **#925**. This PR aligns Java with Python; TS follows when #925 unblocks upstream.

### Validation
- Starter module **671/671** (+11 new tests mirroring the Python #1250 assertions).
- Integration **`uc32_empty_return_values` 4/4** on a **rebuilt Java native** — `tc04_java_provider_py_consumer` recovers `[]`/`{}`/`""`/`null` byte-identically; the new `structuredContent` is present on the wire but doesn't perturb text-first recovery.
- **`uc37_service_view_java` 12/12** — cross-runtime Java envelope unaffected.

## `Closes #1279` — docs: parked vs compute-bound lease gaps

The lease docs said `recvEvent` polls and progress deltas renew the lease but never contrasted the two gap types a real handler hits — and the ambiguity drove a field adopter to a defensive 10× `max_duration` bump with an incorrect in-code rationale.

Adds one contrast paragraph to the lease-recovery section of all four job-doc surfaces (`jobs.md` + `jobs_java.md` + `jobs_typescript.md` man pages + the `docs/concepts/jobs.md` mirror), each in its own runtime's API idiom:
- **Parked gap** (blocked in `recvEvent`) → lease renews automatically; the poll *is* the renewal, no keepalive needed.
- **Compute-bound gap** (a long synchronous stretch between event gates, e.g. an LLM request) → nothing renews the lease; emit a periodic `update_progress` keepalive or size `max_duration` to cover the longest gap.

Explicitly names the blanket "multiplier to be safe" as the wrong fix.

Closes #1282
Closes #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)