### PR TITLE
chore(java): upgrade spring-ai 2.0.0-M4 → 2.0.0 GA

### DIFF
--- a/examples/java/direct-openai-agent/pom.xml
+++ b/examples/java/direct-openai-agent/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <java.version>17</java.version>
         <mcp-mesh.version>3.1.0</mcp-mesh.version>
-        <spring-ai.version>2.0.0-M4</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 
     <!--

--- a/examples/java/gemini-provider-agent/pom.xml
+++ b/examples/java/gemini-provider-agent/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <java.version>17</java.version>
         <mcp-mesh.version>3.1.0</mcp-mesh.version>
-        <spring-ai.version>2.0.0-M4</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 
     <!--
@@ -46,10 +46,11 @@
             <version>${mcp-mesh.version}</version>
         </dependency>
 
-        <!-- Spring AI Vertex AI Gemini -->
+        <!-- Spring AI Google GenAI (API key based; also reaches the Vertex backend
+             via spring.ai.google.genai.* backend config) -->
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-starter-model-vertex-ai-gemini</artifactId>
+            <artifactId>spring-ai-starter-model-google-genai</artifactId>
             <version>${spring-ai.version}</version>
         </dependency>
 

--- a/examples/java/gemini-provider-agent/src/main/resources/application.properties
+++ b/examples/java/gemini-provider-agent/src/main/resources/application.properties
@@ -6,9 +6,8 @@ server.port=9112
 logging.level.io.mcpmesh=DEBUG
 logging.level.com.example=DEBUG
 
-# Vertex AI Gemini Configuration
-spring.ai.vertex.ai.gemini.project-id=eng-cache-151909
-spring.ai.vertex.ai.gemini.location=us-central1
+# Google GenAI (Gemini) Configuration — API key based (like Python/TypeScript)
+spring.ai.google.genai.api-key=${GOOGLE_API_KEY:}
 
 # Model selection
-spring.ai.vertex.ai.gemini.chat.options.model=gemini-3-flash-preview
+spring.ai.google.genai.chat.options.model=gemini-3-flash-preview

--- a/examples/java/gpt-provider-agent/pom.xml
+++ b/examples/java/gpt-provider-agent/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <java.version>17</java.version>
         <mcp-mesh.version>3.1.0</mcp-mesh.version>
-        <spring-ai.version>2.0.0-M4</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 
     <!--

--- a/examples/java/llm-provider-agent/pom.xml
+++ b/examples/java/llm-provider-agent/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <java.version>17</java.version>
         <mcp-mesh.version>3.1.0</mcp-mesh.version>
-        <spring-ai.version>2.0.0-M4</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 
     <dependencies>

--- a/examples/toolcalls/claude-provider-java/pom.xml
+++ b/examples/toolcalls/claude-provider-java/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <java.version>17</java.version>
         <mcp-mesh.version>3.1.0</mcp-mesh.version>
-        <spring-ai.version>2.0.0-M4</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 
     <!--

--- a/examples/toolcalls/gemini-provider-java/pom.xml
+++ b/examples/toolcalls/gemini-provider-java/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <java.version>17</java.version>
         <mcp-mesh.version>3.1.0</mcp-mesh.version>
-        <spring-ai.version>2.0.0-M4</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 
     <!--

--- a/examples/toolcalls/openai-provider-java/pom.xml
+++ b/examples/toolcalls/openai-provider-java/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <java.version>17</java.version>
         <mcp-mesh.version>3.1.0</mcp-mesh.version>
-        <spring-ai.version>2.0.0-M4</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 
     <!--

--- a/src/runtime/java/mcp-mesh-spring-ai/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-ai/pom.xml
@@ -29,7 +29,7 @@
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
         </dependency>
 
