### PR TITLE
chore(java): upgrade MCP Java SDK 1.1.3 → 2.0.0 (GA)

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshMcpServerConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshMcpServerConfiguration.java
@@ -66,11 +66,11 @@ public class MeshMcpServerConfiguration {
     private static final Map<String, Object> WRAP_RESULT_META =
         Map.of("fastmcp", Map.of("wrap_result", true));
 
-    // MCP SDK 1.1.0 uses Jackson 3 (tools.jackson)
+    // MCP SDK 2.0.0 uses Jackson 3 (tools.jackson)
     private final tools.jackson.databind.json.JsonMapper mcpJsonMapper;
 
     public MeshMcpServerConfiguration() {
-        // Create Jackson 3 JsonMapper for MCP SDK 1.1.0
+        // Create Jackson 3 JsonMapper for MCP SDK 2.0.0
         // Jackson 3 has built-in java.time support and writes dates as ISO-8601 by default
         this.mcpJsonMapper = tools.jackson.databind.json.JsonMapper.builder().build();
     }
@@ -119,6 +119,8 @@ public class MeshMcpServerConfiguration {
                 .tools(true)
                 .build())
             .immediateExecution(true)
+            // Preserve mesh's lenient cross-runtime coercion + soft-fail semantics; strictness stays opt-in. Adopting SDK-native input validation is tracked in #1303.
+            .validateToolInputs(false)
             .build();
 
         // Register all tools from wrapper registry (includes both @MeshTool and @MeshLlmProvider)

--- a/src/runtime/java/pom.xml
+++ b/src/runtime/java/pom.xml
@@ -57,7 +57,7 @@
         <!-- Dependency versions -->
         <spring-boot.version>4.0.5</spring-boot.version>
         <spring-ai.version>2.0.0-M4</spring-ai.version>
-        <mcp-sdk.version>1.1.3</mcp-sdk.version>
+        <mcp-sdk.version>2.0.0</mcp-sdk.version>
         <jnr-ffi.version>2.2.16</jnr-ffi.version>
         <!-- Jackson 3 (databind uses tools.jackson, annotations stays on com.fasterxml) -->
         <jackson3.version>3.0.1</jackson3.version>


### PR DESCRIPTION
Upgrades `io.modelcontextprotocol.sdk:mcp` **1.1.3 → 2.0.0** (GA — first major since 1.x, tracks the 2025‑11‑25 MCP spec). All SDK touch-points are confined to `mcp-mesh-spring-boot-starter`; this PR is deliberately isolated to the SDK-major variable (no schema-path modernization, no unrelated churn) so any wire movement is attributable to the SDK alone.

## The one behavioral point — input validation (owner-decided)

2.0 turns tool-input validation **ON by default** (strict JSON-Schema 2020‑12 type checks *before* the handler runs). We set **`validateToolInputs(false)`** to hold mesh's behavior exactly constant:
- lenient cross-runtime coercion + soft-fail semantics preserved (strictness stays opt-in, per mesh's design philosophy);
- validation does not preempt mesh's dependency-unavailable / superseded / settle-grace logic.

Adopting SDK-native validation deliberately is tracked in **#1303**.

## Contained by design — verified during scoping

- **No Maven-coordinate break** (`mcp:2.0.0` on Central).
- **Jackson unchanged** — mesh is already on Jackson 3; 2.0 keeps it.
- **Transport unchanged** — mesh's client is raw OkHttp and its server is already stateless Streamable-HTTP, so the SSE→Streamable-HTTP deprecation is a no-op.
- **`new TextContent(String)` still compiles** — no builder sweep needed.
- **Sealed-interface removal is a no-op** — mesh uses `instanceof`, no exhaustive `switch` over `Content`/`Result`/etc.
- The one new transitive (`jackson-dataformat-yaml:3.1.0` alongside core `3.0.1`) is **benign** — proven by the real-runtime matrix (no serialization anomalies), not just asserted.

## Validation (wire-sensitive bar for an SDK major)

- Starter module: **671/671**.
- Cross-runtime integration on a **rebuilt Java native** (43 non-cached build steps; 50 tests, all green):
  - `uc32_empty_return_values` **4/4** — empty-return round-trip (`[]`/`{}`/`""`/`null`), incl. `tc04_java_provider_py_consumer`.
  - `uc37_service_view_java` **12/12**.
  - `uc38_superseded_signal` **3/3** — typed reserved-envelope round-trip (`tc03` Java).
  - `uc23_meshjob_java` **31/31** — full MeshJob lifecycle, polyglot java↔py↔ts.
- Confirmed on the real native: `validateToolInputs(false)` effective (no rejection envelopes), no empty-return/`structuredContent` drift.

Closes #1304

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated support to the latest MCP SDK version.

* **Bug Fixes**
  * Made tool input handling more tolerant, reducing validation errors for incoming requests across runtimes.
  * Improved compatibility for tool calls with soft-fail behavior when inputs need coercion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->