### PR TITLE
feat(llm): OpenAI GPT-5 hardening — chat-exclusion fix + Responses routing for reasoning+tools

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
@@ -195,10 +195,13 @@ public class OpenAiHandler implements LlmProviderHandler {
 
     /**
      * Whether an OpenAI model restricts {@code temperature}/{@code top_p} to their
-     * default value (rejecting any explicit setting). Verified against the live API:
+     * default value (rejecting any explicit setting). The gpt-5 chat exclusion is
+     * version-agnostic: any gpt-5 id containing a {@code -chat} marker
+     * ({@code gpt-5-chat}, {@code gpt-5-chat-latest}, {@code gpt-5.6-chat}, …) is
+     * treated as a chat variant and left unrestricted. Verified against the live API:
      * <ul>
-     *   <li>REJECT: gpt-5, gpt-5-mini, gpt-5-nano, o1, o3-mini, o4-mini</li>
-     *   <li>ACCEPT: gpt-4o, gpt-4.1, gpt-5-chat-latest</li>
+     *   <li>REJECT: gpt-5, gpt-5-mini, gpt-5-nano, gpt-5.6, o1, o3-mini, o4-mini</li>
+     *   <li>ACCEPT: gpt-4o, gpt-4.1, gpt-5-chat-latest, gpt-5.6-chat</li>
      * </ul>
      * Accepts a bare or {@code vendor/}-qualified model string.
      */
@@ -210,8 +213,9 @@ public class OpenAiHandler implements LlmProviderHandler {
         // o-series reasoning models reject temperature/top_p
         if (m.equals("o1") || m.equals("o3") || m.equals("o4")
             || m.startsWith("o1-") || m.startsWith("o3-") || m.startsWith("o4-")) return true;
-        // gpt-5 family restricts temperature/top_p to default — except gpt-5-chat*
-        if (m.startsWith("gpt-5") && !m.startsWith("gpt-5-chat")) return true;
+        // gpt-5 family restricts temperature/top_p to default — except chat variants.
+        // Version-agnostic: any gpt-5 id with a "-chat" marker is unrestricted (#1332).
+        if (m.startsWith("gpt-5") && !m.contains("-chat")) return true;
         return false;
     }
 

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderDeclaredModelTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderDeclaredModelTest.java
@@ -300,6 +300,26 @@ class ProviderDeclaredModelTest {
             assertEquals(0.7, opts.getTemperature(), 1e-9);
             assertEquals(0.9, opts.getTopP(), 1e-9);
         }
+
+        @Test
+        @DisplayName("gpt-5.6 point release omits temperature/top_p but keeps maxCompletionTokens")
+        void gpt5PointReleaseRestricted() {
+            // #1332 — a gpt-5 point release is restricted like the base model.
+            OpenAiChatOptions opts = callWith("gpt-5.6");
+            assertNull(opts.getTemperature(), "temperature must be omitted for gpt-5.6");
+            assertNull(opts.getTopP(), "top_p must be omitted for gpt-5.6");
+            assertEquals(1000, opts.getMaxCompletionTokens());
+            assertEquals("gpt-5.6", opts.getModel());
+        }
+
+        @Test
+        @DisplayName("gpt-5.6-chat point release applies temperature/top_p")
+        void gpt5PointReleaseChatAllowed() {
+            // #1332 — version-agnostic chat exclusion covers versioned chat ids.
+            OpenAiChatOptions opts = callWith("gpt-5.6-chat");
+            assertEquals(0.7, opts.getTemperature(), 1e-9);
+            assertEquals(0.9, opts.getTopP(), 1e-9);
+        }
     }
 
     @Nested
@@ -315,6 +335,10 @@ class ProviderDeclaredModelTest {
             assertTrue(OpenAiHandler.restrictsSamplingParams("gpt-5-mini"));
             assertTrue(OpenAiHandler.restrictsSamplingParams("gpt-5-nano"));
             assertTrue(OpenAiHandler.restrictsSamplingParams("openai/gpt-5"));
+            // #1332 — version-agnostic: gpt-5 point releases stay restricted.
+            assertTrue(OpenAiHandler.restrictsSamplingParams("gpt-5.6"));
+            assertTrue(OpenAiHandler.restrictsSamplingParams("gpt-5-6"));
+            assertTrue(OpenAiHandler.restrictsSamplingParams("openai/gpt-5.6"));
         }
 
         @Test
@@ -322,7 +346,11 @@ class ProviderDeclaredModelTest {
         void unrestricted() {
             assertFalse(OpenAiHandler.restrictsSamplingParams("gpt-4o"));
             assertFalse(OpenAiHandler.restrictsSamplingParams("gpt-4.1"));
+            assertFalse(OpenAiHandler.restrictsSamplingParams("gpt-5-chat"));
             assertFalse(OpenAiHandler.restrictsSamplingParams("gpt-5-chat-latest"));
+            // #1332 — version-agnostic chat exclusion covers versioned chat ids.
+            assertFalse(OpenAiHandler.restrictsSamplingParams("gpt-5.6-chat"));
+            assertFalse(OpenAiHandler.restrictsSamplingParams("gpt-5.6-chat-latest"));
             assertFalse(OpenAiHandler.restrictsSamplingParams(null));
         }
     }

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/_native_client_helpers.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/_native_client_helpers.py
@@ -64,11 +64,13 @@ def restricts_sampling_params(model: str | None) -> bool:
     default value (rejecting any explicit setting with HTTP 400).
 
     OpenAI o-series reasoning models (o1/o3/o4) and the gpt-5 family (except
-    gpt-5-chat) accept ONLY the default sampling params. Verified against the
-    live API:
+    chat variants) accept ONLY the default sampling params. The chat exclusion
+    is version-agnostic: any gpt-5 id containing a ``-chat`` marker
+    (``gpt-5-chat``, ``gpt-5-chat-latest``, ``gpt-5.6-chat``, …) is treated as
+    a chat variant and left unrestricted. Verified against the live API:
 
-      * REJECT: gpt-5, gpt-5-mini, gpt-5-nano, o1, o3-mini, o4-mini
-      * ACCEPT: gpt-4o, gpt-4.1, gpt-5-chat-latest
+      * REJECT: gpt-5, gpt-5-mini, gpt-5-nano, gpt-5.6, o1, o3-mini, o4-mini
+      * ACCEPT: gpt-4o, gpt-4.1, gpt-5-chat-latest, gpt-5.6-chat
 
     Accepts a bare or ``vendor/``-qualified model string (e.g.
     ``openai/o3-mini``). Returns ``True`` when ``temperature``/``top_p`` should
@@ -81,9 +83,19 @@ def restricts_sampling_params(model: str | None) -> bool:
         m = m.split("/", 1)[1]  # strip vendor prefix e.g. "openai/o3-mini"
     if m in ("o1", "o3", "o4") or m.startswith(("o1-", "o3-", "o4-")):
         return True
-    if m.startswith("gpt-5") and not m.startswith("gpt-5-chat"):
+    # Version-agnostic chat exclusion: any gpt-5 id with a "-chat" marker is a
+    # chat variant (accepts sampling params); everything else is restricted (#1332).
+    if m.startswith("gpt-5") and "-chat" not in m:
         return True
     return False