-        <!-- Spring AI 2.0 (milestone release) -->
+        <!-- Spring AI 2.0 GA -->
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-model</artifactId>
@@ -55,17 +55,6 @@
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-starter-model-google-genai</artifactId>
-            <version>${spring-ai.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <!-- Vertex AI Gemini: needed at compile time so GeminiHandler can branch on
-             VertexAiGeminiChatModel/Options. The starter is pulled in by the consuming
-             agent (e.g., examples/java/vertex-ai-agent); here we only need the core
-             module for the instanceof check and options builder. Optional, mirroring
-             spring-ai-starter-model-google-genai above. -->
-        <dependency>
-            <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-vertex-ai-gemini</artifactId>
             <version>${spring-ai.version}</version>
             <optional>true</optional>
         </dependency>

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/SpringAiLlmProvider.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/SpringAiLlmProvider.java
@@ -25,8 +25,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * <ul>
  *   <li>{@code "claude"}, {@code "anthropic"} - Anthropic Claude models</li>
  *   <li>{@code "openai"}, {@code "gpt"} - OpenAI GPT models</li>
- *   <li>{@code "gemini"}, {@code "google"} - Google Gemini models (prefers AI Studio when both AI Studio + Vertex configured)</li>
- *   <li>{@code "vertex_ai"}, {@code "vertexai"} - Google Gemini via Vertex AI (IAM auth) — forced even if AI Studio is also configured</li>
+ *   <li>{@code "gemini"}, {@code "google"}, {@code "vertex_ai"}, {@code "vertexai"} -
+ *       Google Gemini models. In Spring AI 2.0 GA there is a single google-genai
+ *       ChatModel bean; the backend (AI Studio api-key vs GCP Vertex project/location)
+ *       is chosen purely by google-genai config, so all four aliases resolve to the
+ *       same {@code googleAiGeminiChatModel}.</li>
  * </ul>
  *
  * <h2>Configuration</h2>
@@ -34,8 +37,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * <ul>
  *   <li>{@code ANTHROPIC_API_KEY} - For Claude models</li>
  *   <li>{@code OPENAI_API_KEY} - For OpenAI models</li>
- *   <li>{@code GOOGLE_AI_GEMINI_API_KEY} - For Gemini AI Studio</li>
- *   <li>GCP ADC + {@code spring.ai.vertex.ai.gemini.project-id} + {@code spring.ai.vertex.ai.gemini.location} - For Gemini via Vertex AI</li>
+ *   <li>{@code spring.ai.google.genai.api-key} - For Gemini via AI Studio</li>
+ *   <li>GCP ADC + google-genai project/location config - For Gemini via the Vertex backend</li>
  * </ul>
  *
  * <p>Or in application.yml:
@@ -46,21 +49,18 @@ import java.util.concurrent.ConcurrentHashMap;
  *       api-key: ${ANTHROPIC_API_KEY}
  *     openai:
  *       api-key: ${OPENAI_API_KEY}
- *     vertex:
- *       ai:
- *         gemini:
- *           project-id: ${GOOGLE_PROJECT_ID}
- *           location: us-central1
+ *     google:
+ *       genai:
+ *         api-key: ${GOOGLE_AI_GEMINI_API_KEY}
  * </pre>
  *
- * <p>Note: Spring AI's Vertex AI Gemini auto-config does not key off any
- * fixed env var name itself — it looks at {@code spring.ai.vertex.ai.gemini.*}
- * properties (which Spring Boot can in turn populate from env vars like
- * {@code SPRING_AI_VERTEX_AI_GEMINI_PROJECT_ID}). The {@code GOOGLE_PROJECT_ID}
- * shorthand only works because the example {@code application.properties}
- * substitutes it. Authentication itself uses Google Application Default
+ * <p>Note: The single google-genai ChatModel bean serves both Gemini backends.
+ * Supplying {@code spring.ai.google.genai.api-key} selects the AI Studio backend;
+ * configuring the google-genai project/location (with GCP Application Default
  * Credentials, so {@code GOOGLE_APPLICATION_CREDENTIALS} or {@code gcloud auth
- * application-default login} are still required.
+ * application-default login}) selects the Vertex backend. The {@code vertex_ai}/
+ * {@code vertexai} aliases are just naming conveniences — they resolve to the same
+ * bean and do not force a particular backend.
  */
 public class SpringAiLlmProvider {
 
@@ -73,9 +73,6 @@ public class SpringAiLlmProvider {
 
     @Autowired(required = false)
     private ChatModel openAiChatModel;
-
-    @Autowired(required = false)
-    private ChatModel vertexAiGeminiChatModel;
 
     @Autowired(required = false)
     private ChatModel googleAiGeminiChatModel;
@@ -102,8 +99,7 @@ public class SpringAiLlmProvider {
         return switch (normalizedProvider) {
             case "claude", "anthropic" -> anthropicChatModel != null;
             case "openai", "gpt" -> openAiChatModel != null;
-            case "gemini", "google" -> vertexAiGeminiChatModel != null || googleAiGeminiChatModel != null;
-            case "vertex_ai" -> vertexAiGeminiChatModel != null;
+            case "gemini", "google", "vertex_ai" -> googleAiGeminiChatModel != null;
             default -> false;
         };
     }
@@ -257,28 +253,18 @@ public class SpringAiLlmProvider {
                 }
                 yield openAiChatModel;
             }
-            case "gemini", "google" -> {
-                // Prefer Google AI Gemini (API key based, like Python), fallback to Vertex AI
+            case "gemini", "google", "vertex_ai" -> {
+                // Single google-genai bean in Spring AI 2.0 GA. The backend
+                // (AI Studio vs GCP Vertex) is chosen by google-genai config, so
+                // vertex_ai/vertexai are aliases for the same model.
                 if (googleAiGeminiChatModel != null) {
                     yield googleAiGeminiChatModel;
                 }
-                if (vertexAiGeminiChatModel != null) {
-                    yield vertexAiGeminiChatModel;
-                }
                 throw new IllegalStateException("Gemini ChatModel not configured. " +
-                    "Add spring-ai-google-genai dependency and set GOOGLE_AI_GEMINI_API_KEY, " +
-                    "or add spring-ai-vertex-ai-gemini dependency and configure GCP credentials");
-            }
-            case "vertex_ai" -> {
-                // Explicit Vertex AI: do NOT fall back to AI Studio even if both are configured.
-                // Use this when you specifically need IAM auth, Provisioned Throughput, VPC-SC, etc.
-                if (vertexAiGeminiChatModel != null) {
-                    yield vertexAiGeminiChatModel;
-                }
-                throw new IllegalStateException("Vertex AI Gemini ChatModel not configured. " +
-                    "Add spring-ai-starter-model-vertex-ai-gemini dependency and configure " +
-                    "spring.ai.vertex.ai.gemini.project-id + spring.ai.vertex.ai.gemini.location " +
-                    "(plus GCP Application Default Credentials).");
+                    "Add the spring-ai-starter-model-google-genai dependency and set " +
+                    "spring.ai.google.genai.api-key (AI Studio backend), or configure the " +
+                    "google-genai project/location with GCP Application Default Credentials " +
+                    "(Vertex backend).");
             }
             default -> {
                 // Try anthropic as default fallback
@@ -293,10 +279,6 @@ public class SpringAiLlmProvider {
                 if (googleAiGeminiChatModel != null) {
                     log.warn("Unknown provider '{}', falling back to Gemini (Google AI)", provider);
                     yield googleAiGeminiChatModel;
-                }
-                if (vertexAiGeminiChatModel != null) {
-                    log.warn("Unknown provider '{}', falling back to Gemini (Vertex AI)", provider);
-                    yield vertexAiGeminiChatModel;
                 }
                 throw new IllegalArgumentException("No ChatModel available for provider: " + provider);
             }
@@ -343,25 +325,17 @@ public class SpringAiLlmProvider {
                 }
                 yield openAiChatModel;
             }
-            case "gemini", "google" -> {
-                // Prefer Google AI Gemini (API key based), fallback to Vertex AI
+            case "gemini", "google", "vertex_ai" -> {
+                // Single google-genai bean in Spring AI 2.0 GA; vertex_ai/vertexai
+                // are aliases for the same model (backend chosen by google-genai config).
                 if (googleAiGeminiChatModel != null) {
                     yield googleAiGeminiChatModel;
                 }
-                if (vertexAiGeminiChatModel != null) {
-                    yield vertexAiGeminiChatModel;
-                }
                 throw new IllegalStateException(
-                    "Gemini ChatModel not configured. Add spring-ai-google-genai and set GOOGLE_AI_GEMINI_API_KEY");
-            }
-            case "vertex_ai" -> {
-                if (vertexAiGeminiChatModel != null) {
-                    yield vertexAiGeminiChatModel;
-                }
-                throw new IllegalStateException(
-                    "Vertex AI Gemini ChatModel not configured. " +
-                    "Add spring-ai-starter-model-vertex-ai-gemini and configure " +
-                    "spring.ai.vertex.ai.gemini.project-id + spring.ai.vertex.ai.gemini.location.");
+                    "Gemini ChatModel not configured. Add the spring-ai-starter-model-google-genai " +
+                    "dependency and set spring.ai.google.genai.api-key (AI Studio backend), or " +
+                    "configure the google-genai project/location with GCP Application Default " +
+                    "Credentials (Vertex backend).");
             }
             default -> throw new IllegalArgumentException("Unknown LLM provider: " + provider +
                 ". Supported: claude, anthropic, openai, gpt, gemini, google, vertex_ai");

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
@@ -242,7 +242,7 @@ public class AnthropicHandler implements LlmProviderHandler {
             // Auto-execution mode: Use ChatClient which handles tool execution automatically
             return generateWithToolsAutoExecute(model, springMessages, tools, toolExecutor, formattedSystemPrompt, enforcedSchema, hintSchema, hintTools, options);
         } else {
-            // No-execution mode: Use model.call with internalToolExecutionEnabled(false)
+            // No-execution mode: raw model.call() returns tool_calls without executing them
             return generateWithToolsNoExecute(model, springMessages, tools, formattedSystemPrompt, enforcedSchema, hintSchema, hintTools, options);
         }
     }
