### PR TITLE
release: v3.2.0

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version tag (e.g., v3.1.0)"
+        description: "Version tag (e.g., v3.2.0)"
         required: true
-        default: "v3.1.0"
+        default: "v3.2.0"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version (e.g., v3.1.0)"
+        description: "Version (e.g., v3.2.0)"
         required: true
-        default: "v3.1.0"
+        default: "v3.2.0"
       environment:
         description: "Environment"
         type: choice

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,40 @@
 # MCP Mesh Release Notes
 
-[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.1.0...HEAD)
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.2.0...HEAD)
+
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.1.0...v3.2.0)
+
+## v3.2.0 (2026-07-16)
+
+A capability and modernization release. LLM model support is broadened to the current Claude and OpenAI generations — Claude Sonnet 5, and OpenAI GPT-5 reasoning models used with function tools — the Java runtime moves from spring-ai 2.0.0-M4 to 2.0.0 GA, and meshui collapses live agent replicas into a single grouped entry. Nothing touches the wire protocol, the registry, dependency resolution, or the declaration syntax; runtime model-id handling remains pass-through, so new provider models work without a mesh change. The one migration item is a Java Gemini/Vertex configuration-key change inherited from the spring-ai upgrade.
+
+### 🤖 LLM: current-model support — Sonnet 5, GPT-5 reasoning + tools (#1333, #1337)
+
+Model handling in mesh is pass-through and keyed on the provider vendor, so a newly released model generally works with no code change. Two manually maintained surfaces are refreshed to match the current generation, and one genuine capability gap is closed.
+
+Anthropic: the native `output_config` structured-output allow-list is refreshed to cover the current models (Claude Sonnet 5, Opus 4.6/4.8, Fable 5); an id it doesn't match continues to degrade to the synthetic-tool path rather than failing, so the change is an optimization refresh, not a behavior break. The `meshctl scaffold` default Claude model is now `claude-sonnet-5`.
+
+OpenAI: the GPT-5-family sampling-parameter gate now recognizes chat variants version-agnostically — a versioned chat id such as `gpt-5.6-chat` is correctly treated as a chat model while a reasoning point release such as `gpt-5.6` stays restricted. More substantially, **GPT-5 reasoning models now work with function tools.** OpenAI rejects reasoning + function tools on `/v1/chat/completions`; the Python runtime now routes those requests to the OpenAI Responses API so reasoning and tools coexist, while non-reasoning models and no-tools calls stay on chat.completions unchanged. Because mesh delegation is provider-managed — the provider's runtime makes the vendor call — any consumer, in any language, can use a GPT-5 reasoning model with tools by delegating to a Python provider. TypeScript providers already route OpenAI through the Responses API by default; a Java-provider equivalent awaits spring-ai's Responses support (#1335).
+
+### ☕ Java: spring-ai 2.0.0 GA (#1339)
+
+The Java runtime moves from the spring-ai 2.0.0-M4 milestone to the 2.0.0 GA release. There is no framework jump — mesh was already on Spring Boot 4 / Java 17 — and the embedded MCP SDK is unchanged, so the custom HTTP transport is untouched. The GA API changes are internal to the LLM handlers, and mesh's own `@MeshAgent` / `@MeshTool` / `@MeshLlm` / `@MeshRoute` surface is unchanged. The provider-side no-execute tool-delegation semantics — the provider returns the model's tool calls and mesh executes them — are preserved and were validated end to end against OpenAI, Anthropic, and Gemini.
+
+⚠️ **Migration — Java Gemini/Vertex users only.** spring-ai 2.0 GA consolidated its Google support into the google-genai SDK and dropped the separate Vertex AI module. If you run a Java Gemini provider, update the configuration keys `spring.ai.vertex.ai.gemini.*` → `spring.ai.google.genai.*` (`api-key` for AI Studio, or `project` / `location` for the Vertex AI backend). The `vertex_ai` / `vertexai` provider aliases now resolve to the single google-genai Gemini model, with the backend selected by that configuration. If you call spring-ai APIs directly (beyond mesh's decorators), review spring-ai's own 2.0 migration notes as well.
+
+### 🖥️ meshui: replicas collapse into a single ×N entry (#1330)
+
+Live agent replicas that share an agent name now collapse into one `×N` entry across the Topology, Agents, and Dashboard views, with worst-of aggregate health and a drill-in for per-instance detail — matching the "one logical agent, N pods" mental model rather than rendering N near-identical rows. Edge wiring and per-instance trace lookups are unaffected.
+
+### 📚 Docs: "Why MCP Mesh?" reframed around DDDI (#1329)
+
+The positioning page now leads with the single idea the platform is built on — Distributed Dynamic Dependency Injection — and frames the feature surface as consequences of that primitive, rather than opening with an operations feature list.
+
+### ⚠️ Notes
+
+- **No wire, registry, resolution, or declaration-syntax changes.** Runtime model-id handling is pass-through; new Claude and OpenAI models work without a mesh change.
+- **One migration item — Java Gemini/Vertex configuration keys** — from the spring-ai 2.0 GA upgrade (see above). All other Java behavior is unchanged, and non-Java runtimes are unaffected.
+- **Known limitation.** OpenAI GPT-5 reasoning-plus-tools works through Python and TypeScript providers today; the Java-provider path awaits spring-ai's Responses API support (#1335). Native Responses streaming and multimodal input on the Python path are tracked follow-ups (#1336).
 
 [Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.0.1...v3.1.0)
 

--- a/cmd/meshctl/templates/java/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.1.0
+FROM mcpmesh/java-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/a2a-consumer/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/a2a-consumer/pom.xml.tmpl
@@ -26,7 +26,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.1.0
+FROM mcpmesh/java-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/api/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/api/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.1.0
+FROM mcpmesh/java-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/basic/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/basic/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.1.0
+FROM mcpmesh/java-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.1.0
+FROM mcpmesh/java-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/python/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/a2a-consumer/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/a2a-consumer/package.json.tmpl
@@ -13,7 +13,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/cmd/meshctl/templates/typescript/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/api/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/api/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/basic/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/docs/00-why-mcp-mesh/index.md
+++ b/docs/00-why-mcp-mesh/index.md
@@ -121,7 +121,7 @@ meshctl scaffold --compose --observability
 
 # Or deploy to Kubernetes (OCI registry)
 helm install my-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 -n mcp-mesh --create-namespace
+  --version 3.2.0 -n mcp-mesh --create-namespace
 ```
 
 ### 5. Built-in Observability

--- a/docs/02-local-development.md
+++ b/docs/02-local-development.md
@@ -97,7 +97,7 @@ graph LR
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </dependency>
     ```
 

--- a/docs/03-docker-deployment.md
+++ b/docs/03-docker-deployment.md
@@ -24,10 +24,10 @@ MCP Mesh publishes official images to Docker Hub:
 
 | Image                            | Purpose                                          |
 | -------------------------------- | ------------------------------------------------ |
-| `mcpmesh/registry:3.1.0`           | Go-based registry service                        |
-| `mcpmesh/python-runtime:3.1.0`     | Python agent runtime (includes mcp-mesh SDK)     |
-| `mcpmesh/java-runtime:3.1.0`       | Java agent runtime (includes mcp-mesh SDK)       |
-| `mcpmesh/typescript-runtime:3.1.0` | TypeScript agent runtime (includes @mcpmesh/sdk) |
+| `mcpmesh/registry:3.2.0`           | Go-based registry service                        |
+| `mcpmesh/python-runtime:3.2.0`     | Python agent runtime (includes mcp-mesh SDK)     |
+| `mcpmesh/java-runtime:3.2.0`       | Java agent runtime (includes mcp-mesh SDK)       |
+| `mcpmesh/typescript-runtime:3.2.0` | TypeScript agent runtime (includes @mcpmesh/sdk) |
 
 ## Using Scaffold to Generate Compose Files
 
@@ -53,7 +53,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:3.1.0
+        image: mcpmesh/registry:3.2.0
         ports:
           - "8000:8000"
         healthcheck:
@@ -63,7 +63,7 @@ meshctl scaffold --compose --dry-run -d ./agents
           retries: 3
 
       my-agent:
-        image: mcpmesh/python-runtime:3.1.0
+        image: mcpmesh/python-runtime:3.2.0
         ports:
           - "8080:8080"
         volumes:
@@ -88,7 +88,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:3.1.0
+        image: mcpmesh/registry:3.2.0
         ports:
           - "8000:8000"
         healthcheck:
@@ -122,7 +122,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:3.1.0
+        image: mcpmesh/registry:3.2.0
         ports:
           - "8000:8000"
         healthcheck:
@@ -132,7 +132,7 @@ meshctl scaffold --compose --dry-run -d ./agents
           retries: 3
 
       my-agent:
-        image: mcpmesh/typescript-runtime:3.1.0
+        image: mcpmesh/typescript-runtime:3.2.0
         ports:
           - "8080:8080"
         volumes:
@@ -161,12 +161,12 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:3.1.0
+        image: mcpmesh/registry:3.2.0
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/python-runtime:3.1.0
+        image: mcpmesh/python-runtime:3.2.0
         volumes:
           - ./agent.py:/app/agent.py:ro
         command: ["python", "/app/agent.py"]
@@ -185,7 +185,7 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:3.1.0
+        image: mcpmesh/registry:3.2.0
         ports:
           - "8000:8000"
 
@@ -206,12 +206,12 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:3.1.0
+        image: mcpmesh/registry:3.2.0
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/typescript-runtime:3.1.0
+        image: mcpmesh/typescript-runtime:3.2.0
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]
@@ -232,7 +232,7 @@ If you didn't use scaffold, here's a sample Dockerfile:
 === "Python"
 
     ```dockerfile
-    FROM mcpmesh/python-runtime:3.1.0
+    FROM mcpmesh/python-runtime:3.2.0
 
     COPY ./my-agent /app/agent
 
@@ -257,7 +257,7 @@ If you didn't use scaffold, here's a sample Dockerfile:
 === "TypeScript"
 
     ```dockerfile
-    FROM mcpmesh/typescript-runtime:3.1.0
+    FROM mcpmesh/typescript-runtime:3.2.0
 
     WORKDIR /app/agent
     COPY ./my-agent/package*.json ./
@@ -284,12 +284,12 @@ version: "3.8"
 
 services:
   registry:
-    image: mcpmesh/registry:3.1.0
+    image: mcpmesh/registry:3.2.0
     ports:
       - "8000:8000"
 
   auth-agent:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     volumes:
       - ./agents/auth:/app/agent:ro
     command: ["python", "/app/agent/main.py"]
@@ -298,7 +298,7 @@ services:
       - MCP_MESH_HTTP_PORT=8080
 
   data-agent:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     volumes:
       - ./agents/data:/app/agent:ro
     command: ["python", "/app/agent/main.py"]
@@ -307,7 +307,7 @@ services:
       - MCP_MESH_HTTP_PORT=8080
 
   api-agent:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     volumes:
       - ./agents/api:/app/agent:ro
     command: ["python", "/app/agent/main.py"]

--- a/docs/03-docker-deployment/04-networking.md
+++ b/docs/03-docker-deployment/04-networking.md
@@ -31,12 +31,12 @@ graph TD
     # docker-compose.yml
     services:
       registry:
-        image: mcpmesh/registry:3.1.0
+        image: mcpmesh/registry:3.2.0
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/python-runtime:3.1.0
+        image: mcpmesh/python-runtime:3.2.0
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["python", "/app/agent/main.py"]
@@ -44,7 +44,7 @@ graph TD
           - MCP_MESH_REGISTRY_URL=http://registry:8000
 
       another-agent:
-        image: mcpmesh/python-runtime:3.1.0
+        image: mcpmesh/python-runtime:3.2.0
         volumes:
           - ./another-agent:/app/agent:ro
         command: ["python", "/app/agent/main.py"]
@@ -62,12 +62,12 @@ graph TD
     # docker-compose.yml
     services:
       registry:
-        image: mcpmesh/registry:3.1.0
+        image: mcpmesh/registry:3.2.0
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/typescript-runtime:3.1.0
+        image: mcpmesh/typescript-runtime:3.2.0
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]
@@ -75,7 +75,7 @@ graph TD
           - MCP_MESH_REGISTRY_URL=http://registry:8000
 
       another-agent:
