### PR TITLE
fix(release): make the publish steps idempotent so a partial release can be finished

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -697,7 +697,15 @@ jobs:
         working-directory: dist/node-core
         env:
           NPM_TAG: ${{ steps.version.outputs.npm_tag }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
+          # Idempotency: a re-dispatched release must not fail on an already
+          # published version. Only skip on a confirmed existing version - never
+          # swallow publish errors, which would mask auth/network/registry faults.
+          if [ -n "$(npm view "@mcpmesh/core@${VERSION}" version 2>/dev/null || true)" ]; then
+            echo "@mcpmesh/core@${VERSION} is already published, skipping"
+            exit 0
+          fi
           echo "Publishing @mcpmesh/core with tag ${NPM_TAG}..."
           # Use --ignore-scripts since prepublishOnly runs napi which isn't in the artifact
           npm publish --access public --tag "${NPM_TAG}" --provenance --ignore-scripts
@@ -815,7 +823,13 @@ jobs:
         working-directory: src/runtime/typescript
         env:
           NPM_TAG: ${{ steps.version.outputs.npm_tag }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
+          # Idempotency: skip only on a confirmed existing version (see publish-node-core).
+          if [ -n "$(npm view "@mcpmesh/sdk@${VERSION}" version 2>/dev/null || true)" ]; then
+            echo "@mcpmesh/sdk@${VERSION} is already published, skipping"
+            exit 0
+          fi
           echo "Publishing @mcpmesh/sdk with tag ${NPM_TAG}..."
           npm publish --access public --tag "${NPM_TAG}" --provenance
 
@@ -973,9 +987,15 @@ jobs:
           # Publish platform-specific packages first (order matters!)
           for pkg in cli-linux-x64 cli-linux-arm64 cli-darwin-x64 cli-darwin-arm64; do
             if [ -d "$pkg" ]; then
+              # Idempotency: skip only on a confirmed existing version. Previously
+              # this tolerated any publish failure, masking auth/network/registry errors.
+              if [ -n "$(npm view "@mcpmesh/${pkg}@${VERSION}" version 2>/dev/null || true)" ]; then
+                echo "@mcpmesh/${pkg}@${VERSION} is already published, skipping"
+                continue
+              fi
               echo "Publishing @mcpmesh/$pkg with tag ${NPM_TAG}..."
               cd "$pkg"
-              npm publish --access public --tag "${NPM_TAG}" --provenance || echo "Package may already exist, continuing..."
+              npm publish --access public --tag "${NPM_TAG}" --provenance
               cd ..
             fi
           done
@@ -983,7 +1003,13 @@ jobs:
       - name: Publish main CLI package to npm
         env:
           NPM_TAG: ${{ steps.version.outputs.npm_tag }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
+          # Idempotency: skip only on a confirmed existing version (see above).
+          if [ -n "$(npm view "@mcpmesh/cli@${VERSION}" version 2>/dev/null || true)" ]; then
+            echo "@mcpmesh/cli@${VERSION} is already published, skipping"
+            exit 0
+          fi
           cd dist/npm/cli
           echo "Publishing @mcpmesh/cli with tag ${NPM_TAG}..."
           npm publish --access public --tag "${NPM_TAG}" --provenance

--- a/packaging/scripts/publish-java.sh
+++ b/packaging/scripts/publish-java.sh
@@ -25,6 +25,13 @@ BOM_MODULE="mcp-mesh-bom"
 # Maven coordinates
 GROUP_ID_PATH="io/mcp-mesh"
 
+# Maven Central read endpoint, used to detect an already-published version.
+CENTRAL_REPO_URL="https://repo1.maven.org/maven2"
+# Central releases a deployment bundle atomically - either every module in the
+# bundle lands or none does - so probing one representative artifact is enough
+# to conclude the whole version is already published.
+PROBE_ARTIFACT_ID="mcp-mesh-spring-boot-starter"
+
 # Sonatype Central Portal API
 SONATYPE_API="https://central.sonatype.com/api/v1/publisher/upload"
 SONATYPE_STATUS_API="https://central.sonatype.com/api/v1/publisher/status"
@@ -72,6 +79,23 @@ fi
 
 log "Publishing Java SDK version: ${VERSION}"
 log "Modules: ${MODULES[*]}"
+
+# Idempotency guard: re-running a release (e.g. to finish a partially-completed
+# one) must not re-upload a version that is already on Central. Uploading an
+# existing version is rejected and leaves a FAILED deployment in the portal.
+PROBE_URL="${CENTRAL_REPO_URL}/${GROUP_ID_PATH}/${PROBE_ARTIFACT_ID}/${VERSION}/${PROBE_ARTIFACT_ID}-${VERSION}.pom"
+log "Checking whether ${VERSION} is already on Maven Central..."
+log "  ${PROBE_URL}"
+PROBE_STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 60 -L "${PROBE_URL}" || echo "000")
+
+if [ "${PROBE_STATUS}" = "200" ]; then
+    success "Java SDK ${VERSION} is already published to Maven Central, nothing to do"
+    exit 0
+fi
+
+# Any other response (404, or a transient/unknown code) means we cannot confirm
+# publication, so continue with the normal upload path unchanged.
+log "Not published yet (HTTP ${PROBE_STATUS}); proceeding with upload"
 
 # Create temporary working directory for the bundle
 BUNDLE_DIR=$(mktemp -d)


### PR DESCRIPTION
## Why

The v3.2.3 release published npm, PyPI, node-core, typescript-sdk, rust-core and Helm, then `publish-java-sdk` **timed out** during a live Sonatype incident (*"Delayed publishing to Maven Central"*). The deployment sat in `PUBLISHING` for over an hour and has since published cleanly — **7/7 components validated, all six modules resolvable on repo1**, so #1357's BOM signing fix is confirmed working.

But because that job failed, `build-docker` was skipped and **no 3.2.3 Docker images exist**.

We then couldn't finish the release, because the publish steps aren't re-runnable:

| job | on an already-published version |
|---|---|
| `publish-python` | ✅ `skip-existing: true` |
| `publish-rust-core` | ✅ `skip-existing: true` |
| `publish-java-sdk` | ❌ re-uploads → Central rejects → **second FAILED deployment in the portal** |
| `publish-typescript-sdk` | ❌ bare `npm publish` → EPUBLISHCONFLICT |
| `publish-node-core` | ❌ same |
| `publish-npm` | ❌ inconsistent — one bare call, one blanket-tolerant |

## Change

**`publish-java.sh`** — probe `repo1` for the version before bundling; exit 0 if present. Central releases a bundle atomically, so one representative artifact (`mcp-mesh-spring-boot-starter`) settles the whole version. Verified live: `3.2.3 → 200`, `9.9.9 → 404`. Placed before the temp-dir/trap setup so the skip path does no work.

**The four npm publishes** — skip only on a **confirmed** existing version via `npm view`. The check requires non-empty output rather than exit status, because npm 11 exits 1 on a missing version while older npm exited 0 with empty output.

**Removed a masking bug:** `publish-npm` previously had `|| echo "Package may already exist, continuing..."`, which also swallowed auth, network and registry errors — a publish step that could never fail. Replaced with the explicit check, so real failures still fail the job.

Non-goals: the first-publish path is untouched, and a genuinely `FAILED` Central deployment still exits non-zero.

## ⚠️ How to finish v3.2.3 with this

**Use `workflow_dispatch` from `main` — not "Re-run failed jobs" on the original release run.** A re-run executes the workflow *and scripts as of the commit that triggered it*, which is the `v3.2.3` tag and predates this fix; it would re-upload to Central and fail exactly as before.

Dispatching from `main` is safe for artifact fidelity:
- `v3.2.3` and `main` are the same commit today, so after this merges main is the tag plus one **release-tooling-only** commit (verifiable with `git diff v3.2.3..main --stat`)
- the runtime images don't build from repo source — `python-runtime.Dockerfile` does `pip install mcp-mesh==${VERSION}`, and TS/Java pull from npm/Central, so their contents come from the already-published 3.2.3 artifacts

One known dispatch difference: `combine-checksums` is gated `if: github.event_name == 'release'`, so it and its dependents (`publish-npm`, `update-packages`) skip on a dispatch. Harmless here — those already completed for 3.2.3 — but worth knowing. `build-docker` does not depend on them.

## Validation

`bash -n`, `shellcheck` (clean), workflow YAML parse, plus every `run:` block in the workflow extracted and syntax-checked. The Central probe was exercised against the real endpoint for both an existing and a non-existing version. Nothing was uploaded.

## Follow-up (flagged, not fixed)

`publish-npm`'s "Verify npm installation" step still ends in `|| echo "Package may not be indexed yet"` and a soft `⚠ Binary not found` path, so that verification can never fail the job — same class of masking bug, but it's a verification step rather than a publish step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1cLws2dhLUhhVdGHJ5aXQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing reliability by detecting versions that are already available before attempting to publish.
  * Prevented duplicate package and Java artifact uploads while allowing releases to continue when a version has not yet been published.
  * Improved handling of publishing errors by distinguishing existing versions from other failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->