### PR TITLE
release: v3.2.2

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version tag (e.g., v3.2.1)"
+        description: "Version tag (e.g., v3.2.2)"
         required: true
-        default: "v3.2.1"
+        default: "v3.2.2"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version (e.g., v3.2.1)"
+        description: "Version (e.g., v3.2.2)"
         required: true
-        default: "v3.2.1"
+        default: "v3.2.2"
       environment:
         description: "Environment"
         type: choice

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,55 @@
 # MCP Mesh Release Notes
 
-[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.2.1...HEAD)
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.2.2...HEAD)
+
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.2.1...v3.2.2)
+
+## v3.2.2 (2026-07-20)
+
+A patch release. Two vendor-contract fixes stop mesh sending parameters that current models reject, the `meshctl scaffold` Gemini default is corrected from a retired model id, and meshui gains the resolution detail the CLI already showed. Two test surfaces that had never executed in CI are now wired in — including one that was already failing. Nothing touches the wire protocol, the registry, dependency resolution, or the declaration syntax.
+
+### 🤖 LLM: vendor-removed sampling parameters are no longer forwarded (#1344)
+
+Anthropic removed `temperature`, `top_p` and `top_k` on the Opus 4.7, Opus 4.8, Sonnet 5 and Fable 5 families — passing any of them returns a 400. The Anthropic native path forwarded them unconditionally with no model gating, and mesh already advertises first-class support for exactly those model ids on the native structured-output path. A provider declared on a current model with any sampling knob set therefore failed at the vendor call.
+
+Those parameters are now dropped for the affected families, with a once-per-key warning, across **Python, TypeScript and Java**. Dropping degrades gracefully; forwarding is a hard 400, so the failure is asymmetric and dropping is the safe default.
+
+The restricted set is deliberately **narrower** than the native structured-output allow-list: Opus 4.6, Sonnet 4.6, Haiku 4.5, Sonnet 4.5, Opus 4.5/4.1 and all 3.x still accept sampling parameters and are unaffected. OpenAI's existing gate is unchanged, and remains distinct from the Responses-API routing predicate it shares a shape with.
+
+### 🤖 LLM: Gemini thinking-config conflict resolved before the request leaves mesh (#1346)
+
+Google rejects a request carrying both `thinking_level` and `thinking_budget` with `400 You can only set only one of thinking budget and thinking level`. This is a global request-validation check that fires ahead of any per-model check, and it triggers on field **presence**, not value. mesh now resolves the conflict client-side — keeping `thinking_level`, dropping `thinking_budget` by omission (never by writing an "unspecified" sentinel, which trips the same 400) — and recognizes both the snake_case and camelCase spellings the Google SDK accepts.
+
+Deliberately **no model gate was added**. Measurement against the live API showed `thinking_budget` is accepted and honored on 2.5 and 3.x alike, and `thinking_level` support varies per model with differing accepted value subsets — so a generation-based gate would have been wrong on arrival and would rot on every model launch. Gemini sampling parameters likewise need no gate: `temperature`, `top_p` and `top_k` were verified accepted on every current model.
+
+### 🛠 CLI: `meshctl scaffold` emitted a retired Gemini model (#1345)
+
+The gemini vendor default resolved to `gemini/gemini-1.5-pro`, a **retired** model id — a live `generateContent` call returns 404. Every scaffolded Gemini provider registered successfully and then failed on its first LLM call. The default is now `gemini/gemini-2.5-flash`, matching what the man pages have always documented.
+
+The integration guards written to catch exactly this staleness could never fire: both scaffolded with an explicit `--model`, so the captured output never contained the vendor default at all. They now scaffold via the vendor default and assert on it positively.
+
+### 🖥️ meshui: MCP tool and endpoint in the agent detail panel (#1350)
+
+The agent detail side panel showed only a capability name and a status badge for dependencies and LLM resolutions, while `meshctl` printed the resolved MCP tool and endpoint for the same rows — the information that answers "which service is this actually wired to?". Those fields were already present in the API response the dashboard receives; they were simply never rendered. Each row now shows the resolved MCP tool alongside its capability, and the endpoint beneath it, truncated with the full value on hover.
+
+This also fixes two renders that keyed off a field name absent from every registry response and had therefore never displayed.
+
+### 🖥️ meshui: Jobs page no longer crashes when the registry is unreachable (#1352)
+
+With the registry unreachable, the Jobs page rendered a generic error-boundary crash instead of its connection-error screen — the error UI failing in precisely the situation it exists for. The page passed a string where an `Error` was required, so the component's message inspection threw. The page now shows the "Unable to connect to registry" screen with troubleshooting help and a working retry button, and the component tolerates a non-`Error` value rather than crashing.
+
+### 🧪 CI: two test surfaces that had never executed (#1348, #1352)
+
+Two bodies of tests were invisible to CI, and a green build was asserting coverage over code that was never run:
+
+- The Python `_mcp_mesh` unit-test tree — **20 files, 928 tests**, covering the native LLM clients and provider handlers, the most vendor-drift-prone code in the repo. **Eight of those tests were failing on the released v3.2.1.** They assert the synthetic-tool structured-output path against Haiku 4.5, which v3.2.1 deliberately moved to Anthropic's native `output_config` path — meaning that change shipped on a handler branch with no executing coverage. Those tests are repaired (synthetic-path coverage re-fixtured onto a model genuinely still on that path, guarded by an executable assertion so a future allow-list addition fails loudly), handler-level Haiku 4.5 coverage that did not previously exist is added, and the tree now runs in CI.
+- The meshui dashboard — no type check, no build, and **36 tests that never ran**. A type error the compiler had been reporting all along reached `main`; that error is the Jobs page crash above. The dashboard now runs `tsc --noEmit` and its test suite in CI, wired into the pipeline's failure gate rather than merely reported.
+
+### ⚠️ Notes
+
+- **No upgrade action required.** No wire, registry, resolution, or declaration-syntax changes. Model-id handling remains pass-through and keyed on vendor.
+- **Affected-model behavior change is a fix, not a break.** Sampling parameters set against Opus 4.7/4.8, Sonnet 5 or Fable 5 previously produced a vendor 400; they are now dropped with a warning and the call succeeds. If you relied on those parameters with those models, the calls were failing.
+- **Scaffolded Gemini agents created before this release** carry the retired `gemini/gemini-1.5-pro` id and will 404 on their first LLM call — update the model in the agent declaration.
 
 [Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.2.0...v3.2.1)
 

--- a/cmd/meshctl/templates/java/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.2.1
+FROM mcpmesh/java-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/a2a-consumer/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/a2a-consumer/pom.xml.tmpl
@@ -26,7 +26,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.2.1
+FROM mcpmesh/java-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/api/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/api/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.2.1
+FROM mcpmesh/java-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/basic/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/basic/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.2.1
+FROM mcpmesh/java-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.2.1
+FROM mcpmesh/java-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/python/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/a2a-consumer/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/a2a-consumer/package.json.tmpl
@@ -13,7 +13,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/cmd/meshctl/templates/typescript/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/api/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/api/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/basic/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/docs/00-why-mcp-mesh/index.md
+++ b/docs/00-why-mcp-mesh/index.md
@@ -121,7 +121,7 @@ meshctl scaffold --compose --observability
 
 # Or deploy to Kubernetes (OCI registry)
 helm install my-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 -n mcp-mesh --create-namespace
+  --version 3.2.2 -n mcp-mesh --create-namespace
 ```
 
 ### 5. Built-in Observability

--- a/docs/02-local-development.md
+++ b/docs/02-local-development.md
@@ -97,7 +97,7 @@ graph LR
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </dependency>
     ```
 

--- a/docs/03-docker-deployment.md
+++ b/docs/03-docker-deployment.md
@@ -24,10 +24,10 @@ MCP Mesh publishes official images to Docker Hub:
 
 | Image                            | Purpose                                          |
 | -------------------------------- | ------------------------------------------------ |
-| `mcpmesh/registry:3.2.1`           | Go-based registry service                        |
-| `mcpmesh/python-runtime:3.2.1`     | Python agent runtime (includes mcp-mesh SDK)     |
-| `mcpmesh/java-runtime:3.2.1`       | Java agent runtime (includes mcp-mesh SDK)       |
-| `mcpmesh/typescript-runtime:3.2.1` | TypeScript agent runtime (includes @mcpmesh/sdk) |
+| `mcpmesh/registry:3.2.2`           | Go-based registry service                        |
+| `mcpmesh/python-runtime:3.2.2`     | Python agent runtime (includes mcp-mesh SDK)     |
+| `mcpmesh/java-runtime:3.2.2`       | Java agent runtime (includes mcp-mesh SDK)       |
+| `mcpmesh/typescript-runtime:3.2.2` | TypeScript agent runtime (includes @mcpmesh/sdk) |
 
 ## Using Scaffold to Generate Compose Files
 
@@ -53,7 +53,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:3.2.1
+        image: mcpmesh/registry:3.2.2
         ports:
           - "8000:8000"
         healthcheck:
@@ -63,7 +63,7 @@ meshctl scaffold --compose --dry-run -d ./agents
           retries: 3
 
       my-agent:
-        image: mcpmesh/python-runtime:3.2.1
+        image: mcpmesh/python-runtime:3.2.2
         ports:
           - "8080:8080"
         volumes:
@@ -88,7 +88,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:3.2.1
+        image: mcpmesh/registry:3.2.2
         ports:
           - "8000:8000"
         healthcheck:
@@ -122,7 +122,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:3.2.1
+        image: mcpmesh/registry:3.2.2
         ports:
           - "8000:8000"
         healthcheck:
@@ -132,7 +132,7 @@ meshctl scaffold --compose --dry-run -d ./agents
           retries: 3
 
       my-agent:
-        image: mcpmesh/typescript-runtime:3.2.1
+        image: mcpmesh/typescript-runtime:3.2.2
         ports:
           - "8080:8080"
         volumes:
@@ -161,12 +161,12 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:3.2.1
+        image: mcpmesh/registry:3.2.2
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/python-runtime:3.2.1
+        image: mcpmesh/python-runtime:3.2.2
         volumes:
           - ./agent.py:/app/agent.py:ro
         command: ["python", "/app/agent.py"]
@@ -185,7 +185,7 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:3.2.1
+        image: mcpmesh/registry:3.2.2
         ports:
           - "8000:8000"
 
@@ -206,12 +206,12 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:3.2.1
+        image: mcpmesh/registry:3.2.2
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/typescript-runtime:3.2.1
+        image: mcpmesh/typescript-runtime:3.2.2
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]
@@ -232,7 +232,7 @@ If you didn't use scaffold, here's a sample Dockerfile:
 === "Python"
 
     ```dockerfile
-    FROM mcpmesh/python-runtime:3.2.1
+    FROM mcpmesh/python-runtime:3.2.2
 
     COPY ./my-agent /app/agent
 
@@ -257,7 +257,7 @@ If you didn't use scaffold, here's a sample Dockerfile:
 === "TypeScript"
 
     ```dockerfile
-    FROM mcpmesh/typescript-runtime:3.2.1
+    FROM mcpmesh/typescript-runtime:3.2.2
 
     WORKDIR /app/agent
     COPY ./my-agent/package*.json ./
@@ -284,12 +284,12 @@ version: "3.8"
 
 services:
   registry:
-    image: mcpmesh/registry:3.2.1
+    image: mcpmesh/registry:3.2.2
     ports:
       - "8000:8000"
 
   auth-agent:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     volumes:
       - ./agents/auth:/app/agent:ro
     command: ["python", "/app/agent/main.py"]
@@ -298,7 +298,7 @@ services:
       - MCP_MESH_HTTP_PORT=8080
 
   data-agent:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     volumes:
       - ./agents/data:/app/agent:ro
     command: ["python", "/app/agent/main.py"]
@@ -307,7 +307,7 @@ services:
       - MCP_MESH_HTTP_PORT=8080
 
   api-agent:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     volumes:
       - ./agents/api:/app/agent:ro
     command: ["python", "/app/agent/main.py"]

--- a/docs/03-docker-deployment/04-networking.md
+++ b/docs/03-docker-deployment/04-networking.md
@@ -31,12 +31,12 @@ graph TD
     # docker-compose.yml
     services:
       registry:
-        image: mcpmesh/registry:3.2.1
+        image: mcpmesh/registry:3.2.2
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/python-runtime:3.2.1
+        image: mcpmesh/python-runtime:3.2.2
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["python", "/app/agent/main.py"]
@@ -44,7 +44,7 @@ graph TD
           - MCP_MESH_REGISTRY_URL=http://registry:8000
 
       another-agent:
-        image: mcpmesh/python-runtime:3.2.1
+        image: mcpmesh/python-runtime:3.2.2
         volumes:
           - ./another-agent:/app/agent:ro
         command: ["python", "/app/agent/main.py"]
@@ -62,12 +62,12 @@ graph TD
     # docker-compose.yml
     services:
       registry:
-        image: mcpmesh/registry:3.2.1
+        image: mcpmesh/registry:3.2.2
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/typescript-runtime:3.2.1
+        image: mcpmesh/typescript-runtime:3.2.2
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]
@@ -75,7 +75,7 @@ graph TD
           - MCP_MESH_REGISTRY_URL=http://registry:8000
 
       another-agent:
-        image: mcpmesh/typescript-runtime:3.2.1
+        image: mcpmesh/typescript-runtime:3.2.2
         volumes:
           - ./another-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]

--- a/docs/04-kubernetes-basics.md
+++ b/docs/04-kubernetes-basics.md
@@ -21,7 +21,7 @@ kubectl create namespace mcp-mesh
 
 # Deploy core (OCI registry - no "helm repo add" needed)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   --namespace mcp-mesh
 
 # Wait for registry
@@ -65,7 +65,7 @@ Build the image:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=my-agent \
@@ -76,7 +76,7 @@ For cloud deployments, use your full registry path:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
@@ -138,7 +138,7 @@ resources:
 ```bash
 # Core without Grafana/Tempo (lighter footprint)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   --namespace mcp-mesh \
   --set grafana.enabled=false \
   --set tempo.enabled=false
@@ -149,7 +149,7 @@ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
 ```bash
 # Just the registry, no database or observability
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 3.2.1 \
+  --version 3.2.2 \
   --namespace mcp-mesh
 ```
 
@@ -161,13 +161,13 @@ just match `-n` with `--set global.namespace`:
 ```bash
 # Deploy core to a custom namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n my-namespace --create-namespace \
   --set global.namespace=my-namespace
 
 # Deploy agent to the same namespace
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n my-namespace \
   -f helm-values.yaml
 ```
@@ -180,12 +180,12 @@ For **multi-tenant** clusters (separate core per team), deploy each core to its 
 ```bash
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n team-a --create-namespace --set global.namespace=team-a
 
 # Team B — same values, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n team-b --create-namespace --set global.namespace=team-b
 ```
 
@@ -193,7 +193,7 @@ For **cross-namespace** access (agent in one namespace, core in another), use FQ
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 -n other-ns \
+  --version 3.2.2 -n other-ns \
   --set mesh.registryUrl=http://mcp-core-mcp-mesh-registry.team-a.svc.cluster.local:8000
 ```
 
@@ -205,13 +205,13 @@ helm list -n mcp-mesh
 
 # Upgrade an agent
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   --namespace mcp-mesh \
   --set image.tag=v2
 
 # Scale replicas
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   --namespace mcp-mesh \
   --reuse-values \
   --set replicaCount=3

--- a/docs/04-kubernetes-basics/05-troubleshooting.md
+++ b/docs/04-kubernetes-basics/05-troubleshooting.md
@@ -373,7 +373,7 @@ kubectl exec <pod-name> -n mcp-mesh -- df -h
 **Symptoms:**
 
 ```
-Failed to pull image "mcpmesh/python-runtime:3.2.1": rpc error: code = Unknown desc = Error response from daemon: pull access denied
+Failed to pull image "mcpmesh/python-runtime:3.2.2": rpc error: code = Unknown desc = Error response from daemon: pull access denied
 ```
 
 **Solutions:**

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -216,7 +216,7 @@ Designed for containers and Kubernetes.
 
 ## Multimodal Pipeline
 
-MCP Mesh v3.2.1 adds a media pipeline that lets tools produce and LLMs consume binary content:
+MCP Mesh v3.2.2 adds a media pipeline that lets tools produce and LLMs consume binary content:
 
 ```
 Tool produces media

--- a/docs/concepts/stateful-agents.md
+++ b/docs/concepts/stateful-agents.md
@@ -48,7 +48,7 @@ mcp-mesh runs your agent across two event loops:
 
 The two-loop split means a long-running tool body (LLM call, slow registry hop, multi-minute MeshJob) holds the user loop, but never the framework loop — your K8s liveness/readiness probes stay responsive.
 
-**What this fixes**: loop-bound resources work as expected when created in `lifespan` startup. `asyncpg.Pool`, `redis.asyncio.Redis`, and `aiohttp.ClientSession` are all loop-affine — they bind to the asyncio loop that created them and fail if reused from a different one. Because v3.2.1 runs your `lifespan` AND your tools on the same user loop, the canonical FastMCP idiom is straightforward:
+**What this fixes**: loop-bound resources work as expected when created in `lifespan` startup. `asyncpg.Pool`, `redis.asyncio.Redis`, and `aiohttp.ClientSession` are all loop-affine — they bind to the asyncio loop that created them and fail if reused from a different one. Because v3.2.2 runs your `lifespan` AND your tools on the same user loop, the canonical FastMCP idiom is straightforward:
 
 ```python
 # Module-level — FastMCP's `lifespan` parameter receives a FastMCP server
@@ -104,7 +104,7 @@ long-running work. From mesh's perspective it's an ordinary CRUD
 agent — every tool call is short, idempotent where possible, and
 returns. The pool lives inside the agent process — created in
 `lifespan` startup, stored in a module-level global, and closed in
