### PR TITLE
docs: reframe "Why MCP Mesh?" around the DDDI thesis

### DIFF
--- a/docs/00-why-mcp-mesh/index.md
+++ b/docs/00-why-mcp-mesh/index.md
@@ -1,15 +1,25 @@
 # Why MCP Mesh?
 
-## The Problem: Building Agents is Easy, Deploying Them is Hard
+## The problem isn't building an agent. It's everything that happens when agents need each other.
 
-Every AI framework lets you build agents. But when it's time to deploy:
+Every framework helps you build an agent. Then the real work starts: that agent needs another — and in production the other one moves, dies, gets a new version, scales to ten copies, runs an LLM, holds state, or is written in another language. Most frameworks hand you a *pile* of separate problems — service discovery here, a retry library there, a job queue, a config system, a deployment story — and say _"that's your problem,"_ five times over.
 
-- **How do you deploy 10 agents to Kubernetes?**
-- **How do agents discover each other at runtime?**
-- **How do you scale Agent A independently from Agent B?**
-- **How do you monitor which agent called which?**
+Mesh has one answer to all of them, and it's a single idea: **Distributed Dynamic Dependency Injection (DDDI).** You declare what a piece of your system *needs* — a capability — and the mesh finds it, types it, health-routes it, and hot-swaps it at runtime, across machines and languages. That's the whole primitive. Everything else in mesh is a _consequence_ of it — which is why mesh is large in features but small in ideas.
 
-The answer from most frameworks: _"That's your problem."_
+Because a dependency is a *live, resolved capability*, problems that are normally entire subsystems just fall out:
+
+- **An LLM is a dependency** → "prefer Claude, fall back to Gemini," model routing, and provider failover become declarations, not integrations.
+- **A long-running job is a dependency that outlives the call** → durable jobs, resume, and cancel come for free — same primitive, longer lifetime.
+- **A group of capabilities is a dependency you bundle** → a typed *service view*, functions from many agents behind one interface each resolving on its own, is just DDDI applied N times.
+- **A dependency that moved, died, or upgraded re-wires itself** → the running consumer never restarts; a better provider appears and it rebinds live.
+- **A Python capability consumed by Java is still just a dependency** → polyglot, typed, identical semantics, because the *mesh* owns the contract, not the language.
+- **Local and Kubernetes are the same declaration** → same code, different transport; there's no second mental model between "build" and "deploy."
+
+None of those is a bolt-on you integrate. They're the same idea from different angles. The traditionally-hard parts of a distributed AI system don't get _solved_ in mesh so much as they **stop being separate problems.**
+
+So the "why" isn't "mesh has a feature for that." It's: **learn one idea — DDDI — and a platform's worth of hard problems quietly disappears.** You describe what your agents need; the mesh makes it true, keeps it true, and rearranges the world underneath them without asking.
+
+And yes — it also deploys to Kubernetes, scales each agent independently, and traces every call. But that's the reassurance, not the reason.
 
 ---
 
@@ -78,7 +88,7 @@ That's a complete agent with:
 
 ### 1. True DDDI (Distributed Dynamic Dependency Injection)
 
-MCP Mesh is the only framework with **Distributed Dynamic Dependency Injection**. Dependencies are discovered, injected, and hot-swapped at runtime across machines and languages — no config files, no restarts. [What is DDDI? -->](../concepts/dddi.md)
+DDDI is the one idea everything above rests on — no other framework has it. If you skipped the opener: dependencies are discovered, typed, health-routed, and hot-swapped at runtime across machines and languages, with no config files and no restarts. [What is DDDI? -->](../concepts/dddi.md)
 
 ### 2. Decorators That Do Everything
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ template: home.html
 You write the logic. The mesh discovers, connects, heals, and traces — across languages, machines, and clouds.
 
 !!! tip "Complete Platform for AI Agents"
-MCP Mesh is a complete platform for **building and deploying AI agents to production scale**. [See how MCP Mesh compares →](00-why-mcp-mesh/index.md)
+MCP Mesh is a complete platform for **building and deploying AI agents to production scale** — and it's all built on one idea, **DDDI**: you declare a capability, and the mesh resolves, types, heals, and hot-swaps it at runtime. [See how MCP Mesh compares →](00-why-mcp-mesh/index.md)
 
 !!! info "What is DDDI?"
 **Distributed Dynamic Dependency Injection** — dependencies are discovered, injected, and updated at runtime across machines, languages, and clouds. No configuration files, no restart required. [Learn more →](concepts/dddi.md)


### PR DESCRIPTION
## What

Reframes the **Why MCP Mesh?** page to lead with the programming model instead of ops.

## Why

The page opened with an ops framing — *"Building agents is easy, deploying them is hard"* + four deploy/scale/discover/trace questions. That's the commodity layer generic k8s/Helm/service-mesh tooling can also claim (two of the four questions aren't even agent-specific), so it undersold mesh and read like "a Helm chart + Consul for agents." The differentiator isn't ops — it's that **agents have to depend on each other, and every other framework makes you hand-write that wiring.**

## Changes

- **`docs/00-why-mcp-mesh/index.md`** — new opener: the hard part isn't building an agent, it's what happens when agents need each other, and mesh answers it with **one idea — DDDI**. The breadth (LLM-as-dependency, durable jobs, service views, hot-swap, polyglot, local≡k8s) is presented as *consequences* of the single primitive — "large in features but small in ideas" — not a feature checklist. Ops becomes a closing one-line reassurance. The redundant `### 1. True DDDI` block is now a back-reference; **all strong material preserved** (framework comparison, decorator/auto-DI examples, and the "15 requirements, 14 lines" portfolio example untouched).
- **`docs/index.md`** — home hook echoes the DDDI thesis in one line.
- **`README.md` + persona "Why" sections** — left as-is; they're already model-first.

## Validation

`mkdocs build --strict` — clean apart from the pre-existing Material for MkDocs 2.0 advisory nag (unrelated). Docs-only change; no code/wire/registry impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reframed the introduction to focus on agents depending on other dynamically moving agents.
  - Added and clarified the Distributed Dynamic Dependency Injection (DDDI) concept.
  - Updated homepage messaging to highlight production-scale AI agent development and runtime dependency resolution.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->