### PR TITLE
fix(release): sign the BOM via Maven, verify publication, and gate the Java image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,6 +329,12 @@ jobs:
     if: >
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
+    env:
+      # Single source of truth for the signing key. The trailing '!' pins the
+      # primary key instead of the default signing subkey; publish-java.sh reads
+      # this same value when it signs the BOM POM (which maven-gpg-plugin does
+      # not sign), so every artifact in the bundle carries the same signature.
+      GPG_KEYNAME: "F94266795DCA259D!"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -408,7 +414,7 @@ jobs:
             -Dskip.rust.build=true \
             -Dgpg.skip=false \
             -Dgpg.passphrase="" \
-            -Dgpg.keyname="F94266795DCA259D!"
+            -Dgpg.keyname="${GPG_KEYNAME}"
 
       - name: Publish to Maven Central
         env:
@@ -1421,13 +1427,20 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Wait for Maven Central to index Java SDK
+      # Pre-flight gate for the Java runtime image only. The image build runs
+      # `mvn dependency:resolve` against Maven Central; if the SDK is not there,
+      # the build fails ~37 minutes later with an opaque Dockerfile frame that
+      # names neither Central nor the missing artifact. Fail here instead, with
+      # the artifact and the likely cause spelled out.
+      # NOTE: groupId io.mcp-mesh maps to the Central path io/mcp-mesh/.
+      - name: Verify Java SDK is available on Maven Central
         run: |
           VERSION="${{ steps.meta.outputs.version }}"
+          ARTIFACT="io.mcp-mesh:mcp-mesh-spring-boot-starter:${VERSION}"
           BASE_URL="https://repo1.maven.org/maven2/io/mcp-mesh/mcp-mesh-spring-boot-starter/${VERSION}"
           POM_URL="${BASE_URL}/mcp-mesh-spring-boot-starter-${VERSION}.pom"
           JAR_URL="${BASE_URL}/mcp-mesh-spring-boot-starter-${VERSION}.jar"
-          echo "Waiting for Maven Central to index io.mcp-mesh:mcp-mesh-spring-boot-starter:${VERSION}..."
+          echo "Waiting for Maven Central to index ${ARTIFACT}..."
           MAX_ATTEMPTS=30
           ATTEMPT=0
           while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
@@ -1437,13 +1450,22 @@ jobs:
             JAR_STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$JAR_URL")
             echo "  POM: HTTP $POM_STATUS | JAR: HTTP $JAR_STATUS"
             if [ "$POM_STATUS" = "200" ] && [ "$JAR_STATUS" = "200" ]; then
-              echo "Maven Central has indexed mcp-mesh-spring-boot-starter-${VERSION}.jar"
+              echo "✅ Maven Central has indexed mcp-mesh-spring-boot-starter-${VERSION}.jar"
               exit 0
             fi
             echo "Not fully indexed yet, waiting 20 seconds..."
             sleep 20
           done
-          echo "WARNING: Maven Central may not have fully indexed yet, proceeding with Docker build anyway"
+          echo "❌ ERROR: ${ARTIFACT} is not resolvable from Maven Central"
+          echo "   POM: ${POM_URL} (HTTP ${POM_STATUS})"
+          echo "   JAR: ${JAR_URL} (HTTP ${JAR_STATUS})"
+          echo "   Likely cause: the Central Portal deployment was never published"
+          echo "   (validation failed) or is still validating."
+          echo "   Check https://central.sonatype.com/publishing/deployments"
+          echo "   Aborting before the Java runtime image build, which pre-caches"
+          echo "   this artifact via 'mvn dependency:resolve' and would otherwise"
+          echo "   fail ~37 minutes from now with an opaque Maven error."
+          exit 1
 
       - name: Build and push Java Runtime image
         uses: docker/build-push-action@v5

--- a/packaging/scripts/publish-java.sh
+++ b/packaging/scripts/publish-java.sh
@@ -27,6 +27,19 @@ GROUP_ID_PATH="io/mcp-mesh"
 
 # Sonatype Central Portal API
 SONATYPE_API="https://central.sonatype.com/api/v1/publisher/upload"