-`lifespan` exit. Since v3.2.1, `lifespan` and all tool bodies share
+`lifespan` exit. Since v3.2.2, `lifespan` and all tool bodies share
 the single user loop, so a module-level pool created in `lifespan`
 startup is the supported pattern. (FastMCP's `lifespan` receives a
 FastMCP server instance — there is no `.state` namespace as there is

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,7 @@ docker-compose up
 ```bash
 # Quick start (OCI registry - no helm repo add needed)
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 3.2.1 -n mcp-mesh --create-namespace
+  --version 3.2.2 -n mcp-mesh --create-namespace
 ```
 
 [:material-arrow-right: Kubernetes Guide](04-kubernetes-basics.md){ .md-button .md-button--primary }
@@ -117,7 +117,7 @@ For Kubernetes, configure TLS via Helm values:
 
 ```bash
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 3.2.1 -n mcp-mesh --create-namespace \
+  --version 3.2.2 -n mcp-mesh --create-namespace \
   --set registry.security.tls.mode=strict \
   --set registry.security.trust.backend=k8s-secrets
 ```

--- a/docs/dev-to-production.md
+++ b/docs/dev-to-production.md
@@ -85,10 +85,10 @@ The [TSuite](https://github.com/dhyansraj/mcp-mesh-test-suite) integration testi
 
     ```bash
     helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-      --version 3.2.1 -n mcp-mesh --create-namespace
+      --version 3.2.2 -n mcp-mesh --create-namespace
 
     helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 3.2.1 -n mcp-mesh -f helm-values.yaml
+      --version 3.2.2 -n mcp-mesh -f helm-values.yaml
     ```
 
 Same agent code runs locally, in Docker, and in Kubernetes — no changes needed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,7 @@ Build multi-agent systems that are production-ready from day one. Mesh handles t
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </dependency>
     ```
 
@@ -364,7 +364,7 @@ A `kubectl`-style command-line tool that follows you from first agent to product
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </dependency>
     ```
 
@@ -383,10 +383,10 @@ A `kubectl`-style command-line tool that follows you from first agent to product
 === "Docker Images"
 
     ```bash
-    docker pull mcpmesh/registry:3.2.1
-    docker pull mcpmesh/python-runtime:3.2.1
-    docker pull mcpmesh/java-runtime:3.2.1
-    docker pull mcpmesh/typescript-runtime:3.2.1
+    docker pull mcpmesh/registry:3.2.2
+    docker pull mcpmesh/python-runtime:3.2.2
+    docker pull mcpmesh/java-runtime:3.2.2
+    docker pull mcpmesh/typescript-runtime:3.2.2
     ```
 
     Official container images for production deployments.
@@ -412,7 +412,7 @@ A `kubectl`-style command-line tool that follows you from first agent to product
 
 ## :star: Project Status
 
-- **Latest Release**: v3.2.1 (March 2026)
+- **Latest Release**: v3.2.2 (March 2026)
 - **License**: MIT
 - **Languages**: Python 3.11+, TypeScript/Node.js 18+, and Java 17+ (runtime), Go 1.23+ (registry)
 - **Status**: Production-ready, actively developed

--- a/docs/java/examples.md
+++ b/docs/java/examples.md
@@ -132,7 +132,7 @@ class AssistantAgentTest {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:3.2.1
+    image: mcpmesh/registry:3.2.2
     ports:
       - "8000:8000"
     healthcheck:

--- a/docs/java/getting-started/index.md
+++ b/docs/java/getting-started/index.md
@@ -83,13 +83,13 @@ Create `pom.xml`:
 
     <groupId>com.example</groupId>
     <artifactId>greeter-agent</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
 
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/docs/java/getting-started/prerequisites.md
+++ b/docs/java/getting-started/prerequisites.md
@@ -60,7 +60,7 @@ Add the Spring Boot starter to your `pom.xml`:
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -108,10 +108,10 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.2.1`           | Registry service            |
-| `mcpmesh/python-runtime:3.2.1`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.2.1`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.2.1` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.2.2`           | Registry service            |
+| `mcpmesh/python-runtime:3.2.2`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.2.2`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.2.2` | TypeScript runtime with SDK |
 
 Java agents use standard Maven-based Docker builds (see Docker Deployment guide).
 

--- a/docs/java/index.md
+++ b/docs/java/index.md
@@ -27,7 +27,7 @@ The MCP Mesh Java SDK provides an annotation-based API for building distributed 
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
 </dependency>
 ```
 

--- a/docs/java/local-development/01-getting-started.md
+++ b/docs/java/local-development/01-getting-started.md
@@ -45,7 +45,7 @@ The recommended way is to use `meshctl scaffold` (see next page). If you prefer 
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/docs/java/local-development/troubleshooting.md
+++ b/docs/java/local-development/troubleshooting.md
@@ -38,7 +38,7 @@ Ensure the dependency version matches an available release:
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
 </dependency>
 ```
 

--- a/docs/java/spring-boot-integration.md
+++ b/docs/java/spring-boot-integration.md
@@ -23,7 +23,7 @@ MCP Mesh provides `@MeshRoute` and `@MeshInject` annotations for Spring Boot RES
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/docs/python/dependency-injection.md
+++ b/docs/python/dependency-injection.md
@@ -297,7 +297,7 @@ loop — K8s liveness/readiness probes stay responsive.
 
 ### Default `MCP_MESH_TOOL_WORKERS=1`
 
-Since v3.2.1, default tool dispatch runs on a single-user loop (was
+Since v3.2.2, default tool dispatch runs on a single-user loop (was
 `min(8, max(2, cpu_count()))`). The canonical pattern for loop-bound
 resources works as expected — `lifespan` startup creates the resource
 on the user loop; every tool body uses it on the same loop; `lifespan`

--- a/docs/python/getting-started/prerequisites.md
+++ b/docs/python/getting-started/prerequisites.md
@@ -97,17 +97,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.2.1`           | Registry service            |
-| `mcpmesh/python-runtime:3.2.1`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.2.1`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.2.1` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.2.2`           | Registry service            |
+| `mcpmesh/python-runtime:3.2.2`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.2.2`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.2.2` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:3.2.1
-docker pull mcpmesh/python-runtime:3.2.1
-docker pull mcpmesh/java-runtime:3.2.1
-docker pull mcpmesh/typescript-runtime:3.2.1
+docker pull mcpmesh/registry:3.2.2
+docker pull mcpmesh/python-runtime:3.2.2
+docker pull mcpmesh/java-runtime:3.2.2
+docker pull mcpmesh/typescript-runtime:3.2.2
 ```
 
 ### Generate Docker Compose
@@ -145,12 +145,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/docs/tutorial/day-08-docker-compose.md
+++ b/docs/tutorial/day-08-docker-compose.md
@@ -379,7 +379,7 @@ $ docker compose down -v
 ## Troubleshooting
 
 **Docker build fails with missing requirements.** The compose file uses
-`mcpmesh/python-runtime:3.2.1` images with a dev-mode entrypoint that
+`mcpmesh/python-runtime:3.2.2` images with a dev-mode entrypoint that
 installs `requirements.txt` on startup. If an agent has dependencies not
 in the base image, check that `requirements.txt` exists in the agent
 directory and lists all dependencies.

--- a/docs/tutorial/day-09-kubernetes.md
+++ b/docs/tutorial/day-09-kubernetes.md
@@ -212,7 +212,7 @@ and Grafana as a single Helm release:
 
 ```shell
 $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-    --version 3.2.1 \
+    --version 3.2.2 \
     -n trip-planner \
     -f helm/values-core.yaml \
     --wait --timeout 5m
@@ -246,7 +246,7 @@ $ for agent in "${AGENTS[@]}"; do
     echo "Installing $agent..."
     helm install "$agent" \
       oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 3.2.1 \
+      --version 3.2.2 \
       -n trip-planner \
       -f "helm/values-${agent}.yaml"
   done

--- a/docs/typescript/examples.md
+++ b/docs/typescript/examples.md
@@ -127,7 +127,7 @@ describe("Agent Integration", () => {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:3.2.1
+    image: mcpmesh/registry:3.2.2
     ports:
       - "8000:8000"
     healthcheck:

--- a/docs/typescript/getting-started/prerequisites.md
+++ b/docs/typescript/getting-started/prerequisites.md
@@ -85,17 +85,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.2.1`           | Registry service            |
-| `mcpmesh/python-runtime:3.2.1`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.2.1`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.2.1` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.2.2`           | Registry service            |
+| `mcpmesh/python-runtime:3.2.2`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.2.2`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.2.2` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:3.2.1
-docker pull mcpmesh/python-runtime:3.2.1
-docker pull mcpmesh/java-runtime:3.2.1
-docker pull mcpmesh/typescript-runtime:3.2.1
+docker pull mcpmesh/registry:3.2.2
+docker pull mcpmesh/python-runtime:3.2.2
+docker pull mcpmesh/java-runtime:3.2.2
+docker pull mcpmesh/typescript-runtime:3.2.2
 ```
 
 ### Generate Docker Compose

--- a/examples/docker-examples/agents/claude-provider/Dockerfile
+++ b/examples/docker-examples/agents/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/docker-examples/agents/claude-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/claude-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying claude-provider with mcp-mesh-agent chart
 # Usage: helm install claude-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 3.2.1 -f helm-values.yaml
+#        --version 3.2.2 -f helm-values.yaml
 
 image:
   repository: your-registry/claude-provider

--- a/examples/docker-examples/agents/claude-provider/requirements.txt
+++ b/examples/docker-examples/agents/claude-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=3.2.1
+mcp-mesh>=3.2.2
 
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0

--- a/examples/docker-examples/agents/openai-provider/Dockerfile
+++ b/examples/docker-examples/agents/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/docker-examples/agents/openai-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/openai-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying openai-provider with mcp-mesh-agent chart
 # Usage: helm install openai-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 3.2.1 -f helm-values.yaml
+#        --version 3.2.2 -f helm-values.yaml
 
 image:
   repository: your-registry/openai-provider

--- a/examples/docker-examples/agents/openai-provider/requirements.txt
+++ b/examples/docker-examples/agents/openai-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=3.2.1
+mcp-mesh>=3.2.2
 
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0

--- a/examples/docker-examples/docker-compose.yml
+++ b/examples/docker-examples/docker-compose.yml
@@ -2,12 +2,12 @@
 # Demonstrates Go registry + Python agents architecture using published Docker images
 #
 # Services:
-# - registry: Go-based registry with SQLite storage (mcpmesh/registry:3.2.1)
-# - hello-world-agent: Python agent with greeting capabilities (mcpmesh/python-runtime:3.2.1)
-# - system-agent: Python agent with system monitoring capabilities (mcpmesh/python-runtime:3.2.1)
-# - fastmcp-agent: FastMCP service with mesh integration (mcpmesh/python-runtime:3.2.1)
-# - dependent-agent: Service that depends on fastmcp-agent (mcpmesh/python-runtime:3.2.1)
-# - fastapi-app: FastAPI application with mesh integration (mcpmesh/python-runtime:3.2.1)
+# - registry: Go-based registry with SQLite storage (mcpmesh/registry:3.2.2)
+# - hello-world-agent: Python agent with greeting capabilities (mcpmesh/python-runtime:3.2.2)
+# - system-agent: Python agent with system monitoring capabilities (mcpmesh/python-runtime:3.2.2)
+# - fastmcp-agent: FastMCP service with mesh integration (mcpmesh/python-runtime:3.2.2)
+# - dependent-agent: Service that depends on fastmcp-agent (mcpmesh/python-runtime:3.2.2)
+# - fastapi-app: FastAPI application with mesh integration (mcpmesh/python-runtime:3.2.2)
 #
 # Usage:
 #   docker-compose up

--- a/examples/java/basic-tool-agent/pom.xml
+++ b/examples/java/basic-tool-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/benchmark-chain/svc-a/pom.xml
+++ b/examples/java/benchmark-chain/svc-a/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-b/pom.xml
+++ b/examples/java/benchmark-chain/svc-b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-c/pom.xml
+++ b/examples/java/benchmark-chain/svc-c/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-d/pom.xml
+++ b/examples/java/benchmark-chain/svc-d/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-e/pom.xml
+++ b/examples/java/benchmark-chain/svc-e/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/consumer-date-agent/pom.xml
+++ b/examples/java/consumer-date-agent/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/consumer-report-agent-sse/pom.xml
+++ b/examples/java/consumer-report-agent-sse/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/consumer-report-agent/pom.xml
+++ b/examples/java/consumer-report-agent/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/dependency-agent/pom.xml
+++ b/examples/java/dependency-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/direct-openai-agent/pom.xml
+++ b/examples/java/direct-openai-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/java/employee-service/pom.xml
+++ b/examples/java/employee-service/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/gemini-provider-agent/pom.xml
+++ b/examples/java/gemini-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/java/gpt-provider-agent/pom.xml
+++ b/examples/java/gpt-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/java/header-api/pom.xml
+++ b/examples/java/header-api/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/health-block-test-agent/pom.xml
+++ b/examples/java/health-block-test-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-accurate-provider/pom.xml
+++ b/examples/java/java-accurate-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-alpha-provider/pom.xml
+++ b/examples/java/java-alpha-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-beta-provider/pom.xml
+++ b/examples/java/java-beta-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-booking-consumer/pom.xml
+++ b/examples/java/java-booking-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-calculator/pom.xml
+++ b/examples/java/java-calculator/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-deprecated-provider/pom.xml
+++ b/examples/java/java-deprecated-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-dual-consumer/pom.xml
+++ b/examples/java/java-dual-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-fast-provider/pom.xml
+++ b/examples/java/java-fast-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-math-agent/pom.xml
+++ b/examples/java/java-math-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-schedule-agent/pom.xml
+++ b/examples/java/java-schedule-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-tag-consumer/pom.xml
+++ b/examples/java/java-tag-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-weather-agent/pom.xml
+++ b/examples/java/java-weather-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/llm-mesh-agent/pom.xml
+++ b/examples/java/llm-mesh-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/llm-provider-agent/pom.xml
+++ b/examples/java/llm-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/java/media-consumer-agent/pom.xml
+++ b/examples/java/media-consumer-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/media-producer-agent/pom.xml
+++ b/examples/java/media-producer-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/multijar-api-gateway/pom.xml
+++ b/examples/java/multijar-api-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/multijar-payment-service/pom.xml
+++ b/examples/java/multijar-payment-service/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/producer-date-agent/pom.xml
+++ b/examples/java/producer-date-agent/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/producer-report-agent/pom.xml
+++ b/examples/java/producer-report-agent/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/rest-api-consumer/pom.xml
+++ b/examples/java/rest-api-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/service-view/caption-provider/Dockerfile
+++ b/examples/java/service-view/caption-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for caption-provider MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.2.1
+FROM mcpmesh/java-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/java/service-view/caption-provider/pom.xml
+++ b/examples/java/service-view/caption-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/service-view/media-gateway/Dockerfile
+++ b/examples/java/service-view/media-gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for media-gateway MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.2.1
+FROM mcpmesh/java-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/java/service-view/media-gateway/pom.xml
+++ b/examples/java/service-view/media-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/service-view/thumbnail-provider/Dockerfile
+++ b/examples/java/service-view/thumbnail-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for thumbnail-provider MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.2.1
+FROM mcpmesh/java-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/java/service-view/thumbnail-provider/pom.xml
+++ b/examples/java/service-view/thumbnail-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/service-view/transcribe-provider/Dockerfile
+++ b/examples/java/service-view/transcribe-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for transcribe-provider MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.2.1
+FROM mcpmesh/java-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/java/service-view/transcribe-provider/pom.xml
+++ b/examples/java/service-view/transcribe-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/jobs-java/event-aware-consumer-java/pom.xml
+++ b/examples/jobs-java/event-aware-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/event-aware-provider-java/pom.xml
+++ b/examples/jobs-java/event-aware-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/long-task-consumer-java/pom.xml
+++ b/examples/jobs-java/long-task-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/long-task-provider-java/pom.xml
+++ b/examples/jobs-java/long-task-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/superseded-consumer-java/pom.xml
+++ b/examples/jobs-java/superseded-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/superseded-provider-java/pom.xml
+++ b/examples/jobs-java/superseded-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-claude-java/pom.xml
+++ b/examples/parallel-tools/consumer-claude-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-gemini-java/pom.xml
+++ b/examples/parallel-tools/consumer-gemini-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-gemini-ts/package.json
+++ b/examples/parallel-tools/consumer-gemini-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/consumer-openai-java/pom.xml
+++ b/examples/parallel-tools/consumer-openai-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-openai-ts/package.json
+++ b/examples/parallel-tools/consumer-openai-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/parallel-consumer-java/pom.xml
+++ b/examples/parallel-tools/parallel-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/parallel-consumer-ts/package.json
+++ b/examples/parallel-tools/parallel-consumer-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/slow-tool-java/pom.xml
+++ b/examples/parallel-tools/slow-tool-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/slow-tool-ts/package.json
+++ b/examples/parallel-tools/slow-tool-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/python/service-view/caption-provider/Dockerfile
+++ b/examples/python/service-view/caption-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for caption-provider MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/python/service-view/media-gateway/Dockerfile
+++ b/examples/python/service-view/media-gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for media-gateway MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/python/service-view/thumbnail-provider/Dockerfile
+++ b/examples/python/service-view/thumbnail-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for thumbnail-provider MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/python/service-view/transcribe-provider/Dockerfile
+++ b/examples/python/service-view/transcribe-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for transcribe-provider MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/required-dependency/java/data-provider/Dockerfile
+++ b/examples/required-dependency/java/data-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for data-provider MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.2.1
+FROM mcpmesh/java-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/required-dependency/java/data-provider/pom.xml
+++ b/examples/required-dependency/java/data-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/required-dependency/java/report-consumer/Dockerfile
+++ b/examples/required-dependency/java/report-consumer/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for report-consumer MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.2.1
+FROM mcpmesh/java-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/required-dependency/java/report-consumer/pom.xml
+++ b/examples/required-dependency/java/report-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/required-dependency/python/data-provider/Dockerfile
+++ b/examples/required-dependency/python/data-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for data-provider MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/required-dependency/python/report-consumer/Dockerfile
+++ b/examples/required-dependency/python/report-consumer/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for report-consumer MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/schema-corpus/java/pom.xml
+++ b/examples/schema-corpus/java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/consumer/pom.xml
+++ b/examples/schema/java/consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/producer-bad/pom.xml
+++ b/examples/schema/java/producer-bad/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/producer-good/pom.xml
+++ b/examples/schema/java/producer-good/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/streaming/chatbot-demo/chatbot-agent/Dockerfile
+++ b/examples/streaming/chatbot-demo/chatbot-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chatbot-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/streaming/chatbot-demo/gateway/Dockerfile
+++ b/examples/streaming/chatbot-demo/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/streaming/chatbot-demo/weather-tool/Dockerfile
+++ b/examples/streaming/chatbot-demo/weather-tool/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/chatbot-agent/Dockerfile
+++ b/examples/streaming/fixtures/chatbot-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chatbot-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/gateway-agent/Dockerfile
+++ b/examples/streaming/fixtures/gateway-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway-agent MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/passthrough-agent/Dockerfile
+++ b/examples/streaming/fixtures/passthrough-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for passthrough-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-java/pom.xml
+++ b/examples/toolcalls/analyst-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/toolcalls/analyst-py/Dockerfile
+++ b/examples/toolcalls/analyst-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for analyst-py MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-ts/Dockerfile
+++ b/examples/toolcalls/analyst-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for analyst-ts MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-ts/package.json
+++ b/examples/toolcalls/analyst-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/claude-provider-java/pom.xml
+++ b/examples/toolcalls/claude-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/claude-provider-py/Dockerfile
+++ b/examples/toolcalls/claude-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/toolcalls/claude-provider-ts/Dockerfile
+++ b/examples/toolcalls/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/toolcalls/claude-provider-ts/package.json
+++ b/examples/toolcalls/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/gemini-provider-java/pom.xml
+++ b/examples/toolcalls/gemini-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/gemini-provider-py/Dockerfile
+++ b/examples/toolcalls/gemini-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/toolcalls/gemini-provider-ts/Dockerfile
+++ b/examples/toolcalls/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/toolcalls/gemini-provider-ts/package.json
+++ b/examples/toolcalls/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/openai-provider-java/pom.xml
+++ b/examples/toolcalls/openai-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/openai-provider-py/Dockerfile
+++ b/examples/toolcalls/openai-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/toolcalls/openai-provider-ts/Dockerfile
+++ b/examples/toolcalls/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/toolcalls/openai-provider-ts/package.json
+++ b/examples/toolcalls/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/weather-tool-java/pom.xml
+++ b/examples/toolcalls/weather-tool-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/toolcalls/weather-tool-py/Dockerfile
+++ b/examples/toolcalls/weather-tool-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool-py MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/toolcalls/weather-tool-ts/Dockerfile
+++ b/examples/toolcalls/weather-tool-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool-ts MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/toolcalls/weather-tool-ts/package.json
+++ b/examples/toolcalls/weather-tool-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/tutorial/trip-planner/day-01/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-01/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/docker-compose.yml
+++ b/examples/tutorial/trip-planner/day-08/python/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - trip-planner-network
 
   registry:
-    image: mcpmesh/registry:3.2.1
+    image: mcpmesh/registry:3.2.2
     container_name: trip-planner-registry
     hostname: registry
     ports:
@@ -81,7 +81,7 @@ services:
 
   # --8<-- [start:mesh_ui]
   mesh-ui:
-    image: mcpmesh/ui:3.2.1
+    image: mcpmesh/ui:3.2.2
     container_name: trip-planner-mesh-ui
     hostname: mesh-ui
     ports:
@@ -172,7 +172,7 @@ services:
   # --8<-- [start:gateway]
   # FastAPI Gateway: manually added (scaffold detects @mesh.agent, not @mesh.route)
   gateway:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: trip-planner-gateway
     hostname: gateway
     user: root
@@ -213,7 +213,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   adventure-advisor:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: trip-planner-adventure-advisor
     hostname: adventure-advisor
     user: root
@@ -256,7 +256,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   budget-analyst:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: trip-planner-budget-analyst
     hostname: budget-analyst
     user: root
@@ -299,7 +299,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   chat-history-agent:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: trip-planner-chat-history-agent
     hostname: chat-history-agent
     user: root
@@ -342,7 +342,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   claude-provider:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: trip-planner-claude-provider
     hostname: claude-provider
     user: root
@@ -386,7 +386,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   flight-agent:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: trip-planner-flight-agent
     hostname: flight-agent
     user: root
@@ -429,7 +429,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   hotel-agent:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: trip-planner-hotel-agent
     hostname: hotel-agent
     user: root
@@ -472,7 +472,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   logistics-planner:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: trip-planner-logistics-planner
     hostname: logistics-planner
     user: root
@@ -515,7 +515,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   openai-provider:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: trip-planner-openai-provider
     hostname: openai-provider
     user: root
@@ -559,7 +559,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   planner-agent:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: trip-planner-planner-agent
     hostname: planner-agent
     user: root
@@ -602,7 +602,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   poi-agent:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: trip-planner-poi-agent
     hostname: poi-agent
     user: root
@@ -645,7 +645,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   user-prefs-agent:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: trip-planner-user-prefs-agent
     hostname: user-prefs-agent
     user: root
@@ -688,7 +688,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   weather-agent:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: trip-planner-weather-agent
     hostname: weather-agent
     user: root

--- a/examples/tutorial/trip-planner/day-08/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh streaming API gateway
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh streaming LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/typescript/benchmark-chain/svc-a/package.json
+++ b/examples/typescript/benchmark-chain/svc-a/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-b/package.json
+++ b/examples/typescript/benchmark-chain/svc-b/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-c/package.json
+++ b/examples/typescript/benchmark-chain/svc-c/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-d/package.json
+++ b/examples/typescript/benchmark-chain/svc-d/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-e/package.json
+++ b/examples/typescript/benchmark-chain/svc-e/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/context-self-dep-ts-mesh/Dockerfile
+++ b/examples/typescript/context-self-dep-ts-mesh/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for context-self-dep-ts-mesh MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/examples/typescript/header-api/package.json
+++ b/examples/typescript/header-api/package.json
@@ -11,7 +11,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/examples/typescript/llm-consumer/package.json
+++ b/examples/typescript/llm-consumer/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/examples/typescript/llm-provider/package.json
+++ b/examples/typescript/llm-provider/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/helm/mcp-mesh-agent/Chart.yaml
+++ b/helm/mcp-mesh-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-agent
 description: MCP Mesh Agent - Python runtime for MCP agents with mesh capabilities
 type: application
-version: 3.2.1
-appVersion: "3.2.1"
+version: 3.2.2
+appVersion: "3.2.2"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-agent/README.md
+++ b/helm/mcp-mesh-agent/README.md
@@ -232,7 +232,7 @@ existingSecret: my-secret
 ### Python
 
 ```dockerfile
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 COPY . /app/
 CMD ["-m", "myagent"]
@@ -241,7 +241,7 @@ CMD ["-m", "myagent"]
 ### TypeScript
 
 ```dockerfile
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 COPY . /app/
 CMD ["src/index.ts"]
@@ -250,7 +250,7 @@ CMD ["src/index.ts"]
 ### Java
 
 ```dockerfile
-FROM mcpmesh/java-runtime:3.2.1
+FROM mcpmesh/java-runtime:3.2.2
 
 COPY target/myagent.jar /app/
 CMD ["/app/myagent.jar"]

--- a/helm/mcp-mesh-core/Chart.lock
+++ b/helm/mcp-mesh-core/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: mcp-mesh-postgres
   repository: file://../mcp-mesh-postgres
-  version: 3.2.1
+  version: 3.2.2
 - name: mcp-mesh-redis
   repository: file://../mcp-mesh-redis
-  version: 3.2.1
+  version: 3.2.2
 - name: mcp-mesh-registry
   repository: file://../mcp-mesh-registry
-  version: 3.2.1
+  version: 3.2.2
 - name: mcp-mesh-grafana
   repository: file://../mcp-mesh-grafana
-  version: 3.2.1
+  version: 3.2.2
 - name: mcp-mesh-tempo
   repository: file://../mcp-mesh-tempo
-  version: 3.2.1
+  version: 3.2.2
 - name: mcp-mesh-ui
   repository: file://../mcp-mesh-ui
-  version: 3.2.1
-digest: sha256:ce8205223b21fdfdd20cd74120c02f4388432cf77faca6a2df3150c211bc71b1
-generated: "2026-07-16T22:36:30.824521-04:00"
+  version: 3.2.2
+digest: sha256:e1062ee657e313be6630add29e2e4e6fa3956a039ad9e8625fbae28ea254fece
+generated: "2026-07-20T17:01:48.604501-04:00"

--- a/helm/mcp-mesh-core/Chart.yaml
+++ b/helm/mcp-mesh-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-core
 description: MCP Mesh Core Infrastructure - Registry, PostgreSQL, Redis, and Observability
 type: application
-version: 3.2.1
-appVersion: "3.2.1"
+version: 3.2.2
+appVersion: "3.2.2"
 keywords:
   - mcp
   - mesh
@@ -28,26 +28,26 @@ annotations:
   "artifacthub.io/containsSecurityUpdates": "false"
 dependencies:
   - name: mcp-mesh-postgres
-    version: "3.2.1"
+    version: "3.2.2"
     repository: "file://../mcp-mesh-postgres"
     condition: postgres.enabled
   - name: mcp-mesh-redis
-    version: "3.2.1"
+    version: "3.2.2"
     repository: "file://../mcp-mesh-redis"
     condition: redis.enabled
   - name: mcp-mesh-registry
-    version: "3.2.1"
+    version: "3.2.2"
     repository: "file://../mcp-mesh-registry"
     condition: registry.enabled
   - name: mcp-mesh-grafana
-    version: "3.2.1"
+    version: "3.2.2"
     repository: "file://../mcp-mesh-grafana"
     condition: grafana.enabled
   - name: mcp-mesh-tempo
-    version: "3.2.1"
+    version: "3.2.2"
     repository: "file://../mcp-mesh-tempo"
     condition: tempo.enabled
   - name: mcp-mesh-ui
-    version: "3.2.1"
+    version: "3.2.2"
     repository: "file://../mcp-mesh-ui"
     condition: ui.enabled

--- a/helm/mcp-mesh-grafana/Chart.yaml
+++ b/helm/mcp-mesh-grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-grafana
 description: Grafana observability component for MCP Mesh
 type: application
-version: 3.2.1
+version: 3.2.2
 appVersion: "12.3.1"
 keywords:
   - grafana

--- a/helm/mcp-mesh-ingress/Chart.yaml
+++ b/helm/mcp-mesh-ingress/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ingress
 description: Ingress configuration for MCP Mesh services with flexible DNS routing
 type: application
-version: 3.2.1
-appVersion: "3.2.1"
+version: 3.2.2
+appVersion: "3.2.2"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-postgres/Chart.yaml
+++ b/helm/mcp-mesh-postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-postgres
 description: PostgreSQL database for MCP Mesh Registry
 type: application
-version: 3.2.1
+version: 3.2.2
 appVersion: "15"
 keywords:
   - mcp

--- a/helm/mcp-mesh-redis/Chart.yaml
+++ b/helm/mcp-mesh-redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-redis
 description: Redis cache for MCP Mesh session storage
 type: application
-version: 3.2.1
+version: 3.2.2
 appVersion: "7"
 keywords:
   - mcp

--- a/helm/mcp-mesh-registry/Chart.yaml
+++ b/helm/mcp-mesh-registry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-registry
 description: MCP Mesh Registry Service - Central service registry for MCP agents
 type: application
-version: 3.2.1
-appVersion: "3.2.1"
+version: 3.2.2
+appVersion: "3.2.2"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-tempo/Chart.yaml
+++ b/helm/mcp-mesh-tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-tempo
 description: Tempo distributed tracing component for MCP Mesh
 type: application
-version: 3.2.1
+version: 3.2.2
 appVersion: "2.9.0"
 keywords:
   - tempo

--- a/helm/mcp-mesh-ui/Chart.yaml
+++ b/helm/mcp-mesh-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ui
 description: MCP Mesh Dashboard UI Server - Web dashboard for monitoring MCP agents
 type: application
-version: 3.2.1
-appVersion: "3.2.1"
+version: 3.2.2
+appVersion: "3.2.2"
 keywords:
   - mcp
   - mesh

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/cli",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "CLI for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration",
   "license": "MIT",
   "repository": {
@@ -23,10 +23,10 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@mcpmesh/cli-linux-x64": "3.2.1",
-    "@mcpmesh/cli-linux-arm64": "3.2.1",
-    "@mcpmesh/cli-darwin-x64": "3.2.1",
-    "@mcpmesh/cli-darwin-arm64": "3.2.1"
+    "@mcpmesh/cli-linux-x64": "3.2.2",
+    "@mcpmesh/cli-linux-arm64": "3.2.2",
+    "@mcpmesh/cli-darwin-x64": "3.2.2",
+    "@mcpmesh/cli-darwin-arm64": "3.2.2"
   },
   "keywords": [
     "mcp",

--- a/packaging/homebrew/mcp-mesh.rb
+++ b/packaging/homebrew/mcp-mesh.rb
@@ -2,7 +2,7 @@
 class McpMesh < Formula
   desc "Kubernetes-native platform for distributed MCP applications"
   homepage "https://github.com/dhyansraj/mcp-mesh"
-  version "3.2.1"  # Will be updated by release automation
+  version "3.2.2"  # Will be updated by release automation
 
   if OS.mac?
     if Hardware::CPU.arm?

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "3.2.1"
+version = "3.2.2"
 description = "Python SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration"
 readme = "README.md"
 license = { text = "MIT" }
@@ -58,7 +58,7 @@ requires-python = ">=3.11"
 # LiteLLM.
 dependencies = [
     # Rust core runtime (required - no Python fallback)
-    "mcp-mesh-core>=3.2.1",
+    "mcp-mesh-core>=3.2.2",
     "fastapi>=0.104.0,<1.0.0",
     "uvicorn>=0.24.0,<1.0.0",
     "httpx>=0.25.0,<1.0.0",

--- a/packaging/scoop/mcp-mesh.json
+++ b/packaging/scoop/mcp-mesh.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Kubernetes-native platform for distributed MCP applications",
   "homepage": "https://github.com/dhyansraj/mcp-mesh",
   "license": "MIT",

--- a/src/core/cli/handlers/java_handler.go
+++ b/src/core/cli/handlers/java_handler.go
@@ -79,7 +79,7 @@ func (h *JavaHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns Java Dockerfile content
 func (h *JavaHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh Java agent
-FROM mcpmesh/java-runtime:3.2.1
+FROM mcpmesh/java-runtime:3.2.2
 
 WORKDIR /app
 
@@ -156,7 +156,7 @@ func (h *JavaHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the Java runtime Docker image
 func (h *JavaHandler) GetDockerImage() string {
-	return "mcpmesh/java-runtime:3.2.1"
+	return "mcpmesh/java-runtime:3.2.2"
 }
 
 // ValidatePrerequisites checks Java environment
@@ -304,7 +304,7 @@ const javaPomTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
     </dependencies>
 

--- a/src/core/cli/handlers/language_test.go
+++ b/src/core/cli/handlers/language_test.go
@@ -202,7 +202,7 @@ func TestDetectLanguage_PythonDirectoryRequirements(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Create requirements.txt
-	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==3.2.1"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==3.2.2"), 0644); err != nil {
 		t.Fatalf("Failed to create requirements.txt: %v", err)
 	}
 
@@ -401,7 +401,7 @@ func TestPythonHandler_GetDockerImage(t *testing.T) {
 	// Must equal the exact release tag GetDockerImage() ships (kept in sync by
 	// scripts/bump_version.py). Hard failure, not a log — this is the assertion
 	// that should have caught the 2.8.0 partial bump.
-	if want := "mcpmesh/python-runtime:3.2.1"; image != want {
+	if want := "mcpmesh/python-runtime:3.2.2"; image != want {
 		t.Errorf("GetDockerImage() = %q, want %q", image, want)
 	}
 }
@@ -415,7 +415,7 @@ func TestTypeScriptHandler_GetDockerImage(t *testing.T) {
 	// Must equal the exact release tag GetDockerImage() ships (kept in sync by
 	// scripts/bump_version.py). Hard failure, not a log — this is the assertion
 	// that should have caught the 2.8.0 partial bump.
-	if want := "mcpmesh/typescript-runtime:3.2.1"; image != want {
+	if want := "mcpmesh/typescript-runtime:3.2.2"; image != want {
 		t.Errorf("GetDockerImage() = %q, want %q", image, want)
 	}
 }

--- a/src/core/cli/handlers/python_handler.go
+++ b/src/core/cli/handlers/python_handler.go
@@ -86,7 +86,7 @@ func (h *PythonHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns Python Dockerfile content
 func (h *PythonHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh Python agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 
@@ -170,7 +170,7 @@ func (h *PythonHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the Python runtime Docker image
 func (h *PythonHandler) GetDockerImage() string {
-	return "mcpmesh/python-runtime:3.2.1"
+	return "mcpmesh/python-runtime:3.2.2"
 }
 
 // ValidatePrerequisites checks Python environment
@@ -248,5 +248,5 @@ const pythonInitTemplate = `# {{.Name}} MCP Mesh Agent
 const pythonMainModuleTemplate = `from .main import *
 `
 
-const pythonRequirementsTemplate = `mcp-mesh>=3.2.1
+const pythonRequirementsTemplate = `mcp-mesh>=3.2.2
 `

--- a/src/core/cli/handlers/typescript_handler.go
+++ b/src/core/cli/handlers/typescript_handler.go
@@ -92,7 +92,7 @@ func (h *TypeScriptHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns TypeScript Dockerfile content
 func (h *TypeScriptHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh TypeScript agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 
@@ -167,7 +167,7 @@ func (h *TypeScriptHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the TypeScript runtime Docker image
 func (h *TypeScriptHandler) GetDockerImage() string {
-	return "mcpmesh/typescript-runtime:3.2.1"
+	return "mcpmesh/typescript-runtime:3.2.2"
 }
 
 // ValidatePrerequisites checks TypeScript environment
@@ -269,7 +269,7 @@ const typescriptPackageTemplate = `{
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "fastmcp": "^3.26.0",
     "zod": "^3.23.0"
   },

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -10,12 +10,12 @@ MCP Mesh supports multiple deployment patterns from local development to product
 
 | Image                              | Description                                        |
 | ---------------------------------- | -------------------------------------------------- |
-| `mcpmesh/registry:3.2.1`             | Registry service for agent discovery               |
-| `mcpmesh/python-runtime:3.2.1`       | Python runtime with mcp-mesh SDK pre-installed     |
-| `mcpmesh/typescript-runtime:3.2.1`   | TypeScript runtime with @mcpmesh/sdk pre-installed |
-| `mcpmesh/java-runtime:3.2.1`         | Java runtime with mcp-mesh Spring Boot starter     |
-| `mcpmesh/ui:3.2.1`                   | Dashboard UI server (basePath: /ops/dashboard)     |
-| `mcpmesh/cli:3.2.1`                  | meshctl CLI for management                         |
+| `mcpmesh/registry:3.2.2`             | Registry service for agent discovery               |
+| `mcpmesh/python-runtime:3.2.2`       | Python runtime with mcp-mesh SDK pre-installed     |
+| `mcpmesh/typescript-runtime:3.2.2`   | TypeScript runtime with @mcpmesh/sdk pre-installed |
+| `mcpmesh/java-runtime:3.2.2`         | Java runtime with mcp-mesh Spring Boot starter     |
+| `mcpmesh/ui:3.2.2`                   | Dashboard UI server (basePath: /ops/dashboard)     |
+| `mcpmesh/cli:3.2.2`                  | meshctl CLI for management                         |
 
 ## Local Development
 
@@ -104,7 +104,7 @@ meshctl scaffold basic --name my-agent
 The generated Dockerfile uses the official runtime:
 
 ```dockerfile
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
@@ -132,7 +132,7 @@ meshctl scaffold --compose --observability
 Generated docker-compose.yml includes:
 
 - PostgreSQL database for registry
-- Registry service (`mcpmesh/registry:3.2.1`)
+- Registry service (`mcpmesh/registry:3.2.2`)
 - All detected agents with proper networking
 - Health checks and dependency ordering
 - Optional: Redis, Tempo, Grafana (with `--observability`)
@@ -155,12 +155,12 @@ For production Kubernetes deployment, use the official Helm charts from the MCP 
 # Install core infrastructure (registry + database + observability)
 # No "helm repo add" needed - uses OCI registry directly
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh --create-namespace
 
 # Deploy agent using scaffold-generated helm-values.yaml
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -171,12 +171,12 @@ Deploy into any namespace — just match `-n` with `--set global.namespace`:
 
 ```bash
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n my-namespace --create-namespace \
   --set global.namespace=my-namespace
 
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n my-namespace \
   -f helm-values.yaml
 ```
@@ -195,19 +195,19 @@ its own namespace. Short service names resolve independently within each namespa
 ```bash
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n team-a --create-namespace --set global.namespace=team-a
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 -n team-a -f greeter/helm-values.yaml
+  --version 3.2.2 -n team-a -f greeter/helm-values.yaml
 
 # Team B — same helm-values.yaml, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n team-b --create-namespace --set global.namespace=team-b
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 -n team-b -f greeter/helm-values.yaml
+  --version 3.2.2 -n team-b -f greeter/helm-values.yaml
 ```
 
 ### Available Helm Charts
@@ -256,16 +256,16 @@ meshctl scaffold basic --name my-agent
 
 # 2. Build and push Docker image (works on all platforms)
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v3.2.1 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v3.2.2 --push .
 
 # 3. Update helm-values.yaml with your image repository
 # 4. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v3.2.1
+  --set image.tag=v3.2.2
 ```
 
 ### Disable Optional Components
@@ -273,14 +273,14 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 ```bash
 # Core without observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh --create-namespace \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 
 # Core without PostgreSQL (in-memory registry)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh --create-namespace \
   --set postgres.enabled=false
 ```
@@ -429,7 +429,7 @@ Or use the `mcp-mesh-ingress` chart which handles routing automatically.
 
 ```bash
 # Docker
-docker run -e MCP_MESH_UI_BASE_PATH=/my/custom/path mcpmesh/ui:3.2.1
+docker run -e MCP_MESH_UI_BASE_PATH=/my/custom/path mcpmesh/ui:3.2.2
 
 # Helm
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -16,7 +16,7 @@ MCP Mesh supports multiple deployment patterns for Java/Spring Boot agents. The 
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
 </dependency>
 ```
 
@@ -152,7 +152,7 @@ services:
       retries: 5
 
   registry:
-    image: mcpmesh/registry:3.2.1
+    image: mcpmesh/registry:3.2.2
     ports:
       - "8000:8000"
     environment:
@@ -204,12 +204,12 @@ For production Kubernetes deployment:
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh --create-namespace
 
 # Deploy Java agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -242,15 +242,15 @@ resources:
 ```bash
 # 1. Build and push Docker image
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v3.2.1 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v3.2.2 --push .
 
 # 2. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v3.2.1
+  --set image.tag=v3.2.2
 ```
 
 ## Port Strategy

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -10,8 +10,8 @@ MCP Mesh supports multiple deployment patterns for TypeScript agents. Use `meshc
 
 | Image                            | Description                                        |
 | -------------------------------- | -------------------------------------------------- |
-| `mcpmesh/registry:3.2.1`           | Registry service for agent discovery               |
-| `mcpmesh/typescript-runtime:3.2.1` | TypeScript runtime with @mcpmesh/sdk pre-installed |
+| `mcpmesh/registry:3.2.2`           | Registry service for agent discovery               |
+| `mcpmesh/typescript-runtime:3.2.2` | TypeScript runtime with @mcpmesh/sdk pre-installed |
 
 ## Local Development
 
@@ -75,7 +75,7 @@ meshctl stop               # Stop all
 
 ```dockerfile
 # Dockerfile for my-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 
@@ -123,8 +123,8 @@ meshctl scaffold --compose --observability
 Generated `docker-compose.yml` includes:
 
 - PostgreSQL database for registry
-- Registry service (`mcpmesh/registry:3.2.1`)
-- TypeScript agents with `mcpmesh/typescript-runtime:3.2.1`
+- Registry service (`mcpmesh/registry:3.2.2`)
+- TypeScript agents with `mcpmesh/typescript-runtime:3.2.2`
 - Health checks and dependency ordering
 - Optional: Redis, Tempo, Grafana (with `--observability`)
 
@@ -145,12 +145,12 @@ For production Kubernetes deployment:
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh --create-namespace
 
 # Deploy TypeScript agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -192,15 +192,15 @@ meshctl scaffold basic --name my-agent --lang typescript
 
 # 2. Build and push Docker image
 cd my-agent
-docker buildx build --platform linux/amd64 -t your-registry/my-agent:v3.2.1 --push .
+docker buildx build --platform linux/amd64 -t your-registry/my-agent:v3.2.2 --push .
 
 # 3. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
-  --set image.tag=v3.2.1
+  --set image.tag=v3.2.2
 ```
 
 ## Port Strategy

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -65,12 +65,12 @@ docker compose up -d
 ```bash
 # Install core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh --create-namespace
 
 # Or disable observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh --create-namespace \
   --set tempo.enabled=false \
   --set grafana.enabled=false

--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -89,17 +89,17 @@ docker compose version
 
 | Image                              | Description                 |
 | ---------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.2.1`           | Registry service            |
-| `mcpmesh/python-runtime:3.2.1`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.2.1`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.2.1` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.2.2`           | Registry service            |
+| `mcpmesh/python-runtime:3.2.2`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.2.2`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.2.2` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:3.2.1
-docker pull mcpmesh/python-runtime:3.2.1
-docker pull mcpmesh/java-runtime:3.2.1
-docker pull mcpmesh/typescript-runtime:3.2.1
+docker pull mcpmesh/registry:3.2.2
+docker pull mcpmesh/python-runtime:3.2.2
+docker pull mcpmesh/java-runtime:3.2.2
+docker pull mcpmesh/typescript-runtime:3.2.2
 ```
 
 ### Generate Docker Compose
@@ -137,12 +137,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/src/core/cli/man/content/prerequisites_java.md
+++ b/src/core/cli/man/content/prerequisites_java.md
@@ -52,7 +52,7 @@ Add the Spring Boot starter to your `pom.xml`:
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -100,10 +100,10 @@ docker compose version
 
 | Image                              | Description                 |
 | ---------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.2.1`           | Registry service            |
-| `mcpmesh/python-runtime:3.2.1`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.2.1`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.2.1` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.2.2`           | Registry service            |
+| `mcpmesh/python-runtime:3.2.2`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.2.2`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.2.2` | TypeScript runtime with SDK |
 
 Java agents use standard Maven-based Docker builds (see Docker Deployment guide).
 

--- a/src/core/cli/man/content/prerequisites_typescript.md
+++ b/src/core/cli/man/content/prerequisites_typescript.md
@@ -77,17 +77,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.2.1`           | Registry service            |
-| `mcpmesh/python-runtime:3.2.1`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.2.1`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.2.1` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.2.2`           | Registry service            |
+| `mcpmesh/python-runtime:3.2.2`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.2.2`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.2.2` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:3.2.1
-docker pull mcpmesh/python-runtime:3.2.1
-docker pull mcpmesh/java-runtime:3.2.1
-docker pull mcpmesh/typescript-runtime:3.2.1
+docker pull mcpmesh/registry:3.2.2
+docker pull mcpmesh/python-runtime:3.2.2
+docker pull mcpmesh/java-runtime:3.2.2
+docker pull mcpmesh/typescript-runtime:3.2.2
 ```
 
 ### Generate Docker Compose

--- a/src/core/cli/man/content/quickstart_java.md
+++ b/src/core/cli/man/content/quickstart_java.md
@@ -75,13 +75,13 @@ Create `pom.xml`:
 
     <groupId>com.example</groupId>
     <artifactId>greeter-agent</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
 
     <dependencies>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/core/cli/man/content/registry.md
+++ b/src/core/cli/man/content/registry.md
@@ -202,7 +202,7 @@ The registry supports multiple replicas for high availability. All replicas shar
 ```bash
 # Scale registry replicas
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.2.1 \
+  --version 3.2.2 \
   -n mcp-mesh --create-namespace \
   --set registry.replicas=3
 ```

--- a/src/core/cli/man/content/security.md
+++ b/src/core/cli/man/content/security.md
@@ -208,7 +208,7 @@ Admin endpoints (`/admin/rotate`, `/admin/entities`) are served only on the admi
 ```yaml
 services:
   registry:
-    image: mcpmesh/registry:3.2.1
+    image: mcpmesh/registry:3.2.2
     command: ["--tls-auto"]
     ports: ["8000:8000"]
     volumes:

--- a/src/core/cli/man/content/testing_java.md
+++ b/src/core/cli/man/content/testing_java.md
@@ -124,7 +124,7 @@ class AssistantAgentTest {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:3.2.1
+    image: mcpmesh/registry:3.2.2
     ports:
       - "8000:8000"
     healthcheck:

--- a/src/core/cli/man/content/testing_typescript.md
+++ b/src/core/cli/man/content/testing_typescript.md
@@ -119,7 +119,7 @@ describe("Agent Integration", () => {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:3.2.1
+    image: mcpmesh/registry:3.2.2
     ports:
       - "8000:8000"
     healthcheck:

--- a/src/core/cli/man/content/tutorial.md
+++ b/src/core/cli/man/content/tutorial.md
@@ -1698,7 +1698,7 @@ $ kubectl -n trip-planner create secret generic llm-keys \
 
 ```shell
 $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-    --version 3.2.1 \
+    --version 3.2.2 \
     -n trip-planner \
     -f helm/values-core.yaml \
     --wait --timeout 5m
@@ -1717,7 +1717,7 @@ $ for agent in "${AGENTS[@]}"; do
     echo "Installing $agent..."
     helm install "$agent" \
       oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 3.2.1 \
+      --version 3.2.2 \
       -n trip-planner \
       -f "helm/values-${agent}.yaml"
   done

--- a/src/core/cli/scaffold.go
+++ b/src/core/cli/scaffold.go
@@ -72,9 +72,9 @@ Documentation:
 
 Infrastructure:
   Docker Images:
-    mcpmesh/registry:3.2.1            - Registry service
-    mcpmesh/python-runtime:3.2.1      - Python agent runtime (has mcp-mesh SDK)
-    mcpmesh/typescript-runtime:3.2.1  - TypeScript agent runtime (has @mcpmesh/sdk)
+    mcpmesh/registry:3.2.2            - Registry service
+    mcpmesh/python-runtime:3.2.2      - Python agent runtime (has mcp-mesh SDK)
+    mcpmesh/typescript-runtime:3.2.2  - TypeScript agent runtime (has @mcpmesh/sdk)
 
   Helm Charts (for Kubernetes - OCI registry, no helm repo add needed):
     oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core   - Registry + PostgreSQL + observability

--- a/src/core/cli/scaffold/compose.go
+++ b/src/core/cli/scaffold/compose.go
@@ -1087,7 +1087,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
 #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
 {{ .Name }}:
-  image: mcpmesh/python-runtime:3.2.1
+  image: mcpmesh/python-runtime:3.2.2
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1132,7 +1132,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # NOTE: In dev mode, npm install runs on startup and source is mounted.
 #       In production (Dockerfile), dependencies are pre-installed in the image.
 {{ .Name }}:
-  image: mcpmesh/typescript-runtime:3.2.1
+  image: mcpmesh/typescript-runtime:3.2.2
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1175,7 +1175,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # Agent: {{ .Name }} (Java/Spring Boot)
 # NOTE: In dev mode, maven builds on startup. In production, use the Dockerfile.
 {{ .Name }}:
-  image: mcpmesh/java-runtime:3.2.1
+  image: mcpmesh/java-runtime:3.2.2
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1856,7 +1856,7 @@ services:
       - {{ .NetworkName }}
 
   registry:
-    image: mcpmesh/registry:3.2.1
+    image: mcpmesh/registry:3.2.2
     container_name: {{ .ProjectName }}-registry
     hostname: registry
     ports:
@@ -1965,7 +1965,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   {{ .Name }}:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root
@@ -2011,7 +2011,7 @@ services:
   # NOTE: In dev mode, npm install runs on startup and source is mounted.
   #       In production (Dockerfile), dependencies are pre-installed in the image.
   {{ .Name }}:
-    image: mcpmesh/typescript-runtime:3.2.1
+    image: mcpmesh/typescript-runtime:3.2.2
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root
@@ -2055,7 +2055,7 @@ services:
   # Java Agent: {{ .Name }}
   # NOTE: In dev mode, maven builds on startup. In production, use the Dockerfile.
   {{ .Name }}:
-    image: mcpmesh/java-runtime:3.2.1
+    image: mcpmesh/java-runtime:3.2.2
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root

--- a/src/core/cli/scaffold/compose_test.go
+++ b/src/core/cli/scaffold/compose_test.go
@@ -52,9 +52,9 @@ services:
     environment:
       POSTGRES_USER: customuser
   registry:
-    image: mcpmesh/registry:3.2.1
+    image: mcpmesh/registry:3.2.2
   agent1:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     container_name: test-agent1
     environment:
       CUSTOM_VAR: "user-added-value"
@@ -110,9 +110,9 @@ func TestGenerateDockerCompose_ForceRegenerate(t *testing.T) {
   postgres:
     image: postgres:15-alpine
   registry:
-    image: mcpmesh/registry:3.2.1
+    image: mcpmesh/registry:3.2.2
   agent1:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     environment:
       CUSTOM_VAR: "should-be-gone"
 networks:
@@ -157,9 +157,9 @@ func TestGenerateDockerCompose_NoNewAgents(t *testing.T) {
   postgres:
     image: postgres:15-alpine
   registry:
-    image: mcpmesh/registry:3.2.1
+    image: mcpmesh/registry:3.2.2
   agent1:
-    image: mcpmesh/python-runtime:3.2.1
+    image: mcpmesh/python-runtime:3.2.2
     environment:
       CUSTOM_VAR: "preserved"
 networks:

--- a/src/runtime/core/Cargo.lock
+++ b/src/runtime/core/Cargo.lock
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
@@ -118,7 +118,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -130,7 +130,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -145,13 +145,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -183,9 +183,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -204,9 +204,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cbindgen"
@@ -222,16 +222,16 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.119",
  "tempfile",
  "toml",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -245,9 +245,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -262,18 +262,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
+checksum = "a394189d59f9befacce833f337f7b1eca5e9a91221bcdd4d28e0114d96e597b3"
 
 [[package]]
 name = "data-encoding"
@@ -418,7 +418,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -496,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -506,15 +506,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -523,38 +523,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -701,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -726,9 +726,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "mcp-mesh-core"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1057,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -1078,9 +1078,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1104,7 +1104,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.9.5",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1114,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "3.10.3"
+version = "3.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c71997d6f7ad4a756966e452426848ac27d3b37a295302d63afbbcce0270f93"
+checksum = "6826e5ddc15589b2d68c8ad5321c18e85d40488e93e32962f362e572669bccf6"
 dependencies = [
  "bitflags",
  "ctor",
@@ -1138,36 +1138,36 @@ checksum = "c9c366d2c8c60b86fa632df75f745509b52f9128f91a6bad4c796e44abb505e1"
 
 [[package]]
 name = "napi-derive"
-version = "3.5.9"
+version = "3.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ba572deef53e2c386759a8c2014175a62679d74ff83adc205c8bc0e0285727"
+checksum = "b0fe526e81c105d3640516fcde83909dd1afe757c0d7a15af58830b5bc0fb9a1"
 dependencies = [
  "convert_case",
  "ctor",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "napi-derive-backend"
-version = "5.1.1"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd961eb2aa8965e3f29722d754f3a86907eb1984e2fbcbe3fe87b9a02d6bfba"
+checksum = "514281397bcddd9ea9a876c7a21a57bff2374237a000ca9a64ea0211ec1993e2"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "semver",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "napi-sys"
-version = "3.2.2"
+version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f5bcdf71abd3a50d00b49c1c2c75251cb3c913777d6139cd37dabc093a5e400"
+checksum = "73e43cf2eb0bd1bf95a43c07c076ebd2da5d1e015a71c3d201faeffffcc0ecac"
 dependencies = [
  "libloading",
 ]
@@ -1199,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1298,7 +1298,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1319,9 +1319,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"
@@ -1349,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1376,7 +1376,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1446,7 +1446,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1459,7 +1459,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1520,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1541,9 +1541,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -1630,29 +1630,29 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1662,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1759,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "once_cell",
  "ring",
@@ -1794,9 +1794,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -1818,9 +1818,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1828,29 +1828,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1964,9 +1964,9 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2025,9 +2025,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2051,7 +2062,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2075,38 +2086,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2124,9 +2135,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2144,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2159,9 +2170,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2176,13 +2187,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2379,7 +2390,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2483,9 +2494,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -2582,7 +2593,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -2617,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2769,28 +2780,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2810,7 +2821,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2831,7 +2842,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2864,11 +2875,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/src/runtime/core/Cargo.toml
+++ b/src/runtime/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-mesh-core"
-version = "3.2.1"
+version = "3.2.2"
 edition = "2021"
 # MSRV. CI builds with moving stable (dtolnay/rust-toolchain@stable);
 # this floor documents the newest stdlib API the crate relies on

--- a/src/runtime/core/pyproject.toml
+++ b/src/runtime/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mcp-mesh-core"
-version = "3.2.1"
+version = "3.2.2"
 description = "Rust core runtime for MCP Mesh agents"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/core/typescript/package.json
+++ b/src/runtime/core/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/core",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "MCP Mesh Rust core bindings for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/runtime/java/mcp-mesh-bom/pom.xml
+++ b/src/runtime/java/mcp-mesh-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-bom</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh BOM</name>

--- a/src/runtime/java/mcp-mesh-core/pom.xml
+++ b/src/runtime/java/mcp-mesh-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </parent>
 
     <artifactId>mcp-mesh-core</artifactId>

--- a/src/runtime/java/mcp-mesh-native/pom.xml
+++ b/src/runtime/java/mcp-mesh-native/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </parent>
 
     <artifactId>mcp-mesh-native</artifactId>

--- a/src/runtime/java/mcp-mesh-sdk/pom.xml
+++ b/src/runtime/java/mcp-mesh-sdk/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </parent>
 
     <artifactId>mcp-mesh-sdk</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-ai/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-ai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-ai</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.2.1</version>
+        <version>3.2.2</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>

--- a/src/runtime/java/pom.xml
+++ b/src/runtime/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-parent</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh Java SDK</name>

--- a/src/runtime/python/_mcp_mesh/__init__.py
+++ b/src/runtime/python/_mcp_mesh/__init__.py
@@ -31,7 +31,7 @@ from .engine.decorator_registry import (
     get_decorator_stats,
 )
 
-__version__ = "3.2.1"
+__version__ = "3.2.2"
 
 # Store reference to runtime processor if initialized
 _runtime_processor = None

--- a/src/runtime/python/mesh/__init__.py
+++ b/src/runtime/python/mesh/__init__.py
@@ -34,7 +34,7 @@ from .types import (
 # Note: helpers.llm_provider is imported lazily in __getattr__ to avoid
 # initialization timing issues with @mesh.agent auto_run in tests
 
-__version__ = "3.2.1"
+__version__ = "3.2.2"
 
 
 # Helper function to create FastMCP server with proper naming

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "3.2.1"
+version = "3.2.2"
 description = "Python SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/typescript/package.json
+++ b/src/runtime/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/sdk",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "TypeScript SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -102,12 +102,12 @@ Edit `config.yaml` to set versions:
 
 ```yaml
 packages:
-  cli_version: "3.2.1" # @mcpmesh/cli
-  sdk_python_version: "3.2.1" # mcp-mesh (pip) - PEP 440 format
-  sdk_typescript_version: "3.2.1" # @mcpmesh/sdk
+  cli_version: "3.2.2" # @mcpmesh/cli
+  sdk_python_version: "3.2.2" # mcp-mesh (pip) - PEP 440 format
+  sdk_typescript_version: "3.2.2" # @mcpmesh/sdk
 
 docker:
-  base_image: "tsuite-mesh:3.2.1"
+  base_image: "tsuite-mesh:3.2.2"
 ```
 
 ## Environment Variables

--- a/tests/integration/suites/README.md
+++ b/tests/integration/suites/README.md
@@ -108,7 +108,7 @@ const agent = mesh(server, {
 ```bash
 docker run --rm -it \
   -v $(pwd)/suites/uc01_registry/artifacts:/uc-artifacts:ro \
-  tsuite-mesh:3.2.1 bash
+  tsuite-mesh:3.2.2 bash
 ```
 
 ### Common issues:
@@ -123,9 +123,9 @@ Available in test.yaml via `${config.X}`:
 
 | Variable                                 | Example      |
 | ---------------------------------------- | ------------ |
-| `config.packages.cli_version`            | 3.2.1 |
-| `config.packages.sdk_python_version`     | 3.2.1 |
-| `config.packages.sdk_typescript_version` | 3.2.1 |
+| `config.packages.cli_version`            | 3.2.2 |
+| `config.packages.sdk_python_version`     | 3.2.2 |
+| `config.packages.sdk_typescript_version` | 3.2.2 |
 
 ## Issue Reporting Policy
 

--- a/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-calculator-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-optional-dep-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-report-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-calculator-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-calculator-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-calculator-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-alpha-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-alpha-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-beta-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-beta-provider/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-dual-consumer/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-dual-consumer/package.json
@@ -6,7 +6,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-caller/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-caller/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-provider/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-provider/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-caller/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-caller/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-provider/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/java-slow-agent/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/java-slow-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/ts-slow-agent/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/ts-slow-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc07_llm_agent_py/artifacts/llm-agent/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc07_llm_agent_py/artifacts/llm-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for llm-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc23_structured_output_ts_consumer_py_provider/artifacts/structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc23_structured_output_ts_consumer_py_provider/artifacts/structured-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc28_structured_output_ts_consumer_java_provider/artifacts/structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc28_structured_output_ts_consumer_java_provider/artifacts/structured-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc32_structured_output_ts_consumer_py_openai_provider/artifacts/structured-consumer-openai-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc32_structured_output_ts_consumer_py_openai_provider/artifacts/structured-consumer-openai-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc43_output_mode_hint_override_openai_ts/artifacts/hint-override-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc43_output_mode_hint_override_openai_ts/artifacts/hint-override-consumer-ts/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc44_output_mode_hint_override_openai_java/artifacts/hint-override-java/pom.xml
+++ b/tests/integration/suites/uc04_llm_integration/tc44_output_mode_hint_override_openai_java/artifacts/hint-override-java/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <java.version>17</java.version>
         <!-- maven-install handler aligns this from the container's ~/.m2 repo -->
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
+++ b/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/Dockerfile
+++ b/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-auto-port-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc05_meshctl/tc33_ts_api_port_isolation/artifacts/ts-api-app/package.json
+++ b/tests/integration/suites/uc05_meshctl/tc33_ts_api_port_isolation/artifacts/ts-api-app/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.2.1",
+    "@mcpmesh/sdk": "3.2.2",
     "express": "^4.21.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc06_observability/artifacts/express-api/package.json
+++ b/tests/integration/suites/uc06_observability/artifacts/express-api/package.json
@@ -7,7 +7,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc06_observability/artifacts/py-calculator/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/py-calculator/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for py-calculator MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/py-math-agent/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/py-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for py-math-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.2.1
+FROM mcpmesh/typescript-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-echo-ts/package.json
+++ b/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-echo-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-relay-ts/package.json
+++ b/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-relay-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc12_registration_trust/artifacts/java-greeter/pom.xml
+++ b/tests/integration/suites/uc12_registration_trust/artifacts/java-greeter/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc14_multimedia/tc30_download_media_typescript/artifacts/ts-download-agent/package.json
+++ b/tests/integration/suites/uc14_multimedia/tc30_download_media_typescript/artifacts/ts-download-agent/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
+++ b/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/Dockerfile
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/Dockerfile
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.2.1
+FROM mcpmesh/python-runtime:3.2.2
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
+++ b/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc16_schema_filtering/artifacts/ts-schema-agent/package.json
+++ b/tests/integration/suites/uc16_schema_filtering/artifacts/ts-schema-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc17_ui_server/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc17_ui_server/artifacts/ts-math-agent/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/pom.xml
+++ b/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/package.json
@@ -7,7 +7,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java-sse/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java-sse/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-auth-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-auth-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-report-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-report-agent-ts/package.json
@@ -8,7 +8,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/pom.xml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/pom.xml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/pom.xml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/pom.xml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-consumer/pom.xml
+++ b/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-provider/pom.xml
+++ b/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc32_empty_return_values/artifacts/ts-empty-consumer/package.json
+++ b/tests/integration/suites/uc32_empty_return_values/artifacts/ts-empty-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/pom.xml
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/package.json
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/pom.xml
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-producer/pom.xml
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-producer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc37_service_view_java/fixtures/ts-view-consumer/package.json
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/ts-view-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-consumer/pom.xml
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-consumer/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-provider/pom.xml
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-provider/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.2.1</mcp-mesh.version>
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-consumer/package.json
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1"
+    "@mcpmesh/sdk": "^3.2.2"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/package.json
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.2.1",
+    "@mcpmesh/sdk": "^3.2.2",
     "fastmcp": "^4.3.2"
   },
   "devDependencies": {

--- a/tests/lib-tests/README.md
+++ b/tests/lib-tests/README.md
@@ -68,7 +68,7 @@ tsuite --uc uc04_build_image
 
 After successful run, you'll have:
 
-- `tsuite-mesh:3.2.1` (or current version) Docker image
+- `tsuite-mesh:3.2.2` (or current version) Docker image
 
 Verify with:
 
@@ -82,11 +82,11 @@ Edit `config.yaml` to update versions:
 
 ```yaml
 packages:
-  cli_version: "3.2.1"
-  sdk_python_version: "3.2.1" # PEP 440 format for Python
-  sdk_typescript_version: "3.2.1"
-  core_version: "3.2.1"
-  sdk_java_version: "3.2.1"
+  cli_version: "3.2.2"
+  sdk_python_version: "3.2.2" # PEP 440 format for Python
+  sdk_typescript_version: "3.2.2"
+  core_version: "3.2.2"
+  sdk_java_version: "3.2.2"
 ```
 
 ## Next Steps

--- a/tests/lib-tests/config.yaml
+++ b/tests/lib-tests/config.yaml
@@ -10,11 +10,11 @@ suite:
 
 packages:
   # Version to test - update this for each release
-  cli_version: "3.2.1"
-  sdk_python_version: "3.2.1" # PEP 440 format for pip
-  sdk_typescript_version: "3.2.1"
-  core_version: "3.2.1"
-  sdk_java_version: "3.2.1"
+  cli_version: "3.2.2"
+  sdk_python_version: "3.2.2" # PEP 440 format for pip
+  sdk_typescript_version: "3.2.2"
+  core_version: "3.2.2"
+  sdk_java_version: "3.2.2"
 
 # Docker settings for the base image build
 docker:


### PR DESCRIPTION
Patch release. Two vendor-contract fixes, a retired scaffold model id, two meshui fixes, and two test surfaces that had never executed in CI.

Nothing touches the wire protocol, the registry, dependency resolution, or the declaration syntax.

## Contents

| Issue | Change |
|---|---|
| #1344 | Anthropic sampling params no longer forwarded to models that reject them (Python/TS/Java) |
| #1346 | Gemini `thinking_level`/`thinking_budget` conflict resolved client-side |
| #1345 | `meshctl scaffold` no longer emits the retired `gemini/gemini-1.5-pro` |
| #1350 | meshui agent detail panel shows resolved MCP tool + endpoint |
| #1352 | meshui Jobs page no longer crashes when the registry is unreachable |
| #1348 | `_mcp_mesh` test tree (928 tests) and meshui dashboard now run in CI |

## Release mechanics

- `scripts/bump_version.py 3.2.1 3.2.2` — 613 files across 36 categories; **coverage guard passed** (no stale mesh-shaped 3.2.1 references remain; residual `3.2.1` hits are third-party packages — koa, css-tree, mdast)
- `helm dependency update helm/mcp-mesh-core` — Chart.lock digest regenerated, 6 subcharts
- `cargo generate-lockfile` — `mcp-mesh-core` at 3.2.2 in Cargo.lock
- Version consistency verified across Python (`pyproject.toml`), TypeScript (`package.json`), Java (`pom.xml`), Rust (`Cargo.toml`), Helm (`Chart.yaml`) and the Java scaffold handler
- The Go binary version is injected at build time (`-X main.version=$(VERSION)`), so no source bump applies

## Worth reading in the notes

Two items are stated plainly rather than buried, because they bear on trust in the previous release:

**v3.2.1's Haiku 4.5 change shipped on a handler path with no executing test coverage.** The `_mcp_mesh` tree — 20 files, 928 tests over the native LLM clients and provider handlers — had never run in CI, and 8 of its tests were already failing on the released 3.2.1. They assert the synthetic-tool path against Haiku 4.5, which 3.2.1 deliberately moved to Anthropic's native `output_config`. Repaired, with handler-level Haiku 4.5 coverage that did not previously exist, and the tree now runs.

**The meshui dashboard had no CI at all** — no type check, no build, 36 tests never executed. A type error `tsc` had been reporting all along reached `main`; that error is the Jobs page crash in #1352.

Both surfaces now run in CI and are wired into the pipeline failure gate.

## Upgrade

No action required. One caveat called out in the notes: agents scaffolded before this release carry the retired `gemini/gemini-1.5-pro` id and will 404 on their first LLM call — update the model in the declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