-        image: mcpmesh/typescript-runtime:3.1.0
+        image: mcpmesh/typescript-runtime:3.2.0
         volumes:
           - ./another-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]

--- a/docs/04-kubernetes-basics.md
+++ b/docs/04-kubernetes-basics.md
@@ -21,7 +21,7 @@ kubectl create namespace mcp-mesh
 
 # Deploy core (OCI registry - no "helm repo add" needed)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   --namespace mcp-mesh
 
 # Wait for registry
@@ -65,7 +65,7 @@ Build the image:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=my-agent \
@@ -76,7 +76,7 @@ For cloud deployments, use your full registry path:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
@@ -138,7 +138,7 @@ resources:
 ```bash
 # Core without Grafana/Tempo (lighter footprint)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   --namespace mcp-mesh \
   --set grafana.enabled=false \
   --set tempo.enabled=false
@@ -149,7 +149,7 @@ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
 ```bash
 # Just the registry, no database or observability
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 3.1.0 \
+  --version 3.2.0 \
   --namespace mcp-mesh
 ```
 
@@ -161,13 +161,13 @@ just match `-n` with `--set global.namespace`:
 ```bash
 # Deploy core to a custom namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n my-namespace --create-namespace \
   --set global.namespace=my-namespace
 
 # Deploy agent to the same namespace
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n my-namespace \
   -f helm-values.yaml
 ```
@@ -180,12 +180,12 @@ For **multi-tenant** clusters (separate core per team), deploy each core to its 
 ```bash
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n team-a --create-namespace --set global.namespace=team-a
 
 # Team B — same values, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n team-b --create-namespace --set global.namespace=team-b
 ```
 
@@ -193,7 +193,7 @@ For **cross-namespace** access (agent in one namespace, core in another), use FQ
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 -n other-ns \
+  --version 3.2.0 -n other-ns \
   --set mesh.registryUrl=http://mcp-core-mcp-mesh-registry.team-a.svc.cluster.local:8000
 ```
 
@@ -205,13 +205,13 @@ helm list -n mcp-mesh
 
 # Upgrade an agent
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   --namespace mcp-mesh \
   --set image.tag=v2
 
 # Scale replicas
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   --namespace mcp-mesh \
   --reuse-values \
   --set replicaCount=3

--- a/docs/04-kubernetes-basics/05-troubleshooting.md
+++ b/docs/04-kubernetes-basics/05-troubleshooting.md
@@ -373,7 +373,7 @@ kubectl exec <pod-name> -n mcp-mesh -- df -h
 **Symptoms:**
 
 ```
-Failed to pull image "mcpmesh/python-runtime:3.1.0": rpc error: code = Unknown desc = Error response from daemon: pull access denied
+Failed to pull image "mcpmesh/python-runtime:3.2.0": rpc error: code = Unknown desc = Error response from daemon: pull access denied
 ```
 
 **Solutions:**

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -216,7 +216,7 @@ Designed for containers and Kubernetes.
 
 ## Multimodal Pipeline
 
-MCP Mesh v3.1.0 adds a media pipeline that lets tools produce and LLMs consume binary content:
+MCP Mesh v3.2.0 adds a media pipeline that lets tools produce and LLMs consume binary content:
 
 ```
 Tool produces media

--- a/docs/concepts/stateful-agents.md
+++ b/docs/concepts/stateful-agents.md
@@ -48,7 +48,7 @@ mcp-mesh runs your agent across two event loops:
 
 The two-loop split means a long-running tool body (LLM call, slow registry hop, multi-minute MeshJob) holds the user loop, but never the framework loop — your K8s liveness/readiness probes stay responsive.
 
-**What this fixes**: loop-bound resources work as expected when created in `lifespan` startup. `asyncpg.Pool`, `redis.asyncio.Redis`, and `aiohttp.ClientSession` are all loop-affine — they bind to the asyncio loop that created them and fail if reused from a different one. Because v3.1.0 runs your `lifespan` AND your tools on the same user loop, the canonical FastMCP idiom is straightforward:
+**What this fixes**: loop-bound resources work as expected when created in `lifespan` startup. `asyncpg.Pool`, `redis.asyncio.Redis`, and `aiohttp.ClientSession` are all loop-affine — they bind to the asyncio loop that created them and fail if reused from a different one. Because v3.2.0 runs your `lifespan` AND your tools on the same user loop, the canonical FastMCP idiom is straightforward:
 
 ```python
 # Module-level — FastMCP's `lifespan` parameter receives a FastMCP server
@@ -104,7 +104,7 @@ long-running work. From mesh's perspective it's an ordinary CRUD
 agent — every tool call is short, idempotent where possible, and
 returns. The pool lives inside the agent process — created in
 `lifespan` startup, stored in a module-level global, and closed in