+
+
+# Readability alias: for OpenAI, the models that restrict sampling params are
+# exactly the reasoning models (o-series + gpt-5 non-chat). #1334 routes these
+# to the Responses API when tools are present because they reason by default
+# and OpenAI 400s on reasoning + function tools on /v1/chat/completions. Single
+# implementation — no logic duplication; call whichever name reads best.
+is_openai_reasoning_model = restricts_sampling_params
 
 
 def translate_max_tokens_for_restricted(

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -41,6 +41,7 @@ from typing import Any
 import httpx
 
 from ._native_client_helpers import (
+    is_openai_reasoning_model,
     make_fallback_logger,
     make_is_available,
     reset_unsupported_kwargs_dedupe,
@@ -545,6 +546,467 @@ def _build_create_kwargs(
 
 
 # ---------------------------------------------------------------------------
+# Responses API path (issue #1334)
+# ---------------------------------------------------------------------------
+# OpenAI gpt-5-family / o-series REASONING models reason by default. On
+# ``/v1/chat/completions`` OpenAI returns HTTP 400 when such a model is asked
+# to reason AND is given function tools ("use /v1/responses or set
+# reasoning_effort='none'"). Routing those requests to the Responses API lets
+# reasoning + tools coexist. gpt-4o and gpt-5 *chat* variants — which do not
+# restrict sampling params — stay on chat.completions; no-tools reasoning
+# calls also stay on chat.completions (no 400 there). ``tools`` is constant
+# across an agentic loop so the endpoint never flips mid-conversation.
+
+
+def _openai_wants_responses_api(model: str, request_params: dict[str, Any]) -> bool:
+    """True when this request must route to the OpenAI Responses API.
+
+    Trigger: a reasoning model (o-series / gpt-5 non-chat) *and* the request
+    carries function tools. See the section comment for the rationale.
+
+    Exception: ``reasoning_effort="none"`` is OpenAI's documented way to keep a
+    reasoning model on ``/v1/chat/completions`` with tools (no reasoning, no
+    400). Those requests stay on chat.completions — routing them to Responses
+    would emit ``reasoning={"effort": "none"}``, which Responses rejects.
+    """
+    if request_params.get("reasoning_effort") == "none":
+        return False
+    return is_openai_reasoning_model(model) and bool(request_params.get("tools"))
+
+
+# Chat-completions kwargs the Responses builder consumes/translates itself —
+# the leftover-kwarg WARN must not flag these as "dropped".
+_OPENAI_RESPONSES_HANDLED_KWARGS = frozenset({
+    "messages",
+    "tools",
+    "tool_choice",
+    "reasoning_effort",
+    "response_format",
+    "max_completion_tokens",
+    "max_tokens",
+    "temperature",
+    "top_p",
+    "model",
+    "api_key",
+    "base_url",
+    "stream",
+    "stream_options",
+})
+
+# Kwargs forwarded verbatim to responses.create (shapes are identical on both
+# endpoints).
+_OPENAI_RESPONSES_PASSTHROUGH_KWARGS = frozenset({
+    "parallel_tool_calls",
+    "user",
+    "metadata",
+    "extra_headers",
+    "extra_query",
+    "extra_body",
+})
+
+
+def _stringify_tool_output(content: Any) -> str:
+    """Coerce a chat ``role:tool`` message ``content`` into the Responses
+    ``function_call_output.output`` string."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    try:
+        return json.dumps(content)
+    except (TypeError, ValueError):
+        return str(content)
+
+
+def _translate_response_format_to_text(response_format: Any) -> dict[str, Any]:
+    """chat ``response_format`` → Responses ``text`` block.
+
+    ``{type:json_schema, json_schema:{name,schema,strict}}`` becomes
+    ``{format:{type:json_schema, name, schema, strict}}`` (flattened). Other
+    shapes (``{type:json_object}``, ``{type:text}``) pass through under
+    ``format`` unchanged.
+    """
+    if isinstance(response_format, dict) and response_format.get("type") == "json_schema":
+        js = response_format.get("json_schema") or {}
+        fmt: dict[str, Any] = {"type": "json_schema"}
+        if js.get("name") is not None:
+            fmt["name"] = js.get("name")
+        if js.get("schema") is not None:
+            fmt["schema"] = js.get("schema")
+        if "strict" in js:
+            fmt["strict"] = js.get("strict")
+        return {"format": fmt}
+    return {"format": response_format}
+
+
+def _translate_message_content(content: Any, role: str) -> Any:
+    """Translate chat-style message ``content`` into the Responses input shape.
+
+    Plain-string content passes through unchanged (the common case). A
+    content-part ARRAY is translated part-by-part: text parts
+    ``{"type":"text","text":...}`` become ``input_text`` (user/system) or
+    ``output_text`` (assistant), matching the part types Responses expects.
+
+    Any image or other non-text part raises a clear ``ValueError`` rather than
+    forwarding an untranslated chat-shape part that would yield a cryptic
+    OpenAI 400. Image translation is deliberately NOT attempted here (the
+    Responses image-part shape differs and is unverified for this path).
+    """
+    if not isinstance(content, list):
+        return content
+    text_type = "output_text" if role == "assistant" else "input_text"
+    translated: list[dict[str, Any]] = []
+    for part in content:
+        ptype = part.get("type") if isinstance(part, dict) else None
+        if ptype == "text":
+            translated.append({"type": text_type, "text": part.get("text")})
+        else:
+            raise ValueError(
+                "OpenAI Responses path (reasoning model + tools) does not yet "
+                "support multimodal image content; use string/text content, "
+                "drop tools, or use a non-reasoning model "
+                f"(unsupported content part type={ptype!r})"
+            )
+    return translated
+
+
+def _build_responses_kwargs(
+    request_params: dict[str, Any],
+    *,
+    model: str,
+) -> dict[str, Any]:
+    """Translate mesh/chat.completions-shape request_params → Responses kwargs.
+
+    Parallel to :func:`_build_create_kwargs` but targets ``responses.create``:
+
+      * ``messages`` → ``input`` items (+ ``instructions`` from system turns).
+        The multi-turn history remap is the critical part — prior assistant
+        ``tool_calls`` become ``function_call`` items and ``role:tool`` results
+        become ``function_call_output`` items, preserving ``call_id`` exactly
+        so calls and outputs pair correctly on iteration 2+.
+      * flat tool schema / tool_choice.
+      * ``reasoning_effort`` → ``reasoning={"effort": ...}``.
+      * ``response_format`` → ``text={"format": ...}``.
+      * ``max_completion_tokens`` / ``max_tokens`` → ``max_output_tokens``.
+
+    ``store`` is explicitly set to ``False`` to match the chat path's
+    no-persistence behavior — ``responses.create`` defaults ``store=true``
+    (persisting prompt + output on OpenAI's servers for 30 days) whereas
+    ``chat.completions.create`` defaults ``false``. ``temperature`` / ``top_p``
+    are omitted (reasoning models reject them) with a soft-fail WARN, mirroring
+    the chat path.
+    """
+    # Shallow-copy so we don't mutate the caller's dict (we ``pop`` below).
+    request_params = dict(request_params)
+
+    resolved_timeout = resolve_request_timeout(
+        request_params,
+        adapter_label="Native OpenAI adapter (Responses)",
+        logger=logger,
+    )
+
+    responses_kwargs: dict[str, Any] = {"model": _strip_prefix(model)}
+    # ``responses.create`` defaults ``store=true`` (persists prompt + output on
+    # OpenAI servers for 30 days); ``chat.completions.create`` defaults false.
+    # Set it explicitly so the Responses path matches the chat path's
+    # no-persistence behavior.
+    responses_kwargs["store"] = False
+    if resolved_timeout is not None:
+        responses_kwargs["timeout"] = resolved_timeout
+
+    # --- messages → input items (+ instructions) ----------------------------
+    input_items: list[dict[str, Any]] = []
+    instructions_parts: list[str] = []
+    for msg in request_params.get("messages") or []:
+        role = msg.get("role")
+        content = msg.get("content")
+        if role == "system":
+            # Collect string system prompts into ``instructions``; non-string
+            # (multimodal) system content falls back to an input item.
+            if isinstance(content, str):
+                instructions_parts.append(content)
+            else:
+                input_items.append({
+                    "role": "system",
+                    "content": _translate_message_content(content, "system"),
+                })
+            continue
+        if role == "assistant":
+            # A text turn and tool calls can co-occur — emit both.
+            if content:
+                input_items.append({
+                    "role": "assistant",
+                    "content": _translate_message_content(content, "assistant"),
+                })
+            for tc in msg.get("tool_calls") or []:
+                fn = tc.get("function") or {}
+                input_items.append({
+                    "type": "function_call",
+                    # chat ``tool_call.id`` → Responses ``call_id`` (exact).
+                    "call_id": tc.get("id"),
+                    "name": fn.get("name"),
+                    # Responses expects a string; coerce an explicit None → "".
+                    "arguments": fn.get("arguments") or "",
+                })
+            continue
+        if role == "tool":
+            input_items.append({
+                "type": "function_call_output",
+                # chat ``tool_call_id`` → Responses ``call_id`` (exact).
+                "call_id": msg.get("tool_call_id"),
+                "output": _stringify_tool_output(content),
+            })
+            continue
+        # user / any other role → passthrough input item.
+        input_items.append(
+            {"role": role, "content": _translate_message_content(content, role)}
+        )
+
+    responses_kwargs["input"] = input_items
+    if instructions_parts:
+        responses_kwargs["instructions"] = "\n\n".join(instructions_parts)
+
+    # --- tools: nested {type:function, function:{...}} → flat ---------------
+    tools = request_params.get("tools")
+    if tools:
+        flat_tools: list[dict[str, Any]] = []
+        for t in tools:
+            if isinstance(t, dict) and t.get("type") == "function" and "function" in t:
+                fn = t["function"] or {}
+                flat_tools.append({
+                    "type": "function",
+                    "name": fn.get("name"),
+                    "description": fn.get("description"),
+                    "parameters": fn.get("parameters"),
+                })
+            else:
+                flat_tools.append(t)
+        responses_kwargs["tools"] = flat_tools
+
+    # --- tool_choice: flatten the {type:function, function:{name}} dict ------
+    tool_choice = request_params.get("tool_choice")
+    if tool_choice is not None:
+        if isinstance(tool_choice, dict) and tool_choice.get("type") == "function":
+            fn = tool_choice.get("function") or {}
+            responses_kwargs["tool_choice"] = {
+                "type": "function",
+                "name": fn.get("name"),
+            }
+        else:
+            # "auto" / "none" / "required" pass through unchanged.
+            responses_kwargs["tool_choice"] = tool_choice
+
+    # --- reasoning_effort → reasoning={"effort": ...} ----------------------
+    reasoning_effort = request_params.get("reasoning_effort")
+    if reasoning_effort is not None:
+        responses_kwargs["reasoning"] = {"effort": reasoning_effort}
+
+    # --- response_format → text={"format": ...} ----------------------------
+    response_format = request_params.get("response_format")
+    if response_format is not None:
+        responses_kwargs["text"] = _translate_response_format_to_text(response_format)
+
+    # --- max_completion_tokens / max_tokens → max_output_tokens ------------
+    max_output = request_params.get("max_completion_tokens")
+    if max_output is None:
+        max_output = request_params.get("max_tokens")
+    if max_output is not None:
+        responses_kwargs["max_output_tokens"] = max_output
+
+    # --- sampling-param gating (reasoning models reject temperature/top_p) --
+    for key in ("temperature", "top_p"):
+        if request_params.get(key) is not None:
+            logger.warning(
+                "OpenAI model %s rejects %s; omitting %s=%s "
+                "(only the default is supported)",
+                model,
+                key,
+                key,
+                request_params.get(key),
+            )
+
+    # --- verbatim passthrough kwargs ---------------------------------------
+    for key in _OPENAI_RESPONSES_PASSTHROUGH_KWARGS:
+        value = request_params.get(key)
+        if value is not None:
+            responses_kwargs[key] = value
+
+    # --- WARN on leftover unhandled kwargs (mirrors the chat path) ----------
+    # ``timeout`` / ``request_timeout`` were already popped by
+    # resolve_request_timeout, so they won't surface here.
+    for k in request_params:
+        if k.startswith("_mesh_"):
+            continue
+        if k in _OPENAI_RESPONSES_HANDLED_KWARGS:
+            continue
+        if k in _OPENAI_RESPONSES_PASSTHROUGH_KWARGS:
+            continue
+        _warn_unsupported_kwarg_once(k, sdk_call_label="openai.responses.create")
+
+    return responses_kwargs
+
+
+def _rget(obj: Any, key: str, default: Any = None) -> Any:
+    """Attribute-or-key getter so adapters accept both SDK Pydantic objects
+    and plain dicts (keeps the Responses adapter test-friendly)."""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _adapt_responses_response(raw: Any) -> _Response:
+    """Translate an openai Responses ``Response`` → litellm-shape ``_Response``.
+
+    Maps ``raw.output[]`` items:
+      * ``type=="function_call"`` → :class:`_ToolCall` (``call_id`` → ``id``).
+      * ``type=="message"`` ``output_text`` parts → joined ``_Message.content``.
+        Structured output has no ``message.parsed`` analog on Responses — it
+        arrives as ``output_text`` JSON and is recovered here as the content
+        string.
+      * ``type=="reasoning"`` items are ignored for content.
+    Refusals surface as a ``refusal`` content part (or ``status``) and are
+    raised as the same :class:`LLMRefusedError` the chat path raises.
+    ``raw.usage.input_tokens``/``output_tokens`` → :class:`_Usage`.
+    """
+    output = _rget(raw, "output", None) or []
+
+    text_parts: list[str] = []
+    tool_calls: list[_ToolCall] = []
+    refusal_text: str | None = None
+
+    for item in output:
+        itype = _rget(item, "type", None)
+        if itype == "function_call":
+            call_id = _rget(item, "call_id", None) or _rget(item, "id", "") or ""
+            name = _rget(item, "name", "") or ""
+            arguments = _rget(item, "arguments", "")
+            if not isinstance(arguments, str):
+                try:
+                    arguments = json.dumps(arguments)
+                except (TypeError, ValueError):
+                    arguments = "{}"
+            tool_calls.append(
+                _ToolCall(id=call_id, name=name, arguments=arguments or "")
+            )
+        elif itype == "message":
+            for part in _rget(item, "content", None) or []:
+                ptype = _rget(part, "type", None)
+                if ptype == "refusal":
+                    refusal_text = _rget(part, "refusal", None) or refusal_text
+                elif ptype == "output_text":
+                    text_parts.append(_rget(part, "text", "") or "")
+        # ``reasoning`` (and any other) items contribute no content.
+
+    # Preserve the chat path's refusal behavior: surface a typed exception so
+    # the model's articulated reason reaches the @mesh.llm consumer rather than
+    # collapsing into an opaque empty-response / Pydantic validation error.
+    if refusal_text:
+        from _mcp_mesh.engine.llm_errors import LLMRefusedError
+
+        model_name = _rget(raw, "model", None)
+        logger.info(
+            "Native OpenAI adapter (Responses): model refused structured "
+            "output (model=%s, refusal=%r)",
+            model_name,
+            refusal_text,
+        )
+        raise LLMRefusedError(
+            refusal_text,
+            vendor="openai",
+            model=model_name,
+        )
+
+    content: str | None = "".join(text_parts) if text_parts else None
+
+    message = _Message(
+        content=content,
+        role="assistant",
+        tool_calls=tool_calls or None,
+    )
+
+    usage_obj = _rget(raw, "usage", None)
+    if usage_obj is not None:
+        usage = _Usage(
+            prompt_tokens=_rget(usage_obj, "input_tokens", 0) or 0,
+            completion_tokens=_rget(usage_obj, "output_tokens", 0) or 0,
+        )
+    else:
+        usage = None
+
+    # Preserve a truthful finish_reason (the chat path forwards the real one).
+    # Responses carries the signal on ``status`` / ``incomplete_details`` rather
+    # than a ``finish_reason`` field: map truncation / content-filter /
+    # incomplete outcomes instead of collapsing everything into stop/tool_calls.
+    finish_reason = "tool_calls" if tool_calls else "stop"
+    status = _rget(raw, "status", None)
+    incomplete = _rget(raw, "incomplete_details", None)
+    if status == "incomplete":
+        reason = _rget(incomplete, "reason", None) if incomplete is not None else None
+        if reason == "max_output_tokens":
+            finish_reason = "length"
+        elif reason == "content_filter":
+            finish_reason = "content_filter"
+        else:
+            # An incomplete response with an unmapped (or empty) reason must not
+            # look like a clean stop — surface it for debugging.
+            logger.debug(
+                "Native OpenAI adapter (Responses): incomplete response with "
+                "unmapped reason (status=%r, incomplete_details=%r); keeping "
+                "finish_reason=%r",
+                status,
+                incomplete,
+                finish_reason,
+            )
+    elif status not in (None, "completed"):
+        # "failed" / any other terminal status — keep stop/tool_calls but log so
+        # an empty-output failure isn't a silent clean stop.
+        logger.debug(
+            "Native OpenAI adapter (Responses): non-completed status "
+            "(status=%r, incomplete_details=%r); keeping finish_reason=%r",
+            status,
+            incomplete,
+            finish_reason,
+        )
+
+    return _Response(
+        message=message,
+        usage=usage,
+        model=_rget(raw, "model", None),
+        finish_reason=finish_reason,
+    )
+
+
+def _responses_result_to_stream_chunk(resp: _Response) -> _StreamChunk:
+    """Collapse a buffered Responses ``_Response`` into a single terminal
+    ``_StreamChunk`` carrying content + tool-call deltas + usage + finish_reason.
+
+    Used by the buffered-fallback streaming path (see ``complete_stream``). The
+    provider-side consumer buffers all chunks and merges content / tool_calls /
+    usage across them, so one all-in-one chunk reassembles correctly.
+    """
+    choice = resp.choices[0]
+    msg = choice.message
+    tool_call_deltas: list[_StreamToolCallDelta] | None = None
+    if msg.tool_calls:
+        tool_call_deltas = [
+            _StreamToolCallDelta(
+                index=i,
+                id=tc.id,
+                type="function",
+                name=tc.function.name,
+                arguments=tc.function.arguments,
+            )
+            for i, tc in enumerate(msg.tool_calls)
+        ]
+    return _StreamChunk(
+        delta=_Delta(content=msg.content, tool_calls=tool_call_deltas),
+        usage=resp.usage,
+        model=resp.model,
+        finish_reason=choice.finish_reason,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Response / chunk adaptation
 # ---------------------------------------------------------------------------
 
@@ -744,8 +1206,17 @@ async def complete(
     api_key: str | None = None,
     base_url: str | None = None,
 ) -> _Response:
-    """Run a buffered OpenAI completion and adapt to litellm-shape response."""
+    """Run a buffered OpenAI completion and adapt to litellm-shape response.
+
+    Reasoning models (o-series / gpt-5 non-chat) WITH tools route to the
+    Responses API (issue #1334) so reasoning + function tools coexist; every
+    other model — and no-tools reasoning calls — stay on chat.completions.
+    """
     client = _build_client(model, api_key, base_url)
+    if _openai_wants_responses_api(model, request_params):
+        responses_kwargs = _build_responses_kwargs(request_params, model=model)
+        raw = await client.responses.create(**responses_kwargs)
+        return _adapt_responses_response(raw)
     create_kwargs = _build_create_kwargs(request_params, model=model)
     raw = await client.chat.completions.create(**create_kwargs)
     return _adapt_response(raw)
@@ -773,6 +1244,24 @@ async def complete_stream(
     0 tokens for partial generations.
     """
     client = _build_client(model, api_key, base_url)
+
+    # Reasoning models WITH tools must use the Responses API (issue #1334).
+    # TODO(#1334): native Responses streaming. mesh does not yet stream the
+    # Responses API natively; run the call buffered and emit the terminal
+    # result as a single chunk. The provider-side consumer buffers all chunks
+    # and merges content / tool_calls / usage across them, so a single
+    # all-in-one chunk reassembles correctly (no interrupted-stream fallback
+    # is needed here — a buffered call has no partial-usage hole).
+    if _openai_wants_responses_api(model, request_params):
+        logger.info(
+            "Native OpenAI Responses path: buffering reasoning+tools stream "
+            "(native Responses streaming not yet implemented — #1334)"
+        )
+        responses_kwargs = _build_responses_kwargs(request_params, model=model)
+        raw = await client.responses.create(**responses_kwargs)
+        yield _responses_result_to_stream_chunk(_adapt_responses_response(raw))
+        return
+
     create_kwargs = _build_create_kwargs(request_params, model=model)
     create_kwargs["stream"] = True
 
@@ -874,20 +1363,26 @@ log_fallback_once, is_fallback_logged, _reset_fallback_logged = make_fallback_lo
 _logged_unsupported_kwargs: set[str] = set()
 
 
-def _warn_unsupported_kwarg_once(key: str) -> None:
+def _warn_unsupported_kwarg_once(
+    key: str,
+    *,
+    sdk_call_label: str = "openai.chat.completions.create",
+) -> None:
     """WARN once per unique unsupported kwarg name.
 
     Thin wrapper over the shared helper so call sites stay terse
     (single-arg) and the per-vendor dedupe state stays local to this
     module. Used by ``_build_create_kwargs`` to surface litellm-only
     knobs the adapter is silently dropping (or new fields the OpenAI SDK
-    doesn't accept yet) without logging on every single request.
+    doesn't accept yet) without logging on every single request. The
+    Responses builder passes ``sdk_call_label="openai.responses.create"``
+    so the WARN names the correct endpoint.
     """
     warn_unsupported_kwarg_once(
         _logged_unsupported_kwargs,
         kwarg=key,
         adapter_label="OpenAI",
-        sdk_call_label="openai.chat.completions.create",
+        sdk_call_label=sdk_call_label,
         logger=logger,
     )
 

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
@@ -1572,3 +1572,758 @@ class TestIsFallbackLogged:
 
         openai_native.log_fallback_once()
         assert openai_native.is_fallback_logged() is True
+
+
+# ---------------------------------------------------------------------------
+# Responses API routing (issue #1334)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAiWantsResponsesApi:
+    """Reasoning models WITH tools route to the Responses API; everything else
+    (gpt-4o, gpt-5-chat, no-tools reasoning calls) stays on chat.completions."""
+
+    _TOOLS = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Look up weather.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    @pytest.mark.parametrize(
+        "model,has_tools,expected",
+        [
+            ("gpt-5.6-terra", True, True),        # reasoning + tools → Responses
+            ("gpt-5.6-terra", False, False),      # reasoning, no tools → chat
+            ("gpt-5.6-chat", True, False),        # chat variant → chat
+            ("o3-mini", True, True),              # o-series + tools → Responses
+            ("gpt-4o", True, False),              # non-reasoning → chat
+            ("openai/gpt-5.6-terra", True, True), # vendor-prefixed reasoning
+        ],
+    )
+    def test_routing_table(self, model, has_tools, expected):
+        request_params = {"messages": [{"role": "user", "content": "Hi."}]}
+        if has_tools:
+            request_params["tools"] = self._TOOLS
+        assert (
+            openai_native._openai_wants_responses_api(model, request_params)
+            is expected
+        )
+
+    def test_empty_tools_list_stays_on_chat(self):
+        # An empty tools list is falsy — no 400 risk, stay on chat.completions.
+        assert (
+            openai_native._openai_wants_responses_api(
+                "gpt-5.6-terra", {"tools": []}
+            )
+            is False
+        )
+
+    def test_reasoning_effort_none_stays_on_chat(self):
+        """``reasoning_effort="none"`` is OpenAI's documented way to keep a
+        reasoning model on chat.completions with tools (valid there). It must
+        NOT route to Responses — the builder would emit
+        ``reasoning={"effort":"none"}`` which Responses rejects."""
+        assert (
+            openai_native._openai_wants_responses_api(
+                "gpt-5.6-terra", {"tools": self._TOOLS, "reasoning_effort": "none"}
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize("effort", [None, "low", "medium", "high"])
+    def test_reasoning_effort_non_none_routes_to_responses(self, effort):
+        """Absent or non-"none" reasoning_effort on a reasoning model + tools
+        still routes to Responses."""
+        params = {"tools": self._TOOLS}
+        if effort is not None:
+            params["reasoning_effort"] = effort
+        assert (
+            openai_native._openai_wants_responses_api("gpt-5.6-terra", params)
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
+# _build_responses_kwargs — chat.completions shape → Responses shape (#1334)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildResponsesKwargs:
+    def _build(self, model="openai/gpt-5.6-terra", **params):
+        request_params = {
+            "messages": [{"role": "user", "content": "Hi."}],
+            **params,
+        }
+        return openai_native._build_responses_kwargs(request_params, model=model)
+
+    def test_strips_model_prefix(self):
+        kwargs = self._build()
+        assert kwargs["model"] == "gpt-5.6-terra"
+
+    def test_user_message_becomes_input_item(self):
+        kwargs = self._build()
+        assert kwargs["input"] == [{"role": "user", "content": "Hi."}]
+
+    def test_system_message_becomes_instructions(self):
+        kwargs = openai_native._build_responses_kwargs(
+            {
+                "messages": [
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Hi."},
+                ]
+            },
+            model="openai/gpt-5.6-terra",
+        )
+        assert kwargs["instructions"] == "You are helpful."
+        assert kwargs["input"] == [{"role": "user", "content": "Hi."}]
+
+    def test_tool_schema_flattened(self):
+        kwargs = self._build(
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Look up weather.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                        },
+                    },
+                }
+            ]
+        )
+        assert kwargs["tools"] == [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "description": "Look up weather.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            }
+        ]
+
+    def test_tool_choice_dict_flattened(self):
+        kwargs = self._build(
+            tool_choice={"type": "function", "function": {"name": "get_weather"}}
+        )
+        assert kwargs["tool_choice"] == {"type": "function", "name": "get_weather"}
+
+    @pytest.mark.parametrize("choice", ["auto", "none", "required"])
+    def test_tool_choice_strings_pass_through(self, choice):
+        kwargs = self._build(tool_choice=choice)
+        assert kwargs["tool_choice"] == choice
+
+    def test_reasoning_effort_translated(self):
+        kwargs = self._build(reasoning_effort="low")
+        assert kwargs["reasoning"] == {"effort": "low"}
+
+    def test_response_format_json_schema_translated(self):
+        kwargs = self._build(
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "Weather",
+                    "schema": {"type": "object", "properties": {}},
+                    "strict": True,
+                },
+            }
+        )
+        assert kwargs["text"] == {
+            "format": {
+                "type": "json_schema",
+                "name": "Weather",
+                "schema": {"type": "object", "properties": {}},
+                "strict": True,
+            }
+        }
+
+    def test_max_tokens_becomes_max_output_tokens(self):
+        kwargs = self._build(max_tokens=256)
+        assert kwargs["max_output_tokens"] == 256
+        assert "max_tokens" not in kwargs
+
+    def test_max_completion_tokens_becomes_max_output_tokens(self):
+        kwargs = self._build(max_completion_tokens=512)
+        assert kwargs["max_output_tokens"] == 512
+
+    def test_max_completion_tokens_wins_over_max_tokens(self):
+        kwargs = self._build(max_tokens=256, max_completion_tokens=512)
+        assert kwargs["max_output_tokens"] == 512
+
+    def test_temperature_and_top_p_omitted(self):
+        kwargs = self._build(temperature=0.7, top_p=0.9)
+        assert "temperature" not in kwargs
+        assert "top_p" not in kwargs
+
+    def test_store_explicitly_false(self):
+        """``responses.create`` defaults ``store=true`` (30-day server-side
+        persistence); the builder MUST set it False to match the chat path's
+        no-persistence behavior."""
+        kwargs = self._build()
+        assert kwargs["store"] is False
+
+    def test_unknown_kwarg_warns_not_forwarded(self, caplog):
+        import logging
+
+        openai_native._reset_unsupported_kwargs_dedupe()
+        with caplog.at_level(logging.WARNING):
+            kwargs = self._build(some_litellm_only_knob=1)
+        assert "some_litellm_only_knob" not in kwargs
+        assert any(
+            "some_litellm_only_knob" in r.message
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )
+
+    def test_unknown_kwarg_warn_labels_responses_endpoint(self, caplog):
+        """The leftover-kwarg WARN on the Responses path must name
+        ``openai.responses.create`` — NOT the chat.completions endpoint."""
+        import logging
+
+        openai_native._reset_unsupported_kwargs_dedupe()
+        with caplog.at_level(logging.WARNING, logger=openai_native.logger.name):
+            self._build(another_litellm_knob=1)
+        warn_msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "another_litellm_knob" in r.getMessage()
+        ]
+        assert warn_msgs, "expected a WARN for the dropped kwarg"
+        assert all("openai.responses.create" in m for m in warn_msgs)
+        assert not any("chat.completions" in m for m in warn_msgs)
+
+    def test_multi_turn_history_remap_preserves_call_id(self):
+        """Iteration 2+: prior assistant tool_calls → function_call items and
+        role:tool results → function_call_output items, with call_id preserved
+        exactly so calls and outputs pair correctly."""
+        messages = [
+            {"role": "user", "content": "Weather in Paris?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_abc123",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Paris"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_abc123",
+                "content": '{"temp": 20}',
+            },
+        ]
+        kwargs = openai_native._build_responses_kwargs(
+            {"messages": messages}, model="openai/gpt-5.6-terra"
+        )
+        items = kwargs["input"]
+        # user item, function_call item, function_call_output item
+        fc = next(i for i in items if i.get("type") == "function_call")
+        fco = next(i for i in items if i.get("type") == "function_call_output")
+        assert fc["call_id"] == "call_abc123"
+        assert fc["name"] == "get_weather"
+        assert fc["arguments"] == '{"city": "Paris"}'
+        assert fco["call_id"] == "call_abc123"
+        assert fco["output"] == '{"temp": 20}'
+        # call_id pairs the two items.
+        assert fc["call_id"] == fco["call_id"]
+
+    def test_assistant_text_and_tool_calls_both_emitted(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Let me check.",
+                "tool_calls": [
+                    {
+                        "id": "call_x",
+                        "type": "function",
+                        "function": {"name": "f", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+        kwargs = openai_native._build_responses_kwargs(
+            {"messages": messages}, model="openai/gpt-5.6-terra"
+        )
+        items = kwargs["input"]
+        assert {"role": "assistant", "content": "Let me check."} in items
+        assert any(i.get("type") == "function_call" for i in items)
+
+    def test_string_content_passes_through_unchanged(self):
+        """Plain-string content (the common case) is forwarded verbatim."""
+        kwargs = self._build()
+        assert kwargs["input"] == [{"role": "user", "content": "Hi."}]
+
+    def test_user_text_part_array_translated_to_input_text(self):
+        """A chat-style content-part array on a user turn is translated:
+        ``{"type":"text"}`` → ``{"type":"input_text"}`` (Responses shape)."""
+        kwargs = openai_native._build_responses_kwargs(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "Hello"},
+                            {"type": "text", "text": "world"},
+                        ],
+                    }
+                ]
+            },
+            model="openai/gpt-5.6-terra",
+        )
+        assert kwargs["input"] == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Hello"},
+                    {"type": "input_text", "text": "world"},
+                ],
+            }
+        ]
+
+    def test_assistant_text_part_array_translated_to_output_text(self):
+        """Assistant content parts use ``output_text`` (not ``input_text``)."""
+        kwargs = openai_native._build_responses_kwargs(
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "Sure thing."}],
+                    }
+                ]
+            },
+            model="openai/gpt-5.6-terra",
+        )
+        assert {
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Sure thing."}],
+        } in kwargs["input"]
+
+    def test_image_part_array_raises_value_error(self):
+        """An image (or any non-text) content part raises a clear ValueError
+        rather than forwarding an untranslated shape that yields a cryptic
+        OpenAI 400."""
+        with pytest.raises(ValueError) as exc_info:
+            openai_native._build_responses_kwargs(
+                {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "What is this?"},
+                                {
+                                    "type": "image_url",
+                                    "image_url": {"url": "https://x/y.png"},
+                                },
+                            ],
+                        }
+                    ]
+                },
+                model="openai/gpt-5.6-terra",
+            )
+        msg = str(exc_info.value)
+        assert "multimodal image content" in msg
+        assert "non-reasoning model" in msg
+
+    def test_tool_call_arguments_none_coerced_to_empty_string(self):
+        """A stored ``arguments`` of explicit ``None`` must become ``""`` —
+        Responses expects a string on function_call items."""
+        kwargs = openai_native._build_responses_kwargs(
+            {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_n",
+                                "type": "function",
+                                "function": {"name": "f", "arguments": None},
+                            }
+                        ],
+                    }
+                ]
+            },
+            model="openai/gpt-5.6-terra",
+        )
+        fc = next(i for i in kwargs["input"] if i.get("type") == "function_call")
+        assert fc["arguments"] == ""
+
+
+# ---------------------------------------------------------------------------
+# _adapt_responses_response — Responses Response → litellm-shape _Response
+# ---------------------------------------------------------------------------
+
+
+def _make_responses_response(
+    *,
+    output=None,
+    input_tokens=11,
+    output_tokens=5,
+    model="gpt-5.6-terra",
+    status=None,
+    incomplete_details=None,
+):
+    """Build a fake openai Responses ``Response``-like object (dicts for the
+    output items — the adapter reads both attrs and dict keys via _rget)."""
+    usage = SimpleNamespace(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+    return SimpleNamespace(
+        output=output or [],
+        usage=usage,
+        model=model,
+        status=status,
+        incomplete_details=incomplete_details,
+    )
+
+
+class TestAdaptResponsesResponse:
+    def test_text_message_becomes_content(self):
+        raw = _make_responses_response(
+            output=[
+                {"type": "reasoning", "summary": []},
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "Hello there."}],
+                },
+            ]
+        )
+        resp = openai_native._adapt_responses_response(raw)
+        assert resp.choices[0].message.content == "Hello there."
+        assert resp.choices[0].message.tool_calls is None
+        assert resp.choices[0].finish_reason == "stop"
+
+    def test_function_call_becomes_tool_call(self):
+        raw = _make_responses_response(
+            output=[
+                {
+                    "type": "function_call",
+                    "call_id": "call_zzz",
+                    "name": "get_weather",
+                    "arguments": '{"city": "Paris"}',
+                }
+            ]
+        )
+        resp = openai_native._adapt_responses_response(raw)
+        tcs = resp.choices[0].message.tool_calls
+        assert len(tcs) == 1
+        assert tcs[0].id == "call_zzz"
+        assert tcs[0].function.name == "get_weather"
+        assert tcs[0].function.arguments == '{"city": "Paris"}'
+        assert resp.choices[0].finish_reason == "tool_calls"
+
+    def test_reasoning_items_ignored_for_content(self):
+        raw = _make_responses_response(
+            output=[{"type": "reasoning", "summary": [{"text": "thinking..."}]}]
+        )
+        resp = openai_native._adapt_responses_response(raw)
+        assert resp.choices[0].message.content is None
+
+    def test_usage_mapped_from_input_output_tokens(self):
+        raw = _make_responses_response(input_tokens=100, output_tokens=42)
+        resp = openai_native._adapt_responses_response(raw)
+        assert resp.usage.prompt_tokens == 100
+        assert resp.usage.completion_tokens == 42
+        assert resp.usage.total_tokens == 142
+
+    def test_no_usage_does_not_crash(self):
+        raw = SimpleNamespace(output=[], usage=None, model="gpt-5.6-terra")
+        resp = openai_native._adapt_responses_response(raw)
+        assert resp.usage is None
+
+    def test_structured_output_recovered_from_output_text(self):
+        # No message.parsed analog on Responses — JSON arrives as output_text.
+        raw = _make_responses_response(
+            output=[
+                {
+                    "type": "message",
+                    "content": [
+                        {"type": "output_text", "text": '{"answer": 42}'}
+                    ],
+                }
+            ]
+        )
+        resp = openai_native._adapt_responses_response(raw)
+        assert resp.choices[0].message.content == '{"answer": 42}'
+
+    def test_refusal_raises_llm_refused_error(self):
+        from _mcp_mesh.engine.llm_errors import LLMRefusedError
+
+        raw = _make_responses_response(
+            output=[
+                {
+                    "type": "message",
+                    "content": [
+                        {"type": "refusal", "refusal": "I cannot help with that."}
+                    ],
+                }
+            ]
+        )
+        with pytest.raises(LLMRefusedError) as exc_info:
+            openai_native._adapt_responses_response(raw)
+        assert exc_info.value.refusal_text == "I cannot help with that."
+        assert exc_info.value.vendor == "openai"
+
+
+class TestAdaptResponsesFinishReason:
+    """finish_reason must reflect the real outcome (truncation / content-filter
+    / incomplete), mirroring the chat path forwarding the true finish_reason —
+    not collapse everything into stop/tool_calls (#1334)."""
+
+    def test_completed_with_text_is_stop(self):
+        raw = _make_responses_response(
+            status="completed",
+            output=[
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "done"}],
+                }
+            ],
+        )
+        resp = openai_native._adapt_responses_response(raw)
+        assert resp.choices[0].finish_reason == "stop"
+        assert resp.choices[0].message.content == "done"
+
+    def test_completed_with_tool_calls_is_tool_calls(self):
+        raw = _make_responses_response(
+            status="completed",
+            output=[
+                {
+                    "type": "function_call",
+                    "call_id": "call_c",
+                    "name": "get_weather",
+                    "arguments": "{}",
+                }
+            ],
+        )
+        resp = openai_native._adapt_responses_response(raw)
+        assert resp.choices[0].finish_reason == "tool_calls"
+
+    def test_incomplete_max_output_tokens_is_length(self):
+        raw = _make_responses_response(
+            status="incomplete",
+            incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+            output=[
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "trunc"}],
+                }
+            ],
+        )
+        resp = openai_native._adapt_responses_response(raw)
+        assert resp.choices[0].finish_reason == "length"
+
+    def test_incomplete_content_filter_is_content_filter(self):
+        raw = _make_responses_response(
+            status="incomplete",
+            incomplete_details={"reason": "content_filter"},
+        )
+        resp = openai_native._adapt_responses_response(raw)
+        assert resp.choices[0].finish_reason == "content_filter"
+
+    def test_incomplete_empty_output_unmapped_reason_is_not_misleading(self, caplog):
+        """An empty-output incomplete response with an unmapped reason must not
+        crash and must NOT masquerade as a clean stop silently — a debug log is
+        emitted and finish_reason stays the neutral default."""
+        import logging
+
+        raw = _make_responses_response(
+            status="incomplete",
+            incomplete_details=SimpleNamespace(reason="some_future_reason"),
+            output=[],
+        )
+        with caplog.at_level(logging.DEBUG, logger=openai_native.logger.name):
+            resp = openai_native._adapt_responses_response(raw)
+        # No crash; content is None (empty output); default finish_reason.
+        assert resp.choices[0].message.content is None
+        assert resp.choices[0].finish_reason == "stop"
+        assert any(
+            "incomplete response with unmapped reason" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_failed_status_logs_and_keeps_default(self, caplog):
+        import logging
+
+        raw = _make_responses_response(status="failed", output=[])
+        with caplog.at_level(logging.DEBUG, logger=openai_native.logger.name):
+            resp = openai_native._adapt_responses_response(raw)
+        assert resp.choices[0].finish_reason == "stop"
+        assert any(
+            "non-completed status" in r.getMessage() for r in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch regression — reasoning+tools hits responses.create, gpt-4o hits
+# chat.completions.create (issue #1334)
+# ---------------------------------------------------------------------------
+
+
+def _patched_dual_openai(*, chat_response, responses_response):
+    """Return (cls_mock, instance) whose instance exposes BOTH
+    ``.chat.completions.create`` and ``.responses.create`` AsyncMocks."""
+    instance = MagicMock()
+    instance.chat = MagicMock()
+    instance.chat.completions = MagicMock()
+    instance.chat.completions.create = AsyncMock(return_value=chat_response)
+    instance.responses = MagicMock()
+    instance.responses.create = AsyncMock(return_value=responses_response)
+    cls_mock = MagicMock(return_value=instance)
+    return cls_mock, instance
+
+
+class TestResponsesDispatch:
+    _TOOLS = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Look up weather.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    @pytest.mark.asyncio
+    async def test_reasoning_with_tools_calls_responses_create(self):
+        cls_mock, instance = _patched_dual_openai(
+            chat_response=_make_openai_completion(text="chat"),
+            responses_response=_make_responses_response(
+                output=[
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "resp"}],
+                    }
+                ]
+            ),
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            resp = await openai_native.complete(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "tools": self._TOOLS,
+                },
+                model="openai/gpt-5.6-terra",
+                api_key="sk-test",
+            )
+        instance.responses.create.assert_called_once()
+        instance.chat.completions.create.assert_not_called()
+        assert resp.choices[0].message.content == "resp"
+
+    @pytest.mark.asyncio
+    async def test_gpt4o_with_tools_calls_chat_completions_create(self):
+        cls_mock, instance = _patched_dual_openai(
+            chat_response=_make_openai_completion(text="chat"),
+            responses_response=_make_responses_response(),
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "tools": self._TOOLS,
+                },
+                model="openai/gpt-4o",
+                api_key="sk-test",
+            )
+        instance.chat.completions.create.assert_called_once()
+        instance.responses.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reasoning_no_tools_calls_chat_completions_create(self):
+        cls_mock, instance = _patched_dual_openai(
+            chat_response=_make_openai_completion(text="chat"),
+            responses_response=_make_responses_response(),
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            await openai_native.complete(
+                {"messages": [{"role": "user", "content": "Hi."}]},
+                model="openai/gpt-5.6-terra",
+                api_key="sk-test",
+            )
+        instance.chat.completions.create.assert_called_once()
+        instance.responses.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stream_reasoning_with_tools_buffers_via_responses(self):
+        """Streaming reasoning+tools falls back to a buffered Responses call and
+        emits a single terminal chunk carrying content + usage."""
+        cls_mock, instance = _patched_dual_openai(
+            chat_response=_make_openai_completion(text="chat"),
+            responses_response=_make_responses_response(
+                output=[
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "buffered"}],
+                    }
+                ],
+                input_tokens=9,
+                output_tokens=3,
+            ),
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            stream = openai_native.complete_stream(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "tools": self._TOOLS,
+                },
+                model="openai/gpt-5.6-terra",
+                api_key="sk-test",
+            )
+            chunks = [c async for c in stream]
+
+        instance.responses.create.assert_called_once()
+        instance.chat.completions.create.assert_not_called()
+        # Single terminal chunk with content + usage.
+        assert len(chunks) == 1
+        assert chunks[0].choices[0].delta.content == "buffered"
+        assert chunks[0].usage.prompt_tokens == 9
+        assert chunks[0].usage.completion_tokens == 3
+
+    @pytest.mark.asyncio
+    async def test_stream_reasoning_with_tools_emits_tool_call_delta(self):
+        cls_mock, instance = _patched_dual_openai(
+            chat_response=_make_openai_completion(text="chat"),
+            responses_response=_make_responses_response(
+                output=[
+                    {
+                        "type": "function_call",
+                        "call_id": "call_s1",
+                        "name": "get_weather",
+                        "arguments": '{"city": "Paris"}',
+                    }
+                ]
+            ),
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            stream = openai_native.complete_stream(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "tools": self._TOOLS,
+                },
+                model="openai/gpt-5.6-terra",
+                api_key="sk-test",
+            )
+            chunks = [c async for c in stream]
+
+        instance.responses.create.assert_called_once()
+        tcs = chunks[0].choices[0].delta.tool_calls
+        assert tcs is not None and len(tcs) == 1
+        assert tcs[0].id == "call_s1"
+        assert tcs[0].function.name == "get_weather"
+        assert tcs[0].function.arguments == '{"city": "Paris"}'

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_sampling_param_gating.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_sampling_param_gating.py
@@ -37,6 +37,10 @@ class TestRestrictsSamplingParams:
             "gpt-5",
             "gpt-5-mini",
             "gpt-5-nano",
