### PR TITLE
fix(llm): gate vendor-removed sampling params, guard Gemini thinking config, run the _mcp_mesh test tree in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
         env:
           MCP_MESH_AUTO_RUN: false
         run: |
-          pytest tests/unit/ -v \
+          pytest tests/unit/ _mcp_mesh/ -v \
             --cov=_mcp_mesh \
             --cov-report=xml \
             --cov-report=term-missing \

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/handlers/AnthropicHandler.java
@@ -13,6 +13,7 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.tool.ToolCallback;
 
 import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * LLM provider handler for Anthropic Claude models.
@@ -262,23 +263,77 @@ public class AnthropicHandler implements LlmProviderHandler {
         if (maxTokens != null) {
             builder.maxTokens(maxTokens);
         }
-        Double temperature = LlmProviderHandler.temperatureOption(options);
-        if (temperature != null) {
-            builder.temperature(temperature);
-        }
-        Double topP = LlmProviderHandler.topPOption(options);
-        if (topP != null) {
-            builder.topP(topP);
-        }
-        // Set the effective model on EVERY request: a vendor-matched per-call
-        // override wins, else the provider's declared model. Without this the
-        // request falls through to Spring AI's default Anthropic model.
+
+        // Resolve the effective model FIRST — the sampling gate below keys on it.
+        // Set it on EVERY request: a vendor-matched per-call override wins, else
+        // the provider's declared model. Without this the request falls through
+        // to Spring AI's default Anthropic model.
         String eff = LlmProviderHandler.effectiveModel(options, getVendor(), getAliases());
         if (eff != null) {
             builder.model(eff);
             log.debug("AnthropicHandler: applied model '{}'", eff);
         }
+
+        // Opus 4.7+ / Sonnet 5 / Fable 5 REMOVED temperature/top_p — their
+        // presence is a hard HTTP 400. Drop them with a WARN for those models,
+        // using the SAME effective model resolved above (mirrors OpenAiHandler).
+        boolean restricted = restrictsSamplingParams(eff);
+        Double temperature = LlmProviderHandler.temperatureOption(options);
+        if (temperature != null) {
+            if (restricted) {
+                log.warn("AnthropicHandler: omitting temperature={} for model '{}' (sampling params are not supported by this model family)", temperature, eff);
+            } else {
+                builder.temperature(temperature);
+            }
+        }
+        Double topP = LlmProviderHandler.topPOption(options);
+        if (topP != null) {
+            if (restricted) {
+                log.warn("AnthropicHandler: omitting top_p={} for model '{}' (sampling params are not supported by this model family)", topP, eff);
+            } else {
+                builder.topP(topP);
+            }
+        }
     }