@@ -321,7 +321,7 @@ public class AnthropicHandler implements LlmProviderHandler {
 
         // Add tools if present - Spring AI handles tool execution automatically
         if (!toolCallbacks.isEmpty()) {
-            requestSpec.toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]));
+            requestSpec.tools(toolCallbacks.toArray(new ToolCallback[0]));
         }
 
         // Always build AnthropicChatOptions so the effective model (declared model or
@@ -344,7 +344,7 @@ public class AnthropicHandler implements LlmProviderHandler {
             }
         }
         applyModelParams(optionsBuilder, options);
-        requestSpec.options(optionsBuilder.build());
+        requestSpec.options(optionsBuilder);
 
         // Execute the request — if outputFormat was applied and the API rejects it,
         // retry with HINT-mode instructions instead of native output_format
@@ -365,7 +365,7 @@ public class AnthropicHandler implements LlmProviderHandler {
                 }
                 retrySpec.user(userContent);
                 if (!toolCallbacks.isEmpty()) {
-                    retrySpec.toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]));
+                    retrySpec.tools(toolCallbacks.toArray(new ToolCallback[0]));
                 }
                 // No output_format applied — rely on HINT instructions. Still
                 // re-apply consumer-supplied model_params (max_tokens/temperature/
@@ -373,7 +373,7 @@ public class AnthropicHandler implements LlmProviderHandler {
                 // the rejected output_format.
                 AnthropicChatOptions.Builder retryOptions = AnthropicChatOptions.builder();
                 applyModelParams(retryOptions, options);
-                retrySpec.options(retryOptions.build());
+                retrySpec.options(retryOptions);
                 chatResponse = retrySpec.call().chatResponse();
             } else {
                 throw e;
@@ -391,9 +391,12 @@ public class AnthropicHandler implements LlmProviderHandler {
     /**
      * Generate with tools but WITHOUT executing them.
      *
-     * <p>Uses model.call() with internalToolExecutionEnabled(false) to get
-     * tool_calls back without auto-execution. This is used for mesh delegation
-     * where the consumer (not provider) executes tools.
+     * <p>Calls the raw {@link ChatModel#call(Prompt)} which, in Spring AI GA,
+     * returns the model's {@code tool_calls} WITHOUT auto-execution — tool
+     * execution now lives in a ChatClient-level advisor that is deliberately
+     * absent on this raw path. Tool callbacks are attached to the options only
+     * to advertise the tool schemas to the model. This is used for mesh
+     * delegation where the consumer (not provider) executes tools.
      */
     private LlmResponse generateWithToolsNoExecute(
             ChatModel model,
@@ -425,7 +428,6 @@ public class AnthropicHandler implements LlmProviderHandler {
 
                 AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder()
                     .toolCallbacks(toolCallbacks)
-                    .internalToolExecutionEnabled(false)
                     .outputSchema(schemaJson);
                 applyModelParams(optionsBuilder, options);
 
@@ -435,16 +437,14 @@ public class AnthropicHandler implements LlmProviderHandler {
                 log.warn("Failed to apply output_format for {}: {}, falling back to basic options",
                     outputSchema.name(), e.getMessage());
                 AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder()
-                    .toolCallbacks(toolCallbacks)
-                    .internalToolExecutionEnabled(false);
+                    .toolCallbacks(toolCallbacks);
                 applyModelParams(optionsBuilder, options);
                 prompt = new org.springframework.ai.chat.prompt.Prompt(messagesWithFormattedSystem, optionsBuilder.build());
             }
         } else {
             // No structured output needed — still apply model_params via AnthropicChatOptions.
             AnthropicChatOptions.Builder optionsBuilder = AnthropicChatOptions.builder()
-                .toolCallbacks(toolCallbacks)
-                .internalToolExecutionEnabled(false);
+                .toolCallbacks(toolCallbacks);
             applyModelParams(optionsBuilder, options);
             prompt = new org.springframework.ai.chat.prompt.Prompt(messagesWithFormattedSystem, optionsBuilder.build());
         }
@@ -478,8 +478,7 @@ public class AnthropicHandler implements LlmProviderHandler {
                 // consumer-supplied model_params so the retry matches the initial
                 // request minus the rejected output_format.
                 AnthropicChatOptions.Builder hintBuilder = AnthropicChatOptions.builder()
-                    .toolCallbacks(toolCallbacks)
-                    .internalToolExecutionEnabled(false);
+                    .toolCallbacks(toolCallbacks);
                 applyModelParams(hintBuilder, options);
                 prompt = new org.springframework.ai.chat.prompt.Prompt(hintMessages, hintBuilder.build());
 

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/GeminiHandler.java
@@ -12,8 +12,6 @@ import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
-import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatModel;
-import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatOptions;
 
 import java.util.*;
 
@@ -40,7 +38,6 @@ import java.util.*;
 public class GeminiHandler implements LlmProviderHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GeminiHandler.class);
-    private static final tools.jackson.databind.ObjectMapper MAPPER = new tools.jackson.databind.ObjectMapper();
 
     @Override
     public String getVendor() {
@@ -58,7 +55,7 @@ public class GeminiHandler implements LlmProviderHandler {
      * Google AI Studio ({@code gemini/...}) and Vertex AI ({@code vertex_ai/...})
      * model strings through this single {@code GeminiHandler}, so a
      * {@code vertex_ai/}-qualified override is same-provider and must be accepted
-     * on BOTH the Vertex and GenAI option branches. Kept separate from the public
+     * on the google-genai options builder. Kept separate from the public
      * {@link #getAliases()} (which other surfaces assert returns exactly
      * {@code ["google"]}) so widening override-matching doesn't change that
      * contract. A genuinely cross-vendor override (e.g. {@code openai/...}) is
@@ -118,8 +115,7 @@ public class GeminiHandler implements LlmProviderHandler {
         // override) is set on the request — without it the request falls through to
         // Spring AI's default Gemini model. Consumer-supplied model_params
         // (max_tokens→maxOutputTokens/temperature/top_p) are applied here too.
-        // buildModelParamOptions branches Vertex vs GenAI to match the chat model.
-        ChatOptions paramOptions = buildModelParamOptions(model, options);
+        ChatOptions paramOptions = buildModelParamOptions(options).build();
         Prompt prompt = new Prompt(springMessages, paramOptions);
         ChatResponse response = model.call(prompt);
 
@@ -183,7 +179,7 @@ public class GeminiHandler implements LlmProviderHandler {
             // Auto-execution mode: Use ChatClient which handles tool execution automatically
             return generateWithToolsAutoExecute(model, springMessages, tools, toolExecutor, formattedSystemPrompt, outputSchema, options);
         } else {
-            // No-execution mode: Use model.call with internalToolExecutionEnabled(false)
+            // No-execution mode: raw model.call() returns tool_calls without executing them
             return generateWithToolsNoExecute(model, springMessages, tools, formattedSystemPrompt, outputSchema, options);
         }
     }
@@ -227,18 +223,16 @@ public class GeminiHandler implements LlmProviderHandler {
 
         // Add tools if present
         if (!toolCallbacks.isEmpty()) {
-            requestSpec.toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]));
+            requestSpec.tools(toolCallbacks.toArray(new ToolCallback[0]));
         }
 
         // Don't use applyResponseFormat - Spring AI has issues with Gemini responseSchema
         // Structured output is handled via prompt-based hints in formatSystemPrompt()
 
-        // Always attach a vendor-correct Gemini options object so the effective
-        // model (declared model or a vendor-matched per-call override) is set on
-        // EVERY request, plus any consumer-supplied model_params (max_tokens/
-        // temperature/top_p). The concrete options class must match the underlying
-        // chat model (see buildModelParamOptions).
-        requestSpec.options(buildModelParamOptions(model, options));
+        // Always attach a Gemini options object so the effective model (declared
+        // model or a vendor-matched per-call override) is set on EVERY request,
+        // plus any consumer-supplied model_params (max_tokens/temperature/top_p).
+        requestSpec.options(buildModelParamOptions(options));
 
         // Execute the request
         ChatResponse chatResponse = requestSpec.call().chatResponse();
@@ -254,9 +248,12 @@ public class GeminiHandler implements LlmProviderHandler {
     /**
      * Generate with tools but WITHOUT executing them.
      *
-     * <p>Uses model.call() with internalToolExecutionEnabled(false) to get
-     * tool_calls back without auto-execution. This is used for mesh delegation
-     * where the consumer (not provider) executes tools.
+     * <p>Calls the raw {@link ChatModel#call(Prompt)} which, in Spring AI GA,
+     * returns the model's {@code tool_calls} WITHOUT auto-execution — tool
+     * execution now lives in a ChatClient-level advisor that is deliberately
+     * absent on this raw path. Tool callbacks are attached to the options only
+     * to advertise the tool schemas to the model. This is used for mesh
+     * delegation where the consumer (not provider) executes tools.
      */
     private LlmResponse generateWithToolsNoExecute(
             ChatModel model,
@@ -272,10 +269,8 @@ public class GeminiHandler implements LlmProviderHandler {
         // Create tool callbacks for schema only (no execution)
         List<ToolCallback> toolCallbacks = createToolCallbacksForSchema(tools);
 
-        // Build Gemini-specific chat options with tool execution DISABLED.
-        // The concrete options class must match the underlying ChatModel: Vertex's
-        // chat model does an explicit checkcast to VertexAiGeminiChatOptions and
-        // throws ClassCastException if given GoogleGenAiChatOptions (and vice versa).
+        // Build Gemini chat options. Tools are attached to advertise their schema;
+        // the raw model.call() below does not execute them in Spring AI GA.
         // Don't use responseSchema - Spring AI has issues with Gemini responseSchema
         // Structured output is handled via prompt-based hints in formatSystemPrompt()
         log.debug("Using prompt-based JSON hints for structured output (not responseSchema)");
@@ -321,55 +316,15 @@ public class GeminiHandler implements LlmProviderHandler {
         return new LlmResponse(content, toolCalls, extractUsage(response));
     }
 
-    // Reflection-based lookup of Vertex AI chat model class. The
-    // spring-ai-vertex-ai-gemini dependency is declared <optional>true</optional>
-    // in mcp-mesh-spring-ai/pom.xml, so consumers using only AI Studio
-    // (spring-ai-starter-model-google-genai) won't have these classes on their
-    // runtime classpath. Resolving via Class.forName lets us safely detect
-    // availability without an `instanceof` check that would trigger a
-    // NoClassDefFoundError on consumer classpaths missing the dep.
-    //
-    // The compile-time imports of VertexAiGeminiChatModel/VertexAiGeminiChatOptions
-    // are intentional and benign: imports are erased to fully-qualified bytecode
-    // references, and the JVM only resolves a referenced class when a method
-    // *body* mentioning it is first invoked. By isolating Vertex API calls into
-    // buildVertexOptions(), the class load is deferred until we've already
-    // verified the class is present (VERTEX_OPTIONS_CLASS != null).
-    private static final Class<?> VERTEX_CHAT_MODEL_CLASS;
-    private static final Class<?> VERTEX_OPTIONS_CLASS;
-    static {
-        Class<?> modelClass = null;
-        Class<?> optionsClass = null;
-        try {
-            modelClass = Class.forName("org.springframework.ai.vertexai.gemini.VertexAiGeminiChatModel");
-            optionsClass = Class.forName("org.springframework.ai.vertexai.gemini.VertexAiGeminiChatOptions");
-        } catch (ClassNotFoundException e) {
-            // Vertex AI starter not on classpath -- fine, AI Studio path will be used.
-            // Logged at debug level so we don't spam stdout for normal AI-Studio-only deployments.
-            log.debug("spring-ai-vertex-ai-gemini not on classpath; vertex_ai routing disabled");
-        }
-        VERTEX_CHAT_MODEL_CLASS = modelClass;
-        VERTEX_OPTIONS_CLASS = optionsClass;
-    }
-
     /**
-     * Build provider-specific {@link ChatOptions} for the no-tool-execution path.
+     * Build {@link GoogleGenAiChatOptions} for the no-tool-execution path.
      *
-     * <p>Mesh delegation routes both {@code gemini/...} (Google AI Studio) and
-     * {@code vertex_ai/...} model strings through this {@code GeminiHandler}, but
-     * the underlying {@link ChatModel} differs:
-     * <ul>
-     *   <li>{@code GoogleGenAiChatModel} accepts {@link GoogleGenAiChatOptions}</li>
-     *   <li>{@code VertexAiGeminiChatModel} accepts {@code VertexAiGeminiChatOptions}</li>
-     * </ul>
-     * Each chat model does an explicit checkcast on the options it receives, so
-     * passing the wrong type throws {@link ClassCastException} at request time.
-     * Branch on the chat model type to pick the matching options class.
-     *
-     * <p>The Vertex branch is guarded by {@link #VERTEX_CHAT_MODEL_CLASS} being
-     * non-null, which is only true when {@code spring-ai-vertex-ai-gemini} is on
-     * the consumer's classpath. AI-Studio-only consumers will skip the branch
-     * and never trigger a class load of the Vertex types.
+     * <p>Spring AI GA consolidated Google support onto the single google-genai SDK
+     * ({@link org.springframework.ai.google.genai.GoogleGenAiChatModel}); the Vertex
+     * backend is reached through the same SDK via project/location backend config
+     * ({@code spring.ai.google.genai.*}), so a single options type serves both
+     * Google AI Studio and Vertex-backed routing. Tools are attached to advertise
+     * their schema only — the raw {@code model.call()} does not execute them.
      *
      * <p>Package-private for testability.
      */
@@ -378,42 +333,34 @@ public class GeminiHandler implements LlmProviderHandler {
     }
 
     /**
-     * Build provider-specific {@link ChatOptions} for the no-tool-execution path,
+     * Build {@link GoogleGenAiChatOptions} for the no-tool-execution path,
      * applying any consumer-supplied {@code model_params}
      * (max_tokens→maxOutputTokens, temperature, top_p, vendor-matched model).
      */
     ChatOptions buildToolNoExecuteOptions(ChatModel chatModel, List<ToolCallback> toolCallbacks,
                                           Map<String, Object> options) {
-        if (VERTEX_CHAT_MODEL_CLASS != null && VERTEX_CHAT_MODEL_CLASS.isInstance(chatModel)) {
-            return buildVertexOptions(toolCallbacks, options);
-        }
         GoogleGenAiChatOptions.Builder builder = GoogleGenAiChatOptions.builder()
-            .toolCallbacks(toolCallbacks)
-            .internalToolExecutionEnabled(false);
+            .toolCallbacks(toolCallbacks);
         applyGoogleGenAiModelParams(builder, options);
         return builder.build();
     }
 
     /**
-     * Build a vendor-correct Gemini options object carrying the effective model
+     * Build a {@link GoogleGenAiChatOptions} builder carrying the effective model
      * (declared model or a vendor-matched per-call override) and any
      * consumer-supplied {@code model_params} (no tool callbacks) for the
      * auto-execute (ChatClient) path, where tools are attached via the request
      * spec rather than the options object.
      *
-     * <p>Always returns a non-null options object so the effective model is set on
-     * EVERY request — without it the request falls through to Spring AI's default
-     * Gemini model.
+     * <p>Returns a builder so it can be passed directly to the GA ChatClient
+     * {@code .options(ChatOptions.Builder)} overload, or {@code .build()}ed for
+     * the raw {@code Prompt} path. The effective model is set on EVERY request —
+     * without it the request falls through to Spring AI's default Gemini model.
      */
-    private ChatOptions buildModelParamOptions(ChatModel chatModel, Map<String, Object> options) {
-        if (VERTEX_CHAT_MODEL_CLASS != null && VERTEX_CHAT_MODEL_CLASS.isInstance(chatModel)) {
-            VertexAiGeminiChatOptions.Builder builder = VertexAiGeminiChatOptions.builder();
-            applyVertexModelParams(builder, options);
-            return builder.build();
-        }
+    private GoogleGenAiChatOptions.Builder buildModelParamOptions(Map<String, Object> options) {
         GoogleGenAiChatOptions.Builder builder = GoogleGenAiChatOptions.builder();
         applyGoogleGenAiModelParams(builder, options);
-        return builder.build();
+        return builder;
     }
 
     /**
@@ -442,82 +389,6 @@ public class GeminiHandler implements LlmProviderHandler {
         if (eff != null) {
             builder.model(eff);
             log.debug("GeminiHandler: applied model '{}'", eff);
-        }
-    }
-
-    /**
-     * Isolated method that touches the Vertex options class.
-     *
-     * <p>Only called when {@link #VERTEX_CHAT_MODEL_CLASS} != null (verified at
-     * the call site in {@link #buildToolNoExecuteOptions}), so the JVM's lazy
-     * class resolution of {@code VertexAiGeminiChatOptions} when this method
-     * body is first executed is guaranteed to succeed -- the class IS on the
-     * classpath by the time we get here.
-     */
-    private ChatOptions buildVertexOptions(List<ToolCallback> toolCallbacks, Map<String, Object> options) {
-        VertexAiGeminiChatOptions.Builder builder = VertexAiGeminiChatOptions.builder()
-            .toolCallbacks(toolCallbacks)
-            .internalToolExecutionEnabled(false);
-        applyVertexModelParams(builder, options);
-        return builder.build();
-    }
-
-    /**
-     * Apply {@code model_params} to a Vertex AI Gemini options builder. Mirrors
-     * {@link #applyGoogleGenAiModelParams} but on the Vertex builder type (the
-     * concrete class differs and the chat model does an explicit checkcast).
-     */
-    private void applyVertexModelParams(VertexAiGeminiChatOptions.Builder builder, Map<String, Object> options) {
-        Integer maxTokens = LlmProviderHandler.maxTokensOption(options);
-        if (maxTokens != null) {
-            builder.maxOutputTokens(maxTokens);
-        }
-        Double temperature = LlmProviderHandler.temperatureOption(options);
-        if (temperature != null) {
-            builder.temperature(temperature);
-        }
-        Double topP = LlmProviderHandler.topPOption(options);
-        if (topP != null) {
-            builder.topP(topP);
-        }
-        // Set the effective model on EVERY request (see applyGoogleGenAiModelParams).
-        String eff = LlmProviderHandler.effectiveModel(options, getVendor(), MODEL_OVERRIDE_ALIASES);
-        if (eff != null) {
-            builder.model(eff);
-            log.debug("GeminiHandler (vertex): applied model '{}'", eff);
-        }
-    }
-
-    /**
-     * Apply response format for structured output.
-     *
-     * <p>DISABLED: Spring AI 2.0.0-M2 has a bug where setting responseMimeType +
-     * responseSchema alongside tools causes tool arguments to become empty objects ({}).
-     * This is NOT a Gemini API issue -- the same calls work via LiteLLM and Vercel SDK.
-     * Structured output is handled via prompt-based hints in formatSystemPrompt() instead.
-     *
-     * <p>This method is preserved for future use when Spring AI fixes the bug.
-     * See: Spring AI PR #4977 for related work.
-     */
-    @SuppressWarnings("unused")
-    private void applyResponseFormat(ChatClient.ChatClientRequestSpec requestSpec, OutputSchema outputSchema) {
-        try {
-            // Make schema strict (add additionalProperties: false, all properties required)
-            Map<String, Object> strictSchema = outputSchema.makeStrict(true);
-
-            // Convert schema to JSON string for Gemini
-            String schemaJson = MAPPER
-                .writeValueAsString(strictSchema);
-
-            GoogleGenAiChatOptions geminiOptions = GoogleGenAiChatOptions.builder()
-                .responseMimeType("application/json")
-                .responseSchema(schemaJson)
-                .build();
-
-            requestSpec.options(geminiOptions);
-            log.debug("Applied Gemini response format with schema: {}", outputSchema.name());
-        } catch (Exception e) {
-            log.warn("Failed to apply response format for {}: {}", outputSchema.name(), e.getMessage());
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/OpenAiHandler.java
@@ -9,9 +9,9 @@ import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatModel.ResponseFormat;
+import org.springframework.ai.openai.OpenAiChatModel.ResponseFormat.Type;
 import org.springframework.ai.openai.OpenAiChatOptions;
-import org.springframework.ai.openai.api.ResponseFormat;
-import org.springframework.ai.openai.api.ResponseFormat.Type;
 import org.springframework.ai.tool.ToolCallback;
 
 import java.util.*;
@@ -143,7 +143,7 @@ public class OpenAiHandler implements LlmProviderHandler {
             // Auto-execution mode: Use ChatClient which handles tool execution automatically
             return generateWithToolsAutoExecute(model, springMessages, tools, toolExecutor, formattedSystemPrompt, enforcedSchema, messages, options);
         } else {
-            // No-execution mode: Use model.call with internalToolExecutionEnabled(false)
+            // No-execution mode: raw model.call() returns tool_calls without executing them
             return generateWithToolsNoExecute(model, springMessages, tools, formattedSystemPrompt, enforcedSchema, options);
         }
     }
@@ -259,7 +259,7 @@ public class OpenAiHandler implements LlmProviderHandler {
 
         // Add tools if present - Spring AI handles tool execution automatically
         if (!toolCallbacks.isEmpty()) {
-            requestSpec.toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]));
+            requestSpec.tools(toolCallbacks.toArray(new ToolCallback[0]));
         }
 
         // Always build OpenAiChatOptions so the effective model (declared model or a
@@ -275,13 +275,12 @@ public class OpenAiHandler implements LlmProviderHandler {
                 // Make schema strict (add additionalProperties: false, all properties required)
                 Map<String, Object> strictSchema = outputSchema.makeStrict(true);
 
+                // Spring AI GA: ResponseFormat.jsonSchema is now the schema JSON string
+                // (the model hardcodes name="json_schema" + strict=true internally).
+                String strictSchemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(strictSchema);
                 ResponseFormat responseFormat = ResponseFormat.builder()
                     .type(Type.JSON_SCHEMA)
-                    .jsonSchema(ResponseFormat.JsonSchema.builder()
-                        .name(outputSchema.name())
-                        .schema(strictSchema)
-                        .strict(true)
-                        .build())
+                    .jsonSchema(strictSchemaJson)
                     .build();
                 optionsBuilder.responseFormat(responseFormat);
                 log.debug("Applied OpenAI response_format with schema: {}", outputSchema.name());
@@ -291,7 +290,7 @@ public class OpenAiHandler implements LlmProviderHandler {
             }
         }
         applyModelParams(optionsBuilder, options);
-        requestSpec.options(optionsBuilder.build());
+        requestSpec.options(optionsBuilder);
 
         // Execute the request
         ChatResponse chatResponse = requestSpec.call().chatResponse();
@@ -307,9 +306,12 @@ public class OpenAiHandler implements LlmProviderHandler {
     /**
      * Generate with tools but WITHOUT executing them.
      *
-     * <p>Uses model.call() with internalToolExecutionEnabled(false) to get
-     * tool_calls back without auto-execution. This is used for mesh delegation
-     * where the consumer (not provider) executes tools.
+     * <p>Calls the raw {@link ChatModel#call(Prompt)} which, in Spring AI GA,
+     * returns the model's {@code tool_calls} WITHOUT auto-execution — tool
+     * execution now lives in a ChatClient-level advisor that is deliberately
+     * absent on this raw path. Tool callbacks are attached to the options only
+     * to advertise the tool schemas to the model. This is used for mesh
+     * delegation where the consumer (not provider) executes tools.
      */
     private LlmResponse generateWithToolsNoExecute(
             ChatModel model,
@@ -337,19 +339,20 @@ public class OpenAiHandler implements LlmProviderHandler {
                 // Make schema strict (add additionalProperties: false, all properties required)
                 Map<String, Object> strictSchema = outputSchema.makeStrict(true);
 
+                // Spring AI GA: ResponseFormat.jsonSchema is now the schema JSON string
+                // (the model hardcodes name="json_schema" + strict=true internally).
+                String strictSchemaJson = TOOL_CALLBACK_MAPPER.writeValueAsString(strictSchema);
                 ResponseFormat responseFormat = ResponseFormat.builder()
                     .type(Type.JSON_SCHEMA)
-                    .jsonSchema(ResponseFormat.JsonSchema.builder()
-                        .name(outputSchema.name())
-                        .schema(strictSchema)
-                        .strict(true)
-                        .build())
+                    .jsonSchema(strictSchemaJson)
                     .build();
 
-                // Use OpenAiChatOptions which supports both tools and response_format
+                // Use OpenAiChatOptions which supports both tools and response_format.
+                // The raw model.call() path below does NOT execute tools in Spring AI
+                // GA (tool execution lives in a ChatClient advisor, absent here), so
+                // attaching the callbacks only advertises the tool schema to the model.
                 OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder()
                     .toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]))
-                    .internalToolExecutionEnabled(false)
                     .responseFormat(responseFormat);
                 applyModelParams(optionsBuilder, options);
 
@@ -360,16 +363,14 @@ public class OpenAiHandler implements LlmProviderHandler {
                     outputSchema.name(), e.getMessage());
                 // Fallback to OpenAiChatOptions without response_format (still apply model_params)
                 OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder()
-                    .toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]))
-                    .internalToolExecutionEnabled(false);
+                    .toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]));
                 applyModelParams(optionsBuilder, options);
                 prompt = new Prompt(messagesWithFormattedSystem, optionsBuilder.build());
             }
         } else {
             // No structured output needed — still apply model_params via OpenAiChatOptions.
             OpenAiChatOptions.Builder optionsBuilder = OpenAiChatOptions.builder()
-                .toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]))
-                .internalToolExecutionEnabled(false);
+                .toolCallbacks(toolCallbacks.toArray(new ToolCallback[0]));
             applyModelParams(optionsBuilder, options);
             prompt = new Prompt(messagesWithFormattedSystem, optionsBuilder.build());
         }

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/GeminiHandlerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/GeminiHandlerTest.java
@@ -6,8 +6,6 @@ import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.google.genai.GoogleGenAiChatModel;
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions;
 import org.springframework.ai.tool.ToolCallback;