-`lifespan` exit. Since v3.1.0, `lifespan` and all tool bodies share
+`lifespan` exit. Since v3.2.0, `lifespan` and all tool bodies share
 the single user loop, so a module-level pool created in `lifespan`
 startup is the supported pattern. (FastMCP's `lifespan` receives a
 FastMCP server instance — there is no `.state` namespace as there is

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,7 @@ docker-compose up
 ```bash
 # Quick start (OCI registry - no helm repo add needed)
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 3.1.0 -n mcp-mesh --create-namespace
+  --version 3.2.0 -n mcp-mesh --create-namespace
 ```
 
 [:material-arrow-right: Kubernetes Guide](04-kubernetes-basics.md){ .md-button .md-button--primary }
@@ -117,7 +117,7 @@ For Kubernetes, configure TLS via Helm values:
 
 ```bash
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 3.1.0 -n mcp-mesh --create-namespace \
+  --version 3.2.0 -n mcp-mesh --create-namespace \
   --set registry.security.tls.mode=strict \
   --set registry.security.trust.backend=k8s-secrets
 ```

--- a/docs/dev-to-production.md
+++ b/docs/dev-to-production.md
@@ -85,10 +85,10 @@ The [TSuite](https://github.com/dhyansraj/mcp-mesh-test-suite) integration testi
 
     ```bash
     helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-      --version 3.1.0 -n mcp-mesh --create-namespace
+      --version 3.2.0 -n mcp-mesh --create-namespace
 
     helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 3.1.0 -n mcp-mesh -f helm-values.yaml
+      --version 3.2.0 -n mcp-mesh -f helm-values.yaml
     ```
 
 Same agent code runs locally, in Docker, and in Kubernetes — no changes needed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,7 @@ Build multi-agent systems that are production-ready from day one. Mesh handles t
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </dependency>
     ```
 
@@ -364,7 +364,7 @@ A `kubectl`-style command-line tool that follows you from first agent to product
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </dependency>
     ```
 
@@ -383,10 +383,10 @@ A `kubectl`-style command-line tool that follows you from first agent to product
 === "Docker Images"
 
     ```bash
-    docker pull mcpmesh/registry:3.1.0
-    docker pull mcpmesh/python-runtime:3.1.0
-    docker pull mcpmesh/java-runtime:3.1.0
-    docker pull mcpmesh/typescript-runtime:3.1.0
+    docker pull mcpmesh/registry:3.2.0
+    docker pull mcpmesh/python-runtime:3.2.0
+    docker pull mcpmesh/java-runtime:3.2.0
+    docker pull mcpmesh/typescript-runtime:3.2.0
     ```
 
     Official container images for production deployments.
@@ -412,7 +412,7 @@ A `kubectl`-style command-line tool that follows you from first agent to product
 
 ## :star: Project Status
 
-- **Latest Release**: v3.1.0 (March 2026)
+- **Latest Release**: v3.2.0 (March 2026)
 - **License**: MIT
 - **Languages**: Python 3.11+, TypeScript/Node.js 18+, and Java 17+ (runtime), Go 1.23+ (registry)
 - **Status**: Production-ready, actively developed

--- a/docs/java/examples.md
+++ b/docs/java/examples.md
@@ -132,7 +132,7 @@ class AssistantAgentTest {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:3.1.0
+    image: mcpmesh/registry:3.2.0
     ports:
       - "8000:8000"
     healthcheck:

--- a/docs/java/getting-started/index.md
+++ b/docs/java/getting-started/index.md
@@ -83,13 +83,13 @@ Create `pom.xml`:
 
     <groupId>com.example</groupId>
     <artifactId>greeter-agent</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
 
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/docs/java/getting-started/prerequisites.md
+++ b/docs/java/getting-started/prerequisites.md
@@ -60,7 +60,7 @@ Add the Spring Boot starter to your `pom.xml`:
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -108,10 +108,10 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.1.0`           | Registry service            |
-| `mcpmesh/python-runtime:3.1.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.1.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.1.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.2.0`           | Registry service            |
+| `mcpmesh/python-runtime:3.2.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.2.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.2.0` | TypeScript runtime with SDK |
 
 Java agents use standard Maven-based Docker builds (see Docker Deployment guide).
 

--- a/docs/java/index.md
+++ b/docs/java/index.md
@@ -27,7 +27,7 @@ The MCP Mesh Java SDK provides an annotation-based API for building distributed 
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
 </dependency>
 ```
 

--- a/docs/java/local-development/01-getting-started.md
+++ b/docs/java/local-development/01-getting-started.md
@@ -45,7 +45,7 @@ The recommended way is to use `meshctl scaffold` (see next page). If you prefer 
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/docs/java/local-development/troubleshooting.md
+++ b/docs/java/local-development/troubleshooting.md
@@ -38,7 +38,7 @@ Ensure the dependency version matches an available release:
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
 </dependency>
 ```
 

--- a/docs/java/spring-boot-integration.md
+++ b/docs/java/spring-boot-integration.md
@@ -23,7 +23,7 @@ MCP Mesh provides `@MeshRoute` and `@MeshInject` annotations for Spring Boot RES
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/docs/python/dependency-injection.md
+++ b/docs/python/dependency-injection.md
@@ -297,7 +297,7 @@ loop — K8s liveness/readiness probes stay responsive.
 
 ### Default `MCP_MESH_TOOL_WORKERS=1`
 
-Since v3.1.0, default tool dispatch runs on a single-user loop (was
+Since v3.2.0, default tool dispatch runs on a single-user loop (was
 `min(8, max(2, cpu_count()))`). The canonical pattern for loop-bound
 resources works as expected — `lifespan` startup creates the resource
 on the user loop; every tool body uses it on the same loop; `lifespan`

--- a/docs/python/getting-started/prerequisites.md
+++ b/docs/python/getting-started/prerequisites.md
@@ -97,17 +97,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.1.0`           | Registry service            |
-| `mcpmesh/python-runtime:3.1.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.1.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.1.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.2.0`           | Registry service            |
+| `mcpmesh/python-runtime:3.2.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.2.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.2.0` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:3.1.0
-docker pull mcpmesh/python-runtime:3.1.0
-docker pull mcpmesh/java-runtime:3.1.0
-docker pull mcpmesh/typescript-runtime:3.1.0
+docker pull mcpmesh/registry:3.2.0
+docker pull mcpmesh/python-runtime:3.2.0
+docker pull mcpmesh/java-runtime:3.2.0
+docker pull mcpmesh/typescript-runtime:3.2.0
 ```
 
 ### Generate Docker Compose
@@ -145,12 +145,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/docs/tutorial/day-08-docker-compose.md
+++ b/docs/tutorial/day-08-docker-compose.md
@@ -379,7 +379,7 @@ $ docker compose down -v
 ## Troubleshooting
 
 **Docker build fails with missing requirements.** The compose file uses
-`mcpmesh/python-runtime:3.1.0` images with a dev-mode entrypoint that
+`mcpmesh/python-runtime:3.2.0` images with a dev-mode entrypoint that
 installs `requirements.txt` on startup. If an agent has dependencies not
 in the base image, check that `requirements.txt` exists in the agent
 directory and lists all dependencies.

--- a/docs/tutorial/day-09-kubernetes.md
+++ b/docs/tutorial/day-09-kubernetes.md
@@ -212,7 +212,7 @@ and Grafana as a single Helm release:
 
 ```shell
 $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-    --version 3.1.0 \
+    --version 3.2.0 \
     -n trip-planner \
     -f helm/values-core.yaml \
     --wait --timeout 5m
@@ -246,7 +246,7 @@ $ for agent in "${AGENTS[@]}"; do
     echo "Installing $agent..."
     helm install "$agent" \
       oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 3.1.0 \
+      --version 3.2.0 \
       -n trip-planner \
       -f "helm/values-${agent}.yaml"
   done

--- a/docs/typescript/examples.md
+++ b/docs/typescript/examples.md
@@ -127,7 +127,7 @@ describe("Agent Integration", () => {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:3.1.0
+    image: mcpmesh/registry:3.2.0
     ports:
       - "8000:8000"
     healthcheck:

--- a/docs/typescript/getting-started/prerequisites.md
+++ b/docs/typescript/getting-started/prerequisites.md
@@ -85,17 +85,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.1.0`           | Registry service            |
-| `mcpmesh/python-runtime:3.1.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.1.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.1.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.2.0`           | Registry service            |
+| `mcpmesh/python-runtime:3.2.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.2.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.2.0` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:3.1.0
-docker pull mcpmesh/python-runtime:3.1.0
-docker pull mcpmesh/java-runtime:3.1.0
-docker pull mcpmesh/typescript-runtime:3.1.0
+docker pull mcpmesh/registry:3.2.0
+docker pull mcpmesh/python-runtime:3.2.0
+docker pull mcpmesh/java-runtime:3.2.0
+docker pull mcpmesh/typescript-runtime:3.2.0
 ```
 
 ### Generate Docker Compose

--- a/examples/docker-examples/agents/claude-provider/Dockerfile
+++ b/examples/docker-examples/agents/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/docker-examples/agents/claude-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/claude-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying claude-provider with mcp-mesh-agent chart
 # Usage: helm install claude-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 3.1.0 -f helm-values.yaml
+#        --version 3.2.0 -f helm-values.yaml
 
 image:
   repository: your-registry/claude-provider

--- a/examples/docker-examples/agents/claude-provider/requirements.txt
+++ b/examples/docker-examples/agents/claude-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=3.1.0
+mcp-mesh>=3.2.0
 
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0

--- a/examples/docker-examples/agents/openai-provider/Dockerfile
+++ b/examples/docker-examples/agents/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/docker-examples/agents/openai-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/openai-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying openai-provider with mcp-mesh-agent chart
 # Usage: helm install openai-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 3.1.0 -f helm-values.yaml
+#        --version 3.2.0 -f helm-values.yaml
 
 image:
   repository: your-registry/openai-provider

--- a/examples/docker-examples/agents/openai-provider/requirements.txt
+++ b/examples/docker-examples/agents/openai-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=3.1.0
+mcp-mesh>=3.2.0
 
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0

--- a/examples/docker-examples/docker-compose.yml
+++ b/examples/docker-examples/docker-compose.yml
@@ -2,12 +2,12 @@
 # Demonstrates Go registry + Python agents architecture using published Docker images
 #
 # Services:
-# - registry: Go-based registry with SQLite storage (mcpmesh/registry:3.1.0)
-# - hello-world-agent: Python agent with greeting capabilities (mcpmesh/python-runtime:3.1.0)
-# - system-agent: Python agent with system monitoring capabilities (mcpmesh/python-runtime:3.1.0)
-# - fastmcp-agent: FastMCP service with mesh integration (mcpmesh/python-runtime:3.1.0)
-# - dependent-agent: Service that depends on fastmcp-agent (mcpmesh/python-runtime:3.1.0)
-# - fastapi-app: FastAPI application with mesh integration (mcpmesh/python-runtime:3.1.0)
+# - registry: Go-based registry with SQLite storage (mcpmesh/registry:3.2.0)
+# - hello-world-agent: Python agent with greeting capabilities (mcpmesh/python-runtime:3.2.0)
+# - system-agent: Python agent with system monitoring capabilities (mcpmesh/python-runtime:3.2.0)
+# - fastmcp-agent: FastMCP service with mesh integration (mcpmesh/python-runtime:3.2.0)
+# - dependent-agent: Service that depends on fastmcp-agent (mcpmesh/python-runtime:3.2.0)
+# - fastapi-app: FastAPI application with mesh integration (mcpmesh/python-runtime:3.2.0)
 #
 # Usage:
 #   docker-compose up

--- a/examples/java/basic-tool-agent/pom.xml
+++ b/examples/java/basic-tool-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/benchmark-chain/svc-a/pom.xml
+++ b/examples/java/benchmark-chain/svc-a/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-b/pom.xml
+++ b/examples/java/benchmark-chain/svc-b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-c/pom.xml
+++ b/examples/java/benchmark-chain/svc-c/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-d/pom.xml
+++ b/examples/java/benchmark-chain/svc-d/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-e/pom.xml
+++ b/examples/java/benchmark-chain/svc-e/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/consumer-date-agent/pom.xml
+++ b/examples/java/consumer-date-agent/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/consumer-report-agent-sse/pom.xml
+++ b/examples/java/consumer-report-agent-sse/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/consumer-report-agent/pom.xml
+++ b/examples/java/consumer-report-agent/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/dependency-agent/pom.xml
+++ b/examples/java/dependency-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/direct-openai-agent/pom.xml
+++ b/examples/java/direct-openai-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/java/employee-service/pom.xml
+++ b/examples/java/employee-service/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/gemini-provider-agent/pom.xml
+++ b/examples/java/gemini-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/java/gpt-provider-agent/pom.xml
+++ b/examples/java/gpt-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/java/header-api/pom.xml
+++ b/examples/java/header-api/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/health-block-test-agent/pom.xml
+++ b/examples/java/health-block-test-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-accurate-provider/pom.xml
+++ b/examples/java/java-accurate-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-alpha-provider/pom.xml
+++ b/examples/java/java-alpha-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-beta-provider/pom.xml
+++ b/examples/java/java-beta-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-booking-consumer/pom.xml
+++ b/examples/java/java-booking-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-calculator/pom.xml
+++ b/examples/java/java-calculator/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-deprecated-provider/pom.xml
+++ b/examples/java/java-deprecated-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-dual-consumer/pom.xml
+++ b/examples/java/java-dual-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-fast-provider/pom.xml
+++ b/examples/java/java-fast-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-math-agent/pom.xml
+++ b/examples/java/java-math-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-schedule-agent/pom.xml
+++ b/examples/java/java-schedule-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-tag-consumer/pom.xml
+++ b/examples/java/java-tag-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-weather-agent/pom.xml
+++ b/examples/java/java-weather-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/llm-mesh-agent/pom.xml
+++ b/examples/java/llm-mesh-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/llm-provider-agent/pom.xml
+++ b/examples/java/llm-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/java/media-consumer-agent/pom.xml
+++ b/examples/java/media-consumer-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/media-producer-agent/pom.xml
+++ b/examples/java/media-producer-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/multijar-api-gateway/pom.xml
+++ b/examples/java/multijar-api-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/multijar-payment-service/pom.xml
+++ b/examples/java/multijar-payment-service/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/producer-date-agent/pom.xml
+++ b/examples/java/producer-date-agent/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/producer-report-agent/pom.xml
+++ b/examples/java/producer-report-agent/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/rest-api-consumer/pom.xml
+++ b/examples/java/rest-api-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/service-view/caption-provider/Dockerfile
+++ b/examples/java/service-view/caption-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for caption-provider MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.1.0
+FROM mcpmesh/java-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/java/service-view/caption-provider/pom.xml
+++ b/examples/java/service-view/caption-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/service-view/media-gateway/Dockerfile
+++ b/examples/java/service-view/media-gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for media-gateway MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.1.0
+FROM mcpmesh/java-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/java/service-view/media-gateway/pom.xml
+++ b/examples/java/service-view/media-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/service-view/thumbnail-provider/Dockerfile
+++ b/examples/java/service-view/thumbnail-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for thumbnail-provider MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.1.0
+FROM mcpmesh/java-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/java/service-view/thumbnail-provider/pom.xml
+++ b/examples/java/service-view/thumbnail-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/service-view/transcribe-provider/Dockerfile
+++ b/examples/java/service-view/transcribe-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for transcribe-provider MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.1.0
+FROM mcpmesh/java-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/java/service-view/transcribe-provider/pom.xml
+++ b/examples/java/service-view/transcribe-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/jobs-java/event-aware-consumer-java/pom.xml
+++ b/examples/jobs-java/event-aware-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/event-aware-provider-java/pom.xml
+++ b/examples/jobs-java/event-aware-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/long-task-consumer-java/pom.xml
+++ b/examples/jobs-java/long-task-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/long-task-provider-java/pom.xml
+++ b/examples/jobs-java/long-task-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/superseded-consumer-java/pom.xml
+++ b/examples/jobs-java/superseded-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/superseded-provider-java/pom.xml
+++ b/examples/jobs-java/superseded-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-claude-java/pom.xml
+++ b/examples/parallel-tools/consumer-claude-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-gemini-java/pom.xml
+++ b/examples/parallel-tools/consumer-gemini-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-gemini-ts/package.json
+++ b/examples/parallel-tools/consumer-gemini-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/consumer-openai-java/pom.xml
+++ b/examples/parallel-tools/consumer-openai-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-openai-ts/package.json
+++ b/examples/parallel-tools/consumer-openai-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/parallel-consumer-java/pom.xml
+++ b/examples/parallel-tools/parallel-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/parallel-consumer-ts/package.json
+++ b/examples/parallel-tools/parallel-consumer-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/slow-tool-java/pom.xml
+++ b/examples/parallel-tools/slow-tool-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/slow-tool-ts/package.json
+++ b/examples/parallel-tools/slow-tool-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/python/service-view/caption-provider/Dockerfile
+++ b/examples/python/service-view/caption-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for caption-provider MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/python/service-view/media-gateway/Dockerfile
+++ b/examples/python/service-view/media-gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for media-gateway MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/python/service-view/thumbnail-provider/Dockerfile
+++ b/examples/python/service-view/thumbnail-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for thumbnail-provider MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/python/service-view/transcribe-provider/Dockerfile
+++ b/examples/python/service-view/transcribe-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for transcribe-provider MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/required-dependency/java/data-provider/Dockerfile
+++ b/examples/required-dependency/java/data-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for data-provider MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.1.0
+FROM mcpmesh/java-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/required-dependency/java/data-provider/pom.xml
+++ b/examples/required-dependency/java/data-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/required-dependency/java/report-consumer/Dockerfile
+++ b/examples/required-dependency/java/report-consumer/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for report-consumer MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.1.0
+FROM mcpmesh/java-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/required-dependency/java/report-consumer/pom.xml
+++ b/examples/required-dependency/java/report-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/required-dependency/python/data-provider/Dockerfile
+++ b/examples/required-dependency/python/data-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for data-provider MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/required-dependency/python/report-consumer/Dockerfile
+++ b/examples/required-dependency/python/report-consumer/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for report-consumer MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/schema-corpus/java/pom.xml
+++ b/examples/schema-corpus/java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/consumer/pom.xml
+++ b/examples/schema/java/consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/producer-bad/pom.xml
+++ b/examples/schema/java/producer-bad/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/producer-good/pom.xml
+++ b/examples/schema/java/producer-good/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/streaming/chatbot-demo/chatbot-agent/Dockerfile
+++ b/examples/streaming/chatbot-demo/chatbot-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chatbot-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/streaming/chatbot-demo/gateway/Dockerfile
+++ b/examples/streaming/chatbot-demo/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/streaming/chatbot-demo/weather-tool/Dockerfile
+++ b/examples/streaming/chatbot-demo/weather-tool/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/chatbot-agent/Dockerfile
+++ b/examples/streaming/fixtures/chatbot-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chatbot-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/gateway-agent/Dockerfile
+++ b/examples/streaming/fixtures/gateway-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway-agent MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/passthrough-agent/Dockerfile
+++ b/examples/streaming/fixtures/passthrough-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for passthrough-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-java/pom.xml
+++ b/examples/toolcalls/analyst-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/toolcalls/analyst-py/Dockerfile
+++ b/examples/toolcalls/analyst-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for analyst-py MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-ts/Dockerfile
+++ b/examples/toolcalls/analyst-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for analyst-ts MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-ts/package.json
+++ b/examples/toolcalls/analyst-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/claude-provider-java/pom.xml
+++ b/examples/toolcalls/claude-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/claude-provider-py/Dockerfile
+++ b/examples/toolcalls/claude-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/claude-provider-ts/Dockerfile
+++ b/examples/toolcalls/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/claude-provider-ts/package.json
+++ b/examples/toolcalls/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/gemini-provider-java/pom.xml
+++ b/examples/toolcalls/gemini-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/gemini-provider-py/Dockerfile
+++ b/examples/toolcalls/gemini-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/gemini-provider-ts/Dockerfile
+++ b/examples/toolcalls/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/gemini-provider-ts/package.json
+++ b/examples/toolcalls/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/openai-provider-java/pom.xml
+++ b/examples/toolcalls/openai-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/openai-provider-py/Dockerfile
+++ b/examples/toolcalls/openai-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/openai-provider-ts/Dockerfile
+++ b/examples/toolcalls/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/openai-provider-ts/package.json
+++ b/examples/toolcalls/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/weather-tool-java/pom.xml
+++ b/examples/toolcalls/weather-tool-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/toolcalls/weather-tool-py/Dockerfile
+++ b/examples/toolcalls/weather-tool-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool-py MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/weather-tool-ts/Dockerfile
+++ b/examples/toolcalls/weather-tool-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool-ts MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/weather-tool-ts/package.json
+++ b/examples/toolcalls/weather-tool-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/tutorial/trip-planner/day-01/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-01/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/docker-compose.yml
+++ b/examples/tutorial/trip-planner/day-08/python/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - trip-planner-network
 
   registry:
-    image: mcpmesh/registry:3.1.0
+    image: mcpmesh/registry:3.2.0
     container_name: trip-planner-registry
     hostname: registry
     ports:
@@ -81,7 +81,7 @@ services:
 
   # --8<-- [start:mesh_ui]
   mesh-ui:
-    image: mcpmesh/ui:3.1.0
+    image: mcpmesh/ui:3.2.0
     container_name: trip-planner-mesh-ui
     hostname: mesh-ui
     ports:
@@ -172,7 +172,7 @@ services:
   # --8<-- [start:gateway]
   # FastAPI Gateway: manually added (scaffold detects @mesh.agent, not @mesh.route)
   gateway:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: trip-planner-gateway
     hostname: gateway
     user: root
@@ -213,7 +213,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   adventure-advisor:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: trip-planner-adventure-advisor
     hostname: adventure-advisor
     user: root
@@ -256,7 +256,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   budget-analyst:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: trip-planner-budget-analyst
     hostname: budget-analyst
     user: root
@@ -299,7 +299,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   chat-history-agent:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: trip-planner-chat-history-agent
     hostname: chat-history-agent
     user: root
@@ -342,7 +342,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   claude-provider:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: trip-planner-claude-provider
     hostname: claude-provider
     user: root
@@ -386,7 +386,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   flight-agent:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: trip-planner-flight-agent
     hostname: flight-agent
     user: root
@@ -429,7 +429,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   hotel-agent:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: trip-planner-hotel-agent
     hostname: hotel-agent
     user: root
@@ -472,7 +472,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   logistics-planner:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: trip-planner-logistics-planner
     hostname: logistics-planner
     user: root
@@ -515,7 +515,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   openai-provider:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: trip-planner-openai-provider
     hostname: openai-provider
     user: root
@@ -559,7 +559,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   planner-agent:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: trip-planner-planner-agent
     hostname: planner-agent
     user: root
@@ -602,7 +602,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   poi-agent:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: trip-planner-poi-agent
     hostname: poi-agent
     user: root
@@ -645,7 +645,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   user-prefs-agent:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: trip-planner-user-prefs-agent
     hostname: user-prefs-agent
     user: root
@@ -688,7 +688,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   weather-agent:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: trip-planner-weather-agent
     hostname: weather-agent
     user: root

--- a/examples/tutorial/trip-planner/day-08/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh streaming API gateway
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh streaming LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/typescript/benchmark-chain/svc-a/package.json
+++ b/examples/typescript/benchmark-chain/svc-a/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-b/package.json
+++ b/examples/typescript/benchmark-chain/svc-b/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-c/package.json
+++ b/examples/typescript/benchmark-chain/svc-c/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-d/package.json
+++ b/examples/typescript/benchmark-chain/svc-d/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-e/package.json
+++ b/examples/typescript/benchmark-chain/svc-e/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/context-self-dep-ts-mesh/Dockerfile
+++ b/examples/typescript/context-self-dep-ts-mesh/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for context-self-dep-ts-mesh MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/examples/typescript/header-api/package.json
+++ b/examples/typescript/header-api/package.json
@@ -11,7 +11,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/examples/typescript/llm-consumer/package.json
+++ b/examples/typescript/llm-consumer/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/examples/typescript/llm-provider/package.json
+++ b/examples/typescript/llm-provider/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/helm/mcp-mesh-agent/Chart.yaml
+++ b/helm/mcp-mesh-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-agent
 description: MCP Mesh Agent - Python runtime for MCP agents with mesh capabilities
 type: application
-version: 3.1.0
-appVersion: "3.1.0"
+version: 3.2.0
+appVersion: "3.2.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-agent/README.md
+++ b/helm/mcp-mesh-agent/README.md
@@ -232,7 +232,7 @@ existingSecret: my-secret
 ### Python
 
 ```dockerfile
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 COPY . /app/
 CMD ["-m", "myagent"]
@@ -241,7 +241,7 @@ CMD ["-m", "myagent"]
 ### TypeScript
 
 ```dockerfile
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 COPY . /app/
 CMD ["src/index.ts"]
@@ -250,7 +250,7 @@ CMD ["src/index.ts"]
 ### Java
 
 ```dockerfile
-FROM mcpmesh/java-runtime:3.1.0
+FROM mcpmesh/java-runtime:3.2.0
 
 COPY target/myagent.jar /app/
 CMD ["/app/myagent.jar"]

--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -45,7 +45,7 @@ image:
   repository: mcpmesh/python-runtime
   pullPolicy: IfNotPresent
   # Minor version tag tracks latest patch (0.8 → 0.8.x)
-  tag: "3.1"
+  tag: "3.2"
 
 # Pull secrets for this chart's pods, merged with global.imagePullSecrets
 # (deduplicated by name). Standard shape:

--- a/helm/mcp-mesh-core/Chart.lock
+++ b/helm/mcp-mesh-core/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: mcp-mesh-postgres
   repository: file://../mcp-mesh-postgres
-  version: 3.1.0
+  version: 3.2.0
 - name: mcp-mesh-redis
   repository: file://../mcp-mesh-redis
-  version: 3.1.0
+  version: 3.2.0
 - name: mcp-mesh-registry
   repository: file://../mcp-mesh-registry
-  version: 3.1.0
+  version: 3.2.0
 - name: mcp-mesh-grafana
   repository: file://../mcp-mesh-grafana
-  version: 3.1.0
+  version: 3.2.0
 - name: mcp-mesh-tempo
   repository: file://../mcp-mesh-tempo
-  version: 3.1.0
+  version: 3.2.0
 - name: mcp-mesh-ui
   repository: file://../mcp-mesh-ui
-  version: 3.1.0
-digest: sha256:96e79aa6b99c8cacc8aa4a71d0667068a5a10ecc1ce99235bb2a3352cf44db25
-generated: "2026-07-08T12:13:43.743354-04:00"
+  version: 3.2.0
+digest: sha256:3d2dc6abae3fece921bb3128b01053c018875e3f3ab260c08e56b406a8da6d42
+generated: "2026-07-16T18:16:23.910084-04:00"

--- a/helm/mcp-mesh-core/Chart.yaml
+++ b/helm/mcp-mesh-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-core
 description: MCP Mesh Core Infrastructure - Registry, PostgreSQL, Redis, and Observability
 type: application
-version: 3.1.0
-appVersion: "3.1.0"
+version: 3.2.0
+appVersion: "3.2.0"
 keywords:
   - mcp
   - mesh
@@ -28,26 +28,26 @@ annotations:
   "artifacthub.io/containsSecurityUpdates": "false"
 dependencies:
   - name: mcp-mesh-postgres
-    version: "3.1.0"
+    version: "3.2.0"
     repository: "file://../mcp-mesh-postgres"
     condition: postgres.enabled
   - name: mcp-mesh-redis
-    version: "3.1.0"
+    version: "3.2.0"
     repository: "file://../mcp-mesh-redis"
     condition: redis.enabled
   - name: mcp-mesh-registry
-    version: "3.1.0"
+    version: "3.2.0"
     repository: "file://../mcp-mesh-registry"
     condition: registry.enabled
   - name: mcp-mesh-grafana
-    version: "3.1.0"
+    version: "3.2.0"
     repository: "file://../mcp-mesh-grafana"
     condition: grafana.enabled
   - name: mcp-mesh-tempo
-    version: "3.1.0"
+    version: "3.2.0"
     repository: "file://../mcp-mesh-tempo"
     condition: tempo.enabled
   - name: mcp-mesh-ui
-    version: "3.1.0"
+    version: "3.2.0"
     repository: "file://../mcp-mesh-ui"
     condition: ui.enabled

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -147,7 +147,7 @@ mcp-mesh-redis:
 mcp-mesh-registry:
   image:
     repository: mcpmesh/registry
-    tag: "3.1" # Minor version tracks latest patch
+    tag: "3.2" # Minor version tracks latest patch
   registry:
     # Database configuration (connects to PostgreSQL). The endpoint and
     # credentials are inherited from global.postgres above; set

--- a/helm/mcp-mesh-grafana/Chart.yaml
+++ b/helm/mcp-mesh-grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-grafana
 description: Grafana observability component for MCP Mesh
 type: application
-version: 3.1.0
+version: 3.2.0
 appVersion: "12.3.1"
 keywords:
   - grafana

--- a/helm/mcp-mesh-ingress/Chart.yaml
+++ b/helm/mcp-mesh-ingress/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ingress
 description: Ingress configuration for MCP Mesh services with flexible DNS routing
 type: application
-version: 3.1.0
-appVersion: "3.1.0"
+version: 3.2.0
+appVersion: "3.2.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-postgres/Chart.yaml
+++ b/helm/mcp-mesh-postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-postgres
 description: PostgreSQL database for MCP Mesh Registry
 type: application
-version: 3.1.0
+version: 3.2.0
 appVersion: "15"
 keywords:
   - mcp

--- a/helm/mcp-mesh-redis/Chart.yaml
+++ b/helm/mcp-mesh-redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-redis
 description: Redis cache for MCP Mesh session storage
 type: application
-version: 3.1.0
+version: 3.2.0
 appVersion: "7"
 keywords:
   - mcp

--- a/helm/mcp-mesh-registry/Chart.yaml
+++ b/helm/mcp-mesh-registry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-registry
 description: MCP Mesh Registry Service - Central service registry for MCP agents
 type: application
-version: 3.1.0
-appVersion: "3.1.0"
+version: 3.2.0
+appVersion: "3.2.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -15,7 +15,7 @@ image:
   repository: mcpmesh/registry
   pullPolicy: IfNotPresent
   # Minor version tag tracks latest patch (0.8 → 0.8.x)
-  tag: "3.1"
+  tag: "3.2"
 
 # Image for the wait-for-db init container (rendered for non-sqlite databases;
 # disable the init container via registry.database.waitForDatabase: false).

--- a/helm/mcp-mesh-tempo/Chart.yaml
+++ b/helm/mcp-mesh-tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-tempo
 description: Tempo distributed tracing component for MCP Mesh
 type: application
-version: 3.1.0
+version: 3.2.0
 appVersion: "2.9.0"
 keywords:
   - tempo

--- a/helm/mcp-mesh-ui/Chart.yaml
+++ b/helm/mcp-mesh-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ui
 description: MCP Mesh Dashboard UI Server - Web dashboard for monitoring MCP agents
 type: application
-version: 3.1.0
-appVersion: "3.1.0"
+version: 3.2.0
+appVersion: "3.2.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-ui/values.yaml
+++ b/helm/mcp-mesh-ui/values.yaml
@@ -7,7 +7,7 @@ image:
   registry: ""
   repository: mcpmesh/ui
   pullPolicy: IfNotPresent
-  tag: "3.1"
+  tag: "3.2"
 
 # Pull secrets for this chart's pods, merged with global.imagePullSecrets
 # (deduplicated by name). Standard shape:

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/cli",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "CLI for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration",
   "license": "MIT",
   "repository": {
@@ -23,10 +23,10 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@mcpmesh/cli-linux-x64": "3.1.0",
-    "@mcpmesh/cli-linux-arm64": "3.1.0",
-    "@mcpmesh/cli-darwin-x64": "3.1.0",
-    "@mcpmesh/cli-darwin-arm64": "3.1.0"
+    "@mcpmesh/cli-linux-x64": "3.2.0",
+    "@mcpmesh/cli-linux-arm64": "3.2.0",
+    "@mcpmesh/cli-darwin-x64": "3.2.0",
+    "@mcpmesh/cli-darwin-arm64": "3.2.0"
   },
   "keywords": [
     "mcp",

--- a/packaging/homebrew/mcp-mesh.rb
+++ b/packaging/homebrew/mcp-mesh.rb
@@ -2,7 +2,7 @@
 class McpMesh < Formula
   desc "Kubernetes-native platform for distributed MCP applications"
   homepage "https://github.com/dhyansraj/mcp-mesh"
-  version "3.1.0"  # Will be updated by release automation
+  version "3.2.0"  # Will be updated by release automation
 
   if OS.mac?
     if Hardware::CPU.arm?

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "3.1.0"
+version = "3.2.0"
 description = "Python SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration"
 readme = "README.md"
 license = { text = "MIT" }
@@ -58,7 +58,7 @@ requires-python = ">=3.11"
 # LiteLLM.
 dependencies = [
     # Rust core runtime (required - no Python fallback)
-    "mcp-mesh-core>=3.1.0",
+    "mcp-mesh-core>=3.2.0",
     "fastapi>=0.104.0,<1.0.0",
     "uvicorn>=0.24.0,<1.0.0",
     "httpx>=0.25.0,<1.0.0",

--- a/packaging/scoop/mcp-mesh.json
+++ b/packaging/scoop/mcp-mesh.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Kubernetes-native platform for distributed MCP applications",
   "homepage": "https://github.com/dhyansraj/mcp-mesh",
   "license": "MIT",

--- a/src/core/cli/handlers/java_handler.go
+++ b/src/core/cli/handlers/java_handler.go
@@ -79,7 +79,7 @@ func (h *JavaHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns Java Dockerfile content
 func (h *JavaHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh Java agent
-FROM mcpmesh/java-runtime:3.1.0
+FROM mcpmesh/java-runtime:3.2.0
 
 WORKDIR /app
 
@@ -156,7 +156,7 @@ func (h *JavaHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the Java runtime Docker image
 func (h *JavaHandler) GetDockerImage() string {
-	return "mcpmesh/java-runtime:3.1.0"
+	return "mcpmesh/java-runtime:3.2.0"
 }
 
 // ValidatePrerequisites checks Java environment
@@ -304,7 +304,7 @@ const javaPomTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
         </dependency>
     </dependencies>
 

--- a/src/core/cli/handlers/language_test.go
+++ b/src/core/cli/handlers/language_test.go
@@ -202,7 +202,7 @@ func TestDetectLanguage_PythonDirectoryRequirements(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Create requirements.txt
-	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==3.1.0"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==3.2.0"), 0644); err != nil {
 		t.Fatalf("Failed to create requirements.txt: %v", err)
 	}
 
@@ -401,7 +401,7 @@ func TestPythonHandler_GetDockerImage(t *testing.T) {
 	// Must equal the exact release tag GetDockerImage() ships (kept in sync by
 	// scripts/bump_version.py). Hard failure, not a log — this is the assertion
 	// that should have caught the 2.8.0 partial bump.
-	if want := "mcpmesh/python-runtime:3.1.0"; image != want {
+	if want := "mcpmesh/python-runtime:3.2.0"; image != want {
 		t.Errorf("GetDockerImage() = %q, want %q", image, want)
 	}
 }
@@ -415,7 +415,7 @@ func TestTypeScriptHandler_GetDockerImage(t *testing.T) {
 	// Must equal the exact release tag GetDockerImage() ships (kept in sync by
 	// scripts/bump_version.py). Hard failure, not a log — this is the assertion
 	// that should have caught the 2.8.0 partial bump.
-	if want := "mcpmesh/typescript-runtime:3.1.0"; image != want {
+	if want := "mcpmesh/typescript-runtime:3.2.0"; image != want {
 		t.Errorf("GetDockerImage() = %q, want %q", image, want)
 	}
 }

--- a/src/core/cli/handlers/python_handler.go
+++ b/src/core/cli/handlers/python_handler.go
@@ -86,7 +86,7 @@ func (h *PythonHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns Python Dockerfile content
 func (h *PythonHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh Python agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 
@@ -170,7 +170,7 @@ func (h *PythonHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the Python runtime Docker image
 func (h *PythonHandler) GetDockerImage() string {
-	return "mcpmesh/python-runtime:3.1.0"
+	return "mcpmesh/python-runtime:3.2.0"
 }
 
 // ValidatePrerequisites checks Python environment
@@ -248,5 +248,5 @@ const pythonInitTemplate = `# {{.Name}} MCP Mesh Agent
 const pythonMainModuleTemplate = `from .main import *
 `
 
-const pythonRequirementsTemplate = `mcp-mesh>=3.1.0
+const pythonRequirementsTemplate = `mcp-mesh>=3.2.0
 `

--- a/src/core/cli/handlers/typescript_handler.go
+++ b/src/core/cli/handlers/typescript_handler.go
@@ -92,7 +92,7 @@ func (h *TypeScriptHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns TypeScript Dockerfile content
 func (h *TypeScriptHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh TypeScript agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 
@@ -167,7 +167,7 @@ func (h *TypeScriptHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the TypeScript runtime Docker image
 func (h *TypeScriptHandler) GetDockerImage() string {
-	return "mcpmesh/typescript-runtime:3.1.0"
+	return "mcpmesh/typescript-runtime:3.2.0"
 }
 
 // ValidatePrerequisites checks TypeScript environment
@@ -269,7 +269,7 @@ const typescriptPackageTemplate = `{
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "fastmcp": "^3.26.0",
     "zod": "^3.23.0"
   },

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -10,12 +10,12 @@ MCP Mesh supports multiple deployment patterns from local development to product
 
 | Image                              | Description                                        |
 | ---------------------------------- | -------------------------------------------------- |
-| `mcpmesh/registry:3.1.0`             | Registry service for agent discovery               |
-| `mcpmesh/python-runtime:3.1.0`       | Python runtime with mcp-mesh SDK pre-installed     |
-| `mcpmesh/typescript-runtime:3.1.0`   | TypeScript runtime with @mcpmesh/sdk pre-installed |
-| `mcpmesh/java-runtime:3.1.0`         | Java runtime with mcp-mesh Spring Boot starter     |
-| `mcpmesh/ui:3.1.0`                   | Dashboard UI server (basePath: /ops/dashboard)     |
-| `mcpmesh/cli:3.1.0`                  | meshctl CLI for management                         |
+| `mcpmesh/registry:3.2.0`             | Registry service for agent discovery               |
+| `mcpmesh/python-runtime:3.2.0`       | Python runtime with mcp-mesh SDK pre-installed     |
+| `mcpmesh/typescript-runtime:3.2.0`   | TypeScript runtime with @mcpmesh/sdk pre-installed |
+| `mcpmesh/java-runtime:3.2.0`         | Java runtime with mcp-mesh Spring Boot starter     |
+| `mcpmesh/ui:3.2.0`                   | Dashboard UI server (basePath: /ops/dashboard)     |
+| `mcpmesh/cli:3.2.0`                  | meshctl CLI for management                         |
 
 ## Local Development
 
@@ -104,7 +104,7 @@ meshctl scaffold basic --name my-agent
 The generated Dockerfile uses the official runtime:
 
 ```dockerfile
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
@@ -132,7 +132,7 @@ meshctl scaffold --compose --observability
 Generated docker-compose.yml includes:
 
 - PostgreSQL database for registry
-- Registry service (`mcpmesh/registry:3.1.0`)
+- Registry service (`mcpmesh/registry:3.2.0`)
 - All detected agents with proper networking
 - Health checks and dependency ordering
 - Optional: Redis, Tempo, Grafana (with `--observability`)
@@ -155,12 +155,12 @@ For production Kubernetes deployment, use the official Helm charts from the MCP 
 # Install core infrastructure (registry + database + observability)
 # No "helm repo add" needed - uses OCI registry directly
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy agent using scaffold-generated helm-values.yaml
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -171,12 +171,12 @@ Deploy into any namespace — just match `-n` with `--set global.namespace`:
 
 ```bash
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n my-namespace --create-namespace \
   --set global.namespace=my-namespace
 
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n my-namespace \
   -f helm-values.yaml
 ```
@@ -195,19 +195,19 @@ its own namespace. Short service names resolve independently within each namespa
 ```bash
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n team-a --create-namespace --set global.namespace=team-a
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 -n team-a -f greeter/helm-values.yaml
+  --version 3.2.0 -n team-a -f greeter/helm-values.yaml
 
 # Team B — same helm-values.yaml, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n team-b --create-namespace --set global.namespace=team-b
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 -n team-b -f greeter/helm-values.yaml
+  --version 3.2.0 -n team-b -f greeter/helm-values.yaml
 ```
 
 ### Available Helm Charts
@@ -256,16 +256,16 @@ meshctl scaffold basic --name my-agent
 
 # 2. Build and push Docker image (works on all platforms)
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v3.1.0 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v3.2.0 --push .
 
 # 3. Update helm-values.yaml with your image repository
 # 4. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v3.1.0
+  --set image.tag=v3.2.0
 ```
 
 ### Disable Optional Components
@@ -273,14 +273,14 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 ```bash
 # Core without observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh --create-namespace \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 
 # Core without PostgreSQL (in-memory registry)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh --create-namespace \
   --set postgres.enabled=false
 ```
@@ -429,7 +429,7 @@ Or use the `mcp-mesh-ingress` chart which handles routing automatically.
 
 ```bash
 # Docker
-docker run -e MCP_MESH_UI_BASE_PATH=/my/custom/path mcpmesh/ui:3.1.0
+docker run -e MCP_MESH_UI_BASE_PATH=/my/custom/path mcpmesh/ui:3.2.0
 
 # Helm
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -16,7 +16,7 @@ MCP Mesh supports multiple deployment patterns for Java/Spring Boot agents. The 
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
 </dependency>
 ```
 
@@ -152,7 +152,7 @@ services:
       retries: 5
 
   registry:
-    image: mcpmesh/registry:3.1.0
+    image: mcpmesh/registry:3.2.0
     ports:
       - "8000:8000"
     environment:
@@ -204,12 +204,12 @@ For production Kubernetes deployment:
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy Java agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -242,15 +242,15 @@ resources:
 ```bash
 # 1. Build and push Docker image
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v3.1.0 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v3.2.0 --push .
 
 # 2. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v3.1.0
+  --set image.tag=v3.2.0
 ```
 
 ## Port Strategy

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -10,8 +10,8 @@ MCP Mesh supports multiple deployment patterns for TypeScript agents. Use `meshc
 
 | Image                            | Description                                        |
 | -------------------------------- | -------------------------------------------------- |
-| `mcpmesh/registry:3.1.0`           | Registry service for agent discovery               |
-| `mcpmesh/typescript-runtime:3.1.0` | TypeScript runtime with @mcpmesh/sdk pre-installed |
+| `mcpmesh/registry:3.2.0`           | Registry service for agent discovery               |
+| `mcpmesh/typescript-runtime:3.2.0` | TypeScript runtime with @mcpmesh/sdk pre-installed |
 
 ## Local Development
 
@@ -75,7 +75,7 @@ meshctl stop               # Stop all
 
 ```dockerfile
 # Dockerfile for my-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 
@@ -123,8 +123,8 @@ meshctl scaffold --compose --observability
 Generated `docker-compose.yml` includes:
 
 - PostgreSQL database for registry
-- Registry service (`mcpmesh/registry:3.1.0`)
-- TypeScript agents with `mcpmesh/typescript-runtime:3.1.0`
+- Registry service (`mcpmesh/registry:3.2.0`)
+- TypeScript agents with `mcpmesh/typescript-runtime:3.2.0`
 - Health checks and dependency ordering
 - Optional: Redis, Tempo, Grafana (with `--observability`)
 
@@ -145,12 +145,12 @@ For production Kubernetes deployment:
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy TypeScript agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -192,15 +192,15 @@ meshctl scaffold basic --name my-agent --lang typescript
 
 # 2. Build and push Docker image
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v3.1.0 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v3.2.0 --push .
 
 # 3. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v3.1.0
+  --set image.tag=v3.2.0
 ```
 
 ## Port Strategy

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -65,12 +65,12 @@ docker compose up -d
 ```bash
 # Install core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh --create-namespace
 
 # Or disable observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh --create-namespace \
   --set tempo.enabled=false \
   --set grafana.enabled=false

--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -89,17 +89,17 @@ docker compose version
 
 | Image                              | Description                 |
 | ---------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.1.0`           | Registry service            |
-| `mcpmesh/python-runtime:3.1.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.1.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.1.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.2.0`           | Registry service            |
+| `mcpmesh/python-runtime:3.2.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.2.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.2.0` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:3.1.0
-docker pull mcpmesh/python-runtime:3.1.0
-docker pull mcpmesh/java-runtime:3.1.0
-docker pull mcpmesh/typescript-runtime:3.1.0
+docker pull mcpmesh/registry:3.2.0
+docker pull mcpmesh/python-runtime:3.2.0
+docker pull mcpmesh/java-runtime:3.2.0
+docker pull mcpmesh/typescript-runtime:3.2.0
 ```
 
 ### Generate Docker Compose
@@ -137,12 +137,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/src/core/cli/man/content/prerequisites_java.md
+++ b/src/core/cli/man/content/prerequisites_java.md
@@ -52,7 +52,7 @@ Add the Spring Boot starter to your `pom.xml`:
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -100,10 +100,10 @@ docker compose version
 
 | Image                              | Description                 |
 | ---------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.1.0`           | Registry service            |
-| `mcpmesh/python-runtime:3.1.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.1.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.1.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.2.0`           | Registry service            |
+| `mcpmesh/python-runtime:3.2.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.2.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.2.0` | TypeScript runtime with SDK |
 
 Java agents use standard Maven-based Docker builds (see Docker Deployment guide).
 

--- a/src/core/cli/man/content/prerequisites_typescript.md
+++ b/src/core/cli/man/content/prerequisites_typescript.md
@@ -77,17 +77,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.1.0`           | Registry service            |
-| `mcpmesh/python-runtime:3.1.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.1.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.1.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.2.0`           | Registry service            |
+| `mcpmesh/python-runtime:3.2.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.2.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.2.0` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:3.1.0
-docker pull mcpmesh/python-runtime:3.1.0
-docker pull mcpmesh/java-runtime:3.1.0
-docker pull mcpmesh/typescript-runtime:3.1.0
+docker pull mcpmesh/registry:3.2.0
+docker pull mcpmesh/python-runtime:3.2.0
+docker pull mcpmesh/java-runtime:3.2.0
+docker pull mcpmesh/typescript-runtime:3.2.0
 ```
 
 ### Generate Docker Compose

--- a/src/core/cli/man/content/quickstart_java.md
+++ b/src/core/cli/man/content/quickstart_java.md
@@ -75,13 +75,13 @@ Create `pom.xml`:
 
     <groupId>com.example</groupId>
     <artifactId>greeter-agent</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
 
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/core/cli/man/content/registry.md
+++ b/src/core/cli/man/content/registry.md
@@ -202,7 +202,7 @@ The registry supports multiple replicas for high availability. All replicas shar
 ```bash
 # Scale registry replicas
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.1.0 \
+  --version 3.2.0 \
   -n mcp-mesh --create-namespace \
   --set registry.replicas=3
 ```

--- a/src/core/cli/man/content/security.md
+++ b/src/core/cli/man/content/security.md
@@ -208,7 +208,7 @@ Admin endpoints (`/admin/rotate`, `/admin/entities`) are served only on the admi
 ```yaml
 services:
   registry:
-    image: mcpmesh/registry:3.1.0
+    image: mcpmesh/registry:3.2.0
     command: ["--tls-auto"]
     ports: ["8000:8000"]
     volumes:

--- a/src/core/cli/man/content/testing_java.md
+++ b/src/core/cli/man/content/testing_java.md
@@ -124,7 +124,7 @@ class AssistantAgentTest {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:3.1.0
+    image: mcpmesh/registry:3.2.0
     ports:
       - "8000:8000"
     healthcheck:

--- a/src/core/cli/man/content/testing_typescript.md
+++ b/src/core/cli/man/content/testing_typescript.md
@@ -119,7 +119,7 @@ describe("Agent Integration", () => {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:3.1.0
+    image: mcpmesh/registry:3.2.0
     ports:
       - "8000:8000"
     healthcheck:

--- a/src/core/cli/man/content/tutorial.md
+++ b/src/core/cli/man/content/tutorial.md
@@ -1698,7 +1698,7 @@ $ kubectl -n trip-planner create secret generic llm-keys \
 
 ```shell
 $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-    --version 3.1.0 \
+    --version 3.2.0 \
     -n trip-planner \
     -f helm/values-core.yaml \
     --wait --timeout 5m
@@ -1717,7 +1717,7 @@ $ for agent in "${AGENTS[@]}"; do
     echo "Installing $agent..."
     helm install "$agent" \
       oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 3.1.0 \
+      --version 3.2.0 \
       -n trip-planner \
       -f "helm/values-${agent}.yaml"
   done

--- a/src/core/cli/scaffold.go
+++ b/src/core/cli/scaffold.go
@@ -72,9 +72,9 @@ Documentation:
 
 Infrastructure:
   Docker Images:
-    mcpmesh/registry:3.1.0            - Registry service
-    mcpmesh/python-runtime:3.1.0      - Python agent runtime (has mcp-mesh SDK)
-    mcpmesh/typescript-runtime:3.1.0  - TypeScript agent runtime (has @mcpmesh/sdk)
+    mcpmesh/registry:3.2.0            - Registry service
+    mcpmesh/python-runtime:3.2.0      - Python agent runtime (has mcp-mesh SDK)
+    mcpmesh/typescript-runtime:3.2.0  - TypeScript agent runtime (has @mcpmesh/sdk)
 
   Helm Charts (for Kubernetes - OCI registry, no helm repo add needed):
     oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core   - Registry + PostgreSQL + observability

--- a/src/core/cli/scaffold/compose.go
+++ b/src/core/cli/scaffold/compose.go
@@ -1087,7 +1087,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
 #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
 {{ .Name }}:
-  image: mcpmesh/python-runtime:3.1.0
+  image: mcpmesh/python-runtime:3.2.0
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1132,7 +1132,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # NOTE: In dev mode, npm install runs on startup and source is mounted.
 #       In production (Dockerfile), dependencies are pre-installed in the image.
 {{ .Name }}:
-  image: mcpmesh/typescript-runtime:3.1.0
+  image: mcpmesh/typescript-runtime:3.2.0
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1175,7 +1175,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # Agent: {{ .Name }} (Java/Spring Boot)
 # NOTE: In dev mode, maven builds on startup. In production, use the Dockerfile.
 {{ .Name }}:
-  image: mcpmesh/java-runtime:3.1.0
+  image: mcpmesh/java-runtime:3.2.0
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1856,7 +1856,7 @@ services:
       - {{ .NetworkName }}
 
   registry:
-    image: mcpmesh/registry:3.1.0
+    image: mcpmesh/registry:3.2.0
     container_name: {{ .ProjectName }}-registry
     hostname: registry
     ports:
@@ -1965,7 +1965,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   {{ .Name }}:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root
@@ -2011,7 +2011,7 @@ services:
   # NOTE: In dev mode, npm install runs on startup and source is mounted.
   #       In production (Dockerfile), dependencies are pre-installed in the image.
   {{ .Name }}:
-    image: mcpmesh/typescript-runtime:3.1.0
+    image: mcpmesh/typescript-runtime:3.2.0
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root
@@ -2055,7 +2055,7 @@ services:
   # Java Agent: {{ .Name }}
   # NOTE: In dev mode, maven builds on startup. In production, use the Dockerfile.
   {{ .Name }}:
-    image: mcpmesh/java-runtime:3.1.0
+    image: mcpmesh/java-runtime:3.2.0
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root

--- a/src/core/cli/scaffold/compose_test.go
+++ b/src/core/cli/scaffold/compose_test.go
@@ -52,9 +52,9 @@ services:
     environment:
       POSTGRES_USER: customuser
   registry:
-    image: mcpmesh/registry:3.1.0
+    image: mcpmesh/registry:3.2.0
   agent1:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     container_name: test-agent1
     environment:
       CUSTOM_VAR: "user-added-value"
@@ -110,9 +110,9 @@ func TestGenerateDockerCompose_ForceRegenerate(t *testing.T) {
   postgres:
     image: postgres:15-alpine
   registry:
-    image: mcpmesh/registry:3.1.0
+    image: mcpmesh/registry:3.2.0
   agent1:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     environment:
       CUSTOM_VAR: "should-be-gone"
 networks:
@@ -157,9 +157,9 @@ func TestGenerateDockerCompose_NoNewAgents(t *testing.T) {
   postgres:
     image: postgres:15-alpine
   registry:
-    image: mcpmesh/registry:3.1.0
+    image: mcpmesh/registry:3.2.0
   agent1:
-    image: mcpmesh/python-runtime:3.1.0
+    image: mcpmesh/python-runtime:3.2.0
     environment:
       CUSTOM_VAR: "preserved"
 networks:

--- a/src/runtime/core/Cargo.lock
+++ b/src/runtime/core/Cargo.lock
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-mesh-core"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/src/runtime/core/Cargo.toml
+++ b/src/runtime/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-mesh-core"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2021"
 # MSRV. CI builds with moving stable (dtolnay/rust-toolchain@stable);
 # this floor documents the newest stdlib API the crate relies on

--- a/src/runtime/core/pyproject.toml
+++ b/src/runtime/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mcp-mesh-core"
-version = "3.1.0"
+version = "3.2.0"
 description = "Rust core runtime for MCP Mesh agents"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/core/typescript/package.json
+++ b/src/runtime/core/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/core",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "MCP Mesh Rust core bindings for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/runtime/java/mcp-mesh-bom/pom.xml
+++ b/src/runtime/java/mcp-mesh-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-bom</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh BOM</name>

--- a/src/runtime/java/mcp-mesh-core/pom.xml
+++ b/src/runtime/java/mcp-mesh-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </parent>
 
     <artifactId>mcp-mesh-core</artifactId>

--- a/src/runtime/java/mcp-mesh-native/pom.xml
+++ b/src/runtime/java/mcp-mesh-native/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </parent>
 
     <artifactId>mcp-mesh-native</artifactId>

--- a/src/runtime/java/mcp-mesh-sdk/pom.xml
+++ b/src/runtime/java/mcp-mesh-sdk/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </parent>
 
     <artifactId>mcp-mesh-sdk</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-ai/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-ai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-ai</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>

--- a/src/runtime/java/pom.xml
+++ b/src/runtime/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-parent</artifactId>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh Java SDK</name>

--- a/src/runtime/python/_mcp_mesh/__init__.py
+++ b/src/runtime/python/_mcp_mesh/__init__.py
@@ -31,7 +31,7 @@ from .engine.decorator_registry import (
     get_decorator_stats,
 )
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 # Store reference to runtime processor if initialized
 _runtime_processor = None

--- a/src/runtime/python/mesh/__init__.py
+++ b/src/runtime/python/mesh/__init__.py
@@ -34,7 +34,7 @@ from .types import (
 # Note: helpers.llm_provider is imported lazily in __getattr__ to avoid
 # initialization timing issues with @mesh.agent auto_run in tests
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 
 # Helper function to create FastMCP server with proper naming

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "3.1.0"
+version = "3.2.0"
 description = "Python SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/typescript/package.json
+++ b/src/runtime/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/sdk",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "TypeScript SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -102,12 +102,12 @@ Edit `config.yaml` to set versions:
 
 ```yaml
 packages:
-  cli_version: "3.1.0" # @mcpmesh/cli
-  sdk_python_version: "3.1.0" # mcp-mesh (pip) - PEP 440 format
-  sdk_typescript_version: "3.1.0" # @mcpmesh/sdk
+  cli_version: "3.2.0" # @mcpmesh/cli
+  sdk_python_version: "3.2.0" # mcp-mesh (pip) - PEP 440 format
+  sdk_typescript_version: "3.2.0" # @mcpmesh/sdk
 
 docker:
-  base_image: "tsuite-mesh:3.1.0"
+  base_image: "tsuite-mesh:3.2.0"
 ```
 
 ## Environment Variables

--- a/tests/integration/suites/README.md
+++ b/tests/integration/suites/README.md
@@ -108,7 +108,7 @@ const agent = mesh(server, {
 ```bash
 docker run --rm -it \
   -v $(pwd)/suites/uc01_registry/artifacts:/uc-artifacts:ro \
-  tsuite-mesh:3.1.0 bash
+  tsuite-mesh:3.2.0 bash
 ```
 
 ### Common issues:
@@ -123,9 +123,9 @@ Available in test.yaml via `${config.X}`:
 
 | Variable                                 | Example      |
 | ---------------------------------------- | ------------ |
-| `config.packages.cli_version`            | 3.1.0 |
-| `config.packages.sdk_python_version`     | 3.1.0 |
-| `config.packages.sdk_typescript_version` | 3.1.0 |
+| `config.packages.cli_version`            | 3.2.0 |
+| `config.packages.sdk_python_version`     | 3.2.0 |
+| `config.packages.sdk_typescript_version` | 3.2.0 |
 
 ## Issue Reporting Policy
 

--- a/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-calculator-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-optional-dep-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-report-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-calculator-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-calculator-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-calculator-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-alpha-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-alpha-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-beta-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-beta-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-dual-consumer/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-dual-consumer/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-caller/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-caller/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-provider/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-provider/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-caller/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-caller/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-provider/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/java-slow-agent/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/java-slow-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/ts-slow-agent/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/ts-slow-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc07_llm_agent_py/artifacts/llm-agent/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc07_llm_agent_py/artifacts/llm-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for llm-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc23_structured_output_ts_consumer_py_provider/artifacts/structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc23_structured_output_ts_consumer_py_provider/artifacts/structured-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc28_structured_output_ts_consumer_java_provider/artifacts/structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc28_structured_output_ts_consumer_java_provider/artifacts/structured-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc32_structured_output_ts_consumer_py_openai_provider/artifacts/structured-consumer-openai-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc32_structured_output_ts_consumer_py_openai_provider/artifacts/structured-consumer-openai-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc43_output_mode_hint_override_openai_ts/artifacts/hint-override-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc43_output_mode_hint_override_openai_ts/artifacts/hint-override-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc44_output_mode_hint_override_openai_java/artifacts/hint-override-java/pom.xml
+++ b/tests/integration/suites/uc04_llm_integration/tc44_output_mode_hint_override_openai_java/artifacts/hint-override-java/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <java.version>17</java.version>
         <!-- maven-install handler aligns this from the container's ~/.m2 repo -->
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
+++ b/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/Dockerfile
+++ b/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-auto-port-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc05_meshctl/tc33_ts_api_port_isolation/artifacts/ts-api-app/package.json
+++ b/tests/integration/suites/uc05_meshctl/tc33_ts_api_port_isolation/artifacts/ts-api-app/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.1.0",
+    "@mcpmesh/sdk": "3.2.0",
     "express": "^4.21.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc06_observability/artifacts/express-api/package.json
+++ b/tests/integration/suites/uc06_observability/artifacts/express-api/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc06_observability/artifacts/py-calculator/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/py-calculator/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for py-calculator MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/py-math-agent/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/py-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for py-math-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.1.0
+FROM mcpmesh/typescript-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-echo-ts/package.json
+++ b/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-echo-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-relay-ts/package.json
+++ b/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-relay-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc12_registration_trust/artifacts/java-greeter/pom.xml
+++ b/tests/integration/suites/uc12_registration_trust/artifacts/java-greeter/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc14_multimedia/tc30_download_media_typescript/artifacts/ts-download-agent/package.json
+++ b/tests/integration/suites/uc14_multimedia/tc30_download_media_typescript/artifacts/ts-download-agent/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
+++ b/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/Dockerfile
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/Dockerfile
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.1.0
+FROM mcpmesh/python-runtime:3.2.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
+++ b/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc16_schema_filtering/artifacts/ts-schema-agent/package.json
+++ b/tests/integration/suites/uc16_schema_filtering/artifacts/ts-schema-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc17_ui_server/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc17_ui_server/artifacts/ts-math-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/pom.xml
+++ b/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java-sse/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java-sse/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-auth-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-auth-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-report-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-report-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/pom.xml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/pom.xml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/pom.xml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/pom.xml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-consumer/pom.xml
+++ b/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-provider/pom.xml
+++ b/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc32_empty_return_values/artifacts/ts-empty-consumer/package.json
+++ b/tests/integration/suites/uc32_empty_return_values/artifacts/ts-empty-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/pom.xml
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/package.json
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/pom.xml
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-producer/pom.xml
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-producer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc37_service_view_java/fixtures/ts-view-consumer/package.json
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/ts-view-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-consumer/pom.xml
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-consumer/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-provider/pom.xml
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-provider/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.1.0</mcp-mesh.version>
+        <mcp-mesh.version>3.2.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-consumer/package.json
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0"
+    "@mcpmesh/sdk": "^3.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/package.json
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.1.0",
+    "@mcpmesh/sdk": "^3.2.0",
     "fastmcp": "^4.3.2"
   },
   "devDependencies": {

--- a/tests/lib-tests/README.md
+++ b/tests/lib-tests/README.md
@@ -68,7 +68,7 @@ tsuite --uc uc04_build_image
 
 After successful run, you'll have:
 
-- `tsuite-mesh:3.1.0` (or current version) Docker image
+- `tsuite-mesh:3.2.0` (or current version) Docker image
 
 Verify with:
 
@@ -82,11 +82,11 @@ Edit `config.yaml` to update versions:
 
 ```yaml
 packages:
-  cli_version: "3.1.0"
-  sdk_python_version: "3.1.0" # PEP 440 format for Python
-  sdk_typescript_version: "3.1.0"
-  core_version: "3.1.0"
-  sdk_java_version: "3.1.0"
+  cli_version: "3.2.0"
+  sdk_python_version: "3.2.0" # PEP 440 format for Python
+  sdk_typescript_version: "3.2.0"
+  core_version: "3.2.0"
+  sdk_java_version: "3.2.0"
 ```
 
 ## Next Steps

--- a/tests/lib-tests/config.yaml
+++ b/tests/lib-tests/config.yaml
@@ -10,11 +10,11 @@ suite:
 
 packages:
   # Version to test - update this for each release
-  cli_version: "3.1.0"
-  sdk_python_version: "3.1.0" # PEP 440 format for pip
-  sdk_typescript_version: "3.1.0"
-  core_version: "3.1.0"
-  sdk_java_version: "3.1.0"
+  cli_version: "3.2.0"
+  sdk_python_version: "3.2.0" # PEP 440 format for pip
+  sdk_typescript_version: "3.2.0"
+  core_version: "3.2.0"
+  sdk_java_version: "3.2.0"
 
 # Docker settings for the base image build
 docker:


### PR DESCRIPTION
## Release v3.2.0

Version bump 3.1.0 → 3.2.0 across all runtimes + Helm charts + image tags, refreshed helm/cargo lockfiles, and the v3.2.0 RELEASE_NOTES section. No code-logic changes — the underlying work already landed and was validated in its own PRs.

### Highlights (since v3.1.0)
- **🤖 LLM** — Claude **Sonnet 5** support + scaffold default; OpenAI **GPT-5 reasoning models now work with function tools** (Python routes reasoning+tools to the Responses API); version-agnostic gpt-5-chat handling. (#1333, #1337)
- **☕ Java** — **spring-ai 2.0.0 GA** (from 2.0.0-M4). No framework jump; `@MeshLlm`/`@MeshTool` surface unchanged; no-execute delegation live-validated. **⚠️ Migration (Java Gemini/Vertex only):** `spring.ai.vertex.ai.gemini.*` → `spring.ai.google.genai.*`. (#1339)
- **🖥️ meshui** — live replicas collapse into a single ×N entry across Topology/Agents/Dashboard. (#1330)
- **📚 Docs** — "Why MCP Mesh?" reframed around DDDI. (#1329)

**No wire, registry, resolution, or declaration-syntax changes.** Full details in `RELEASE_NOTES.md`.

### Release integrity
- Coverage guard: no stray mesh `3.1.0` references remain; third-party pins (`spring-ai` 2.0.0, `mcp-sdk` 2.0.0, jackson/fastmcp/mcp/anthropic/openai, `jinja2>=3.1.0`) **untouched**.
- Canonical versions at 3.2.0: pyproject, `helm/mcp-mesh-core/Chart.yaml` (version + appVersion), Java pom, TS package.json, Rust Cargo.toml. Chart.lock subchart pins + Cargo.lock refreshed.

### Post-merge — owner-gated
1. Push tag `v3.2.0` → **build-only** workflow (tag-first gate)
2. Inspect built artifacts
3. Publish the GitHub Release → **publish** workflow (PyPI / npm / Maven / Docker)
4. mesh-expert refresh on beelink3 + partner pings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ
