### PR TITLE
feat(ui): show MCP tool and endpoint in the agent detail side panel

### DIFF
--- a/cmd/mcp-mesh-ui/dist/index.html
+++ b/cmd/mcp-mesh-ui/dist/index.html
@@ -10,8 +10,8 @@
       window.__MESH_BASE_PATH__ = window.__MESH_BASE_PATH__ || "";
       window.__MESH_REGISTRY_URL__ = window.__MESH_REGISTRY_URL__ || "";
     </script>
-    <script type="module" crossorigin src="./assets/index-CQT5X4Kv.js"></script>
-    <link rel="stylesheet" crossorigin href="./assets/index-C8jMKAKW.css">
+    <script type="module" crossorigin src="./assets/index-Hv4E7O7T.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-6yT8cErM.css">
   </head>
   <body class="antialiased">
     <div id="root"></div>

--- a/cmd/mcp-mesh-ui/dist/index.html
+++ b/cmd/mcp-mesh-ui/dist/index.html
@@ -10,7 +10,7 @@
       window.__MESH_BASE_PATH__ = window.__MESH_BASE_PATH__ || "";
       window.__MESH_REGISTRY_URL__ = window.__MESH_REGISTRY_URL__ || "";
     </script>
-    <script type="module" crossorigin src="./assets/index-CSLaz6-u.js"></script>
+    <script type="module" crossorigin src="./assets/index-CQT5X4Kv.js"></script>
     <link rel="stylesheet" crossorigin href="./assets/index-C8jMKAKW.css">
   </head>
   <body class="antialiased">