+SONATYPE_STATUS_API="https://central.sonatype.com/api/v1/publisher/status"
+
+# GPG key used to sign artifacts that maven-gpg-plugin does not sign (the BOM).
+# The trailing '!' pins the primary key rather than letting gpg pick the default
+# signing subkey. This MUST match the -Dgpg.keyname value used by Maven in
+# .github/workflows/release.yml, otherwise the bundle mixes two signing keys and
+# Central rejects the deployment. The workflow exports GPG_KEYNAME; the default
+# below only applies to manual/local runs.
+GPG_KEYNAME="${GPG_KEYNAME:-F94266795DCA259D!}"
+
+# Deployment status polling bounds
+POLL_INTERVAL_SECONDS=15
+POLL_TIMEOUT_SECONDS=1800
 
 # Colors for output
 RED='\033[0;31m'
@@ -78,7 +91,22 @@ for MODULE in "${MODULES[@]}"; do
 
     # Collect artifacts based on module type
     if [ "${MODULE}" = "${BOM_MODULE}" ]; then
-        # BOM module: pom-packaging only - may not have target/ from Maven build
+        # BOM module: pom-packaging only - no JARs.
+        #
+        # Two paths exist here, and the Maven one is the expected path:
+        #   1. `mvn verify` with -Dgpg.skip=false runs maven-gpg-plugin's
+        #      sign-artifacts execution (declared directly in mcp-mesh-bom/pom.xml
+        #      because the BOM has no <parent> to inherit it from). For pom
+        #      packaging the plugin copies the module's pom.xml to
+        #      target/<finalName>.pom and signs THAT file, writing
+        #      target/<finalName>.pom.asc alongside it. finalName defaults to
+        #      <artifactId>-<version>, i.e. exactly POM_FILE below - so both the
+        #      POM and its signature are picked up straight from target/ and are
+        #      guaranteed to be over identical bytes.
+        #   2. Fallback: if target/ has no POM (Maven not run, or signing
+        #      skipped), copy the source pom.xml in and sign it here. This is
+        #      defense in depth only; it must use the same pinned key as Maven,
+        #      otherwise the bundle mixes signing keys and Central rejects it.
         log "  BOM module - collecting POM artifacts only"
 
         # Create target dir if Maven didn't
@@ -86,19 +114,26 @@ for MODULE in "${MODULES[@]}"; do
 
         POM_FILE="${TARGET_DIR}/${ARTIFACT_ID}-${VERSION}.pom"
 
-        # If POM not in target, copy from module directory
+        # If POM not in target, copy from module directory.
+        # Any pre-existing .asc signs the previous bytes, so drop it: the
+        # signature must always be regenerated together with the POM.
         if [ ! -f "${POM_FILE}" ]; then
             log "  POM not in target/, copying from module directory"
             cp "${MODULE}/pom.xml" "${POM_FILE}"
+            rm -f "${POM_FILE}.asc"
+        else
+            log "  Using Maven-produced POM from target/"
         fi
 
         cp "${POM_FILE}" "${BUNDLE_MODULE_DIR}/"
         log "  Collected: $(basename "${POM_FILE}")"
 
-        # GPG signature - sign if not already signed by Maven
+        # GPG signature - only sign if maven-gpg-plugin did not already.
         if [ ! -f "${POM_FILE}.asc" ]; then
-            log "  Signing POM with GPG..."
-            gpg --batch --armor --detach-sign "${POM_FILE}"
+            log "  No Maven signature found; signing POM with GPG (key: ${GPG_KEYNAME})..."
+            gpg --local-user "${GPG_KEYNAME}" --batch --armor --detach-sign "${POM_FILE}"
+        else
+            log "  Using Maven-produced GPG signature"
         fi
         cp "${POM_FILE}.asc" "${BUNDLE_MODULE_DIR}/"
         log "  Collected: $(basename "${POM_FILE}").asc"
