### PR TITLE
fix(ui): Jobs page crashed when the registry was unreachable; run src/ui in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,31 @@ jobs:
         working-directory: src/runtime/typescript
         run: npm test
 
+  ui-test:
+    name: UI Dashboard Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: src/ui/package-lock.json
+
+      - name: Install dashboard dependencies
+        run: npm ci
+
+      - name: Type check dashboard
+        run: npx tsc --noEmit
+
+      - name: Run dashboard tests
+        run: npm test
+
   java-test:
     name: Java Tests
     runs-on: ubuntu-latest
@@ -339,6 +364,7 @@ jobs:
         rust-test,
         typescript-test,
         java-test,
+        ui-test,
         build-and-package,
       ]
     if: always()
@@ -353,6 +379,7 @@ jobs:
           echo "Rust Tests: ${{ needs.rust-test.result }}"
           echo "TypeScript Tests: ${{ needs.typescript-test.result }}"
           echo "Java Tests: ${{ needs.java-test.result }}"
+          echo "UI Dashboard Tests: ${{ needs.ui-test.result }}"
           echo "Build and Package: ${{ needs.build-and-package.result }}"
 
           # Allow skipped status for temporarily disabled jobs
@@ -361,6 +388,7 @@ jobs:
              [[ "${{ needs.rust-test.result }}" != "success" ]] || \
              [[ "${{ needs.typescript-test.result }}" != "success" ]] || \
              [[ "${{ needs.java-test.result }}" != "success" ]] || \
+             [[ "${{ needs.ui-test.result }}" != "success" ]] || \
              [[ "${{ needs.build-and-package.result }}" != "success" ]]; then
             echo "❌ CI pipeline failed"
             exit 1

--- a/cmd/mcp-mesh-ui/dist/index.html
+++ b/cmd/mcp-mesh-ui/dist/index.html
@@ -10,7 +10,7 @@
       window.__MESH_BASE_PATH__ = window.__MESH_BASE_PATH__ || "";
       window.__MESH_REGISTRY_URL__ = window.__MESH_REGISTRY_URL__ || "";
     </script>
-    <script type="module" crossorigin src="./assets/index-Hv4E7O7T.js"></script>
+    <script type="module" crossorigin src="./assets/index-DQ9kFtl5.js"></script>
     <link rel="stylesheet" crossorigin href="./assets/index-6yT8cErM.css">
   </head>
   <body class="antialiased">

--- a/src/ui/app/jobs/page.tsx
+++ b/src/ui/app/jobs/page.tsx
@@ -53,7 +53,7 @@ export default function JobsPage() {
     return (
       <div className="flex flex-col h-full">
         <Header title="Jobs" subtitle="Long-running MeshJob coordination (read-only)" />
-        <ConnectionError error={error} onRetry={refresh} />
+        <ConnectionError error={new Error(error)} onRetry={refresh} />
       </div>
     );
   }

--- a/src/ui/components/layout/ConnectionError.tsx
+++ b/src/ui/components/layout/ConnectionError.tsx
@@ -9,10 +9,14 @@ interface ConnectionErrorProps {
 }
 
 export function ConnectionError({ error, onRetry }: ConnectionErrorProps) {
+  // Tolerate a non-Error value: a miscast call site should degrade to a
+  // readable message rather than crash the page inside the error boundary.
+  const message = error instanceof Error ? error.message : String(error ?? "");
+
   const isNetworkError =
-    error.message.includes("Failed to fetch") ||
-    error.message.includes("NetworkError") ||
-    error.message.includes("ECONNREFUSED");
+    message.includes("Failed to fetch") ||
+    message.includes("NetworkError") ||
+    message.includes("ECONNREFUSED");
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center px-6 py-8">
@@ -32,7 +36,7 @@ export function ConnectionError({ error, onRetry }: ConnectionErrorProps) {
           <p className="mt-1 text-sm text-muted-foreground">
             {isNetworkError
               ? `The dashboard cannot reach the MCP Mesh registry at ${API_BASE}`
-              : error.message}
+              : message}
           </p>
         </div>
 


### PR DESCRIPTION
## The bug

With the registry unreachable, `/jobs` rendered a generic error-boundary crash instead of its connect-error screen:

```
Something went wrong
An unexpected error occurred while rendering this page.
Cannot read properties of undefined (reading 'includes')
```

**The error UI failed in exactly the situation it exists for.**

`useJobs` returns `error: string | null` (`lib/use-jobs.ts:47`), but `ConnectionError` declares `error: Error` (`components/layout/ConnectionError.tsx:7`) and dereferences it immediately:

```tsx
const isNetworkError =
  error.message.includes("Failed to fetch") ||   // :13
  error.message.includes("NetworkError") ||      // :14
  error.message.includes("ECONNREFUSED");        // :15
```

A string has no `.message`, so `undefined.includes(...)` throws.

## The fix

One line at `app/jobs/page.tsx:56`, matching the convention the two schemas pages already use with the same `string | null` hook shape (`schemas/page.tsx:140`, `schemas/[hash]/page.tsx:221`):

```diff
-<ConnectionError error={error} onRetry={refresh} />
+<ConnectionError error={new Error(error)} onRetry={refresh} />
```

`useJobs`'s return type and `ConnectionError`'s prop type are deliberately unchanged — the other five call sites already pass real `Error` objects and depend on that signature.

`ConnectionError` additionally derives its message defensively (`error instanceof Error ? error.message : String(error ?? "")`) so a future miscast degrades to a readable message rather than a crash. The declared prop type stays `Error`; this is belt-and-braces, not an API change.

## Why it reached main: `src/ui` had zero CI coverage

```
$ grep -rn "src/ui" .github/workflows/     # across all 8 workflow files
(nothing)
```

No type check, no build, and the **36 vitest tests never ran**. The "TypeScript Tests" job covers `src/runtime/typescript` (the SDK), not the dashboard. `tsc --noEmit` had been reporting this error the whole time:

```
app/jobs/page.tsx(56,26): error TS2322: Type 'string' is not assignable to type 'Error'.
```

Added a `ui-test` job running `tsc --noEmit` + vitest.

**Its own job, not a step in `typescript-test`** — the dashboard is a separate npm package with its own lockfile and needs none of that job's Rust toolchain or native `@mcpmesh/core` build. Coupling them would let a native-module failure mask dashboard results and vice versa; a separate job also runs in parallel and reports as its own check.

Wired into `integration-status` **including the failure gate**, not just the `needs:` list — a job that runs but cannot fail the pipeline is the same false-green signal that hid this bug, and the lesson from #1348.

## Verification

Type check and tests:
- `npx tsc --noEmit` — **completely clean**; this was the only error. Re-running on the reverted tree reproduces `app/jobs/page.tsx(56,26)`, confirming the new CI job would have caught it.
- `npm test` — 4 files, 36/36 pass.

Runtime, in a real browser against a dead registry (`MCP_MESH_REGISTRY_URL=http://localhost:9`):

| build | `/jobs` renders |
|---|---|
| pre-fix | `Something went wrong` / `Cannot read properties of undefined (reading 'includes')` |
| post-fix | **`Unable to connect to registry`**, with troubleshooting help and a working Retry button |

`curl` returns 200 in both cases — the page is client-rendered, so HTTP status proves nothing here; the DOM had to be read back.

Closes #1352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection error handling when unexpected error values are received.
  * Prevented crashes and ensured clearer error messages are shown on the Jobs page.

* **Tests**
  * Added automated UI type-checking and test execution to the continuous integration workflow.
  * Updated integration status reporting to include UI test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->