### PR TITLE
feat(meshui): collapse live agent replicas into a single ×N entry (#1328)

### DIFF
--- a/cmd/mcp-mesh-ui/dist/index.html
+++ b/cmd/mcp-mesh-ui/dist/index.html
@@ -10,8 +10,8 @@
       window.__MESH_BASE_PATH__ = window.__MESH_BASE_PATH__ || "";
       window.__MESH_REGISTRY_URL__ = window.__MESH_REGISTRY_URL__ || "";
     </script>
-    <script type="module" crossorigin src="./assets/index-BH6sKVIS.js"></script>
-    <link rel="stylesheet" crossorigin href="./assets/index-D-K0AOPU.css">
+    <script type="module" crossorigin src="./assets/index-Jhoh_D38.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-C8jMKAKW.css">
   </head>
   <body class="antialiased">
     <div id="root"></div>

--- a/cmd/mcp-mesh-ui/dist/index.html
+++ b/cmd/mcp-mesh-ui/dist/index.html
@@ -10,7 +10,7 @@
       window.__MESH_BASE_PATH__ = window.__MESH_BASE_PATH__ || "";
       window.__MESH_REGISTRY_URL__ = window.__MESH_REGISTRY_URL__ || "";
     </script>
-    <script type="module" crossorigin src="./assets/index-Jhoh_D38.js"></script>
+    <script type="module" crossorigin src="./assets/index-CSLaz6-u.js"></script>
     <link rel="stylesheet" crossorigin href="./assets/index-C8jMKAKW.css">
   </head>
   <body class="antialiased">

--- a/src/ui/__tests__/agent-group.test.ts
+++ b/src/ui/__tests__/agent-group.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { Agent } from "../lib/types";
+import { groupKeyOf, aggregateStatus, groupAgentsByName } from "../lib/agent-group";
+import { buildIdToNodeKey } from "../lib/topology";
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "svc-00000000",
+    name: "svc",
+    agent_type: "mcp_agent",
+    status: "healthy",
+    endpoint: "http://svc:8080",
+    total_dependencies: 0,
+    dependencies_resolved: 0,
+    capabilities: [],
+    ...overrides,
+  };
+}
+
+describe("groupKeyOf", () => {
+  it("uses agent.name as the canonical key", () => {
+    expect(groupKeyOf(makeAgent({ name: "fortuna", id: "fortuna-abc12345" }))).toBe("fortuna");
+  });
+
+  it("falls back to id when name is empty", () => {
+    expect(groupKeyOf(makeAgent({ name: "", id: "legacy-99999999" }))).toBe("legacy-99999999");
+  });
+});
+
+describe("aggregateStatus", () => {
+  it("returns healthy when all instances are healthy", () => {
+    expect(aggregateStatus([makeAgent(), makeAgent()])).toBe("healthy");
+  });
+
+  it("is worst-of: healthy + unhealthy -> unhealthy", () => {
+    expect(
+      aggregateStatus([makeAgent({ status: "healthy" }), makeAgent({ status: "unhealthy" })]),
+    ).toBe("unhealthy");
+  });
+
+  it("is worst-of: healthy + unknown -> unknown", () => {
+    expect(
+      aggregateStatus([makeAgent({ status: "healthy" }), makeAgent({ status: "unknown" })]),
+    ).toBe("unknown");
+  });
+
+  it("prefers unhealthy over unknown", () => {
+    expect(
+      aggregateStatus([makeAgent({ status: "unknown" }), makeAgent({ status: "unhealthy" })]),
+    ).toBe("unhealthy");
+  });
+});
+
+describe("groupAgentsByName", () => {
+  it("collapses two instances of the same name into one group of replicaCount 2", () => {
+    const groups = groupAgentsByName([
+      makeAgent({ name: "fortuna", id: "fortuna-aaaa1111" }),
+      makeAgent({ name: "fortuna", id: "fortuna-bbbb2222" }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].name).toBe("fortuna");
+    expect(groups[0].replicaCount).toBe(2);
+    expect(groups[0].instances).toHaveLength(2);
+  });
+
+  it("keeps a single instance as a group of one", () => {
+    const groups = groupAgentsByName([makeAgent({ name: "solo", id: "solo-11112222" })]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].replicaCount).toBe(1);
+    expect(groups[0].representative.id).toBe("solo-11112222");
+  });
+
+  it("aggregates status worst-of across instances", () => {
+    const groups = groupAgentsByName([
+      makeAgent({ name: "svc", id: "svc-1", status: "healthy" }),
+      makeAgent({ name: "svc", id: "svc-2", status: "unhealthy" }),
+    ]);
+    expect(groups[0].aggregateStatus).toBe("unhealthy");
+  });
+
+  it("sums dependency totals across instances", () => {
+    const groups = groupAgentsByName([
+      makeAgent({ name: "svc", id: "svc-1", total_dependencies: 3, dependencies_resolved: 2 }),
+      makeAgent({ name: "svc", id: "svc-2", total_dependencies: 4, dependencies_resolved: 4 }),
+    ]);
+    expect(groups[0].totalDependencies).toBe(7);
+    expect(groups[0].dependenciesResolved).toBe(6);
+  });
+
+  it("collects unique non-empty endpoints", () => {
+    const groups = groupAgentsByName([
+      makeAgent({ name: "svc", id: "svc-1", endpoint: "http://a:8080" }),
+      makeAgent({ name: "svc", id: "svc-2", endpoint: "http://a:8080" }),
+      makeAgent({ name: "svc", id: "svc-3", endpoint: "http://b:8080" }),
+      makeAgent({ name: "svc", id: "svc-4", endpoint: "" }),
+    ]);
+    expect(groups[0].endpoints).toEqual(["http://a:8080", "http://b:8080"]);
+  });
+
+  it("picks the most-recent last_seen and newest representative", () => {
+    const groups = groupAgentsByName([
+      makeAgent({ name: "svc", id: "svc-old", last_seen: "2026-01-01T00:00:00Z" }),
+      makeAgent({ name: "svc", id: "svc-new", last_seen: "2026-06-01T00:00:00Z" }),
+    ]);
+    expect(groups[0].lastSeen).toBe("2026-06-01T00:00:00Z");
+    expect(groups[0].representative.id).toBe("svc-new");
+    // Instances sorted newest-first.
+    expect(groups[0].instances.map((i) => i.id)).toEqual(["svc-new", "svc-old"]);
+  });
+
+  it("breaks a last_seen tie by created_at for the representative", () => {
+    const groups = groupAgentsByName([
+      makeAgent({ name: "svc", id: "svc-a", last_seen: "2026-06-01T00:00:00Z", created_at: "2026-05-01T00:00:00Z" }),
+      makeAgent({ name: "svc", id: "svc-b", last_seen: "2026-06-01T00:00:00Z", created_at: "2026-05-10T00:00:00Z" }),
+    ]);
+    expect(groups[0].representative.id).toBe("svc-b");
+  });
+
+  it("groups an empty-name agent under its id", () => {
+    const groups = groupAgentsByName([makeAgent({ name: "", id: "legacy-77778888" })]);
+    expect(groups[0].name).toBe("legacy-77778888");
+    expect(groups[0].replicaCount).toBe(1);
+  });
+
+  it("sorts groups by name", () => {
+    const groups = groupAgentsByName([
+      makeAgent({ name: "zeta", id: "zeta-1" }),
+      makeAgent({ name: "alpha", id: "alpha-1" }),
+      makeAgent({ name: "media", id: "media-1" }),
+    ]);
+    expect(groups.map((g) => g.name)).toEqual(["alpha", "media", "zeta"]);
+  });
+});
+
+describe("buildIdToNodeKey (topology re-key)", () => {
+  it("maps two same-name instances' ids to the same group:<name> key", () => {
+    const map = buildIdToNodeKey([
+      makeAgent({ name: "fortuna", id: "fortuna-aaaa1111" }),
+      makeAgent({ name: "fortuna", id: "fortuna-bbbb2222" }),
+    ]);
+    expect(map.get("fortuna-aaaa1111")).toBe("group:fortuna");
+    expect(map.get("fortuna-bbbb2222")).toBe("group:fortuna");
+  });
+
+  it("maps a lone instance to its own id (no group collapse)", () => {
+    const map = buildIdToNodeKey([makeAgent({ name: "solo", id: "solo-11112222" })]);
+    expect(map.get("solo-11112222")).toBe("solo-11112222");
+  });
+});

