### PR TITLE
feat(llm): refresh native output_config models + Sonnet 5 scaffold default

### DIFF
--- a/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -20,10 +20,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
     description = "{{ default "LLM provider" .Description }}",
     port = {{ .Port }}
 )
+{{- $model := default "anthropic/claude-sonnet-5" .Model }}
 @MeshLlmProvider(
-    model = "{{ default "anthropic/claude-sonnet-5" .Model }}",
+    model = "{{ $model }}",
     capability = "llm",
-    tags = {{ "{" }}{{ if .Tags }}{{ range $i, $t := .Tags }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}{{ else if contains .Model "anthropic" }}"llm", "claude", "anthropic", "provider"{{ else if contains .Model "openai" }}"llm", "openai", "gpt", "provider"{{ else }}"llm", "provider"{{ end }}{{ "}" }},
+    tags = {{ "{" }}{{ if .Tags }}{{ range $i, $t := .Tags }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}{{ else if contains $model "anthropic" }}"llm", "claude", "anthropic", "provider"{{ else if contains $model "openai" }}"llm", "openai", "gpt", "provider"{{ else }}"llm", "provider"{{ end }}{{ "}" }},
     version = "1.0.0"
 )
 @SpringBootApplication

--- a/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -21,7 +21,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
     port = {{ .Port }}
 )
 @MeshLlmProvider(
-    model = "{{ default "anthropic/claude-sonnet-4-5" .Model }}",
+    model = "{{ default "anthropic/claude-sonnet-5" .Model }}",
     capability = "llm",
     tags = {{ "{" }}{{ if .Tags }}{{ range $i, $t := .Tags }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}{{ else if contains .Model "anthropic" }}"llm", "claude", "anthropic", "provider"{{ else if contains .Model "openai" }}"llm", "openai", "gpt", "provider"{{ else }}"llm", "provider"{{ end }}{{ "}" }},
     version = "1.0.0"

--- a/cmd/meshctl/templates/python/llm-provider/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/helm-values.yaml.tmpl
@@ -60,7 +60,7 @@ env:
 
 # Optional: Configure model settings
 # - name: DEFAULT_MODEL
-#   value: "claude-3-5-sonnet-20241022"
+#   value: "claude-sonnet-5"
 # - name: MAX_TOKENS
 #   value: "4096"
 

--- a/src/core/cli/scaffold.go
+++ b/src/core/cli/scaffold.go
@@ -113,7 +113,7 @@ Infrastructure:
 	cmd.Flags().String("filter-mode", "all", "Filter mode: all, best_match, * (wildcard)")
 
 	// LLM-provider specific flags
-	cmd.Flags().String("model", "", "LiteLLM model (e.g., anthropic/claude-sonnet-4-5)")
+	cmd.Flags().String("model", "", "LiteLLM model (e.g., anthropic/claude-sonnet-5)")
 	cmd.Flags().StringSlice("tags", nil, "Tags for discovery (comma-separated)")
 
 	// Docker-compose generation flags

--- a/src/core/cli/scaffold/interactive.go
+++ b/src/core/cli/scaffold/interactive.go
@@ -421,15 +421,15 @@ func promptLLMProviderConfig(config *InteractiveConfig) error {
 	modelPrompt := &survey.Select{
 		Message: "Which LLM model should this provider expose?",
 		Options: []string{
-			"anthropic/claude-sonnet-4-5 - Claude Sonnet 4.5 (latest)",
-			"anthropic/claude-3-5-sonnet-20241022 - Claude 3.5 Sonnet",
-			"anthropic/claude-3-5-haiku-20241022 - Claude 3.5 Haiku (fast)",
+			"anthropic/claude-sonnet-5 - Claude Sonnet 5 (recommended)",
+			"anthropic/claude-opus-4-8 - Claude Opus 4.8 (most capable)",
+			"anthropic/claude-haiku-4-5 - Claude Haiku 4.5 (fast)",
 			"openai/gpt-4o - GPT-4o (recommended)",
 			"openai/gpt-4o-mini - GPT-4o Mini (fast, cheap)",
 			"openai/gpt-4-turbo - GPT-4 Turbo",
 			"custom - Enter custom model string",
 		},
-		Default: "anthropic/claude-sonnet-4-5 - Claude Sonnet 4.5 (latest)",
+		Default: "anthropic/claude-sonnet-5 - Claude Sonnet 5 (recommended)",
 	}
 	if err := survey.AskOne(modelPrompt, &model); err != nil {
 		return fmt.Errorf("failed to get model: %w", err)

--- a/src/core/cli/scaffold/llm_subcommand.go
+++ b/src/core/cli/scaffold/llm_subcommand.go
@@ -17,7 +17,7 @@ var supportedLLMRuntimes = []string{"python", "typescript", "java"}
 // vendorToModel maps a vendor shortcut to a default LiteLLM model string.
 // Used by `meshctl scaffold llm-provider`.
 var vendorToModel = map[string]string{
-	"claude":           "anthropic/claude-sonnet-4-5",
+	"claude":           "anthropic/claude-sonnet-5",
 	"openai":           "openai/gpt-4o",
 	"gemini":           "gemini/gemini-1.5-pro",
 	"litellm-fallback": "openai/gpt-4o",

--- a/src/core/cli/scaffold/llm_subcommand_test.go
+++ b/src/core/cli/scaffold/llm_subcommand_test.go
@@ -29,7 +29,7 @@ func TestIsValidLLMVendor(t *testing.T) {
 }
 
 func TestVendorToModel(t *testing.T) {
-	assert.Equal(t, "anthropic/claude-sonnet-4-5", VendorToModel("claude"))
+	assert.Equal(t, "anthropic/claude-sonnet-5", VendorToModel("claude"))
 	assert.Equal(t, "openai/gpt-4o", VendorToModel("openai"))
 	assert.Equal(t, "gemini/gemini-1.5-pro", VendorToModel("gemini"))
 	assert.NotEmpty(t, VendorToModel("litellm-fallback"))
@@ -204,7 +204,7 @@ func TestRunScaffoldLLMProvider_DryRun_Python(t *testing.T) {
 
 	output := out.String()
 	assert.Contains(t, output, "Dry-run")
-	assert.Contains(t, output, "anthropic/claude-sonnet-4-5")
+	assert.Contains(t, output, "anthropic/claude-sonnet-5")
 	assert.Contains(t, output, "+claude")
 }
 

--- a/src/core/cli/scaffold/provider.go
+++ b/src/core/cli/scaffold/provider.go
@@ -78,7 +78,7 @@ type ScaffoldContext struct {
 	FilterMode string // "all", "best_match", "*" (default: "all")
 
 	// LLM-provider specific (for @mesh.llm_provider decorator)
-	Model string // LiteLLM model string (e.g., "anthropic/claude-sonnet-4-5")
+	Model string // LiteLLM model string (e.g., "anthropic/claude-sonnet-5")
 
 	// Java-specific
 	JavaPackage string // Java package name (e.g., "com.example.greeter")

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
@@ -724,16 +724,18 @@ _ANTHROPIC_PASSTHROUGH_KWARGS = frozenset(
 # ---------------------------------------------------------------------------
 # Native ``output_config`` (structured output) — model gating + schema filter
 # ---------------------------------------------------------------------------
-# Sonnet 4.5+ / Opus 4.1+ accept Anthropic's first-class
-# ``output_config.format`` primitive. The wire shape is one transform shallower
-# than LiteLLM's ``response_format``:
+# Sonnet 4.5+ / Sonnet 5 / Opus 4.1+ / Opus 4.8 / Fable 5 accept Anthropic's
+# first-class ``output_config.format`` primitive. The wire shape is one
+# transform shallower than LiteLLM's ``response_format``:
 #
 #   output_config = {"format": {"type": "json_schema", "schema": {...}}}
 #
 # Older models (Haiku, Sonnet 3.x / 4.0, Opus 3.x) reject the field, so we
 # fall through to the existing synthetic-tool injection path for those.
 # LiteLLM uses a substring allow-list at transformation.py:822-830; we mirror
-# it plus the Sonnet 4.6 / Opus 4.5 / 4.7 releases.
+# it plus the Sonnet 4.6 / 5, Opus 4.5 / 4.6 / 4.7 / 4.8, and Fable 5 releases
+# (per current Anthropic docs these support native structured outputs; Haiku
+# stays out — see the ``_supports_native_output_format`` docstring).
 #
 # Patterns (not raw substrings) so the trailing minor-version digit is
 # boundary-anchored: ``opus-4-1`` must NOT match a hypothetical future
@@ -748,9 +750,13 @@ _NATIVE_OUTPUT_FORMAT_MODEL_PATTERNS = tuple(
     for p in (
         r"(?<!\d)sonnet-4[-.]5(?!\d)",
         r"(?<!\d)sonnet-4[-.]6(?!\d)",
+        r"(?<!\d)sonnet-5(?!\d)",
         r"(?<!\d)opus-4[-.]1(?!\d)",
         r"(?<!\d)opus-4[-.]5(?!\d)",
+        r"(?<!\d)opus-4[-.]6(?!\d)",
         r"(?<!\d)opus-4[-.]7(?!\d)",
+        r"(?<!\d)opus-4[-.]8(?!\d)",
+        r"(?<!\d)fable-5(?!\d)",
     )
 )
 

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native_output_format.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native_output_format.py
@@ -108,9 +108,20 @@ class TestSupportsNativeOutputFormat:
             "anthropic/claude-opus-4-5",
             "anthropic/claude-opus-4-7",
             "anthropic/claude-opus-4.7",
+            # #1331 refresh: Sonnet 5, Opus 4.6 / 4.8, Fable 5.
+            "anthropic/claude-sonnet-5",
+            "anthropic/claude-sonnet-5-20260101",
+            "anthropic/claude-opus-4-8",
+            "anthropic/claude-opus-4.8",
+            "anthropic/claude-opus-4-6",
+            "anthropic/claude-opus-4.6",
+            "anthropic/claude-fable-5",
+            "anthropic/claude-fable-5-20260101",
             # Bedrock prefix + substring match.
             "bedrock/anthropic.claude-sonnet-4-6-20260301-v1:0",
             "bedrock/anthropic.claude-opus-4-7-20260401-v1:0",
+            "bedrock/anthropic.claude-sonnet-5-20260101-v1:0",
+            "bedrock/anthropic.claude-opus-4-8-20260401-v1:0",
             # Databricks prefix.
             "databricks/anthropic.claude-sonnet-4-6",
             # Case-insensitive (defensive).
@@ -159,6 +170,11 @@ class TestSupportsNativeOutputFormat:
             "anthropic/claude-sonnet-4-50",
             "anthropic/claude-sonnet-4-60",
             "anthropic/claude-sonnet-4-55",
+            # #1331 refresh — overmatch guard for the new patterns.
+            "anthropic/claude-sonnet-50",
+            "anthropic/claude-opus-4-80",
+            "anthropic/claude-opus-4-88",
+            "anthropic/claude-fable-50",
             # Dot-form overmatch — same problem, dot separator.
             "anthropic/claude-opus-4.10",
             "anthropic/claude-sonnet-4.55",

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
@@ -53,8 +53,15 @@ class TestAnthropicResolver:
             "anthropic/claude-opus-4-1",
             "anthropic/claude-opus-4-5",
             "anthropic/claude-opus-4-7",
+            # #1331 refresh: Sonnet 5, Opus 4.6 / 4.8, Fable 5.
+            "anthropic/claude-sonnet-5",
+            "anthropic/claude-opus-4-6",
+            "anthropic/claude-opus-4-8",
+            "anthropic/claude-fable-5",
             # Bedrock-prefixed + date-pinned still match (re.search, not anchored).
             "anthropic.claude-sonnet-4-6-20260301-v1:0",
+            "anthropic.claude-sonnet-5-20260101-v1:0",
+            "anthropic.claude-opus-4-8-20260401-v1:0",
             # Dot separator variant.
             "anthropic/claude-sonnet-4.5",
         ],

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
@@ -109,7 +109,14 @@ class TestAnthropicResolver:
             "anthropic/claude-opus-4-1",
             "anthropic/claude-opus-4-5",
             "anthropic/claude-opus-4-7",
+            # #1331 refresh: Sonnet 5, Opus 4.6 / 4.8, Fable 5.
+            "anthropic/claude-sonnet-5",
+            "anthropic/claude-opus-4-6",
+            "anthropic/claude-opus-4-8",
+            "anthropic/claude-fable-5",
             "anthropic.claude-sonnet-4-6-20260301-v1:0",
+            "anthropic.claude-sonnet-5-20260101-v1:0",
+            "anthropic.claude-opus-4-8-20260401-v1:0",
             "anthropic/claude-sonnet-4.5",
         ],
     )

--- a/tests/integration/suites/uc01_scaffolding/tc06_py_llm_provider/test.yaml
+++ b/tests/integration/suites/uc01_scaffolding/tc06_py_llm_provider/test.yaml
@@ -23,7 +23,7 @@ test:
     handler: shell
     command: |
       meshctl scaffold --name test-llm-provider --agent-type llm-provider \
-        --lang python --model anthropic/claude-sonnet-4-5 -o /workspace
+        --lang python --model anthropic/claude-sonnet-5 -o /workspace
     workdir: /workspace
     capture: scaffold_output
 

--- a/tests/integration/suites/uc01_scaffolding/tc10_java_llm_provider/test.yaml
+++ b/tests/integration/suites/uc01_scaffolding/tc10_java_llm_provider/test.yaml
@@ -20,7 +20,7 @@ test:
     handler: shell
     command: |
       meshctl scaffold --name test-llm-provider-java --agent-type llm-provider \
-        --lang java --model anthropic/claude-sonnet-4-5 --no-interactive -o /workspace
+        --lang java --model anthropic/claude-sonnet-5 --no-interactive -o /workspace
     workdir: /workspace
     capture: scaffold_output
 

--- a/tests/integration/suites/uc05_meshctl/tc03_scaffold_llm_provider_claude_py/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc03_scaffold_llm_provider_claude_py/test.yaml
@@ -2,7 +2,7 @@
 # Verifies meshctl scaffold generates Claude provider with correct model version
 
 name: "Scaffold LLM Provider - Claude Py"
-description: "Verify Claude Python provider scaffold uses current model (claude-sonnet-4-5)"
+description: "Verify Claude Python provider scaffold uses current model (claude-sonnet-5)"
 tags:
   - scaffolding
   - meshctl
@@ -17,7 +17,7 @@ test:
   # Scaffold Claude LLM provider
   - name: "Scaffold Claude provider"
     handler: shell
-    command: "meshctl scaffold --name claude-test --agent-type llm-provider --model anthropic/claude-sonnet-4-5 --lang python"
+    command: "meshctl scaffold --name claude-test --agent-type llm-provider --model anthropic/claude-sonnet-5 --lang python"
     workdir: /workspace
     capture: scaffold_output
 
@@ -56,9 +56,9 @@ assertions:
   - expr: "${captured.main_content} contains '@mesh.llm_provider'"
     message: "main.py should have @mesh.llm_provider decorator"
 
-  # Model should be claude-sonnet-4-5
-  - expr: "${captured.main_content} contains 'claude-sonnet-4-5'"
-    message: "Should use claude-sonnet-4-5 model"
+  # Model should be claude-sonnet-5
+  - expr: "${captured.main_content} contains 'claude-sonnet-5'"
+    message: "Should use claude-sonnet-5 model"
 
   # Should have anthropic in model path
   - expr: "${captured.main_content} contains 'anthropic/'"

--- a/tests/integration/suites/uc05_meshctl/tc14_ts_scaffold_llm_provider_claude/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc14_ts_scaffold_llm_provider_claude/test.yaml
@@ -2,7 +2,7 @@
 # Verifies meshctl scaffold generates Claude provider with correct model version for TypeScript
 
 name: "Scaffold LLM Provider - Claude TS"
-description: "Verify Claude TypeScript provider scaffold uses current model (claude-sonnet-4-5)"
+description: "Verify Claude TypeScript provider scaffold uses current model (claude-sonnet-5)"
 tags:
   - scaffolding
   - meshctl
@@ -17,7 +17,7 @@ test:
   # Scaffold Claude LLM provider for TypeScript
   - name: "Scaffold Claude provider"
     handler: shell
-    command: "meshctl scaffold --name claude-test-ts --agent-type llm-provider --model anthropic/claude-sonnet-4-5 --lang typescript"
+    command: "meshctl scaffold --name claude-test-ts --agent-type llm-provider --model anthropic/claude-sonnet-5 --lang typescript"
     workdir: /workspace
     capture: scaffold_output
 
@@ -52,9 +52,9 @@ assertions:
   - expr: "${captured.index_content} contains 'addLlmProvider'"
     message: "src/index.ts should have addLlmProvider call"
 
-  # Model should be claude-sonnet-4-5
-  - expr: "${captured.index_content} contains 'claude-sonnet-4-5'"
-    message: "Should use claude-sonnet-4-5 model"
+  # Model should be claude-sonnet-5
+  - expr: "${captured.index_content} contains 'claude-sonnet-5'"
+    message: "Should use claude-sonnet-5 model"
 
   # Should have anthropic in model path
   - expr: "${captured.index_content} contains 'anthropic/'"

--- a/tests/integration/suites/uc05_meshctl/tc16_java_scaffold_llm_provider_claude/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc16_java_scaffold_llm_provider_claude/test.yaml
@@ -2,7 +2,7 @@
 # Verifies meshctl scaffold generates Claude provider with correct model version for Java
 
 name: "Scaffold LLM Provider - Claude Java"
-description: "Verify Claude Java provider scaffold uses current model (claude-sonnet-4-5)"
+description: "Verify Claude Java provider scaffold uses current model (claude-sonnet-5)"
 tags:
   - scaffolding
   - meshctl
@@ -17,7 +17,7 @@ test:
   # Scaffold Claude LLM provider for Java
   - name: "Scaffold Claude provider"
     handler: shell
-    command: "meshctl scaffold --name claude-test-java --agent-type llm-provider --model anthropic/claude-sonnet-4-5 --lang java"
+    command: "meshctl scaffold --name claude-test-java --agent-type llm-provider --model anthropic/claude-sonnet-5 --lang java"
     workdir: /workspace
     capture: scaffold_output
 
@@ -60,9 +60,9 @@ assertions:
   - expr: "${captured.app_content} contains '@MeshAgent'"
     message: "Application.java should have @MeshAgent annotation"
 
-  # Model should be claude-sonnet-4-5
-  - expr: "${captured.app_content} contains 'claude-sonnet-4-5'"
-    message: "Should use claude-sonnet-4-5 model"
+  # Model should be claude-sonnet-5
+  - expr: "${captured.app_content} contains 'claude-sonnet-5'"
+    message: "Should use claude-sonnet-5 model"
 
   # Should have anthropic in model path
   - expr: "${captured.app_content} contains 'anthropic/'"


### PR DESCRIPTION
## Summary

Claude/OpenAI model ids flow through mesh as **pass-through strings keyed on vendor**, so a newly-released model (e.g. Sonnet 5) needs **no runtime change**. This PR refreshes the two manually-maintained Anthropic surfaces that had drifted behind model releases, defaults new scaffolds to Sonnet 5, and adds regression coverage so these lists stop silently lagging.

### 1. Native `output_config` capability list
`_NATIVE_OUTPUT_FORMAT_MODEL_PATTERNS` (`anthropic_native.py`) gates which Claude models use Anthropic's native `output_config.format` structured-output primitive vs. the synthetic-tool fallback. A non-match **degrades gracefully** (synthetic-tool path stays correct), so this is an **optimization refresh, not a behavior break**. Added `sonnet-5`, `opus-4-6`, `opus-4-8`, `fable-5` — all documented by Anthropic as supporting native structured outputs — preserving the `(?<!\d)…(?!\d)` digit-guards and `[-.]` separator tolerance.

### 2. Scaffold defaults → Sonnet 5
Claude now defaults to `anthropic/claude-sonnet-5` across every scaffold surface: the `vendorToModel` map, the interactive prompt default, flag-help/doc examples, and the Java `llm-provider` template fallback. The interactive menu's two **retired** options (`claude-3-5-sonnet-20241022`, `claude-3-5-haiku-20241022`) are replaced with current models, and a retired-model example in the Python helm-values template is modernized. Sonnet 5 is the same sticker price as 4.5 ($3/$15 per MTok, introductory $2/$10 through 2026-08-31) and a stronger coding/agentic model.

### 3. Regression tests
Native-gate and capability-resolver parametrize tables now cover the new ids (including Bedrock-prefixed / date-pinned variants) plus overmatch negatives (`sonnet-50`, `opus-4-80`, `fable-50`, etc.), so a future model gap fails loudly.

### 4. Integration tests
The `uc05`/`uc01` Claude scaffold codegen tests are updated to `claude-sonnet-5` (command `--model` and `contains` assertions in lockstep).

## Review notes
- Independent zero-context review: 0 blockers. Both warnings it raised — a Java template default and a Python helm-values comment still on stale/retired ids — are fixed in this PR. Remaining INFOs (round-trip test fixtures; ~180 docs/man/example references) are the deferred modernization sweep.
- **Runtime support for any new Claude id is pass-through and unchanged** — this PR touches only the capability/scaffold surfaces and tests.

## Deliberately out of scope (follow-ups)
- Docs / man-page model-string modernization (broad, separate sweep).
- OpenAI/GPT path cleanup — tracked in #1332.
- The possibly-stale Haiku exclusion from the native `output_config` gate (current Anthropic docs list Haiku 4.5 as structured-output-capable) — left untouched here.

## Test plan
- [x] `pytest` native-gate + capability-resolver tests green
- [x] `go build ./...` + `go test ./cli/scaffold/...` green
- [x] Zero-context code review (0 blockers)
- [ ] CI matrix (Go/Java/Py/Rust/TS + CodeRabbit)
- [ ] `tsuite` uc05/uc01 scaffold suites (mechanical string swaps; validated by inspection — command↔assertion lockstep)

Closes #1331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated LLM provider scaffolding defaults and examples to use Claude Sonnet 5 across languages and interactive setup.
  * Expanded native structured-output support to include newer Claude Sonnet/Opus/Fable model variants.
* **Bug Fixes**
  * Improved model matching/gating so additional supported variants work, while “no-separator”/unsupported variants are not incorrectly accepted.
* **Tests**
  * Updated unit and integration test expectations for the new Claude model defaults and native capability allow-list behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->