-import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatModel;
-import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatOptions;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
@@ -320,18 +318,6 @@ class GeminiHandlerTest {
     @Nested
     @DisplayName("buildToolNoExecuteOptions")
     class BuildToolNoExecuteOptionsTests {
-
-        @Test
-        @DisplayName("returns VertexAiGeminiChatOptions for VertexAiGeminiChatModel")
-        void returnsVertexOptionsForVertexChatModel() {
-            VertexAiGeminiChatModel mockModel = mock(VertexAiGeminiChatModel.class);
-            List<ToolCallback> callbacks = List.of();
-
-            ChatOptions opts = handler.buildToolNoExecuteOptions(mockModel, callbacks);
-
-            assertInstanceOf(VertexAiGeminiChatOptions.class, opts,
-                "Vertex chat model must receive VertexAiGeminiChatOptions to avoid ClassCastException");
-        }
 
         @Test
         @DisplayName("returns GoogleGenAiChatOptions for GoogleGenAiChatModel")

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderDeclaredModelTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderDeclaredModelTest.java
@@ -219,6 +219,10 @@ class ProviderDeclaredModelTest {
         void openAiKeepsModelOnSchemaFailure() {
             ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
             ChatModel model = mockModel(captor);
+            // Spring AI GA's ChatClient merges request options over chatModel.getOptions()
+            // (mutate()); a real OpenAiChatModel always has non-null options, so give the
+            // mock one for the auto-execute (ChatClient) path.
+            when(model.getOptions()).thenReturn(OpenAiChatOptions.builder().build());
 
             new OpenAiHandler().generateWithTools(
                 model, userMessages(), List.of(), noopExecutor, brokenSchema(), declared("gpt-4o"));
@@ -232,6 +236,8 @@ class ProviderDeclaredModelTest {
         void anthropicKeepsModelOnSchemaFailure() {
             ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
             ChatModel model = mockModel(captor);
+            // See note above: GA's ChatClient merges over chatModel.getOptions().
+            when(model.getOptions()).thenReturn(AnthropicChatOptions.builder().build());
 
             new AnthropicHandler().generateWithTools(
                 model, userMessages(), List.of(), noopExecutor, brokenSchema(),

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderModelParamsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderModelParamsTest.java
@@ -114,8 +114,13 @@ class ProviderModelParamsTest {
                 Map.of(LlmProviderHandler.OPTION_MODEL, "anthropic/claude-3-5-sonnet-latest"));
 
             ChatOptions opts = captor.getValue().getOptions();
-            assertNull(opts.getModel(),
-                "cross-vendor model override must be ignored — provider keeps its own default model");
+            // Spring AI GA populates the vendor SDK default model on the options builder
+            // (previously null). The mesh guarantee is unchanged: the cross-vendor
+            // override is NOT applied — the provider keeps its own/default model.
+            assertNotEquals("claude-3-5-sonnet-latest", opts.getModel(),
+                "cross-vendor model override must be ignored");
+            assertEquals(OpenAiChatOptions.DEFAULT_CHAT_MODEL, opts.getModel(),
+                "unresolved model falls back to the OpenAI SDK default (GA)");
         }
 
         @Test
@@ -131,7 +136,10 @@ class ProviderModelParamsTest {
                 "absent max_tokens must not be force-set");
             assertNull(opts.getTemperature(), "absent temperature must not be force-set");
             assertNull(opts.getTopP(), "absent top_p must not be force-set");
-            assertNull(opts.getModel(), "absent model must not be force-set");
+            // Spring AI GA: the options builder carries the vendor SDK default model
+            // when mesh resolves none (previously null). Mesh still does not force-set it.
+            assertEquals(OpenAiChatOptions.DEFAULT_CHAT_MODEL, opts.getModel(),
+                "absent model falls back to the OpenAI SDK default (GA), not force-set by mesh");
         }
     }
 
@@ -185,8 +193,12 @@ class ProviderModelParamsTest {
                 Map.of(LlmProviderHandler.OPTION_MODEL, "openai/gpt-4o"));
 
             ChatOptions opts = captor.getValue().getOptions();
-            assertNull(opts.getModel(),
-                "cross-vendor model override must be ignored — Anthropic keeps its own default model");
+            // Spring AI GA populates the vendor SDK default model on the options builder
+            // (previously null). The cross-vendor override is still NOT applied.
+            assertNotEquals("gpt-4o", opts.getModel(),
+                "cross-vendor model override must be ignored");
+            assertEquals(AnthropicChatOptions.DEFAULT_MODEL, opts.getModel(),
+                "unresolved model falls back to the Anthropic SDK default (GA)");
         }
     }
 
@@ -196,10 +208,9 @@ class ProviderModelParamsTest {
 
         private final GeminiHandler handler = new GeminiHandler();
 
-        // A plain mock(ChatModel.class) is NOT a VertexAiGeminiChatModel, so the
-        // handler takes the Google AI Studio (GenAI) branch and produces
-        // GoogleGenAiChatOptions. The Vertex branch needs the concrete
-        // VertexAiGeminiChatModel and is out of scope for this unit harness.
+        // Spring AI GA consolidated Google onto the single google-genai SDK, so the
+        // handler always produces GoogleGenAiChatOptions (the Vertex backend is now
+        // reached through google-genai backend config, not a separate options type).
 
         @Test
         @DisplayName("max_tokens→maxOutputTokens/temperature/top_p flow onto GoogleGenAiChatOptions")
@@ -264,8 +275,14 @@ class ProviderModelParamsTest {
             handler.generateWithTools(model, userMessages(), List.of(), null, null,
                 Map.of(LlmProviderHandler.OPTION_MODEL, "openai/gpt-4o"));
 
-            assertNull(captor.getValue().getOptions().getModel(),
-                "cross-vendor model override must be ignored — Gemini keeps its own default model");
+            ChatOptions opts = captor.getValue().getOptions();
+            // Spring AI GA populates the vendor SDK default model on the options builder
+            // (previously null). The cross-vendor override is still NOT applied — Gemini
+            // keeps its own/default model (non-null vendor default).
+            assertNotEquals("gpt-4o", opts.getModel(),
+                "cross-vendor model override must be ignored");
+            assertNotNull(opts.getModel(),
+                "unresolved model falls back to the Gemini SDK default (GA)");
         }
 
         @Test
@@ -294,13 +311,14 @@ class ProviderModelParamsTest {
 
             handler.generateWithMessages(model, userMessages(), Map.of());
 
-            // The handler now always builds a vendor-correct options object so the
-            // effective model can be set on every request. With no declared model
-            // and no override, the model stays null (Spring AI default applies).
+            // The handler always builds a vendor-correct options object so the effective
+            // model can be set on every request. With no declared model and no override,
+            // mesh sets nothing — and Spring AI GA leaves the builder's own SDK default
+            // model in place (previously null on M-series).
             ChatOptions opts = captor.getValue().getOptions();
             assertInstanceOf(GoogleGenAiChatOptions.class, opts);
-            assertNull(opts.getModel(),
-                "no declared model and no override → model stays null (Spring AI default)");
+            assertNotNull(opts.getModel(),
+                "no declared model and no override → Gemini SDK default applies (GA)");
         }
     }
 

--- a/src/runtime/java/pom.xml
+++ b/src/runtime/java/pom.xml
@@ -56,7 +56,7 @@
 
         <!-- Dependency versions -->
         <spring-boot.version>4.0.5</spring-boot.version>
-        <spring-ai.version>2.0.0-M4</spring-ai.version>
+        <spring-ai.version>2.0.0</spring-ai.version>
         <mcp-sdk.version>2.0.0</mcp-sdk.version>
         <jnr-ffi.version>2.2.16</jnr-ffi.version>
         <!-- Jackson 3 (databind uses tools.jackson, annotations stays on com.fasterxml) -->


### PR DESCRIPTION
## Summary

Upgrades mesh's Java runtime from the spring-ai **2.0.0-M4** milestone to **2.0.0 GA**.

**No framework churn** — mesh is already on Spring Boot 4.0.5 / Java 17 (GA is Java 17), and the MCP Java SDK is pinned independently at 2.0.0 (GA ships the same), so the custom `HttpServletStatelessServerTransport` is untouched. All breaking changes are confined to the three LLM handlers.

### GA breaking changes handled
- **`ResponseFormat`** relocated to nested `OpenAiChatModel.ResponseFormat`; `.jsonSchema(String)` now takes the schema JSON string (GA hardcodes `name="json_schema"` — only the custom label is dropped, schema body preserved).
- **`ChatClient.options()`** now takes a `ChatOptions.Builder` (raw `ChatModel.call` still takes a built `ChatOptions`) — fixed per call site.
- **`internalToolExecutionEnabled` removed.** The no-execute delegation path now uses the raw **`ChatModel.call(Prompt)`** (no ChatClient tool-calling advisor → returns *unexecuted* tool calls), preserving mesh's provider-returns-calls / mesh-executes semantics. Verified live for all three vendors.
- **Vertex module dropped** (GA consolidated Google → the google-genai SDK). Removed `spring-ai-vertex-ai-gemini` + GeminiHandler's Vertex branch (−193 lines). `vertex_ai`/`vertexai` now **alias the single google-genai Gemini bean** — backend is chosen by google-genai config (api-key = AI Studio, project/location = Vertex). This also fixed a regression the naive migration introduced (`provider="vertex_ai"` was hard-failing with impossible remediation text).
- `toolCallbacks()` → `tools()` on ChatClient specs.

Examples: bumped `spring-ai.version` to 2.0.0 across all Java example poms; migrated the gemini example config to `spring.ai.google.genai.*`.

## Validation
- **`mvn test` green**: mcp-mesh-spring-ai 184/184, upstream module 657/657.
- **Live end-to-end gate — PASSED all three vendors** (Java providers, real API calls): OpenAI, Anthropic, and **Gemini (google-genai)** each started clean, **autowired the correct GA ChatModel bean**, and completed a **no-execute** delegated tool loop (tool executed exactly once via the mesh endpoint — no auto-execution, no double-exec).
- **Independent review**: 0 blockers, 1 warning (the `vertex_ai` routing regression — **fixed in this PR**), 3 benign infos (one dead method removed).

## Known / out of scope
- The GCP **Vertex backend** (google-genai `project`/`location` config) routes correctly but wasn't exercised end-to-end here (no GCP creds in the test env) — the **AI Studio** (api-key) Gemini path was live-validated.
- Reaching spring-ai's OpenAI **Responses API** is still upstream `spring-projects/spring-ai#2962` (2.1.x) — tracked in #1335, unrelated to this bump.

## Test plan
- [x] `mvn test` (spring-ai module + upstream) green
- [x] Live delegation smoke — OpenAI + Anthropic + Gemini Java providers, no-execute tool loop
- [x] Independent review, warning fixed
- [ ] CI matrix (Go/Java/Py/Rust/TS + CodeRabbit)

Closes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Java examples and runtime components to Spring AI 2.0 GA.
  - Consolidated Gemini integrations on Google GenAI, supporting API-key and Vertex configuration.
  - Improved Gemini model selection and configuration messaging.

- **Bug Fixes**
  - Improved tool-calling and structured-output handling for Anthropic, Gemini, and OpenAI.
  - Preserved declared model parameters and vendor defaults across requests.
  - Updated tests for Spring AI 2.0 behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->