+
+    /**
+     * Whether an Anthropic model rejects {@code temperature}/{@code top_p}
+     * outright (HTTP 400 when the field is present). Anthropic removed the
+     * sampling params on the Opus 4.7+ / Sonnet 5 / Fable 5 families:
+     * <ul>
+     *   <li>REJECT: claude-opus-4-7, claude-opus-4-8, claude-sonnet-5, claude-fable-5</li>
+     *   <li>ACCEPT: claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5,
+     *       claude-sonnet-4-5, claude-opus-4-5, claude-opus-4-1, all 3.x</li>
+     * </ul>
+     * Deliberately narrower than the native structured-output model set —
+     * {@code opus-4-6} / {@code sonnet-4-6} / {@code haiku-4-5} support that but
+     * still accept sampling params.
+     *
+     * <p>Patterns (not raw substrings) so the trailing minor-version digit is
+     * boundary-anchored: {@code opus-4-7} must NOT match a hypothetical future
+     * {@code opus-4-70}. Both {@code -} and {@code .} separators are accepted,
+     * and the match is unanchored so vendor prefixes ({@code anthropic/},
+     * {@code bedrock/anthropic.}, {@code databricks/anthropic.}) and date-pinned
+     * ids still match. Mirrors Python {@code restricts_anthropic_sampling_params}
+     * and TypeScript {@code restrictsAnthropicSamplingParams}.
+     *
+     * <p>Java never sets {@code top_k} on the Anthropic options builder, so it is
+     * intentionally not handled here.
+     */
+    static boolean restrictsSamplingParams(String model) {
+        if (model == null) return false;
+        for (Pattern p : SAMPLING_RESTRICTED_MODEL_PATTERNS) {
+            if (p.matcher(model).find()) return true;
+        }
+        return false;
+    }
+
+    private static final List<Pattern> SAMPLING_RESTRICTED_MODEL_PATTERNS = List.of(
+        Pattern.compile("(?<!\\d)sonnet-5(?!\\d)", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("(?<!\\d)opus-4[-.]7(?!\\d)", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("(?<!\\d)opus-4[-.]8(?!\\d)", Pattern.CASE_INSENSITIVE),
+        Pattern.compile("(?<!\\d)fable-5(?!\\d)", Pattern.CASE_INSENSITIVE)
+    );
 
     /**
      * Generate with tools and auto-execute them via ChatClient.

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderModelParamsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/handlers/ProviderModelParamsTest.java
@@ -3,6 +3,8 @@ package io.mcpmesh.ai.handlers;
 import io.mcpmesh.ai.handlers.LlmProviderHandler.OutputSchema;
 import io.mcpmesh.ai.handlers.LlmProviderHandler.ToolDefinition;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.springframework.ai.anthropic.AnthropicChatOptions;
 import org.springframework.ai.chat.messages.AssistantMessage;
@@ -199,6 +201,101 @@ class ProviderModelParamsTest {
                 "cross-vendor model override must be ignored");
             assertEquals(AnthropicChatOptions.DEFAULT_MODEL, opts.getModel(),
                 "unresolved model falls back to the Anthropic SDK default (GA)");
+        }
+
+        // -----------------------------------------------------------------
+        // Sampling-param gating (#1344)
+        // -----------------------------------------------------------------
+        // Anthropic REMOVED temperature/top_p on the Opus 4.7+ / Sonnet 5 /
+        // Fable 5 families — their presence is a hard HTTP 400. Mirrors the
+        // OpenAiHandler gate; Java never sets top_k so only two params apply.
+
+        private AnthropicChatOptions callWith(String model) {
+            ArgumentCaptor<Prompt> captor = ArgumentCaptor.forClass(Prompt.class);
+            ChatModel chatModel = mockModel(captor);
+
+            Map<String, Object> options = new LinkedHashMap<>();
+            options.put(LlmProviderHandler.OPTION_MODEL, "anthropic/" + model);
+            options.put(LlmProviderHandler.OPTION_MAX_TOKENS, 1000);
+            options.put(LlmProviderHandler.OPTION_TEMPERATURE, 0.7);
+            options.put(LlmProviderHandler.OPTION_TOP_P, 0.9);
+
+            handler.generateWithTools(chatModel, userMessages(), List.of(), null, null, options);
+            return (AnthropicChatOptions) captor.getValue().getOptions();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "claude-sonnet-5",
+            "claude-fable-5",
+            "claude-opus-4.8",
+            "claude-sonnet-5-20260201",
+        })
+        @DisplayName("restricted models omit temperature/top_p but keep maxTokens")
+        void restrictedModelOmitsSamplingParams(String model) {
+            AnthropicChatOptions opts = callWith(model);
+            assertNull(opts.getTemperature(), "temperature must be omitted for " + model);
+            assertNull(opts.getTopP(), "top_p must be omitted for " + model);
+            // Anthropic REQUIRES max_tokens — never stripped.
+            assertEquals(1000, opts.getMaxTokens());
+            assertEquals(model, opts.getModel());
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "claude-opus-4-6",
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+            "claude-sonnet-4-5",
+            "claude-opus-4-1",
+            "claude-3-5-sonnet-20241022",
+            // Boundary guard — a future minor version must not match the
+            // shorter "opus-4-7" pattern.
+            "claude-opus-4-70",
+        })
+        @DisplayName("unrestricted models still apply temperature/top_p")
+        void unrestrictedModelAppliesSamplingParams(String model) {
+            AnthropicChatOptions opts = callWith(model);
+            assertEquals(0.7, opts.getTemperature(), 1e-9);
+            assertEquals(0.9, opts.getTopP(), 1e-9);
+        }
+
+        @Test
+        @DisplayName("restrictsSamplingParams truth table")
+        void restrictsSamplingParamsTruthTable() {
+            // Restricted — bare, vendor-prefixed, bedrock/databricks, dotted,
+            // date-pinned, and case-insensitive forms.
+            assertTrue(AnthropicHandler.restrictsSamplingParams("claude-sonnet-5"));
+            assertTrue(AnthropicHandler.restrictsSamplingParams("claude-opus-4-7"));
+            assertTrue(AnthropicHandler.restrictsSamplingParams("claude-opus-4-8"));
+            assertTrue(AnthropicHandler.restrictsSamplingParams("claude-fable-5"));
+            assertTrue(AnthropicHandler.restrictsSamplingParams("anthropic/claude-opus-4-8"));
+            assertTrue(AnthropicHandler.restrictsSamplingParams(
+                "bedrock/anthropic.claude-opus-4-8-20260101-v1:0"));
+            assertTrue(AnthropicHandler.restrictsSamplingParams(
+                "databricks/anthropic.claude-sonnet-5"));
+            assertTrue(AnthropicHandler.restrictsSamplingParams("anthropic/claude-opus-4.7"));
+            assertTrue(AnthropicHandler.restrictsSamplingParams("claude-sonnet-5-20260201"));
+            assertTrue(AnthropicHandler.restrictsSamplingParams("ANTHROPIC/CLAUDE-OPUS-4-8"));
+
+            // Unrestricted — structured-output-capable models that still accept
+            // sampling params, plus the boundary/leading-digit guards.
+            assertFalse(AnthropicHandler.restrictsSamplingParams("claude-opus-4-6"));
+            assertFalse(AnthropicHandler.restrictsSamplingParams("claude-sonnet-4-6"));
+            assertFalse(AnthropicHandler.restrictsSamplingParams("claude-haiku-4-5"));
+            assertFalse(AnthropicHandler.restrictsSamplingParams("claude-sonnet-4-5"));
+            assertFalse(AnthropicHandler.restrictsSamplingParams("claude-opus-4-5"));
+            assertFalse(AnthropicHandler.restrictsSamplingParams("claude-opus-4-1"));
+            assertFalse(AnthropicHandler.restrictsSamplingParams("claude-3-5-sonnet-20241022"));
+            assertFalse(AnthropicHandler.restrictsSamplingParams("claude-opus-4-70"));
+            assertFalse(AnthropicHandler.restrictsSamplingParams("claude-opus-4-80"));
+            assertFalse(AnthropicHandler.restrictsSamplingParams("claude-sonnet-50"));
+            assertFalse(AnthropicHandler.restrictsSamplingParams("claude-fable-50"));
+            assertFalse(AnthropicHandler.restrictsSamplingParams("claude-opus-14-7"));
+            assertFalse(AnthropicHandler.restrictsSamplingParams("openai/gpt-4o"));
+            assertFalse(AnthropicHandler.restrictsSamplingParams(null));
         }
     }
 

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/_native_client_helpers.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/_native_client_helpers.py
@@ -13,6 +13,7 @@ otherwise — no module-level state here.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Callable
 
 
@@ -59,7 +60,61 @@ def reset_unsupported_kwargs_dedupe(dedupe_set: set[str]) -> None:
     dedupe_set.clear()
 
 
-def restricts_sampling_params(model: str | None) -> bool:
+# Sampling knobs that a restricted model rejects. ``top_k`` is Anthropic-only
+# (OpenAI has no such param); the OpenAI branch strips the first two.
+SAMPLING_PARAM_KEYS = ("temperature", "top_p", "top_k")
+
+
+# Anthropic REMOVED ``temperature`` / ``top_p`` / ``top_k`` on the Opus 4.7+ /
+# Sonnet 5 / Fable 5 families — presence of any of them is HTTP 400 (Sonnet 5
+# 400s on non-default values; mesh only forwards explicitly-set values, so
+# dropping is correct for both shapes).
+#
+# This list is deliberately NARROWER than
+# ``anthropic_native._NATIVE_OUTPUT_FORMAT_MODEL_PATTERNS``: ``opus-4-6``,
+# ``sonnet-4-6`` and ``haiku-4-5`` support native structured output but still
+# ACCEPT sampling params, so the two lists cannot be shared.
+#
+# Patterns (not raw substrings) so the trailing minor-version digit is
+# boundary-anchored: ``opus-4-7`` must NOT match a hypothetical future
+# ``opus-4-70``. Each pattern accepts both dash and dot separators (callers pass
+# both forms in the wild). ``re.search`` (not anchored to start) so vendor
+# prefixes (``anthropic/``, ``bedrock/anthropic.``, ``databricks/anthropic.``)
+# and date-pinned Bedrock ids still match — consistent with
+# ``anthropic_native.is_anthropic_model`` / ``supports_model``.
+_ANTHROPIC_SAMPLING_RESTRICTED_MODEL_PATTERNS = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"(?<!\d)sonnet-5(?!\d)",
+        r"(?<!\d)opus-4[-.]7(?!\d)",
+        r"(?<!\d)opus-4[-.]8(?!\d)",
+        r"(?<!\d)fable-5(?!\d)",
+    )
+)
+
+
+def restricts_anthropic_sampling_params(model: str | None) -> bool:
+    """Whether an Anthropic model rejects ``temperature``/``top_p``/``top_k``
+    outright (HTTP 400 when the field is present).
+
+    Matches the Opus 4.7 / Opus 4.8 / Sonnet 5 / Fable 5 families only:
+
+      * REJECT: claude-opus-4-7, claude-opus-4-8, claude-sonnet-5,
+        claude-fable-5 (bare, ``anthropic/``-, ``bedrock/anthropic.``- and
+        ``databricks/anthropic.``-prefixed, and date-pinned forms)
+      * ACCEPT: claude-opus-4-6, claude-sonnet-4-6, claude-haiku-4-5,
+        claude-sonnet-4-5, claude-opus-4-5, claude-opus-4-1, all 3.x
+
+    Kept separate from the OpenAI predicate: the two vendors restrict different
+    key sets (Anthropic also drops ``top_k``) and OpenAI's restricted set has a
+    second meaning (Responses-API routing) that must not follow Anthropic ids.
+    """
+    if not model:
+        return False
+    return any(p.search(model) for p in _ANTHROPIC_SAMPLING_RESTRICTED_MODEL_PATTERNS)
+
+
+def restricts_openai_sampling_params(model: str | None) -> bool:
     """Whether an OpenAI model restricts ``temperature``/``top_p`` to their
     default value (rejecting any explicit setting with HTTP 400).
 
@@ -95,7 +150,28 @@ def restricts_sampling_params(model: str | None) -> bool:
 # to the Responses API when tools are present because they reason by default
 # and OpenAI 400s on reasoning + function tools on /v1/chat/completions. Single
 # implementation — no logic duplication; call whichever name reads best.
-is_openai_reasoning_model = restricts_sampling_params
+#
+# DELIBERATELY aliased to the OpenAI-ONLY predicate, not the vendor-agnostic
+# ``restricts_sampling_params`` below: "restricts sampling params" is now true
+# for Claude ids too, and an ``is_openai_reasoning_model("claude-opus-4-8")``
+# returning True would wrongly route Anthropic models to the OpenAI Responses
+# API (#1344).
+is_openai_reasoning_model = restricts_openai_sampling_params
+
+
+def restricts_sampling_params(model: str | None) -> bool:
+    """Vendor-agnostic gate: does ``model`` reject explicitly-set sampling
+    params (``temperature`` / ``top_p`` / ``top_k``)?
+
+    Union of the per-vendor predicates — OpenAI o-series + gpt-5 non-chat
+    (only-the-default) and Anthropic Opus 4.7+ / Sonnet 5 / Fable 5 (removed
+    entirely). Callers that need vendor-specific follow-on behavior (the
+    ``max_tokens`` → ``max_completion_tokens`` translation, Responses-API
+    routing) must use the vendor-specific predicate instead.
+    """
+    if restricts_openai_sampling_params(model):
+        return True
+    return restricts_anthropic_sampling_params(model)
 
 
 def translate_max_tokens_for_restricted(
@@ -110,7 +186,7 @@ def translate_max_tokens_for_restricted(
     Shared by the native OpenAI adapter and the LiteLLM path so their behavior
     cannot drift.
     """
-    if not restricts_sampling_params(model):
+    if not restricts_openai_sampling_params(model):
         return
     if params.get("max_tokens") is None:
         return

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/anthropic_native.py
@@ -45,10 +45,12 @@ from .._structured_output_helpers import (
     schema_to_synthetic_tool,
 )
 from ._native_client_helpers import (
+    SAMPLING_PARAM_KEYS,
     make_fallback_logger,
     make_is_available,
     reset_unsupported_kwargs_dedupe,
     resolve_request_timeout,
+    restricts_anthropic_sampling_params,
     warn_unsupported_kwarg_once,
 )
 
@@ -1000,10 +1002,19 @@ def _build_create_kwargs(
     if system_value is not None:
         create_kwargs["system"] = system_value
 
+    # Opus 4.7+ / Sonnet 5 / Fable 5 REMOVED temperature/top_p/top_k — their
+    # presence is a hard HTTP 400. Drop them with a once-per-key WARN rather
+    # than letting the vendor reject the request: dropping degrades gracefully,
+    # forwarding does not (#1344).
+    sampling_restricted = restricts_anthropic_sampling_params(model)
+
     for key in _ANTHROPIC_PASSTHROUGH_KWARGS:
         if key == "max_tokens":
             continue  # handled above
         if key in request_params and request_params[key] is not None:
+            if sampling_restricted and key in SAMPLING_PARAM_KEYS:
+                _warn_dropped_sampling_param_once(model, key, request_params[key])
+                continue
             create_kwargs[key] = request_params[key]
 
     # Tool choice: litellm uses {"type": "function", "function": {"name": "..."}}
@@ -1355,3 +1366,32 @@ def _reset_unsupported_kwargs_dedupe() -> None:
     WARN trail. NOT for production use.
     """
     reset_unsupported_kwargs_dedupe(_logged_unsupported_kwargs)
+    reset_unsupported_kwargs_dedupe(_logged_dropped_sampling_params)
+
+
+# Separate dedupe set for the sampling-param drops (#1344). Kept apart from
+# ``_logged_unsupported_kwargs`` because the two carry different signals: the
+# other set means "mesh does not translate this LiteLLM knob", this one means
+# "the target Claude model removed this param". Same once-per-key-per-process
+# budget so high-volume providers don't flood the log.
+_logged_dropped_sampling_params: set[str] = set()
+
+
+def _warn_dropped_sampling_param_once(model: str, key: str, value: Any) -> None:
+    """WARN once per dropped sampling-param name.
+
+    Wording mirrors ``openai_native._build_create_kwargs`` so both native
+    adapters read the same in a log trail; the parenthetical differs because
+    Anthropic REMOVED the params (not "only the default is accepted").
+    """
+    if key in _logged_dropped_sampling_params:
+        return
+    _logged_dropped_sampling_params.add(key)
+    logger.warning(
+        "Anthropic model %s rejects %s; omitting %s=%s "
+        "(sampling params are not supported by this model family)",
+        model,
+        key,
+        key,
+        value,
+    )

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -1129,7 +1129,7 @@ def _resolve_thinking_config_exclusion(thinking_config: Any) -> Any:
     (Google no longer documents ``thinking_budget``); keeping it means a caller
     who set both gets the more future-proof of the two honored.
 
-    The dropped field is OMITTED entirely (dict key removed / model field set
+    The dropped field is OMITTED entirely (dict key(s) removed / model field set
     to ``None``) — never replaced with an "unspecified" sentinel, which would
     still trip the 400 since presence is what is checked. ``None`` fields are
     excluded at serialization time by google-genai, so this keeps the verified
@@ -1137,11 +1137,20 @@ def _resolve_thinking_config_exclusion(thinking_config: Any) -> Any:
     ``{"thinkingBudget": 512}``.
 
     Accepts (and returns) either a plain dict or a ``ThinkingConfig`` instance.
-    A no-op when fewer than two of the fields are set to non-``None`` values.
+    For dicts BOTH spellings are recognized — google-genai accepts the
+    camelCase aliases (``thinkingLevel`` / ``thinkingBudget``) as constructor
+    kwargs, so a camelCase or mixed-spelling dict must not bypass the guard.
+    The surviving level keeps the caller's original key spelling; every budget
+    spelling is removed. A no-op when fewer than two of the fields are set to
+    non-``None`` values.
     """
     if isinstance(thinking_config, dict):
         level = thinking_config.get("thinking_level")
+        if level is None:
+            level = thinking_config.get("thinkingLevel")
         budget = thinking_config.get("thinking_budget")
+        if budget is None:
+            budget = thinking_config.get("thinkingBudget")
         if level is None or budget is None:
             return thinking_config
         logger.warning(
@@ -1153,6 +1162,7 @@ def _resolve_thinking_config_exclusion(thinking_config: Any) -> Any:
         )
         resolved = dict(thinking_config)
         resolved.pop("thinking_budget", None)
+        resolved.pop("thinkingBudget", None)
         return resolved
 
     level = getattr(thinking_config, "thinking_level", None)

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/gemini_native.py
@@ -1107,6 +1107,69 @@ _GEMINI_HANDLED_KWARGS = frozenset({
 })
 
 
+def _resolve_thinking_config_exclusion(thinking_config: Any) -> Any:
+    """Enforce Google's ``thinking_level`` / ``thinking_budget`` mutual
+    exclusion before the request leaves mesh (#1346).
+
+    Google's ``generateContent`` rejects a request carrying BOTH fields with
+    ``400 You can only set only one of thinking budget and thinking level.``
+    This is a **global request-validation check** that fires ahead of the
+    per-model support check — it is model-independent (it is the error even on
+    models that support neither field), so this guard is deliberately NOT gated
+    on model id or generation. Do not add a model allowlist here: measurement
+    against the live API shows level/budget support is per-model with differing
+    accepted value subsets, and any hard-coded table would be wrong on day one
+    and rot on every model launch.
+
+    The check fires on field PRESENCE, not value: ``{"thinkingLevel":
+    "THINKING_LEVEL_UNSPECIFIED", "thinkingBudget": 1024}`` still 400s.
+
+    **Resolution is deterministic: ``thinking_level`` WINS, ``thinking_budget``
+    is dropped.** ``thinking_level`` is the newer, portable-forward field
+    (Google no longer documents ``thinking_budget``); keeping it means a caller
+    who set both gets the more future-proof of the two honored.
+
+    The dropped field is OMITTED entirely (dict key removed / model field set
+    to ``None``) — never replaced with an "unspecified" sentinel, which would
+    still trip the 400 since presence is what is checked. ``None`` fields are
+    excluded at serialization time by google-genai, so this keeps the verified
+    property that ``ThinkingConfig(**{"thinking_budget": 512})`` emits exactly
+    ``{"thinkingBudget": 512}``.
+
+    Accepts (and returns) either a plain dict or a ``ThinkingConfig`` instance.
+    A no-op when fewer than two of the fields are set to non-``None`` values.
+    """
+    if isinstance(thinking_config, dict):
+        level = thinking_config.get("thinking_level")
+        budget = thinking_config.get("thinking_budget")
+        if level is None or budget is None:
+            return thinking_config
+        logger.warning(
+            "Native Gemini adapter: thinking_config sets both thinking_level=%r "
+            "and thinking_budget=%r; Google accepts only one — dropping "
+            "thinking_budget and keeping thinking_level",
+            level,
+            budget,
+        )
+        resolved = dict(thinking_config)
+        resolved.pop("thinking_budget", None)
+        return resolved
+
+    level = getattr(thinking_config, "thinking_level", None)
+    budget = getattr(thinking_config, "thinking_budget", None)
+    if level is None or budget is None:
+        return thinking_config
+    logger.warning(
+        "Native Gemini adapter: thinking_config sets both thinking_level=%r "
+        "and thinking_budget=%r; Google accepts only one — dropping "
+        "thinking_budget and keeping thinking_level",
+        level,
+        budget,
+    )
+    # Pydantic model → copy with the loser set to None (excluded on the wire).
+    return thinking_config.model_copy(update={"thinking_budget": None})
+
+
 def _build_create_kwargs(
     request_params: dict[str, Any],
     *,
@@ -1235,9 +1298,13 @@ def _build_create_kwargs(
         from google.genai.types import ThinkingConfig
 
         if isinstance(thinking_config, ThinkingConfig):
-            config["thinking_config"] = thinking_config
+            config["thinking_config"] = _resolve_thinking_config_exclusion(
+                thinking_config
+            )
         elif isinstance(thinking_config, dict):
-            config["thinking_config"] = ThinkingConfig(**thinking_config)
+            config["thinking_config"] = ThinkingConfig(
+                **_resolve_thinking_config_exclusion(thinking_config)
+            )
         else:
             # Unsupported type — key is in the passthrough set so the generic
             # "unknown kwarg" WARN-once filter won't fire; emit a dedicated

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -46,7 +46,7 @@ from ._native_client_helpers import (
     make_is_available,
     reset_unsupported_kwargs_dedupe,
     resolve_request_timeout,
-    restricts_sampling_params,
+    restricts_openai_sampling_params,
     translate_max_tokens_for_restricted,
     warn_unsupported_kwarg_once,
 )
@@ -488,7 +488,7 @@ def _build_create_kwargs(
     # Omit those two params for the restricted models (everything else,
     # including ``max_completion_tokens``, is forwarded normally). Soft-fail
     # with a WARN per omitted param rather than letting the request 400.
-    restricted = restricts_sampling_params(model)
+    restricted = restricts_openai_sampling_params(model)
 
     for key in _OPENAI_PASSTHROUGH_KWARGS:
         value = request_params.get(key)

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native.py
@@ -1914,3 +1914,106 @@ class TestIsFallbackLogged:
 
         anthropic_native.log_fallback_once()
         assert anthropic_native.is_fallback_logged() is True
+
+
+# ---------------------------------------------------------------------------
+# Sampling-param gating on the native path (#1344)
+# ---------------------------------------------------------------------------
+# Anthropic REMOVED temperature/top_p/top_k on Opus 4.7+ / Sonnet 5 / Fable 5;
+# forwarding them is a hard HTTP 400. The adapter drops them (with a
+# once-per-key WARN) for those families and forwards them unchanged elsewhere.
+
+
+class TestSamplingParamGating:
+    @pytest.fixture(autouse=True)
+    def _reset_dedupe(self):
+        anthropic_native._logged_dropped_sampling_params.clear()
+        yield
+        anthropic_native._logged_dropped_sampling_params.clear()
+
+    def _build(self, model: str, **params):
+        request_params = {
+            "messages": [{"role": "user", "content": "Hi."}],
+            **params,
+        }
+        return anthropic_native._build_create_kwargs(
+            request_params, model=model, stream=False
+        )
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic/claude-opus-4-7",
+            "anthropic/claude-opus-4-8",
+            "anthropic/claude-sonnet-5",
+            "anthropic/claude-fable-5",
+            "bedrock/anthropic.claude-opus-4-8-20260101-v1:0",
+        ],
+    )
+    def test_restricted_model_drops_all_three_sampling_params(self, model):
+        kwargs = self._build(model, temperature=0.7, top_p=0.9, top_k=40)
+        assert "temperature" not in kwargs
+        assert "top_p" not in kwargs
+        assert "top_k" not in kwargs
+        # max_tokens is REQUIRED by Anthropic — never stripped.
+        assert kwargs["max_tokens"] == 8192
+
+    def test_restricted_model_keeps_other_kwargs(self):
+        kwargs = self._build(
+            "anthropic/claude-opus-4-8",
+            temperature=0.7,
+            max_tokens=1024,
+            stop_sequences=["END"],
+        )
+        assert "temperature" not in kwargs
+        assert kwargs["max_tokens"] == 1024
+        assert kwargs["stop_sequences"] == ["END"]
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic/claude-opus-4-6",
+            "anthropic/claude-sonnet-4-6",
+            "anthropic/claude-haiku-4-5",
+            "anthropic/claude-sonnet-4-5",
+            # Boundary guard — a future minor version must not be caught by the
+            # shorter ``opus-4-7`` pattern.
+            "anthropic/claude-opus-4-70",
+        ],
+    )
+    def test_unrestricted_model_forwards_sampling_params(self, model):
+        kwargs = self._build(model, temperature=0.7, top_p=0.9, top_k=40)
+        assert kwargs["temperature"] == 0.7
+        assert kwargs["top_p"] == 0.9
+        assert kwargs["top_k"] == 40
+
+    def test_drop_emits_warn_naming_each_key(self, caplog):
+        with caplog.at_level("WARNING", logger=anthropic_native.logger.name):
+            self._build("anthropic/claude-opus-4-8", temperature=0.7, top_p=0.9, top_k=40)
+        warn_msgs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any("temperature" in m for m in warn_msgs)
+        assert any("top_p" in m for m in warn_msgs)
+        assert any("top_k" in m for m in warn_msgs)
+
+    def test_warn_fires_once_per_key_across_requests(self, caplog):
+        with caplog.at_level("WARNING", logger=anthropic_native.logger.name):
+            for _ in range(3):
+                self._build("anthropic/claude-opus-4-8", temperature=0.7, top_p=0.9)
+        warn_msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "rejects" in r.getMessage()
+        ]
+        assert len(warn_msgs) == 2, f"expected one WARN per key; got {warn_msgs}"
+        assert sum("rejects temperature" in m for m in warn_msgs) == 1
+        assert sum("rejects top_p" in m for m in warn_msgs) == 1
+
+    def test_dropped_params_do_not_trip_unsupported_kwarg_warn(self, caplog):
+        """The sampling keys stay in the passthrough allow-list — dropping them
+        must NOT also fire the generic 'dropping unsupported kwarg' WARN."""
+        anthropic_native._logged_unsupported_kwargs.clear()
+        with caplog.at_level("WARNING", logger=anthropic_native.logger.name):
+            self._build("anthropic/claude-opus-4-8", temperature=0.7)
+        assert not any(
+            "dropping unsupported kwarg" in r.getMessage() for r in caplog.records
+        )

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native_response_format.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_anthropic_native_response_format.py
@@ -14,11 +14,11 @@ Two injection paths exist:
     ``helpers._run_response_format_retry``) bypasses the handler and emits
     ``response_format`` directly.
 
-All tests target a model NOT in
-``_NATIVE_OUTPUT_FORMAT_MODEL_SUBSTRINGS`` (Haiku 4.5) so the
-adapter routes through the synthetic-tool path. Native
-``output_config`` behaviour for Sonnet 4.5+ / Opus 4.1+ is covered by
-``test_anthropic_native_output_format.py``.
+All tests target ``_SYNTHETIC_PATH_MODEL`` — a model NOT matched by
+``anthropic_native._NATIVE_OUTPUT_FORMAT_MODEL_PATTERNS`` (Claude 3 Haiku) —
+so the adapter routes through the synthetic-tool path. Native
+``output_config`` behaviour for Sonnet 4.5+ / Opus 4.1+ / Haiku 4.5 (#1342)
+is covered by ``test_anthropic_native_output_format.py``.
 
 Real network calls are mocked.
 """
@@ -67,6 +67,12 @@ def _patched_async_anthropic(api_response):
     return cls_mock, create_mock
 
 
+# Model deliberately OFF ``_NATIVE_OUTPUT_FORMAT_MODEL_PATTERNS`` so
+# ``response_format`` is translated into the synthetic-tool injection this
+# module exists to cover. Guarded by
+# ``test_synthetic_path_model_is_not_native_capable`` below.
+_SYNTHETIC_PATH_MODEL = "anthropic/claude-3-haiku-20240307"
+
 _SIMPLE_SCHEMA = {
     "type": "object",
     "properties": {"answer": {"type": "string"}},
@@ -98,6 +104,15 @@ def _reset_dedupe():
 # ---------------------------------------------------------------------------
 
 
+def test_synthetic_path_model_is_not_native_capable():
+    """Guard for the whole module: if ``_SYNTHETIC_PATH_MODEL`` ever lands on
+    the native ``output_config`` allow-list, every test below would silently
+    stop covering the synthetic-tool path."""
+    assert not anthropic_native._supports_native_output_format(
+        _SYNTHETIC_PATH_MODEL
+    )
+
+
 class TestResponseFormatTranslation:
     @pytest.mark.asyncio
     async def test_pops_response_format_before_sdk_call(self):
@@ -111,7 +126,7 @@ class TestResponseFormatTranslation:
                     "messages": [{"role": "user", "content": "Hi."}],
                     "response_format": _RESPONSE_FORMAT,
                 },
-                model="anthropic/claude-haiku-4-5",
+                model=_SYNTHETIC_PATH_MODEL,
                 api_key="sk-test",
             )
 
@@ -138,7 +153,7 @@ class TestResponseFormatTranslation:
                     "tools": [handler_injected_tool],
                     "response_format": _RESPONSE_FORMAT,
                 },
-                model="anthropic/claude-haiku-4-5",
+                model=_SYNTHETIC_PATH_MODEL,
                 api_key="sk-test",
             )
 
@@ -163,7 +178,7 @@ class TestResponseFormatTranslation:
                     "messages": [{"role": "user", "content": "Hi."}],
                     "response_format": _RESPONSE_FORMAT,
                 },
-                model="anthropic/claude-haiku-4-5",
+                model=_SYNTHETIC_PATH_MODEL,
                 api_key="sk-test",
             )
 
@@ -196,7 +211,7 @@ class TestResponseFormatTranslation:
                     "tools": [real_tool],
                     "response_format": _RESPONSE_FORMAT,
                 },
-                model="anthropic/claude-haiku-4-5",
+                model=_SYNTHETIC_PATH_MODEL,
                 api_key="sk-test",
             )
 
@@ -222,7 +237,7 @@ class TestResponseFormatTranslation:
                         "response_format": _RESPONSE_FORMAT,
                         "tool_choice": "none",
                     },
-                    model="anthropic/claude-haiku-4-5",
+                    model=_SYNTHETIC_PATH_MODEL,
                     api_key="sk-test",
                 )
 
@@ -259,7 +274,7 @@ class TestResponseFormatTranslation:
                     "response_format": _RESPONSE_FORMAT,
                     "tool_choice": forced_choice,
                 },
-                model="anthropic/claude-haiku-4-5",
+                model=_SYNTHETIC_PATH_MODEL,
                 api_key="sk-test",
             )
 
@@ -284,7 +299,7 @@ class TestResponseFormatTranslation:
                     ],
                     "response_format": _RESPONSE_FORMAT,
                 },
-                model="anthropic/claude-haiku-4-5",
+                model=_SYNTHETIC_PATH_MODEL,
                 api_key="sk-test",
             )
 
@@ -305,7 +320,7 @@ class TestResponseFormatTranslation:
                     "messages": [{"role": "user", "content": "Hi."}],
                     "response_format": _RESPONSE_FORMAT,
                 },
-                model="anthropic/claude-haiku-4-5",
+                model=_SYNTHETIC_PATH_MODEL,
                 api_key="sk-test",
             )
 
@@ -325,7 +340,7 @@ class TestResponseFormatTranslation:
                     "messages": [{"role": "user", "content": "Hi."}],
                     "response_format": {"type": "json_object"},  # not json_schema
                 },
-                model="anthropic/claude-haiku-4-5",
+                model=_SYNTHETIC_PATH_MODEL,
                 api_key="sk-test",
             )
 
@@ -352,7 +367,7 @@ class TestRequestTimeoutRename:
                     "messages": [{"role": "user", "content": "Hi."}],
                     "request_timeout": 42,
                 },
-                model="anthropic/claude-haiku-4-5",
+                model=_SYNTHETIC_PATH_MODEL,
                 api_key="sk-test",
             )
 
@@ -372,7 +387,7 @@ class TestRequestTimeoutRename:
                     "timeout": 10,
                     "request_timeout": 99,
                 },
-                model="anthropic/claude-haiku-4-5",
+                model=_SYNTHETIC_PATH_MODEL,
                 api_key="sk-test",
             )
 
@@ -392,7 +407,7 @@ class TestRequestTimeoutRename:
                         "messages": [{"role": "user", "content": "Hi."}],
                         "request_timeout": 90,
                     },
-                    model="anthropic/claude-haiku-4-5",
+                    model=_SYNTHETIC_PATH_MODEL,
                     api_key="sk-test",
                 )
 
@@ -426,7 +441,7 @@ class TestResponseFormatNoLongerWarns:
                         "messages": [{"role": "user", "content": "Hi."}],
                         "response_format": _RESPONSE_FORMAT,
                     },
-                    model="anthropic/claude-haiku-4-5",
+                    model=_SYNTHETIC_PATH_MODEL,
                     api_key="sk-test",
                 )
 

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
@@ -2413,3 +2413,118 @@ class TestThoughtSignatureRoundTrip:
         # And confirm the args round-trip too (sanity).
         assert fc_part["function_call"]["name"] == "get_weather"
         assert fc_part["function_call"]["args"] == {"city": "NYC"}
+
+
+# ---------------------------------------------------------------------------
+# thinking_level / thinking_budget mutual exclusion (#1346)
+# ---------------------------------------------------------------------------
+# Google returns ``400 You can only set only one of thinking budget and
+# thinking level.`` whenever BOTH fields are present in one request. It is a
+# global request-validation check — model-independent, fires on field PRESENCE
+# not value. mesh resolves it deterministically (thinking_level wins) instead
+# of letting an opaque vendor 400 escape.
+
+
+class TestThinkingConfigMutualExclusion:
+    def _build(self, thinking_config, model="gemini/gemini-3.5-flash"):
+        return gemini_native._build_create_kwargs(
+            {
+                "messages": [{"role": "user", "content": "Hi"}],
+                "thinking_config": thinking_config,
+            },
+            model=model,
+        )
+
+    def test_both_set_drops_budget_keeps_level(self):
+        out = self._build({"thinking_level": "HIGH", "thinking_budget": 1024})
+        tc = out["config"]["thinking_config"]
+        assert tc.thinking_level == "HIGH"
+        # Dropped entirely — None, never a sentinel.
+        assert tc.thinking_budget is None
+
+    def test_both_set_emits_warn_naming_both(self, caplog):
+        with caplog.at_level("WARNING", logger=gemini_native.logger.name):
+            self._build({"thinking_level": "LOW", "thinking_budget": 512})
+        warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any(
+            "thinking_level" in m and "thinking_budget" in m and "dropping" in m
+            for m in warnings
+        ), warnings
+
+    def test_dropped_field_is_omitted_from_the_wire_shape(self):
+        """The resolved config must serialize WITHOUT a thinkingBudget key —
+        sending an 'unspecified' sentinel would still trip the 400 (presence,
+        not value, is what Google checks)."""
+        out = self._build({"thinking_level": "HIGH", "thinking_budget": 1024})
+        payload = out["config"]["thinking_config"].model_dump(
+            exclude_none=True, by_alias=True
+        )
+        assert payload == {"thinkingLevel": "HIGH"}
+        assert "thinkingBudget" not in payload
+
+    @pytest.mark.parametrize(
+        "cfg, expected",
+        [
+            ({"thinking_budget": 512}, {"thinkingBudget": 512}),
+            ({"thinking_budget": 0}, {"thinkingBudget": 0}),
+            ({"thinking_level": "HIGH"}, {"thinkingLevel": "HIGH"}),
+        ],
+    )
+    def test_single_field_passes_through_untouched(self, cfg, expected):
+        out = self._build(cfg)
+        payload = out["config"]["thinking_config"].model_dump(
+            exclude_none=True, by_alias=True
+        )
+        assert payload == expected
+
+    def test_budget_zero_with_level_still_resolves(self):
+        """Guard fires on PRESENCE, not truthiness — budget=0 is 'set'."""
+        out = self._build({"thinking_level": "MINIMAL", "thinking_budget": 0})
+        tc = out["config"]["thinking_config"]
+        assert tc.thinking_level == "MINIMAL"
+        assert tc.thinking_budget is None
+
+    def test_include_thoughts_survives_the_resolution(self):
+        out = self._build(
+            {
+                "thinking_level": "HIGH",
+                "thinking_budget": 256,
+                "include_thoughts": True,
+            }
+        )
+        tc = out["config"]["thinking_config"]
+        assert tc.include_thoughts is True
+        assert tc.thinking_level == "HIGH"
+        assert tc.thinking_budget is None
+
+    def test_thinking_config_instance_with_both_is_resolved(self):
+        from google.genai.types import ThinkingConfig
+
+        instance = ThinkingConfig(thinking_level="HIGH", thinking_budget=1024)
+        out = self._build(instance)
+        tc = out["config"]["thinking_config"]
+        assert tc.thinking_level == "HIGH"
+        assert tc.thinking_budget is None
+        # The caller's object is NOT mutated — a copy is returned.
+        assert instance.thinking_budget == 1024
+        assert tc is not instance
+
+    def test_thinking_config_instance_with_one_field_is_same_object(self):
+        from google.genai.types import ThinkingConfig
+
+        instance = ThinkingConfig(thinking_budget=512)
+        out = self._build(instance)
+        assert out["config"]["thinking_config"] is instance
+
+    def test_caller_dict_is_not_mutated(self):
+        cfg = {"thinking_level": "HIGH", "thinking_budget": 1024}
+        self._build(cfg)
+        assert cfg == {"thinking_level": "HIGH", "thinking_budget": 1024}
+
+    @pytest.mark.parametrize(
+        "model", ["gemini/gemini-2.5-flash", "gemini/gemini-3.5-flash"]
+    )
+    def test_guard_is_model_independent(self, model):
+        """No model allowlist / generation gate — the vendor check is global."""
+        out = self._build({"thinking_level": "HIGH", "thinking_budget": 1024}, model)
+        assert out["config"]["thinking_config"].thinking_budget is None

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_gemini_native.py
@@ -2521,6 +2521,63 @@ class TestThinkingConfigMutualExclusion:
         self._build(cfg)
         assert cfg == {"thinking_level": "HIGH", "thinking_budget": 1024}
 
+    # -- camelCase aliases ---------------------------------------------------
+    # google-genai's ThinkingConfig accepts the camelCase aliases as
+    # constructor kwargs, so a camelCase (or mixed-spelling) dict must not
+    # bypass the guard and land both fields on the wire.
+
+    def test_camel_case_both_set_drops_budget_keeps_level(self):
+        out = self._build({"thinkingLevel": "HIGH", "thinkingBudget": 1024})
+        tc = out["config"]["thinking_config"]
+        assert tc.thinking_level == "HIGH"
+        assert tc.thinking_budget is None
+
+    def test_camel_case_preserves_caller_key_spelling(self):
+        cfg = {"thinkingLevel": "HIGH", "thinkingBudget": 1024}
+        resolved = gemini_native._resolve_thinking_config_exclusion(cfg)
+        assert resolved == {"thinkingLevel": "HIGH"}
+        # Caller's dict untouched.
+        assert cfg == {"thinkingLevel": "HIGH", "thinkingBudget": 1024}
+
+    def test_camel_case_dropped_field_is_omitted_from_the_wire_shape(self):
+        out = self._build({"thinkingLevel": "HIGH", "thinkingBudget": 1024})
+        payload = out["config"]["thinking_config"].model_dump(
+            exclude_none=True, by_alias=True
+        )
+        assert payload == {"thinkingLevel": "HIGH"}
+        assert "thinkingBudget" not in payload
+
+    @pytest.mark.parametrize(
+        "cfg",
+        [
+            {"thinking_level": "HIGH", "thinkingBudget": 512},
+            {"thinkingLevel": "HIGH", "thinking_budget": 512},
+        ],
+    )
+    def test_mixed_spelling_both_set_drops_budget(self, cfg):
+        out = self._build(cfg)
+        tc = out["config"]["thinking_config"]
+        assert tc.thinking_level == "HIGH"
+        assert tc.thinking_budget is None
+        payload = tc.model_dump(exclude_none=True, by_alias=True)
+        assert "thinkingBudget" not in payload
+
+    @pytest.mark.parametrize(
+        "cfg, expected",
+        [
+            ({"thinkingLevel": "HIGH"}, {"thinkingLevel": "HIGH"}),
+            ({"thinkingBudget": 512}, {"thinkingBudget": 512}),
+            ({"thinkingBudget": 0}, {"thinkingBudget": 0}),
+        ],
+    )
+    def test_camel_case_single_field_passes_through_untouched(self, cfg, expected):
+        assert gemini_native._resolve_thinking_config_exclusion(cfg) is cfg
+        out = self._build(cfg)
+        payload = out["config"]["thinking_config"].model_dump(
+            exclude_none=True, by_alias=True
+        )
+        assert payload == expected
+
     @pytest.mark.parametrize(
         "model", ["gemini/gemini-2.5-flash", "gemini/gemini-3.5-flash"]
     )

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_sampling_param_gating.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_sampling_param_gating.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import pytest
 
 from _mcp_mesh.engine.native_clients._native_client_helpers import (
+    is_openai_reasoning_model,
+    restricts_anthropic_sampling_params,
     restricts_sampling_params,
     translate_max_tokens_for_restricted,
 )
@@ -224,3 +226,129 @@ class TestTranslateMaxTokensForRestricted:
         params = {"max_completion_tokens": 512}
         translate_max_tokens_for_restricted(params, "openai/o3-mini", self._log())
         assert params == {"max_completion_tokens": 512}
+
+
+# ---------------------------------------------------------------------------
+# Anthropic classifier truth table (#1344)
+# ---------------------------------------------------------------------------
+# Anthropic REMOVED temperature/top_p/top_k on the Opus 4.7+ / Sonnet 5 /
+# Fable 5 families — presence is HTTP 400. Narrower than the native
+# structured-output list: opus-4-6 / sonnet-4-6 / haiku-4-5 still accept them.
+
+
+class TestRestrictsAnthropicSamplingParams:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            # bare ids
+            "claude-sonnet-5",
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "claude-fable-5",
+            # anthropic/ prefix
+            "anthropic/claude-sonnet-5",
+            "anthropic/claude-opus-4-7",
+            "anthropic/claude-opus-4-8",
+            "anthropic/claude-fable-5",
+            # bedrock / databricks prefixes keep the ``anthropic.`` segment
+            "bedrock/anthropic.claude-opus-4-8-20260101-v1:0",
+            "databricks/anthropic.claude-sonnet-5",
+            # dot-separated version form
+            "anthropic/claude-opus-4.7",
+            "anthropic/claude-opus-4.8",
+            # date-pinned
+            "claude-sonnet-5-20260201",
+            # case-insensitive
+            "ANTHROPIC/CLAUDE-OPUS-4-8",
+        ],
+    )
+    def test_restricted_models(self, model):
+        assert restricts_anthropic_sampling_params(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            # Structured-output-capable but sampling params still accepted.
+            "anthropic/claude-opus-4-6",
+            "anthropic/claude-sonnet-4-6",
+            "anthropic/claude-haiku-4-5",
+            "anthropic/claude-sonnet-4-5",
+            "anthropic/claude-opus-4-5",
+            "anthropic/claude-opus-4-1",
+            "claude-3-5-sonnet-20241022",
+            "claude-3-opus-20240229",
+            "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+            # Boundary guard: a hypothetical future minor version must NOT
+            # match the shorter pattern.
+            "anthropic/claude-opus-4-70",
+            "anthropic/claude-opus-4-80",
+            "anthropic/claude-sonnet-50",
+            "anthropic/claude-fable-50",
+            # Leading-digit guard.
+            "anthropic/claude-opus-14-7",
+            # Other vendors.
+            "openai/gpt-4o",
+            "gemini/gemini-2.5-flash",
+            None,
+            "",
+        ],
+    )
+    def test_unrestricted_models(self, model):
+        assert restricts_anthropic_sampling_params(model) is False
+
+
+class TestGeneralizedRestrictsSamplingParams:
+    """The vendor-agnostic gate is the union of the two vendor predicates."""
+
+    @pytest.mark.parametrize(
+        "model",
+        ["o3-mini", "openai/gpt-5", "anthropic/claude-opus-4-8", "claude-sonnet-5"],
+    )
+    def test_union_matches(self, model):
+        assert restricts_sampling_params(model) is True
+
+    @pytest.mark.parametrize(
+        "model", ["gpt-4o", "anthropic/claude-sonnet-4-5", "gemini/gemini-2.5-flash"]
+    )
+    def test_union_does_not_match(self, model):
+        assert restricts_sampling_params(model) is False
+
+
+class TestIsOpenAiReasoningModelStaysOpenAiOnly:
+    """``is_openai_reasoning_model`` drives Responses-API routing (#1334) —
+    generalizing the sampling gate must NOT make Claude ids reasoning models.
+    """
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic/claude-opus-4-8",
+            "anthropic/claude-opus-4-7",
+            "anthropic/claude-sonnet-5",
+            "anthropic/claude-fable-5",
+        ],
+    )
+    def test_claude_is_not_an_openai_reasoning_model(self, model):
+        assert is_openai_reasoning_model(model) is False
+        # …even though the vendor-agnostic gate does match it.
+        assert restricts_sampling_params(model) is True
+
+    @pytest.mark.parametrize("model", ["o3-mini", "openai/gpt-5-mini"])
+    def test_openai_reasoning_unchanged(self, model):
+        assert is_openai_reasoning_model(model) is True
+
+
+class TestAnthropicMaxTokensUntouched:
+    """Anthropic REQUIRES max_tokens — the OpenAI-only
+    max_tokens → max_completion_tokens translation must not follow the
+    generalized gate onto Claude ids.
+    """
+
+    def test_restricted_claude_keeps_max_tokens(self):
+        import logging
+
+        params = {"max_tokens": 256}
+        translate_max_tokens_for_restricted(
+            params, "anthropic/claude-opus-4-8", logging.getLogger("t")
+        )
+        assert params == {"max_tokens": 256}

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_claude_handler_output_config.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/tests/test_claude_handler_output_config.py
@@ -1,11 +1,11 @@
 """Unit tests for ClaudeHandler's native ``output_config`` branch.
 
-The handler routes Sonnet 4.5+ / Opus 4.1+ buffered structured-output to a
-``response_format`` payload (which the native Anthropic adapter translates to
-``output_config.format`` on the wire) and stamps ``_mesh_output_config_mode``
-so the agentic loop skips synthetic-fallback recovery. Older Claude models
-(Haiku, Sonnet 3.x / 4.0, Opus 3.x) and the LiteLLM path keep their existing
-synthetic-tool / HINT behavior.
+The handler routes Sonnet 4.5+ / Opus 4.1+ / Haiku 4.5 buffered
+structured-output to a ``response_format`` payload (which the native Anthropic
+adapter translates to ``output_config.format`` on the wire) and stamps
+``_mesh_output_config_mode`` so the agentic loop skips synthetic-fallback
+recovery. Older Claude models (Haiku 3.x, Sonnet 3.x / 4.0, Opus 3.x) and the
+LiteLLM path keep their existing synthetic-tool / HINT behavior.
 
 Companion loop-side tests live in
 ``tests/unit/test_provider_agentic_loop_output_config.py``.
@@ -133,6 +133,34 @@ class TestApplyStructuredOutputOutputConfig:
         assert "response_format" in result
         assert result["_mesh_output_config_mode"] is True
         assert "_mesh_synthetic_format_tool" not in result
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic/claude-haiku-4-5",
+            "anthropic/claude-haiku-4.5",
+            "anthropic/claude-haiku-4-5-20251001",
+            "anthropic.claude-haiku-4-5-20251001-v1:0",
+        ],
+    )
+    def test_haiku_4_5_buffered_native_sets_response_format_and_sentinel(
+        self, _native_on, model
+    ):
+        """#1342: Haiku 4.5 accepts ``output_config.format``, so it takes the
+        native branch — NOT the synthetic-tool fallback used by Haiku 3.x."""
+        handler = ClaudeHandler()
+        params: dict = {
+            "messages": [{"role": "system", "content": "S"}]
+        }
+        result = handler.apply_structured_output(
+            _trip_schema(), "Trip", params, model=model
+        )
+
+        assert "response_format" in result
+        assert result["_mesh_output_config_mode"] is True
+        assert "_mesh_synthetic_format_tool" not in result
+        assert "_mesh_synthetic_format_tool_name" not in result
+        assert "_mesh_hint_mode" not in result
 
     @pytest.mark.parametrize(
         "model",
@@ -358,14 +386,16 @@ class TestApplyNativeOutputConfigStrictification:
         assert "minItems" not in rf_tags
 
 
-class TestApplyStructuredOutputHaikuFallsThroughToSynthetic:
-    """Haiku / older Claude models route to the synthetic-tool path even on
-    the native SDK — they don't accept ``output_config.format``."""
+class TestApplyStructuredOutputLegacyModelsFallThroughToSynthetic:
+    """Pre-``output_config`` Claude models (Haiku 3.x, Sonnet 3.x / 4.0,
+    Opus 3.x) route to the synthetic-tool path even on the native SDK — they
+    don't accept ``output_config.format``. Haiku 4.5 does accept it (#1342)
+    and is asserted on the native branch above."""
 
     @pytest.mark.parametrize(
         "model",
         [
-            "anthropic/claude-haiku-4-5",
+            "anthropic/claude-3-haiku-20240307",
             "anthropic/claude-3-5-haiku-20241022",
             "anthropic/claude-3-5-sonnet-20241022",  # Sonnet 3.5 (pre-4.5)
             "anthropic/claude-3-opus-20240229",  # Opus 3 (pre-4.1)

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -2408,29 +2408,50 @@ def _sanitize_sampling_params(
     completion_args: dict[str, Any], effective_model: str
 ) -> None:
     """Rewrite restricted-model sampling params in ``completion_args`` in place
-    when the effective OpenAI model rejects them (o-series / gpt-5 non-chat).
+    when the effective model rejects them.
 
-    OpenAI reasoning models and the gpt-5 family (except gpt-5-chat) return
-    HTTP 400 for any explicit ``temperature``/``top_p`` and for the raw
-    ``max_tokens`` param. For those models this:
+    Two vendor branches:
 
-      * pops ``temperature``/``top_p`` (only the default is accepted), and
-      * translates ``max_tokens`` → ``max_completion_tokens`` (unless a
-        ``max_completion_tokens`` is already present, which wins), popping the
-        raw ``max_tokens`` so it never reaches the wire.
+      * **Anthropic** (Opus 4.7+ / Sonnet 5 / Fable 5) — ``temperature``,
+        ``top_p`` and ``top_k`` were REMOVED; their presence is HTTP 400. All
+        three are popped. ``max_tokens`` is required by Anthropic and left
+        alone (#1344).
+      * **OpenAI** (o-series / gpt-5 non-chat) — return HTTP 400 for any
+        explicit ``temperature``/``top_p`` and for the raw ``max_tokens``. Those
+        two sampling params are popped and ``max_tokens`` is translated to
+        ``max_completion_tokens`` (unless a ``max_completion_tokens`` is already
+        present, which wins), popping the raw ``max_tokens`` so it never reaches
+        the wire.
 
-    Each rewrite emits a WARN (soft-fail, mesh philosophy). The classifier
-    strips the vendor prefix and matches only OpenAI restricted names, so this
-    is a safe no-op for gemini/anthropic and for unrestricted OpenAI models
-    (gpt-4o, gpt-4.1, gpt-5-chat-latest). Only present params are touched —
-    mesh sends no defaults, so an unset value is left unset.
+    Each rewrite emits a WARN (soft-fail, mesh philosophy). Non-matching models
+    are untouched, so this is a safe no-op for gemini, for unrestricted OpenAI
+    models (gpt-4o, gpt-4.1, gpt-5-chat-latest) and for unrestricted Claude
+    models (opus-4-6, sonnet-4-6, haiku-4-5, 3.x). Only present params are
+    touched — mesh sends no defaults, so an unset value is left unset.
     """
     from _mcp_mesh.engine.native_clients._native_client_helpers import (
-        restricts_sampling_params,
+        SAMPLING_PARAM_KEYS,
+        restricts_anthropic_sampling_params,
+        restricts_openai_sampling_params,
         translate_max_tokens_for_restricted,
     )
 
-    if not restricts_sampling_params(effective_model):
+    if restricts_anthropic_sampling_params(effective_model):
+        for key in SAMPLING_PARAM_KEYS:
+            if completion_args.get(key) is not None:
+                value = completion_args.pop(key)
+                logger.warning(
+                    "Anthropic model %s rejects %s; omitting %s=%s "
+                    "(sampling params are not supported by this model family)",
+                    effective_model,
+                    key,
+                    key,
+                    value,
+                )
+        # Anthropic REQUIRES max_tokens — no translation, no removal.
+        return
+
+    if not restricts_openai_sampling_params(effective_model):
         return
     for key in ("temperature", "top_p"):
         if completion_args.get(key) is not None:

--- a/src/runtime/python/tests/unit/test_llm_sampling_param_gating.py
+++ b/src/runtime/python/tests/unit/test_llm_sampling_param_gating.py
@@ -143,3 +143,73 @@ class TestBuildIterationCompletionArgsGating:
         args = self._build("gpt-4o", {"temperature": 0.7, "top_p": 0.9})
         assert args["temperature"] == 0.7
         assert args["top_p"] == 0.9
+
+
+# ---------------------------------------------------------------------------
+# Anthropic branch (#1344)
+# ---------------------------------------------------------------------------
+# Anthropic REMOVED temperature/top_p/top_k on Opus 4.7+ / Sonnet 5 / Fable 5;
+# their presence is HTTP 400. The sanitizer must strip all three for those
+# families and leave max_tokens alone (Anthropic REQUIRES it).
+
+
+class TestSanitizeSamplingParamsAnthropic:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic/claude-opus-4-7",
+            "anthropic/claude-opus-4-8",
+            "anthropic/claude-sonnet-5",
+            "anthropic/claude-fable-5",
+            "bedrock/anthropic.claude-opus-4-8-20260101-v1:0",
+            "databricks/anthropic.claude-sonnet-5",
+            "claude-opus-4-8",
+        ],
+    )
+    def test_restricted_claude_pops_all_three(self, model):
+        args = {"temperature": 0.7, "top_p": 0.9, "top_k": 40, "model": model}
+        _sanitize_sampling_params(args, model)
+        assert args == {"model": model}
+
+    def test_restricted_claude_keeps_max_tokens(self):
+        args = {"temperature": 0.7, "max_tokens": 1024}
+        _sanitize_sampling_params(args, "anthropic/claude-opus-4-8")
+        assert args == {"max_tokens": 1024}
+        assert "max_completion_tokens" not in args
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic/claude-opus-4-6",
+            "anthropic/claude-sonnet-4-6",
+            "anthropic/claude-haiku-4-5",
+            "anthropic/claude-sonnet-4-5",
+            "anthropic/claude-opus-4-1",
+            "claude-3-5-sonnet-20241022",
+            # Boundary guard.
+            "anthropic/claude-opus-4-70",
+        ],
+    )
+    def test_unrestricted_claude_is_noop(self, model):
+        args = {"temperature": 0.7, "top_p": 0.9, "top_k": 40, "max_tokens": 512}
+        _sanitize_sampling_params(args, model)
+        assert args == {
+            "temperature": 0.7,
+            "top_p": 0.9,
+            "top_k": 40,
+            "max_tokens": 512,
+        }
+
+    def test_restricted_claude_warns_per_dropped_key(self, caplog):
+        args = {"temperature": 0.7, "top_p": 0.9, "top_k": 40}
+        with caplog.at_level(logging.WARNING):
+            _sanitize_sampling_params(args, "anthropic/claude-opus-4-8")
+        warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("temperature" in m for m in warnings)
+        assert any("top_p" in m for m in warnings)
+        assert any("top_k" in m for m in warnings)
+
+    def test_unset_params_are_left_unset(self):
+        args = {"temperature": 0.7}
+        _sanitize_sampling_params(args, "anthropic/claude-sonnet-5")
+        assert args == {}

--- a/src/runtime/typescript/src/__tests__/llm-provider-sampling-gating.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-provider-sampling-gating.test.ts
@@ -38,7 +38,11 @@ vi.mock("../tracing.js", () => ({
   matchesPropagateHeader: () => false,
 }));
 
-import { llmProvider, restrictsSamplingParams } from "../llm-provider.js";
+import {
+  llmProvider,
+  restrictsAnthropicSamplingParams,
+  restrictsSamplingParams,
+} from "../llm-provider.js";
 
 // ----------------------------------------------------------------------------
 // Classifier truth table
@@ -244,5 +248,164 @@ describe("OpenAI sampling-param gating — vendor call options", () => {
     const opts = generateObjectMock.mock.calls[0][0] as Record<string, unknown>;
     expect(opts.temperature).toBe(0.7);
     expect(opts.topP).toBe(0.9);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Anthropic classifier truth table (#1344)
+// ----------------------------------------------------------------------------
+// Anthropic REMOVED temperature/top_p/top_k on the Opus 4.7+ / Sonnet 5 /
+// Fable 5 families — presence is a hard HTTP 400. Narrower than the native
+// structured-output model set: opus-4-6 / sonnet-4-6 / haiku-4-5 still accept
+// sampling params and must NOT be caught. Mirrors Python
+// `restricts_anthropic_sampling_params` / Java
+// `AnthropicHandler.restrictsSamplingParams`.
+
+describe("restrictsAnthropicSamplingParams truth table", () => {
+  it.each([
+    "claude-sonnet-5",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-fable-5",
+    "anthropic/claude-sonnet-5",
+    "anthropic/claude-opus-4-7",
+    "anthropic/claude-opus-4-8",
+    "anthropic/claude-fable-5",
+    "bedrock/anthropic.claude-opus-4-8-20260101-v1:0",
+    "databricks/anthropic.claude-sonnet-5",
+    "anthropic/claude-opus-4.7",
+    "anthropic/claude-opus-4.8",
+    "claude-sonnet-5-20260201",
+    "ANTHROPIC/CLAUDE-OPUS-4-8", // case-insensitive
+  ])("restricts %s", (model) => {
+    expect(restrictsAnthropicSamplingParams(model)).toBe(true);
+    expect(restrictsSamplingParams(model)).toBe(true);
+  });
+
+  it.each([
+    "anthropic/claude-opus-4-6",
+    "anthropic/claude-sonnet-4-6",
+    "anthropic/claude-haiku-4-5",
+    "anthropic/claude-sonnet-4-5",
+    "anthropic/claude-opus-4-5",
+    "anthropic/claude-opus-4-1",
+    "claude-3-5-sonnet-20241022",
+    "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+    // Boundary guard: a hypothetical future minor version must NOT match the
+    // shorter pattern.
+    "anthropic/claude-opus-4-70",
+    "anthropic/claude-opus-4-80",
+    "anthropic/claude-sonnet-50",
+    "anthropic/claude-fable-50",
+    // Leading-digit guard.
+    "anthropic/claude-opus-14-7",
+    "openai/gpt-4o",
+    "gemini/gemini-2.5-flash",
+    undefined,
+    null,
+    "",
+  ])("does not restrict %s", (model) => {
+    expect(
+      restrictsAnthropicSamplingParams(model as string | undefined | null),
+    ).toBe(false);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Behavioral — Anthropic (#1344)
+// ----------------------------------------------------------------------------
+
+describe("Anthropic sampling-param gating — vendor call options", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.env.ANTHROPIC_API_KEY = "sk-test";
+    generateObjectMock.mockReset();
+    generateTextMock.mockReset();
+    generateObjectMock.mockResolvedValue({
+      object: { answer: "ok" },
+      usage: { inputTokens: 1, outputTokens: 1 },
+      finishReason: "stop",
+    });
+    generateTextMock.mockResolvedValue({
+      text: "ok",
+      toolCalls: [],
+      usage: { inputTokens: 1, outputTokens: 1 },
+      finishReason: "stop",
+    });
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    "anthropic/claude-opus-4-8",
+    "anthropic/claude-opus-4-7",
+    "anthropic/claude-sonnet-5",
+    "anthropic/claude-fable-5",
+  ])("omits temperature/topP for a restricted model (%s)", async (model) => {
+    const tool = llmProvider({
+      model,
+      capability: "llm",
+      temperature: 0.7,
+      topP: 0.9,
+    });
+    await tool.execute(baseRequest({}) as never);
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    const opts = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect("temperature" in opts).toBe(false);
+    expect("topP" in opts).toBe(false);
+    // mesh surfaces its own warning (one per omitted param).
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    "anthropic/claude-opus-4-6",
+    "anthropic/claude-sonnet-4-6",
+    "anthropic/claude-haiku-4-5",
+    "anthropic/claude-opus-4-70",
+  ])("keeps temperature/topP for an unrestricted model (%s)", async (model) => {
+    const tool = llmProvider({
+      model,
+      capability: "llm",
+      temperature: 0.7,
+      topP: 0.9,
+    });
+    await tool.execute(baseRequest({}) as never);
+
+    const opts = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.temperature).toBe(0.7);
+    expect(opts.topP).toBe(0.9);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("omits temperature/topP supplied via model_params for a restricted model", async () => {
+    const tool = llmProvider({
+      model: "anthropic/claude-opus-4-8",
+      capability: "llm",
+    });
+    await tool.execute(baseRequest({ temperature: 0.3, top_p: 0.5 }) as never);
+
+    const opts = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect("temperature" in opts).toBe(false);
+    expect("topP" in opts).toBe(false);
+  });
+
+  it("does not touch maxOutputTokens for a restricted model", async () => {
+    // Anthropic REQUIRES max_tokens — the gate must never strip it.
+    const tool = llmProvider({
+      model: "anthropic/claude-opus-4-8",
+      capability: "llm",
+      maxOutputTokens: 4096,
+      temperature: 0.7,
+    });
+    await tool.execute(baseRequest({}) as never);
+
+    const opts = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(opts.maxOutputTokens).toBe(4096);
+    expect("temperature" in opts).toBe(false);
   });
 });

--- a/src/runtime/typescript/src/llm-provider.ts
+++ b/src/runtime/typescript/src/llm-provider.ts
@@ -241,9 +241,9 @@ export function extractModelName(model: string): string {
  * Accepts a bare or ``vendor/``-qualified model string (e.g. "openai/o3-mini").
  * Returns true when ``temperature``/``topP`` should be omitted. Mirrors the
  * Java ``OpenAiHandler.restrictsSamplingParams`` and Python
- * ``restricts_sampling_params``.
+ * ``restricts_openai_sampling_params``.
  */
-export function restrictsSamplingParams(model: string | undefined | null): boolean {
+export function restrictsOpenAiSamplingParams(model: string | undefined | null): boolean {
   if (!model) return false;
   let m = model.toLowerCase();
   const slash = m.indexOf("/");
@@ -262,32 +262,77 @@ export function restrictsSamplingParams(model: string | undefined | null): boole
 }
 
 /**
+ * Anthropic REMOVED ``temperature``/``top_p``/``top_k`` on the Opus 4.7+ /
+ * Sonnet 5 / Fable 5 families — their presence is a hard HTTP 400 (#1344).
+ *
+ * Deliberately NARROWER than the native structured-output model list:
+ * ``opus-4-6``, ``sonnet-4-6`` and ``haiku-4-5`` still ACCEPT sampling params
+ * and must not be caught.
+ *
+ * Patterns (not raw substrings) so the trailing minor-version digit is
+ * boundary-anchored — ``opus-4-7`` must NOT match a hypothetical future
+ * ``opus-4-70``. Both dash and dot separators are accepted (callers pass both
+ * forms), and the match is unanchored so vendor prefixes (`anthropic/`,
+ * `bedrock/anthropic.`, `databricks/anthropic.`) and date-pinned Bedrock ids
+ * still match. Mirrors Python ``restricts_anthropic_sampling_params`` and Java
+ * ``AnthropicHandler.restrictsSamplingParams``.
+ */
+const ANTHROPIC_SAMPLING_RESTRICTED_MODEL_PATTERNS: RegExp[] = [
+  /(?<!\d)sonnet-5(?!\d)/i,
+  /(?<!\d)opus-4[-.]7(?!\d)/i,
+  /(?<!\d)opus-4[-.]8(?!\d)/i,
+  /(?<!\d)fable-5(?!\d)/i,
+];
+
+export function restrictsAnthropicSamplingParams(model: string | undefined | null): boolean {
+  if (!model) return false;
+  return ANTHROPIC_SAMPLING_RESTRICTED_MODEL_PATTERNS.some((p) => p.test(model));
+}
+
+/**
+ * Vendor-agnostic gate: does `model` reject explicitly-set sampling params?
+ * Union of the OpenAI (only-the-default) and Anthropic (removed entirely)
+ * predicates.
+ */
+export function restrictsSamplingParams(model: string | undefined | null): boolean {
+  return restrictsOpenAiSamplingParams(model) || restrictsAnthropicSamplingParams(model);
+}
+
+/**
  * Remove ``temperature``/``topP`` from a fully-assembled request options object
- * for OpenAI models that reject non-default sampling params (see
+ * for models that reject explicitly-set sampling params (see
  * {@link restrictsSamplingParams}). No-op for unrestricted models and when the
  * param is absent (mesh sends no default unless configured).
  *
  * This is version-independent hardening: it makes mesh self-contained rather
- * than silently relying on @ai-sdk/openai to strip these, and surfaces mesh's
+ * than silently relying on the vendor SDK to strip these, and surfaces mesh's
  * OWN warning (the SDK's `warnings` array is not surfaced by mesh). One warning
- * is logged per omitted param. Does NOT touch maxOutputTokens.
+ * is logged per omitted param. Does NOT touch maxOutputTokens (Anthropic
+ * REQUIRES max_tokens).
+ *
+ * TS does not plumb `topK`, so only `temperature`/`topP` are handled here.
  */
 export function sanitizeSamplingParams(
   options: { temperature?: number; topP?: number },
   model: string | undefined | null,
 ): void {
-  if (!restrictsSamplingParams(model)) return;
+  const anthropicRestricted = restrictsAnthropicSamplingParams(model);
+  if (!anthropicRestricted && !restrictsOpenAiSamplingParams(model)) return;
+  const vendor = anthropicRestricted ? "Anthropic" : "OpenAI";
+  const reason = anthropicRestricted
+    ? "sampling params are not supported by this model family"
+    : "only the default is supported";
   if (options.temperature !== undefined) {
     console.warn(
-      `OpenAI model ${model} rejects temperature=${options.temperature}; ` +
-        `omitting it (only the default is supported)`
+      `${vendor} model ${model} rejects temperature=${options.temperature}; ` +
+        `omitting it (${reason})`
     );
     delete options.temperature;
   }
   if (options.topP !== undefined) {
     console.warn(
-      `OpenAI model ${model} rejects top_p=${options.topP}; ` +
-        `omitting it (only the default is supported)`
+      `${vendor} model ${model} rejects top_p=${options.topP}; ` +
+        `omitting it (${reason})`
     );
     delete options.topP;
   }
@@ -996,9 +1041,10 @@ export function llmProvider(config: LlmProviderConfig): {
     }
 
     // Version-independent hardening: OpenAI o-series (o1/o3/o4) and gpt-5
-    // (except gpt-5-chat) reject non-default temperature/top_p with HTTP 400.
+    // (except gpt-5-chat) reject non-default temperature/top_p with HTTP 400,
+    // and Anthropic Opus 4.7+ / Sonnet 5 / Fable 5 removed them outright (#1344).
     // Strip them from the fully-assembled options BEFORE handing off to the
-    // SDK (rather than relying on @ai-sdk/openai to strip them silently), and
+    // SDK (rather than relying on the vendor SDK to strip them silently), and
     // surface mesh's own warning. Sanitizing requestOptions here covers BOTH
     // generateText call sites (the manual agentic loop and the plain/Gemini
     // path both consume requestOptions) AND the generateObject structured path,
@@ -1078,8 +1124,8 @@ export function llmProvider(config: LlmProviderConfig): {
       const strictSchema = makeSchemaStrict(cleanSchema as Record<string, unknown>, { addAllRequired: true });
 
       // temperature/topP inherit from requestOptions, which has already been
-      // run through sanitizeSamplingParams above — so for restricted OpenAI
-      // models these are already stripped (undefined) here. Only include a key
+      // run through sanitizeSamplingParams above — so for restricted OpenAI /
+      // Anthropic models these are already stripped (undefined) here. Only include a key
       // when it is actually set so the vendor call carries NO temperature/topP
       // for restricted models (mirrors Java/Python omission, not "pass null").
       const generateObjectOptions: {


### PR DESCRIPTION
Three related fixes for the 3.2.2 patch. All three are vendor-contract or coverage issues; no API surface changes.

---

## 1. Anthropic sampling params (#1344)

Anthropic **removed** `temperature` / `top_p` / `top_k` on Opus 4.7, Opus 4.8, Sonnet 5 and Fable 5 — passing any of them is a hard 400. The native path forwarded them unconditionally with no model gating, and mesh already advertises first-class support for exactly those ids on the native `output_config` path. A provider declared on a current model with any sampling knob set failed at the vendor call.

Fixed by **generalizing the existing sanitizer** rather than adding a parallel predicate — the call sites already existed on every path; only the gate was OpenAI-shaped. `restricts_sampling_params` is now the vendor-agnostic union of `restricts_openai_sampling_params` and a new `restricts_anthropic_sampling_params`. Mirrored in TypeScript (`llm-provider.ts`) and Java (`AnthropicHandler`, mirroring the shape already in `OpenAiHandler`).

Patterns use the boundary-anchored convention already established by `_NATIVE_OUTPUT_FORMAT_MODEL_PATTERNS`, so `opus-4-7` can never match `opus-4-70`:

```python
r"(?<!\d)sonnet-5(?!\d)", r"(?<!\d)opus-4[-.]7(?!\d)",
r"(?<!\d)opus-4[-.]8(?!\d)", r"(?<!\d)fable-5(?!\d)"
```

The restricted set is deliberately **narrower** than the structured-output list: `opus-4-6`, `sonnet-4-6` and `haiku-4-5` are on that list but still accept sampling params, and must not be caught. Works across bare, `anthropic/`, `bedrock/anthropic.` and `databricks/anthropic.` forms.

**Two things stay deliberately separate — both would be silent bugs otherwise:**

- `is_openai_reasoning_model` remains aliased to the **OpenAI-only** predicate. It drives OpenAI Responses-API routing (#1334); pointing it at the union would route Claude ids down the OpenAI Responses path. Pinned by a dedicated test class asserting Claude ids are `False` for the reasoning predicate but `True` for the sampling gate.
- `translate_max_tokens_for_restricted` likewise stays OpenAI-only. Anthropic **requires** `max_tokens` and has no `max_completion_tokens`, so following the generalized gate there would have translated a required param into a nonexistent one.

Also fixes a pre-existing ordering bug in `AnthropicHandler.applyModelParams`: the effective model was resolved *after* the params were applied, so a gate keyed on it would have read nothing.

Behavior on match: drop the param with a once-per-key WARN. Dropping degrades gracefully; forwarding is a hard 400 — the failure is asymmetric.

## 2. Gemini thinking config (#1346)

The original issue proposed a model-generation gate. **Measurement against the live API showed that would have been wrong**, and the correction is recorded on the issue. In brief:

- `thinking_budget` is **not** generation-split — accepted *and honored* on 2.5 and 3.x alike (verified via `thoughtsTokenCount`)
- `thinking_level` splits **per-model**, not per-generation: pro-class rejects `MINIMAL`, `gemini-3.1-flash-image` accepts only `MINIMAL`/`HIGH`, Gemma 4 takes level but rejects budget, `*-latest` aliases don't version-parse
- ListModels' `thinking` boolean doesn't discriminate and is `true` on Gemma 4, which rejects budget
- Sampling params need no gate at all here — all three are accepted on every current model

So this implements **only** the model-independent guard: `thinking_level` + `thinking_budget` in one request is a global 400 (`You can only set only one of thinking budget and thinking level.`), fired by field *presence*, before any per-model check. Guarded client-side, keeping `thinking_level` and dropping `thinking_budget` **by omission** — never by writing the `THINKING_LEVEL_UNSPECIFIED` sentinel, which triggers the same 400. A test asserts the serialized payload contains no `thinkingBudget` key.

No allowlist, no `_gemini_major` gate. A version gate would be wrong today and would rot on every model launch — the same manual-sync-point failure that produced #1345.

TS and Java need no guard: `thinking_config` never reaches the Google provider from a TS provider, and `GeminiHandler` has no thinking plumbing at all.

## 3. CI blind spot (#1348)

CI ran exactly one Python test invocation — `pytest tests/unit/` — leaving the **20-file `_mcp_mesh/**/tests/` tree unexecuted since it was created**, including the native LLM clients and provider handlers: the most vendor-drift-prone code in the repo.

**Eight tests in it were red on released v3.2.1.** They fixture on `claude-haiku-4-5` and assert the synthetic-tool path, which #1342 deliberately inverted after confirming live that Haiku 4.5 accepts `output_config`. Not flaky — an accurate record of behavior we changed and never updated, in a place CI structurally could not see.

- `ci.yml:238` → `pytest tests/unit/ _mcp_mesh/`
- Synthetic-path coverage **re-fixtured** onto `claude-3-haiku-20240307` rather than deleted, so the fallback path stays covered
- The choice is pinned by an executable guard, so a future allow-list addition fails loudly instead of silently testing the wrong branch:
  ```python
  def test_synthetic_path_model_is_not_native_capable():
      assert not anthropic_native._supports_native_output_format(_SYNTHETIC_PATH_MODEL)
  ```
- `TestApplyStructuredOutputHaikuFallsThroughToSynthetic` renamed — the name became false after #1342
- **Handler-level Haiku 4.5 coverage was missing entirely.** #1342 changed `ClaudeHandler` routing but shipped only adapter-level tests, so the handler branch it depended on was untested. Added across 4 id shapes (dash, dot, date-pinned, Bedrock-prefixed).

No `skip`/`xfail` used. Cost: ~2s on a ~70s job; a matrix split would cost more in runner startup than the tests take.

---

## Verification

- Combined CI-equivalent invocation from `src/runtime/python`: **2372 passed, 2 skipped** (opt-in live-integration only), exit 0, no collection errors, no basename collisions
- TypeScript: 83 files, **1179 passed**
- Java: **987 tests**, 0 failures across 4 modules
- Re-verified after rebase onto `main` @ 3d6619c80

Closes #1344
Closes #1346
Closes #1348

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unsupported sampling parameters from being sent to restricted Anthropic and OpenAI model families (temperature/top-p/top-k), while preserving token limits.
  * Added model-aware, per-parameter warnings when sampling options are omitted.
  * Fixed Gemini request construction to resolve mutual exclusivity between thinking settings to avoid invalid requests.
  * Improved structured-output routing and model compatibility for newer Claude variants (including Haiku 4.5).
* **Tests**
  * Expanded sampling-parameter gating coverage across Python, TypeScript, and Java, including warning behavior and max-token translation rules.
  * Added coverage for Gemini thinking config mutual exclusion and Anthropic response-format synthetic path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->