### PR TITLE
fix(llm): add Claude Haiku 4.5 to the native output_config allow-list

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
@@ -724,18 +724,19 @@ _ANTHROPIC_PASSTHROUGH_KWARGS = frozenset(
 # ---------------------------------------------------------------------------
 # Native ``output_config`` (structured output) — model gating + schema filter
 # ---------------------------------------------------------------------------
-# Sonnet 4.5+ / Sonnet 5 / Opus 4.1+ / Opus 4.8 / Fable 5 accept Anthropic's
-# first-class ``output_config.format`` primitive. The wire shape is one
-# transform shallower than LiteLLM's ``response_format``:
+# Sonnet 4.5+ / Sonnet 5 / Opus 4.1+ / Opus 4.8 / Haiku 4.5 / Fable 5 accept
+# Anthropic's first-class ``output_config.format`` primitive. The wire shape is
+# one transform shallower than LiteLLM's ``response_format``:
 #
 #   output_config = {"format": {"type": "json_schema", "schema": {...}}}
 #
-# Older models (Haiku, Sonnet 3.x / 4.0, Opus 3.x) reject the field, so we
+# Pre-4.5 Haiku (3.x), Sonnet 3.x / 4.0, and Opus 3.x reject the field, so we
 # fall through to the existing synthetic-tool injection path for those.
 # LiteLLM uses a substring allow-list at transformation.py:822-830; we mirror
-# it plus the Sonnet 4.6 / 5, Opus 4.5 / 4.6 / 4.7 / 4.8, and Fable 5 releases
-# (per current Anthropic docs these support native structured outputs; Haiku
-# stays out — see the ``_supports_native_output_format`` docstring).
+# it plus the Sonnet 4.6 / 5, Opus 4.5 / 4.6 / 4.7 / 4.8, Haiku 4.5, and Fable
+# 5 releases (per current Anthropic docs these support native structured
+# outputs; pre-4.5 Haiku stays out — see the
+# ``_supports_native_output_format`` docstring).
 #
 # Patterns (not raw substrings) so the trailing minor-version digit is
 # boundary-anchored: ``opus-4-1`` must NOT match a hypothetical future
@@ -756,6 +757,7 @@ _NATIVE_OUTPUT_FORMAT_MODEL_PATTERNS = tuple(
         r"(?<!\d)opus-4[-.]6(?!\d)",
         r"(?<!\d)opus-4[-.]7(?!\d)",
         r"(?<!\d)opus-4[-.]8(?!\d)",
+        r"(?<!\d)haiku-4[-.]5(?!\d)",
         r"(?<!\d)fable-5(?!\d)",
     )
 )
@@ -771,9 +773,9 @@ def _supports_native_output_format(model: str | None) -> bool:
     wild. The trailing-digit guard (``(?!\\d)``) prevents a future
     ``opus-4-10`` from being silently accepted on the ``opus-4-1`` pattern.
 