--- a/src/ui/components/agents/AgentDetail.tsx
+++ b/src/ui/components/agents/AgentDetail.tsx
@@ -349,12 +349,12 @@ export function AgentDetail({ agent }: AgentDetailProps) {
                         </div>
                         <StatusBadge status={res.status} />
                       </div>
-                      {(res.provider_agent_id || res.provider_function_name || res.endpoint) && (
+                      {(res.provider_agent_id || res.mcp_tool || res.endpoint) && (
                         <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
                           {res.provider_agent_id && (
                             <span>Provider: <span className={getDepStatusColor(res.status)}>{res.provider_agent_id}</span></span>
                           )}
-                          {res.provider_function_name && <span>Function: {res.provider_function_name}</span>}
+                          {res.mcp_tool && <span>MCP Tool: {res.mcp_tool}</span>}
                           {res.provider_capability && <span>Capability: {res.provider_capability}</span>}
                           {res.endpoint && (
                             <span className="font-mono truncate max-w-xs">{res.endpoint}</span>
@@ -395,12 +395,12 @@ export function AgentDetail({ agent }: AgentDetailProps) {
                         </div>
                         <StatusBadge status={res.status} />
                       </div>
-                      {(res.provider_agent_id || res.provider_function_name || res.endpoint) && (
+                      {(res.provider_agent_id || res.mcp_tool || res.endpoint) && (
                         <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
                           {res.provider_agent_id && (
                             <span>Provider: <span className={getDepStatusColor(res.status)}>{res.provider_agent_id}</span></span>
                           )}
-                          {res.provider_function_name && <span>Function: {res.provider_function_name}</span>}
+                          {res.mcp_tool && <span>MCP Tool: {res.mcp_tool}</span>}
                           {res.endpoint && (
                             <span className="font-mono truncate max-w-xs">{res.endpoint}</span>
                           )}

--- a/src/ui/components/agents/AgentGrid.tsx
+++ b/src/ui/components/agents/AgentGrid.tsx
@@ -96,7 +96,10 @@ function AgentGroupDrawer({ group, onClose }: AgentGroupDrawerProps) {
         </div>
 
         {/* Scrollable content */}
-        <ScrollArea className="flex-1 overflow-auto">
+        {/* Radix lays the viewport content out in a `display: table` wrapper, which
+            shrink-to-fits to the widest child and defeats `truncate` on long
+            endpoints — force it back to a block so the 360px panel constrains width. */}
+        <ScrollArea className="flex-1 overflow-auto [&>[data-radix-scroll-area-viewport]>div]:block!">
           <div className="p-4">
             <AgentGroupDetail name={group.name} instances={group.instances} />
           </div>

--- a/src/ui/components/agents/AgentGroupDetail.tsx
+++ b/src/ui/components/agents/AgentGroupDetail.tsx
@@ -141,8 +141,13 @@ export function AgentDetailBlock({ agent }: { agent: Agent }) {
                 </div>
                 <p className="text-[10px] text-muted-foreground">
                   {dep.capability}
-                  {dep.mcp_tool ? ` (tool: ${dep.mcp_tool})` : ""}
+                  {dep.mcp_tool ? ` · ${dep.mcp_tool}` : ""}
                 </p>
+                {dep.endpoint && (
+                  <p className="text-[10px] text-muted-foreground/80 font-mono truncate" title={dep.endpoint}>
+                    {dep.endpoint}
+                  </p>
+                )}
               </div>
             ))}
           </div>
@@ -163,7 +168,15 @@ export function AgentDetailBlock({ agent }: { agent: Agent }) {
                   </div>
                   <DepStatusBadge status={llm.status} />
                 </div>
-                <p className="text-[10px] text-muted-foreground">{llm.filter_capability}</p>
+                <p className="text-[10px] text-muted-foreground">
+                  {llm.filter_capability}
+                  {llm.mcp_tool ? ` · ${llm.mcp_tool}` : ""}
+                </p>
+                {llm.endpoint && (
+                  <p className="text-[10px] text-muted-foreground/80 font-mono truncate" title={llm.endpoint}>
+                    {llm.endpoint}
+                  </p>
+                )}
               </div>
             ))}
           </div>
@@ -184,7 +197,15 @@ export function AgentDetailBlock({ agent }: { agent: Agent }) {
                   </div>
                   <DepStatusBadge status={prov.status} />
                 </div>
-                <p className="text-[10px] text-muted-foreground">{prov.required_capability}</p>
+                <p className="text-[10px] text-muted-foreground">
+                  {prov.required_capability}
+                  {prov.mcp_tool ? ` · ${prov.mcp_tool}` : ""}
+                </p>
+                {prov.endpoint && (
+                  <p className="text-[10px] text-muted-foreground/80 font-mono truncate" title={prov.endpoint}>
+                    {prov.endpoint}
+                  </p>
+                )}
               </div>
             ))}
           </div>

--- a/src/ui/components/agents/AgentGroupDetail.tsx
+++ b/src/ui/components/agents/AgentGroupDetail.tsx
@@ -37,6 +37,16 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
   return <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">{children}</h3>;
 }
 
+// Context line under a resolution row (capability · mcp tool). The registry can
+// return an empty string for either part — not just null/undefined — so parts
+// are filtered on truthiness and joined, and the whole line is dropped when
+// nothing is left rather than rendering an empty <p> or an orphaned separator.
+function ResolutionContextLine({ parts }: { parts: (string | null | undefined)[] }) {
+  const text = parts.filter((p): p is string => !!p).join(" · ");
+  if (!text) return null;
+  return <p className="text-[10px] text-muted-foreground">{text}</p>;
+}
+
 // Per-agent detail block — used for both single-agent selection and each
 // expanded accordion item in a group selection.
 export function AgentDetailBlock({ agent }: { agent: Agent }) {
@@ -139,10 +149,7 @@ export function AgentDetailBlock({ agent }: { agent: Agent }) {
                   </div>
                   <DepStatusBadge status={dep.status} />
                 </div>
-                <p className="text-[10px] text-muted-foreground">
-                  {dep.capability}
-                  {dep.mcp_tool ? ` · ${dep.mcp_tool}` : ""}
-                </p>
+                <ResolutionContextLine parts={[dep.capability, dep.mcp_tool]} />
                 {dep.endpoint && (
                   <p className="text-[10px] text-muted-foreground/80 font-mono truncate" title={dep.endpoint}>
                     {dep.endpoint}
@@ -168,10 +175,7 @@ export function AgentDetailBlock({ agent }: { agent: Agent }) {
                   </div>
                   <DepStatusBadge status={llm.status} />
                 </div>
-                <p className="text-[10px] text-muted-foreground">
-                  {llm.filter_capability}
-                  {llm.mcp_tool ? ` · ${llm.mcp_tool}` : ""}
-                </p>
+                <ResolutionContextLine parts={[llm.filter_capability, llm.mcp_tool]} />
                 {llm.endpoint && (
                   <p className="text-[10px] text-muted-foreground/80 font-mono truncate" title={llm.endpoint}>
                     {llm.endpoint}
@@ -197,10 +201,7 @@ export function AgentDetailBlock({ agent }: { agent: Agent }) {
                   </div>
                   <DepStatusBadge status={prov.status} />
                 </div>
-                <p className="text-[10px] text-muted-foreground">
-                  {prov.required_capability}
-                  {prov.mcp_tool ? ` · ${prov.mcp_tool}` : ""}
-                </p>
+                <ResolutionContextLine parts={[prov.required_capability, prov.mcp_tool]} />
                 {prov.endpoint && (
                   <p className="text-[10px] text-muted-foreground/80 font-mono truncate" title={prov.endpoint}>
                     {prov.endpoint}

--- a/src/ui/components/topology/TopologySidebar.tsx
+++ b/src/ui/components/topology/TopologySidebar.tsx
@@ -40,7 +40,7 @@ export function TopologySidebar({ selection, onClose }: TopologySidebarProps) {
         </div>
 
         {/* Scrollable content */}
-        <ScrollArea className="flex-1 overflow-auto">
+        <ScrollArea className="flex-1 overflow-auto [&>[data-radix-scroll-area-viewport]>div]:block!">
           <div className="p-4">
             <AgentDetailBlock agent={agent} />
           </div>
@@ -73,7 +73,7 @@ export function TopologySidebar({ selection, onClose }: TopologySidebarProps) {
       </div>
 
       {/* Scrollable content */}
-      <ScrollArea className="flex-1 overflow-auto">
+      <ScrollArea className="flex-1 overflow-auto [&>[data-radix-scroll-area-viewport]>div]:block!">
         <div className="p-4">
           <AgentGroupDetail name={name} instances={instances} />
         </div>

--- a/src/ui/lib/types.ts
+++ b/src/ui/lib/types.ts
@@ -74,7 +74,7 @@ export interface LLMToolResolution {
   filter_mode?: string;
   status: "available" | "unavailable" | "unresolved";
   provider_agent_id?: string;
-  provider_function_name?: string;
+  mcp_tool?: string;
   provider_capability?: string;
   endpoint?: string;
 }
@@ -85,7 +85,7 @@ export interface LLMProviderResolution {
   required_tags?: string[];
   status: "available" | "unavailable" | "unresolved";
   provider_agent_id?: string;
-  provider_function_name?: string;
+  mcp_tool?: string;
   endpoint?: string;
 }
 


### PR DESCRIPTION
## Problem

The meshui agent-detail side panel showed materially less than `meshctl` for the same agent — capability name and an `available` badge, nothing else. The endpoint is the field that answers *"which service is this actually wired to?"*, and its absence forced a drop to the CLI.

```
# meshctl
FUNCTION            REQUIRED CAP   MCP TOOL          ENDPOINT
avatar_chat_sfw     llm            haiku_provider    http://claude-provider.maya:8080

# meshui (before)
avatar_chat_sfw                                      [available]
llm
```

## The data was already in the browser

Front-end only — no API, registry, or DB change:

- Registry populates both fields for all three resolution kinds — `ent_service.go:1846,1880,1911`
- Serialized as `endpoint` / `mcp_tool` — `generated/server.go:696,703 / 1098,1100 / 1199,1211`
- meshui proxies the body **unmodified** — `proxy.go:68`
- meshctl reads its columns from that same response — `cli/list.go:497`

The UI and CLI consume identical bytes. The panel just never rendered them.

## Change

Three lines per row: capability + badge (unchanged), then `context · mcp_tool`, then the endpoint in muted monospace — `truncate` + `title` so it clips with an ellipsis and reveals in full on hover. The panel is ~450px; raw URLs would otherwise wrap or overflow.

Applied to all three sections in `AgentGroupDetail.tsx` (used by the topology sidebar, agents grid, and agents table).

Every field is optional on the wire, so each is null-guarded — a row with nothing extra renders exactly as it does today, with no empty label, stray separator, or blank line.

Class vocabulary is entirely pre-existing in the file: `text-[10px] text-muted-foreground` is the section body scale, `text-muted-foreground/80` already styles capability descriptions at `:110`, and `truncate font-mono` + `title` is the endpoint idiom already used at `:55` and `:234`.

## Latent bug fixed alongside

`AgentDetail.tsx:357,403` rendered `res.provider_function_name` — **a key that exists in no registry response.** It's an ent DB column name only; the wire key is `mcp_tool` (confirmed by `cli/list.go:472,482`, where the Go field is `ProviderFunctionName` but the JSON tag is `mcp_tool`). That "Function:" line had never rendered.

`lib/types.ts` declared the phantom field on both LLM resolution types while omitting the real `mcp_tool`, so the correct key would have failed type-check. Both corrected. Zero `provider_function_name` references remain in `src/ui` source.

## Note on one visible change

The dependency row separator changes from `(tool: X)` to `· X` for consistency with the two LLM sections, which now use the same shape. That's a change to an already-working row, not purely additive.

## Verification

- `npx tsc --noEmit` — no new errors. One pre-existing failure in `app/jobs/page.tsx:56` (`Type 'string' is not assignable to type 'Error'`), confirmed identical on a clean tree; unrelated and left alone.
- `npm test` (vitest) — 4 files, 36 tests, all pass
- `make ui-server-build` — succeeds; meshui embeds the SPA via `go:embed`, so a plain `make build` would not pick up `src/ui/` changes
- `cmd/mcp-mesh-ui/dist/index.html` is included, matching the precedent set by every recent UI PR (#1330, #1290, #1258, #1245). `src/ui/tsconfig.tsbuildinfo` is deliberately excluded — it is an incremental build cache and no UI PR since #986 has committed it.

**Not visually verified against a live mesh** — the change is markup-only against fields already proven present by the CLI, but a screenshot against a topology with LLM resolutions would be worth a look before merge.

Closes #1350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