### PR TITLE
docs(man): fix stale A2A producer-parity claims + wrong media import

### DIFF
--- a/src/core/cli/man/content/a2a.md
+++ b/src/core/cli/man/content/a2a.md
@@ -7,7 +7,7 @@
 
 MCP Mesh implements the A2A v1.0 protocol on both sides of the wire:
 
-- **Producer** (Python only today): expose mesh tools as A2A skills via `@mesh.a2a` + `mesh.a2a.mount(app, ...)`. Auto-generates `/.well-known/agent.json` and the JSON-RPC entry route.
+- **Producer** (Python, Java, TypeScript): expose mesh tools as A2A skills — Python `@mesh.a2a` + `mesh.a2a.mount(app, ...)`, Java `@MeshA2A`, TypeScript `mesh.a2a.mount(app, ...)`. Auto-generates `/.well-known/agent.json` and the JSON-RPC entry route. Sync, long-running, and SSE surfaces in all three.
 - **Consumer** (Python, Java, TypeScript): bridge an external A2A skill into the mesh as a regular capability. Downstream callers consume it with no awareness of A2A.
 
 Cross-vendor failover, DDDI, health-driven rewiring, and long-running jobs all apply on top — without any changes to the A2A protocol itself. See `https://mcp-mesh.ai/a2a/` for the full guide with diagrams and architecture deep-dive.
@@ -96,7 +96,7 @@ public class DateConsumerAgentApplication {
 }
 ```
 
-## Producer (Python only)
+## Producer
 
 ```python
 import mesh
@@ -131,7 +131,7 @@ The user owns the FastAPI app AND the uvicorn lifecycle (no `@mesh.agent` decora
 
 A single Python process may NOT host both `@mesh.tool` capabilities and a `mesh.a2a.mount(...)` surface — the framework rejects mixed-mode at boot. Split into two agents (one provider, one A2A surface that depends on it).
 
-Java and TypeScript producer support is future work.
+The same producer surface ships in Java (`@MeshA2A`) and TypeScript (`mesh.a2a.mount(...)`), each with the identical sync / long-running / SSE behavior — see the respective SDK docs for the runtime-specific syntax.
 
 ## Consumer (Python / Java / TypeScript)
 

--- a/src/core/cli/man/content/decorators.md
+++ b/src/core/cli/man/content/decorators.md
@@ -13,7 +13,7 @@ MCP Mesh provides decorators (Python), annotations (Java), and function wrappers
 | `@mesh.llm`          | Enable LLM-powered tools        |
 | `@mesh.llm_provider` | Create LLM provider (zero-code) |
 | `@mesh.route`        | FastAPI route with mesh DI      |
-| `@mesh.a2a`          | Expose mesh tools as A2A v1.0 skills (producer, Python only) |
+| `@mesh.a2a`          | Expose mesh tools as A2A v1.0 skills (producer; Java `@MeshA2A`, TypeScript `mesh.a2a.mount`) |
 | `@mesh.a2a_consumer` | Bridge an external A2A skill into the mesh as a capability   |
 
 ## Decorator Order (Critical!)
@@ -224,7 +224,7 @@ async def chat_endpoint(
 
 See `meshctl man api` for complete FastAPI integration guide.
 
-## @mesh.a2a (Producer — Python only)
+## @mesh.a2a (Producer)
 
 Expose mesh tools as A2A v1.0 skills via the `mesh.a2a.mount(...)` style. The user owns the FastAPI app AND the uvicorn lifecycle — no `@mesh.agent` decorator. The mount auto-generates the `/.well-known/agent.json` card and the JSON-RPC entry route.
 
@@ -260,7 +260,7 @@ The mount attaches both:
 
 **Note**: A single Python process may NOT host both `@mesh.tool` capabilities and a `mesh.a2a.mount(...)` surface — the framework rejects mixed-mode at boot. Split into two agents (one provider, one A2A surface that depends on it).
 
-Java and TypeScript producer support is future work.
+The same producer surface ships in Java (`@MeshA2A`) and TypeScript (`mesh.a2a.mount(...)`), each with the identical sync / long-running / SSE behavior.
 
 See `meshctl man a2a` for the full producer + bearer auth + skill-card guide.
 

--- a/src/core/cli/man/content/decorators_java.md
+++ b/src/core/cli/man/content/decorators_java.md
@@ -411,7 +411,7 @@ public class DateConsumerAgentApplication {
 
 Bearer auth is wired via `@A2AConsumer(authBearerEnv = "UPSTREAM_TOKEN")` when the upstream card requires it.
 
-A2A producer support in Java is future work — only consumer is available today.
+Java ships the A2A producer surface too via the `@MeshA2A` annotation (sync, long-running, and SSE) — see `meshctl man a2a` for the producer guide.
 
 See `meshctl man a2a` for the full A2A protocol bridge guide.
 

--- a/src/core/cli/man/content/decorators_typescript.md
+++ b/src/core/cli/man/content/decorators_typescript.md
@@ -291,7 +291,7 @@ agent.addTool({
 
 Bearer auth is wired via `a2aConfig.auth = { tokenEnv: "UPSTREAM_TOKEN" }` when the upstream card requires it.
 
-A2A producer support in TypeScript is future work — only consumer is available today.
+TypeScript ships the A2A producer surface too via `mesh.a2a.mount(app, config, handler)` (sync, long-running, and SSE) — see `meshctl man a2a` for the producer guide.
 
 See `meshctl man a2a` for the full A2A protocol bridge guide.
 

--- a/src/core/cli/man/content/media.md
+++ b/src/core/cli/man/content/media.md
@@ -44,7 +44,7 @@ so CI/local-dev environments without real AWS creds keep working).
 ## Uploading Media
 
 ```python
-from mcp_mesh import mesh
+import mesh
 
 uri = await mesh.upload_media(png_bytes, "chart.png", "image/png")
 ```


### PR DESCRIPTION
Two factual bugs on the hand-maintained `meshctl man` content surface (surfaced during the docs audit).

## Closes #1310

**1. A2A producers are no longer Python-only.** Java (`@MeshA2A`) and TypeScript (`mesh.a2a.mount`) A2A producers ship today (sync + long-running + SSE), with runnable examples (`examples/java/producer-*`). But several man pages still claimed they were "Python only" / "future work":
- `a2a.md` — the producer bullet (L10), the `## Producer (Python only)` heading (L99), and "Java and TypeScript producer support is future work" (L134).
- `decorators.md`, `decorators_java.md`, `decorators_typescript.md` — the same false claim (`(producer, Python only)`, "A2A producer support in Java/TypeScript is future work — only consumer is available today").

All corrected to name the real surfaces (`@mesh.a2a`/`mesh.a2a.mount`, `@MeshA2A`, `mesh.a2a.mount`) with the sync/long-running/SSE parity note. Surface names verified against the runtime source.

**2. `media.md` wrong import.** `from mcp_mesh import mesh` → `import mesh` (there is no `mcp_mesh` package; canonical is `import mesh`).

## Deliberately left (separate, accurate claims)
`a2a.md` OAuth/mTLS "future work" (A2A auth, not producer parity) and the `jobs*.md` MeshJob-resumable-mode "future work" (tracked in `MESHJOB_DESIGN.org`).

Man-content only; `+9/−9`.

Closes #1310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that A2A producer support is available across Python, Java, and TypeScript.
  * Updated the producer guidance to describe consistent sync, long-running, and SSE behavior in all supported runtimes.
  * Revised language in the decorator and language-specific guides to remove outdated “future work” messaging.
  * Corrected a Python media example to use the current import style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->