### PR TITLE
fix(cli): scaffold emits retired gemini/gemini-1.5-pro (404 on first call)

### DIFF
--- a/src/core/cli/scaffold/llm_subcommand.go
+++ b/src/core/cli/scaffold/llm_subcommand.go
@@ -19,7 +19,7 @@ var supportedLLMRuntimes = []string{"python", "typescript", "java"}
 var vendorToModel = map[string]string{
 	"claude":           "anthropic/claude-sonnet-5",
 	"openai":           "openai/gpt-4o",
-	"gemini":           "gemini/gemini-1.5-pro",
+	"gemini":           "gemini/gemini-2.5-flash",
 	"litellm-fallback": "openai/gpt-4o",
 }
 

--- a/src/core/cli/scaffold/llm_subcommand_test.go
+++ b/src/core/cli/scaffold/llm_subcommand_test.go
@@ -31,7 +31,7 @@ func TestIsValidLLMVendor(t *testing.T) {
 func TestVendorToModel(t *testing.T) {
 	assert.Equal(t, "anthropic/claude-sonnet-5", VendorToModel("claude"))
 	assert.Equal(t, "openai/gpt-4o", VendorToModel("openai"))
-	assert.Equal(t, "gemini/gemini-1.5-pro", VendorToModel("gemini"))
+	assert.Equal(t, "gemini/gemini-2.5-flash", VendorToModel("gemini"))
 	assert.NotEmpty(t, VendorToModel("litellm-fallback"))
 	assert.Equal(t, "", VendorToModel("unknown"))
 }

--- a/tests/integration/suites/uc05_meshctl/tc01_scaffold_llm_provider_gemini_py/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc01_scaffold_llm_provider_gemini_py/test.yaml
@@ -37,6 +37,18 @@ test:
     command: "grep -E 'model\\s*=' gemini-test/main.py || echo 'model not found'"
     workdir: /workspace
     capture: model_line
+  # Scaffold with the vendor default (no --model) to guard the scaffolder default
+  - name: "Scaffold Gemini provider with vendor default model"
+    handler: shell
+    command: "meshctl scaffold llm-provider --vendor gemini --name gemini-default --lang python"
+    workdir: /workspace
+    capture: default_scaffold_output
+  # Check the default-model main.py
+  - name: "Check default main.py content"
+    handler: shell
+    command: "cat gemini-default/main.py"
+    workdir: /workspace
+    capture: default_main_content
 assertions:
   # Scaffold succeeded
   - expr: ${last.exit_code} == 0
@@ -56,8 +68,8 @@ assertions:
   # Model should be gemini-2.5-pro (not outdated 1.5-flash)
   - expr: "${captured.main_content} contains 'gemini-2.5-pro'"
     message: "Should use gemini-2.5-pro model"
-  # Should NOT contain outdated model
-  - expr: "${captured.main_content} not contains 'gemini-1.5-flash'"
-    message: "Should NOT use outdated gemini-1.5-flash model"
+  # Vendor default must be the current gemini model, not a retired id
+  - expr: "${captured.default_main_content} contains 'gemini/gemini-2.5-flash'"
+    message: "Should scaffold the current gemini model"
 post_run:
   - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc05_meshctl/tc02_scaffold_llm_provider_gemini_ts/test.yaml
+++ b/tests/integration/suites/uc05_meshctl/tc02_scaffold_llm_provider_gemini_ts/test.yaml
@@ -37,6 +37,18 @@ test:
     command: "cat gemini-test-ts/package.json"
     workdir: /workspace
     capture: package_json
+  # Scaffold with the vendor default (no --model) to guard the scaffolder default
+  - name: "Scaffold Gemini provider with vendor default model"
+    handler: shell
+    command: "meshctl scaffold llm-provider --vendor gemini --name gemini-default-ts --lang typescript"
+    workdir: /workspace
+    capture: default_scaffold_output
+  # Check the default-model index.ts
+  - name: "Check default index.ts content"
+    handler: shell
+    command: "cat gemini-default-ts/src/index.ts"
+    workdir: /workspace
+    capture: default_index_content
 assertions:
   # Scaffold succeeded
   - expr: ${last.exit_code} == 0
@@ -53,9 +65,9 @@ assertions:
   # Model should be gemini-2.5-pro (not outdated 1.5-flash)
   - expr: "${captured.index_content} contains 'gemini-2.5-pro'"
     message: "Should use gemini-2.5-pro model"
-  # Should NOT contain outdated model
-  - expr: "${captured.index_content} not contains 'gemini-1.5-flash'"
-    message: "Should NOT use outdated gemini-1.5-flash model"
+  # Vendor default must be the current gemini model, not a retired id
+  - expr: "${captured.default_index_content} contains 'gemini/gemini-2.5-flash'"
+    message: "Should scaffold the current gemini model"
   # package.json should have @mcpmesh/sdk dependency
   - expr: "${captured.package_json} contains '@mcpmesh/sdk'"
     message: "package.json should have @mcpmesh/sdk dependency"


### PR DESCRIPTION
## Problem

`meshctl scaffold` defaulted the gemini vendor to `gemini/gemini-1.5-pro` — a **retired** model id. Verified live:

```
HTTP 404 — models/gemini-1.5-pro is not found for API version v1beta,
or is not supported for generateContent
```

Every scaffolded Gemini provider registered fine, then 404'd on its first LLM call. First-contact breakage for anyone starting from the scaffolder, and inconsistent with our own docs — every man page already shows `gemini/gemini-2.5-flash`.

## Why the existing guards didn't catch it

Both integration tests already carried an assertion written for exactly this failure mode:

```yaml
${captured.main_content} not contains 'gemini-1.5-flash'
message: "Should NOT use outdated gemini-1.5-flash model"
```

It was vacuous for **two** independent reasons:

1. It blacklisted `gemini-1.5-flash` while the default was `gemini-1.5-pro` — a one-word miss.
2. More fundamentally, **neither test ever exercised the default.** Both scaffold with an explicit `--model gemini/gemini-2.5-pro`, so the captured content never contained the vendor default at all. The assertion could never have failed regardless of what the default was.

This is the more useful lesson: a negative assertion against a capture that doesn't contain the thing under test is guaranteed-green dead weight.

## Changes

- `llm_subcommand.go:22` — gemini default → `gemini/gemini-2.5-flash`
- `llm_subcommand_test.go:34` — assertion updated
- Both `uc05_meshctl` gemini tests — added a step that scaffolds via the **canonical** `meshctl scaffold llm-provider --vendor gemini` form with no `--model`, capturing separately, and replaced the negative assertion with a positive one on the resulting model id

Existing explicit-`--model` steps are left alone; they still cover pass-through (via the deprecated `--agent-type` form, which is intentional back-compat coverage).

## Verification

- `go build ./...` passes; `go test ./src/core/cli/scaffold/...` passes
- Built `meshctl` and ran both scaffolds: generated `main.py` has `model="gemini/gemini-2.5-flash"`, `index.ts` has `model: "gemini/gemini-2.5-flash"` — the new assertions match real output
- No second surface: `interactive.go` has no gemini model menu, and `cmd/meshctl/templates/**` has no hardcoded gemini id (only `{{ if contains .Model "gemini" }}` branches). This was the trap that was initially missed in #1331.

## Scope

Other `gemini-1.5-*` references are deliberately untouched — they're vendor-inference/prefix-stripping fixtures using the id as an opaque parsing input, plus generated artifact READMEs. No live calls.

Separately noted for follow-up: the `GeminiHandler` docstring model lists (`gemini_handler.py:156-162`, `gemini-handler.ts:51-57`) contain retired ids including `gemini-3-pro-preview`. Refreshing those needs measured-live ids across all runtimes and doesn't belong in this fix.

Closes #1345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default Gemini model used by LLM provider scaffolding to `gemini/gemini-2.5-flash` when no model is specified.
  * Explicit model selections continue to be respected.

* **Tests**
  * Added coverage confirming the updated default model for Python and TypeScript scaffolds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->