@@ -230,14 +265,109 @@ rm -f "${BUNDLE_ZIP}"
 
 if [ "${HTTP_STATUS}" -ge 200 ] && [ "${HTTP_STATUS}" -lt 300 ]; then
     success "Bundle uploaded successfully (HTTP ${HTTP_STATUS})"
-    if [ -n "${HTTP_BODY}" ]; then
-        log "Deployment ID: ${HTTP_BODY}"
-    fi
-    log "Monitor status at: https://central.sonatype.com/publishing"
 else
     error "Upload failed with HTTP ${HTTP_STATUS}"
     error "Response: ${HTTP_BODY}"
     exit 1
 fi
 
-success "Java SDK ${VERSION} published to Maven Central"
+# The upload response body is the deployment ID. Upload acceptance is NOT
+# publication: with publishingType=AUTOMATIC the portal still has to validate
+# the bundle (signatures, POM metadata, checksums) before releasing it, and that
+# validation can fail after the upload returned 2xx.
+DEPLOYMENT_ID=$(printf '%s' "${HTTP_BODY}" | tr -d '[:space:]')
+if [ -z "${DEPLOYMENT_ID}" ]; then
+    error "Upload accepted but no deployment ID was returned; cannot verify publication"
+    exit 1
+fi
+
+PORTAL_URL="https://central.sonatype.com/publishing/deployments"
+log "Deployment ID: ${DEPLOYMENT_ID}"
+log "Monitor status at: ${PORTAL_URL}"
+
+# Extract .deploymentState from a status response body
+deployment_state() {
+    if command -v jq >/dev/null 2>&1; then
+        printf '%s' "$1" | jq -r '.deploymentState // empty' 2>/dev/null || true
+    else
+        printf '%s' "$1" | tr -d ' \n' \
+            | sed -n 's/.*"deploymentState":"\([A-Z_]*\)".*/\1/p' || true
+    fi
+}
+
+# Pretty-print a status response body (validation errors live in .errors)
+dump_status_body() {
+    if command -v jq >/dev/null 2>&1; then
+        printf '%s' "$1" | jq . 2>/dev/null || printf '%s\n' "$1"
+    else
+        printf '%s\n' "$1"
+    fi
+}
+
+# Poll the deployment until it reaches a terminal state.
+# States (Sonatype Publisher API): PENDING, VALIDATING, VALIDATED, PUBLISHING,
+# PUBLISHED, FAILED. With AUTOMATIC publishing, PUBLISHED is the success
+# terminal state and FAILED is the failure terminal state; the rest are
+# transitional.
+log "Waiting for deployment ${DEPLOYMENT_ID} to reach a terminal state..."
+
+DEADLINE=$(( $(date +%s) + POLL_TIMEOUT_SECONDS ))
+LAST_STATE=""
+LAST_BODY=""
+
+while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+    STATUS_BODY=$(curl -s -X POST \
+        "${SONATYPE_STATUS_API}?id=${DEPLOYMENT_ID}" \
+        -H "Authorization: Bearer ${TOKEN}") || STATUS_BODY=""
+    STATE=$(deployment_state "${STATUS_BODY}")
+
+    if [ -n "${STATUS_BODY}" ]; then
+        LAST_BODY="${STATUS_BODY}"
+    fi
+
+    if [ -z "${STATE}" ]; then
+        log "  Could not read deployment state (transient?), retrying..."
+    else
+        if [ "${STATE}" != "${LAST_STATE}" ]; then
+            log "  Deployment state: ${STATE}"
+            LAST_STATE="${STATE}"
+        fi
+
+        case "${STATE}" in
+            PUBLISHED)
+                success "Deployment ${DEPLOYMENT_ID} published to Maven Central"
+                success "Java SDK ${VERSION} published to Maven Central"
+                exit 0
+                ;;
+            FAILED)
+                error "Deployment ${DEPLOYMENT_ID} FAILED validation"
+                error "Central reported the following component errors:"
+                dump_status_body "${STATUS_BODY}" >&2
+                error "Inspect at: ${PORTAL_URL}"
+                exit 1
+                ;;
+            PENDING|VALIDATING|VALIDATED|PUBLISHING)
+                # Transitional; keep polling. VALIDATED is not treated as
+                # success here: with AUTOMATIC it advances to PUBLISHING on its
+                # own, and reporting success before the artifacts are on Central
+                # is exactly the failure mode this polling exists to prevent.
+                :
+                ;;
+            *)
+                log "  Unrecognized deployment state '${STATE}', continuing to poll"
+                ;;
+        esac
+    fi
+
+    sleep "${POLL_INTERVAL_SECONDS}"
+done
+
+error "Timed out after ${POLL_TIMEOUT_SECONDS}s waiting for deployment to publish"
+error "Deployment ID: ${DEPLOYMENT_ID}"
+error "Last observed state: ${LAST_STATE:-unknown}"
+if [ -n "${LAST_BODY}" ]; then
+    error "Last status response:"
+    dump_status_body "${LAST_BODY}" >&2
+fi
+error "Inspect at: ${PORTAL_URL}"
+exit 1

