### PR TITLE
fix(core,sdk): independent-clock dependency reconcile + idempotent apply + agent_id diff (never-restart-consumer)

### DIFF
--- a/src/runtime/core/src/runtime.rs
+++ b/src/runtime/core/src/runtime.rs
@@ -213,6 +213,20 @@ impl AgentRuntime {
     pub async fn run(mut self) {
         info!("Starting agent runtime for '{}'", self.spec.name);
 
+        // Independent wall-clock cadence for the dependency reconcile (issue
+        // #1314). Full heartbeats only fire on registry TopologyChanged /
+        // re-register / forced — never on a clock — so a downstream apply-drop
+        // under a subsequently stable topology would otherwise never be
+        // re-driven. This timer re-emits the believed-delivered edge set every
+        // ~reconcile_interval regardless of heartbeat activity. `tick()` is
+        // cancellation-safe: the Interval owns the deadline, so dropping the
+        // future when another `select!` arm wins does NOT lose the schedule.
+        // The first tick resolves immediately; `last_dep_reconcile` (shared
+        // with the change-driven path) throttles it, and topology is empty at
+        // startup so an early tick is a no-op.
+        let mut reconcile_timer = tokio::time::interval(self.reconcile_interval);
+        reconcile_timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
         loop {
             // Check for shutdown signal (non-blocking)
             if self.shutdown_rx.try_recv().is_ok() {
@@ -259,6 +273,15 @@ impl AgentRuntime {
                             if let Some(cmd) = cmd {
                                 self.handle_command(cmd);
                             }
+                        }
+                        // Independent wall-clock reconcile tick (issue #1314).
+                        // Empty `just_emitted`: nothing was change-emitted on
+                        // this tick, so the whole believed-delivered set is
+                        // eligible. The interval's throttle prevents an
+                        // over-emit when a change-driven reconcile fired just
+                        // before this tick.
+                        _ = reconcile_timer.tick() => {
+                            self.maybe_reconcile(&HashSet::new()).await;
                         }
                     }
                 }
@@ -598,6 +621,12 @@ impl AgentRuntime {
                 Some(old_value) => (
                     old_value.endpoint != value.endpoint
                         || old_value.function_name != value.function_name
+                        // Issue #1315: an in-place provider restart keeps the
+                        // same endpoint but gets a fresh agent_id (UUID). The
+                        // diff gate must treat that as a change so a fresh
+                        // `dependency_changed` re-binds the consumer proxy to
+                        // the new instance. Mirrors `process_llm_providers_changes`.
+                        || old_value.agent_id != value.agent_id
                         || old_value.kwargs != value.kwargs,
                     false,
                 ),
@@ -710,48 +739,72 @@ impl AgentRuntime {
             self.topology.dependencies.insert(key, value);
         }
 
-        // Reconcile pass (issue #1256): the edge-diff above records an edge as
-        // delivered when `send()` succeeds — i.e. on enqueue, not on apply. If
-        // a dependency event is ever dropped downstream of the channel, the
-        // diff gate would suppress it forever and the consumer's proxy stays
-        // unbound. To self-heal, periodically re-emit the FULL set of
-        // currently resolved dependencies (idempotent on the SDK side).
-        //
-        // Throttled by `reconcile_interval` so bursts of full heartbeats
-        // (topology churn) don't produce a re-emit storm. Only re-emits edges
-        // that are already recorded in `topology` (i.e. believed-delivered);
-        // brand-new edges are left to the diff gate's own next-heartbeat retry
-        // so a genuinely-failed `send` isn't masked. Skips edges just emitted
-        // above to avoid a double-emit within the same heartbeat.
+        // Reconcile pass (issue #1256): re-emit the believed-delivered set so a
+        // silently-dropped event self-heals. Runs here on the change-driven
+        // path with this cycle's real `just_emitted` set (to avoid a
+        // double-emit within the same heartbeat) and is ALSO driven from the
+        // run loop on an independent wall clock (issue #1314).
+        self.maybe_reconcile(&just_emitted).await;
+    }
+
+    /// Re-emit `dependency_available` for the believed-delivered dependency set
+    /// so a silently-dropped edge event self-heals (issues #1256 / #1314).
+    ///
+    /// The edge-diff in [`Self::process_dependency_changes`] records an edge as
+    /// delivered when `send()` succeeds — i.e. on enqueue, not on apply. If a
+    /// dependency event is ever dropped downstream of the channel, the diff
+    /// gate would suppress it forever and the consumer's proxy stays unbound.
+    /// To self-heal, this re-emits the FULL set of currently-resolved
+    /// dependencies (idempotent on the SDK side).
+    ///
+    /// Throttled by `reconcile_interval` (shared `last_dep_reconcile` stamp) so
+    /// the change-driven path and the run loop's wall-clock timer can't both
+    /// fire within one interval, and so bursts of full heartbeats (topology
+    /// churn) don't produce a re-emit storm. Edges in `just_emitted` are
+    /// skipped so the caller's own same-cycle emissions aren't doubled; pass an
+    /// empty set from the timer path (nothing was emitted this tick).
+    ///
+    /// Issue #1314: full heartbeats only fire on registry `TopologyChanged` /
+    /// re-register / forced — never on a wall clock. So a downstream apply-drop
+    /// under a subsequently stable topology would never be re-driven. Driving
+    /// this from the run loop's own ~10s clock closes that gap.
+    async fn maybe_reconcile(&mut self, just_emitted: &HashSet<DepKey>) {
         let reconcile_due = self
             .last_dep_reconcile
             .map(|t| t.elapsed() >= self.reconcile_interval)
             .unwrap_or(true);
-        if reconcile_due {
-            self.last_dep_reconcile = Some(Instant::now());
-            for (key, value) in &new_deps {
-                if just_emitted.contains(key) {
-                    continue;
-                }
-                if !self.topology.dependencies.contains_key(key) {
-                    continue;
-                }
-                let event = MeshEvent::dependency_available(
-                    value.capability.clone(),
-                    value.endpoint.clone(),
-                    value.function_name.clone(),
-                    value.agent_id.clone(),
-                    key.requesting_function.clone(),
-                    key.dep_index,
-                    value.kwargs.clone(),
+        if !reconcile_due {
+            return;
+        }
+        self.last_dep_reconcile = Some(Instant::now());
+
+        // Snapshot the believed-delivered edges (those recorded in topology and
+        // not just emitted) so we don't hold a borrow of `self.topology` across
+        // the `.await` on `event_tx.send`.
+        let to_reemit: Vec<(DepKey, DepValue)> = self
+            .topology
+            .dependencies
+            .iter()
+            .filter(|(key, _)| !just_emitted.contains(*key))
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+
+        for (key, value) in to_reemit {
+            let event = MeshEvent::dependency_available(
+                value.capability.clone(),
+                value.endpoint.clone(),
+                value.function_name.clone(),
+                value.agent_id.clone(),
+                key.requesting_function.clone(),
+                key.dep_index,
+                value.kwargs.clone(),
+            );
+            if let Err(e) = self.event_tx.send(event).await {
+                warn!(
+                    "Reconcile: failed to re-emit dependency '{}' at {}:{}: {}; \
+                     will retry on next reconcile",
+                    value.capability, key.requesting_function, key.dep_index, e
                 );
-                if let Err(e) = self.event_tx.send(event).await {
-                    warn!(
-                        "Reconcile: failed to re-emit dependency '{}' at {}:{}: {}; \
-                         will retry on next reconcile",
-                        value.capability, key.requesting_function, key.dep_index, e
-                    );
-                }
             }
         }
     }
@@ -1374,6 +1427,128 @@ mod tests {
             drain_available(&mut event_rx),
             1,
             "a changed edge emits exactly once even when reconcile is due"
+        );
+    }
+
+    // ---- Issue #1315: agent_id participates in the dependency diff gate ----
+
+    fn resolved_with_agent(
+        agent_id: &str,
+    ) -> HashMap<String, Vec<crate::registry::ResolvedDependency>> {
+        let mut m = HashMap::new();
+        m.insert(
+            "consumer_fn".to_string(),
+            vec![crate::registry::ResolvedDependency {
+                agent_id: agent_id.to_string(),
+                endpoint: "http://provider:9000".to_string(),
+                function_name: "provider_fn".to_string(),
+                capability: "weather".to_string(),
+                status: "available".to_string(),
+                ttl: 0,
+                kwargs: None,
+            }],
+        );
+        m
+    }
+
+    /// Issue #1315: an in-place provider restart keeps the same endpoint /
+    /// function_name / kwargs but gets a fresh agent_id (UUID). Two resolutions
+    /// for the same DepKey differing ONLY in agent_id must trip the diff gate
+    /// and emit exactly one `dependency_changed` (mirrors the LLM-provider path).
+    #[tokio::test]
+    async fn test_1315_agent_id_diff() {
+        use crate::events::EventType;
+
+        let (event_tx, mut event_rx) = mpsc::channel(100);
+        let mut runtime = new_reconcile_runtime(event_tx).await;
+
+        // First resolution establishes the edge (DependencyAvailable once).
+        runtime
+            .process_dependency_changes(&resolved_with_agent("agent-uuid-1"))
+            .await;
+        assert_eq!(drain_available(&mut event_rx), 1, "new edge emits once");
+
+        // Same endpoint/function/kwargs, NEW agent_id. The reconcile is still
+        // throttled (last_dep_reconcile was stamped microseconds ago), so the
+        // only event this cycle must be the diff gate's dependency_changed.
+        runtime
+            .process_dependency_changes(&resolved_with_agent("agent-uuid-2"))
+            .await;
+
+        let mut changed = 0;
+        let mut available = 0;
+        while let Ok(ev) = event_rx.try_recv() {
+            match ev.event_type {
+                EventType::DependencyChanged => changed += 1,
+                EventType::DependencyAvailable => available += 1,
+                _ => {}
+            }
+        }
+        assert_eq!(
+            changed, 1,
+            "an agent_id-only change (in-place restart) must emit dependency_changed"
+        );
+        assert_eq!(available, 0, "no spurious dependency_available on a restart");
+    }
+
+    // ---- Issue #1314: reconcile driven by an independent wall clock ----
+
+    /// Issue #1314: full heartbeats never fire on a wall clock, so a downstream
+    /// apply-drop under a subsequently stable topology would never be re-driven.
+    /// Driving `maybe_reconcile` directly (as the run loop's timer arm does,
+    /// with an EMPTY just_emitted set) after the interval elapses must re-emit
+    /// the believed-delivered edge — no heartbeat involved.
+    #[tokio::test]
+    async fn test_1314_reconcile_wall_clock() {
+        let (event_tx, mut event_rx) = mpsc::channel(100);
+        let mut runtime = new_reconcile_runtime(event_tx).await;
+
+        // Establish a believed-delivered edge via one change cycle.
+        runtime
+            .process_dependency_changes(&resolved_single("weather", "http://provider:9000"))
+            .await;
+        assert_eq!(drain_available(&mut event_rx), 1);
+
+        // No full heartbeat. Advance past the interval and drive the timer path
+        // directly with an empty just_emitted set.
+        runtime.last_dep_reconcile =
+            Some(Instant::now() - runtime.reconcile_interval - Duration::from_secs(1));
+        runtime.maybe_reconcile(&HashSet::new()).await;
+
+        assert_eq!(
+            drain_available(&mut event_rx),
+            1,
+            "wall-clock reconcile re-emits the believed-delivered edge with no heartbeat"
+        );
+    }
+
+    /// Issue #1314: on a change cycle, an edge that was just change-emitted must
+    /// NOT be re-emitted by the same-cycle reconcile — the shared throttle and
+    /// the `just_emitted` set together keep it to exactly one event.
+    #[tokio::test]
+    async fn test_1314_no_double_emit() {
+        let (event_tx, mut event_rx) = mpsc::channel(100);
+        let mut runtime = new_reconcile_runtime(event_tx).await;
+
+        // New edge established.
+        runtime
+            .process_dependency_changes(&resolved_single("weather", "http://provider:9000"))
+            .await;
+        assert_eq!(drain_available(&mut event_rx), 1);
+
+        // Force reconcile due, then change the endpoint on the SAME cycle.
+        runtime.last_dep_reconcile =
+            Some(Instant::now() - runtime.reconcile_interval - Duration::from_secs(1));
+        runtime
+            .process_dependency_changes(&resolved_single("weather", "http://provider:9999"))
+            .await;
+
+        // The changed edge is in just_emitted, so the same-cycle reconcile skips
+        // it: exactly one event total.
+        assert_eq!(
+            drain_available(&mut event_rx),
+            1,
+            "a just-emitted edge is not double-emitted by the same-cycle reconcile"
         );
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshToolProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpMeshToolProxy.java
@@ -60,8 +60,33 @@ public class McpMeshToolProxy<T> implements McpMeshTool<T> {
         this.returnType = returnType;
     }
 
-    void updateEndpoint(String endpoint, String functionName) {
-        endpointRef.set(new EndpointInfo(endpoint, functionName, true));
+    /**
+     * Repoint this proxy at {@code endpoint}:{@code functionName}, marking it
+     * available.
+     *
+     * <p>Idempotency guard (#1314): the Rust core self-heals dropped applies by
+     * re-emitting {@code dependency_available} for every believed-delivered edge
+     * on an independent ~10s wall-clock tick. Those re-emits carry the SAME
+     * resolution, so short-circuit when the incoming {@link EndpointInfo} equals
+     * the current one — no atomic repoint, no downstream churn on this shared
+     * per-capability handle (the {@code @MeshRoute} funnel and the injector both
+     * drive this method). {@code EndpointInfo} is a record, so its {@code equals}
+     * is value-based over {@code (endpoint, functionName, available)}; that's the
+     * full identity available at this layer (agentId is not threaded to the proxy
+     * — the endpoint already uniquely identifies the providing agent here, and
+     * agentId-level de-duplication lives in
+     * {@link MeshToolWrapperRegistry#updateDependency}).
+     *
+     * @return {@code true} if the endpoint actually changed, {@code false} on a
+     *         no-op idempotent re-apply
+     */
+    boolean updateEndpoint(String endpoint, String functionName) {
+        EndpointInfo next = new EndpointInfo(endpoint, functionName, true);
+        if (next.equals(endpointRef.get())) {
+            return false;
+        }
+        endpointRef.set(next);
+        return true;
     }
 
     void markUnavailable() {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
@@ -197,7 +197,8 @@ public class MeshEventProcessor implements SmartLifecycle {
                 wrapperRegistry.updateDependency(
                     compositeKey,
                     event.getEndpoint(),
-                    event.getFunctionName()
+                    event.getFunctionName(),
+                    event.getAgentId()
                 );
             } else {
                 wrapperRegistry.markDependencyUnavailable(compositeKey);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapperRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapperRegistry.java
@@ -54,6 +54,27 @@ public class MeshToolWrapperRegistry {
 
     private final McpMeshToolProxyFactory proxyFactory;
 
+    // compositeKey (funcId:dep_N) → last-applied resolution signature.
+    // Idempotency guard (#1314): the Rust core re-emits dependency_available
+    // for every believed-delivered edge on an independent ~10s tick to
+    // self-heal dropped applies. Those re-emits carry an identical resolution;
+    // skipping them here avoids re-resolving the return type, re-fetching the
+    // proxy, and rewriting the wrapper's injected slot (which re-counts the
+    // settle latch) every 10s for a no-op.
+    private final Map<String, DepSignature> lastAppliedByKey = new ConcurrentHashMap<>();
+
+    /**
+     * Per-slot last-applied resolution identity.
+     *
+     * <p>Includes {@code agentId} so the guard composes with #1315: an
+     * agent_id-only change is a genuine update (different signature → applies),
+     * while an unchanged reconcile re-emit carries the same agentId → skip.
+     * {@code kwargs} is not part of the signature because it is not threaded to
+     * this layer on {@link MeshEvent} today; if it becomes available it should
+     * be added here. Record → value-based equals over all components.
+     */
+    private record DepSignature(String endpoint, String functionName, String agentId) {}
+
     public MeshToolWrapperRegistry(McpMeshToolProxyFactory proxyFactory) {
         this.proxyFactory = proxyFactory;
     }
@@ -224,6 +245,28 @@ public class MeshToolWrapperRegistry {
      * @param functionName The function name at the endpoint
      */
     public void updateDependency(String compositeKey, String endpoint, String functionName) {
+        updateDependency(compositeKey, endpoint, functionName, null);
+    }
+
+    /**
+     * Update a McpMeshTool dependency using composite key.
+     *
+     * <p>Idempotency guard (#1314): the Rust core re-emits
+     * {@code dependency_available} for every believed-delivered edge on an
+     * independent ~10s tick to self-heal dropped applies. When the incoming
+     * resolution equals what is already wired for this slot
+     * {@code (endpoint, functionName, agentId)} the apply is a no-op — skip it
+     * so the proxy is not re-fetched and the wrapper slot is not rewritten. A
+     * genuine change (different endpoint/function/agentId) still applies exactly
+     * as before.
+     *
+     * @param compositeKey The composite key (funcId:dep_N)
+     * @param endpoint     The resolved endpoint URL
+     * @param functionName The function name at the endpoint
+     * @param agentId      The providing agent id (part of the idempotency
+     *                     signature; may be {@code null})
+     */
+    public void updateDependency(String compositeKey, String endpoint, String functionName, String agentId) {
         int depIndex = parseKeyIndex(compositeKey, DEP_SEPARATOR);
         if (depIndex < 0) {
             log.warn("Invalid composite key format (missing {}): {}", DEP_SEPARATOR, compositeKey);
@@ -237,6 +280,15 @@ public class MeshToolWrapperRegistry {
             return;
         }
 
+        // Idempotency guard (#1314): skip a re-emit that carries the identical
+        // resolution already wired into this slot.
+        DepSignature incoming = new DepSignature(endpoint, functionName, agentId);
+        if (incoming.equals(lastAppliedByKey.get(compositeKey))) {
+            log.debug("Skipping idempotent dependency apply {} for {} → {}:{} (agentId={})",
+                depIndex, funcId, endpoint, functionName, agentId);
+            return;
+        }
+
         // Get the expected return type for this dependency (from McpMeshTool<T>)
         Type returnType = wrapper.getDependencyReturnType(depIndex);
 
@@ -246,8 +298,10 @@ public class MeshToolWrapperRegistry {
         // Update wrapper's dependency array
         wrapper.updateDependency(depIndex, proxy);
 
-        log.debug("Updated dependency {} for {} → {}:{} (returnType={})",
-            depIndex, funcId, endpoint, functionName, returnType);
+        lastAppliedByKey.put(compositeKey, incoming);
+
+        log.debug("Updated dependency {} for {} → {}:{} (returnType={}, agentId={})",
+            depIndex, funcId, endpoint, functionName, returnType, agentId);
     }
 
     /**
@@ -260,6 +314,10 @@ public class MeshToolWrapperRegistry {
         if (depIndex < 0) {
             return;
         }
+
+        // Clear the idempotency signature (#1314) so a later re-add of the same
+        // endpoint/function/agentId is treated as a genuine change and re-wires.
+        lastAppliedByKey.remove(compositeKey);
 
         String funcId = parseKeyFuncId(compositeKey, DEP_SEPARATOR);
         MeshToolWrapper wrapper = resolveWrapper(funcId);

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependencyIdempotencyGuardTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDependencyIdempotencyGuardTest.java
@@ -1,0 +1,154 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.Param;
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Idempotency guard on the dependency-apply path (#1314).
+ *
+ * <p>The Rust core re-emits {@code dependency_available} for every
+ * believed-delivered edge on an independent ~10s wall-clock tick to self-heal
+ * dropped applies. Those re-emits carry the SAME resolution. Without a guard
+ * the SDK would re-fetch the proxy and rewrite the wrapper's injected slot (and
+ * repoint the shared per-capability handle) every 10s for a no-op. These tests
+ * assert the guard short-circuits an unchanged re-apply while a genuine change
+ * (endpoint, function, or agentId) still updates.
+ */
+class MeshDependencyIdempotencyGuardTest {
+
+    @SuppressWarnings("unused")
+    static class Tool {
+        public String lookup(@Param("q") String q, McpMeshTool<String> db) {
+            return (db != null && db.isAvailable()) ? "resolved" : "degraded";
+        }
+    }
+
+    private static Method find(Class<?> cls, String name) {
+        for (Method m : cls.getDeclaredMethods()) {
+            if (m.getName().equals(name)) return m;
+        }
+        throw new AssertionError("not found: " + name);
+    }
+
+    private static MeshToolWrapper newWrapper() {
+        return new MeshToolWrapper(
+            "Tool.lookup",
+            "lookup",
+            "test",
+            new Tool(),
+            find(Tool.class, "lookup"),
+            List.of("db_cap"),
+            JsonMapper.builder().build());
+    }
+
+    /** Counts every getOrCreateProxy invocation so a skipped apply is observable. */
+    static class CountingProxyFactory extends McpMeshToolProxyFactory {
+        final AtomicInteger calls = new AtomicInteger();
+
+        CountingProxyFactory() {
+            super(new McpHttpClient());
+        }
+
+        @Override
+        public <T> McpMeshTool<T> getOrCreateProxy(String endpoint, String functionName, Type returnType) {
+            calls.incrementAndGet();
+            return super.getOrCreateProxy(endpoint, functionName, returnType);
+        }
+    }
+
+    // ---- Registry per-slot signature guard -----------------------------------
+
+    @Test
+    void identicalReapply_isNoOp() {
+        CountingProxyFactory factory = new CountingProxyFactory();
+        MeshToolWrapperRegistry registry = new MeshToolWrapperRegistry(factory);
+        registry.registerWrapper(newWrapper());
+        String key = MeshToolWrapperRegistry.buildDependencyKey("Tool.lookup", 0);
+
+        registry.updateDependency(key, "http://localhost:1", "remote_fn", "agent-a");
+        registry.updateDependency(key, "http://localhost:1", "remote_fn", "agent-a");
+
+        assertEquals(1, factory.calls.get(),
+            "second apply with an identical signature must short-circuit (no proxy fetch)");
+    }
+
+    @Test
+    void differentEndpoint_updates() {
+        CountingProxyFactory factory = new CountingProxyFactory();
+        MeshToolWrapperRegistry registry = new MeshToolWrapperRegistry(factory);
+        registry.registerWrapper(newWrapper());
+        String key = MeshToolWrapperRegistry.buildDependencyKey("Tool.lookup", 0);
+
+        registry.updateDependency(key, "http://localhost:1", "remote_fn", "agent-a");
+        registry.updateDependency(key, "http://localhost:2", "remote_fn", "agent-a");
+
+        assertEquals(2, factory.calls.get(), "a different endpoint is a genuine change");
+    }
+
+    @Test
+    void differentAgentId_updates() {
+        CountingProxyFactory factory = new CountingProxyFactory();
+        MeshToolWrapperRegistry registry = new MeshToolWrapperRegistry(factory);
+        registry.registerWrapper(newWrapper());
+        String key = MeshToolWrapperRegistry.buildDependencyKey("Tool.lookup", 0);
+
+        // Same endpoint/function, agent_id-only change (composes with #1315).
+        registry.updateDependency(key, "http://localhost:1", "remote_fn", "agent-a");
+        registry.updateDependency(key, "http://localhost:1", "remote_fn", "agent-b");
+
+        assertEquals(2, factory.calls.get(),
+            "an agent_id-only change must still update");
+    }
+
+    @Test
+    void removalThenReadd_updates() {
+        CountingProxyFactory factory = new CountingProxyFactory();
+        MeshToolWrapperRegistry registry = new MeshToolWrapperRegistry(factory);
+        registry.registerWrapper(newWrapper());
+        String key = MeshToolWrapperRegistry.buildDependencyKey("Tool.lookup", 0);
+
+        registry.updateDependency(key, "http://localhost:1", "remote_fn", "agent-a");
+        registry.markDependencyUnavailable(key);
+        // Re-add of the SAME resolution must re-wire — the removal cleared the
+        // stored signature, so this is not treated as a no-op.
+        registry.updateDependency(key, "http://localhost:1", "remote_fn", "agent-a");
+
+        assertEquals(2, factory.calls.get(),
+            "re-add after removal must update even with the same signature");
+    }
+
+    // ---- Shared-handle guard (McpMeshToolProxy.updateEndpoint) ----------------
+
+    @Test
+    void updateEndpoint_shortCircuitsUnchanged() {
+        McpMeshToolProxy<?> proxy = new McpMeshToolProxy<>("db_cap", new McpHttpClient());
+
+        assertTrue(proxy.updateEndpoint("http://localhost:1", "remote_fn"),
+            "first apply changes the endpoint");
+        assertFalse(proxy.updateEndpoint("http://localhost:1", "remote_fn"),
+            "identical re-apply is a no-op repoint");
+        assertTrue(proxy.updateEndpoint("http://localhost:2", "remote_fn"),
+            "a different endpoint repoints");
+    }
+
+    @Test
+    void updateEndpoint_reappliesAfterUnavailable() {
+        McpMeshToolProxy<?> proxy = new McpMeshToolProxy<>("db_cap", new McpHttpClient());
+
+        assertTrue(proxy.updateEndpoint("http://localhost:1", "remote_fn"));
+        proxy.markUnavailable();
+        // Availability flipped false, so the same endpoint/function is a real
+        // change back to available — must repoint.
+        assertTrue(proxy.updateEndpoint("http://localhost:1", "remote_fn"),
+            "re-apply after markUnavailable must repoint (availability changed)");
+    }
+}

--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -1118,6 +1118,12 @@ class DependencyInjector:
         self._dependency_mapping: dict[str, set[str]] = (
             {}
         )  # dep_name -> set of function_ids
+        # Last-applied resolution signature per dependency key (issue #1314).
+        # The Rust core re-emits ``dependency_available`` for believed-delivered
+        # edges on an independent wall-clock tick to self-heal dropped applies.
+        # We record the signature of what was last wired so an identical
+        # re-emit can be skipped without churning proxies + connection pools.
+        self._applied_dep_signatures: dict[str, Any] = {}
         self._lock = asyncio.Lock()
 
         # LLM agent injector for MeshLlmAgent parameters
@@ -1189,6 +1195,9 @@ class DependencyInjector:
         """
         async with self._lock:
             logger.info(f"🗑️ INJECTOR: Unregistering dependency: {name}")
+            # Idempotency guard (issue #1314): drop the last-applied signature so
+            # a later re-add of the same resolution rebuilds instead of skipping.
+            self._applied_dep_signatures.pop(name, None)
             if name in self._dependencies:
                 del self._dependencies[name]
                 logger.info(f"🗑️ INJECTOR: Removed {name} from dependencies registry")
@@ -1238,6 +1247,29 @@ class DependencyInjector:
     def get_dependency(self, name: str) -> Any | None:
         """Get current instance of a dependency."""
         return self._dependencies.get(name)
+
+    def get_applied_dependency_signature(self, name: str) -> Any | None:
+        """Return the last-applied resolution signature for ``name`` (#1314).
+
+        Callers on the dependency-apply path compare the incoming resolution's
+        signature against this to skip rebuilding a proxy that is already wired
+        identically (the Rust core re-emits believed-delivered edges on a
+        wall-clock tick). Returns ``None`` when nothing is currently applied.
+        """
+        return self._applied_dep_signatures.get(name)
+
+    def set_applied_dependency_signature(self, name: str, signature: Any) -> None:
+        """Record the resolution signature just wired for ``name`` (#1314)."""
+        self._applied_dep_signatures[name] = signature
+
+    def clear_applied_dependency_signature(self, name: str) -> None:
+        """Drop the last-applied signature for ``name`` (#1314).
+
+        Used by consumer paths that wire dependencies without going through
+        ``unregister_dependency`` (e.g. the API/route path, which updates route
+        wrappers directly) so a later re-add of the same resolution rebuilds.
+        """
+        self._applied_dep_signatures.pop(name, None)
 
     def find_original_function(self, function_name: str) -> Any | None:
         """Find the original function by name from wrapper registry or decorator registry.

--- a/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/rust_api_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/rust_api_heartbeat.py
@@ -275,7 +275,18 @@ async def _handle_api_dependency_change(
     )
 
     from ...engine.decorator_registry import DecoratorRegistry
+    from ...engine.dependency_injector import get_global_injector
     from ...engine.unified_mcp_proxy import EnhancedUnifiedMCPProxy
+
+    # Idempotency guard (issue #1314): the Rust core re-emits
+    # ``dependency_available`` for believed-delivered edges on an independent
+    # wall-clock tick to self-heal dropped applies. The API/route path pulls
+    # from that same reconciling core, so without a guard @mesh.route gateways
+    # would churn proxies + connection pools every tick. We reuse the shared
+    # global DependencyInjector's signature store; the API path wires route
+    # wrappers directly (no injector registration) so keys are namespaced
+    # ``api:{route_id}:dep_{N}`` to avoid colliding with MCP dep keys.
+    injector = get_global_injector()
 
     parsed_producer_kwargs: dict = {}
     if producer_kwargs:
@@ -315,11 +326,22 @@ async def _handle_api_dependency_change(
                 if dep_cap == capability:
                     # Set to None to indicate unavailable
                     wrapper._mesh_update_dependency(dep_index, None)
+                    # Clear the last-applied signature so a later re-add of the
+                    # same resolution rebuilds (issue #1314).
+                    injector.clear_applied_dependency_signature(
+                        f"api:{route_id}:dep_{dep_index}"
+                    )
                     logger.info(
                         f"Cleared dependency '{capability}' at index {dep_index} "
                         f"for route '{route_id}'"
                     )
         return
+
+    # Normalize producer kwargs to a stable string so equal-but-not-identical
+    # dicts compare equal in the idempotency signature (issue #1314).
+    normalized_kwargs = json.dumps(
+        dict(parsed_producer_kwargs), sort_keys=True, default=str
+    )
 
     # Dependency is available - update all route wrappers that need it
     for route_id, route_info in route_wrappers.items():
@@ -332,6 +354,29 @@ async def _handle_api_dependency_change(
         # Find which dependency index(es) match this capability
         for dep_index, dep_cap in enumerate(dependencies):
             if dep_cap == capability:
+                # Idempotency guard (issue #1314): skip rebuilding the proxy
+                # when the incoming resolution is identical to what is already
+                # wired for this route slot. ``agent_id`` is part of the
+                # signature so it composes with #1315 (an agent_id-only change
+                # still rebuilds, since self-dependency proxy-kind selection
+                # below keys off agent_id).
+                sig_key = f"api:{route_id}:dep_{dep_index}"
+                applied_signature = (
+                    endpoint,
+                    function_name,
+                    normalized_kwargs,
+                    agent_id,
+                )
+                if (
+                    injector.get_applied_dependency_signature(sig_key)
+                    == applied_signature
+                ):
+                    logger.debug(
+                        f"Dependency '{capability}' for route '{route_id}' "
+                        f"unchanged (idempotent re-emit); skipping proxy rebuild"
+                    )
+                    continue
+
                 # Check for self-dependency (rare for API services but handle it)
                 current_service_id = context.get("service_id") or context.get(
                     "agent_id"
@@ -389,6 +434,9 @@ async def _handle_api_dependency_change(
 
                 # Update the route wrapper
                 wrapper._mesh_update_dependency(dep_index, proxy)
+                injector.set_applied_dependency_signature(
+                    sig_key, applied_signature
+                )
                 logger.info(
                     f"Updated dependency '{capability}' at index {dep_index} "
                     f"for route '{route_id}' -> {endpoint}/{function_name}"

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
@@ -761,6 +761,34 @@ async def _handle_dependency_change(
             current_agent_id and agent_id and current_agent_id == agent_id
         )
 
+        # Idempotency guard (issue #1314): the Rust core re-emits
+        # ``dependency_available`` for believed-delivered edges on an
+        # independent wall-clock tick to self-heal dropped applies. If the
+        # incoming resolution is identical to what is already wired, rebuilding
+        # the proxy would churn proxies + connection pools for nothing. Skip.
+        #
+        # ``agent_id`` is part of the signature so this composes with #1315: an
+        # agent_id-only change still rebuilds (self-dependency proxy-kind
+        # selection above keys off agent_id), while an unchanged reconcile
+        # re-emit carries the same agent_id and is correctly skipped.
+        # ``kwargs_config`` is normalized to a sorted JSON string so equal-but-
+        # not-identical dicts compare equal.
+        applied_signature = (
+            endpoint,
+            function_name,
+            json.dumps(kwargs_config, sort_keys=True, default=str),
+            agent_id,
+        )
+        if (
+            injector.get_applied_dependency_signature(dep_key)
+            == applied_signature
+        ):
+            logger.debug(
+                f"Dependency {dep_key} unchanged (idempotent re-emit); "
+                f"skipping proxy rebuild"
+            )
+            return
+
         if is_self_dependency:
             from ...engine.self_dependency_proxy import SelfDependencyProxy
 
@@ -784,6 +812,7 @@ async def _handle_dependency_change(
             )
 
         await injector.register_dependency(dep_key, proxy)
+        injector.set_applied_dependency_signature(dep_key, applied_signature)
         logger.info(f"Registered dependency: {dep_key}")
         return
 

--- a/src/runtime/python/tests/unit/test_1314_dependency_apply_idempotency.py
+++ b/src/runtime/python/tests/unit/test_1314_dependency_apply_idempotency.py
@@ -1,0 +1,527 @@
+"""Unit tests for issue #1314: idempotency guard on the dependency-apply path.
+
+The Rust core re-emits ``dependency_available`` for every believed-delivered
+edge on an independent ~10s wall-clock tick to self-heal dropped applies.
+Without a guard the SDK would rebuild the injected proxy (and its connection
+pool) every tick even when nothing changed.
+
+The guard records a per-``dep_key`` signature of what was last wired —
+``(endpoint, function_name, kwargs_config, agent_id)`` — and skips the rebuild
+when an incoming resolution matches it exactly. A genuine change (different
+endpoint, function, kwargs, or agent_id) still rebuilds, and unregistering
+clears the signature so a later re-add rebuilds.
+
+Covers both the MCP consumer path (``rust_heartbeat.py``) and the API/route
+consumer path (``rust_api_heartbeat.py``); both pull from the same reconciling
+Rust core and reuse the same shared ``DependencyInjector`` signature store.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def _register_consumer():
+    """Register a consumer tool with a single ``chat`` dependency.
+
+    Returns ``(consumer_func, dep_key)`` where ``dep_key`` matches what the
+    heartbeat position-path builds for ``requesting_function="consumer"`` and
+    ``dep_index=0``.
+    """
+    from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+    DecoratorRegistry.clear_all()
+
+    async def consumer(prompt: str, chat=None):
+        return chat
+
+    DecoratorRegistry.register_mesh_tool(
+        consumer,
+        {
+            "capability": "consumer_tool",
+            "dependencies": [{"capability": "chat"}],
+        },
+    )
+    func_id = f"{consumer.__module__}.{consumer.__qualname__}"
+    return consumer, f"{func_id}:dep_0"
+
+
+async def _apply(rust_heartbeat, *, endpoint, agent_id, producer_kwargs=None):
+    await rust_heartbeat._handle_dependency_change(
+        capability="chat",
+        endpoint=endpoint,
+        function_name="chat",
+        agent_id=agent_id,
+        available=True,
+        context={},
+        requesting_function="consumer",
+        dep_index=0,
+        producer_kwargs=producer_kwargs,
+    )
+
+
+class TestDependencyApplyIdempotency:
+    @pytest.mark.asyncio
+    async def test_identical_reemit_is_noop(self):
+        """Two identical applies build + register the proxy exactly once."""
+        from unittest.mock import patch
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.engine.dependency_injector import get_global_injector
+        from _mcp_mesh.pipeline.mcp_heartbeat import rust_heartbeat
+
+        _, dep_key = _register_consumer()
+        injector = get_global_injector()
+        await injector.unregister_dependency(dep_key)  # clean slate
+
+        builds: list = []
+
+        class CountingProxy:
+            def __init__(self, endpoint, function_name, kwargs_config=None):
+                self.endpoint = endpoint
+                self.function_name = function_name
+                self.kwargs_config = kwargs_config
+                builds.append(self)
+
+        try:
+            with patch(
+                "_mcp_mesh.engine.unified_mcp_proxy.EnhancedUnifiedMCPProxy",
+                CountingProxy,
+            ):
+                await _apply(
+                    rust_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-id",
+                    producer_kwargs=json.dumps({"stream_type": "text"}),
+                )
+                first_instance = injector.get_dependency(dep_key)
+
+                # Identical re-emit — must be a no-op (no rebuild, no re-register).
+                await _apply(
+                    rust_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-id",
+                    producer_kwargs=json.dumps({"stream_type": "text"}),
+                )
+                second_instance = injector.get_dependency(dep_key)
+
+            assert len(builds) == 1
+            assert first_instance is second_instance
+        finally:
+            await injector.unregister_dependency(dep_key)
+            DecoratorRegistry.clear_all()
+
+    @pytest.mark.asyncio
+    async def test_equal_but_distinct_kwargs_dicts_are_noop(self):
+        """kwargs_config is compared by value: equal dicts do not rebuild."""
+        from unittest.mock import patch
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.engine.dependency_injector import get_global_injector
+        from _mcp_mesh.pipeline.mcp_heartbeat import rust_heartbeat
+
+        _, dep_key = _register_consumer()
+        injector = get_global_injector()
+        await injector.unregister_dependency(dep_key)
+
+        builds: list = []
+
+        class CountingProxy:
+            def __init__(self, endpoint, function_name, kwargs_config=None):
+                builds.append(self)
+
+        try:
+            with patch(
+                "_mcp_mesh.engine.unified_mcp_proxy.EnhancedUnifiedMCPProxy",
+                CountingProxy,
+            ):
+                # Same key/values, different key ordering in the JSON — must
+                # normalize to an equal signature.
+                await _apply(
+                    rust_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-id",
+                    producer_kwargs=json.dumps({"a": 1, "b": 2}),
+                )
+                await _apply(
+                    rust_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-id",
+                    producer_kwargs=json.dumps({"b": 2, "a": 1}),
+                )
+
+            assert len(builds) == 1
+        finally:
+            await injector.unregister_dependency(dep_key)
+            DecoratorRegistry.clear_all()
+
+    @pytest.mark.asyncio
+    async def test_different_endpoint_rebuilds(self):
+        """A genuine endpoint change rebuilds + re-registers a new instance."""
+        from unittest.mock import patch
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.engine.dependency_injector import get_global_injector
+        from _mcp_mesh.pipeline.mcp_heartbeat import rust_heartbeat
+
+        _, dep_key = _register_consumer()
+        injector = get_global_injector()
+        await injector.unregister_dependency(dep_key)
+
+        builds: list = []
+
+        class CountingProxy:
+            def __init__(self, endpoint, function_name, kwargs_config=None):
+                self.endpoint = endpoint
+                builds.append(self)
+
+        try:
+            with patch(
+                "_mcp_mesh.engine.unified_mcp_proxy.EnhancedUnifiedMCPProxy",
+                CountingProxy,
+            ):
+                await _apply(
+                    rust_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-id",
+                )
+                first_instance = injector.get_dependency(dep_key)
+
+                await _apply(
+                    rust_heartbeat,
+                    endpoint="http://producer-2:9170",
+                    agent_id="producer-id",
+                )
+                second_instance = injector.get_dependency(dep_key)
+
+            assert len(builds) == 2
+            assert first_instance is not second_instance
+            assert second_instance.endpoint == "http://producer-2:9170"
+        finally:
+            await injector.unregister_dependency(dep_key)
+            DecoratorRegistry.clear_all()
+
+    @pytest.mark.asyncio
+    async def test_different_agent_id_rebuilds(self):
+        """An agent_id-only change rebuilds (composes with #1315)."""
+        from unittest.mock import patch
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.engine.dependency_injector import get_global_injector
+        from _mcp_mesh.pipeline.mcp_heartbeat import rust_heartbeat
+
+        _, dep_key = _register_consumer()
+        injector = get_global_injector()
+        await injector.unregister_dependency(dep_key)
+
+        builds: list = []
+
+        class CountingProxy:
+            def __init__(self, endpoint, function_name, kwargs_config=None):
+                builds.append(self)
+
+        try:
+            with patch(
+                "_mcp_mesh.engine.unified_mcp_proxy.EnhancedUnifiedMCPProxy",
+                CountingProxy,
+            ):
+                await _apply(
+                    rust_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-a",
+                )
+                await _apply(
+                    rust_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-b",
+                )
+
+            assert len(builds) == 2
+        finally:
+            await injector.unregister_dependency(dep_key)
+            DecoratorRegistry.clear_all()
+
+    @pytest.mark.asyncio
+    async def test_unregister_clears_signature_so_readd_rebuilds(self):
+        """Unregistering clears the signature; re-applying the same rebuilds."""
+        from unittest.mock import patch
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.engine.dependency_injector import get_global_injector
+        from _mcp_mesh.pipeline.mcp_heartbeat import rust_heartbeat
+
+        _, dep_key = _register_consumer()
+        injector = get_global_injector()
+        await injector.unregister_dependency(dep_key)
+
+        builds: list = []
+
+        class CountingProxy:
+            def __init__(self, endpoint, function_name, kwargs_config=None):
+                builds.append(self)
+
+        try:
+            with patch(
+                "_mcp_mesh.engine.unified_mcp_proxy.EnhancedUnifiedMCPProxy",
+                CountingProxy,
+            ):
+                await _apply(
+                    rust_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-id",
+                )
+                assert len(builds) == 1
+
+                # Dependency goes away — clears the stored signature.
+                await rust_heartbeat._handle_dependency_change(
+                    capability="chat",
+                    endpoint=None,
+                    function_name=None,
+                    agent_id="producer-id",
+                    available=False,
+                    context={},
+                    requesting_function="consumer",
+                    dep_index=0,
+                )
+                assert injector.get_applied_dependency_signature(dep_key) is None
+
+                # Re-add identical resolution — must rebuild (not skipped).
+                await _apply(
+                    rust_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-id",
+                )
+
+            assert len(builds) == 2
+        finally:
+            await injector.unregister_dependency(dep_key)
+            DecoratorRegistry.clear_all()
+
+
+def _register_route(dependencies=("chat",)):
+    """Register a route wrapper with the given dependency capabilities.
+
+    Returns ``(wrapper, route_id)``. ``route_id`` matches the API path's
+    ``{method}:{path}`` convention, and the signature key it uses is
+    ``api:{route_id}:dep_{index}``.
+    """
+    from unittest.mock import MagicMock
+
+    from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+    DecoratorRegistry.clear_all()
+
+    wrapper = MagicMock()
+    wrapper._mesh_update_dependency = MagicMock()
+    DecoratorRegistry.register_route_wrapper(
+        method="POST",
+        path="/api/chat",
+        wrapper=wrapper,
+        dependencies=list(dependencies),
+    )
+    return wrapper, "POST:/api/chat"
+
+
+async def _apply_api(rust_api_heartbeat, *, endpoint, agent_id, producer_kwargs=None):
+    await rust_api_heartbeat._handle_api_dependency_change(
+        capability="chat",
+        endpoint=endpoint,
+        function_name="chat",
+        agent_id=agent_id,
+        available=True,
+        context={},
+        producer_kwargs=producer_kwargs,
+    )
+
+
+class TestApiDependencyApplyIdempotency:
+    """The API/route consumer path (@mesh.route gateways) shares the guard.
+
+    It reuses the same global ``DependencyInjector`` signature store as the MCP
+    path, keyed ``api:{route_id}:dep_{N}`` since routes are wired via route
+    wrappers rather than injector registration.
+    """
+
+    @pytest.mark.asyncio
+    async def test_identical_reemit_is_noop(self):
+        from unittest.mock import patch
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.engine.dependency_injector import get_global_injector
+        from _mcp_mesh.pipeline.api_heartbeat import rust_api_heartbeat
+
+        wrapper, route_id = _register_route()
+        injector = get_global_injector()
+        sig_key = f"api:{route_id}:dep_0"
+        injector.clear_applied_dependency_signature(sig_key)
+
+        builds: list = []
+
+        class CountingProxy:
+            def __init__(self, endpoint, function_name, kwargs_config=None):
+                builds.append(self)
+
+        try:
+            with patch(
+                "_mcp_mesh.engine.unified_mcp_proxy.EnhancedUnifiedMCPProxy",
+                CountingProxy,
+            ):
+                await _apply_api(
+                    rust_api_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-id",
+                    producer_kwargs=json.dumps({"stream_type": "text"}),
+                )
+                # Identical re-emit — no rebuild, no wrapper re-update.
+                await _apply_api(
+                    rust_api_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-id",
+                    producer_kwargs=json.dumps({"stream_type": "text"}),
+                )
+
+            assert len(builds) == 1
+            assert wrapper._mesh_update_dependency.call_count == 1
+        finally:
+            injector.clear_applied_dependency_signature(sig_key)
+            DecoratorRegistry.clear_all()
+
+    @pytest.mark.asyncio
+    async def test_different_endpoint_rebuilds(self):
+        from unittest.mock import patch
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.engine.dependency_injector import get_global_injector
+        from _mcp_mesh.pipeline.api_heartbeat import rust_api_heartbeat
+
+        wrapper, route_id = _register_route()
+        injector = get_global_injector()
+        sig_key = f"api:{route_id}:dep_0"
+        injector.clear_applied_dependency_signature(sig_key)
+
+        builds: list = []
+
+        class CountingProxy:
+            def __init__(self, endpoint, function_name, kwargs_config=None):
+                self.endpoint = endpoint
+                builds.append(self)
+
+        try:
+            with patch(
+                "_mcp_mesh.engine.unified_mcp_proxy.EnhancedUnifiedMCPProxy",
+                CountingProxy,
+            ):
+                await _apply_api(
+                    rust_api_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-id",
+                )
+                await _apply_api(
+                    rust_api_heartbeat,
+                    endpoint="http://producer-2:9170",
+                    agent_id="producer-id",
+                )
+
+            assert len(builds) == 2
+            assert wrapper._mesh_update_dependency.call_count == 2
+        finally:
+            injector.clear_applied_dependency_signature(sig_key)
+            DecoratorRegistry.clear_all()
+
+    @pytest.mark.asyncio
+    async def test_different_agent_id_rebuilds(self):
+        from unittest.mock import patch
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.engine.dependency_injector import get_global_injector
+        from _mcp_mesh.pipeline.api_heartbeat import rust_api_heartbeat
+
+        wrapper, route_id = _register_route()
+        injector = get_global_injector()
+        sig_key = f"api:{route_id}:dep_0"
+        injector.clear_applied_dependency_signature(sig_key)
+
+        builds: list = []
+
+        class CountingProxy:
+            def __init__(self, endpoint, function_name, kwargs_config=None):
+                builds.append(self)
+
+        try:
+            with patch(
+                "_mcp_mesh.engine.unified_mcp_proxy.EnhancedUnifiedMCPProxy",
+                CountingProxy,
+            ):
+                await _apply_api(
+                    rust_api_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-a",
+                )
+                await _apply_api(
+                    rust_api_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-b",
+                )
+
+            assert len(builds) == 2
+            assert wrapper._mesh_update_dependency.call_count == 2
+        finally:
+            injector.clear_applied_dependency_signature(sig_key)
+            DecoratorRegistry.clear_all()
+
+    @pytest.mark.asyncio
+    async def test_unavailable_clears_signature_so_readd_rebuilds(self):
+        from unittest.mock import patch
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.engine.dependency_injector import get_global_injector
+        from _mcp_mesh.pipeline.api_heartbeat import rust_api_heartbeat
+
+        wrapper, route_id = _register_route()
+        injector = get_global_injector()
+        sig_key = f"api:{route_id}:dep_0"
+        injector.clear_applied_dependency_signature(sig_key)
+
+        builds: list = []
+
+        class CountingProxy:
+            def __init__(self, endpoint, function_name, kwargs_config=None):
+                builds.append(self)
+
+        try:
+            with patch(
+                "_mcp_mesh.engine.unified_mcp_proxy.EnhancedUnifiedMCPProxy",
+                CountingProxy,
+            ):
+                await _apply_api(
+                    rust_api_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-id",
+                )
+                assert len(builds) == 1
+
+                # Dependency goes away — clears the stored signature.
+                await rust_api_heartbeat._handle_api_dependency_change(
+                    capability="chat",
+                    endpoint=None,
+                    function_name=None,
+                    agent_id=None,
+                    available=False,
+                    context={},
+                    producer_kwargs=None,
+                )
+                assert injector.get_applied_dependency_signature(sig_key) is None
+
+                # Re-add identical resolution — must rebuild (not skipped).
+                await _apply_api(
+                    rust_api_heartbeat,
+                    endpoint="http://producer:9170",
+                    agent_id="producer-id",
+                )
+
+            assert len(builds) == 2
+        finally:
+            injector.clear_applied_dependency_signature(sig_key)
+            DecoratorRegistry.clear_all()

--- a/src/runtime/typescript/src/__tests__/api-runtime-apply-idempotency.spec.ts
+++ b/src/runtime/typescript/src/__tests__/api-runtime-apply-idempotency.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * #1314 — idempotency guard on the ApiRuntime (@mesh.route / Express gateway)
+ * dependency-apply path.
+ *
+ * ApiRuntime consumes the SAME reconciling napi core as MeshAgent
+ * (`this.handle.nextEvent()`), which re-emits `dependency_available` for every
+ * believed-delivered edge on an independent ~10s tick. Without a guard each
+ * gateway agent would call `createProxy` and rewire the RouteRegistry on every
+ * tick. The guard records the last-applied signature
+ * `(endpoint, functionName, kwargs, agentId)` per depKey and skips the rebuild
+ * when an incoming apply carries the same signature; a genuine change still
+ * rebuilds, and removal clears the signature so a re-add rebuilds.
+ *
+ * These drive the REAL private `handleDependencyAvailable` /
+ * `handleDependencyUnavailable` against a stub `this` (only
+ * `appliedDepSignatures` is read/written) with a real RouteRegistry passed as
+ * the explicit `registry` argument — no napi runtime needed.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { MockInstance } from "vitest";
+
+import { ApiRuntime } from "../api-runtime.js";
+import { RouteRegistry } from "../route.js";
+import { resetSettleStateForTests } from "../settle.js";
+import * as proxyModule from "../proxy.js";
+import type { McpMeshTool } from "../types.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handleAvailable = (ApiRuntime.prototype as any).handleDependencyAvailable;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handleUnavailable = (ApiRuntime.prototype as any)
+  .handleDependencyUnavailable;
+
+describe("ApiRuntime dependency-apply idempotency (#1314)", () => {
+  let createProxySpy: MockInstance;
+  let registry: RouteRegistry;
+  let routeId: string;
+  let stub: { appliedDepSignatures: Map<string, string> };
+
+  beforeEach(() => {
+    RouteRegistry.reset();
+    resetSettleStateForTests();
+    registry = RouteRegistry.getInstance();
+    routeId = registry.registerRoute("GET", "/report", ["calculator"], [
+      { timeout: 30 },
+    ]);
+    stub = { appliedDepSignatures: new Map<string, string>() };
+
+    createProxySpy = vi
+      .spyOn(proxyModule, "createProxy")
+      .mockImplementation(
+        () => (() => Promise.resolve("ok")) as unknown as McpMeshTool,
+      );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function apply(endpoint: string, agentId: string): void {
+    handleAvailable.call(
+      stub,
+      registry,
+      "calculator",
+      endpoint,
+      "fn",
+      agentId,
+      routeId,
+      0,
+    );
+  }
+
+  it("skips rebuild when the re-emit carries an identical signature", () => {
+    apply("http://p:8080", "agent-1");
+    expect(createProxySpy).toHaveBeenCalledTimes(1);
+    const firstProxy = registry.getDependency(routeId, 0);
+    expect(firstProxy).not.toBeNull();
+
+    // Identical re-emit → no createProxy, proxy identity unchanged.
+    apply("http://p:8080", "agent-1");
+    expect(createProxySpy).toHaveBeenCalledTimes(1);
+    expect(registry.getDependency(routeId, 0)).toBe(firstProxy);
+  });
+
+  it("rebuilds when the endpoint changes", () => {
+    apply("http://p:8080", "agent-1");
+    const firstProxy = registry.getDependency(routeId, 0);
+
+    apply("http://p:9090", "agent-1");
+    expect(createProxySpy).toHaveBeenCalledTimes(2);
+    expect(registry.getDependency(routeId, 0)).not.toBe(firstProxy);
+  });
+
+  it("rebuilds when only the agentId changes (composes with #1315)", () => {
+    apply("http://p:8080", "agent-1");
+    const firstProxy = registry.getDependency(routeId, 0);
+
+    apply("http://p:8080", "agent-2");
+    expect(createProxySpy).toHaveBeenCalledTimes(2);
+    expect(registry.getDependency(routeId, 0)).not.toBe(firstProxy);
+  });
+
+  it("rebuilds after removal even when the same signature returns", () => {
+    apply("http://p:8080", "agent-1");
+    const firstProxy = registry.getDependency(routeId, 0);
+    expect(createProxySpy).toHaveBeenCalledTimes(1);
+
+    handleUnavailable.call(stub, registry, "calculator", routeId, 0);
+    expect(registry.getDependency(routeId, 0)).toBeNull();
+    expect(stub.appliedDepSignatures.has(`${routeId}:dep_0`)).toBe(false);
+
+    apply("http://p:8080", "agent-1");
+    expect(createProxySpy).toHaveBeenCalledTimes(2);
+    expect(registry.getDependency(routeId, 0)).not.toBe(firstProxy);
+  });
+});

--- a/src/runtime/typescript/src/__tests__/dependency-apply-idempotency.spec.ts
+++ b/src/runtime/typescript/src/__tests__/dependency-apply-idempotency.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * #1314 — idempotency guard on the TS dependency-apply path.
+ *
+ * The Rust core re-emits `dependency_available` for every believed-delivered
+ * edge on an independent ~10s wall-clock tick (self-heals dropped applies).
+ * Without a guard the SDK would call `createProxy` and rewire `resolvedDeps`
+ * on every tick — needless churn. The guard records the last-applied
+ * resolution signature `(endpoint, functionName, kwargs, agentId)` per depKey
+ * and skips the rebuild when an incoming apply carries the same signature.
+ *
+ * A genuine change (different endpoint / function / kwargs / agentId) must
+ * still rebuild, and a removal must clear the signature so a later re-add
+ * rebuilds.
+ *
+ * These drive the REAL private `handleDependencyAvailable` /
+ * `handleDependencyUnavailable` against a stub `this` — the methods only touch
+ * `this.tools`, `this.resolvedDeps` and `this.appliedDepSignatures` plus the
+ * settle singleton, so no napi runtime is needed.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { MockInstance } from "vitest";
+
+import { MeshAgent } from "../agent.js";
+import { resetSettleStateForTests } from "../settle.js";
+import * as proxyModule from "../proxy.js";
+import type { McpMeshTool } from "../types.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handleAvailable = (MeshAgent.prototype as any).handleDependencyAvailable;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handleUnavailable = (MeshAgent.prototype as any)
+  .handleDependencyUnavailable;
+
+/** Minimal stub `this` mirroring the fields the two handlers read/write. */
+function makeStub(kwargs?: unknown) {
+  return {
+    tools: new Map([
+      [
+        "myTool",
+        {
+          dependencyKwargs: [kwargs],
+        },
+      ],
+    ]),
+    resolvedDeps: new Map<string, McpMeshTool>(),
+    appliedDepSignatures: new Map<string, string>(),
+  };
+}
+
+const DEP_KEY = "myTool:dep_0";
+
+describe("dependency-apply idempotency (#1314)", () => {
+  let createProxySpy: MockInstance;
+
+  beforeEach(() => {
+    resetSettleStateForTests();
+    // Each call returns a fresh, identity-distinct proxy so we can assert both
+    // call-count AND that the stored proxy reference did not change.
+    createProxySpy = vi
+      .spyOn(proxyModule, "createProxy")
+      .mockImplementation(
+        () => (() => Promise.resolve("ok")) as unknown as McpMeshTool,
+      );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("skips rebuild when the re-emit carries an identical signature", () => {
+    const stub = makeStub({ tags: ["a"] });
+
+    handleAvailable.call(stub, "cap", "http://p:8080", "fn", "agent-1", "myTool", 0);
+    expect(createProxySpy).toHaveBeenCalledTimes(1);
+    const firstProxy = stub.resolvedDeps.get(DEP_KEY);
+    expect(firstProxy).toBeDefined();
+
+    // Identical re-emit → no createProxy, proxy identity unchanged.
+    handleAvailable.call(stub, "cap", "http://p:8080", "fn", "agent-1", "myTool", 0);
+    expect(createProxySpy).toHaveBeenCalledTimes(1);
+    expect(stub.resolvedDeps.get(DEP_KEY)).toBe(firstProxy);
+  });
+
+  it("treats value-equal-but-distinct kwargs objects as the same signature", () => {
+    // Two calls whose kwargs are structurally equal but reference-distinct
+    // (as happens when the core re-parses the payload each tick).
+    const stubA = makeStub({ tags: ["x"], timeout: 5 });
+    handleAvailable.call(stubA, "cap", "http://p:8080", "fn", "agent-1", "myTool", 0);
+
+    // Rewrite the stub's kwargs to a fresh, deep-equal object and re-fire.
+    stubA.tools.set("myTool", {
+      dependencyKwargs: [{ timeout: 5, tags: ["x"] }],
+    });
+    handleAvailable.call(stubA, "cap", "http://p:8080", "fn", "agent-1", "myTool", 0);
+
+    expect(createProxySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("rebuilds when the endpoint changes", () => {
+    const stub = makeStub({ tags: ["a"] });
+
+    handleAvailable.call(stub, "cap", "http://p:8080", "fn", "agent-1", "myTool", 0);
+    const firstProxy = stub.resolvedDeps.get(DEP_KEY);
+
+    handleAvailable.call(stub, "cap", "http://p:9090", "fn", "agent-1", "myTool", 0);
+    expect(createProxySpy).toHaveBeenCalledTimes(2);
+    expect(stub.resolvedDeps.get(DEP_KEY)).not.toBe(firstProxy);
+  });
+
+  it("rebuilds when only the agentId changes (composes with #1315)", () => {
+    const stub = makeStub({ tags: ["a"] });
+
+    handleAvailable.call(stub, "cap", "http://p:8080", "fn", "agent-1", "myTool", 0);
+    const firstProxy = stub.resolvedDeps.get(DEP_KEY);
+
+    // Same endpoint/function/kwargs, different provider identity → rebuild.
+    handleAvailable.call(stub, "cap", "http://p:8080", "fn", "agent-2", "myTool", 0);
+    expect(createProxySpy).toHaveBeenCalledTimes(2);
+    expect(stub.resolvedDeps.get(DEP_KEY)).not.toBe(firstProxy);
+  });
+
+  it("rebuilds after removal even when the same signature returns", () => {
+    const stub = makeStub({ tags: ["a"] });
+
+    handleAvailable.call(stub, "cap", "http://p:8080", "fn", "agent-1", "myTool", 0);
+    const firstProxy = stub.resolvedDeps.get(DEP_KEY);
+    expect(createProxySpy).toHaveBeenCalledTimes(1);
+
+    // Removal clears both the proxy and the stored signature.
+    handleUnavailable.call(stub, "cap", "myTool", 0);
+    expect(stub.resolvedDeps.has(DEP_KEY)).toBe(false);
+    expect(stub.appliedDepSignatures.has(DEP_KEY)).toBe(false);
+
+    // Same signature re-add must rebuild (the guard was cleared on removal).
+    handleAvailable.call(stub, "cap", "http://p:8080", "fn", "agent-1", "myTool", 0);
+    expect(createProxySpy).toHaveBeenCalledTimes(2);
+    expect(stub.resolvedDeps.get(DEP_KEY)).not.toBe(firstProxy);
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -198,6 +198,37 @@ function scheduleAutoStart(): void {
   });
 }
 
+// #1314: canonical JSON so that value-equal-but-reference-distinct objects
+// (e.g. re-parsed kwargs on a reconcile re-emit) hash identically. Object keys
+// are emitted in sorted order recursively; arrays keep their order.
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`)
+    .join(",")}}`;
+}
+
+// #1314: the resolution signature actually wired for a dependency edge. Two
+// applies with the same signature produce an identical proxy, so the second is
+// a no-op we can skip. `agentId` is included so this composes with #1315: an
+// agent_id-only change still rebuilds, while an unchanged reconcile re-emit
+// (same agentId) is skipped.
+export function depSignature(
+  endpoint: string,
+  functionName: string,
+  kwargs: unknown,
+  agentId: string
+): string {
+  return stableStringify([endpoint, functionName, kwargs, agentId]);
+}
+
 /**
  * MeshAgent wraps a FastMCP server with MCP Mesh capabilities.
  *
@@ -261,6 +292,15 @@ export class MeshAgent {
    * different tags/settings without overwriting each other.
    */
   private resolvedDeps: Map<string, McpMeshTool> = new Map();
+
+  // #1314: last-applied resolution signature per depKey. The Rust core
+  // re-emits `dependency_available` for every believed-delivered edge on an
+  // independent ~10s wall-clock tick (self-heals dropped applies). Without a
+  // guard the SDK would rebuild every proxy on each tick. We record the
+  // signature (endpoint, functionName, kwargs, agentId) actually wired for a
+  // depKey and skip the rebuild when an incoming apply carries the same one.
+  // Cleared on the unavailable/removal path so a later re-add rebuilds.
+  private appliedDepSignatures: Map<string, string> = new Map();
 
   // True when this MeshAgent is constructed inside a worker_threads Worker.
   // In worker mode addTool() only stashes execute fns and skips all FastMCP /
@@ -2446,8 +2486,18 @@ export class MeshAgent {
       const kwargs = meta?.dependencyKwargs?.[depIndex];
 
       const depKey = `${requestingFunction}:dep_${depIndex}`;
+
+      // #1314 idempotency guard: the Rust core re-emits dependency_available
+      // for believed-delivered edges on a ~10s tick. If the incoming
+      // resolution matches what is already wired, skip the rebuild entirely.
+      const signature = depSignature(endpoint, functionName, kwargs, agentId);
+      if (this.appliedDepSignatures.get(depKey) === signature) {
+        return;
+      }
+
       const proxy = createProxy(endpoint, capability, functionName, kwargs);
       this.resolvedDeps.set(depKey, proxy);
+      this.appliedDepSignatures.set(depKey, signature);
       // Settling-window grace (#1193): wake any settling call waiting on
       // this dependency AFTER the proxy is stored so the woken call
       // re-reads a real proxy.
@@ -2469,8 +2519,14 @@ export class MeshAgent {
         if (dep.capability === capability) {
           const kwargs = meta.dependencyKwargs?.[idx];
           const depKey = `${toolName}:dep_${idx}`;
+          // #1314 idempotency guard (see position-info path above).
+          const signature = depSignature(endpoint, functionName, kwargs, agentId);
+          if (this.appliedDepSignatures.get(depKey) === signature) {
+            return;
+          }
           const proxy = createProxy(endpoint, capability, functionName, kwargs);
           this.resolvedDeps.set(depKey, proxy);
+          this.appliedDepSignatures.set(depKey, signature);
           getSettleState().markResolved(depKey);
           matchCount++;
         }
@@ -2495,6 +2551,8 @@ export class MeshAgent {
     if (requestingFunction !== undefined && depIndex !== undefined) {
       const depKey = `${requestingFunction}:dep_${depIndex}`;
       this.resolvedDeps.delete(depKey);
+      // #1314: drop the applied signature so a later re-add rebuilds.
+      this.appliedDepSignatures.delete(depKey);
 
       console.log(
         `Dependency unavailable: ${capability} (tool: ${requestingFunction}, index: ${depIndex})`
@@ -2511,6 +2569,8 @@ export class MeshAgent {
         if (dep.capability === capability) {
           const depKey = `${toolName}:dep_${idx}`;
           this.resolvedDeps.delete(depKey);
+          // #1314: drop the applied signature so a later re-add rebuilds.
+          this.appliedDepSignatures.delete(depKey);
           removeCount++;
         }
       });

--- a/src/runtime/typescript/src/api-runtime.ts
+++ b/src/runtime/typescript/src/api-runtime.ts
@@ -47,6 +47,7 @@ import {
 } from "./config.js";
 import { RouteRegistry, type RouteMetadata } from "./route.js";
 import { createProxy } from "./proxy.js";
+import { depSignature } from "./agent.js";
 import { initTracing, type AgentMetadata } from "./tracing.js";
 import { getTlsConfigCached, prepareTls, cleanupTls } from "./tls-config.js";
 import { A2AProducerRegistry } from "./a2a/producer/registry.js";
@@ -111,6 +112,15 @@ class ApiRuntime {
   private starting = false;
   private scheduledStart = false;
   private shutdownRequested = false;
+  /**
+   * #1314: last-applied resolution signature per depKey
+   * (`${requestingFunction}:dep_${depIndex}`). The napi core re-emits
+   * `dependency_available` for believed-delivered edges on an independent
+   * ~10s tick; without this guard every @mesh.route / Express gateway agent
+   * would rebuild its proxies each tick. Skip the rebuild when an incoming
+   * apply matches the wired signature; cleared on the removal path.
+   */
+  private appliedDepSignatures: Map<string, string> = new Map();
   /**
    * Memoized in-flight (or completed) teardown. `shutdown()` is
    * idempotent: the first caller creates this promise and every later
@@ -457,8 +467,17 @@ class ApiRuntime {
       const route = registry.getRoute(requestingFunction);
       const kwargs = route?.dependencyKwargs?.[depIndex];
 
+      // #1314 idempotency guard: skip the rebuild when the core's ~10s
+      // reconcile re-emit matches what is already wired for this edge.
+      const depKey = `${requestingFunction}:dep_${depIndex}`;
+      const signature = depSignature(endpoint, functionName, kwargs, agentId);
+      if (this.appliedDepSignatures.get(depKey) === signature) {
+        return;
+      }
+
       const proxy = createProxy(endpoint, capability, functionName, kwargs);
       registry.setDependency(requestingFunction, depIndex, proxy);
+      this.appliedDepSignatures.set(depKey, signature);
 
       console.log(
         `Dependency available: ${capability} at ${endpoint} (route: ${requestingFunction}, agent: ${agentId})`
@@ -472,8 +491,15 @@ class ApiRuntime {
       route.dependencies.forEach((dep, idx) => {
         if (dep.capability === capability) {
           const kwargs = route.dependencyKwargs?.[idx];
+          // #1314 idempotency guard (see position-info path above).
+          const depKey = `${route.routeId}:dep_${idx}`;
+          const signature = depSignature(endpoint, functionName, kwargs, agentId);
+          if (this.appliedDepSignatures.get(depKey) === signature) {
+            return;
+          }
           const proxy = createProxy(endpoint, capability, functionName, kwargs);
           registry.setDependency(route.routeId, idx, proxy);
+          this.appliedDepSignatures.set(depKey, signature);
           matchCount++;
         }
       });
@@ -496,6 +522,8 @@ class ApiRuntime {
     // If we have position info, use it directly
     if (requestingFunction !== undefined && depIndex !== undefined) {
       registry.removeDependency(requestingFunction, depIndex);
+      // #1314: drop the applied signature so a later re-add rebuilds.
+      this.appliedDepSignatures.delete(`${requestingFunction}:dep_${depIndex}`);
       console.log(`Dependency unavailable: ${capability} (route: ${requestingFunction})`);
       return;
     }
@@ -506,6 +534,8 @@ class ApiRuntime {
       route.dependencies.forEach((dep, idx) => {
         if (dep.capability === capability) {
           registry.removeDependency(route.routeId, idx);
+          // #1314: drop the applied signature so a later re-add rebuilds.
+          this.appliedDepSignatures.delete(`${route.routeId}:dep_${idx}`);
           removeCount++;
         }
       });

--- a/tests/integration/suites/uc40_dependency_rewire/tc01_provider_move/artifacts/rewire-consumer/main.py
+++ b/tests/integration/suites/uc40_dependency_rewire/tc01_provider_move/artifacts/rewire-consumer/main.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+rewire-consumer - Depends on `rewire_probe` and reports which provider answered.
+
+`which_provider` injects the `rewire_probe` capability, calls it, and returns
+the provider's result verbatim ({"port": <provider's serving port>}). The
+consumer process is started ONCE and never restarted during the test: the only
+way its result can flip from the old provider port to the new one is if the
+runtime re-wires the injected proxy to the moved provider on its own.
+"""
+
+import mesh
+from fastmcp import FastMCP
+from mesh.types import McpMeshTool
+
+app = FastMCP("Rewire Consumer")
+
+
+@app.tool()
+@mesh.tool(
+    capability="which_provider",
+    description="Call rewire_probe and return which provider instance answered",
+    tags=["rewire"],
+    dependencies=["rewire_probe"],
+)
+async def which_provider(probe: McpMeshTool = None) -> dict:
+    """Return the provider's self-reported serving port."""
+    if probe is None:
+        return {"error": "rewire_probe dependency not injected"}
+    return await probe()
+
+
+@mesh.agent(
+    name="rewire-consumer",
+    version="1.0.0",
+    description="Consumer that must re-wire when the provider moves endpoints",
+    http_port=0,  # Actual port comes from MCP_MESH_HTTP_PORT env
+    enable_http=True,
+    auto_run=True,
+)
+class RewireConsumer:
+    pass

--- a/tests/integration/suites/uc40_dependency_rewire/tc01_provider_move/artifacts/rewire-provider/main.py
+++ b/tests/integration/suites/uc40_dependency_rewire/tc01_provider_move/artifacts/rewire-provider/main.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+rewire-provider - Provides the `rewire_probe` capability.
+
+The tool returns the HTTP port this instance is serving on (read from
+MCP_MESH_HTTP_PORT). That port is the *instance fingerprint*: when this
+provider "moves" to a new endpoint (started again on a different port),
+the consumer's call result reveals WHICH provider instance answered.
+
+Identity is pinned via MCP_MESH_AGENT_ID (set by the test) so that the
+moved instance keeps the SAME agent_id and only its endpoint (port)
+changes. That is the precise scenario the dependency re-wire invariant
+(#1314/#1315) must survive: an idempotency guard that keys on
+agent_id/function/kwargs but forgets the endpoint would over-skip the
+rebuild and leave the consumer wired to the OLD port.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Rewire Provider")
+
+
+@app.tool()
+@mesh.tool(
+    capability="rewire_probe",
+    description="Report the HTTP port this provider instance is serving on",
+    tags=["rewire"],
+)
+async def rewire_probe() -> dict:
+    """Return the serving port so callers can tell which instance answered."""
+    return {"port": os.environ.get("MCP_MESH_HTTP_PORT", "unknown")}
+
+
+@mesh.agent(
+    name="rewire-provider",
+    version="1.0.0",
+    description="Provider whose endpoint moves to test consumer re-wire",
+    http_port=0,  # Actual port comes from MCP_MESH_HTTP_PORT env
+    enable_http=True,
+    auto_run=True,
+)
+class RewireProvider:
+    pass

--- a/tests/integration/suites/uc40_dependency_rewire/tc01_provider_move/test.yaml
+++ b/tests/integration/suites/uc40_dependency_rewire/tc01_provider_move/test.yaml
@@ -1,0 +1,181 @@
+# Test Case: Provider Move -> Consumer Re-wire (WITHOUT restart)
+#
+# Proves the dependency re-wire invariant (#1314/#1315) end-to-end on real
+# natives: when a provider MOVES (re-registers at a NEW endpoint), a running
+# consumer re-wires its injected proxy to the new endpoint on its own — the
+# consumer process is started ONCE and NEVER restarted.
+#
+# The failure this test catches: the SDK apply-path idempotency guard (skip
+# proxy rebuild when endpoint/function/kwargs/agent_id are unchanged)
+# OVER-SKIPPING a genuine change. Here the provider's agent_id is pinned
+# (MCP_MESH_AGENT_ID) so ONLY the endpoint (port) changes on the move — the
+# precise case where a guard that forgot to compare the endpoint would keep
+# the consumer wired to the OLD port.
+#
+# Instance fingerprint = the port. Provider's rewire_probe returns its own
+# MCP_MESH_HTTP_PORT; consumer's which_provider returns that verbatim. So the
+# consumer's result literally reports WHICH provider instance answered:
+#   - baseline: 3040 (v1)
+#   - after move: 3041 (v2)   <-- the assertion that fails on over-skip
+
+name: "Provider Move Re-wire (no consumer restart)"
+description: "Moved provider (new endpoint, same agent_id) must re-wire a running consumer without restarting it"
+tags:
+  - rewire
+  - reconcile
+  - dependency_injection
+  - python
+  - integration
+timeout: 360
+
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+
+test:
+  - name: "Copy artifacts to workspace"
+    handler: shell
+    command: "cp -r /artifacts/* /workspace/"
+
+  # --- Bring up provider v1 (port 3040) with a PINNED agent_id ---------------
+  - name: "Start provider v1 on port 3040 (pinned agent_id)"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start rewire-provider/main.py --env MCP_MESH_HTTP_PORT=3040 --env MCP_MESH_AGENT_ID=rewire-provider-pinned -d"
+    capture: start_provider_v1
+
+  # --- Bring up the consumer ONCE (port 3042) --------------------------------
+  # MCP_MESH_SETTLE_TIMEOUT=60: first call held until the rewire_probe
+  # dependency resolves (settle window, PR #1200) — no dep-resolution polling.
+  - name: "Start consumer on port 3042 (started ONCE, never restarted)"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start rewire-consumer/main.py --env MCP_MESH_HTTP_PORT=3042 --env MCP_MESH_SETTLE_TIMEOUT=60 -d 2>&1 || echo 'START_FAILED'"
+    capture: start_consumer
+
+  - name: "Wait for provider and consumer to register (liveness only)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for rewire-provider and rewire-consumer to register..."
+      for i in $(seq 1 60); do
+        AGENTS=$(meshctl list 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' || true)
+        if echo "$AGENTS" | grep -q "rewire-provider" && echo "$AGENTS" | grep -q "rewire-consumer"; then
+          echo "Both agents registered after ~${i}s"
+          meshctl list
+          exit 0
+        fi
+        sleep 1
+      done
+      echo "ERROR: agents did not register within 60s"
+      meshctl list 2>/dev/null || true
+      exit 1
+    capture: wait_registered
+    timeout: 90
+
+  # --- Baseline: consumer is wired to v1 (must report 3040) ------------------
+  - name: "Baseline call: which provider answers? (expect 3040)"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl call which_provider '{}' 2>&1 || echo 'CALL_FAILED'"
+    capture: baseline_result
+    timeout: 90
+
+  # --- MOVE the provider: stop v1, start v2 on a DIFFERENT port (3041) --------
+  # Same pinned agent_id => only the endpoint changes. Consumer is untouched.
+  - name: "Move provider: stop v1 (by registered name)"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl stop rewire-provider 2>&1 || echo 'STOP_FAILED'"
+    capture: stop_v1
+
+  - name: "Brief settle after stopping v1"
+    handler: wait
+    seconds: 3
+
+  - name: "Move provider: start v2 on port 3041 (same pinned agent_id)"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start rewire-provider/main.py --env MCP_MESH_HTTP_PORT=3041 --env MCP_MESH_AGENT_ID=rewire-provider-pinned -d 2>&1 || echo 'START_V2_FAILED'"
+    capture: start_provider_v2
+
+  # --- Poll (do NOT restart the consumer) until it re-wires to v2 (3041) ------
+  # Generous headroom for: v1 health-flip/eviction + v2 registration + the
+  # ~10s reconcile tick + the consumer's re-resolution/apply. Transient call
+  # errors during the flip are tolerated; we keep polling.
+  - name: "Poll consumer until it re-wires to moved provider (expect 3041)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Polling which_provider for re-wire to port 3041 (consumer NOT restarted)..."
+      LAST=""
+      for i in $(seq 1 60); do
+        RES=$(meshctl call which_provider '{}' 2>&1 || true)
+        LAST="$RES"
+        echo "attempt $i: $RES"
+        if echo "$RES" | grep -q "3041"; then
+          echo "RE-WIRED to v2 after ~$((i*2))s"
+          break
+        fi
+        sleep 2
+      done
+      echo "LAST_POLL_RESULT: $LAST"
+    capture: rewire_poll
+    timeout: 180
+
+  # --- Post-move verdict call: must now report 3041 --------------------------
+  - name: "Post-move call: which provider answers now? (expect 3041)"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl call which_provider '{}' 2>&1 || echo 'CALL_FAILED'"
+    capture: postmove_result
+    timeout: 90
+
+  # --- Diagnostics (captured for the report if the guard over-skips) ---------
+  - name: "Diagnostic: consumer logs (resolution/apply state)"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl logs rewire-consumer 2>&1 | tail -60 || echo 'NO_CONSUMER_LOGS'"
+    capture: consumer_logs
+
+  - name: "Diagnostic: agent list after move"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list 2>&1 || true"
+    capture: list_after_move
+
+  - name: "Stop all agents"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl stop 2>/dev/null || true"
+    ignore_errors: true
+
+assertions:
+  # Both registered
+  - expr: "${captured.wait_registered} contains 'rewire-provider'"
+    message: "rewire-provider should register"
+  - expr: "${captured.wait_registered} contains 'rewire-consumer'"
+    message: "rewire-consumer should register"
+
+  # Baseline: wired to v1 (3040), definitely not the future port
+  - expr: "${captured.baseline_result} contains '3040'"
+    message: "BASELINE: consumer should be wired to provider v1 on port 3040"
+  - expr: "${captured.baseline_result} not contains '3041'"
+    message: "BASELINE: consumer must not already report the not-yet-started v2 port 3041"
+
+  # THE re-wire invariant: after the provider moved to 3041 (same agent_id,
+  # new endpoint), the never-restarted consumer must reach the NEW endpoint.
+  # If this reports 3040, the idempotency guard OVER-SKIPPED the endpoint change.
+  - expr: "${captured.postmove_result} contains '3041'"
+    message: "RE-WIRE: after the move, consumer must reach v2 on port 3041 (over-skip if still 3040)"
+  - expr: "${captured.postmove_result} not contains '3040'"
+    message: "RE-WIRE: consumer must NOT still be wired to the old endpoint 3040"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: "meshctl stop 2>/dev/null || true"
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
Closes the two re-wire correctness findings from the topology-change→resolve→re-wire analysis. **A running consumer never needs a manual restart to pick up a topology change** — any stale wiring, from any cause, now self-heals within the reconcile interval.

## #1314 — independent-clock reconcile + idempotent SDK apply

The pipeline records an edge as *delivered* on **enqueue** (`send()`), not on apply, and the mitigating reconcile ran only inside `process_dependency_changes` — i.e. only on a **full heartbeat**, which fires only on a registry topology signal, **never on a wall clock**. So a downstream apply-drop under a subsequently *stable* topology was never re-driven (the "consumer still on the old agent; had to restart it" symptom).

- **Rust core:** extract the re-emit into `maybe_reconcile()` and drive it from **both** the change path (with the cycle's `just_emitted`) and an independent `tokio::time::interval` tick in the run loop (empty `just_emitted`). The shared `last_dep_reconcile` throttle prevents double-fire; `tick()` is cancellation-safe (`Interval` owns the deadline); `MissedTickBehavior::Skip` avoids bursts.
- **SDKs (idempotent apply):** each consumer apply path skips rebuilding a proxy when the incoming resolution equals what's wired — signature `(endpoint, function, kwargs, agent_id)` per dep_key, cleared on the unavailable path. So the ~10s re-emit is **free in steady state** (no proxy/connection churn) and rebuilds only a genuinely stale edge. Covers **both mcp and @mesh.route/api consumer paths**: Python (`rust_heartbeat` + `rust_api_heartbeat`), TS (`MeshAgent` + `ApiRuntime`), Java (`MeshToolWrapperRegistry` + `McpMeshToolProxy`, covering tool + `@MeshRoute` via the single `MeshEventProcessor`).

## #1315 — `agent_id` in the dependency diff gate

`runtime.rs`'s diff compared `endpoint`/`function`/`kwargs` but omitted `agent_id`, so an in-place provider restart (same endpoint, fresh UUID) wasn't diff-detected. Added `agent_id` to the comparison, matching the LLM-provider path. Composes with the SDK guard (agent_id is in the signature → an agent_id-only change still rebuilds).

## Validation

- **Rust core:** `cargo test --lib` **492 + 3** (`test_1314_reconcile_wall_clock`, `test_1314_no_double_emit`, `test_1315_agent_id_diff`).
- **Per-SDK idempotency unit tests:** Python 9 (5 mcp + 4 route), TS 9 (MeshAgent + ApiRuntime), Java 6.
- **End-to-end on rebuilt natives — the decisive proof (`uc40_dependency_rewire`):** a provider moves to a new endpoint with **agent_id pinned so *only* the endpoint changes** (the exact case an over-skipping guard would miss); the consumer is **never restarted** and flips `3040 → 3041` in ~6s. src-tests **12/12**, `uc03_tool_calling` **10/10** (no DI regression). The momentary "not injected" during the flip is the expected settle window — self-healed with no restart.

The reconcile deliberately does **not** tick during a registry-down window (retain-on-disconnect holds; nothing new to reconcile to), and no per-consumer notification/ack state is introduced — the pull-model registry's stateless gate is preserved.

Closes #1314
Closes #1315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dependency updates are now re-applied more intelligently, helping services recover from provider restarts and periodic re-emissions without manual intervention.
  * Added support for re-wiring consumers to a provider that moves to a new endpoint while keeping the same service identity.

* **Bug Fixes**
  * Prevented duplicate dependency refreshes when nothing meaningful changed.
  * Improved detection of provider changes so updates are triggered when service identity changes, not just connection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->