-    Haiku and pre-4.5 Sonnet / pre-4.1 Opus models are intentionally NOT
-    matched by any pattern — they route through the existing synthetic-tool
-    path.
+    Haiku 4.5 accepts native ``output_config``. Pre-4.5 Haiku (3.x), pre-4.5
+    Sonnet (3.x / 4.0), and pre-4.1 Opus (3.x) are intentionally NOT matched by
+    any pattern — they route through the existing synthetic-tool path.
     """
     if not model:
         return False

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native_output_format.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native_output_format.py
@@ -7,7 +7,7 @@ tool, the adapter translates ``response_format`` into Anthropic's
 first-class ``output_config.format`` primitive instead of synthetic-tool
 injection.
 
-Older models (Haiku, Sonnet 3.x / 4.0, Opus 3.x) fall through to the
+Pre-4.5 Haiku (3.x), Sonnet 3.x / 4.0, and Opus 3.x fall through to the
 existing synthetic-tool path — that fallback path is covered by
 ``test_anthropic_native_response_format.py``.
 
@@ -117,6 +117,11 @@ class TestSupportsNativeOutputFormat:
             "anthropic/claude-opus-4.6",
             "anthropic/claude-fable-5",
             "anthropic/claude-fable-5-20260101",
+            # #1331 refresh: Haiku 4.5 now supports native output_config.
+            "anthropic/claude-haiku-4-5",
+            "anthropic/claude-haiku-4.5",
+            "anthropic/claude-haiku-4-5-20251001",
+            "anthropic.claude-haiku-4-5-20251001-v1:0",
             # Bedrock prefix + substring match.
             "bedrock/anthropic.claude-sonnet-4-6-20260301-v1:0",
             "bedrock/anthropic.claude-opus-4-7-20260401-v1:0",
@@ -138,10 +143,11 @@ class TestSupportsNativeOutputFormat:
     @pytest.mark.parametrize(
         "model",
         [
-            # Haiku — intentionally excluded per LiteLLM design.
-            "anthropic/claude-haiku-4-5",
-            "anthropic/claude-haiku-4-5-20250929",
-            "bedrock/anthropic.claude-haiku-4-5-20250929-v1:0",
+            # Pre-4.5 Haiku (3.x) — intentionally excluded (no native support).
+            "anthropic/claude-haiku-3-5",
+            "anthropic/claude-haiku-3-5-20241022",
+            "anthropic/claude-3-5-haiku-20241022",
+            "bedrock/anthropic.claude-3-haiku-20240307-v1:0",
             # Pre-4.5 Sonnet variants — synthetic-tool path.
             "anthropic/claude-3-5-sonnet",
             "anthropic/claude-3-5-sonnet-20241022",
@@ -174,6 +180,8 @@ class TestSupportsNativeOutputFormat:
             "anthropic/claude-sonnet-50",
             "anthropic/claude-opus-4-80",
             "anthropic/claude-opus-4-88",
+            "anthropic/claude-haiku-4-50",
+            "anthropic/claude-haiku-4-55",
             "anthropic/claude-fable-50",
             # Dot-form overmatch — same problem, dot separator.
             "anthropic/claude-opus-4.10",
@@ -382,8 +390,9 @@ class TestNativeOutputConfigRouting:
         assert kwargs["output_config"]["format"]["type"] == "json_schema"
 
     @pytest.mark.asyncio
-    async def test_haiku_4_5_falls_through_to_synthetic_tool(self):
-        """Haiku 4.5 + response_format → synthetic-tool path (no output_config)."""
+    async def test_haiku_4_5_emits_output_config(self):
+        """Haiku 4.5 + response_format → native ``output_config`` (same routing
+        as Sonnet 4.6 / Opus 4.7); synthetic-tool path NOT taken."""
         cls_mock, create_mock = _patched_async_anthropic(_make_anthropic_message())
         with patch("anthropic.AsyncAnthropic", cls_mock):
             await anthropic_native.complete(
@@ -392,6 +401,28 @@ class TestNativeOutputConfigRouting:
                     "response_format": _RESPONSE_FORMAT,
                 },
                 model="anthropic/claude-haiku-4-5",
+                api_key="sk-test",
+            )
+
+        kwargs = create_mock.call_args.kwargs
+        assert "response_format" not in kwargs
+        assert "output_config" in kwargs
+        assert kwargs["output_config"]["format"]["type"] == "json_schema"
+        # Synthetic-tool path NOT taken.
+        assert "tools" not in kwargs or not kwargs.get("tools")
+
+    @pytest.mark.asyncio
+    async def test_haiku_3_5_falls_through_to_synthetic_tool(self):
+        """Pre-4.5 Haiku (3.5) + response_format → synthetic-tool path (no
+        output_config; older Haiku has no native structured-output support)."""
+        cls_mock, create_mock = _patched_async_anthropic(_make_anthropic_message())
+        with patch("anthropic.AsyncAnthropic", cls_mock):
+            await anthropic_native.complete(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "response_format": _RESPONSE_FORMAT,
+                },
+                model="anthropic/claude-3-5-haiku-20241022",
                 api_key="sk-test",
             )
 

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_capability_resolver.py
@@ -58,6 +58,8 @@ class TestAnthropicResolver:
             "anthropic/claude-opus-4-6",
             "anthropic/claude-opus-4-8",
             "anthropic/claude-fable-5",
+            # #1331 refresh: Haiku 4.5 now supports native output_config.
+            "anthropic/claude-haiku-4-5",
             # Bedrock-prefixed + date-pinned still match (re.search, not anchored).
             "anthropic.claude-sonnet-4-6-20260301-v1:0",
             "anthropic.claude-sonnet-5-20260101-v1:0",
@@ -114,6 +116,7 @@ class TestAnthropicResolver:
             "anthropic/claude-opus-4-6",
             "anthropic/claude-opus-4-8",
             "anthropic/claude-fable-5",
+            "anthropic/claude-haiku-4-5",
             "anthropic.claude-sonnet-4-6-20260301-v1:0",
             "anthropic.claude-sonnet-5-20260101-v1:0",
             "anthropic.claude-opus-4-8-20260401-v1:0",


### PR DESCRIPTION
## Summary

mesh excluded **all** Claude Haiku from Anthropic's native `output_config` structured-output primitive, routing it to the synthetic-tool fallback. That exclusion was mirrored from an older LiteLLM allow-list that predates Haiku 4.5's structured-output support and lumped "Haiku" in with genuinely-unsupported older models (Sonnet 3.x/4.0, Opus 3.x).

**Claude Haiku 4.5 supports native `output_config`** per current Anthropic docs (supported set: Fable 5, Opus 4.8, Sonnet 5, Haiku 4.5). The native path is cheaper and more reliable than the synthetic-tool workaround — which matters for cost-driven Haiku usage doing structured output with tools.

## Change
- Add a version-targeted pattern `r"(?<!\d)haiku-4[-.]5(?!\d)"` to `_NATIVE_OUTPUT_FORMAT_MODEL_PATTERNS` so **Haiku 4.5** uses native `output_config`; **pre-4.5 Haiku (3.x)** stays correctly excluded (it rejects the field — a wrong add would 400).
- Correct the stale comment/docstring that framed all Haiku as unsupported.

## Validation
- **Unit tests** (180 green): the file previously asserted Haiku 4.5 → synthetic (now flipped to → `output_config`); pre-4.5 Haiku coverage re-pointed at 3.5; overmatch guards (`haiku-4-50`) added.
- **Live end-to-end**: a Haiku 4.5 provider + a structured-output consumer (`AnalysisResult`) + a function tool — returned a valid schema-conforming result via the **native `output_config` path** (confirmed in logs, not synthetic-tool), the tool loop completed, and there was **no 400**. So `output_config` + function tools co-work on Haiku 4.5.

Closes #1341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native structured-output support for Anthropic Claude Haiku 4.5 models.
  * Haiku 4.5 now uses Anthropic’s native output formatting for streaming and non-streaming requests.

* **Bug Fixes**
  * Earlier Haiku versions continue using the compatible fallback path.
  * Improved model matching to prevent unsupported future Haiku versions from being incorrectly classified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->