--- a/src/runtime/java/mcp-mesh-bom/pom.xml
+++ b/src/runtime/java/mcp-mesh-bom/pom.xml
@@ -34,6 +34,18 @@
         <developerConnection>scm:git:git@github.com:dhyansraj/mcp-mesh.git</developerConnection>
     </scm>
 
+    <!--
+        This BOM deliberately has NO <parent>: consumers importing it via
+        dependencyManagement must not be forced to resolve mcp-mesh-parent.
+        The cost is that nothing is inherited, so the GPG signing property and
+        the signing plugin execution below are duplicated from
+        ../pom.xml (mcp-mesh-parent) and must be kept in sync with it.
+    -->
+    <properties>
+        <!-- GPG signing: disabled by default, enable with -Dgpg.skip=false for releases -->
+        <gpg.skip>true</gpg.skip>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -63,4 +75,39 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <!--
+        A <build> section in a BOM is inert for consumers: importing a BOM via
+        dependencyManagement pulls in only its dependencyManagement (and
+        properties used to resolve it), never its build plugins.
+        This exists solely so that `mvn verify` signs the BOM POM on the same
+        maven-gpg-plugin code path as every other module, instead of leaving it
+        to be signed ad hoc at publish time.
+        Mirrors the sign-artifacts execution in ../pom.xml.
+    -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.2.7</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${gpg.skip}</skip>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
The v3.2.2 Java SDK never reached Maven Central. Everything else published fine (npm, PyPI ×2, Helm OCI, 3 of 4 Docker images), but the Java SDK and `java-runtime` image are absent for 3.2.2.

Three defects: one caused it, one hid it, one reported it 90 minutes late.

## 1. The BOM was the only artifact Maven didn't sign

Central rejected the deployment with exactly one failed component:

```
pkg:maven/io.mcp-mesh/mcp-mesh-bom@3.2.2?type=pom
Invalid signature for file: mcp-mesh-bom-3.2.2.pom.asc — Failed to verify the PGP signature
6 out of 7 Components Validated
```

`mcp-mesh-bom` has **no `<parent>`**, so it inherits nothing from `mcp-mesh-parent` — including the `maven-gpg-plugin` `sign-artifacts` execution (`pom.xml:256-276`). The release log confirms it: `gpg:3.2.7:sign` runs for six modules and never for the BOM. It alone fell to an ad-hoc `gpg` call in `publish-java.sh`.

**Six Maven-signed components validated. The one signed by the script did not.**

Fix: declare the signing plugin directly in the BOM so every artifact is produced by the same code path. **No `<parent>` added** — a parent-less BOM is deliberate, so consumers importing it via `dependencyManagement` don't have to resolve `mcp-mesh-parent`. The cost is a duplicated plugin block, called out in a comment.