--- a/src/ui/__tests__/replica-collapse.test.tsx
+++ b/src/ui/__tests__/replica-collapse.test.tsx
@@ -66,4 +66,15 @@ describe("replica collapse — Dashboard stats", () => {
     expect(card.textContent).toContain("1");
     expect(card.textContent).not.toContain("2");
   });
+
+  it("sums dependency counts across all instances of a ×N group", () => {
+    // Each replica reports 1/1 deps, so the collapsed group's Dependencies
+    // card must show the per-instance sum (2/2), not the representative (1/1).
+    render(<StatsCards agents={twoReplicas} />);
+
+    const depsLabel = screen.getByText("Dependencies");
+    const card = depsLabel.closest("div")?.parentElement as HTMLElement;
+    expect(card).toBeTruthy();
+    expect(card.textContent).toContain("2/2");
+  });
 });

--- a/src/ui/__tests__/replica-collapse.test.tsx
+++ b/src/ui/__tests__/replica-collapse.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Agent } from "../lib/types";
+import { groupAgentsByName } from "../lib/agent-group";
+import { AgentGrid } from "../components/agents/AgentGrid";
+import { AgentTable } from "../components/agents/AgentTable";
+import { StatsCards } from "../components/dashboard/StatsCards";
+
+// AgentTable calls useMesh() for traceActivity; stub it so we can render
+// without a live MeshProvider (network + SSE).
+vi.mock("../lib/mesh-context", () => ({
+  useMesh: () => ({ traceActivity: {} }),
+}));
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "svc-00000000",
+    name: "svc",
+    agent_type: "mcp_agent",
+    status: "healthy",
+    endpoint: "http://svc:8080",
+    runtime: "python",
+    total_dependencies: 1,
+    dependencies_resolved: 1,
+    capabilities: [{ function_name: "do_thing", name: "svc.thing", version: "1.0.0" }],
+    ...overrides,
+  };
+}
+
+const twoReplicas: Agent[] = [
+  makeAgent({ name: "fortuna", id: "fortuna-aaaa1111", last_seen: "2026-06-01T00:00:00Z" }),
+  makeAgent({ name: "fortuna", id: "fortuna-bbbb2222", last_seen: "2026-05-01T00:00:00Z" }),
+];
+
+describe("replica collapse — Agents grid", () => {
+  it("renders ONE card with a ×N badge for two same-name instances", () => {
+    const groups = groupAgentsByName(twoReplicas);
+    render(<AgentGrid groups={groups} />);
+
+    // Single group heading.
+    const headings = screen.getAllByText("fortuna");
+    expect(headings).toHaveLength(1);
+    // Replica badge shows the collapsed count.
+    expect(screen.getByText(/×2/)).toBeInTheDocument();
+  });
+});
+
+describe("replica collapse — Agents table", () => {
+  it("renders ONE row with a ×N badge for two same-name instances", () => {
+    const groups = groupAgentsByName(twoReplicas);
+    render(<AgentTable groups={groups} />);
+
+    expect(screen.getAllByText("fortuna")).toHaveLength(1);
+    expect(screen.getByText(/×2/)).toBeInTheDocument();
+  });
+});
+
+describe("replica collapse — Dashboard stats", () => {
+  it("counts two same-name instances as ONE logical agent", () => {
+    render(<StatsCards agents={twoReplicas} />);
+
+    // "Total Agents" value should be 1, not 2 (replicas collapse).
+    const totalLabel = screen.getByText("Total Agents");
+    const card = totalLabel.closest("div")?.parentElement as HTMLElement;
+    expect(card).toBeTruthy();
+    expect(card.textContent).toContain("1");
+    expect(card.textContent).not.toContain("2");
+  });
+});

--- a/src/ui/app/agents/page.tsx
+++ b/src/ui/app/agents/page.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from "react";
 import { Header } from "@/components/layout/Header";
 import { AgentTable } from "@/components/agents/AgentTable";
 import { AgentGrid } from "@/components/agents/AgentGrid";
 import { Button } from "@/components/ui/button";
 import { ConnectionError } from "@/components/layout/ConnectionError";
 import { useMesh } from "@/lib/mesh-context";
+import { useGroupedAgents } from "@/lib/use-grouped-agents";
 import { useLocalStorage } from "@/lib/use-local-storage";
 import { Eye, EyeOff, LayoutGrid, List, Loader2 } from "lucide-react";
 
@@ -19,13 +19,11 @@ export default function AgentsPage() {
     (v): v is "list" | "grid" => v === "list" || v === "grid",
   );
 
-  // Issue #990: server payload order isn't stable, so cards reshuffle on
-  // every 30s refresh / SSE event. Sort once at the page level so both
-  // grid and table views consume the same ordered list.
-  const sortedAgents = useMemo(
-    () => [...agents].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" })),
-    [agents],
-  );
+  // Issue #1328: collapse replicas of the same declared name into one logical
+  // group. groupAgentsByName sorts groups by name, so this also gives the
+  // stable ordering that issue #990 required (server payload order isn't
+  // stable). Grouping composes on top of the already health-filtered `agents`.
+  const groups = useGroupedAgents(agents);
 
   if (loading) {
     return (
@@ -89,7 +87,7 @@ export default function AgentsPage() {
             )}
           </Button>
         </div>
-        {view === "grid" ? <AgentGrid agents={sortedAgents} /> : <AgentTable agents={sortedAgents} />}
+        {view === "grid" ? <AgentGrid groups={groups} /> : <AgentTable groups={groups} />}
       </div>
     </div>
   );

--- a/src/ui/components/agents/AgentCard.tsx
+++ b/src/ui/components/agents/AgentCard.tsx
@@ -1,5 +1,5 @@
-import { Link } from "react-router-dom";
-import { Agent } from "@/lib/types";
+import { Layers } from "lucide-react";
+import { AgentGroup } from "@/lib/agent-group";
 import { Badge } from "@/components/ui/badge";
 import {
   formatRelativeTime,
@@ -10,9 +10,11 @@ import {
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { AgentBadges, unavailableBadgeCount } from "./AgentBadges";
+import type { Agent } from "@/lib/types";
 
 interface AgentCardProps {
-  agent: Agent;
+  group: AgentGroup;
+  onClick: () => void;
 }
 
 // Same logic as AgentTable.getDepsColor — inlined per the issue brief to
@@ -37,17 +39,31 @@ function hasAnyAgentBadge(agent: Agent): boolean {
   return Boolean(agent.capabilities?.some((c) => c.task === true));
 }
 
-export function AgentCard({ agent }: AgentCardProps) {
+// Health tally suffix for the replica badge, e.g. " · 2 healthy / 1 down".
+// Omitted entirely when every replica is healthy.
+function replicaHealthSuffix(group: AgentGroup): string {
+  const healthy = group.instances.filter((i) => i.status === "healthy").length;
+  const down = group.replicaCount - healthy;
+  if (down === 0) return "";
+  return ` · ${healthy} healthy / ${down} down`;
+}
+
+export function AgentCard({ group, onClick }: AgentCardProps) {
+  // The representative (newest) instance sources the shared runtime/type/
+  // version/description/badges shown for the collapsed group.
+  const agent = group.representative;
   // Match AgentDetail's whitespace-defensive description handling (issue
   // #969) so an empty header reads the same in both views.
   const description = agent.description?.trim() ?? "";
   const showBadgeRow = hasAnyAgentBadge(agent);
+  const isReplicated = group.replicaCount > 1;
 
   return (
-    <Link
-      to={`/agents/${encodeURIComponent(agent.id)}`}
+    <button
+      type="button"
+      onClick={onClick}
       className={cn(
-        "flex min-h-[180px] flex-col rounded-lg border border-border bg-background/40 p-4",
+        "flex min-h-[180px] flex-col rounded-lg border border-border bg-background/40 p-4 text-left",
         "hover:border-primary/40 hover:bg-accent/10 transition-colors",
       )}
     >
@@ -55,13 +71,22 @@ export function AgentCard({ agent }: AgentCardProps) {
         <span
           className={cn(
             "inline-flex h-2.5 w-2.5 shrink-0 rounded-full",
-            getStatusBgColor(agent.status),
+            getStatusBgColor(group.aggregateStatus),
           )}
-          aria-label={agent.status}
+          aria-label={group.aggregateStatus}
         />
-        <h3 className="truncate text-sm font-semibold text-foreground" title={agent.name}>
-          {agent.name}
+        <h3 className="truncate text-sm font-semibold text-foreground" title={group.name}>
+          {group.name}
         </h3>
+        {isReplicated && (
+          <span
+            className="inline-flex items-center gap-0.5 rounded-full border border-primary/40 bg-primary/15 px-1.5 py-0.5 text-[10px] font-semibold text-primary shrink-0"
+            title={`${group.replicaCount} replicas`}
+          >
+            <Layers className="h-2.5 w-2.5" />×{group.replicaCount}
+            {replicaHealthSuffix(group)}
+          </span>
+        )}
       </div>
 
       {description ? (
@@ -101,13 +126,13 @@ export function AgentCard({ agent }: AgentCardProps) {
         <span
           className={cn(
             "font-mono",
-            getDepsColor(agent.dependencies_resolved, agent.total_dependencies),
+            getDepsColor(group.dependenciesResolved, group.totalDependencies),
           )}
         >
-          {agent.dependencies_resolved}/{agent.total_dependencies} deps
+          {group.dependenciesResolved}/{group.totalDependencies} deps
         </span>
-        <span className="text-muted-foreground">{formatRelativeTime(agent.last_seen)}</span>
+        <span className="text-muted-foreground">{formatRelativeTime(group.lastSeen)}</span>
       </div>
-    </Link>
+    </button>
   );
 }

--- a/src/ui/components/agents/AgentGrid.tsx
+++ b/src/ui/components/agents/AgentGrid.tsx
@@ -1,13 +1,21 @@
-import { Bot } from "lucide-react";
-import { Agent } from "@/lib/types";
+import { useState } from "react";
+import { Bot, X, Layers } from "lucide-react";
+import { AgentGroup } from "@/lib/agent-group";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { AgentCard } from "./AgentCard";
+import { AgentGroupDetail, StatusDot } from "./AgentGroupDetail";
 
 interface AgentGridProps {
-  agents: Agent[];
+  groups: AgentGroup[];
 }
 
-export function AgentGrid({ agents }: AgentGridProps) {
-  if (agents.length === 0) {
+export function AgentGrid({ groups }: AgentGridProps) {
+  // Drill-in reuses the Topology sidebar pattern: clicking a card opens a
+  // right-side slide-over rendering the shared AgentGroupDetail (group summary
+  // + per-instance accordion), mirroring the Topology sidebar's look.
+  const [selected, setSelected] = useState<AgentGroup | null>(null);
+
+  if (groups.length === 0) {
     // Mirror AgentTable's empty state copy verbatim so the toggle doesn't
     // change wording. Deliberately inlined — see issue brief.
     return (
@@ -20,10 +28,63 @@ export function AgentGrid({ agents }: AgentGridProps) {
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-      {agents.map((agent) => (
-        <AgentCard key={agent.id} agent={agent} />
-      ))}
-    </div>
+    <>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        {groups.map((group) => (
+          <AgentCard key={group.name} group={group} onClick={() => setSelected(group)} />
+        ))}
+      </div>
+      <AgentGroupDrawer group={selected} onClose={() => setSelected(null)} />
+    </>
+  );
+}
+
+interface AgentGroupDrawerProps {
+  group: AgentGroup | null;
+  onClose: () => void;
+}
+
+// Right-side slide-over that mirrors the Topology sidebar's chrome (status dot,
+// name, ×N replica badge, close button, scrollable AgentGroupDetail body).
+function AgentGroupDrawer({ group, onClose }: AgentGroupDrawerProps) {
+  if (!group) return null;
+  const isReplicated = group.replicaCount > 1;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40 bg-black/50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div className="fixed right-0 top-0 h-full w-[360px] z-50 border-l border-border bg-card shadow-2xl flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-3 shrink-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <StatusDot status={group.aggregateStatus} />
+            <h2 className="text-sm font-semibold text-foreground truncate">{group.name}</h2>
+            {isReplicated && (
+              <span className="inline-flex items-center gap-0.5 rounded-full border border-primary/40 bg-primary/15 px-1.5 py-0.5 text-[10px] font-semibold text-primary shrink-0">
+                <Layers className="h-2.5 w-2.5" />×{group.replicaCount}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="Close panel"
+            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Scrollable content */}
+        <ScrollArea className="flex-1 overflow-auto">
+          <div className="p-4">
+            <AgentGroupDetail name={group.name} instances={group.instances} />
+          </div>
+        </ScrollArea>
+      </div>
+    </>
   );
 }

--- a/src/ui/components/agents/AgentGrid.tsx
+++ b/src/ui/components/agents/AgentGrid.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Bot, X, Layers } from "lucide-react";
 import { AgentGroup } from "@/lib/agent-group";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -47,6 +47,18 @@ interface AgentGroupDrawerProps {
 // Right-side slide-over that mirrors the Topology sidebar's chrome (status dot,
 // name, ×N replica badge, close button, scrollable AgentGroupDetail body).
 function AgentGroupDrawer({ group, onClose }: AgentGroupDrawerProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!group) return;
+    closeButtonRef.current?.focus();
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [group, onClose]);
+
   if (!group) return null;
   const isReplicated = group.replicaCount > 1;
 
@@ -57,7 +69,11 @@ function AgentGroupDrawer({ group, onClose }: AgentGroupDrawerProps) {
         onClick={onClose}
         aria-hidden="true"
       />
-      <div className="fixed right-0 top-0 h-full w-[360px] z-50 border-l border-border bg-card shadow-2xl flex flex-col">
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="fixed right-0 top-0 h-full w-[360px] z-50 border-l border-border bg-card shadow-2xl flex flex-col"
+      >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-border px-4 py-3 shrink-0">
           <div className="flex items-center gap-2 min-w-0">
@@ -70,6 +86,7 @@ function AgentGroupDrawer({ group, onClose }: AgentGroupDrawerProps) {
             )}
           </div>
           <button
+            ref={closeButtonRef}
             onClick={onClose}
             aria-label="Close panel"
             className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"

--- a/src/ui/components/agents/AgentGroupDetail.tsx
+++ b/src/ui/components/agents/AgentGroupDetail.tsx
@@ -1,0 +1,281 @@
+import { Globe, Hash, Clock, Cpu, Tag, GitBranch, Puzzle, Zap, BrainCircuit, Layers } from "lucide-react";
+import { Agent } from "@/lib/types";
+import { formatRelativeTime, getRuntimeLabel, getAgentTypeLabel, getDepStatusColor } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
+import { cn } from "@/lib/utils";
+
+// Shared drill-in primitives for a collapsed agent group. Extracted from the
+// Topology sidebar so both the Topology sidebar and the Agents page can render
+// an identical group summary + per-instance detail view.
+
+export function StatusDot({ status }: { status: string }) {
+  const color =
+    status === "healthy"
+      ? "bg-green-500"
+      : status === "unhealthy"
+        ? "bg-red-500"
+        : "bg-yellow-500";
+  return <span className={cn("inline-block h-2 w-2 rounded-full shrink-0", color)} />;
+}
+
+function DepStatusBadge({ status }: { status: string }) {
+  const colors =
+    status === "available"
+      ? "bg-green-500/15 text-green-400 border-green-500/30"
+      : status === "unavailable"
+        ? "bg-red-500/15 text-red-400 border-red-500/30"
+        : "bg-yellow-500/15 text-yellow-400 border-yellow-500/30";
+  return (
+    <span className={cn("inline-flex items-center rounded-md border px-1.5 py-0.5 text-[10px] font-medium", colors)}>
+      {status}
+    </span>
+  );
+}
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">{children}</h3>;
+}
+
+// Per-agent detail block — used for both single-agent selection and each
+// expanded accordion item in a group selection.
+export function AgentDetailBlock({ agent }: { agent: Agent }) {
+  const deps = agent.dependency_resolutions ?? [];
+  const llmTools = agent.llm_tool_resolutions ?? [];
+  const llmProviders = agent.llm_provider_resolutions ?? [];
+
+  return (
+    <div className="space-y-5">
+      {/* General info */}
+      <div className="space-y-2">
+        <SectionTitle>Details</SectionTitle>
+        <div className="space-y-1.5 text-xs">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Globe className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate font-mono" title={agent.endpoint}>{agent.endpoint}</span>
+          </div>
+          {agent.entity_id && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Hash className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate font-mono">{agent.entity_id}</span>
+            </div>
+          )}
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Cpu className="h-3.5 w-3.5 shrink-0" />
+            <span>
+              {getRuntimeLabel(agent.runtime)}
+              {agent.version ? ` v${agent.version}` : ""}
+              {" / "}
+              {getAgentTypeLabel(agent.agent_type)}
+            </span>
+          </div>
+          {agent.created_at && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Clock className="h-3.5 w-3.5 shrink-0" />
+              <span>Created {formatRelativeTime(agent.created_at)}</span>
+            </div>
+          )}
+          {agent.last_seen && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Clock className="h-3.5 w-3.5 shrink-0" />
+              <span>Last seen {formatRelativeTime(agent.last_seen)}</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Capabilities */}
+      {(agent.capabilities ?? []).length > 0 && (
+        <div>
+          <SectionTitle>Capabilities ({(agent.capabilities ?? []).length})</SectionTitle>
+          <div className="space-y-2">
+            {(agent.capabilities ?? []).map((cap) => (
+              <div key={cap.function_name} className="rounded-md border border-border bg-background/50 p-2">
+                <div className="flex items-center gap-1.5 mb-1">
+                  <Puzzle className="h-3 w-3 text-primary shrink-0" />
+                  <span className="text-xs font-medium text-foreground truncate">{cap.function_name}</span>
+                </div>
+                <p className="text-[10px] text-muted-foreground mb-1">
+                  {cap.name} v{cap.version}
+                </p>
+                {cap.available === false && (
+                  <p
+                    className="text-[10px] text-red-400 mb-1"
+                    title={cap.unavailable_reason || "A required dependency chain is broken"}
+                  >
+                    unavailable{cap.unavailable_reason ? `: ${cap.unavailable_reason}` : ""}
+                  </p>
+                )}
+                {cap.description && (
+                  <p className="text-[10px] text-muted-foreground/80 mb-1">{cap.description}</p>
+                )}
+                {cap.tags && cap.tags.length > 0 && (
+                  <div className="flex flex-wrap gap-1">
+                    {cap.tags.map((tag) => (
+                      <Badge key={tag} variant="outline" className="text-[9px] px-1.5 py-0">
+                        <Tag className="h-2.5 w-2.5 mr-0.5" />
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Dependency Resolutions */}
+      {deps.length > 0 && (
+        <div>
+          <SectionTitle>Dependencies ({deps.length})</SectionTitle>
+          <div className="space-y-2">
+            {deps.map((dep, idx) => (
+              <div key={`${dep.function_name}-${dep.capability}-${idx}`} className="rounded-md border border-border bg-background/50 p-2">
+                <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <GitBranch className={cn("h-3 w-3 shrink-0", getDepStatusColor(dep.status))} />
+                    <span className="text-xs font-medium text-foreground truncate">{dep.function_name}</span>
+                  </div>
+                  <DepStatusBadge status={dep.status} />
+                </div>
+                <p className="text-[10px] text-muted-foreground">
+                  {dep.capability}
+                  {dep.mcp_tool ? ` (tool: ${dep.mcp_tool})` : ""}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* LLM Tool Resolutions */}
+      {llmTools.length > 0 && (
+        <div>
+          <SectionTitle>LLM Tool Resolutions ({llmTools.length})</SectionTitle>
+          <div className="space-y-2">
+            {llmTools.map((llm, idx) => (
+              <div key={`${llm.function_name}-${llm.filter_capability}-${idx}`} className="rounded-md border border-border bg-background/50 p-2">
+                <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <Zap className={cn("h-3 w-3 shrink-0", getDepStatusColor(llm.status))} />
+                    <span className="text-xs font-medium text-foreground truncate">{llm.function_name}</span>
+                  </div>
+                  <DepStatusBadge status={llm.status} />
+                </div>
+                <p className="text-[10px] text-muted-foreground">{llm.filter_capability}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* LLM Provider Resolutions */}
+      {llmProviders.length > 0 && (
+        <div>
+          <SectionTitle>LLM Provider Resolutions ({llmProviders.length})</SectionTitle>
+          <div className="space-y-2">
+            {llmProviders.map((prov, idx) => (
+              <div key={`${prov.function_name}-${prov.required_capability}-${idx}`} className="rounded-md border border-border bg-background/50 p-2">
+                <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <BrainCircuit className={cn("h-3 w-3 shrink-0", getDepStatusColor(prov.status))} />
+                    <span className="text-xs font-medium text-foreground truncate">{prov.function_name}</span>
+                  </div>
+                  <DepStatusBadge status={prov.status} />
+                </div>
+                <p className="text-[10px] text-muted-foreground">{prov.required_capability}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface AgentGroupDetailProps {
+  /** Canonical group name (agent.name). */
+  name: string;
+  /** All instances in the group. Order is preserved for the accordion. */
+  instances: Agent[];
+}
+
+// Group drill-in: an aggregate summary (instance count, shared/divergent
+// endpoint, aggregate dependency resolution) followed by a per-instance
+// accordion of AgentDetailBlock. Aggregate figures are derived from the
+// instances so the component is self-contained and reusable standalone.
+export function AgentGroupDetail({ name, instances }: AgentGroupDetailProps) {
+  // Determine whether all replicas share a single endpoint. If so, show it
+  // directly; otherwise indicate divergence — per-instance endpoints are
+  // available in the accordion below.
+  const uniqueEndpoints = Array.from(
+    new Set(instances.map((i) => i.endpoint).filter((e): e is string => !!e))
+  );
+  const sharedEndpoint = uniqueEndpoints.length === 1 ? uniqueEndpoints[0] : "";
+  const endpointsDiffer = uniqueEndpoints.length > 1;
+
+  const totalDependencies = instances.reduce((sum, a) => sum + (a.total_dependencies ?? 0), 0);
+  const dependenciesResolved = instances.reduce((sum, a) => sum + (a.dependencies_resolved ?? 0), 0);
+
+  return (
+    <div className="space-y-5">
+      {/* Group summary */}
+      <div className="space-y-2">
+        <SectionTitle>Group</SectionTitle>
+        <div className="space-y-1.5 text-xs">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Layers className="h-3.5 w-3.5 shrink-0" />
+            <span>{instances.length} instances</span>
+          </div>
+          {sharedEndpoint && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Globe className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate font-mono" title={sharedEndpoint}>{sharedEndpoint}</span>
+            </div>
+          )}
+          {endpointsDiffer && (
+            <div
+              className="flex items-center gap-2 text-muted-foreground"
+              title={uniqueEndpoints.join("\n")}
+            >
+              <Globe className="h-3.5 w-3.5 shrink-0" />
+              <span>Endpoints: {uniqueEndpoints.length} (varies — see instances)</span>
+            </div>
+          )}
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <GitBranch className="h-3.5 w-3.5 shrink-0" />
+            <span>
+              Dependencies {dependenciesResolved}/{totalDependencies} resolved (aggregate)
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Instance accordion */}
+      <div>
+        <SectionTitle>Instances</SectionTitle>
+        <Accordion type="single" collapsible className="rounded-md border border-border bg-background/50 px-2">
+          {instances.map((inst) => (
+            <AccordionItem key={inst.id} value={inst.id}>
+              <AccordionTrigger>
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <StatusDot status={inst.status} />
+                  <span className="truncate font-mono text-[11px]">{inst.id}</span>
+                  {inst.last_seen && (
+                    <span className="text-[10px] text-muted-foreground shrink-0 ml-auto pr-2">
+                      {formatRelativeTime(inst.last_seen)}
+                    </span>
+                  )}
+                </div>
+              </AccordionTrigger>
+              <AccordionContent>
+                <AgentDetailBlock agent={inst} />
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/agents/AgentTable.tsx
+++ b/src/ui/components/agents/AgentTable.tsx
@@ -8,23 +8,22 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { Agent } from "@/lib/types";
+import { AgentGroup } from "@/lib/agent-group";
 import {
   formatRelativeTime,
   getStatusBgColor,
   getRuntimeLabel,
   getRuntimeBadgeColor,
   getAgentTypeLabel,
-  extractAgentName,
 } from "@/lib/api";
 import { useMesh } from "@/lib/mesh-context";
-import { ChevronDown, ChevronRight, Bot, Activity, ArrowUp, ArrowDown } from "lucide-react";
+import { ChevronDown, ChevronRight, Bot, Activity, ArrowUp, ArrowDown, Layers } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { AgentDetail } from "./AgentDetail";
+import { AgentGroupDetail } from "./AgentGroupDetail";
 import { AgentBadges } from "./AgentBadges";
 
 interface AgentTableProps {
-  agents: Agent[];
+  groups: AgentGroup[];
 }
 
 type SortKey = "name" | "type" | "runtime" | "deps" | "last_seen";
@@ -37,24 +36,24 @@ function getDepsColor(resolved: number, total: number): string {
   return "text-orange-400";
 }
 
-function sortAgents(agents: Agent[], key: SortKey, dir: SortDir): Agent[] {
-  const sorted = [...agents].sort((a, b) => {
+function sortGroups(groups: AgentGroup[], key: SortKey, dir: SortDir): AgentGroup[] {
+  const sorted = [...groups].sort((a, b) => {
     let cmp = 0;
     switch (key) {
       case "name":
         cmp = a.name.localeCompare(b.name);
         break;
       case "type":
-        cmp = a.agent_type.localeCompare(b.agent_type);
+        cmp = a.representative.agent_type.localeCompare(b.representative.agent_type);
         break;
       case "runtime":
-        cmp = (a.runtime || "").localeCompare(b.runtime || "");
+        cmp = (a.representative.runtime || "").localeCompare(b.representative.runtime || "");
         break;
       case "deps":
-        cmp = a.dependencies_resolved - b.dependencies_resolved;
+        cmp = a.dependenciesResolved - b.dependenciesResolved;
         break;
       case "last_seen":
-        cmp = (a.last_seen || "").localeCompare(b.last_seen || "");
+        cmp = (a.lastSeen || "").localeCompare(b.lastSeen || "");
         break;
     }
     return dir === "asc" ? cmp : -cmp;
@@ -95,8 +94,8 @@ function SortableHead({
   );
 }
 
-export function AgentTable({ agents }: AgentTableProps) {
-  const [expandedId, setExpandedId] = useState<string | null>(null);
+export function AgentTable({ groups }: AgentTableProps) {
+  const [expandedName, setExpandedName] = useState<string | null>(null);
   const [sortKey, setSortKey] = useState<SortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
   const { traceActivity } = useMesh();
@@ -110,9 +109,9 @@ export function AgentTable({ agents }: AgentTableProps) {
     }
   };
 
-  const sorted = useMemo(() => sortAgents(agents, sortKey, sortDir), [agents, sortKey, sortDir]);
+  const sorted = useMemo(() => sortGroups(groups, sortKey, sortDir), [groups, sortKey, sortDir]);
 
-  if (agents.length === 0) {
+  if (groups.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
         <Bot className="mb-3 h-12 w-12 opacity-40" />
@@ -137,16 +136,16 @@ export function AgentTable({ agents }: AgentTableProps) {
         </TableRow>
       </TableHeader>
       <TableBody>
-        {sorted.map((agent) => {
-          const isExpanded = expandedId === agent.id;
+        {sorted.map((group) => {
+          const isExpanded = expandedName === group.name;
 
           return (
             <AgentRow
-              key={agent.id}
-              agent={agent}
+              key={group.name}
+              group={group}
               isExpanded={isExpanded}
-              onToggle={() => setExpandedId(isExpanded ? null : agent.id)}
-              traceCount={traceActivity[extractAgentName(agent.id)] || 0}
+              onToggle={() => setExpandedName(isExpanded ? null : group.name)}
+              traceCount={traceActivity[group.name] || 0}
             />
           );
         })}
@@ -156,13 +155,16 @@ export function AgentTable({ agents }: AgentTableProps) {
 }
 
 interface AgentRowProps {
-  agent: Agent;
+  group: AgentGroup;
   isExpanded: boolean;
   onToggle: () => void;
   traceCount: number;
 }
 
-function AgentRow({ agent, isExpanded, onToggle, traceCount }: AgentRowProps) {
+function AgentRow({ group, isExpanded, onToggle, traceCount }: AgentRowProps) {
+  const agent = group.representative;
+  const isReplicated = group.replicaCount > 1;
+
   return (
     <>
       <TableRow
@@ -178,12 +180,20 @@ function AgentRow({ agent, isExpanded, onToggle, traceCount }: AgentRowProps) {
         </TableCell>
         <TableCell>
           <span
-            className={`inline-flex h-2.5 w-2.5 rounded-full ${getStatusBgColor(agent.status)}`}
+            className={`inline-flex h-2.5 w-2.5 rounded-full ${getStatusBgColor(group.aggregateStatus)}`}
           />
         </TableCell>
         <TableCell className="font-medium text-foreground">
           <span className="inline-flex items-center gap-1.5 flex-wrap">
-            {agent.name}
+            {group.name}
+            {isReplicated && (
+              <span
+                className="inline-flex items-center gap-0.5 rounded-full border border-primary/40 bg-primary/15 px-1.5 py-0.5 text-[10px] font-semibold text-primary"
+                title={`${group.replicaCount} replicas`}
+              >
+                <Layers className="h-2.5 w-2.5" />×{group.replicaCount}
+              </span>
+            )}
             {traceCount > 0 && (
               <span className="inline-flex items-center gap-0.5 text-cyan-400" title={`${traceCount} recent trace(s)`}>
                 <Activity className="h-3 w-3 animate-pulse" />
@@ -209,21 +219,21 @@ function AgentRow({ agent, isExpanded, onToggle, traceCount }: AgentRowProps) {
           )}
         </TableCell>
         <TableCell className="text-muted-foreground font-mono text-xs">
-          {agent.version || "\u2014"}
+          {agent.version || "—"}
         </TableCell>
         <TableCell>
-          <span className={`font-mono text-xs ${getDepsColor(agent.dependencies_resolved, agent.total_dependencies)}`}>
-            {agent.dependencies_resolved}/{agent.total_dependencies}
+          <span className={`font-mono text-xs ${getDepsColor(group.dependenciesResolved, group.totalDependencies)}`}>
+            {group.dependenciesResolved}/{group.totalDependencies}
           </span>
         </TableCell>
         <TableCell className="text-xs text-muted-foreground">
-          {formatRelativeTime(agent.last_seen)}
+          {formatRelativeTime(group.lastSeen)}
         </TableCell>
       </TableRow>
       {isExpanded && (
         <TableRow className="hover:bg-transparent">
-          <TableCell colSpan={8} className="bg-background/50 p-0">
-            <AgentDetail agent={agent} />
+          <TableCell colSpan={8} className="bg-background/50 p-4">
+            <AgentGroupDetail name={group.name} instances={group.instances} />
           </TableCell>
         </TableRow>
       )}

--- a/src/ui/components/dashboard/StatsCards.tsx
+++ b/src/ui/components/dashboard/StatsCards.tsx
@@ -1,17 +1,22 @@
 import { Bot, HeartPulse, AlertTriangle, Puzzle } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Agent } from "@/lib/types";
+import { groupAgentsByName } from "@/lib/agent-group";
 
 interface StatsCardsProps {
   agents: Agent[];
 }
 
 export function StatsCards({ agents }: StatsCardsProps) {
-  const totalAgents = agents.length;
-  const healthyCount = agents.filter((a) => a.status === "healthy").length;
-  const totalDeps = agents.reduce((sum, a) => sum + a.total_dependencies, 0);
-  const resolvedDeps = agents.reduce((sum, a) => sum + a.dependencies_resolved, 0);
-  const capabilitiesCount = agents.reduce((sum, a) => sum + (a.capabilities?.length || 0), 0);
+  // Count logical agents (replica-collapsed), not raw instances, so replicas
+  // don't inflate every figure. Dependencies/capabilities are counted once per
+  // logical agent via the group's representative instance.
+  const groups = groupAgentsByName(agents);
+  const totalAgents = groups.length;
+  const healthyCount = groups.filter((g) => g.aggregateStatus === "healthy").length;
+  const totalDeps = groups.reduce((sum, g) => sum + (g.representative.total_dependencies || 0), 0);
+  const resolvedDeps = groups.reduce((sum, g) => sum + (g.representative.dependencies_resolved || 0), 0);
+  const capabilitiesCount = groups.reduce((sum, g) => sum + (g.representative.capabilities?.length || 0), 0);
 
   const stats = [
     {

--- a/src/ui/components/dashboard/StatsCards.tsx
+++ b/src/ui/components/dashboard/StatsCards.tsx
@@ -1,7 +1,7 @@
 import { Bot, HeartPulse, AlertTriangle, Puzzle } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Agent } from "@/lib/types";
-import { groupAgentsByName } from "@/lib/agent-group";
+import { useGroupedAgents } from "@/lib/use-grouped-agents";
 
 interface StatsCardsProps {
   agents: Agent[];
@@ -11,11 +11,11 @@ export function StatsCards({ agents }: StatsCardsProps) {
   // Count logical agents (replica-collapsed), not raw instances, so replicas
   // don't inflate every figure. Dependencies/capabilities are counted once per
   // logical agent via the group's representative instance.
-  const groups = groupAgentsByName(agents);
+  const groups = useGroupedAgents(agents);
   const totalAgents = groups.length;
   const healthyCount = groups.filter((g) => g.aggregateStatus === "healthy").length;
-  const totalDeps = groups.reduce((sum, g) => sum + (g.representative.total_dependencies || 0), 0);
-  const resolvedDeps = groups.reduce((sum, g) => sum + (g.representative.dependencies_resolved || 0), 0);
+  const totalDeps = groups.reduce((sum, g) => sum + (g.totalDependencies || 0), 0);
+  const resolvedDeps = groups.reduce((sum, g) => sum + (g.dependenciesResolved || 0), 0);
   const capabilitiesCount = groups.reduce((sum, g) => sum + (g.representative.capabilities?.length || 0), 0);
 
   const stats = [

--- a/src/ui/components/topology/TopologyGraph.tsx
+++ b/src/ui/components/topology/TopologyGraph.tsx
@@ -227,8 +227,6 @@ export function TopologyGraph({ agents }: TopologyGraphProps) {
         name: data.name as string,
         instances: data.instances as Agent[],
         status: data.status as string,
-        totalDependencies: data.total_dependencies as number,
-        dependenciesResolved: data.dependencies_resolved as number,
       };
     }
     return { kind: "single", agent: data.agent as Agent };

--- a/src/ui/components/topology/TopologySidebar.tsx
+++ b/src/ui/components/topology/TopologySidebar.tsx
@@ -10,8 +10,6 @@ export type SidebarSelection =
       name: string;
       instances: Agent[];
       status: string;
-      totalDependencies: number;
-      dependenciesResolved: number;
     };
 
 interface TopologySidebarProps {

--- a/src/ui/components/topology/TopologySidebar.tsx
+++ b/src/ui/components/topology/TopologySidebar.tsx
@@ -1,10 +1,7 @@
-import { X, Globe, Hash, Clock, Cpu, Tag, GitBranch, Puzzle, Zap, BrainCircuit, Layers } from "lucide-react";
+import { X, Layers } from "lucide-react";
 import { Agent } from "@/lib/types";
-import { formatRelativeTime, getRuntimeLabel, getAgentTypeLabel, getDepStatusColor } from "@/lib/api";
-import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
-import { cn } from "@/lib/utils";
+import { AgentDetailBlock, AgentGroupDetail, StatusDot } from "@/components/agents/AgentGroupDetail";
 
 export type SidebarSelection =
   | { kind: "single"; agent: Agent }
@@ -20,191 +17,6 @@ export type SidebarSelection =
 interface TopologySidebarProps {
   selection: SidebarSelection | null;
   onClose: () => void;
-}
-
-function StatusDot({ status }: { status: string }) {
-  const color =
-    status === "healthy"
-      ? "bg-green-500"
-      : status === "unhealthy"
-        ? "bg-red-500"
-        : "bg-yellow-500";
-  return <span className={cn("inline-block h-2 w-2 rounded-full shrink-0", color)} />;
-}
-
-function DepStatusBadge({ status }: { status: string }) {
-  const colors =
-    status === "available"
-      ? "bg-green-500/15 text-green-400 border-green-500/30"
-      : status === "unavailable"
-        ? "bg-red-500/15 text-red-400 border-red-500/30"
-        : "bg-yellow-500/15 text-yellow-400 border-yellow-500/30";
-  return (
-    <span className={cn("inline-flex items-center rounded-md border px-1.5 py-0.5 text-[10px] font-medium", colors)}>
-      {status}
-    </span>
-  );
-}
-
-function SectionTitle({ children }: { children: React.ReactNode }) {
-  return <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">{children}</h3>;
-}
-
-// Reusable per-agent detail block — used for both single-agent selection and
-// each expanded accordion item in a group selection.
-function AgentDetailBlock({ agent }: { agent: Agent }) {
-  const deps = agent.dependency_resolutions ?? [];
-  const llmTools = agent.llm_tool_resolutions ?? [];
-  const llmProviders = agent.llm_provider_resolutions ?? [];
-
-  return (
-    <div className="space-y-5">
-      {/* General info */}
-      <div className="space-y-2">
-        <SectionTitle>Details</SectionTitle>
-        <div className="space-y-1.5 text-xs">
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Globe className="h-3.5 w-3.5 shrink-0" />
-            <span className="truncate font-mono" title={agent.endpoint}>{agent.endpoint}</span>
-          </div>
-          {agent.entity_id && (
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <Hash className="h-3.5 w-3.5 shrink-0" />
-              <span className="truncate font-mono">{agent.entity_id}</span>
-            </div>
-          )}
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <Cpu className="h-3.5 w-3.5 shrink-0" />
-            <span>
-              {getRuntimeLabel(agent.runtime)}
-              {agent.version ? ` v${agent.version}` : ""}
-              {" / "}
-              {getAgentTypeLabel(agent.agent_type)}
-            </span>
-          </div>
-          {agent.created_at && (
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <Clock className="h-3.5 w-3.5 shrink-0" />
-              <span>Created {formatRelativeTime(agent.created_at)}</span>
-            </div>
-          )}
-          {agent.last_seen && (
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <Clock className="h-3.5 w-3.5 shrink-0" />
-              <span>Last seen {formatRelativeTime(agent.last_seen)}</span>
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* Capabilities */}
-      {(agent.capabilities ?? []).length > 0 && (
-        <div>
-          <SectionTitle>Capabilities ({(agent.capabilities ?? []).length})</SectionTitle>
-          <div className="space-y-2">
-            {(agent.capabilities ?? []).map((cap) => (
-              <div key={cap.function_name} className="rounded-md border border-border bg-background/50 p-2">
-                <div className="flex items-center gap-1.5 mb-1">
-                  <Puzzle className="h-3 w-3 text-primary shrink-0" />
-                  <span className="text-xs font-medium text-foreground truncate">{cap.function_name}</span>
-                </div>
-                <p className="text-[10px] text-muted-foreground mb-1">
-                  {cap.name} v{cap.version}
-                </p>
-                {cap.available === false && (
-                  <p
-                    className="text-[10px] text-red-400 mb-1"
-                    title={cap.unavailable_reason || "A required dependency chain is broken"}
-                  >
-                    unavailable{cap.unavailable_reason ? `: ${cap.unavailable_reason}` : ""}
-                  </p>
-                )}
-                {cap.description && (
-                  <p className="text-[10px] text-muted-foreground/80 mb-1">{cap.description}</p>
-                )}
-                {cap.tags && cap.tags.length > 0 && (
-                  <div className="flex flex-wrap gap-1">
-                    {cap.tags.map((tag) => (
-                      <Badge key={tag} variant="outline" className="text-[9px] px-1.5 py-0">
-                        <Tag className="h-2.5 w-2.5 mr-0.5" />
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Dependency Resolutions */}
-      {deps.length > 0 && (
-        <div>
-          <SectionTitle>Dependencies ({deps.length})</SectionTitle>
-          <div className="space-y-2">
-            {deps.map((dep, idx) => (
-              <div key={`${dep.function_name}-${dep.capability}-${idx}`} className="rounded-md border border-border bg-background/50 p-2">
-                <div className="flex items-center justify-between mb-1">
-                  <div className="flex items-center gap-1.5 min-w-0">
-                    <GitBranch className={cn("h-3 w-3 shrink-0", getDepStatusColor(dep.status))} />
-                    <span className="text-xs font-medium text-foreground truncate">{dep.function_name}</span>
-                  </div>
-                  <DepStatusBadge status={dep.status} />
-                </div>
-                <p className="text-[10px] text-muted-foreground">
-                  {dep.capability}
-                  {dep.mcp_tool ? ` (tool: ${dep.mcp_tool})` : ""}
-                </p>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* LLM Tool Resolutions */}
-      {llmTools.length > 0 && (
-        <div>
-          <SectionTitle>LLM Tool Resolutions ({llmTools.length})</SectionTitle>
-          <div className="space-y-2">
-            {llmTools.map((llm, idx) => (
-              <div key={`${llm.function_name}-${llm.filter_capability}-${idx}`} className="rounded-md border border-border bg-background/50 p-2">
-                <div className="flex items-center justify-between mb-1">
-                  <div className="flex items-center gap-1.5 min-w-0">
-                    <Zap className={cn("h-3 w-3 shrink-0", getDepStatusColor(llm.status))} />
-                    <span className="text-xs font-medium text-foreground truncate">{llm.function_name}</span>
-                  </div>
-                  <DepStatusBadge status={llm.status} />
-                </div>
-                <p className="text-[10px] text-muted-foreground">{llm.filter_capability}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* LLM Provider Resolutions */}
-      {llmProviders.length > 0 && (
-        <div>
-          <SectionTitle>LLM Provider Resolutions ({llmProviders.length})</SectionTitle>
-          <div className="space-y-2">
-            {llmProviders.map((prov, idx) => (
-              <div key={`${prov.function_name}-${prov.required_capability}-${idx}`} className="rounded-md border border-border bg-background/50 p-2">
-                <div className="flex items-center justify-between mb-1">
-                  <div className="flex items-center gap-1.5 min-w-0">
-                    <BrainCircuit className={cn("h-3 w-3 shrink-0", getDepStatusColor(prov.status))} />
-                    <span className="text-xs font-medium text-foreground truncate">{prov.function_name}</span>
-                  </div>
-                  <DepStatusBadge status={prov.status} />
-                </div>
-                <p className="text-[10px] text-muted-foreground">{prov.required_capability}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
 }
 
 export function TopologySidebar({ selection, onClose }: TopologySidebarProps) {
@@ -240,15 +52,7 @@ export function TopologySidebar({ selection, onClose }: TopologySidebarProps) {
   }
 
   // Group selection
-  const { name, instances, status, totalDependencies, dependenciesResolved } = selection;
-  // Determine whether all replicas share a single endpoint. If so, show it
-  // directly; otherwise indicate divergence — per-instance endpoints are
-  // available in the accordion below.
-  const uniqueEndpoints = Array.from(
-    new Set(instances.map((i) => i.endpoint).filter((e): e is string => !!e))
-  );
-  const sharedEndpoint = uniqueEndpoints.length === 1 ? uniqueEndpoints[0] : "";
-  const endpointsDiffer = uniqueEndpoints.length > 1;
+  const { name, instances, status } = selection;
 
   return (
     <div className="absolute right-0 top-0 h-full w-[360px] z-50 border-l border-border bg-card shadow-2xl flex flex-col">
@@ -272,63 +76,8 @@ export function TopologySidebar({ selection, onClose }: TopologySidebarProps) {
 
       {/* Scrollable content */}
       <ScrollArea className="flex-1 overflow-auto">
-        <div className="p-4 space-y-5">
-          {/* Group summary */}
-          <div className="space-y-2">
-            <SectionTitle>Group</SectionTitle>
-            <div className="space-y-1.5 text-xs">
-              <div className="flex items-center gap-2 text-muted-foreground">
-                <Layers className="h-3.5 w-3.5 shrink-0" />
-                <span>{instances.length} instances</span>
-              </div>
-              {sharedEndpoint && (
-                <div className="flex items-center gap-2 text-muted-foreground">
-                  <Globe className="h-3.5 w-3.5 shrink-0" />
-                  <span className="truncate font-mono" title={sharedEndpoint}>{sharedEndpoint}</span>
-                </div>
-              )}
-              {endpointsDiffer && (
-                <div
-                  className="flex items-center gap-2 text-muted-foreground"
-                  title={uniqueEndpoints.join("\n")}
-                >
-                  <Globe className="h-3.5 w-3.5 shrink-0" />
-                  <span>Endpoints: {uniqueEndpoints.length} (varies — see instances)</span>
-                </div>
-              )}
-              <div className="flex items-center gap-2 text-muted-foreground">
-                <GitBranch className="h-3.5 w-3.5 shrink-0" />
-                <span>
-                  Dependencies {dependenciesResolved}/{totalDependencies} resolved (aggregate)
-                </span>
-              </div>
-            </div>
-          </div>
-
-          {/* Instance accordion */}
-          <div>
-            <SectionTitle>Instances</SectionTitle>
-            <Accordion type="single" collapsible className="rounded-md border border-border bg-background/50 px-2">
-              {instances.map((inst) => (
-                <AccordionItem key={inst.id} value={inst.id}>
-                  <AccordionTrigger>
-                    <div className="flex items-center gap-2 min-w-0 flex-1">
-                      <StatusDot status={inst.status} />
-                      <span className="truncate font-mono text-[11px]">{inst.id}</span>
-                      {inst.last_seen && (
-                        <span className="text-[10px] text-muted-foreground shrink-0 ml-auto pr-2">
-                          {formatRelativeTime(inst.last_seen)}
-                        </span>
-                      )}
-                    </div>
-                  </AccordionTrigger>
-                  <AccordionContent>
-                    <AgentDetailBlock agent={inst} />
-                  </AccordionContent>
-                </AccordionItem>
-              ))}
-            </Accordion>
-          </div>
+        <div className="p-4">
+          <AgentGroupDetail name={name} instances={instances} />
         </div>
       </ScrollArea>
     </div>

--- a/src/ui/lib/agent-group.ts
+++ b/src/ui/lib/agent-group.ts
@@ -56,7 +56,7 @@ function byRecencyDesc(a: Agent, b: Agent): number {
   const ca = a.created_at ?? "";
   const cb = b.created_at ?? "";
   if (ca !== cb) return ca < cb ? 1 : -1;
-  return 0;
+  return a.id.localeCompare(b.id);
 }
 
 // Collapse a health-filtered agent set into one group per canonical name.

--- a/src/ui/lib/agent-group.ts
+++ b/src/ui/lib/agent-group.ts
@@ -1,0 +1,108 @@
+import { Agent } from "./types";
+
+// A collapsed view of one logical agent and all of its running replicas.
+// The canonical grouping key is the declared agent name (`agent.name`), which
+// aligns with the registry's edge/trace stat keys. Replicas of the same name
+// collapse into a single group; a lone instance is a group of one.
+export interface AgentGroup {
+  /** Canonical key = agent.name (falls back to agent.id when name is empty). */
+  name: string;
+  /** All instances in the (already health-filtered) set, newest first. */
+  instances: Agent[];
+  replicaCount: number;
+  /** Worst-of across instances: unhealthy > unknown > healthy. */
+  aggregateStatus: "healthy" | "unhealthy" | "unknown";
+  /**
+   * Newest instance by last_seen (tie: created_at). Source of the runtime,
+   * type, version, description, capabilities and badges shown for the group.
+   */
+  representative: Agent;
+  /** Σ total_dependencies across instances. */
+  totalDependencies: number;
+  /** Σ dependencies_resolved across instances. */
+  dependenciesResolved: number;
+  /** Unique, non-empty endpoint values across instances (for drill-in). */
+  endpoints: string[];
+  /** Most-recent last_seen across instances, if any instance reported one. */
+  lastSeen?: string;
+}
+
+// Canonical grouping key for an agent: the declared name, falling back to the
+// full id when the name is empty (older/degenerate registrations).
+export function groupKeyOf(agent: Agent): string {
+  return agent.name || agent.id;
+}
+
+// Worst-of aggregation for a group's status.
+// Any unhealthy -> unhealthy; else any unknown -> unknown; else healthy.
+export function aggregateStatus(
+  instances: Agent[],
+): "healthy" | "unhealthy" | "unknown" {
+  let hasUnknown = false;
+  for (const a of instances) {
+    if (a.status === "unhealthy") return "unhealthy";
+    if (a.status === "unknown") hasUnknown = true;
+  }
+  return hasUnknown ? "unknown" : "healthy";
+}
+
+// Recency comparator: newest first by last_seen, tie-broken by created_at.
+// Missing timestamps sort last (treated as the empty string). ISO-8601 strings
+// compare correctly lexicographically.
+function byRecencyDesc(a: Agent, b: Agent): number {
+  const la = a.last_seen ?? "";
+  const lb = b.last_seen ?? "";
+  if (la !== lb) return la < lb ? 1 : -1;
+  const ca = a.created_at ?? "";
+  const cb = b.created_at ?? "";
+  if (ca !== cb) return ca < cb ? 1 : -1;
+  return 0;
+}
+
+// Collapse a health-filtered agent set into one group per canonical name.
+// Groups are sorted by name (localeCompare); instances within a group are
+// sorted newest-first by last_seen (tie: created_at).
+export function groupAgentsByName(agents: Agent[]): AgentGroup[] {
+  const buckets = new Map<string, Agent[]>();
+  for (const a of agents) {
+    const key = groupKeyOf(a);
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(a);
+    else buckets.set(key, [a]);
+  }
+
+  const groups: AgentGroup[] = [];
+  for (const [name, raw] of buckets.entries()) {
+    const instances = [...raw].sort(byRecencyDesc);
+    const totalDependencies = instances.reduce(
+      (sum, a) => sum + (a.total_dependencies ?? 0),
+      0,
+    );
+    const dependenciesResolved = instances.reduce(
+      (sum, a) => sum + (a.dependencies_resolved ?? 0),
+      0,
+    );
+    const endpoints = Array.from(
+      new Set(instances.map((a) => a.endpoint).filter((e): e is string => !!e)),
+    );
+    const lastSeen = instances.reduce<string | undefined>((max, a) => {
+      if (!a.last_seen) return max;
+      return !max || a.last_seen > max ? a.last_seen : max;
+    }, undefined);
+
+    groups.push({
+      name,
+      instances,
+      replicaCount: instances.length,
+      aggregateStatus: aggregateStatus(instances),
+      representative: instances[0],
+      totalDependencies,
+      dependenciesResolved,
+      endpoints,
+      lastSeen,
+    });
+  }
+
+  groups.sort((a, b) => a.name.localeCompare(b.name));
+  return groups;
+}

--- a/src/ui/lib/topology.ts
+++ b/src/ui/lib/topology.ts
@@ -1,21 +1,14 @@
 import dagre from "dagre";
 import { type Node, type Edge } from "@xyflow/react";
 import { Agent } from "./types";
-import { extractAgentName } from "./api";
+import { groupKeyOf, aggregateStatus } from "./agent-group";
 
-// Returns the base name for an agent by stripping the registry-assigned
-// "-{8hex}" suffix from the full agent ID.
-//
-// Modern SDKs send `name` (base, e.g. "fortuna") and `agent_id` (full, e.g.
-// "fortuna-abc12345") as distinct fields. We still derive the base from
-// `agent.id` here for two reasons:
-//   1. Robustness across SDK versions — older agents collapsed `name == id`,
-//      so trusting `name` as the base would mis-group them.
-//   2. Single source of truth for display grouping — all replica bucketing
-//      happens off the normalized ID suffix, keeping the UI independent of
-//      whatever the sending SDK chose to put in `name`.
+// Returns the canonical grouping key for an agent — the declared `agent.name`
+// (falling back to the full id when empty). Replica bucketing keys off this
+// name, which aligns with the registry's edge/trace stat keys (accumulator.go
+// keys by the declared agent name).
 export function getAgentBaseName(agent: Agent): string {
-  return extractAgentName(agent.id);
+  return groupKeyOf(agent);
 }
 
 // Group key used for collapsed (multi-replica) nodes.
@@ -41,17 +34,6 @@ function bucketAgents(agents: Agent[]): Map<string, GroupInfo> {
     }
   }
   return buckets;
-}
-
-// Worst-of aggregation for group status.
-// Any unhealthy -> unhealthy; any unknown -> unknown; else healthy.
-function aggregateStatus(instances: Agent[]): "healthy" | "unhealthy" | "unknown" {
-  let hasUnknown = false;
-  for (const a of instances) {
-    if (a.status === "unhealthy") return "unhealthy";
-    if (a.status === "unknown") hasUnknown = true;
-  }
-  return hasUnknown ? "unknown" : "healthy";
 }
 
 // Given a set of agents, compute mapping from agent ID to either a group key

--- a/src/ui/lib/use-grouped-agents.ts
+++ b/src/ui/lib/use-grouped-agents.ts
@@ -1,0 +1,9 @@
+import { useMemo } from "react";
+import { Agent } from "./types";
+import { AgentGroup, groupAgentsByName } from "./agent-group";
+
+// Memoized replica-collapse for Dashboard/Agents consumers. Recomputes only
+// when the agents array identity changes.
+export function useGroupedAgents(agents: Agent[]): AgentGroup[] {
+  return useMemo(() => groupAgentsByName(agents), [agents]);
+}


### PR DESCRIPTION
## What

Replicas of the same agent (multiple instances sharing one declared `@MeshAgent` name) were shown **per-instance** on the Agents page and inflated the Dashboard counts — only Topology collapsed them. This propagates Topology's grouping everywhere it matters, so a `×3` agent is one entry with a badge, not three duplicate cards.

**UI-only** (see scope note below).

## Changes

- **Shared grouper** — new `src/ui/lib/agent-group.ts` (`groupAgentsByName`, keyed on **`agent.name`**): per-group newest-by-`last_seen` representative, worst-of aggregate status, summed deps, unique endpoints. All surfaces now group identically off one layer.
- **Topology re-keyed onto it** — `getAgentBaseName` switched from id-suffix-strip to `agent.name`. Pure refactor: public signatures unchanged, the id→nodeKey map stays id-keyed (edge wiring safe), and the name key now *aligns* with the accumulator's declared-name edge/trace stats. `TopologyGraph.tsx`/`AgentNode.tsx` untouched.
- **Reusable drill-in** — extracted the sidebar's group→instances→expand-to-details/capabilities into `AgentGroupDetail`; `TopologySidebar` now consumes it (visually identical).
- **Agents page** — one card/row per logical agent with a **`×N` badge + aggregate health** (`×3 · 2 healthy / 1 down`). Card click opens a right-side drawer, list rows expand — both render `AgentGroupDetail`. Cards no longer navigate to `/agents/:id` (that route still works); the drawer is the drill-in.
- **Dashboard** — counts go **logical**: a `×3` agent counts once (deps/caps per representative). This intentionally changes those numbers — replicas no longer inflate them.

## Scope decisions (locked in the issue)

- **Group key = `agent.name`** (declared name; Topology's id-strip was a fragile heuristic and disagreed with the CLI's key).
- **CLI (`meshctl list`) stays per-instance — by design.** `meshctl` is kubectl-shaped and `kubectl get pods` doesn't collapse pods by Deployment; per-instance rows are the expected CLI idiom, and the CLI is dev-first (single instance). The logical view is the meshui Agents page.
- **Version skew** collapses all live instances under one name (mirrors Topology); a mixed-version marker is a follow-up non-goal.
- Registry `GET /agents` stays per-instance — grouping is presentation-only, **no wire/registry change**.

## Validation

- vitest **35 passing** (grouper rules + Topology re-key key assertion + Agents/Dashboard render), `vite build` + `make ui-server-build` clean.
- **Live smoke** on a real replicated dev mesh (system-agent ×3, fastmcp-service ×2, hello-world ×1): Agents cards/list collapse with `×N`, drawer drill-in lists instances, Dashboard counts logical, Topology grouped — all confirmed in-browser.

Closes #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Agents sharing the same name are now collapsed into a single logical agent group, showing replica counts, worst-case aggregated health, combined dependency metrics, and unified endpoints.
  - Agents page now renders grouped results in both grid and table layouts, with expandable group details.
  - Added a slide-over panel to inspect grouped agent details and updated topology views to reflect the same grouping/status logic.
  - Dashboard stats now reflect logical groups instead of individual replicas.
- **Tests**
  - Added UI and unit test coverage for grouping, replica collapsing, aggregated badge/dependency counts, and the updated dashboard/topology behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->