+            # #1332 — version-agnostic: gpt-5 point releases stay restricted.
+            "gpt-5.6",
+            "gpt-5-6",
+            "openai/gpt-5.6",
             "openai/gpt-5",
             "openai/o3-mini",
             "GPT-5-MINI",  # case-insensitive
@@ -53,6 +57,9 @@ class TestRestrictsSamplingParams:
             "gpt-4o-mini",
             "gpt-5-chat-latest",
             "gpt-5-chat",
+            # #1332 — version-agnostic chat exclusion covers versioned chat ids.
+            "gpt-5.6-chat",
+            "gpt-5.6-chat-latest",
             "openai/gpt-4o",
             "gemini/gemini-2.5-flash",
             "anthropic/claude-sonnet-4-5",
@@ -98,6 +105,12 @@ class TestNativeBuildCreateKwargsGating:
         assert "temperature" not in kwargs
         assert "top_p" not in kwargs
 
+    def test_restricted_gpt5_point_release_omits_sampling_params(self):
+        # #1332 — a gpt-5 point release is restricted like the base model.
+        kwargs = self._build("openai/gpt-5.6", temperature=0.5, top_p=0.8)
+        assert "temperature" not in kwargs
+        assert "top_p" not in kwargs
+
     def test_unrestricted_model_keeps_temperature(self):
         kwargs = self._build("openai/gpt-4o", temperature=0.7, top_p=0.9)
         assert kwargs["temperature"] == 0.7
