### PR TITLE
fix(cli): healthy-only meshctl list default + CAPS column

### DIFF
--- a/src/core/cli/list.go
+++ b/src/core/cli/list.go
@@ -41,14 +41,16 @@ func NewListCommand() *cobra.Command {
 Shows agent status, dependency resolution, uptime, and endpoint information
 in a docker-compose-style format for easy monitoring.
 
-By default the table shows healthy agents only. Instances superseded by a
-newer registration of the same agent (common with watch-driven restarts)
+By default the table shows healthy (running) agents only. Instances superseded
+by a newer registration of the same agent (common with watch-driven restarts)
 collapse into a dimmed "(+N superseded)" annotation, and down agents are
-reported as a footer count rather than a named row — unless a down instance
-declares a capability that a live agent is missing, in which case it appears
-as a red row to explain the dependency gap. Use --all to see every instance
-(unhealthy instances are purged after MCP_MESH_RETENTION, default 1h).
-With --json, output keeps the healthy-only default for script compatibility.
+reported as a footer count ("N down hidden (use --all)") rather than a named
+row. The DEPS column shows dependencies consumed (resolved/total) and the CAPS
+column shows capabilities provided (available/total); both turn red when short
+of their total. Use --all to see every instance including unhealthy and
+superseded ones (unhealthy instances are purged after MCP_MESH_RETENTION,
+default 1h). With --json, output keeps the healthy-only default for script
+compatibility.
 
 Examples:
   meshctl list                                    # Healthy agents (down agents counted in the footer)
@@ -372,13 +374,12 @@ func runListCommand(cmd *cobra.Command, args []string) error {
 
 	view := computeSupersessionView(output.Agents)
 
-	// Default view (no --all): healthy rows only, preserving the readiness
-	// contract that `meshctl list | grep -q <name>` matching implies a live
-	// agent. Superseded instances collapse into the (+N superseded)
-	// annotation; genuinely-down agents are reported as a nameless footer
-	// count — except a down instance declaring a capability some live agent
-	// is missing, which stays visible as a named red row because it explains
-	// the dependency gap (and readiness greps are failing anyway).
+	// Default view (no --all): healthy rows only (#1309), preserving the
+	// readiness contract that `meshctl list | grep -q <name>` matching implies
+	// a live agent. Superseded instances collapse into the (+N superseded)
+	// annotation; all down agents (including one declaring a capability some
+	// live agent is missing) are hidden and reported as a nameless footer
+	// count, and surfaced with `--all`.
 	var summary listDefaultSummary
 	if !showAll {
 		output.Agents, summary = collapseDefaultView(output.Agents, view)
@@ -1201,67 +1202,57 @@ func formatSupersededAnnotation(count int) string {
 	return fmt.Sprintf(" %s(+%d superseded)%s", colorGray, count, colorReset)
 }
 
-// countUnavailableCapabilities returns the number of the agent's capabilities
-// the registry has marked unavailable (issue #1249). A nil Available pointer
-// means the registry didn't report availability (older versions) and is
-// treated as available, so it never contributes to the count.
-func countUnavailableCapabilities(agent EnhancedAgent) int {
-	n := 0
+// capabilityAvailability returns the (available, total) count of capabilities
+// the agent PROVIDES, feeding the CAPS column (issue #1307). total excludes the
+// framework-internal __mesh_* synthetics — the SAME predicate (on the same
+// function-name key with a Name fallback) `--tools` uses to hide them (#1290),
+// so CAPS counts only user-facing capabilities. A capability is available when
+// the registry reports Available true OR doesn't report it at all (nil, older
+// registries) — so a registry without the #1258 field reads as fully available
+// and never produces a spurious degraded marker.
+func capabilityAvailability(agent EnhancedAgent) (available, total int) {
 	for _, tool := range agent.Tools {
-		if tool.Available != nil && !*tool.Available {
-			n++
+		funcName := tool.FunctionName
+		if funcName == "" {
+			funcName = tool.Name
+		}
+		if isFrameworkInternalTool(funcName) {
+			continue
+		}
+		total++
+		if tool.Available == nil || *tool.Available {
+			available++
 		}
 	}
-	return n
+	return available, total
 }
 
-// formatUnavailableAnnotation renders the red per-row marker flagging a healthy
-// agent that nonetheless owns one or more unavailable capabilities (issue
-// #1249) — e.g. " (1 capability unavailable)". This is the compact signal that
-// some capability's required dependency chain is broken; the per-capability
-// reason is shown by `meshctl list --verbose` and `--tools=<name>`. Empty when
-// the agent has no unavailable capabilities.
-//
-// Suppressed for a non-live agent: the registry marks EVERY capability of an
-// unhealthy agent available:false with reason "agent unhealthy", which is fully
-// redundant with the row's own red status. The capability-level signal is only
-// interesting on a live agent, where it reveals a broken required-dependency
-// chain the agent status alone wouldn't explain.
-func formatUnavailableAnnotation(agent EnhancedAgent) string {
-	if !isLiveStatus(agent.Status) {
-		return ""
+// formatCapabilities renders the CAPS column value "available/total" (issue
+// #1307), mirroring formatDependencies: green when every provided capability is
+// available, red when any is unavailable (available < total).
+func formatCapabilities(available, total int) string {
+	color := colorGreen
+	if available < total {
+		color = colorRed
 	}
-	n := countUnavailableCapabilities(agent)
-	if n <= 0 {
-		return ""
-	}
-	return fmt.Sprintf(" %s(%d capabilit%s unavailable)%s",
-		colorRed, n, pluralY(n), colorReset)
-}
-
-// pluralY returns the correct suffix for "capabilit(y|ies)".
-func pluralY(n int) string {
-	if n == 1 {
-		return "y"
-	}
-	return "ies"
+	return fmt.Sprintf("%s%d/%d%s", color, available, total, colorReset)
 }
 
 // formatListFooter renders the summary line printed after the default table,
-// e.g. "3 agents (3 healthy) - 1 inactive instance hidden (use --all) - 2 superseded hidden".
+// e.g. "3 agents (3 healthy) - 1 down hidden (use --all) - 2 superseded hidden".
 // displayed and healthy count distinct declared agent names among the rendered
-// rows. The hidden down agents counted here are orphaned non-blocking instances
-// (a genuinely blocking down instance is promoted to a visible red row by
-// collapseDefaultView and never reaches this count), so they block nothing and
-// are disclosed in neutral gray as "inactive" pending retention purge rather
-// than as a red "agent down" alarm. The superseded clause is likewise gray, and
+// rows. The hidden down agents counted here are every non-live instance the
+// healthy-only default view suppresses (#1309) — orphaned stale instances as
+// well as a down instance that declares a capability a live agent depends on.
+// They are disclosed in neutral gray as "down" rather than as a red alarm, and
+// surfaced with `--all`. The superseded clause is likewise gray, and
 // "(use --all)" rides on whichever hidden clause appears first. Clauses are
 // omitted when zero.
 func formatListFooter(displayed, healthy int, summary listDefaultSummary) string {
 	footer := fmt.Sprintf("%d agent%s (%d healthy)", displayed, pluralS(displayed), healthy)
 	if summary.hiddenDownAgents > 0 {
-		footer += fmt.Sprintf(" - %s%d inactive instance%s hidden (use --all)%s",
-			colorGray, summary.hiddenDownAgents, pluralS(summary.hiddenDownAgents), colorReset)
+		footer += fmt.Sprintf(" - %s%d down hidden (use --all)%s",
+			colorGray, summary.hiddenDownAgents, colorReset)
 	}
 	if summary.hiddenSuperseded > 0 {
 		clause := fmt.Sprintf("%d superseded hidden", summary.hiddenSuperseded)
@@ -1349,6 +1340,9 @@ func printTableHeader(nameWidth, runtimeWidth, statusWidth, typeWidth, endpointW
 
 	if !noDeps {
 		fmt.Printf(" %-8s", "DEPS")
+		// CAPS mirrors DEPS but for provided capabilities (issue #1307);
+		// right-aligned numeric field, so its header is right-aligned too.
+		fmt.Printf(" %8s", "CAPS")
 	}
 
 	// Always show endpoint in standard view, tools only in wide mode
@@ -1375,7 +1369,7 @@ func printTableHeader(nameWidth, runtimeWidth, statusWidth, typeWidth, endpointW
 func printTableSeparator(nameWidth, runtimeWidth, statusWidth, typeWidth, endpointWidth int, noDeps, wide, verbose bool) {
 	totalWidth := nameWidth + runtimeWidth + statusWidth + typeWidth + 13 // base width including TYPE and RUNTIME columns
 	if !noDeps {
-		totalWidth += 9
+		totalWidth += 18 // DEPS (8+1) + CAPS (8+1)
 	}
 	// Always include endpoint width in standard view
 	totalWidth += endpointWidth + 1
@@ -1433,6 +1427,17 @@ func printAgentRow(agent EnhancedAgent, nameWidth, runtimeWidth, statusWidth, ty
 		if padding > 0 {
 			fmt.Printf("%s", strings.Repeat(" ", padding))
 		}
+
+		// Capabilities column (issue #1307): available/total provided
+		// capabilities, right-aligned in an 8-char field, red when degraded.
+		capsAvail, capsTotal := capabilityAvailability(agent)
+		capsStr := formatCapabilities(capsAvail, capsTotal)
+		capsVisualLen := len(fmt.Sprintf("%d/%d", capsAvail, capsTotal))
+		capsPadding := 8 - capsVisualLen
+		if capsPadding < 0 {
+			capsPadding = 0
+		}
+		fmt.Printf(" %s%s", strings.Repeat(" ", capsPadding), capsStr)
 	}
 
 	// Endpoint column (always shown)
@@ -1459,13 +1464,6 @@ func printAgentRow(agent EnhancedAgent, nameWidth, runtimeWidth, statusWidth, ty
 	// Superseded annotation (pre-colored, includes leading space)
 	if annotation != "" {
 		fmt.Printf("%s", annotation)
-	}
-
-	// Unavailable-capability annotation (issue #1249): flags a live agent whose
-	// capability chain is broken. Rendered even for healthy rows, since a
-	// capability can be unavailable while its owning agent is perfectly healthy.
-	if ua := formatUnavailableAnnotation(agent); ua != "" {
-		fmt.Printf("%s", ua)
 	}
 
 	fmt.Println()
@@ -1991,24 +1989,27 @@ type listDefaultSummary struct {
 	// hiddenSuperseded is the number of superseded instances dropped.
 	hiddenSuperseded int
 	// hiddenDownAgents is the number of distinct declared names hidden
-	// because they are down (not live, not superseded, not blocking).
+	// because they are down (not live, not superseded). Includes blocking
+	// down instances, which are no longer promoted to visible rows (#1309).
 	hiddenDownAgents int
 }
 
 // collapseDefaultView reduces the agent list to the rows shown by the default
-// table (issue #1195): live instances plus down instances that explain a live
-// agent's unresolved dependency (view.blocking). Everything else is hidden and
-// counted in the returned summary — superseded instances per instance, other
-// down agents per distinct declared name — preserving the readiness-check
-// contract that a name appearing in default output implies a live agent
-// (unless it explains a dependency gap).
+// table (issues #1195, #1309): live instances only. Everything non-live is
+// hidden and counted in the returned summary — superseded instances per
+// instance, all other down agents (including a down instance that explains a
+// live agent's dependency gap) per distinct declared name — preserving the
+// readiness-check contract that a name appearing in default output implies a
+// live agent. A blocking down instance is NOT promoted to a visible red row
+// (#1309 reverted #1198's promotion); it is disclosed in the footer's hidden
+// down count and surfaced with `--all`, keeping the default view healthy-only.
 func collapseDefaultView(agents []EnhancedAgent, view supersessionView) ([]EnhancedAgent, listDefaultSummary) {
 	var kept []EnhancedAgent
 	var summary listDefaultSummary
 	downNames := make(map[string]bool)
 	for _, agent := range agents {
 		switch {
-		case isLiveStatus(agent.Status) || view.blocking[agent.ID]:
+		case isLiveStatus(agent.Status):
 			kept = append(kept, agent)
 		case view.superseded[agent.ID]:
 			summary.hiddenSuperseded++

--- a/src/core/cli/list.go
+++ b/src/core/cli/list.go
@@ -1343,6 +1343,9 @@ func printTableHeader(nameWidth, runtimeWidth, statusWidth, typeWidth, endpointW
 		// CAPS mirrors DEPS but for provided capabilities (issue #1307);
 		// right-aligned numeric field, so its header is right-aligned too.
 		fmt.Printf(" %8s", "CAPS")
+		// Extra gap so the right-aligned CAPS value doesn't sit flush against
+		// ENDPOINT.
+		fmt.Printf(" ")
 	}
 
 	// Always show endpoint in standard view, tools only in wide mode
@@ -1369,7 +1372,7 @@ func printTableHeader(nameWidth, runtimeWidth, statusWidth, typeWidth, endpointW
 func printTableSeparator(nameWidth, runtimeWidth, statusWidth, typeWidth, endpointWidth int, noDeps, wide, verbose bool) {
 	totalWidth := nameWidth + runtimeWidth + statusWidth + typeWidth + 13 // base width including TYPE and RUNTIME columns
 	if !noDeps {
-		totalWidth += 18 // DEPS (8+1) + CAPS (8+1)
+		totalWidth += 19 // DEPS (8+1) + CAPS (8+1) + extra gap before ENDPOINT (1)
 	}
 	// Always include endpoint width in standard view
 	totalWidth += endpointWidth + 1
@@ -1438,6 +1441,9 @@ func printAgentRow(agent EnhancedAgent, nameWidth, runtimeWidth, statusWidth, ty
 			capsPadding = 0
 		}
 		fmt.Printf(" %s%s", strings.Repeat(" ", capsPadding), capsStr)
+		// Extra gap so the right-aligned CAPS value doesn't sit flush against
+		// ENDPOINT (matches the header spacing).
+		fmt.Printf(" ")
 	}
 
 	// Endpoint column (always shown)

--- a/src/core/cli/list_test.go
+++ b/src/core/cli/list_test.go
@@ -280,14 +280,16 @@ func TestRegistryCountsDiscloseDownBuckets(t *testing.T) {
 	assert.NotContains(t, s, "2 unhealthy",
 		"a down instance that blocks nothing must not inflate the red unhealthy count")
 
-	// And the footer (orphaned down hidden, blocking promoted to a row).
+	// And the footer: both down instances are hidden in the healthy-only default
+	// (#1309 no longer promotes the blocking one to a visible row), disclosed as
+	// a neutral gray "down" count and surfaced with --all.
 	_, summary := collapseDefaultView(agents, view)
-	require.Equal(t, 1, summary.hiddenDownAgents, "only the orphaned down instance is hidden")
-	footer := formatListFooter(2, 1, summary)
-	assert.Contains(t, footer, colorGray+"1 inactive instance hidden",
-		"the hidden orphan is disclosed as gray inactive in the footer, not red 'agent down'")
+	require.Equal(t, 2, summary.hiddenDownAgents, "both down instances are hidden in the healthy-only default")
+	footer := formatListFooter(1, 1, summary)
+	assert.Contains(t, footer, colorGray+"2 down hidden",
+		"the hidden down instances are disclosed as gray 'down' in the footer, not a red alarm")
 	assert.NotContains(t, footer, colorRed,
-		"nothing in the footer is a genuine alarm: the blocking instance is a visible red row, not a footer count")
+		"nothing in the footer is a genuine alarm: down instances are surfaced with --all")
 }
 
 func TestCollapseDefaultView(t *testing.T) {
@@ -310,7 +312,10 @@ func TestCollapseDefaultView(t *testing.T) {
 			"a non-blocking down agent must be hidden and counted namelessly — `meshctl list | grep -q <name>` matching must imply a live agent")
 	})
 
-	t.Run("blocking down instance promoted to named row", func(t *testing.T) {
+	t.Run("blocking down instance hidden by default", func(t *testing.T) {
+		// #1309 reverts #1198: a down instance that explains a live agent's
+		// dependency gap is NOT promoted to a visible red row — the default view
+		// is strictly healthy-only. It is hidden and disclosed in the footer.
 		provider := testAgent("provider-solo", "provider", "unhealthy", base, nil)
 		provider.Tools = []ToolInfo{{Name: "date_service", Capability: "date_service"}}
 		consumer := testAgent("consumer-1", "consumer", "healthy", base, nil)
@@ -319,14 +324,15 @@ func TestCollapseDefaultView(t *testing.T) {
 		}
 		agents := []EnhancedAgent{provider, consumer}
 		view := computeSupersessionView(agents)
+		require.True(t, view.blocking["provider-solo"], "the provider is still recorded as blocking for the header count")
 
 		kept, summary := collapseDefaultView(agents, view)
 
-		require.Len(t, kept, 2)
-		keptIDs := []string{kept[0].ID, kept[1].ID}
-		assert.Contains(t, keptIDs, "provider-solo",
-			"down instance explaining a live dependency gap must stay visible as a named row")
-		assert.Equal(t, 0, summary.hiddenDownAgents)
+		require.Len(t, kept, 1)
+		assert.Equal(t, "consumer-1", kept[0].ID, "only the healthy consumer is shown")
+		assert.NotContains(t, []string{kept[0].ID}, "provider-solo",
+			"a blocking down instance is hidden from the healthy-only default view")
+		assert.Equal(t, 1, summary.hiddenDownAgents, "the blocking down instance is counted as hidden down")
 		assert.Equal(t, 0, summary.hiddenSuperseded)
 	})
 
@@ -379,36 +385,33 @@ func TestFormatListFooter(t *testing.T) {
 		assert.Equal(t, "7 agents (7 healthy)", footer)
 	})
 
-	t.Run("inactive and superseded clauses", func(t *testing.T) {
+	t.Run("down and superseded clauses", func(t *testing.T) {
 		footer := formatListFooter(3, 3, listDefaultSummary{hiddenSuperseded: 2, hiddenDownAgents: 1})
 		assert.Contains(t, footer, "3 agents (3 healthy)")
-		assert.Contains(t, footer, "1 inactive instance hidden (use --all)")
+		assert.Contains(t, footer, "1 down hidden (use --all)")
 		assert.Contains(t, footer, "2 superseded hidden")
-		// Orphaned non-blocking down instances block nothing, so they are a
-		// muted gray "inactive" disclosure rather than a red "agent down"
-		// alarm (issue #1198).
-		assert.Contains(t, footer, colorGray+"1 inactive instance hidden",
-			"a hidden non-blocking down instance is a neutral gray disclosure, not a red alarm")
+		// Hidden down instances are surfaced with --all, so they are a muted
+		// gray disclosure rather than a red alarm (issues #1198, #1309).
+		assert.Contains(t, footer, colorGray+"1 down hidden",
+			"a hidden down instance is a neutral gray disclosure, not a red alarm")
 		assert.NotContains(t, footer, colorRed,
 			"no clause in this footer is a genuine alarm, so nothing renders red")
-		assert.NotContains(t, footer, "agent down",
-			"the alarming 'agent down' wording is reserved; hidden orphans read as 'inactive'")
 		assert.Contains(t, footer, colorGray+"2 superseded hidden",
 			"the superseded clause is neutral gray")
 		assert.NotContains(t, footer, "superseded hidden (use --all)",
-			"--all hint is not repeated when the inactive clause already carries it")
+			"--all hint is not repeated when the down clause already carries it")
 	})
 
 	t.Run("superseded-only clause carries the --all hint", func(t *testing.T) {
 		footer := formatListFooter(7, 7, listDefaultSummary{hiddenSuperseded: 8})
 		assert.Contains(t, footer, "8 superseded hidden (use --all)")
-		assert.NotContains(t, footer, "inactive")
+		assert.NotContains(t, footer, "down hidden")
 	})
 
-	t.Run("plural inactive clause", func(t *testing.T) {
+	t.Run("plural down clause", func(t *testing.T) {
 		footer := formatListFooter(1, 1, listDefaultSummary{hiddenDownAgents: 2})
 		assert.Contains(t, footer, "1 agent (1 healthy)")
-		assert.Contains(t, footer, "2 inactive instances hidden (use --all)")
+		assert.Contains(t, footer, "2 down hidden (use --all)")
 		assert.NotContains(t, footer, colorRed)
 	})
 }
@@ -490,75 +493,154 @@ func TestFormatSupersededAnnotation(t *testing.T) {
 
 func boolPtr(b bool) *bool { return &b }
 
-// TestCountUnavailableCapabilities covers the nil/true/false tri-state of the
-// per-capability Available pointer. nil (older registries that don't report
-// availability) must be treated as available and never counted.
-func TestCountUnavailableCapabilities(t *testing.T) {
+// TestCapabilityAvailability covers the (available, total) computation feeding
+// the CAPS column (issue #1307): the nil/true/false tri-state of the
+// per-capability Available pointer (nil = available), and the __mesh_*
+// framework-synthetic exclusion from BOTH counts.
+func TestCapabilityAvailability(t *testing.T) {
 	agent := EnhancedAgent{
 		Tools: []ToolInfo{
-			{Name: "greet", Available: boolPtr(true)},
-			{Name: "forecast", Available: boolPtr(false), UnavailableReason: "required dep 'weather-api' unresolved"},
-			{Name: "legacy", Available: nil}, // registry didn't report -> available
-			{Name: "enrich", Available: boolPtr(false)},
+			{Name: "greet", FunctionName: "greet", Available: boolPtr(true)},
+			{Name: "forecast", FunctionName: "forecast", Available: boolPtr(false), UnavailableReason: "required dep 'weather-api' unresolved"},
+			{Name: "legacy", FunctionName: "legacy", Available: nil}, // registry didn't report -> available
+			{Name: "enrich", FunctionName: "enrich", Available: boolPtr(false)},
 		},
 	}
-	assert.Equal(t, 2, countUnavailableCapabilities(agent),
-		"only capabilities with Available==false count; nil is treated as available")
+	avail, total := capabilityAvailability(agent)
+	assert.Equal(t, 4, total, "all four user capabilities count toward the total")
+	assert.Equal(t, 2, avail,
+		"Available==false subtracts; nil (unreported) counts as available")
 
-	assert.Equal(t, 0, countUnavailableCapabilities(EnhancedAgent{
-		Tools: []ToolInfo{{Name: "a", Available: boolPtr(true)}, {Name: "b"}},
-	}), "an agent with no unavailable capabilities counts zero")
-}
-
-// TestFormatUnavailableAnnotation guards the compact per-row marker: empty when
-// nothing is unavailable, singular/plural wording otherwise, and always red so
-// it reads as an alarm even on a healthy (green) row.
-func TestFormatUnavailableAnnotation(t *testing.T) {
-	// All available -> no annotation.
-	assert.Empty(t, formatUnavailableAnnotation(EnhancedAgent{
-		Status: "healthy",
-		Tools:  []ToolInfo{{Name: "a", Available: boolPtr(true)}},
-	}))
-	// nil Available -> treated as available -> no annotation.
-	assert.Empty(t, formatUnavailableAnnotation(EnhancedAgent{
-		Status: "healthy",
-		Tools:  []ToolInfo{{Name: "a"}},
-	}))
-
-	one := formatUnavailableAnnotation(EnhancedAgent{
-		Status: "healthy",
-		Tools:  []ToolInfo{{Name: "a", Available: boolPtr(false)}},
-	})
-	assert.Contains(t, one, "(1 capability unavailable)")
-	assert.Contains(t, one, colorRed, "the marker must render red")
-
-	two := formatUnavailableAnnotation(EnhancedAgent{
-		Status: "healthy",
+	// __mesh_* synthetics are excluded from both counts, matching --tools hiding.
+	withFramework := EnhancedAgent{
 		Tools: []ToolInfo{
-			{Name: "a", Available: boolPtr(false)},
-			{Name: "b", Available: boolPtr(false)},
+			{Name: "greet", FunctionName: "greet", Available: boolPtr(true)},
+			{Name: "job_status", FunctionName: "__mesh_job_status", Available: boolPtr(false)},
+			{Name: "svc_deps", FunctionName: "__mesh_service_deps", Available: boolPtr(false)},
 		},
-	})
-	assert.Contains(t, two, "(2 capabilities unavailable)")
+	}
+	avail, total = capabilityAvailability(withFramework)
+	assert.Equal(t, 1, total, "framework __mesh_* synthetics are excluded from the total")
+	assert.Equal(t, 1, avail, "excluded synthetics never drag availability down")
+
+	// FunctionName empty -> falls back to Name for the framework check.
+	fallback := EnhancedAgent{
+		Tools: []ToolInfo{{Name: "__mesh_job_result", Available: boolPtr(false)}},
+	}
+	avail, total = capabilityAvailability(fallback)
+	assert.Equal(t, 0, total, "the __mesh_* Name fallback excludes the synthetic")
+	assert.Equal(t, 0, avail)
 }
 
-// TestFormatUnavailableAnnotation_SuppressedForUnhealthyAgent guards the
-// double-signal fix: the registry marks EVERY capability of an unhealthy agent
-// available:false (reason "agent unhealthy"), which is redundant with the row's
-// own red status. The annotation must therefore be suppressed on a non-live
-// agent even though its capabilities are technically unavailable.
-func TestFormatUnavailableAnnotation_SuppressedForUnhealthyAgent(t *testing.T) {
-	for _, status := range []string{"unhealthy", "", "unknown"} {
-		agent := EnhancedAgent{
-			Status: status,
-			Tools: []ToolInfo{
-				{Name: "a", Available: boolPtr(false), UnavailableReason: "agent unhealthy"},
-				{Name: "b", Available: boolPtr(false), UnavailableReason: "agent unhealthy"},
-			},
-		}
-		assert.Empty(t, formatUnavailableAnnotation(agent),
-			"unavailable annotation must be suppressed for non-live status %q", status)
+// TestFormatCapabilities guards the CAPS column value: green when every provided
+// capability is available, red the moment any is unavailable (available < total).
+func TestFormatCapabilities(t *testing.T) {
+	// Fully available -> green.
+	full := formatCapabilities(3, 3)
+	assert.Contains(t, full, "3/3")
+	assert.Contains(t, full, colorGreen)
+	assert.NotContains(t, full, colorRed)
+
+	// No capabilities -> green 0/0 (never a false alarm).
+	assert.Contains(t, formatCapabilities(0, 0), colorGreen)
+
+	// Degraded -> red.
+	degraded := formatCapabilities(2, 3)
+	assert.Contains(t, degraded, "2/3")
+	assert.Contains(t, degraded, colorRed, "any shortfall renders red")
+}
+
+// TestPrintAgentRow_CapsColumnReplacesTrailingText guards issue #1307: a healthy
+// agent with a broken capability renders a red CAPS available/total value and no
+// longer carries the trailing "(N capabilities unavailable)" free-text.
+func TestPrintAgentRow_CapsColumnReplacesTrailingText(t *testing.T) {
+	agent := testAgent("analyst-1", "analyst", "healthy", time.Now().Add(-time.Hour), nil)
+	agent.Runtime = "python"
+	agent.Endpoint = "http://localhost:9001"
+	agent.Tools = []ToolInfo{
+		{Name: "summarize", FunctionName: "summarize", Capability: "summarize", Available: boolPtr(true)},
+		{Name: "forecast", FunctionName: "forecast", Capability: "forecast", Available: boolPtr(false), UnavailableReason: "required dep unresolved"},
+		{Name: "job_status", FunctionName: "__mesh_job_status", Available: boolPtr(false)},
 	}
+	nameW, rtW, stW, tyW, epW := calculateColumnWidths([]EnhancedAgent{agent}, false)
+
+	out := captureStdout(t, func() {
+		printAgentRow(agent, nameW, rtW, stW, tyW, epW, false, false, false, "", false)
+	})
+
+	assert.Contains(t, out, colorRed+"1/2",
+		"CAPS shows available/total user capabilities (excluding __mesh_*) and reddens when degraded")
+	assert.NotContains(t, out, "capability unavailable",
+		"the trailing (N capability unavailable) free-text is gone — the CAPS column replaces it")
+	assert.NotContains(t, out, "capabilities unavailable")
+}
+
+// TestVerboseDetailsKeepsUnavailableReasons guards that #1307 only moved the
+// terse trailing count into the CAPS column — the per-capability reason detail
+// still renders under --verbose.
+func TestVerboseDetailsKeepsUnavailableReasons(t *testing.T) {
+	agent := testAgent("analyst-1", "analyst", "healthy", time.Now().Add(-time.Hour), nil)
+	agent.Tools = []ToolInfo{
+		{Name: "forecast", FunctionName: "forecast", Capability: "forecast",
+			Available: boolPtr(false), UnavailableReason: "required dep 'weather-api' unresolved"},
+	}
+
+	out := captureStdout(t, func() { printVerboseDetails([]EnhancedAgent{agent}) })
+
+	assert.Contains(t, out, "unavailable: required dep 'weather-api' unresolved",
+		"--verbose keeps the per-capability unavailable reason")
+}
+
+// TestOutputDockerComposeStyle_HeaderFooterConsistent is an end-to-end guard over
+// issue #1309: with a blocking down instance hidden from the healthy-only default
+// view, the footer's "N agents (N healthy)" claim never contradicts the rows on
+// screen (no red status row is rendered), and the down instance is disclosed as a
+// gray "down hidden" footer count rather than a red row.
+func TestOutputDockerComposeStyle_HeaderFooterConsistent(t *testing.T) {
+	base := time.Now().Add(-time.Hour)
+	provider := testAgent("provider-solo", "provider", "unhealthy", base, nil)
+	provider.Runtime = "python"
+	provider.Tools = []ToolInfo{{Name: "date_service", FunctionName: "date_service", Capability: "date_service"}}
+	consumer := testAgent("consumer-1", "consumer", "healthy", base, nil)
+	consumer.Runtime = "python"
+	consumer.DependencyResolutions = []DependencyResolution{{Capability: "date_service", Status: "unresolved"}}
+
+	agents := []EnhancedAgent{provider, consumer}
+	headerView := computeSupersessionView(agents)
+
+	t.Run("default view hides the blocking down row", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			kept := agents
+			view := computeSupersessionView(kept)
+			collapsed, summary := collapseDefaultView(kept, view)
+			output := ListOutput{
+				Registry: RegistryStatus{Status: "running", HealthyCount: 1, UnhealthyCount: 1},
+				Agents:   collapsed,
+			}
+			require.NoError(t, outputDockerComposeStyle(output, headerView, view, summary, false, false, false, false))
+		})
+
+		assert.Contains(t, out, "CAPS", "the CAPS column header is present")
+		assert.Contains(t, out, "consumer-1", "the healthy agent is shown")
+		assert.NotContains(t, out, "provider-solo",
+			"the blocking down instance is hidden from the healthy-only default view")
+		assert.Contains(t, out, "1 agent (1 healthy)", "footer reports only the shown healthy agent")
+		assert.Contains(t, out, "1 down hidden (use --all)", "the hidden down instance is disclosed in gray")
+	})
+
+	t.Run("--all shows the down agent", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			view := computeSupersessionView(agents)
+			output := ListOutput{
+				Registry: RegistryStatus{Status: "running", HealthyCount: 1, UnhealthyCount: 1},
+				Agents:   agents,
+			}
+			require.NoError(t, outputDockerComposeStyle(output, headerView, view, listDefaultSummary{}, true, false, false, false))
+		})
+
+		assert.Contains(t, out, "provider-solo", "--all surfaces the down instance")
+		assert.Contains(t, out, "consumer-1")
+	})
 }
 
 // TestFormatToolUnavailableMarker covers the bulk `--tools` table suffix: shown
@@ -624,8 +706,10 @@ func TestProcessAgentData_ParsesAvailability(t *testing.T) {
 		"required dep 'weather-api' unresolved (via analyst → enricher)",
 		forecast.UnavailableReason)
 
-	// And the derived aggregate the row marker uses.
-	assert.Equal(t, 1, countUnavailableCapabilities(agent))
+	// And the derived aggregate the CAPS column uses.
+	avail, total := capabilityAvailability(agent)
+	assert.Equal(t, 1, avail, "one of the two capabilities is available")
+	assert.Equal(t, 2, total, "both user capabilities count toward the total")
 }
 
 // --- RFC #1280 phase 4: service grouping (display-only) ---------------------

--- a/src/core/cli/man/content/cli.md
+++ b/src/core/cli/man/content/cli.md
@@ -139,13 +139,13 @@ meshctl status --registry-url http://remote:8000
 
 Lists agents, tools, or canonical schemas depending on flags.
 
-By default the agent table shows healthy agents only. Instances superseded by
-a newer registration of the same agent (common with watch-driven restarts)
-collapse into a dimmed `(+N superseded)` annotation, and down agents are
-counted in the footer rather than shown as named rows — unless a down instance
-declares a capability a live agent is missing, in which case it appears as a
-red row to explain the dependency gap. `--json` keeps the healthy-only default
-for script compatibility.
+By default the agent table shows healthy (running) agents only. Instances
+superseded by a newer registration of the same agent (common with watch-driven
+restarts) collapse into a dimmed `(+N superseded)` annotation, and down agents
+are counted in the footer (`N down hidden (use --all)`) rather than shown as
+named rows. Use `--all` to see every instance, including unhealthy and
+superseded ones. `--json` keeps the healthy-only default for script
+compatibility.
 
 ```bash
 # Agents (default)
@@ -173,14 +173,24 @@ meshctl list --schemas --limit 20  # Last 20
 meshctl list --schemas --json      # Raw envelope from GET /schemas
 ```
 
+The agent table carries two resolution columns: `DEPS` (dependencies the agent
+consumes, `resolved/total`) and `CAPS` (capabilities the agent provides,
+`available/total`). Both turn red when short of their total. The `CAPS` total
+excludes the framework-internal `__mesh_*` synthetics:
+
+```
+NAME       RUNTIME  TYPE   STATUS   DEPS     CAPS  ENDPOINT               AGE   LAST SEEN
+------------------------------------------------------------------------------------------
+analyst    Python   Agent  healthy  1/1       1/2  http://localhost:9001  2h    5s
+greeter    Python   Agent  healthy  0/0       3/3  http://localhost:9002  2h    3s
+```
+
 **Capability availability.** When an agent is healthy but one of its
-capabilities has a broken `required` dependency chain, its row is flagged in
-red with `(N capabilities unavailable)`. `--verbose` expands each affected
+capabilities has a broken `required` dependency chain, that shortfall shows in
+its red `CAPS` column (`available/total`). `--verbose` expands each affected
 tool with its reason (`[unavailable: required dep '…' unresolved]`); the
 `--tools` table marks the row with a trailing red `unavailable`; and
-`--tools=<name>` prints an `Availability:` line naming the broken edge. The
-markers appear only on healthy agents — an unhealthy agent's capabilities are
-all unavailable by definition, so the row status already says so.
+`--tools=<name>` prints an `Availability:` line naming the broken edge.
 
 **Grouped service views (`--services`).** `meshctl list --services` renders one
 row per (capability, agent), with the SERVICE column derived from the


### PR DESCRIPTION
Two related `meshctl list` output fixes.

## `Closes #1309` — restore healthy-only default + reconcile counts

PR #1198 promoted a "blocking" down instance (one declaring a capability some live agent has an unresolved dep on) to a **red row in the default view**, and the header (per-instance) and footer (per-name) counts could **contradict what's on screen** — e.g. `8 agents (8 healthy)` printed while an unhealthy red row was visible.

- Dropped the `|| view.blocking[agent.ID]` promotion in `collapseDefaultView` → the default view keeps only **live (healthy/running)** rows; blocking-down joins ordinary down in the hidden `N down hidden (use --all)` footer clause.
- With no non-healthy rows in the default table, the per-name footer is **self-consistent by construction**. The dependency-gap signal is preserved from the consumer side (the `(N capabilities unavailable)` info, now the CAPS column).
- `--all` (unhealthy + superseded) and the JSON healthy-only default are unaffected. The ~20 grep-readiness integration checks gate on healthy rows, so a strict healthy-only default is what they expect.

## `Closes #1307` — CAPS column

- New **`CAPS`** column parallel to `DEPS`: `available/total` capabilities the agent **provides**, right-aligned, **red when `available < total`** (mirrors `DEPS` coloring).
- `total` **excludes the synthetic `__mesh_*` family** (same predicate as the `--tools` #1290 hiding); `available` uses the #1258 per-capability availability (nil / older registries = available → no spurious markers).
- Replaces the trailing `(N capabilities unavailable)` free-text on the default rows; **per-capability reasons stay in `--verbose`**. `--json` unchanged (structured fields already present).

```
NAME                RUNTIME  TYPE   STATUS   DEPS   CAPS   ENDPOINT ...
```

## Man page

`cli.md` `meshctl list` section updated: healthy-only default + `--all`, the DEPS/CAPS table, and the shortfall signal moved to the red `CAPS` column + `--verbose` reasons.

## Validation

`go build` clean; `cli/...` suite green including new tests — CAPS tri-state + `__mesh_*` exclusion (`TestCapabilityAvailability`), red-when-degraded (`TestFormatCapabilities`), trailing-text-replaced (`TestPrintAgentRow_CapsColumnReplacesTrailingText`), and header/footer consistency in both default and `--all` (`TestOutputDockerComposeStyle_HeaderFooterConsistent`).

## Follow-up (not in this PR)

meshui `AgentDetail` CAPS-column parity — separate TS/React surface.

Closes #1309
Closes #1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)