### PR TITLE
fix(python): disable FastMCP DNS-rebinding host guard (k8s /mcp 421) + pin fastmcp/mcp

### DIFF
--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -69,8 +69,12 @@ dependencies = [
     "click>=8.1.0,<9.0.0",
     "rich>=13.0.0,<14.0.0",
     "typer>=0.9.1,<1.0.0",
-    "mcp>=1.26.0,<2.0.0",
-    "fastmcp>=3.0.0,<4.0.0",
+    # Pinned exact (#1312): an upstream FastMCP default-flip enabling
+    # DNS-rebinding Host validation drifted in on rebuild and broke every
+    # k8s Service-DNS /mcp call with 421. Loose ranges hid it. Follow-up:
+    # add a full transitive lockfile.
+    "mcp==1.28.1",
+    "fastmcp==3.4.3",
     "litellm>=1.80.5,!=1.82.7,!=1.82.8",
     "anthropic>=0.42",
     "openai>=1.60",

--- a/src/runtime/python/_mcp_mesh/engine/http_wrapper.py
+++ b/src/runtime/python/_mcp_mesh/engine/http_wrapper.py
@@ -15,6 +15,7 @@ from typing import Any, Optional
 import httpx
 from fastmcp import FastMCP
 
+from ..shared.fastmcp_transport import FASTMCP_TRANSPORT_SECURITY_KWARGS
 from ..shared.logging_config import configure_logging
 
 # Ensure logging is configured
@@ -162,7 +163,7 @@ class HttpMcpWrapper:
                 self._mcp_app = mcp_server.http_app(
                     stateless_http=True,
                     transport="streamable-http",
-                    host_origin_protection=False,
+                    **FASTMCP_TRANSPORT_SECURITY_KWARGS,
                 )
                 logger.debug(f"✅ Created FastMCP app: {type(self._mcp_app)}")
                 if hasattr(self._mcp_app, "lifespan"):
@@ -174,7 +175,9 @@ class HttpMcpWrapper:
                 try:
                     logger.debug("🔄 Trying FastMCP HTTP app without stateless_http")
                     # Keep the #1312 Host-guard override on the fallback path too.
-                    self._mcp_app = mcp_server.http_app(host_origin_protection=False)
+                    self._mcp_app = mcp_server.http_app(
+                        **FASTMCP_TRANSPORT_SECURITY_KWARGS
+                    )
                     if hasattr(self._mcp_app, "lifespan"):
                         self._lifespan = self._mcp_app.lifespan
                         logger.debug("✅ Got FastMCP lifespan (fallback)")

--- a/src/runtime/python/_mcp_mesh/engine/http_wrapper.py
+++ b/src/runtime/python/_mcp_mesh/engine/http_wrapper.py
@@ -154,8 +154,15 @@ class HttpMcpWrapper:
             try:
                 # Create FastMCP HTTP app with stateless transport
                 logger.debug("🔍 Creating FastMCP HTTP app with stateless transport")
+                # Disable FastMCP's DNS-rebinding Host/Origin guard (#1312):
+                # it defaults to localhost-only allowed_hosts and rejects
+                # server-to-server calls whose Host is the k8s Service DNS name
+                # with 421 Misdirected Request. Mesh is an internal service
+                # mesh, so the browser DNS-rebinding threat model does not apply.
                 self._mcp_app = mcp_server.http_app(
-                    stateless_http=True, transport="streamable-http"
+                    stateless_http=True,
+                    transport="streamable-http",
+                    host_origin_protection=False,
                 )
                 logger.debug(f"✅ Created FastMCP app: {type(self._mcp_app)}")
                 if hasattr(self._mcp_app, "lifespan"):
@@ -166,7 +173,8 @@ class HttpMcpWrapper:
                 # Try without stateless_http parameter
                 try:
                     logger.debug("🔄 Trying FastMCP HTTP app without stateless_http")
-                    self._mcp_app = mcp_server.http_app()
+                    # Keep the #1312 Host-guard override on the fallback path too.
+                    self._mcp_app = mcp_server.http_app(host_origin_protection=False)
                     if hasattr(self._mcp_app, "lifespan"):
                         self._lifespan = self._mcp_app.lifespan
                         logger.debug("✅ Got FastMCP lifespan (fallback)")

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
@@ -609,7 +609,10 @@ mcp_mesh_up{{agent="{agent_name}"}} 1
             if hasattr(server_instance, "http_app") and callable(
                 server_instance.http_app
             ):
-                fastmcp_app = server_instance.http_app()
+                # Disable FastMCP's DNS-rebinding Host/Origin guard (#1312):
+                # the localhost-only default rejects k8s Service-DNS Host
+                # headers with 421. Internal mesh traffic, guard not needed.
+                fastmcp_app = server_instance.http_app(host_origin_protection=False)
                 # Mount at /mcp path for MCP protocol access
                 mount_path = "/mcp"
                 app.mount(mount_path, fastmcp_app)

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
@@ -609,10 +609,16 @@ mcp_mesh_up{{agent="{agent_name}"}} 1
             if hasattr(server_instance, "http_app") and callable(
                 server_instance.http_app
             ):
+                from ...shared.fastmcp_transport import (
+                    FASTMCP_TRANSPORT_SECURITY_KWARGS,
+                )
+
                 # Disable FastMCP's DNS-rebinding Host/Origin guard (#1312):
                 # the localhost-only default rejects k8s Service-DNS Host
                 # headers with 421. Internal mesh traffic, guard not needed.
-                fastmcp_app = server_instance.http_app(host_origin_protection=False)
+                fastmcp_app = server_instance.http_app(
+                    **FASTMCP_TRANSPORT_SECURITY_KWARGS
+                )
                 # Mount at /mcp path for MCP protocol access
                 mount_path = "/mcp"
                 app.mount(mount_path, fastmcp_app)

--- a/src/runtime/python/_mcp_mesh/shared/fastmcp_transport.py
+++ b/src/runtime/python/_mcp_mesh/shared/fastmcp_transport.py
@@ -1,0 +1,11 @@
+"""Shared FastMCP transport-security override (single source of truth).
+
+Leaf module (no mesh imports) so every ``http_app()`` call site can spread the
+same kwargs without circular-import risk. See issue #1312.
+"""
+
+# host_origin_protection: mesh is an internal service mesh addressed by k8s
+# Service DNS; the FastMCP DNS-rebinding (browser) host guard 421s any
+# non-localhost Host. Disable it everywhere. Single source of truth so a new
+# http_app() call site can't silently drop it. See issue #1312.
+FASTMCP_TRANSPORT_SECURITY_KWARGS = {"host_origin_protection": False}

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -1702,8 +1702,14 @@ def agent(
                             fastmcp_server.http_app
                         ):
                             try:
+                                # Disable FastMCP's DNS-rebinding Host/Origin
+                                # guard (#1312): its localhost-only default
+                                # rejects k8s Service-DNS Host headers with 421.
+                                # Internal mesh traffic, so the guard is unwanted.
                                 fastmcp_http_app = fastmcp_server.http_app(
-                                    stateless_http=True, transport="streamable-http"
+                                    stateless_http=True,
+                                    transport="streamable-http",
+                                    host_origin_protection=False,
                                 )
                                 if hasattr(fastmcp_http_app, "lifespan"):
                                     fastmcp_lifespan = fastmcp_http_app.lifespan

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -1702,6 +1702,10 @@ def agent(
                             fastmcp_server.http_app
                         ):
                             try:
+                                from _mcp_mesh.shared.fastmcp_transport import (
+                                    FASTMCP_TRANSPORT_SECURITY_KWARGS,
+                                )
+
                                 # Disable FastMCP's DNS-rebinding Host/Origin
                                 # guard (#1312): its localhost-only default
                                 # rejects k8s Service-DNS Host headers with 421.
@@ -1709,7 +1713,7 @@ def agent(
                                 fastmcp_http_app = fastmcp_server.http_app(
                                     stateless_http=True,
                                     transport="streamable-http",
-                                    host_origin_protection=False,
+                                    **FASTMCP_TRANSPORT_SECURITY_KWARGS,
                                 )
                                 if hasattr(fastmcp_http_app, "lifespan"):
                                     fastmcp_lifespan = fastmcp_http_app.lifespan

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -67,8 +67,12 @@ dependencies = [
     "click>=8.1.0",
     "rich>=13.0.0",
     "typer>=0.9.0",
-    "mcp>=1.26.0,<2.0.0",
-    "fastmcp>=3.0.0,<4.0.0",
+    # Pinned exact (#1312): an upstream FastMCP default-flip enabling
+    # DNS-rebinding Host validation drifted in on rebuild and broke every
+    # k8s Service-DNS /mcp call with 421. Loose ranges hid it. Follow-up:
+    # add a full transitive lockfile.
+    "mcp==1.28.1",
+    "fastmcp==3.4.3",
     "litellm>=1.80.5,!=1.82.7,!=1.82.8",
     "anthropic>=0.77",
     "openai>=1.60",

--- a/src/runtime/python/tests/unit/test_1312_host_origin_protection.py
+++ b/src/runtime/python/tests/unit/test_1312_host_origin_protection.py
@@ -15,9 +15,15 @@ not apply — so it builds every served FastMCP app with
   while the same app with protection left on returns 421 (proving the fix
   matters). Skipped on FastMCP versions whose ``http_app`` predates the
   ``host_origin_protection`` kwarg.
-* structural: ``HttpMcpWrapper`` actually passes ``host_origin_protection=False``
-  to ``http_app`` — meaningful on any FastMCP version, so it still guards the
-  wiring even before the version pin takes effect.
+* structural: every mesh site that builds a served FastMCP app actually passes
+  ``host_origin_protection=False`` to ``http_app`` — meaningful on any FastMCP
+  version, so it still guards the wiring even before the version pin takes
+  effect. All THREE override sites are guarded here:
+  ``HttpMcpWrapper`` (engine), ``FastAPIServerSetupStep._mount_fastmcp_server``
+  (pipeline mount), and the ``@mesh.agent`` auto-run lifespan extraction in
+  ``mesh.decorators``. The assertions check the effective call kwarg
+  (``host_origin_protection=False``), not any shared-constant name, so they
+  guard behavior regardless of how the override is centralized internally.
 """
 
 import inspect
@@ -104,6 +110,67 @@ def test_1312_http_wrapper_passes_override():
     mock_server.http_app.return_value = MagicMock()
 
     HttpMcpWrapper(mock_server)
+
+    mock_server.http_app.assert_called_once()
+    assert mock_server.http_app.call_args.kwargs.get("host_origin_protection") is False
+
+
+def test_1312_mount_fastmcp_server_passes_override():
+    """Structural guard: FastAPIServerSetupStep._mount_fastmcp_server must call
+    http_app with host_origin_protection=False."""
+    from unittest.mock import MagicMock
+
+    from _mcp_mesh.pipeline.mcp_startup.fastapiserver_setup import (
+        FastAPIServerSetupStep,
+    )
+
+    step = FastAPIServerSetupStep()
+
+    mock_app = MagicMock()  # the FastAPI app that gets .mount(...)
+    mock_server = MagicMock()  # the FastMCP server instance
+    mock_server.http_app.return_value = MagicMock()
+
+    step._mount_fastmcp_server(mock_app, "test-server", mock_server)
+
+    mock_server.http_app.assert_called_once()
+    assert mock_server.http_app.call_args.kwargs.get("host_origin_protection") is False
+
+
+def test_1312_agent_autorun_lifespan_extraction_passes_override(monkeypatch):
+    """Structural guard: the @mesh.agent auto-run lifespan extraction in
+    mesh.decorators must call the FastMCP server's http_app with
+    host_origin_protection=False."""
+    import sys
+    import types
+    from unittest.mock import MagicMock, patch
+
+    import mesh.decorators as decorators
+
+    # The suite-wide conftest forces MCP_MESH_AUTO_RUN=false; the extraction
+    # path only runs under auto-run, so re-enable it for this test.
+    monkeypatch.setenv("MCP_MESH_AUTO_RUN", "true")
+
+    # The extraction path looks up ``sys.modules[target.__module__].app`` and
+    # calls ``app.http_app(...)``. Stage a fake module + FastMCP server.
+    fake_module_name = "_test_1312_fake_agent_module"
+    fake_module = types.ModuleType(fake_module_name)
+    mock_server = MagicMock()
+    mock_server.http_app.return_value = MagicMock()
+    fake_module.app = mock_server
+    sys.modules[fake_module_name] = fake_module
+
+    def target():
+        return None
+
+    target.__module__ = fake_module_name
+
+    try:
+        # Neutralize the actual server start so the decorator returns after the
+        # extraction we care about (uvicorn/TLS are out of scope for this test).
+        with patch.object(decorators, "_start_uvicorn_immediately"):
+            decorators.agent(name="test-1312-agent", auto_run=True)(target)
+    finally:
+        sys.modules.pop(fake_module_name, None)
 
     mock_server.http_app.assert_called_once()
     assert mock_server.http_app.call_args.kwargs.get("host_origin_protection") is False

--- a/src/runtime/python/tests/unit/test_1312_host_origin_protection.py
+++ b/src/runtime/python/tests/unit/test_1312_host_origin_protection.py
@@ -1,0 +1,109 @@
+"""
+Regression tests for issue #1312.
+
+FastMCP enables DNS-rebinding Host/Origin validation by default
+(``http_host_origin_protection = True``), whose allowed-hosts list is
+localhost-only. In Kubernetes every ``/mcp`` call arrives with a ``Host``
+header set to the Service DNS name (e.g. ``my-agent.default:8080``), which is
+not localhost, so the guard rejects it with ``421 Misdirected Request``.
+
+Mesh is an internal service mesh — the browser DNS-rebinding threat model does
+not apply — so it builds every served FastMCP app with
+``host_origin_protection=False``. These tests guard that override:
+
+* behavioral: a served app with the override accepts a non-localhost Host,
+  while the same app with protection left on returns 421 (proving the fix
+  matters). Skipped on FastMCP versions whose ``http_app`` predates the
+  ``host_origin_protection`` kwarg.
+* structural: ``HttpMcpWrapper`` actually passes ``host_origin_protection=False``
+  to ``http_app`` — meaningful on any FastMCP version, so it still guards the
+  wiring even before the version pin takes effect.
+"""
+
+import inspect
+
+import pytest
+
+FOREIGN_HOST = "some-service.namespace:8080"
+
+_HTTP_APP_ACCEPTS_OVERRIDE = "host_origin_protection" in inspect.signature(
+    __import__("fastmcp").FastMCP.http_app
+).parameters
+
+
+def _build_app(protection):
+    """Build a served mesh-style streamable-HTTP app."""
+    from fastmcp import FastMCP
+
+    server = FastMCP("test-1312")
+
+    @server.tool
+    def ping() -> str:
+        return "pong"
+
+    kwargs = {"stateless_http": True, "transport": "streamable-http"}
+    if protection is not None:
+        kwargs["host_origin_protection"] = protection
+    return server.http_app(**kwargs)
+
+
+def _post_initialize(app, host):
+    from starlette.testclient import TestClient
+
+    body = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "c", "version": "1"},
+        },
+    }
+    headers = {
+        "Host": host,
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    with TestClient(app) as client:
+        return client.post("/mcp/", json=body, headers=headers)
+
+
+@pytest.mark.skipif(
+    not _HTTP_APP_ACCEPTS_OVERRIDE,
+    reason="installed FastMCP predates host_origin_protection kwarg",
+)
+def test_1312_override_accepts_foreign_host():
+    """With the override, a non-localhost (k8s Service-DNS) Host is NOT 421."""
+    resp = _post_initialize(_build_app(protection=False), FOREIGN_HOST)
+    assert resp.status_code != 421, resp.text
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.skipif(
+    not _HTTP_APP_ACCEPTS_OVERRIDE,
+    reason="installed FastMCP predates host_origin_protection kwarg",
+)
+def test_1312_default_protection_rejects_foreign_host():
+    """Without the override the guard rejects the same Host with 421.
+
+    Demonstrates the regression the override fixes.
+    """
+    resp = _post_initialize(_build_app(protection=None), FOREIGN_HOST)
+    assert resp.status_code == 421, resp.text
+
+
+def test_1312_http_wrapper_passes_override():
+    """Structural guard (version-independent): HttpMcpWrapper must call
+    http_app with host_origin_protection=False."""
+    from unittest.mock import MagicMock
+
+    from _mcp_mesh.engine.http_wrapper import HttpMcpWrapper
+
+    mock_server = MagicMock()
+    mock_server.http_app.return_value = MagicMock()
+
+    HttpMcpWrapper(mock_server)
+
+    mock_server.http_app.assert_called_once()
+    assert mock_server.http_app.call_args.kwargs.get("host_origin_protection") is False

--- a/src/runtime/python/tests/unit/test_14_http_wrapper.py
+++ b/src/runtime/python/tests/unit/test_14_http_wrapper.py
@@ -42,9 +42,11 @@ class TestHttpMcpWrapperInitialization:
 
         wrapper = HttpMcpWrapper(mock_fastmcp_server)
 
-        # Verify stateless HTTP app was created
+        # Verify stateless HTTP app was created with the #1312 Host-guard override
         mock_fastmcp_server.http_app.assert_called_once_with(
-            stateless_http=True, transport="streamable-http"
+            stateless_http=True,
+            transport="streamable-http",
+            host_origin_protection=False,
         )
         assert wrapper._mcp_app == mock_fastmcp_app
         assert wrapper._lifespan == mock_lifespan
@@ -66,12 +68,14 @@ class TestHttpMcpWrapperInitialization:
 
         # Verify both calls were made
         assert mock_fastmcp_server.http_app.call_count == 2
-        # First call with stateless params
+        # First call with stateless params + #1312 Host-guard override
         mock_fastmcp_server.http_app.assert_any_call(
-            stateless_http=True, transport="streamable-http"
+            stateless_http=True,
+            transport="streamable-http",
+            host_origin_protection=False,
         )
-        # Second call without params (fallback)
-        mock_fastmcp_server.http_app.assert_any_call()
+        # Second call (fallback) still carries the #1312 override
+        mock_fastmcp_server.http_app.assert_any_call(host_origin_protection=False)
 
         assert wrapper._mcp_app == mock_fastmcp_app
         assert wrapper._lifespan == mock_lifespan

--- a/tests/integration/suites/uc39_host_origin_protection/artifacts/host-consumer
+++ b/tests/integration/suites/uc39_host_origin_protection/artifacts/host-consumer
@@ -1,0 +1,1 @@
+../fixtures/host-consumer

--- a/tests/integration/suites/uc39_host_origin_protection/artifacts/host-provider
+++ b/tests/integration/suites/uc39_host_origin_protection/artifacts/host-provider
@@ -1,0 +1,1 @@
+../fixtures/host-provider

--- a/tests/integration/suites/uc39_host_origin_protection/fixtures/host-consumer/main.py
+++ b/tests/integration/suites/uc39_host_origin_protection/fixtures/host-consumer/main.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""uc39 host-consumer — calls host_probe across the mesh (issue #1312).
+
+Depends on the ``host_probe`` capability and, when invoked, makes a real
+cross-agent call to the provider's ``/mcp`` endpoint. Because the provider is
+advertised on a NON-loopback host (see host-provider + test.yaml), this call
+carries ``Host: <non-loopback>`` — the exact condition FastMCP's DNS-rebinding
+guard rejects with 421 on a pre-#1312 build.
+
+On this branch (fix present: ``host_origin_protection=False``) the downstream
+call succeeds and this tool returns the provider's result. A 421 would make
+``await probe()`` raise, so a successful, well-formed return is the regression
+guard the test asserts on.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("HostProbe Consumer")
+
+
+@app.tool()
+@mesh.tool(
+    capability="host_probe_consume",
+    description="Calls host_probe across the mesh and returns the provider's result verbatim",
+    dependencies=["host_probe"],
+)
+async def consume_host_probe(probe: mesh.McpMeshTool = None) -> dict:
+    if probe is None:
+        # Dependency never resolved — distinct from a 421 so failures are legible.
+        return {"error": "host_probe proxy is None (dependency unresolved)"}
+    # This is the load-bearing hop: a cross-agent /mcp call to the provider's
+    # non-loopback advertised host. Pre-#1312 this 421s and raises.
+    result = await probe()
+    return {"provider_result": result}
+
+
+@mesh.agent(
+    name="host-consumer",
+    version="1.0.0",
+    description="uc39 consumer that calls host_probe on a non-loopback provider",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9202")),
+    enable_http=True,
+    auto_run=True,
+)
+class HostConsumer:
+    pass

--- a/tests/integration/suites/uc39_host_origin_protection/fixtures/host-consumer/requirements.txt
+++ b/tests/integration/suites/uc39_host_origin_protection/fixtures/host-consumer/requirements.txt
@@ -1,0 +1,1 @@
+# uc39 host-consumer deps. mesh + fastmcp come from the runtime image.

--- a/tests/integration/suites/uc39_host_origin_protection/fixtures/host-provider/main.py
+++ b/tests/integration/suites/uc39_host_origin_protection/fixtures/host-provider/main.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""uc39 host-provider — advertises the ``host_probe`` capability (issue #1312).
+
+Deliberately trivial: a single tool returning a constant. The point of this UC
+is NOT what the tool computes but WHERE the provider is advertised. The test
+starts this agent with ``MCP_MESH_HTTP_HOST`` set to a NON-loopback but
+pod-reachable host, so a consumer's mesh call carries ``Host: <non-loopback>``
+against this agent's ``/mcp`` endpoint.
+
+FastMCP's DNS-rebinding guard (``host_origin_protection``) would 421 any
+non-localhost Host header. #1312 fixes that by passing
+``host_origin_protection=False`` when mesh builds the http_app. This provider
+exists so the consumer's cross-agent call actually exercises that path — every
+other suite co-locates agents on loopback, so ``Host: localhost`` is always
+allowed and the regression slips through.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("HostProbe Provider")
+
+
+@app.tool()
+@mesh.tool(
+    capability="host_probe",
+    description="Trivial probe that returns a constant, used to exercise the /mcp Host guard",
+)
+def host_probe() -> dict:
+    return {"ok": True}
+
+
+@mesh.agent(
+    name="host-provider",
+    version="1.0.0",
+    description="uc39 provider of host_probe (advertised on a non-loopback host)",
+    http_port=int(os.environ.get("MCP_MESH_HTTP_PORT", "9201")),
+    enable_http=True,
+    auto_run=True,
+)
+class HostProvider:
+    pass

--- a/tests/integration/suites/uc39_host_origin_protection/fixtures/host-provider/requirements.txt
+++ b/tests/integration/suites/uc39_host_origin_protection/fixtures/host-provider/requirements.txt
@@ -1,0 +1,1 @@
+# uc39 host-provider deps. mesh + fastmcp come from the runtime image.

--- a/tests/integration/suites/uc39_host_origin_protection/routines.yaml
+++ b/tests/integration/suites/uc39_host_origin_protection/routines.yaml
@@ -1,0 +1,18 @@
+# UC-level routines for uc39_host_origin_protection (issue #1312).
+#
+# This UC deliberately advertises a provider on a NON-loopback host so a
+# consumer's cross-agent /mcp call carries a non-localhost Host header —
+# reproducing the real-k8s (Service-DNS) condition that FastMCP's
+# DNS-rebinding guard would 421 pre-#1312. All other suites co-locate agents
+# on loopback (Host: localhost), which the guard always allows, so #1312
+# slipped every existing suite.
+
+routines:
+  # Stop everything started by this test (agents + registry).
+  stop_all:
+    description: "Stop all mesh processes started by this test"
+    steps:
+      - handler: shell
+        workdir: /workspace
+        command: meshctl stop 2>/dev/null || true
+        ignore_errors: true

--- a/tests/integration/suites/uc39_host_origin_protection/tc01_non_loopback_host/test.yaml
+++ b/tests/integration/suites/uc39_host_origin_protection/tc01_non_loopback_host/test.yaml
@@ -1,0 +1,155 @@
+# tc01_non_loopback_host — a consumer's cross-agent /mcp call must succeed when
+# the provider is advertised on a NON-loopback host (issue #1312).
+#
+# WHY THIS UC EXISTS
+# tsuite k8s mode co-locates a test's agents as OS processes in ONE pod and they
+# address each other over loopback: with no MCP_MESH_HTTP_HOST set, the
+# advertised http_host resolves to localhost, so every /mcp call carries
+# `Host: localhost`, which FastMCP's DNS-rebinding guard (host_origin_protection)
+# ALWAYS allows. That is exactly why #1312 — which 421s any NON-localhost Host —
+# slipped every existing suite.
+#
+# This TC deliberately starts host-provider with MCP_MESH_HTTP_HOST set to a
+# NON-loopback but pod-reachable host (the pod's own primary IP from
+# `hostname -i`, with an /etc/hosts alias fallback). The provider still BINDS
+# 0.0.0.0 (binding host is independent of the advertised host), so the address
+# is reachable; but the ADVERTISED endpoint is non-loopback. When host-consumer
+# resolves host_probe and calls it, its httpx request to the provider's /mcp
+# endpoint carries `Host: <non-loopback>` — the precise real-k8s (Service-DNS)
+# condition.
+#
+# REGRESSION GUARD
+#   * On THIS branch (fix present: host_app built with host_origin_protection=
+#     False) the downstream /mcp call succeeds and consume_host_probe returns
+#     {"provider_result": {"ok": true}} — asserted below.
+#   * On a pre-#1312 build the guard 421s that call, `await probe()` raises, and
+#     the tool never returns provider_result — the success assertion fails.
+#
+# MEANINGFULNESS GUARD
+# A dedicated step extracts the provider's ADVERTISED endpoint from
+# `meshctl list --json` and asserts its host is NOT localhost / 127.0.0.1. If
+# the host injection silently fell back to loopback, THIS assertion fails first,
+# so the test can never pass by accidentally exercising the trivial localhost
+# path.
+
+name: "Host-origin protection: non-loopback advertised host cross-agent call (Python)"
+description: "Provider advertised on a non-loopback pod host; consumer's /mcp call (Host: non-loopback) must succeed — guards #1312 FastMCP DNS-rebinding 421"
+tags:
+  - integration
+  - python
+  - registry
+  - host-origin
+  - issue-1312
+timeout: 300
+
+pre_run:
+  - routine: global.setup_for_python_agent
+
+test:
+  - name: "Copy artifacts"
+    handler: shell
+    workdir: /workspace
+    command: |
+      cp -rL /uc-artifacts/host-provider /workspace/
+      cp -rL /uc-artifacts/host-consumer /workspace/
+
+  - name: "Install host-provider deps"
+    handler: pip-install
+    path: /workspace/host-provider
+
+  - name: "Install host-consumer deps"
+    handler: pip-install
+    path: /workspace/host-consumer
+
+  # Resolve a NON-loopback but pod-reachable host and start the provider
+  # advertising it. The env value is computed IN-SHELL so there is no
+  # cross-step interpolation of the host string. Primary: the pod's own
+  # primary IP (`hostname -i`). Fallback (empty / loopback IP): an /etc/hosts
+  # alias that maps a non-localhost name onto 127.0.0.1 — still a non-localhost
+  # Host header for the guard, still reachable because the agent binds 0.0.0.0.
+  - name: "Start host-provider on a non-loopback advertised host (port 9201)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      HOST_IP=$(hostname -i 2>/dev/null | awk '{print $1}')
+      if [ -z "$HOST_IP" ] || echo "$HOST_IP" | grep -Eq '^(127\.|::1$|localhost$)'; then
+        echo "hostname -i unusable ('$HOST_IP'); using /etc/hosts alias fallback"
+        echo "127.0.0.1 mesh-nonloopback.test" >> /etc/hosts
+        HOST_IP="mesh-nonloopback.test"
+      fi
+      echo "ADVERTISED_HOST=$HOST_IP"
+      meshctl start host-provider/main.py \
+        --env MCP_MESH_HTTP_PORT=9201 \
+        --env MCP_MESH_HTTP_HOST=$HOST_IP \
+        -d
+    capture: provider_start
+
+  - name: "Start host-consumer (port 9202)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl start host-consumer/main.py \
+        --env MCP_MESH_HTTP_PORT=9202 \
+        --env MCP_MESH_SETTLE_TIMEOUT=60 \
+        -d
+    capture: consumer_start
+
+  # Liveness only (issue #1193): both agents must APPEAR in meshctl list.
+  # Dependency resolution is covered by the consumer's settle window at call
+  # time — do NOT gate on "1/1" here.
+  - routine: global.wait_for_agents_registered
+    params:
+      agents: "host-provider host-consumer"
+
+  # MEANINGFULNESS GUARD: prove the provider actually advertised a non-loopback
+  # endpoint (not a silent localhost fallback). This is the host string the
+  # consumer's /mcp call will carry as its Host header.
+  - name: "Capture provider advertised endpoint"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl list --json 2>/dev/null | python -c "import sys, json; d = json.load(sys.stdin); e = [a.get('endpoint','') for a in d.get('agents', []) if a.get('name') == 'host-provider']; print('PROVIDER_ENDPOINT=' + (e[0] if e else 'MISSING'))"
+    capture: provider_endpoint
+
+  # Invoke the consumer's tool. Its first mesh call blocks on the settle window
+  # until host_probe resolves, then makes the load-bearing cross-agent /mcp call
+  # to the non-loopback provider. `|| true` so a downstream failure surfaces as
+  # a clear assertion miss (below) rather than an opaque step failure.
+  - name: "Call consumer tool (cross-agent /mcp to non-loopback host)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call consume_host_probe '{}' 2>&1 || true
+    capture: call_result
+    timeout: 150
+
+assertions:
+  # The provider start step resolved a concrete advertised host.
+  - expr: "${captured.provider_start} contains 'ADVERTISED_HOST='"
+    message: "provider start step must resolve and echo the advertised host it was given"
+
+  # MEANINGFULNESS: the advertised endpoint must be a real non-loopback host.
+  # If either of these fails, the test silently fell back to localhost and would
+  # prove nothing — so these gate the whole scenario.
+  - expr: "${captured.provider_endpoint} contains 'PROVIDER_ENDPOINT=http://'"
+    message: "host-provider must be registered with an http endpoint"
+  - expr: "${captured.provider_endpoint} not contains 'localhost'"
+    message: "MEANINGFULNESS: advertised host must NOT be localhost — else the /mcp Host guard is never exercised"
+  - expr: "${captured.provider_endpoint} not contains '127.0.0.1'"
+    message: "MEANINGFULNESS: advertised host must NOT be 127.0.0.1 — else the /mcp Host guard is never exercised"
+
+  # REGRESSION GUARD: the cross-agent call over a non-loopback Host succeeded and
+  # returned the provider's result verbatim. A pre-#1312 421 makes await probe()
+  # raise, so provider_result is never produced.
+  - expr: "${captured.call_result} contains 'provider_result'"
+    message: "consumer's cross-agent /mcp call must succeed and return the provider result — a #1312 regression 421s this call"
+  - expr: "${captured.call_result} icontains 'ok'"
+    message: "provider result {\"ok\": true} must round-trip back through the consumer"
+  - expr: "${captured.call_result} not contains '421'"
+    message: "no 421 — FastMCP's DNS-rebinding guard must accept the non-loopback Host (host_origin_protection=False, #1312)"
+  - expr: "${captured.call_result} not contains 'proxy is None'"
+    message: "host_probe dependency must have resolved before the call"
+
+post_run:
+  - routine: stop_all
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Problem

Python mesh providers reachable by a **non-localhost `Host`** (a k8s Service DNS) reject every `/mcp` call with **`421 Misdirected Request`** — breaking all cross-pod tool and LLM-provider calls to Python providers in Kubernetes.

```
Host: <service-dns>:8080  → 421
Host: localhost           → 200
Host: 127.0.0.1           → 200
```

## Root cause

Recent `mcp`/`fastmcp` default **`enable_dns_rebinding_protection=True`** with an empty `allowed_hosts` (localhost only). Mesh built the streamable-HTTP app (`http_wrapper.py`, `decorators.py`, `fastapiserver_setup.py`) **without configuring transport security**, inheriting the localhost-only default → 421 for any Service-DNS `Host`.

**Not an intentional bump** — the Python pins were unchanged (`fastmcp>=3.0.0,<4`, `mcp>=1.26.0,<2`). It drifted in via **loose unpinned ranges + no lockfile**: a rebuild resolved a newer fastmcp/mcp where the security default had flipped. A rebuild of an older release exhibits the same 421.

## Fix

- **`host_origin_protection=False`** at all **four** `FastMCP.http_app(...)` call sites. Verified in fastmcp 3.4.3: `False` removes the `HostOriginGuardMiddleware` entirely. Mesh is an internal service mesh addressed by Service DNS — the DNS-rebinding (browser) threat model doesn't apply to server-to-server calls, so disabling the localhost-only check is correct.
- **Pin `fastmcp==3.4.3` / `mcp==1.28.1`** in both pyproject files, so an upstream security-default flip can't silently land on a rebuild. (A full transitive lockfile is a noted follow-up.)
- **Regression test** (`tests/unit/test_1312_host_origin_protection.py`): a served app accepts a non-localhost `Host` (200, not 421); the negative proves the default guard 421s a foreign Host; plus a version-independent structural check that the override is wired.

## Validation

- In-process (fastmcp 3.4.3): default → 421, `host_origin_protection=False` → 200, `True` → 421.
- **src-tests 12/12** — rebuilt image ships `fastmcp 3.4.3` / `mcp 1.28.1`.
- **Decisive:** on the rebuilt runtime a Python agent returns **200** for `Host: some-provider.ns:8080` (was 421); localhost control 200.
- `uc03_tool_calling` **10/10** — normal mesh-internal Python-provider calls unaffected with the guard disabled.

## Scope

Affects Python providers only (Java uses a different transport). Fixes the k8s regression that made v3.0.0's "no breaking changes" false for Kubernetes Python deployments — release-note correction to follow in the 3.0.1 bundle.

Closes #1312

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for hosted MCP endpoints so requests from valid non-local addresses are less likely to be rejected.
  * Strengthened app startup behavior to better support deployment and forwarding scenarios.

* **Tests**
  * Added regression coverage for the request-handling change and updated existing checks to match the new behavior.

* **Chores**
  * Locked key runtime package versions to keep installs more consistent across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->