### PR TITLE
fix(llm): forward the consumer's max_iterations to the provider-managed loop

### DIFF
--- a/docs/java/annotations.md
+++ b/docs/java/annotations.md
@@ -200,7 +200,7 @@ public AnalysisResult analyze(
 | Attribute          | Required | Default | Description                          |
 | ------------------ | -------- | ------- | ------------------------------------ |
 | `providerSelector` | Yes      |         | `@Selector` for mesh LLM discovery   |
-| `maxIterations`    | No       | `1`     | Max agentic loop iterations          |
+| `maxIterations`    | No       | `10`    | Max agentic loop iterations (when set explicitly it is also forwarded to the provider-managed loop) |
 | `systemPrompt`     | No       | `""`    | System prompt or template path       |
 | `contextParam`     | No       | `""`    | Parameter name for template context  |
 | `filter`           | No       |         | `@Selector` for tool filtering       |

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -57,7 +57,7 @@ def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
 | Parameter        | Type | Description                                       |
 | ---------------- | ---- | ------------------------------------------------- |
 | `provider`       | dict | LLM provider selector (capability + tags)         |
-| `max_iterations` | int  | Max agentic loop iterations (default: 1)          |
+| `max_iterations` | int  | Max agentic loop iterations (default: 10; when set explicitly it is also forwarded to the provider-managed loop) |
 | `system_prompt`  | str  | Inline prompt or `file://path` to Jinja2 template |
 | `response_model` | type | Pydantic model the LLM must emit and is validated against (separate from the return type) |
 | `context_param`  | str  | Parameter name receiving context object           |

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlm.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlm.java
@@ -89,8 +89,14 @@ public @interface MeshLlm {
      * Maximum iterations for the agentic loop.
      *
      * <p>Each iteration allows the LLM to make tool calls.
+     *
+     * <p>Unset by default ({@link MeshLlmDefaults#MAX_ITERATIONS_UNSET}), which
+     * means "10, and let the provider decide its own cap". When set explicitly
+     * — here or via {@code MESH_LLM_MAX_ITERATIONS} — the cap is ALSO forwarded
+     * to the provider on the wire ({@code model_params.max_iterations}) so the
+     * provider-managed loop honors it (issue #1356).
      */
-    int maxIterations() default MeshLlmDefaults.MAX_ITERATIONS;
+    int maxIterations() default MeshLlmDefaults.MAX_ITERATIONS_UNSET;
 
     /**
      * System prompt for the LLM.

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlmDefaults.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshLlmDefaults.java
@@ -22,6 +22,15 @@ public final class MeshLlmDefaults {
     public static final int MAX_ITERATIONS = 10;
 
     /**
+     * Sentinel for an unset {@code maxIterations} (issue #1356). When
+     * {@code maxIterations} equals this value the consumer's own loop uses
+     * {@link #MAX_ITERATIONS} but no {@code max_iterations} is sent on the
+     * wire, so the provider-managed loop applies its own
+     * {@code MESH_LLM_MAX_ITERATIONS} (or the same default of 10).
+     */
+    public static final int MAX_ITERATIONS_UNSET = 0;
+
+    /**
      * Sentinel for an unset {@code maxTokens}. When {@code maxTokens} equals
      * this value, no {@code max_tokens} is sent on the wire and the provider's
      * own default applies.

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/MeshLlmProviderProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/MeshLlmProviderProcessor.java
@@ -2,6 +2,7 @@ package io.mcpmesh.ai;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
+import io.mcpmesh.MeshLlmDefaults;
 import io.mcpmesh.MeshLlmProvider;
 import io.mcpmesh.core.MeshObjectMappers;
 import io.mcpmesh.ai.handlers.LlmProviderHandler;
@@ -345,6 +346,12 @@ public class MeshLlmProviderProcessor implements BeanPostProcessor, ApplicationC
             parallelToolCalls = Boolean.TRUE.equals(ptc) || "true".equals(String.valueOf(ptc));
         }
 
+        // Issue #1356: consumer-forwarded provider-managed loop cap. Removed from
+        // model_params (like parallel_tool_calls) so it can never reach the vendor
+        // API. Precedence: forwarded value → MESH_LLM_MAX_ITERATIONS → 10.
+        int resolvedMaxIterations = extractMaxIterations(
+            modelParams, System.getenv("MESH_LLM_MAX_ITERATIONS"));
+
         // Extract consumer-supplied output_mode override (issue #1112). When absent
         // or invalid the handler falls back to per-vendor auto-selection (zero
         // regression). Threaded to handlers via the options map.
@@ -439,7 +446,7 @@ public class MeshLlmProviderProcessor implements BeanPostProcessor, ApplicationC
                     MediaStore mediaStore = getMediaStore();
                     List<Map<String, Object>> currentMessages = new ArrayList<>(messages);
                     LlmProviderHandler.LlmResponse lastResponse = null;
-                    int maxIterations = 10;
+                    int maxIterations = resolvedMaxIterations;
                     boolean completed = false;
 
                     for (int iteration = 0; iteration < maxIterations; iteration++) {
@@ -888,6 +895,69 @@ public class MeshLlmProviderProcessor implements BeanPostProcessor, ApplicationC
         if (v != null) {
             handlerOptions.put(key, v);
         }
+    }
+
+    /**
+     * Coerce an arbitrary wire value to a positive integer iteration cap, or
+     * {@code null} when it is unset/invalid (non-numeric, NaN, infinite,
+     * {@code <= 0}, or floors to 0). Floors BEFORE the {@code > 0} check so
+     * fractional values in (0,1) are rejected, not zeroed. Parity with
+     * TypeScript {@code sanitizeMaxIterations} and Python
+     * {@code _sanitize_max_iterations}.
+     *
+     * @param value raw value (Number, String, or anything else)
+     * @return the sanitized cap, or {@code null} when invalid
+     */
+    static Integer sanitizeMaxIterations(Object value) {
+        double parsed;
+        if (value instanceof Number n) {
+            parsed = n.doubleValue();
+        } else if (value instanceof Boolean b) {
+            parsed = b ? 1 : 0;
+        } else if (value instanceof String s) {
+            try {
+                parsed = Double.parseDouble(s.trim());
+            } catch (NumberFormatException | NullPointerException e) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+        if (Double.isNaN(parsed) || Double.isInfinite(parsed)) {
+            return null;
+        }
+        long floored = (long) Math.floor(parsed);
+        if (floored <= 0) {
+            return null;
+        }
+        return (int) Math.min(floored, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Issue #1356: resolve the provider-managed agentic-loop cap and STRIP the
+     * key from {@code modelParams} so it never reaches the vendor API.
+     *
+     * <p>Precedence: consumer-forwarded {@code model_params.max_iterations} →
+     * {@code MESH_LLM_MAX_ITERATIONS} → default 10. A <em>present</em> key
+     * (even with an invalid value) never falls through to the env branch —
+     * invalid param → default. The env value is consulted only when the key is
+     * ABSENT. Parity with TypeScript {@code resolveMaxIterations}.
+     *
+     * <p>Pure w.r.t. the environment: the raw env value is passed in so this is
+     * unit-testable without mutating process env (same style as
+     * {@code MeshLlmRegistry.resolveMaxIterations}).
+     *
+     * @param modelParams wire model_params (may be null); mutated to drop the key
+     * @param envVal      raw value of {@code MESH_LLM_MAX_ITERATIONS} (may be null)
+     * @return the effective iteration cap
+     */
+    static int extractMaxIterations(Map<String, Object> modelParams, String envVal) {
+        if (modelParams != null && modelParams.containsKey("max_iterations")) {
+            Integer sanitized = sanitizeMaxIterations(modelParams.remove("max_iterations"));
+            return sanitized != null ? sanitized : MeshLlmDefaults.MAX_ITERATIONS;
+        }
+        Integer fromEnv = sanitizeMaxIterations(envVal);
+        return fromEnv != null ? fromEnv : MeshLlmDefaults.MAX_ITERATIONS;
     }
 
     private LlmProviderConfig findProvider(String capability) {

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/MeshLlmProviderMaxIterationsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/MeshLlmProviderMaxIterationsTest.java
@@ -1,0 +1,126 @@
+package io.mcpmesh.ai;
+
+import io.mcpmesh.MeshLlmDefaults;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1356: the provider-managed agentic loop must honour the consumer's
+ * forwarded {@code model_params.max_iterations} instead of a hardcoded 10.
+ *
+ * <p>Contract mirrors the TypeScript reference ({@code sanitizeMaxIterations} /
+ * {@code resolveMaxIterations} in {@code llm-provider.ts}) and the Python
+ * helpers in {@code mesh/helpers.py}. The helpers are pure w.r.t. the
+ * environment (env value is a parameter), same style as
+ * {@code MeshLlmRegistry.resolveMaxIterations}.
+ */
+@DisplayName("MeshLlmProviderProcessor — max_iterations resolution (#1356)")
+class MeshLlmProviderMaxIterationsTest {
+
+    // ---------------------------------------------------------------- sanitize
+
+    @Test
+    @DisplayName("sanitize: positive integers pass through (Number and String)")
+    void sanitizeValid() {
+        assertEquals(3, MeshLlmProviderProcessor.sanitizeMaxIterations(3));
+        assertEquals(7, MeshLlmProviderProcessor.sanitizeMaxIterations("7"));
+        assertEquals(1, MeshLlmProviderProcessor.sanitizeMaxIterations(1L));
+        assertEquals(42, MeshLlmProviderProcessor.sanitizeMaxIterations(" 42 "));
+    }
+
+    @Test
+    @DisplayName("sanitize: fractional values are floored BEFORE the >0 check")
+    void sanitizeFractional() {
+        assertEquals(2, MeshLlmProviderProcessor.sanitizeMaxIterations(2.9));
+        assertEquals(2, MeshLlmProviderProcessor.sanitizeMaxIterations("2.9"));
+        // 0.5 floors to 0 → rejected, NOT a zero cap
+        assertNull(MeshLlmProviderProcessor.sanitizeMaxIterations(0.5));
+    }
+
+    @Test
+    @DisplayName("sanitize: zero, negative, NaN, infinite, non-numeric and null are invalid")
+    void sanitizeInvalid() {
+        assertNull(MeshLlmProviderProcessor.sanitizeMaxIterations(0));
+        assertNull(MeshLlmProviderProcessor.sanitizeMaxIterations(-1));
+        assertNull(MeshLlmProviderProcessor.sanitizeMaxIterations("0"));
+        assertNull(MeshLlmProviderProcessor.sanitizeMaxIterations("-4"));
+        assertNull(MeshLlmProviderProcessor.sanitizeMaxIterations(Double.NaN));
+        assertNull(MeshLlmProviderProcessor.sanitizeMaxIterations(Double.POSITIVE_INFINITY));
+        assertNull(MeshLlmProviderProcessor.sanitizeMaxIterations("abc"));
+        assertNull(MeshLlmProviderProcessor.sanitizeMaxIterations(""));
+        assertNull(MeshLlmProviderProcessor.sanitizeMaxIterations(null));
+        assertNull(MeshLlmProviderProcessor.sanitizeMaxIterations(Map.of()));
+    }
+
+    // ----------------------------------------------------------------- resolve
+
+    @Test
+    @DisplayName("resolve: a forwarded value wins over the provider env")
+    void forwardedValueWins() {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("max_iterations", 3);
+        assertEquals(3, MeshLlmProviderProcessor.extractMaxIterations(params, "8"));
+    }
+
+    @Test
+    @DisplayName("resolve: a PRESENT but invalid value falls back to 10, NOT to env")
+    void invalidExplicitFallsBackToDefaultNotEnv() {
+        for (Object bad : new Object[] {0, -3, "abc", null, Double.NaN}) {
+            Map<String, Object> params = new HashMap<>();
+            params.put("max_iterations", bad);
+            assertEquals(MeshLlmDefaults.MAX_ITERATIONS,
+                MeshLlmProviderProcessor.extractMaxIterations(params, "8"),
+                "invalid explicit value " + bad + " must resolve to the default");
+        }
+    }
+
+    @Test
+    @DisplayName("resolve: absent key consults MESH_LLM_MAX_ITERATIONS")
+    void absentUsesEnv() {
+        assertEquals(8, MeshLlmProviderProcessor.extractMaxIterations(new LinkedHashMap<>(), "8"));
+        assertEquals(8, MeshLlmProviderProcessor.extractMaxIterations(null, "8"));
+    }
+
+    @Test
+    @DisplayName("resolve: absent key + missing/invalid env → default 10")
+    void absentWithoutEnvUsesDefault() {
+        assertEquals(MeshLlmDefaults.MAX_ITERATIONS,
+            MeshLlmProviderProcessor.extractMaxIterations(new LinkedHashMap<>(), null));
+        assertEquals(MeshLlmDefaults.MAX_ITERATIONS,
+            MeshLlmProviderProcessor.extractMaxIterations(new LinkedHashMap<>(), "not-a-number"));
+        assertEquals(MeshLlmDefaults.MAX_ITERATIONS,
+            MeshLlmProviderProcessor.extractMaxIterations(new LinkedHashMap<>(), "0"));
+    }
+
+    // ------------------------------------------------------------------ strip
+
+    @Test
+    @DisplayName("the key is stripped from model_params so it never reaches the vendor API")
+    void keyIsStripped() {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("max_iterations", 4);
+        params.put("temperature", 0.1);
+
+        MeshLlmProviderProcessor.extractMaxIterations(params, null);
+
+        assertFalse(params.containsKey("max_iterations"));
+        assertEquals(0.1, params.get("temperature"));
+    }
+
+    @Test
+    @DisplayName("an invalid forwarded value is stripped too")
+    void invalidKeyIsStripped() {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("max_iterations", "abc");
+
+        assertEquals(MeshLlmDefaults.MAX_ITERATIONS,
+            MeshLlmProviderProcessor.extractMaxIterations(params, null));
+        assertFalse(params.containsKey("max_iterations"));
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshEventProcessor.java
@@ -331,7 +331,7 @@ public class MeshEventProcessor implements SmartLifecycle {
             String contextParam = config != null ? config.contextParam() : "ctx";
             int maxIterations = config != null ? config.maxIterations()
                 : MeshLlmRegistry.resolveMaxIterations(
-                    System.getenv("MESH_LLM_MAX_ITERATIONS"), MeshLlmDefaults.MAX_ITERATIONS);
+                    System.getenv("MESH_LLM_MAX_ITERATIONS"), MeshLlmDefaults.MAX_ITERATIONS_UNSET);
             boolean parallelToolCalls = config != null && config.parallelToolCalls();
             int maxTokens = config != null ? config.maxTokens() : MeshLlmDefaults.MAX_TOKENS_UNSET;
             double temperature = config != null ? config.temperature() : MeshLlmDefaults.TEMPERATURE_UNSET;
@@ -514,7 +514,7 @@ public class MeshEventProcessor implements SmartLifecycle {
             String contextParam = config != null ? config.contextParam() : "ctx";
             int maxIterations = config != null ? config.maxIterations()
                 : MeshLlmRegistry.resolveMaxIterations(
-                    System.getenv("MESH_LLM_MAX_ITERATIONS"), MeshLlmDefaults.MAX_ITERATIONS);
+                    System.getenv("MESH_LLM_MAX_ITERATIONS"), MeshLlmDefaults.MAX_ITERATIONS_UNSET);
             boolean parallelToolCalls = config != null && config.parallelToolCalls();
             int maxTokens = config != null ? config.maxTokens() : MeshLlmDefaults.MAX_TOKENS_UNSET;
             double temperature = config != null ? config.temperature() : MeshLlmDefaults.TEMPERATURE_UNSET;

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -86,6 +86,8 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
     private volatile String systemPromptTemplate = "";
     private volatile String contextParamName = "ctx";
     private volatile int defaultMaxIterations = MeshLlmDefaults.MAX_ITERATIONS;
+    /** Issue #1356: true when the cap was explicitly configured (annotation or env). */
+    private volatile boolean defaultMaxIterationsExplicit = false;
     private volatile int defaultMaxTokens = MeshLlmDefaults.MAX_TOKENS_UNSET;
     private volatile double defaultTemperature = MeshLlmDefaults.TEMPERATURE_UNSET;
     private volatile boolean parallelToolCalls = false;
@@ -142,6 +144,10 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
         this.dependencyInjector = dependencyInjector;
         this.systemPromptTemplate = systemPrompt != null ? systemPrompt : "";
         this.contextParamName = contextParamName != null ? contextParamName : "ctx";
+        // Issue #1356: a non-positive value is the "unset" sentinel — the local
+        // loop still runs 10 iterations, but nothing goes on the wire so the
+        // provider keeps its own MESH_LLM_MAX_ITERATIONS / default.
+        this.defaultMaxIterationsExplicit = maxIterations > 0;
         this.defaultMaxIterations = maxIterations > 0 ? maxIterations : MeshLlmDefaults.MAX_ITERATIONS;
     }
 
@@ -404,6 +410,7 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
         private Double topP = null;
         private List<String> stopSequences = null;
         private int maxIterations = defaultMaxIterations;
+        private final boolean maxIterationsExplicit = defaultMaxIterationsExplicit;
 
         // Issue #1019: escape-hatch for vendor-specific model_params kwargs
         // (e.g., thinking_config, output_config, reasoning_effort) not exposed
@@ -768,6 +775,14 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
             }
             if (parallelToolCalls && !modelParams.containsKey("parallel_tool_calls")) {
                 modelParams.put("parallel_tool_calls", true);
+            }
+            // max_iterations (issue #1356): forward the provider-managed loop cap
+            // only when explicitly configured (@MeshLlm(maxIterations=...) or
+            // MESH_LLM_MAX_ITERATIONS) AND the escape-hatch modelParams did not
+            // already supply it. Unset → key omitted → the provider applies its
+            // own MESH_LLM_MAX_ITERATIONS / default of 10.
+            if (maxIterationsExplicit && !modelParams.containsKey("max_iterations")) {
+                modelParams.put("max_iterations", maxIterations);
             }
             // output_mode (issue #1112): inject the annotation's resolved mode only
             // when explicitly set (non-UNSET) AND the escape-hatch modelParams did

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyMaxIterationsTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyMaxIterationsTest.java
@@ -1,0 +1,145 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshLlmDefaults;
+import io.mcpmesh.core.MeshObjectMappers;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1356: the consumer forwards {@code model_params.max_iterations} to the
+ * provider ONLY when the cap was explicitly configured
+ * ({@code @MeshLlm(maxIterations=...)} or {@code MESH_LLM_MAX_ITERATIONS}).
+ *
+ * <p>When unset ({@link MeshLlmDefaults#MAX_ITERATIONS_UNSET}) the key is
+ * omitted so the provider keeps its own {@code MESH_LLM_MAX_ITERATIONS} /
+ * default of 10 — matching the TypeScript reference and the Python SDK.
+ *
+ * <p>Wiring mirrors {@code MeshLlmAgentProxyModelParamsTest}.
+ */
+@DisplayName("MeshLlmAgentProxy — max_iterations forwarding (#1356)")
+class MeshLlmAgentProxyMaxIterationsTest {
+
+    private MockWebServer server;
+    private McpHttpClient client;
+    private ObjectMapper mapper;
+
+    @BeforeAll
+    static void initTlsConfig() throws Exception {
+        Constructor<MeshTlsConfig> ctor = MeshTlsConfig.class.getDeclaredConstructor(
+            boolean.class, String.class, String.class, String.class, String.class);
+        ctor.setAccessible(true);
+        MeshTlsConfig disabled = ctor.newInstance(false, "off", null, null, null);
+
+        Field cachedField = MeshTlsConfig.class.getDeclaredField("cached");
+        cachedField.setAccessible(true);
+        cachedField.set(null, disabled);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        mapper = MeshObjectMappers.create();
+        client = new McpHttpClient(mapper);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (client != null) client.close();
+        server.shutdown();
+    }
+
+    private MeshLlmAgentProxy proxyWith(int maxIterations) {
+        MeshLlmAgentProxy proxy = new MeshLlmAgentProxy("test.maxiterations");
+        proxy.configure(client, null, null, null, "", "ctx", maxIterations, false);
+        proxy.updateProvider(
+            server.url("/").toString().replaceAll("/$", ""),
+            "process_chat",
+            "mesh-delegated"
+        );
+        return proxy;
+    }
+
+    private MockResponse stubLlmResponse(String reply) {
+        Map<String, Object> innerPayload = Map.of("role", "assistant", "content", reply);
+        String innerJson = mapper.writeValueAsString(innerPayload);
+        Map<String, Object> envelope = Map.of(
+            "jsonrpc", "2.0",
+            "id", System.currentTimeMillis(),
+            "result", Map.of("content", List.of(Map.of("type", "text", "text", innerJson)))
+        );
+        return new MockResponse()
+            .setBody(mapper.writeValueAsString(envelope))
+            .setHeader("Content-Type", "application/json");
+    }
+
+    private JsonNode readModelParams(RecordedRequest request) throws Exception {
+        JsonNode root = mapper.readTree(request.getBody().readUtf8());
+        JsonNode modelParams = root.get("params").get("arguments").get("request").get("model_params");
+        assertNotNull(modelParams, "request.model_params must be present");
+        return modelParams;
+    }
+
+    @Test
+    @DisplayName("explicit cap is forwarded on the wire")
+    void explicitCapForwarded() throws Exception {
+        server.enqueue(stubLlmResponse("ok"));
+
+        assertEquals("ok", proxyWith(4).request().user("hi").generate());
+
+        JsonNode modelParams = readModelParams(server.takeRequest());
+        assertEquals(4, modelParams.get("max_iterations").asInt());
+    }
+
+    @Test
+    @DisplayName("unset cap is NOT forwarded — provider keeps its own resolution")
+    void unsetCapOmitted() throws Exception {
+        server.enqueue(stubLlmResponse("ok"));
+
+        assertEquals("ok",
+            proxyWith(MeshLlmDefaults.MAX_ITERATIONS_UNSET).request().user("hi").generate());
+
+        JsonNode modelParams = readModelParams(server.takeRequest());
+        assertFalse(modelParams.has("max_iterations"),
+            "unset maxIterations must not put a cap on the wire");
+    }
+
+    @Test
+    @DisplayName("unset cap still runs the local loop with the default of 10")
+    void unsetCapStillDefaultsLocally() throws Exception {
+        MeshLlmAgentProxy proxy = proxyWith(MeshLlmDefaults.MAX_ITERATIONS_UNSET);
+        Object builder = proxy.request();
+        Field f = builder.getClass().getDeclaredField("maxIterations");
+        f.setAccessible(true);
+        assertEquals(MeshLlmDefaults.MAX_ITERATIONS, f.getInt(builder));
+    }
+
+    @Test
+    @DisplayName("modelParams escape hatch wins over the annotation cap")
+    void escapeHatchWins() throws Exception {
+        server.enqueue(stubLlmResponse("ok"));
+
+        proxyWith(4).request()
+            .user("hi")
+            .modelParams(Map.of("max_iterations", 2))
+            .generate();
+
+        JsonNode modelParams = readModelParams(server.takeRequest());
+        assertEquals(2, modelParams.get("max_iterations").asInt());
+    }
+}

--- a/src/runtime/python/_mcp_mesh/engine/llm_config.py
+++ b/src/runtime/python/_mcp_mesh/engine/llm_config.py
@@ -27,8 +27,14 @@ class LLMConfig:
        When set, the consumer requests this specific model from the provider; otherwise
        the provider uses its decorator-time default."""
 
-    max_iterations: int = 10
-    """Maximum iterations for the agentic loop"""
+    max_iterations: Optional[int] = None
+    """Maximum iterations for the agentic loop.
+
+       ``None`` means "not explicitly configured" (issue #1356): the consumer's
+       own loop uses ``effective_max_iterations`` (10), and nothing is forwarded
+       to the provider so the provider's own MESH_LLM_MAX_ITERATIONS / default
+       applies. Any non-None value is treated as an explicit user setting and IS
+       forwarded on the wire."""
 
     system_prompt: Optional[str] = None
     """Optional system prompt to prepend to all interactions"""
@@ -36,9 +42,19 @@ class LLMConfig:
     output_mode: Optional[str] = None
     """Output mode override: 'strict', 'hint', or 'text'. If None, auto-detected by handler."""
 
+    @property
+    def effective_max_iterations(self) -> int:
+        """Iteration cap for the consumer's own loop (default 10 when unset)."""
+        return self.max_iterations if self.max_iterations is not None else 10
+
+    @property
+    def max_iterations_explicit(self) -> bool:
+        """True when a cap was explicitly configured (decorator arg or env)."""
+        return self.max_iterations is not None
+
     def __post_init__(self):
         """Validate configuration after initialization."""
-        if self.max_iterations < 1:
+        if self.max_iterations is not None and self.max_iterations < 1:
             raise ValueError("max_iterations must be >= 1")
         if self.provider is None:
             raise ValueError("provider cannot be empty")

--- a/src/runtime/python/_mcp_mesh/engine/llm_config.py
+++ b/src/runtime/python/_mcp_mesh/engine/llm_config.py
@@ -7,6 +7,13 @@ Consolidates LLM-related configuration into a single type-safe structure.
 from dataclasses import dataclass
 from typing import Any, Optional
 
+# Issue #1356: effective agentic-loop cap when nothing configured one. Lives
+# here (a leaf module with no intra-package imports) so both the consumer-side
+# helpers (``mesh.helpers``) and the registration path
+# (``_mcp_mesh.pipeline.mcp_heartbeat.rust_heartbeat``) can import it without
+# creating a cycle through the ``mesh`` package.
+DEFAULT_MAX_ITERATIONS = 10
+
 
 @dataclass
 class LLMConfig:
@@ -45,7 +52,11 @@ class LLMConfig:
     @property
     def effective_max_iterations(self) -> int:
         """Iteration cap for the consumer's own loop (default 10 when unset)."""
-        return self.max_iterations if self.max_iterations is not None else 10
+        return (
+            self.max_iterations
+            if self.max_iterations is not None
+            else DEFAULT_MAX_ITERATIONS
+        )
 
     @property
     def max_iterations_explicit(self) -> bool:

--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent.py
@@ -249,7 +249,9 @@ class MeshLlmAgent:
         self.model = config.model
         self.tools_metadata = filtered_tools  # Tool metadata for schema building
         self.tool_proxies = tool_proxies or {}  # Proxies for execution
-        self.max_iterations = config.max_iterations
+        self.max_iterations = config.effective_max_iterations
+        # Issue #1356: only a cap the user actually configured goes on the wire.
+        self._max_iterations_explicit = config.max_iterations_explicit
         self.output_type = output_type
         self.system_prompt = config.system_prompt  # Public attribute for tests
         self.output_mode = config.output_mode  # Output mode override (strict/hint/text)
@@ -302,7 +304,7 @@ class MeshLlmAgent:
 
         logger.debug(
             f"🤖 MeshLlmAgent initialized: provider={config.provider}, model={config.model}, "
-            f"tools={len(filtered_tools)}, max_iterations={config.max_iterations}, handler={self._provider_handler}"
+            f"tools={len(filtered_tools)}, max_iterations={self.max_iterations}, handler={self._provider_handler}"
         )
 
     def set_system_prompt(self, prompt: str) -> None:
@@ -1030,6 +1032,13 @@ class MeshLlmAgent:
                     if self._parallel_tool_calls:
                         model_params["parallel_tool_calls"] = True
 
+                    # Issue #1356: forward the provider-managed loop cap ONLY
+                    # when the consumer explicitly configured one. Omitting it
+                    # leaves the provider free to apply its own
+                    # MESH_LLM_MAX_ITERATIONS (or the default 10).
+                    if self._max_iterations_explicit:
+                        model_params["max_iterations"] = self.max_iterations
+
                     logger.debug(
                         f"📤 Delegating to mesh provider with handler-prepared params: "
                         f"keys={list(model_params.keys())}"
@@ -1486,6 +1495,10 @@ class MeshLlmAgent:
             model_params["output_type_name"] = self.output_type.__name__
         if self._parallel_tool_calls:
             model_params["parallel_tool_calls"] = True
+        # Issue #1356: forward the loop cap only when explicitly configured
+        # (mirrors __call__).
+        if self._max_iterations_explicit:
+            model_params["max_iterations"] = self.max_iterations
 
         request = MeshLlmRequest(
             messages=messages,

--- a/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/mesh_llm_agent_injector.py
@@ -661,7 +661,9 @@ class MeshLlmAgentInjector(BaseInjector):
         llm_config = LLMConfig(
             provider=config_dict.get("provider"),
             model=config_dict.get("model"),  # Optional consumer-side override
-            max_iterations=config_dict.get("max_iterations", 10),
+            # Issue #1356: absent/None = not explicitly configured (LLMConfig
+            # falls back to 10 for the local loop and forwards nothing).
+            max_iterations=config_dict.get("max_iterations"),
             system_prompt=config_dict.get("system_prompt"),
             output_mode=config_dict.get(
                 "output_mode"

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
@@ -18,6 +18,8 @@ import logging
 import os
 from typing import Any, Optional
 
+from ...engine.llm_config import DEFAULT_MAX_ITERATIONS
+
 logger = logging.getLogger(__name__)
 
 
@@ -503,12 +505,24 @@ def _build_agent_spec(context: dict[str, Any]) -> Any:
         filter_spec = config.get("filter")
         filter_json = json.dumps(filter_spec) if filter_spec else None
 
+        # Issue #1356: the decorator now emits ``max_iterations=None`` when
+        # nothing configured a cap (so the consumer can tell "unset" from
+        # "explicitly 10" for wire forwarding). The registration spec has
+        # always carried a concrete number and the Rust ``LlmAgentSpec`` types
+        # it as a non-optional u32 — passing None through fails the heartbeat
+        # and the agent never registers. Register the EFFECTIVE cap instead.
+        # Note `config.get("max_iterations", ...)` alone is not enough: the key
+        # is always present, just valued None.
+        configured_max_iterations = config.get("max_iterations")
+        if configured_max_iterations is None:
+            configured_max_iterations = DEFAULT_MAX_ITERATIONS
+
         llm_spec = core.LlmAgentSpec(
             function_id=func_id,
             provider=provider_json,
             filter=filter_json,
             filter_mode=config.get("filter_mode", "all"),
-            max_iterations=config.get("max_iterations", 1),
+            max_iterations=configured_max_iterations,
         )
         llm_agents.append(llm_spec)
 

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -2829,7 +2829,7 @@ def llm(
     filter_mode: str = "all",
     provider: dict[str, Any],
     model: str | None = None,
-    max_iterations: int = 10,
+    max_iterations: int | None = None,
     system_prompt: str | None = None,
     system_prompt_file: str | None = None,
     response_model: type | None = None,
@@ -2881,7 +2881,13 @@ def llm(
                consumer pin to a specific model (e.g., haiku) when the provider
                otherwise defaults to a different one (e.g., sonnet). May be
                overridden by MESH_LLM_MODEL.
-        max_iterations: Max agentic loop iterations (can be overridden by MESH_LLM_MAX_ITERATIONS)
+        max_iterations: Max agentic loop iterations (can be overridden by
+                        MESH_LLM_MAX_ITERATIONS). When set — here or via the env
+                        var — the cap is ALSO forwarded to the provider on the
+                        wire (``model_params.max_iterations``) so the
+                        provider-managed loop honors it (issue #1356). When left
+                        unset (None), nothing is forwarded and the provider
+                        applies its own MESH_LLM_MAX_ITERATIONS / default of 10.
         system_prompt: Default system prompt (literal string or ``file://`` template)
         system_prompt_file: Path to Jinja2 template file (deprecated — use system_prompt="file://...")
         response_model: Schema the LLM is required to emit and validate against. When
@@ -3013,10 +3019,16 @@ def llm(
             ),
             "provider": resolved_provider,
             "model": resolved_model,
+            # Issue #1356: resolve to None when NOTHING configured it (no
+            # decorator arg, no env var) so the consumer can tell "user asked
+            # for 10" from "user said nothing". Only an explicitly configured
+            # cap is forwarded to the provider; leaving it unset keeps the
+            # provider's own MESH_LLM_MAX_ITERATIONS alive. The consumer's own
+            # loop falls back to 10 via LLMConfig.effective_max_iterations.
             "max_iterations": get_config_value(
                 "MESH_LLM_MAX_ITERATIONS",
                 override=max_iterations,
-                default=10,
+                default=None,
                 rule=ValidationRule.NONZERO_RULE,
             ),
             "system_prompt": effective_system_prompt,

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -8,6 +8,7 @@ mesh decorators to simplify common patterns like zero-code LLM providers.
 import asyncio
 import json
 import logging
+import math
 import os
 import re
 from collections.abc import AsyncIterator
@@ -19,6 +20,48 @@ from _mcp_mesh.engine.provider_handlers import ProviderHandlerRegistry
 from _mcp_mesh.shared.logging_config import format_log_value
 
 logger = logging.getLogger(__name__)
+
+# Issue #1356: provider-managed agentic-loop cap.
+DEFAULT_MAX_ITERATIONS = 10
+
+# Sentinel for "the caller did not send max_iterations at all". Distinct from a
+# wire value of ``None`` (explicit JSON null), which is an INVALID explicit
+# value and therefore falls back to the default instead of consulting env —
+# matching TypeScript's ``paramValue !== undefined`` check.
+_MAX_ITERATIONS_UNSET = object()
+
+
+def _sanitize_max_iterations(value: Any) -> int | None:
+    """Coerce an arbitrary value to a positive integer iteration cap.
+
+    Returns ``None`` when the value is unset/invalid (non-numeric, NaN,
+    infinite, <= 0, or floors to 0). Floors BEFORE the > 0 check so fractional
+    values in (0, 1) are rejected rather than silently zeroed. Parity with
+    TypeScript's ``sanitizeMaxIterations`` in ``llm-provider.ts``.
+    """
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    floored = math.floor(parsed)
+    return floored if floored > 0 else None
+
+
+def _resolve_max_iterations(param_value: Any = _MAX_ITERATIONS_UNSET) -> int:
+    """Resolve the provider-managed agentic-loop cap (issue #1356).
+
+    Precedence: consumer-forwarded ``model_params.max_iterations`` →
+    ``MESH_LLM_MAX_ITERATIONS`` env → default 10. A *present* param (even an
+    invalid one) never falls through to the env branch — invalid param →
+    default. The env branch is consulted only when the param is ABSENT.
+    Parity with TypeScript's ``resolveMaxIterations``.
+    """
+    if param_value is not _MAX_ITERATIONS_UNSET:
+        return _sanitize_max_iterations(param_value) or DEFAULT_MAX_ITERATIONS
+    env_value = os.environ.get("MESH_LLM_MAX_ITERATIONS")
+    return _sanitize_max_iterations(env_value) or DEFAULT_MAX_ITERATIONS
 
 
 def _hint_response_parses(content: str, schema: dict[str, Any]) -> bool:
@@ -2643,6 +2686,7 @@ def llm_provider(
             list[dict[str, Any]] | None,
             dict[str, str],
             dict[str, Any],
+            int,
         ]:
             """Shared setup for ``process_chat`` and ``process_chat_stream``.
 
@@ -2662,9 +2706,9 @@ def llm_provider(
             streaming — synthetic-tool produces a single discrete tool call
             that doesn't actually stream as chunks.
 
-            Returns a 5-tuple:
+            Returns a 6-tuple:
                 ``(effective_model, messages, clean_tools, tool_endpoints,
-                model_params_copy)``
+                model_params_copy, max_iterations)``
             where ``clean_tools`` is ``None`` when ``request.tools`` is
             None / empty (preserving the legacy buffered path's existing
             behavior of omitting ``tools`` from ``completion_args``).
@@ -2713,6 +2757,14 @@ def llm_provider(
             # handler's apply_structured_output honors a valid value over its
             # per-vendor auto-selection. None preserves the auto behavior.
             output_mode_override = model_params_copy.pop("output_mode", None)
+
+            # Issue #1356: consumer-forwarded provider-managed loop cap. Popped
+            # here (like output_mode) so it can never leak into completion_args
+            # / LiteLLM on either the loop path or the legacy single-call path.
+            # Precedence: forwarded value → MESH_LLM_MAX_ITERATIONS → 10.
+            resolved_max_iterations = _resolve_max_iterations(
+                model_params_copy.pop("max_iterations", _MAX_ITERATIONS_UNSET)
+            )
 
             # Source-of-truth for messages downstream. Defaults to the
             # request's messages; ``apply_structured_output`` may swap in a
@@ -2790,6 +2842,7 @@ def llm_provider(
                 clean_tools,
                 tool_endpoints,
                 model_params_copy,
+                resolved_max_iterations,
             )
 
         # Generate the LLM handler function
@@ -2811,6 +2864,7 @@ def llm_provider(
                 clean_tools,
                 tool_endpoints,
                 model_params_copy,
+                resolved_max_iterations,
             ) = _prepare_provider_request(request, streaming=False)
             effective_tools = clean_tools if clean_tools is not None else request.tools
 
@@ -2826,7 +2880,7 @@ def llm_provider(
                     tool_endpoints=tool_endpoints,
                     model_params=model_params_copy,
                     litellm_kwargs=litellm_kwargs,
-                    max_iterations=10,
+                    max_iterations=resolved_max_iterations,
                     loop_logger=logger,
                     vendor=vendor,
                 )
@@ -3152,6 +3206,7 @@ def llm_provider(
                 clean_tools,
                 tool_endpoints,
                 model_params_copy,
+                resolved_max_iterations,
             ) = _prepare_provider_request(request, streaming=True)
             effective_tools = (
                 clean_tools if clean_tools is not None else request.tools
@@ -3168,7 +3223,7 @@ def llm_provider(
                     tool_endpoints=tool_endpoints,
                     model_params=model_params_copy,
                     litellm_kwargs=litellm_kwargs,
-                    max_iterations=10,
+                    max_iterations=resolved_max_iterations,
                     loop_logger=logger,
                     vendor=vendor,
                 ):

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -16,13 +16,15 @@ from typing import Any
 
 import jsonschema  # type: ignore
 
+from _mcp_mesh.engine.llm_config import DEFAULT_MAX_ITERATIONS
 from _mcp_mesh.engine.provider_handlers import ProviderHandlerRegistry
 from _mcp_mesh.shared.logging_config import format_log_value
 
 logger = logging.getLogger(__name__)
 
-# Issue #1356: provider-managed agentic-loop cap.
-DEFAULT_MAX_ITERATIONS = 10
+# Issue #1356: ``DEFAULT_MAX_ITERATIONS`` (the provider-managed agentic-loop
+# cap) is defined in ``_mcp_mesh.engine.llm_config`` and re-exported here for
+# back-compat with existing importers.
 
 # Sentinel for "the caller did not send max_iterations at all". Distinct from a
 # wire value of ``None`` (explicit JSON null), which is an INVALID explicit

--- a/src/runtime/python/tests/unit/test_max_iterations_forwarding.py
+++ b/src/runtime/python/tests/unit/test_max_iterations_forwarding.py
@@ -1,0 +1,439 @@
+"""Issue #1356: the consumer's ``max_iterations`` must reach the
+provider-managed agentic loop.
+
+Before the fix the provider loop was invoked with a hardcoded ``10`` and the
+consumer never put the value on the wire, so a ``@mesh.llm(max_iterations=...)``
+setting was inert for every mesh-delegated consumer.
+
+Contract (matches the TypeScript reference in ``llm-agent.ts`` /
+``llm-provider.ts``):
+
+  * Consumer forwards ``model_params.max_iterations`` ONLY when explicitly
+    configured (decorator arg or ``MESH_LLM_MAX_ITERATIONS``).
+  * Provider resolves: forwarded value → its own ``MESH_LLM_MAX_ITERATIONS``
+    → 10. A *present* but invalid forwarded value falls back to 10 and does
+    NOT consult env.
+  * The key is stripped provider-side so it never reaches the vendor API.
+"""
+
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from _mcp_mesh.engine.llm_config import LLMConfig
+from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+from mesh.helpers import (
+    DEFAULT_MAX_ITERATIONS,
+    _MAX_ITERATIONS_UNSET,
+    _resolve_max_iterations,
+    _sanitize_max_iterations,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sanitization / resolution (parity with TS sanitizeMaxIterations)
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeMaxIterations:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (3, 3),
+            ("7", 7),
+            (2.9, 2),  # floored
+            ("2.9", 2),
+            (1, 1),
+            (0, None),
+            (-1, None),
+            (0.5, None),  # floors to 0 BEFORE the >0 check — not a zero cap
+            ("0", None),
+            ("-4", None),
+            ("abc", None),
+            ("", None),
+            (None, None),
+            (float("nan"), None),
+            (float("inf"), None),
+            ([], None),
+            ({}, None),
+        ],
+    )
+    def test_sanitize(self, value, expected):
+        assert _sanitize_max_iterations(value) == expected
+
+
+class TestResolveMaxIterations:
+    def test_valid_param_wins(self, monkeypatch):
+        monkeypatch.setenv("MESH_LLM_MAX_ITERATIONS", "4")
+        assert _resolve_max_iterations(6) == 6
+
+    def test_invalid_explicit_param_falls_back_to_default_not_env(self, monkeypatch):
+        """A *present* param never falls through to env — invalid → 10."""
+        monkeypatch.setenv("MESH_LLM_MAX_ITERATIONS", "4")
+        for bad in (0, -3, "abc", None, float("nan")):
+            assert _resolve_max_iterations(bad) == DEFAULT_MAX_ITERATIONS
+
+    def test_absent_param_uses_env(self, monkeypatch):
+        monkeypatch.setenv("MESH_LLM_MAX_ITERATIONS", "4")
+        assert _resolve_max_iterations() == 4
+        assert _resolve_max_iterations(_MAX_ITERATIONS_UNSET) == 4
+
+    def test_absent_param_invalid_env_uses_default(self, monkeypatch):
+        monkeypatch.setenv("MESH_LLM_MAX_ITERATIONS", "not-a-number")
+        assert _resolve_max_iterations() == DEFAULT_MAX_ITERATIONS
+
+    def test_absent_param_no_env_uses_default(self, monkeypatch):
+        monkeypatch.delenv("MESH_LLM_MAX_ITERATIONS", raising=False)
+        assert _resolve_max_iterations() == DEFAULT_MAX_ITERATIONS
+
+
+# ---------------------------------------------------------------------------
+# LLMConfig: None means "not explicitly configured"
+# ---------------------------------------------------------------------------
+
+
+def _config(max_iterations=None) -> LLMConfig:
+    return LLMConfig(
+        provider={"capability": "llm"},
+        model=None,
+        max_iterations=max_iterations,
+        system_prompt=None,
+    )
+
+
+class TestLLMConfigDefaults:
+    def test_unset_is_none_but_effective_is_ten(self):
+        cfg = _config()
+        assert cfg.max_iterations is None
+        assert cfg.effective_max_iterations == 10
+        assert cfg.max_iterations_explicit is False
+
+    def test_explicit_value_is_kept(self):
+        cfg = _config(3)
+        assert cfg.effective_max_iterations == 3
+        assert cfg.max_iterations_explicit is True
+
+    def test_explicit_ten_is_still_explicit(self):
+        assert _config(10).max_iterations_explicit is True
+
+    def test_zero_still_rejected(self):
+        with pytest.raises(ValueError, match="max_iterations must be >= 1"):
+            _config(0)
+
+
+# ---------------------------------------------------------------------------
+# Consumer: forwards on the wire only when explicitly configured
+# ---------------------------------------------------------------------------
+
+
+def _agent(max_iterations, provider_proxy) -> MeshLlmAgent:
+    return MeshLlmAgent(
+        config=_config(max_iterations),
+        filtered_tools=[],
+        output_type=str,
+        provider_proxy=provider_proxy,
+        vendor="anthropic",
+    )
+
+
+class TestConsumerForwarding:
+    @pytest.mark.asyncio
+    async def test_buffered_forwards_when_explicit(self):
+        captured: dict = {}
+
+        async def provider(request):
+            captured["request"] = request
+            return {"role": "assistant", "content": "done"}
+
+        assert await _agent(4, provider)("hi") == "done"
+        assert captured["request"]["model_params"]["max_iterations"] == 4
+
+    @pytest.mark.asyncio
+    async def test_buffered_omits_when_unset(self):
+        captured: dict = {}
+
+        async def provider(request):
+            captured["request"] = request
+            return {"role": "assistant", "content": "done"}
+
+        assert await _agent(None, provider)("hi") == "done"
+        model_params = captured["request"]["model_params"] or {}
+        assert "max_iterations" not in model_params
+
+    @pytest.mark.asyncio
+    async def test_stream_forwards_when_explicit(self):
+        agent = _agent(6, None)
+        captured: dict = {}
+
+        class _FakeAsyncIter:
+            def __init__(self, items):
+                self._items = list(items)
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self._items:
+                    raise StopAsyncIteration
+                return self._items.pop(0)
+
+        proxy = MagicMock()
+        proxy.endpoint = "http://provider"
+        proxy.function_name = "claude_provider_stream"
+        proxy.stream = MagicMock(
+            side_effect=lambda *, name, request: (
+                captured.update(request=request),
+                _FakeAsyncIter(["ok"]),
+            )[1]
+        )
+        agent._mesh_provider_proxy = proxy
+
+        collected = [piece async for piece in agent.stream("hi")]
+        assert collected == ["ok"]
+        assert captured["request"]["model_params"]["max_iterations"] == 6
+
+    @pytest.mark.asyncio
+    async def test_stream_omits_when_unset(self):
+        agent = _agent(None, None)
+        captured: dict = {}
+
+        class _FakeAsyncIter:
+            def __init__(self, items):
+                self._items = list(items)
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if not self._items:
+                    raise StopAsyncIteration
+                return self._items.pop(0)
+
+        proxy = MagicMock()
+        proxy.endpoint = "http://provider"
+        proxy.function_name = "claude_provider_stream"
+        proxy.stream = MagicMock(
+            side_effect=lambda *, name, request: (
+                captured.update(request=request),
+                _FakeAsyncIter(["ok"]),
+            )[1]
+        )
+        agent._mesh_provider_proxy = proxy
+
+        collected = [piece async for piece in agent.stream("hi")]
+        assert collected == ["ok"]
+        assert "max_iterations" not in (captured["request"]["model_params"] or {})
+
+
+# ---------------------------------------------------------------------------
+# Decorator: unset stays unset; decorator arg / env mark it explicit
+# ---------------------------------------------------------------------------
+
+
+class TestDecoratorResolution:
+    def _config_for(self, **llm_kwargs) -> dict:
+        import mesh
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+        snapshot = dict(DecoratorRegistry._mesh_llm_agents)
+        DecoratorRegistry._mesh_llm_agents.clear()
+        try:
+
+            @mesh.llm(provider={"capability": "llm"}, **llm_kwargs)
+            def chat(message: str, llm: mesh.MeshLlmAgent = None) -> str:
+                return ""
+
+            agent_data = next(iter(DecoratorRegistry.get_mesh_llm_agents().values()))
+            return agent_data.config
+        finally:
+            DecoratorRegistry._mesh_llm_agents.clear()
+            DecoratorRegistry._mesh_llm_agents.update(snapshot)
+
+    def test_unset_resolves_to_none(self, monkeypatch):
+        monkeypatch.delenv("MESH_LLM_MAX_ITERATIONS", raising=False)
+        assert self._config_for()["max_iterations"] is None
+
+    def test_decorator_arg_is_explicit(self, monkeypatch):
+        monkeypatch.delenv("MESH_LLM_MAX_ITERATIONS", raising=False)
+        assert self._config_for(max_iterations=3)["max_iterations"] == 3
+
+    def test_env_marks_explicit_without_decorator_arg(self, monkeypatch):
+        """A consumer-side env var counts as "explicitly configured": it drives
+        the consumer's own loop AND goes on the wire."""
+        monkeypatch.setenv("MESH_LLM_MAX_ITERATIONS", "7")
+        assert self._config_for()["max_iterations"] == 7
+
+    def test_env_wins_over_decorator_arg(self, monkeypatch):
+        monkeypatch.setenv("MESH_LLM_MAX_ITERATIONS", "7")
+        assert self._config_for(max_iterations=3)["max_iterations"] == 7
+
+
+# ---------------------------------------------------------------------------
+# Provider: honours the forwarded value, strips the key
+# ---------------------------------------------------------------------------
+
+
+def _make_provider_module(module_name: str):
+    """Register a @mesh.llm_provider in a throwaway module with a FastMCP app."""
+    import sys
+
+    from fastmcp import FastMCP
+
+    from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+    mod = types.ModuleType(module_name)
+    mod.app = FastMCP(module_name)
+    sys.modules[module_name] = mod
+    snapshot = dict(DecoratorRegistry._mesh_tools)
+    DecoratorRegistry._mesh_tools.clear()
+    return mod, snapshot
+
+
+def _drop_provider_module(module_name: str, snapshot: dict):
+    import sys
+
+    from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+    sys.modules.pop(module_name, None)
+    DecoratorRegistry._mesh_tools.clear()
+    DecoratorRegistry._mesh_tools.update(snapshot)
+
+
+def _decorate_provider(mod, module_name: str, func_name: str):
+    import mesh
+
+    def placeholder():
+        pass
+
+    placeholder.__name__ = func_name
+    placeholder.__qualname__ = func_name
+    placeholder.__module__ = module_name
+    decorated = mesh.llm_provider(
+        model="anthropic/claude-3-5-haiku-20241022",
+        capability="llm",
+        tags=["claude"],
+    )(placeholder)
+    setattr(mod, func_name, decorated)
+    return decorated
+
+
+def _tool_with_endpoint() -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": "noop_tool",
+            "description": "noop",
+            "parameters": {"type": "object", "properties": {}},
+            "_mesh_endpoint": "http://tool-agent:9090",
+        },
+    }
+
+
+class TestProviderResolution:
+    """Drives the auto-generated ``process_chat`` and inspects what the
+    provider-managed loop receives."""
+
+    def _buffered_handler(self, mod):
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+        wrapper = DecoratorRegistry.get_mesh_tools()["claude_provider"].function
+        return getattr(wrapper, "_mesh_original_func", wrapper)
+
+    async def _run(self, monkeypatch, model_params: dict | None, env: str | None):
+        from mesh.types import MeshLlmRequest
+
+        module_name = "_test_max_iterations_provider"
+        mod, snapshot = _make_provider_module(module_name)
+        try:
+            _decorate_provider(mod, module_name, "claude_provider")
+            handler = self._buffered_handler(mod)
+
+            if env is None:
+                monkeypatch.delenv("MESH_LLM_MAX_ITERATIONS", raising=False)
+            else:
+                monkeypatch.setenv("MESH_LLM_MAX_ITERATIONS", env)
+
+            captured: dict = {}
+
+            async def fake_loop(**kwargs):
+                captured.update(kwargs)
+                return {"role": "assistant", "content": "done"}
+
+            request = MeshLlmRequest(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[_tool_with_endpoint()],
+                model_params=model_params,
+            )
+            with patch("mesh.helpers._provider_agentic_loop", new=fake_loop):
+                await handler(request)
+            return captured
+        finally:
+            _drop_provider_module(module_name, snapshot)
+
+    @pytest.mark.asyncio
+    async def test_forwarded_value_is_honoured(self, monkeypatch):
+        captured = await self._run(
+            monkeypatch, {"max_iterations": 3}, env="8"
+        )
+        assert captured["max_iterations"] == 3
+        # ...and never reaches the vendor call params.
+        assert "max_iterations" not in captured["model_params"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_forwarded_value_falls_back_to_default(self, monkeypatch):
+        captured = await self._run(monkeypatch, {"max_iterations": 0}, env="8")
+        assert captured["max_iterations"] == DEFAULT_MAX_ITERATIONS
+        assert "max_iterations" not in captured["model_params"]
+
+    @pytest.mark.asyncio
+    async def test_absent_uses_provider_env(self, monkeypatch):
+        captured = await self._run(monkeypatch, None, env="8")
+        assert captured["max_iterations"] == 8
+
+    @pytest.mark.asyncio
+    async def test_absent_without_env_uses_default(self, monkeypatch):
+        captured = await self._run(monkeypatch, None, env=None)
+        assert captured["max_iterations"] == DEFAULT_MAX_ITERATIONS
+
+    @pytest.mark.asyncio
+    async def test_key_never_reaches_litellm_on_legacy_no_tools_path(
+        self, monkeypatch
+    ):
+        """No tool endpoints → single litellm call. The consumer-only key must
+        not appear in completion args (vendor APIs reject unknown params)."""
+        monkeypatch.setenv("MCP_MESH_NATIVE_LLM", "0")
+        from mesh.types import MeshLlmRequest
+
+        module_name = "_test_max_iterations_provider_legacy"
+        mod, snapshot = _make_provider_module(module_name)
+        try:
+            _decorate_provider(mod, module_name, "claude_provider")
+            handler = self._buffered_handler(mod)
+
+            message = MagicMock()
+            message.content = "hello"
+            message.role = "assistant"
+            message.tool_calls = None
+            choice = MagicMock()
+            choice.message = message
+            response = MagicMock()
+            response.choices = [choice]
+            response.usage = MagicMock(prompt_tokens=1, completion_tokens=1)
+            response.model = "claude-3-5-haiku"
+
+            request = MeshLlmRequest(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=None,
+                model_params={"max_iterations": 5, "temperature": 0.1},
+            )
+
+            with patch(
+                "asyncio.to_thread", new=AsyncMock(return_value=response)
+            ) as mock_thread:
+                await handler(request)
+
+            completion_kwargs = mock_thread.call_args.kwargs
+            assert "max_iterations" not in completion_kwargs
+            assert completion_kwargs["temperature"] == 0.1
+        finally:
+            _drop_provider_module(module_name, snapshot)

--- a/src/runtime/python/tests/unit/test_max_iterations_registration.py
+++ b/src/runtime/python/tests/unit/test_max_iterations_registration.py
@@ -1,0 +1,115 @@
+"""Issue #1356 regression: a @mesh.llm consumer with max_iterations UNSET must
+still register.
+
+The decorator now resolves ``max_iterations`` to ``None`` when nothing
+configured it, so "unset" can be told apart from "explicitly 10" for wire
+forwarding. The registration spec, however, has always carried a concrete
+number — the Rust ``LlmAgentSpec`` types it as a non-optional ``u32``. Passing
+``None`` through made every heartbeat raise::
+
+    TypeError: argument 'max_iterations': 'NoneType' object cannot be
+               interpreted as an integer
+
+which meant the agent served HTTP but never registered (and never retried).
+
+These tests use the REAL Rust ``LlmAgentSpec`` so the type contract is actually
+exercised; only ``AgentSpec`` is stubbed, to capture what got built.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import mesh
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+from _mcp_mesh.engine.llm_config import DEFAULT_MAX_ITERATIONS
+
+
+@pytest.fixture(autouse=True)
+def _clear_decorator_registry(monkeypatch):
+    """Reset shared decorator state and any env-driven cap between tests."""
+    monkeypatch.delenv("MESH_LLM_MAX_ITERATIONS", raising=False)
+    DecoratorRegistry.clear_all()
+    yield
+    DecoratorRegistry.clear_all()
+
+
+def _build_llm_agent_specs():
+    """Run the real registration builder, returning the LlmAgentSpec list.
+
+    Uses the genuine ``core.LlmAgentSpec`` (so a ``None`` cap raises exactly as
+    it does in production) and a stub ``AgentSpec`` to capture the result.
+    """
+    from _mcp_mesh.pipeline.mcp_heartbeat import rust_heartbeat
+
+    real_core = rust_heartbeat._get_rust_core()
+    captured = {}
+
+    class _FakeAgentSpec:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    class _HybridCore:
+        AgentSpec = _FakeAgentSpec
+        LlmAgentSpec = real_core.LlmAgentSpec
+        ToolSpec = real_core.ToolSpec
+        DependencySpec = getattr(real_core, "DependencySpec", None)
+
+    context = {
+        "agent_config": {
+            "name": "test-agent",
+            "namespace": "default",
+            "version": "1.0.0",
+            "http_host": "localhost",
+            "http_port": 9000,
+        },
+        "agent_id": "test-agent-deadbeef",
+    }
+
+    with patch.object(
+        rust_heartbeat, "_get_rust_core", return_value=_HybridCore
+    ):
+        rust_heartbeat._build_agent_spec(context)
+
+    return captured.get("llm_agents") or []
+
+
+def test_unset_max_iterations_registers_effective_default():
+    """@mesh.llm(provider=...) with no cap must register with 10, not None."""
+
+    @mesh.llm(provider={"capability": "llm", "tags": ["+claude"]})
+    def chat(message: str, llm: mesh.MeshLlmAgent = None) -> str:
+        return llm(message)
+
+    # Precondition: the decorator really does leave it unset (tri-state).
+    config = next(iter(DecoratorRegistry.get_mesh_llm_agents().values())).config
+    assert config["max_iterations"] is None
+
+    llm_agents = _build_llm_agent_specs()
+    assert len(llm_agents) == 1
+    assert llm_agents[0].max_iterations == DEFAULT_MAX_ITERATIONS == 10
+
+
+def test_explicit_max_iterations_is_registered_verbatim():
+    """An explicitly configured cap must reach the spec unchanged."""
+
+    @mesh.llm(provider={"capability": "llm"}, max_iterations=3)
+    def chat(message: str, llm: mesh.MeshLlmAgent = None) -> str:
+        return llm(message)
+
+    llm_agents = _build_llm_agent_specs()
+    assert len(llm_agents) == 1
+    assert llm_agents[0].max_iterations == 3
+
+
+def test_env_configured_max_iterations_is_registered(monkeypatch):
+    """MESH_LLM_MAX_ITERATIONS on the consumer also reaches the spec."""
+    monkeypatch.setenv("MESH_LLM_MAX_ITERATIONS", "7")
+
+    @mesh.llm(provider={"capability": "llm"})
+    def chat(message: str, llm: mesh.MeshLlmAgent = None) -> str:
+        return llm(message)
+
+    llm_agents = _build_llm_agent_specs()
+    assert len(llm_agents) == 1
+    assert llm_agents[0].max_iterations == 7

--- a/src/runtime/python/tests/unit/test_mesh_llm_decorator.py
+++ b/src/runtime/python/tests/unit/test_mesh_llm_decorator.py
@@ -120,7 +120,10 @@ class TestMeshLlmDecoratorConfiguration:
         assert isinstance(config["provider"], dict)
         assert config["provider"].get("capability") == "llm"
         assert config["filter_mode"] == "all"
-        assert config["max_iterations"] == 10
+        # Issue #1356: unset (None) — distinguishable from an explicit 10 so the
+        # cap is not forwarded to the provider. Effective local cap is still 10
+        # (LLMConfig.effective_max_iterations).
+        assert config["max_iterations"] is None
 
     def test_decorator_custom_provider_filter(self):
         """Test decorator with custom provider filter (mesh delegation)."""

--- a/tests/integration/suites/uc04_llm_integration/artifacts/iteration-probe-agent/main.py
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/iteration-probe-agent/main.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""
+iteration-probe-agent - deterministic agentic-loop iteration counter (issue #1356).
+
+WHY THIS AGENT EXISTS
+---------------------
+Issue #1356 / PR #1359 made a consumer's ``max_iterations`` reach the
+PROVIDER-managed agentic loop on the wire (``model_params.max_iterations``).
+Proving that end-to-end needs an observable that says *how many tool rounds the
+provider-managed loop actually executed*.
+
+The obvious observable is the provider's exhaustion sentinel
+("Maximum tool call iterations reached"), but issue #1355 is going to replace
+that synthetic message with a structured signal. Any test that asserts on it
+breaks the moment #1355 lands. So this agent provides a signal that is
+independent of BOTH the sentinel text and the provider's log format: an
+in-process invocation COUNTER.
+
+TOOL LAYOUT (3 tools, deliberately on 3 DIFFERENT capabilities)
+---------------------------------------------------------------
+  advance_ticket  capability="iteration_probe"  <- the ONLY tool consumers filter
+                  in, i.e. the only tool the LLM ever sees. Increments the
+                  counter on every invocation.
+  probe_count     capability="probe_count"      <- readout, called DIRECTLY by the
+                  test via `meshctl call`. NOT matched by the consumers'
+                  filter={"capability": "iteration_probe"}, so the LLM can never
+                  call it and can never perturb the measurement.
+  probe_reset     capability="probe_reset"      <- zeroes the counter, called
+                  DIRECTLY by the test right before the measured call so any
+                  warm-up / readiness traffic cannot contaminate the count.
+                  Also invisible to the LLM for the same reason.
+
+FORCED SEQUENTIALITY (why the count is a faithful iteration count)
+------------------------------------------------------------------
+``advance_ticket`` takes a ``token`` and returns a RANDOM ``next_token`` that the
+model cannot guess. The model therefore cannot batch several ``advance_ticket``
+calls into a single turn — it must wait for each result before it can produce
+the next token. One tool round == one counter increment, so
+``probe_count`` reports exactly how many agentic-loop tool rounds ran.
+
+The ticket only reaches ``status="COMPLETE"`` after TOTAL_STEPS (4) invocations,
+so an UNCAPPED run (provider default of 10) reliably produces 4 invocations.
+A run capped at 1 produces exactly 1. That gap is what the tcs assert on.
+"""
+
+import uuid
+from typing import Any
+
+from fastmcp import FastMCP
+
+import mesh
+
+app = FastMCP("IterationProbeAgent")
+
+# Number of advance_ticket invocations before the ticket reports COMPLETE.
+# Chosen > 1 so a capped (1) run and an uncapped (default 10) run are clearly
+# distinguishable, and small enough that an uncapped run stays cheap/bounded.
+TOTAL_STEPS = 4
+
+# Sentinel the model can only ever learn by driving the ticket all the way to
+# completion. Its ABSENCE from a capped run's answer is a secondary, sentinel-
+# text-independent proof that the loop stopped early.
+FINAL_CODE = "PROBE-COMPLETE-9F3A"
+
+_state: dict[str, Any] = {"invocations": 0}
+
+
+@app.tool()
+@mesh.tool(
+    capability="iteration_probe",
+    description=(
+        "Advance the ticket by EXACTLY ONE step. Pass the token you were given "
+        "('START' for the first call, otherwise the 'next_token' from the "
+        "previous response). Returns status INCOMPLETE plus a new next_token "
+        "until the ticket is finished, then status COMPLETE with the final_code. "
+        "You cannot know the next token without calling this tool first, so call "
+        "it once, read the result, then call it again."
+    ),
+    version="1.0.0",
+    tags=["probe", "loop", "iteration"],
+)
+def advance_ticket(token: str) -> dict:
+    """Advance the probe ticket one step and count the invocation.
+
+    The counter is incremented UNCONDITIONALLY (the token is never validated) so
+    that ``probe_count`` reports the literal number of times the agentic loop
+    executed this tool — nothing else. Validating the token would make the count
+    depend on the model echoing it correctly, which is exactly the kind of
+    LLM-dependent flakiness this probe is meant to avoid.
+    """
+    _state["invocations"] += 1
+    step = _state["invocations"]
+
+    if step >= TOTAL_STEPS:
+        return {
+            "status": "COMPLETE",
+            "step": step,
+            "final_code": FINAL_CODE,
+            "instruction": (
+                "The ticket is COMPLETE. Reply with the final_code and stop "
+                "calling tools."
+            ),
+        }
+
+    return {
+        "status": "INCOMPLETE",
+        "step": step,
+        "steps_remaining": TOTAL_STEPS - step,
+        # Unguessable: forces the model to serialize its tool calls (one per
+        # turn) instead of batching several into a single iteration.
+        "next_token": f"T-{uuid.uuid4().hex[:12]}",
+        "instruction": (
+            "The ticket is NOT finished. Call advance_ticket again, passing the "
+            "next_token above as 'token'. Repeat until status is COMPLETE."
+        ),
+    }
+
+
+@app.tool()
+@mesh.tool(
+    capability="probe_count",
+    description="Report how many times advance_ticket has been invoked.",
+    version="1.0.0",
+    tags=["probe", "readout"],
+)
+def probe_count() -> str:
+    """Readout for the test harness (never exposed to the LLM).
+
+    Returns a bracketed marker so a plain substring assertion is unambiguous:
+    'PROBE_INVOCATIONS=[1]' can never accidentally match a count of 10 or 11.
+    """
+    return f"PROBE_INVOCATIONS=[{_state['invocations']}]"
+
+
+@app.tool()
+@mesh.tool(
+    capability="probe_reset",
+    description="Reset the advance_ticket invocation counter to zero.",
+    version="1.0.0",
+    tags=["probe", "reset"],
+)
+def probe_reset() -> str:
+    """Zero the counter (never exposed to the LLM).
+
+    Called by the test immediately before the MEASURED call so readiness /
+    warm-up traffic cannot contaminate the measurement.
+    """
+    _state["invocations"] = 0
+    return "PROBE_RESET_OK"
+
+
+@mesh.agent(
+    name="iteration-probe-agent",
+    version="1.0.0",
+    description="Deterministic agentic-loop iteration counter for issue #1356",
+    http_port=9036,
+    enable_http=True,
+    auto_run=True,
+)
+class IterationProbeAgentConfig:
+    """Probe tool provider for the max_iterations forwarding tcs."""
+
+    pass

--- a/tests/integration/suites/uc04_llm_integration/tc45_max_iterations_explicit_cap_py/artifacts/ticket-agent/main.py
+++ b/tests/integration/suites/uc04_llm_integration/tc45_max_iterations_explicit_cap_py/artifacts/ticket-agent/main.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+ticket-agent - Python @mesh.llm consumer with an EXPLICIT max_iterations=1 (tc45).
+
+Issue #1356: before PR #1359 the consumer's ``max_iterations`` never went on the
+wire and the Python provider's agentic loop hardcoded 10, so
+``@mesh.llm(max_iterations=N)`` was INERT on the mesh-delegated path.
+
+This agent is the minimal consumer that proves the fix end-to-end:
+  - it declares max_iterations=1 EXPLICITLY (so the value is forwarded as
+    model_params.max_iterations),
+  - it filters in exactly ONE mesh tool (capability "iteration_probe" ->
+    advance_ticket on iteration-probe-agent), and
+  - the prompt it is driven with requires FOUR sequential advance_ticket rounds
+    to finish the ticket.
+
+With the cap honored the provider-managed loop executes advance_ticket exactly
+ONCE. Without it, the loop runs to completion (4 invocations). The tc reads the
+probe agent's invocation counter to tell those apart — deliberately NOT the
+provider's "Maximum tool call iterations reached" sentinel, which issue #1355
+will replace with a structured signal.
+
+Return type is plain ``str``: when the loop is capped, the provider returns its
+exhaustion payload rather than a completed answer, and a structured/Pydantic
+return type would turn that into an unrelated validation error instead of the
+observable under test.
+"""
+
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+import mesh
+
+app = FastMCP("TicketAgent")
+
+
+class TicketContext(BaseModel):
+    """Context for the ticket-processing request."""
+
+    instruction: str = Field(
+        ..., description="Instruction describing the multi-step ticket to process"
+    )
+
+
+@app.tool()
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["+claude", "+provider"]},
+    # Only advance_ticket is exposed to the model. probe_count / probe_reset sit
+    # on DIFFERENT capabilities so the model can neither read nor reset the
+    # counter it is being measured with.
+    filter={"capability": "iteration_probe"},
+    # THE THING UNDER TEST: an explicitly configured cap must be forwarded to
+    # the provider-managed loop (model_params.max_iterations).
+    max_iterations=1,
+    system_prompt=(
+        "You are a ticket-processing agent. You MUST use the advance_ticket "
+        "tool to make progress on a ticket; never guess, fabricate or predict a "
+        "token, a step number or a final_code. Call advance_ticket AT MOST ONCE "
+        "per turn and wait for its result before calling it again — the token "
+        "for the next call only exists in the previous call's response. Keep "
+        "going until the tool reports status COMPLETE, then reply with the "
+        "final_code it returned."
+    ),
+    context_param="ctx",
+)
+@mesh.tool(
+    capability="run_ticket",
+    description="Drive the probe ticket to completion using the advance_ticket tool",
+    version="1.0.0",
+    tags=["llm", "ticket", "iteration"],
+)
+async def run_ticket(
+    ctx: TicketContext,
+    llm: mesh.MeshLlmAgent = None,
+) -> str:
+    """Hand the ticket instruction to the mesh LLM provider."""
+    if llm is None:
+        raise RuntimeError("Mesh provider not resolved for run_ticket")
+
+    return await llm(ctx.instruction)
+
+
+@mesh.agent(
+    name="ticket-agent",
+    version="1.0.0",
+    description="Consumer with explicit max_iterations=1 (issue #1356)",
+    http_port=9037,
+    enable_http=True,
+    auto_run=True,
+)
+class TicketAgentConfig:
+    """Consumer agent for tc45."""
+
+    pass

--- a/tests/integration/suites/uc04_llm_integration/tc45_max_iterations_explicit_cap_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc45_max_iterations_explicit_cap_py/test.yaml
@@ -1,0 +1,222 @@
+# Test Case: consumer max_iterations is honored by the PROVIDER-managed loop - Python
+#
+# Issue: https://github.com/dhyansraj/mcp-mesh/issues/1356  (PR #1359)
+#
+# WHAT WAS BROKEN
+#   A consumer's @mesh.llm(max_iterations=N) never reached the provider: the
+#   value was not put on the wire, and the Python provider's agentic loop
+#   hardcoded 10. On the mesh-delegated path (the normal path) the setting was
+#   therefore completely INERT. Unit tests now cover the wire contract in every
+#   runtime, but nothing proved the cap survives the provider->consumer hop.
+#
+# WHAT THIS TC PROVES
+#   A Python consumer with an EXPLICIT max_iterations=1 causes the
+#   PROVIDER-managed agentic loop to execute exactly ONE tool round.
+#
+# THE OBSERVABLE (and why it is NOT the exhaustion sentinel)
+#   The provider currently signals exhaustion with the synthetic string
+#   "Maximum tool call iterations reached". Issue #1355 will replace that with a
+#   STRUCTURED signal, so any assertion on that text is scheduled to break.
+#   Instead this tc counts ACTUAL TOOL INVOCATIONS: iteration-probe-agent keeps
+#   an in-process counter that advance_ticket increments, and exposes it through
+#   a SEPARATE capability (probe_count) that the consumer's filter does not match
+#   — so the model can never see or perturb it. probe_reset (also outside the
+#   filter) zeroes the counter immediately before the measured call.
+#
+#   The ticket needs FOUR advance_ticket rounds to reach status COMPLETE, so:
+#       cap honored  (max_iterations=1) -> PROBE_INVOCATIONS=[1]
+#       cap ignored  (provider default 10) -> PROBE_INVOCATIONS=[4]
+#   The assertion PROBE_INVOCATIONS=[1] therefore genuinely discriminates; it
+#   does not depend on any sentinel text or log wording.
+#
+# WHY CLAUDE (anthropic/claude-sonnet-4-5, the shared uc04 claude-provider)
+#   This is a tool-CALLING determinism test, not a content test. Claude is the
+#   most reliable of the three vendors at (a) actually invoking a tool it is told
+#   to invoke and (b) respecting a "one call per turn, wait for the result"
+#   instruction rather than speculatively batching parallel tool calls — which
+#   would inflate the counter within a single iteration and make the measurement
+#   meaningless. advance_ticket's unguessable random next_token enforces the same
+#   serialization structurally; Claude just makes it reliable in practice.
+#
+# NOTE ON PARALLEL TOOL CALLS
+#   parallel_tool_calls is left OFF and the tool's contract (random next_token)
+#   makes batching impossible, so one counter increment == one loop iteration.
+
+name: "max_iterations forwarded to provider loop - Py"
+description: "Issue #1356: an explicit @mesh.llm(max_iterations=1) caps the PROVIDER-managed agentic loop at exactly one tool round (measured by tool-invocation count, not the exhaustion sentinel)"
+tags:
+  - llm
+  - claude
+  - python
+  - tools
+  - max-iterations
+  - issue-1356
+timeout: 300
+# Skip with --skip-tag llm if no API key is available.
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+test:
+  # --- Copy artifacts ---
+  - name: "Copy Claude provider to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/claude-provider /workspace/"
+    capture: copy_provider_output
+  - name: "Copy iteration-probe-agent to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/iteration-probe-agent /workspace/"
+    capture: copy_probe_output
+  - name: "Copy ticket-agent to workspace"
+    handler: shell
+    command: "cp -r /artifacts/ticket-agent /workspace/"
+    capture: copy_consumer_output
+  - name: "Create env file with secrets"
+    handler: secrets
+    target: /workspace/.env
+  - name: "Verify workspace files"
+    handler: shell
+    command: "ls -la /workspace/"
+    capture: ls_output
+
+  # --- Start the probe tool provider ---
+  - name: "Start iteration-probe-agent"
+    handler: shell
+    command: "meshctl start iteration-probe-agent/main.py -d"
+    workdir: /workspace
+    capture: start_probe_output
+  - name: "Wait for probe agent to register"
+    handler: wait
+    seconds: 5
+
+  # --- Start the LLM provider (no MESH_LLM_MAX_ITERATIONS: the provider's own
+  #     default is 10, so any cap observed below can ONLY have come from the
+  #     consumer's forwarded value) ---
+  - name: "Start Claude provider (no provider-side cap)"
+    handler: shell
+    command: "meshctl start claude-provider/main.py --env-file .env -d"
+    workdir: /workspace
+    capture: start_provider_output
+  - name: "Wait for provider to register"
+    handler: wait
+    seconds: 15
+
+  # --- Start the consumer (max_iterations=1) ---
+  - name: "Start ticket-agent (max_iterations=1)"
+    handler: shell
+    command: "meshctl start ticket-agent/main.py -d --debug"
+    workdir: /workspace
+    capture: start_consumer_output
+  - name: "Wait for consumer to register and resolve dependencies"
+    handler: wait
+    seconds: 15
+  - name: "Verify all agents running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: all_list_output
+  - name: "List available tools"
+    handler: shell
+    command: "meshctl list -t"
+    workdir: /workspace
+    capture: tools_output
+
+  # --- Zero the counter right before the measured call ---
+  - name: "Reset the probe invocation counter"
+    handler: shell
+    command: "meshctl call probe_reset '{}'"
+    workdir: /workspace
+    capture: reset_output
+
+  # --- THE MEASURED CALL (exactly one; never retried, a retry would add a
+  #     second provider-managed loop and a second tool invocation) ---
+  - name: "Call run_ticket (single measured call)"
+    handler: shell
+    command: |
+      meshctl call run_ticket '{"ctx": {"instruction": "Process ticket ABC-1 to completion. Begin by calling advance_ticket with token \"START\". Each response gives you a next_token; call advance_ticket again with it. Keep going until the tool reports status COMPLETE, then reply with the final_code."}}'
+    workdir: /workspace
+    capture: ticket_response
+    timeout: 180
+
+  # --- Read the counter: THE observable ---
+  - name: "Read the probe invocation counter"
+    handler: shell
+    command: "meshctl call probe_count '{}'"
+    workdir: /workspace
+    capture: probe_count_output
+
+  # --- Structural guard: prove the PROVIDER-managed loop is the loop that ran.
+  #     Without this, a cap enforced only by the consumer's own local loop could
+  #     produce the same count. This log line ("Provider-managed loop: N tools
+  #     with endpoints") is emitted when the consumer forwards tool endpoints and
+  #     is independent of the #1355 exhaustion signal. ---
+  - name: "Confirm the provider-managed loop path was taken"
+    handler: shell
+    command: |
+      if meshctl logs claude-provider 2>/dev/null | grep -q "Provider-managed loop"; then
+        echo "PROVIDER_MANAGED_LOOP_OK"
+      else
+        echo "PROVIDER_MANAGED_LOOP_MISSING"
+      fi
+    workdir: /workspace
+    capture: provider_loop_marker
+    ignore_errors: true
+  - name: "Capture provider log tail (diagnostics)"
+    handler: shell
+    command: "meshctl logs claude-provider 2>/dev/null | tail -120 || true"
+    workdir: /workspace
+    capture: provider_log
+    ignore_errors: true
+
+  - name: "Stop all agents"
+    handler: shell
+    command: "meshctl stop"
+    workdir: /workspace
+    ignore_errors: true
+
+assertions:
+  # --- Infrastructure (must hold for the measurement to mean anything) ---
+  - expr: ${captured.all_list_output} contains 'iteration-probe-agent'
+    message: "iteration-probe-agent should be registered"
+  - expr: ${captured.all_list_output} contains 'claude-provider'
+    message: "claude-provider should be registered"
+  - expr: ${captured.all_list_output} contains 'ticket-agent'
+    message: "ticket-agent should be registered"
+  - expr: ${captured.tools_output} contains 'run_ticket'
+    message: "run_ticket tool should be listed"
+  - expr: ${captured.tools_output} contains 'advance_ticket'
+    message: "advance_ticket tool should be listed"
+  - expr: ${captured.reset_output} contains 'PROBE_RESET_OK'
+    message: "Counter should be reset before the measured call"
+
+  # --- The loop that ran was the PROVIDER-managed one ---
+  - expr: ${captured.provider_loop_marker} contains 'PROVIDER_MANAGED_LOOP_OK'
+    message: "The provider-managed agentic loop should have executed (tools forwarded with endpoints)"
+
+  # --- THE OBSERVABLE: exactly one tool round ---
+  # Uncapped this ticket takes 4 advance_ticket rounds to reach COMPLETE, so
+  # [1] vs [4] cleanly separates "cap honored" from "cap ignored".
+  - expr: ${captured.probe_count_output} contains 'PROBE_INVOCATIONS=[1]'
+    message: "Provider-managed loop should have executed advance_ticket EXACTLY ONCE (consumer max_iterations=1 must reach the provider)"
+  - expr: ${captured.probe_count_output} not contains 'PROBE_INVOCATIONS=[0]'
+    message: "advance_ticket should have run at least once (a zero count means the model never called the tool, so nothing was measured)"
+
+  # --- Secondary, sentinel-text-independent evidence that the loop stopped
+  #     early: the final_code only exists after the 4th round, so a capped run
+  #     can never have seen it. ---
+  - expr: ${captured.ticket_response} not contains 'PROBE-COMPLETE-9F3A'
+    message: "A run capped at 1 iteration cannot have driven the ticket to completion (final_code must be absent)"
+
+  # --- No infrastructure failure masquerading as a small count ---
+  - expr: ${captured.ticket_response} not contains 'Mesh provider not resolved'
+    message: "The consumer's LLM provider should have been resolved"
+  - expr: ${captured.ticket_response} not contains 'timed out'
+    message: "The measured call should not time out"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc04_llm_integration/tc46_max_iterations_provider_env_py/artifacts/ticket-agent-unset/main.py
+++ b/tests/integration/suites/uc04_llm_integration/tc46_max_iterations_provider_env_py/artifacts/ticket-agent-unset/main.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+ticket-agent-unset - Python @mesh.llm consumer that configures NO cap (tc46).
+
+Issue #1356 contract: ``max_iterations`` is forwarded to the provider ONLY when
+the consumer explicitly configured it (decorator argument or consumer-side
+MESH_LLM_MAX_ITERATIONS). When the consumer says nothing, the key must be ABSENT
+from the wire so the PROVIDER's own MESH_LLM_MAX_ITERATIONS (or its default of
+10) applies.
+
+This agent is the "says nothing" half of that contract: it is byte-for-byte the
+tc45 consumer MINUS the ``max_iterations`` argument. Everything else — provider
+selector, tool filter, system prompt — is identical on purpose, so the only
+variable between tc45 and tc46 is who configures the cap.
+
+If the runtime were to forward a value unconditionally (e.g. always sending the
+default 10), that forwarded 10 would SHADOW the provider's env and the tc46
+assertion would fail. That is exactly what makes this tc a real test of
+explicit-only forwarding rather than a restatement of tc45.
+"""
+
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+import mesh
+
+app = FastMCP("TicketAgentUnset")
+
+
+class TicketContext(BaseModel):
+    """Context for the ticket-processing request."""
+
+    instruction: str = Field(
+        ..., description="Instruction describing the multi-step ticket to process"
+    )
+
+
+@app.tool()
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["+claude", "+provider"]},
+    filter={"capability": "iteration_probe"},
+    # NO max_iterations HERE. This is the point of tc46: nothing must go on the
+    # wire, leaving the provider's MESH_LLM_MAX_ITERATIONS in charge.
+    system_prompt=(
+        "You are a ticket-processing agent. You MUST use the advance_ticket "
+        "tool to make progress on a ticket; never guess, fabricate or predict a "
+        "token, a step number or a final_code. Call advance_ticket AT MOST ONCE "
+        "per turn and wait for its result before calling it again — the token "
+        "for the next call only exists in the previous call's response. Keep "
+        "going until the tool reports status COMPLETE, then reply with the "
+        "final_code it returned."
+    ),
+    context_param="ctx",
+)
+@mesh.tool(
+    capability="run_ticket",
+    description="Drive the probe ticket to completion using the advance_ticket tool",
+    version="1.0.0",
+    tags=["llm", "ticket", "iteration"],
+)
+async def run_ticket(
+    ctx: TicketContext,
+    llm: mesh.MeshLlmAgent = None,
+) -> str:
+    """Hand the ticket instruction to the mesh LLM provider."""
+    if llm is None:
+        raise RuntimeError("Mesh provider not resolved for run_ticket")
+
+    return await llm(ctx.instruction)
+
+
+@mesh.agent(
+    name="ticket-agent-unset",
+    version="1.0.0",
+    description="Consumer with NO configured max_iterations (issue #1356)",
+    http_port=9038,
+    enable_http=True,
+    auto_run=True,
+)
+class TicketAgentUnsetConfig:
+    """Consumer agent for tc46."""
+
+    pass

--- a/tests/integration/suites/uc04_llm_integration/tc46_max_iterations_provider_env_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc46_max_iterations_provider_env_py/test.yaml
@@ -1,0 +1,211 @@
+# Test Case: an UNSET consumer cap lets the PROVIDER's env apply - Python
+#
+# Issue: https://github.com/dhyansraj/mcp-mesh/issues/1356  (PR #1359)
+#
+# THE HALF OF THE CONTRACT tc45 DOES NOT COVER
+#   max_iterations is forwarded ONLY when the consumer explicitly configured it.
+#   When the consumer says nothing, the key must be ABSENT from the wire so the
+#   provider's own MESH_LLM_MAX_ITERATIONS applies. tc45 proves "explicit is
+#   forwarded"; this tc proves "unset is NOT forwarded".
+#
+# SETUP
+#   Consumer (ticket-agent-unset): identical to tc45's consumer EXCEPT it does
+#     not pass max_iterations at all, and no consumer-side
+#     MESH_LLM_MAX_ITERATIONS is set.
+#   Provider (claude-provider): started with MESH_LLM_MAX_ITERATIONS=1 in its
+#     OWN environment.
+#
+# WHY THE ASSERTION REALLY DISCRIMINATES
+#   The observable is the probe agent's tool-invocation counter, not the
+#   exhaustion sentinel (issue #1355 will restructure that sentinel; see the
+#   header of tc45 and of iteration-probe-agent/main.py). The ticket needs FOUR
+#   advance_ticket rounds to reach COMPLETE, so:
+#
+#     provider env applied (cap 1)        -> PROBE_INVOCATIONS=[1]   PASS
+#     old behavior: provider hardcoded 10 -> PROBE_INVOCATIONS=[4]   FAIL
+#     naive "always forward the default"  -> consumer sends 10, which SHADOWS
+#                                            the provider env -> [4]  FAIL
+#
+#   So the count separates the correct behavior from BOTH failure modes,
+#   including the subtle one where a runtime forwards a value unconditionally.
+#   A "no exhaustion happened" style assertion would not have done that.
+#
+# WHY CLAUDE: see tc45's header — this is a tool-calling determinism test, and
+#   Claude most reliably invokes the tool and honors "one call per turn" instead
+#   of speculatively batching parallel calls (which would inflate the count
+#   within a single iteration).
+
+name: "Unset consumer cap defers to provider env - Py"
+description: "Issue #1356: with NO consumer-configured max_iterations, nothing is forwarded and the provider's own MESH_LLM_MAX_ITERATIONS=1 caps the provider-managed loop at one tool round"
+tags:
+  - llm
+  - claude
+  - python
+  - tools
+  - max-iterations
+  - issue-1356
+timeout: 300
+# Skip with --skip-tag llm if no API key is available.
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+test:
+  # --- Copy artifacts ---
+  - name: "Copy Claude provider to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/claude-provider /workspace/"
+    capture: copy_provider_output
+  - name: "Copy iteration-probe-agent to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/iteration-probe-agent /workspace/"
+    capture: copy_probe_output
+  - name: "Copy ticket-agent-unset to workspace"
+    handler: shell
+    command: "cp -r /artifacts/ticket-agent-unset /workspace/"
+    capture: copy_consumer_output
+  - name: "Create env file with secrets"
+    handler: secrets
+    target: /workspace/.env
+  - name: "Verify workspace files"
+    handler: shell
+    command: "ls -la /workspace/"
+    capture: ls_output
+
+  # --- Start the probe tool provider ---
+  - name: "Start iteration-probe-agent"
+    handler: shell
+    command: "meshctl start iteration-probe-agent/main.py -d"
+    workdir: /workspace
+    capture: start_probe_output
+  - name: "Wait for probe agent to register"
+    handler: wait
+    seconds: 5
+
+  # --- Start the LLM provider WITH its own cap in the environment. The cap is
+  #     passed via --env (NOT the shared .env) so it can only ever reach the
+  #     provider process, never the consumer. ---
+  - name: "Start Claude provider with MESH_LLM_MAX_ITERATIONS=1"
+    handler: shell
+    command: "meshctl start claude-provider/main.py --env-file .env --env MESH_LLM_MAX_ITERATIONS=1 -d"
+    workdir: /workspace
+    capture: start_provider_output
+  - name: "Wait for provider to register"
+    handler: wait
+    seconds: 15
+
+  # --- Start the consumer that configures NOTHING ---
+  - name: "Start ticket-agent-unset (no configured cap)"
+    handler: shell
+    command: "meshctl start ticket-agent-unset/main.py -d --debug"
+    workdir: /workspace
+    capture: start_consumer_output
+  - name: "Wait for consumer to register and resolve dependencies"
+    handler: wait
+    seconds: 15
+  - name: "Verify all agents running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: all_list_output
+  - name: "List available tools"
+    handler: shell
+    command: "meshctl list -t"
+    workdir: /workspace
+    capture: tools_output
+
+  # --- Zero the counter right before the measured call ---
+  - name: "Reset the probe invocation counter"
+    handler: shell
+    command: "meshctl call probe_reset '{}'"
+    workdir: /workspace
+    capture: reset_output
+
+  # --- THE MEASURED CALL (exactly one; a retry would add another loop and
+  #     another tool invocation and corrupt the count) ---
+  - name: "Call run_ticket (single measured call)"
+    handler: shell
+    command: |
+      meshctl call run_ticket '{"ctx": {"instruction": "Process ticket ABC-1 to completion. Begin by calling advance_ticket with token \"START\". Each response gives you a next_token; call advance_ticket again with it. Keep going until the tool reports status COMPLETE, then reply with the final_code."}}'
+    workdir: /workspace
+    capture: ticket_response
+    timeout: 180
+
+  # --- Read the counter: THE observable ---
+  - name: "Read the probe invocation counter"
+    handler: shell
+    command: "meshctl call probe_count '{}'"
+    workdir: /workspace
+    capture: probe_count_output
+
+  # --- Structural guard: the loop under measurement is the PROVIDER-managed
+  #     one. Log line is independent of the #1355 exhaustion signal. ---
+  - name: "Confirm the provider-managed loop path was taken"
+    handler: shell
+    command: |
+      if meshctl logs claude-provider 2>/dev/null | grep -q "Provider-managed loop"; then
+        echo "PROVIDER_MANAGED_LOOP_OK"
+      else
+        echo "PROVIDER_MANAGED_LOOP_MISSING"
+      fi
+    workdir: /workspace
+    capture: provider_loop_marker
+    ignore_errors: true
+  - name: "Capture provider log tail (diagnostics)"
+    handler: shell
+    command: "meshctl logs claude-provider 2>/dev/null | tail -120 || true"
+    workdir: /workspace
+    capture: provider_log
+    ignore_errors: true
+
+  - name: "Stop all agents"
+    handler: shell
+    command: "meshctl stop"
+    workdir: /workspace
+    ignore_errors: true
+
+assertions:
+  # --- Infrastructure ---
+  - expr: ${captured.all_list_output} contains 'iteration-probe-agent'
+    message: "iteration-probe-agent should be registered"
+  - expr: ${captured.all_list_output} contains 'claude-provider'
+    message: "claude-provider should be registered"
+  - expr: ${captured.all_list_output} contains 'ticket-agent-unset'
+    message: "ticket-agent-unset should be registered"
+  - expr: ${captured.tools_output} contains 'run_ticket'
+    message: "run_ticket tool should be listed"
+  - expr: ${captured.tools_output} contains 'advance_ticket'
+    message: "advance_ticket tool should be listed"
+  - expr: ${captured.reset_output} contains 'PROBE_RESET_OK'
+    message: "Counter should be reset before the measured call"
+
+  # --- The loop that ran was the PROVIDER-managed one ---
+  - expr: ${captured.provider_loop_marker} contains 'PROVIDER_MANAGED_LOOP_OK'
+    message: "The provider-managed agentic loop should have executed (tools forwarded with endpoints)"
+
+  # --- THE OBSERVABLE: the PROVIDER's env cap took effect ---
+  # [1] = provider env applied. [4] = the ticket ran to completion, meaning the
+  # provider's env was ignored (old hardcoded 10) or shadowed by an
+  # unconditionally-forwarded consumer value.
+  - expr: ${captured.probe_count_output} contains 'PROBE_INVOCATIONS=[1]'
+    message: "Provider's own MESH_LLM_MAX_ITERATIONS=1 should cap the loop at exactly one tool round (an unset consumer must forward nothing)"
+  - expr: ${captured.probe_count_output} not contains 'PROBE_INVOCATIONS=[0]'
+    message: "advance_ticket should have run at least once (a zero count means the model never called the tool, so nothing was measured)"
+
+  # --- Secondary, sentinel-text-independent evidence the loop stopped early ---
+  - expr: ${captured.ticket_response} not contains 'PROBE-COMPLETE-9F3A'
+    message: "A run capped at 1 iteration cannot have driven the ticket to completion (final_code must be absent)"
+
+  # --- No infrastructure failure masquerading as a small count ---
+  - expr: ${captured.ticket_response} not contains 'Mesh provider not resolved'
+    message: "The consumer's LLM provider should have been resolved"
+  - expr: ${captured.ticket_response} not contains 'timed out'
+    message: "The measured call should not time out"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc04_llm_integration/tc47_max_iterations_cross_runtime_java_py/artifacts/max-iterations-java/pom.xml
+++ b/tests/integration/suites/uc04_llm_integration/tc47_max_iterations_cross_runtime_java_py/artifacts/max-iterations-java/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>max-iterations-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Max Iterations Java Consumer (tc47)</name>
+    <description>Dedicated single-@MeshLlm Java consumer forwarding maxIterations=1 to a Python provider (issue #1356)</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <!-- maven-install handler aligns this from the container's ~/.m2 repo -->
+        <mcp-mesh.version>3.2.2</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- MCP Mesh Spring AI Integration -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-ai</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.maxiterations.MaxIterationsAgentApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+</project>

--- a/tests/integration/suites/uc04_llm_integration/tc47_max_iterations_cross_runtime_java_py/artifacts/max-iterations-java/src/main/java/com/example/maxiterations/MaxIterationsAgentApplication.java
+++ b/tests/integration/suites/uc04_llm_integration/tc47_max_iterations_cross_runtime_java_py/artifacts/max-iterations-java/src/main/java/com/example/maxiterations/MaxIterationsAgentApplication.java
@@ -1,0 +1,139 @@
+package com.example.maxiterations;
+
+import io.mcpmesh.FilterMode;
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshLlm;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+import io.mcpmesh.types.MeshLlmAgent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * DEDICATED minimal Java consumer for tc47 — issue #1356 (PR #1359).
+ *
+ * <p>Java consumer-side {@code max_iterations} forwarding is BRAND NEW in that
+ * PR ({@code MeshLlmAgentProxy} now puts {@code model_params.max_iterations} on
+ * the wire when the cap was explicitly configured) and has no end-to-end
+ * coverage at all — the Java unit tests mock the provider side, and the Python
+ * unit tests mock the consumer side. This agent closes the cross-runtime gap:
+ * JAVA consumer -> PYTHON provider-managed agentic loop.
+ *
+ * <p>WHY A DEDICATED AGENT (not the shared {@code llm-mesh-agent} analyst): the
+ * same reason tc44 has one. A confirmed pre-existing bug (#1141) makes
+ * per-funcId LLM-provider proxies bind UNRELIABLY when a single agent declares
+ * MANY {@code @MeshLlm} functions. This agent declares EXACTLY ONE, the normal
+ * case, so its proxy binds reliably and the tc measures only the thing under
+ * test.
+ *
+ * <p>WHY {@code maxIterations = 1} AND NOTHING ELSE: with the Java consumer
+ * forwarding the cap, the Python provider's loop must stop after ONE tool round.
+ * The tc measures that by reading iteration-probe-agent's invocation counter,
+ * NOT by matching the provider's "Maximum tool call iterations reached"
+ * sentinel — issue #1355 is going to replace that sentinel with a structured
+ * signal.
+ *
+ * <p>NOTE ON THE JAVA-LOCAL LOOP: {@code maxIterations} also caps this agent's
+ * OWN loop. That is not what makes the count come out at 1 — the Java proxy
+ * sends {@code _mesh_endpoint} with each tool, so the PYTHON provider executes
+ * the tools inside ITS loop and returns a finished message; the Java-local loop
+ * makes exactly one provider call either way. If the cap were NOT forwarded, the
+ * Python loop would run the ticket to completion (4 tool rounds) inside that
+ * single provider call. The tc additionally asserts the provider-managed path
+ * was taken, so the count cannot be explained by the Java-local cap.
+ *
+ * <p>RETURN TYPE IS {@code String}: when the loop is capped the provider returns
+ * its exhaustion payload instead of a completed answer; a structured record
+ * return type would turn that into an unrelated deserialization error rather
+ * than the observable under test.
+ */
+@MeshAgent(
+    name = "max-iterations-java",
+    version = "1.0.0",
+    description = "Dedicated single-@MeshLlm Java consumer forwarding maxIterations=1 (issue #1356)",
+    port = 9047
+)
+@SpringBootApplication
+public class MaxIterationsAgentApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(MaxIterationsAgentApplication.class);
+
+    /** Returned when the LLM proxy has not bound yet — the tc's readiness poll keys off this. */
+    static final String UNAVAILABLE = "LLM_UNAVAILABLE";
+
+    public static void main(String[] args) {
+        log.info("Starting Max-Iterations Java Consumer (single @MeshLlm)...");
+        SpringApplication.run(MaxIterationsAgentApplication.class, args);
+    }
+
+    /**
+     * The ONLY {@code @MeshLlm} function on this agent: drive the probe ticket
+     * with an explicit cap of ONE iteration.
+     *
+     * <p>The filter selects ONLY {@code capability="iteration_probe"}
+     * ({@code advance_ticket}). The probe agent's {@code probe_count} and
+     * {@code probe_reset} tools sit on different capabilities, so the model can
+     * neither read nor reset the counter it is being measured with.
+     */
+    @MeshLlm(
+        providerSelector = @Selector(capability = "llm", tags = {"+claude", "+provider"}),
+        // THE THING UNDER TEST: explicitly configured, therefore forwarded as
+        // model_params.max_iterations to the Python provider-managed loop.
+        maxIterations = 1,
+        systemPrompt = "You are a ticket-processing agent. You MUST use the advance_ticket "
+            + "tool to make progress on a ticket; never guess, fabricate or predict a token, "
+            + "a step number or a final_code. Call advance_ticket AT MOST ONCE per turn and "
+            + "wait for its result before calling it again - the token for the next call only "
+            + "exists in the previous call's response. Keep going until the tool reports status "
+            + "COMPLETE, then reply with the final_code it returned.",
+        contextParam = "ctx",
+        filter = @Selector(capability = "iteration_probe"),
+        filterMode = FilterMode.ALL,
+        maxTokens = 2048,
+        temperature = 0.0
+    )
+    @MeshTool(
+        capability = "runTicket",
+        description = "Drive the probe ticket using the advance_ticket tool (capped at 1 iteration)",
+        tags = {"llm", "ticket", "iteration", "java"}
+    )
+    public String runTicket(
+        @Param(value = "ctx", description = "Ticket context") TicketContext ctx,
+        MeshLlmAgent llm
+    ) {
+        log.info("Running ticket: {}", ctx.instruction());
+
+        if (llm == null || !llm.isAvailable()) {
+            log.warn("LLM provider not available yet");
+            return UNAVAILABLE;
+        }
+
+        try {
+            String result = llm.request()
+                .user(ctx.instruction())
+                .maxTokens(2048)
+                .temperature(0.0)
+                .generate();
+
+            var meta = llm.request().lastMeta();
+            if (meta != null) {
+                log.info("Ticket run completed: {} iterations, {}ms latency",
+                    meta.iterations(), meta.latencyMs());
+            }
+
+            return result;
+
+        } catch (Exception e) {
+            log.error("Ticket run failed: {}", e.getMessage(), e);
+            return "ERROR: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Ticket context record.
+     */
+    public record TicketContext(String instruction) {}
+}

--- a/tests/integration/suites/uc04_llm_integration/tc47_max_iterations_cross_runtime_java_py/artifacts/max-iterations-java/src/main/resources/application.properties
+++ b/tests/integration/suites/uc04_llm_integration/tc47_max_iterations_cross_runtime_java_py/artifacts/max-iterations-java/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=9047

--- a/tests/integration/suites/uc04_llm_integration/tc47_max_iterations_cross_runtime_java_py/artifacts/max-iterations-java/src/main/resources/application.yml
+++ b/tests/integration/suites/uc04_llm_integration/tc47_max_iterations_cross_runtime_java_py/artifacts/max-iterations-java/src/main/resources/application.yml
@@ -1,0 +1,31 @@
+# MCP Mesh Max-Iterations Java Consumer Configuration (tc47)
+#
+# Overridable via environment variables:
+#   MCP_MESH_REGISTRY_URL - Registry URL
+#   MCP_MESH_HTTP_PORT    - Agent HTTP port
+#   MCP_MESH_AGENT_NAME   - Agent name
+
+spring:
+  application:
+    name: max-iterations-java
+
+server:
+  port: ${MCP_MESH_HTTP_PORT:9047}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:max-iterations-java}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+  llm:
+    # Capability-only default; the single @MeshLlm annotation selects the provider
+    # and owns the iteration cap (maxIterations = 1).
+    default-provider:
+      capability: llm
+    timeout: 60000
+
+logging:
+  level:
+    io.mcpmesh: DEBUG
+    com.example: DEBUG

--- a/tests/integration/suites/uc04_llm_integration/tc47_max_iterations_cross_runtime_java_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc47_max_iterations_cross_runtime_java_py/test.yaml
@@ -1,0 +1,290 @@
+# Test Case: cross-runtime max_iterations forwarding - Java consumer -> Py provider
+#
+# Issue: https://github.com/dhyansraj/mcp-mesh/issues/1356  (PR #1359)
+#
+# THE GAP THIS CLOSES
+#   Java consumer-side forwarding of the agentic-loop cap
+#   (MeshLlmAgentProxy putting model_params.max_iterations on the wire when the
+#   cap is explicitly configured) is BRAND NEW in PR #1359 and has no end-to-end
+#   coverage whatsoever. The Java unit tests mock the provider; the Python unit
+#   tests mock the consumer. Nothing exercises the actual cross-runtime hop.
+#   This tc runs a JAVA consumer against the PYTHON provider-managed loop.
+#
+# THE OBSERVABLE (and why it is NOT the exhaustion sentinel)
+#   iteration-probe-agent keeps an in-process counter that advance_ticket
+#   increments, and exposes it on a SEPARATE capability (probe_count) that the
+#   consumer's filter does not match, so the model can never see or perturb it.
+#   probe_reset (also outside the filter) zeroes it right before the measured
+#   call. The provider's "Maximum tool call iterations reached" string is
+#   deliberately NOT asserted on: issue #1355 will replace it with a structured
+#   signal.
+#
+#   The ticket needs FOUR advance_ticket rounds to reach COMPLETE, so:
+#       cap forwarded and honored -> PROBE_INVOCATIONS=[1]
+#       cap not forwarded (old)   -> Python provider's default 10 lets the
+#                                    ticket finish -> PROBE_INVOCATIONS=[4]
+#
+# WHY THE JAVA-LOCAL LOOP CANNOT EXPLAIN A COUNT OF 1
+#   The Java proxy sends _mesh_endpoint with every tool definition, so the
+#   PYTHON provider runs the agentic loop and executes the tools itself; the
+#   Java-local loop makes exactly ONE provider call regardless of its own cap.
+#   Were the cap not forwarded, that single provider call would internally run
+#   the ticket to completion (4 tool rounds). The tc also asserts the
+#   "Provider-managed loop" marker in the Python provider's log, so a count of 1
+#   provably means the Python loop stopped at 1 — i.e. the Java-forwarded cap
+#   arrived and was applied.
+#
+# WHY CLAUDE (anthropic/claude-sonnet-4-5, shared uc04 claude-provider)
+#   This is a tool-calling determinism test. Claude most reliably (a) invokes a
+#   tool it is told to invoke and (b) honors "one call per turn, wait for the
+#   result" instead of speculatively batching parallel tool calls, which would
+#   inflate the counter WITHIN a single iteration and destroy the measurement.
+#   advance_ticket's unguessable random next_token enforces that serialization
+#   structurally; Claude makes it reliable in practice.
+#
+# READINESS WITHOUT CORRUPTING THE MEASUREMENT
+#   Java @MeshLlm proxies bind asynchronously (see tc44's header, #1141), so the
+#   call has to be polled until it stops returning the local LLM_UNAVAILABLE
+#   sentinel. Each of those readiness calls DOES bump the probe counter — which
+#   is exactly why the counter is reset AFTER readiness is established and
+#   BEFORE the single measured call. The measured call is never retried.
+
+name: "Cross-Runtime max_iterations - Java consumer -> Py provider"
+description: "Issue #1356: a Java @MeshLlm(maxIterations=1) consumer forwards the cap to the Python provider-managed loop, which executes exactly one tool round"
+tags:
+  - llm
+  - claude
+  - cross-runtime
+  - java
+  - python
+  - tools
+  - max-iterations
+  - issue-1356
+timeout: 600
+# Skip with --skip-tag llm if no API key is available.
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+  - routine: global.setup_for_java_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+test:
+  # --- Copy artifacts ---
+  - name: "Copy Python Claude provider to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/claude-provider /workspace/"
+    capture: copy_provider
+  - name: "Copy iteration-probe-agent to workspace"
+    handler: shell
+    command: "cp -r /uc-artifacts/iteration-probe-agent /workspace/"
+    capture: copy_probe
+  - name: "Copy Java max-iterations consumer to workspace"
+    handler: shell
+    command: "cp -r /artifacts/max-iterations-java /workspace/"
+    capture: copy_consumer
+  - name: "Create env file with secrets"
+    handler: secrets
+    target: /workspace/.env
+
+  # --- Build the Java consumer ---
+  - name: "Install Maven dependencies for the Java consumer"
+    handler: maven-install
+    path: /workspace/max-iterations-java
+    timeout: 600
+
+  # --- Start the probe tool provider (Python) ---
+  - name: "Start iteration-probe-agent"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start iteration-probe-agent/main.py -d"
+    capture: start_probe
+  - name: "Wait for probe agent to register"
+    handler: wait
+    seconds: 5
+
+  # --- Start the Python LLM provider. NO MESH_LLM_MAX_ITERATIONS here: its own
+  #     default is 10, so any cap observed below can ONLY have come from the
+  #     Java consumer's forwarded value. ---
+  - name: "Start Python Claude provider (no provider-side cap)"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start claude-provider/main.py --env-file .env -d"
+    capture: start_provider
+  - name: "Wait for provider to register"
+    handler: wait
+    seconds: 15
+  - name: "Verify probe agent and provider are running"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: pre_agent_list
+
+  # --- Start the Java consumer ---
+  - name: "Start Java max-iterations consumer"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl start /workspace/max-iterations-java --env MCP_MESH_HTTP_PORT=0 -d
+    capture: start_consumer
+  - name: "Wait for the Java consumer to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for max-iterations-java agent..."
+      for i in $(seq 1 45); do
+        AGENTS=$(meshctl list 2>/dev/null || echo "")
+        if echo "$AGENTS" | grep -q "max-iterations-java"; then
+          echo "max-iterations-java registered after $((i*2))s"
+          exit 0
+        fi
+        if [ $((i % 10)) -eq 0 ]; then
+          echo "Still waiting... ($((i*2))s)"
+          echo "$AGENTS"
+        fi
+        sleep 2
+      done
+      echo "WARNING: max-iterations-java not registered within 90s"
+      meshctl list 2>/dev/null || true
+      meshctl logs max-iterations-java 2>/dev/null | tail -50 || true
+      exit 1
+    capture: wait_consumer
+    timeout: 120
+  - name: "Verify all agents running"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: all_list
+  - name: "List available tools"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list --tools"
+    capture: tools_output
+
+  # --- READINESS: poll the real call until the Java @MeshLlm proxy has bound
+  #     (i.e. it stops returning the local LLM_UNAVAILABLE sentinel). These
+  #     attempts intentionally bump the probe counter; the counter is reset
+  #     afterwards, before the single measured call. ---
+  - name: "Poll runTicket until the LLM proxy has bound (readiness only)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      # Diagnostics to STDERR so the capture stays readable.
+      ARGS='{"ctx": {"instruction": "Process ticket ABC-1 to completion. Begin by calling advance_ticket with token \"START\". Each response gives you a next_token; call advance_ticket again with it. Keep going until the tool reports status COMPLETE, then reply with the final_code."}}'
+      for i in $(seq 1 10); do
+        RESP=$(meshctl call runTicket "$ARGS" 2>/dev/null || echo "")
+        if [ -n "$RESP" ] && ! echo "$RESP" | grep -q "LLM_UNAVAILABLE"; then
+          echo "PROXY_BOUND after attempt $i"
+          exit 0
+        fi
+        echo "Attempt $i: proxy not bound yet, retrying in 5s..." >&2
+        sleep 5
+      done
+      echo "ERROR: runTicket still returned LLM_UNAVAILABLE after 10 attempts" >&2
+      meshctl logs max-iterations-java 2>/dev/null | tail -80 >&2 || true
+      exit 1
+    capture: readiness_output
+    timeout: 240
+
+  # --- Zero the counter: everything measured from here is ONE call ---
+  - name: "Reset the probe invocation counter"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl call probe_reset '{}'"
+    capture: reset_output
+
+  # --- THE MEASURED CALL (exactly one, never retried) ---
+  - name: "Call runTicket (single measured call)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl call runTicket '{"ctx": {"instruction": "Process ticket ABC-1 to completion. Begin by calling advance_ticket with token \"START\". Each response gives you a next_token; call advance_ticket again with it. Keep going until the tool reports status COMPLETE, then reply with the final_code."}}'
+    capture: ticket_response
+    timeout: 180
+
+  # --- Read the counter: THE observable ---
+  - name: "Read the probe invocation counter"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl call probe_count '{}'"
+    capture: probe_count_output
+
+  # --- Structural guard: the loop under measurement is the PYTHON
+  #     provider-managed one, not the Java-local one. ---
+  - name: "Confirm the Python provider-managed loop path was taken"
+    handler: shell
+    workdir: /workspace
+    command: |
+      if meshctl logs claude-provider 2>/dev/null | grep -q "Provider-managed loop"; then
+        echo "PROVIDER_MANAGED_LOOP_OK"
+      else
+        echo "PROVIDER_MANAGED_LOOP_MISSING"
+      fi
+    capture: provider_loop_marker
+    ignore_errors: true
+  - name: "Capture provider log tail (diagnostics)"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl logs claude-provider 2>/dev/null | tail -120 || true"
+    capture: provider_log
+    ignore_errors: true
+
+  - name: "Stop all agents"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl stop"
+    ignore_errors: true
+
+assertions:
+  # --- Infrastructure ---
+  - expr: "${captured.pre_agent_list} contains 'iteration-probe-agent'"
+    message: "iteration-probe-agent should be registered"
+  - expr: "${captured.pre_agent_list} contains 'claude-provider'"
+    message: "Python claude-provider should be registered"
+  - expr: "${captured.all_list} contains 'max-iterations-java'"
+    message: "Java max-iterations-java consumer should be registered"
+  - expr: "${captured.tools_output} contains 'runTicket'"
+    message: "runTicket tool should be available"
+  - expr: "${captured.tools_output} contains 'advance_ticket'"
+    message: "advance_ticket tool should be available"
+
+  # --- Readiness actually succeeded: the LLM proxy bound, so the measured call
+  #     really went through the mesh rather than the local sentinel ---
+  - expr: "${captured.readiness_output} contains 'PROXY_BOUND'"
+    message: "The Java @MeshLlm proxy should have bound before the measured call"
+  - expr: "${captured.ticket_response} not contains 'LLM_UNAVAILABLE'"
+    message: "The measured call must reach the mesh provider, not the local unavailable sentinel"
+  - expr: "${captured.reset_output} contains 'PROBE_RESET_OK'"
+    message: "Counter should be reset after readiness and before the measured call"
+
+  # --- The loop that ran was the PYTHON provider-managed one ---
+  - expr: "${captured.provider_loop_marker} contains 'PROVIDER_MANAGED_LOOP_OK'"
+    message: "The Python provider-managed agentic loop should have executed (Java forwards _mesh_endpoint per tool)"
+
+  # --- THE OBSERVABLE: exactly one tool round ---
+  # Uncapped, the ticket takes 4 advance_ticket rounds to reach COMPLETE.
+  - expr: "${captured.probe_count_output} contains 'PROBE_INVOCATIONS=[1]'"
+    message: "Python provider-managed loop should have executed advance_ticket EXACTLY ONCE (Java's maxIterations=1 must reach the provider)"
+  - expr: "${captured.probe_count_output} not contains 'PROBE_INVOCATIONS=[0]'"
+    message: "advance_ticket should have run at least once (a zero count means the model never called the tool, so nothing was measured)"
+
+  # --- Secondary, sentinel-text-independent evidence the loop stopped early ---
+  - expr: "${captured.ticket_response} not contains 'PROBE-COMPLETE-9F3A'"
+    message: "A run capped at 1 iteration cannot have driven the ticket to completion (final_code must be absent)"
+
+  # --- No infrastructure failure masquerading as a small count ---
+  - expr: "${captured.ticket_response} not contains '\"isError\":true'"
+    message: "The measured call should not return an MCP error envelope"
+  - expr: "${captured.ticket_response} not contains '\"isError\": true'"
+    message: "The measured call should not return an MCP error envelope (spaced form)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop 2>/dev/null || true
+      pkill -f "spring-boot:run" 2>/dev/null || true
+      pkill -f "java.*max-iterations" 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
A consumer's `max_iterations` was **inert on the path it actually takes**. The Python provider-managed loop hardcoded `10` (`helpers.py:2829`, `:3171`) and the consumer never put the value on the wire — so a `@mesh.llm(provider={...})` consumer setting it got no error, no warning, and no effect. Java hardcoded `10` the same way (`MeshLlmProviderProcessor.java:442`) and its consumer never forwarded the key either.

## Contract

Wire key `model_params.max_iterations`, resolved provider-side with the semantics TypeScript already ships (#1116):

```
sanitize(v)     = floor(Number(v)) if finite and > 0 else unset
resolve(param)  = param present ? (sanitize(param) ?? 10)
                                : (sanitize($MESH_LLM_MAX_ITERATIONS) ?? 10)
```

Including the subtlety that a **present-but-invalid** value falls back to 10 rather than to the environment.

The key is **stripped provider-side** so it can never leak into a vendor API request. Two tests cover this: the loop path, and the legacy single-call path where `completion_args.update(model_params_copy)` would otherwise hand it straight to LiteLLM.

## Precedence decision

Forwarding is **explicit-only**, so a provider operator's `MESH_LLM_MAX_ITERATIONS` still applies to consumers that configured nothing.

That required making "unset" representable:
- **Python** — decorator default moves `10` → `None`. `LLMConfig` exposes `effective_max_iterations` (`None` → 10) and `max_iterations_explicit`, so nothing downstream ever sees `None`. `get_config_value` semantics are untouched (other call sites depend on them); a consumer-side env var still counts as explicit, since only "nothing configured anywhere" yields `None`.
- **Java** — new `MeshLlmDefaults.MAX_ITERATIONS_UNSET = 0`, matching the existing `MAX_TOKENS_UNSET` pattern. `@MeshLlm(maxIterations)` defaults to it: source- and binary-compatible, and behavior-preserving locally since `0` already normalized to `10`.

⚠️ **Release note:** `@MeshLlm(maxIterations)`'s annotation default changes from `10` to the unset sentinel. No behavioral change, but it is a visible default.

## Known remaining gap — TypeScript, deliberately not changed here

The issue described TypeScript as the correct reference. **It isn't.** Its guard looks explicit-only:

```ts
if (options?.maxIterations !== undefined) { modelParams.max_iterations = options.maxIterations; }
```

but `llm.ts:234` defaults `config.maxIterations ?? 10`, and `llm-agent.ts:674-677,712` passes the **resolved** value into the very `options` the guard tests — so the guard always fires. A TS consumer that configures nothing still sends `max_iterations: 10`, leaving the provider's env inert for it.

Python and Java now behave correctly; TS keeps the old behavior. The sanitize/resolve semantics are byte-identical across all three, so only the omit-when-unset case differs. Tracked separately rather than widened into this PR.

## Also found

- **Consumer-side env parsing is stricter than the wire path in Python.** `MESH_LLM_MAX_ITERATIONS=3.5` on a consumer is rejected by `NONZERO_RULE` (→ unset), while the same value forwarded on the wire floors to `3`. Pre-existing `get_config_value` behavior, left alone rather than widening shared semantics.
- **Stale docs corrected**: `docs/python/llm/index.md` and `docs/java/annotations.md` both documented the default as `1`; now `10` plus the forwarding note. No `meshctl man` page mentions `max_iterations`, so no parallel man edit.

## Tests

- **Python** (new, 39 tests): sanitize table (zero/negative/NaN/inf/non-numeric/fractional/empty/None/collections), resolve (valid, invalid-explicit→10 *with env set*, absent→env, absent+invalid env→10, absent+no env→10), `LLMConfig` unset/explicit/explicit-10/zero-rejected, consumer forward-vs-omit on **both** buffered and stream paths, decorator resolution, and the two leak tests.
- **Java** (new, 13 tests): provider sanitize/resolve + key-stripping; consumer explicit-forwarded / unset-omitted / unset-still-10-locally / escape-hatch-wins.
- One pre-existing test updated (`test_mesh_llm_decorator.py:123`) — it encoded the old default.

## Verification

Run independently, not just reported:
- Python CI-equivalent (`pytest tests/unit/ _mcp_mesh/`): **0 failures** (2419 passed, 2 pre-existing live-integration skips)
- Java (`mvn -pl mcp-mesh-spring-ai,mcp-mesh-spring-boot-starter -am test`): **BUILD SUCCESS**, exit 0 — spring-ai 207, starter 661, 0 failures/errors
- TypeScript: 83 files, 1179 tests pass (unchanged)

Closes #1356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM iteration limits can now be left unset, allowing the provider’s configured limit or default to apply.
  * Explicit iteration limits are forwarded to provider-managed agent loops across Python and Java runtimes.
  * Environment-based iteration limits are supported when no explicit limit is configured.
  * Invalid iteration-limit values are safely rejected or replaced with defaults.

* **Documentation**
  * Updated Java and Python documentation to describe unset behavior, provider delegation, and defaults.

* **Tests**
  * Added coverage for forwarding, provider configuration, registration, and cross-runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->