@@ -139,6 +152,12 @@ class TestNativeMaxTokensTranslation:
 
     def test_restricted_gpt5_moves_max_tokens(self):
         kwargs = self._build("openai/gpt-5-mini", max_tokens=256)
+        assert "max_tokens" not in kwargs
+        assert kwargs["max_completion_tokens"] == 256
+
+    def test_restricted_gpt5_point_release_moves_max_tokens(self):
+        # #1332 — a gpt-5 point release translates max_tokens like the base model.
+        kwargs = self._build("openai/gpt-5.6", max_tokens=256)
         assert "max_tokens" not in kwargs
         assert kwargs["max_completion_tokens"] == 256
 

--- a/src/runtime/typescript/src/__tests__/llm-provider-sampling-gating.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-provider-sampling-gating.test.ts
@@ -52,6 +52,10 @@ describe("restrictsSamplingParams truth table", () => {
     "gpt-5",
     "gpt-5-mini",
     "gpt-5-nano",
+    // #1332 — version-agnostic: gpt-5 point releases stay restricted.
+    "gpt-5.6",
+    "gpt-5-6",
+    "openai/gpt-5.6",
     "openai/o3-mini",
     "openai/gpt-5",
     "O3-MINI", // case-insensitive
@@ -62,7 +66,11 @@ describe("restrictsSamplingParams truth table", () => {
   it.each([
     "gpt-4o",
     "gpt-4.1",
+    "gpt-5-chat",
     "gpt-5-chat-latest",
+    // #1332 — version-agnostic chat exclusion covers versioned chat ids.
+    "gpt-5.6-chat",
+    "gpt-5.6-chat-latest",
     "openai/gpt-4o",
     "gemini/gemini-2.0-flash",
     "anthropic/claude-sonnet-4-5",
@@ -169,6 +177,22 @@ describe("OpenAI sampling-param gating — vendor call options", () => {
     await tool.execute(
       baseRequest({ temperature: 0.3, top_p: 0.5 }) as never,
     );
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    const opts = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect("temperature" in opts).toBe(false);
+    expect("topP" in opts).toBe(false);
+  });
+
+  it("omits temperature/topP for a gpt-5 point release (gpt-5.6) — generateText", async () => {
+    // #1332 — a gpt-5 point release is restricted like the base model.
+    const tool = llmProvider({
+      model: "openai/gpt-5.6",
+      capability: "llm",
+      temperature: 0.7,
+      topP: 0.9,
+    });
+    await tool.execute(baseRequest({}) as never);
 
     expect(generateTextMock).toHaveBeenCalledTimes(1);
     const opts = generateTextMock.mock.calls[0][0] as Record<string, unknown>;

--- a/src/runtime/typescript/src/llm-provider.ts
+++ b/src/runtime/typescript/src/llm-provider.ts
@@ -231,10 +231,12 @@ export function extractModelName(model: string): string {
  * value (rejecting any explicit setting with HTTP 400).
  *
  * OpenAI o-series reasoning models (o1/o3/o4) and the gpt-5 family (except
- * gpt-5-chat) accept ONLY the default sampling params. Verified against the
- * live API:
- *   - REJECT: gpt-5, gpt-5-mini, gpt-5-nano, o1, o3-mini, o4-mini
- *   - ACCEPT: gpt-4o, gpt-4.1, gpt-5-chat-latest
+ * chat variants) accept ONLY the default sampling params. The chat exclusion
+ * is version-agnostic: any gpt-5 id containing a `-chat` marker (`gpt-5-chat`,
+ * `gpt-5-chat-latest`, `gpt-5.6-chat`, …) is treated as a chat variant and left
+ * unrestricted. Verified against the live API:
+ *   - REJECT: gpt-5, gpt-5-mini, gpt-5-nano, gpt-5.6, o1, o3-mini, o4-mini
+ *   - ACCEPT: gpt-4o, gpt-4.1, gpt-5-chat-latest, gpt-5.6-chat
  *
  * Accepts a bare or ``vendor/``-qualified model string (e.g. "openai/o3-mini").
  * Returns true when ``temperature``/``topP`` should be omitted. Mirrors the
@@ -253,8 +255,9 @@ export function restrictsSamplingParams(model: string | undefined | null): boole
   ) {
     return true;
   }
-  // gpt-5 family restricts temperature/top_p to default — except gpt-5-chat*
-  if (m.startsWith("gpt-5") && !m.startsWith("gpt-5-chat")) return true;
+  // gpt-5 family restricts temperature/top_p to default — except chat variants.
+  // Version-agnostic: any gpt-5 id with a "-chat" marker is unrestricted (#1332).
+  if (m.startsWith("gpt-5") && !m.includes("-chat")) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary

Two related fixes to mesh's native OpenAI path for the GPT-5 family. **Model ids remain pass-through — no scaffold-default change** (per owner decision, the OpenAI default stays `gpt-4o`).

### #1332 — version-agnostic `gpt-5-chat` sampling exclusion (Python / TS / Java)
The reasoning-model sampling-param gate (`restricts_sampling_params`) excluded chat variants via an exact `gpt-5-chat` prefix, so a **versioned** chat variant like `gpt-5.6-chat` was wrongly restricted (sampling params dropped). Now uses a version-agnostic `-chat` marker, identical across all three runtimes, with parity tests. gpt-5 point releases (`gpt-5.6`) stay restricted; chat variants don't.

### #1334 — route gpt-5/o-series reasoning models **with tools** to the OpenAI Responses API (Python)
OpenAI **400s on reasoning + function tools** on `/v1/chat/completions` ("use /v1/responses or set reasoning_effort='none'"). So any gpt-5 reasoning model used with the common `@mesh.llm` tool pattern failed. Fix: route `is_openai_reasoning_model(model) and request has tools` to `client.responses.create`; **gpt-4o, gpt-5 chat variants, and no-tools reasoning calls stay on chat.completions unchanged**. Contained to `openai_native.py` + a one-line helper alias — the agentic loop, handlers, and `_Response`/`_StreamChunk` contract are untouched.

Includes: the chat→Responses request translation (multi-turn `function_call`/`function_call_output` history remap with `call_id` pairing, flat tool schema, `reasoning_effort`→`reasoning`, `response_format`→`text.format`, `max_output_tokens`), response/usage/refusal adaptation, **`store=False`** for no-persistence parity with the chat path, truthful `finish_reason` mapping (length/content_filter/incomplete), multimodal text-part translation (image parts raise a clear error), and a buffered streaming fallback.

## Cross-runtime
- **TypeScript** — already correct, no change: `@ai-sdk/openai` v3 defaults `openai(id)` to the Responses API.
- **Java** — same reasoning+tools gap (spring-ai is chat.completions-only); larger effort → **#1335**.
- Native Responses **streaming** + **multimodal image** input → **#1336**.

Because mesh delegation is provider-managed, this Python fix lets **any** consumer language (Java/TS/Python) use a Python provider on a gpt-5 reasoning model with tools.

## Validation
- Unit tests green: `openai_native` 123, sampling-gating (Py), TS vitest, Java `mvn` (`ProviderDeclaredModelTest`).
- **Live end-to-end smoke** (toolcalls triad, real OpenAI): **gpt-4o** (regression, chat.completions) and **gpt-5.6-terra** (Responses) each completed a real **2-iteration agentic tool loop** with no 400 — plus a post-fix re-smoke after `store=False`.
- Independent zero-context review of the Responses path: 1 BLOCKER (`store` persistence) + findings all fixed in-PR.

## Review notes
The multi-turn history remap (`call_id` pairing on iteration 2+) is the highest-risk part; it's covered by unit tests and proven by the live 2-iteration tool loop.

## Test plan
- [x] Cross-runtime unit tests
- [x] Live both-models agentic smoke (gpt-4o + gpt-5.6-terra) + post-fix re-smoke
- [x] Zero-context review, findings fixed
- [ ] CI matrix (Go/Java/Py/Rust/TS + CodeRabbit)

Closes #1332
Closes #1334

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OpenAI reasoning-model requests that use tools now use the Responses API automatically.
  - Tool calls, structured outputs, refusals, usage details, and completion statuses are translated consistently across supported integrations.
  - Streaming responses remain supported with terminal content, tool-call, and usage results.

- **Bug Fixes**
  - Updated GPT-5 sampling-parameter handling, including versioned models and chat variants.
  - GPT-5 chat models now correctly allow sampling parameters, while non-chat GPT-5 models continue to restrict them.
  - Improved warnings for unsupported request options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->