Verified locally rather than assumed:
- `maven-gpg-plugin` copies `pom.xml` → `target/<finalName>.pom` and signs *that copy*; `finalName` defaults to `<artifactId>-<version>`, exactly the path the bundler reads — so POM and `.asc` cannot come from different bytes
- `diff pom.xml target/mcp-mesh-bom-3.2.2.pom` → byte-identical
- `gpg --verify` → `Good signature`, from the **primary** key
- CLI `-D` properties **do** reach a parent-less reactor module (observed `gpg.skip` and `gpg.keyname` taking effect), so the release invocation still controls signing
- A BOM-local `<gpg.skip>true</gpg.skip>` keeps a plain local `mvn verify` from signing — load-bearing, since nothing is inherited

**A theory I had to discard.** I first concluded the script's unpinned `gpg` call selected the signing *subkey* while Maven pinned the primary. That doesn't hold alone: `mcp-mesh-native`'s placeholder javadoc was signed by the *same unpinned call* in the same bundle and **validated**. The script path is still pinned and its POM/`.asc` staleness checks coupled — worth doing regardless — but the substantive fix is that Maven now signs the BOM. I can't say precisely why the script's signature was rejected; putting the BOM on the path that demonstrably works is the fix I can justify.

## 2. The publish step reported success on upload, not on publication

`publish-java.sh` exited 0 on a 2xx from the **upload**. With `publishingType=AUTOMATIC` the portal still validates before releasing, so `publish-java-sdk` showed ✅ for a release that does not exist.

It now polls the deployment to a terminal state — `PUBLISHED` → 0, `FAILED` → dump Central's component-level errors and exit 1 — bounded at 30 minutes. API contract from [Sonatype's Publisher API docs](https://central.sonatype.org/publish/publish-portal-api/); the existing `Authorization: Bearer` token (already `base64(user:token)`) is reused.

`VALIDATED` is deliberately **not** treated as success: under AUTOMATIC it advances on its own, and accepting it would reproduce the exact bug this polling exists to prevent.

## 3. The pipeline already knew, and shrugged

`build-docker` **already had** a Maven Central check. In the v3.2.2 run it polled **30 times over 10 minutes** and got `HTTP 404` every single time:

```
Attempt 1/30: POM: HTTP 404 | JAR: HTTP 404
...  (30 × 404)
WARNING: Maven Central may not have fully indexed yet, proceeding with Docker build anyway
```

It then proceeded into a 37-minute build that could not succeed, failing with a Dockerfile frame naming neither Central nor the missing artifact — which reads as an infrastructure outage rather than a missing dependency.

The check now **fails the job**, naming the artifact, both URLs with their status codes, and the likely cause. Retry-with-backoff is kept (repo1 sync lags Central by minutes even on a healthy release); only exhaustion is fatal. Placement is unchanged, so a Central problem still can't block the python/typescript/registry images.

## Validation

`bash -n`, workflow YAML parse, BOM XML well-formedness, `mvn -pl mcp-mesh-bom validate`, and the local signing round-trip above all pass.

**Not verifiable here:** none of this runs in CI, and the only true test is a real release. `shellcheck` isn't installed locally, so only `bash -n` ran. One consequence worth noting: the BOM isn't flattened (flatten-maven-plugin also lives in the parent), so the published POM will now carry the added `<properties>` and `<build>` blocks. Central's required-metadata checks are unaffected and `<build>` is not a rejection criterion, but it is a visible change to the published BOM.

## Release-state note

Maven Central never received 3.2.2, so that version is unclaimed there and 3.2.3 proceeds cleanly (Central goes 3.2.1 → 3.2.3). **3.2.2 should not be published to Central retroactively** — otherwise "3.2.2" would denote different code across ecosystems.

Also currently true, and corrected by the next successful release: `java-runtime:3.2` and `:latest` still point at 3.2.1 content, so a Java agent deployed from the 3.2.2 chart (which defaults to `tag: "3.2"`) silently runs the 3.2.1 runtime.

Closes #1357

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Java package publishing reliability with stronger signing-key selection and validation.
  * Added deployment-status monitoring to confirm releases are successfully published before reporting success.
  * Prevented Java runtime image builds when required Maven artifacts are unavailable.
  * Added clearer diagnostics and troubleshooting guidance when publishing or artifact verification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->