### PR TITLE
fix(tracing): background re-probe so telemetry Redis recovers off the request path

### DIFF
--- a/src/runtime/core/src/ffi.rs
+++ b/src/runtime/core/src/ffi.rs
@@ -999,9 +999,17 @@ pub extern "C" fn mesh_init_trace_publisher() -> i32 {
         tracing_publish::init_trace_publisher().await
     });
 
-    if result {
-        // Arm the non-blocking publish path (queue + drain task).
+    // Arm the non-blocking publish path (queue + drain task) whenever tracing
+    // is enabled, even if the initial connect failed: the background re-prober
+    // (issue #1364) may bring Redis up later, and the drain task calls
+    // publish_span which short-circuits instantly while unavailable. Without
+    // arming here a Redis-down-at-startup Java agent could never publish spans
+    // after recovery.
+    if is_tracing_enabled() {
         let _ = ensure_span_queue();
+    }
+
+    if result {
         info!("FFI: Trace publisher initialized successfully");
         1
     } else {

--- a/src/runtime/core/src/tracing_publish.rs
+++ b/src/runtime/core/src/tracing_publish.rs
@@ -4,13 +4,14 @@
 //! This is the core implementation used by all language SDKs.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use redis::aio::{ConnectionManager, ConnectionManagerConfig};
 use redis::AsyncCommands;
 use tokio::sync::RwLock;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
@@ -20,14 +21,37 @@ use crate::config::{get_redis_url, is_tracing_enabled};
 /// Redis stream name for trace data.
 const TRACE_STREAM_NAME: &str = "mesh:trace";
 
-/// Cooldown between re-probes once Redis has been marked unavailable.
+/// Cooldown between re-probe attempts once Redis has been marked unavailable
+/// (issue #1364). Stored as an atomic so tests can shrink it for a
+/// deterministic recovery assertion; production always uses the 5s default.
+static REPROBE_COOLDOWN_MS: AtomicU64 = AtomicU64::new(5_000);
+
+/// Current re-probe cooldown as a `Duration`.
+fn reprobe_cooldown() -> Duration {
+    Duration::from_millis(REPROBE_COOLDOWN_MS.load(Ordering::Relaxed))
+}
+
+/// Hard outer bound on a single connect + PING (issue #1363/#1364). Shared by
+/// the startup connect and every background re-probe so the two never diverge.
 ///
-/// Issue #1363 RC2: on a publish failure `available` is flipped to false so
-/// subsequent spans short-circuit instantly instead of each paying the full
-/// Redis timeout (connect 500ms + response 2s × retries) for the whole
-/// outage. Redis can recover though, so one span per cooldown is let through
-/// to re-test the connection and flip `available` back on when it succeeds.
-const REPROBE_COOLDOWN: Duration = Duration::from_secs(5);
+/// `set_connection_timeout` on `ConnectionManagerConfig` does NOT reliably
+/// bound the very first dial for every failure mode: a black-holed Redis (a
+/// host that silently drops the SYN) was observed stalling ~118s — the OS TCP
+/// connect timeout — despite the 500ms per-attempt setting, because that
+/// per-attempt timeout isn't applied to the initial connection in the redis
+/// crate version in use. This `tokio::time::timeout` guarantees the connect can
+/// never stall a caller past the budget.
+const INIT_CONNECT_BUDGET: Duration = Duration::from_secs(3);
+
+/// Single-flight guard for the background re-prober (issue #1364): at most one
+/// prober task exists at a time. Set via CAS before spawning and cleared by a
+/// RAII [`ReproberGuard`] when the prober task ends for ANY reason — normal
+/// return, panic, or cancellation at runtime shutdown — so it can never wedge
+/// `true` and silently kill recovery (issue #1364 W1). As a second safety net,
+/// `publish_span`'s unavailable short-circuit re-spawns the prober (idempotent
+/// via the CAS), so even a prober that somehow died self-heals on the next
+/// suppressed span.
+static REPROBE_RUNNING: AtomicBool = AtomicBool::new(false);
 
 /// Global trace publisher state.
 struct TracePublisherState {
@@ -43,13 +67,11 @@ struct TracePublisherState {
     conn: Option<ConnectionManager>,
     /// Whether tracing is enabled.
     enabled: bool,
-    /// Whether Redis is available.
+    /// Whether Redis is available. When false the publish path short-circuits
+    /// instantly (read-lock only) and a single-flight background re-prober
+    /// (issue #1364) is responsible for flipping it back on — no request ever
+    /// pays a Redis reconnect.
     available: bool,
-    /// When Redis publishing was last marked unavailable / last re-probed
-    /// (issue #1363 RC2). Gates the lazy re-probe: while unavailable, only one
-    /// span per `REPROBE_COOLDOWN` is let through to re-test the connection so
-    /// a sustained outage never makes every span pay the full Redis timeout.
-    last_failure: Option<Instant>,
     /// Redis URL.
     redis_url: String,
 }
@@ -60,7 +82,6 @@ impl Default for TracePublisherState {
             conn: None,
             enabled: false,
             available: false,
-            last_failure: None,
             redis_url: String::new(),
         }
     }
@@ -75,6 +96,166 @@ fn get_publisher() -> Arc<RwLock<TracePublisherState>> {
         .clone()
 }
 
+/// Build a fresh bounded `ConnectionManager` and verify it with a PING, all
+/// under the hard [`INIT_CONNECT_BUDGET`] timeout.
+///
+/// Shared by [`init_trace_publisher`] and the background re-prober (issue
+/// #1364) so the connect configuration and hard bound can never diverge.
+/// Because it always constructs a brand-new manager it handles BOTH the cold
+/// start (`conn == None`) and the rebuild-after-death (`conn == Some`) cases —
+/// we never rely on a dead `ConnectionManager`'s own internal reconnect.
+///
+/// Takes no lock and performs no shared-state mutation; callers store the
+/// result. Returns `None` (already logged) on any client-open, connect, PING,
+/// or timeout failure.
+async fn connect_and_verify(redis_url: &str) -> Option<ConnectionManager> {
+    let client = match redis::Client::open(redis_url) {
+        Ok(client) => client,
+        Err(e) => {
+            warn!("Failed to create Redis client for tracing: {}", e);
+            return None;
+        }
+    };
+
+    // Bounded config: ConnectionManager's DEFAULTS retry the first connection 6
+    // times with exponential backoff and no connect timeout, which turns a down
+    // Redis into a multi-second stall. 2 retries × 500ms per-attempt connect
+    // timeout (hard-wrapped by INIT_CONNECT_BUDGET below) keeps a down or
+    // black-holed Redis from stalling. The response timeout bounds every
+    // subsequent command (the XADD): without it a black-holed Redis (accepts
+    // connections, never replies) would stall publishes forever.
+    let cm_config = ConnectionManagerConfig::new()
+        .set_number_of_retries(2)
+        .set_connection_timeout(Duration::from_millis(500))
+        .set_response_timeout(Duration::from_secs(2));
+
+    let connect = async {
+        let mut conn = ConnectionManager::new_with_config(client, cm_config).await?;
+        // Ping to verify the connection is actually usable.
+        let _: String = redis::cmd("PING").query_async(&mut conn).await?;
+        Ok::<ConnectionManager, redis::RedisError>(conn)
+    };
+
+    match tokio::time::timeout(INIT_CONNECT_BUDGET, connect).await {
+        Ok(Ok(conn)) => {
+            debug!("Redis connection established for tracing");
+            Some(conn)
+        }
+        Ok(Err(e)) => {
+            warn!("Failed to connect to Redis for tracing: {}", e);
+            None
+        }
+        Err(_) => {
+            warn!(
+                "Redis connect for tracing exceeded {}s budget; tracing paused (will re-probe)",
+                INIT_CONNECT_BUDGET.as_secs()
+            );
+            None
+        }
+    }
+}
+
+/// RAII reset for the single-flight guard (issue #1364 W1).
+///
+/// Dropping this clears [`REPROBE_RUNNING`] unconditionally. It is constructed
+/// inside the spawned prober task right after the CAS wins, so it is dropped —
+/// and the guard reset to `false` — on EVERY way the task can end: a normal
+/// `return`, a panic while dialing Redis or taking a lock (the runtime catches
+/// task panics and drops the future), or cancellation when the tokio runtime is
+/// torn down. That guarantees the guard can never wedge `true` and permanently
+/// kill recovery.
+struct ReproberGuard;
+
+impl Drop for ReproberGuard {
+    fn drop(&mut self) {
+        REPROBE_RUNNING.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Spawn the single-flight background re-prober (issue #1364).
+///
+/// This is the ONLY place that dials Redis on the unhealthy path — no request
+/// ever pays a reconnect. Guarded by [`REPROBE_RUNNING`] via CAS so at most one
+/// prober runs at a time. The prober loops `sleep(reprobe_cooldown())` → one
+/// bounded [`connect_and_verify`] → on success stores the fresh connection and
+/// flips `available` back on, then exits (the [`ReproberGuard`] clears the
+/// single-flight guard on the way out); on failure it loops again — immortal
+/// until it reconnects. `available == false` suppresses publishes, so the loop
+/// must never give up on its own; single-flight keeps it to one task, the tokio
+/// runtime cancels it at process shutdown, and `publish_span`'s unavailable
+/// branch re-kicks it (idempotent CAS) should a prober ever die.
+///
+/// Spawned on the current tokio runtime handle. Every caller (the pyo3
+/// `get_runtime().block_on`, the napi runtime, and the ffi `block_on`) reaches
+/// this from inside an async context, so a current handle is always available;
+/// if somehow it is not, we clear the guard and bail rather than panic.
+///
+/// Cheap and idempotent on the request path: when called from a suppressed
+/// span the whole cost is `Handle::try_current` + a failed CAS (no lock, no
+/// dial) if a prober is already running.
+fn spawn_reprober(publisher: Arc<RwLock<TracePublisherState>>) {
+    // Single-flight: only spawn if no prober is already running.
+    if REPROBE_RUNNING
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+
+    let handle = match tokio::runtime::Handle::try_current() {
+        Ok(handle) => handle,
+        Err(_) => {
+            // No runtime to spawn on (should never happen — every call site is
+            // inside an async context). No task was spawned, so no
+            // ReproberGuard exists yet; release the guard directly so a later
+            // failure can try again.
+            REPROBE_RUNNING.store(false, Ordering::Release);
+            warn!("trace re-prober not spawned: no current tokio runtime");
+            return;
+        }
+    };
+
+    handle.spawn(async move {
+        // RAII reset: clears REPROBE_RUNNING on EVERY exit of this task —
+        // normal return, panic, or cancellation (issue #1364 W1). Held for the
+        // whole task body and dropped LAST, after the write lock below is
+        // released, so a racing publish-failure that observes the cleared guard
+        // has already seen `available == true` and won't spawn a redundant
+        // prober (no lost-recovery window).
+        let _guard = ReproberGuard;
+
+        loop {
+            tokio::time::sleep(reprobe_cooldown()).await;
+
+            // Read the URL / enabled flag under a short read lock; never hold a
+            // lock across the network dial below.
+            let (enabled, url) = {
+                let state = publisher.read().await;
+                (state.enabled, state.redis_url.clone())
+            };
+            if !enabled {
+                return;
+            }
+
+            // ONE bounded reconnect, off any lock.
+            if let Some(conn) = connect_and_verify(&url).await {
+                // Flip state ON under the write lock, then return. The write
+                // guard drops at the end of this block (releasing the lock);
+                // `_guard` drops afterwards, clearing REPROBE_RUNNING only once
+                // `available == true` is already visible — so a racing publish-
+                // failure that sees the cleared guard also sees availability
+                // recovered (no spawn needed) or, if it flipped `available` off
+                // again, re-spawns a fresh prober.
+                let mut state = publisher.write().await;
+                state.conn = Some(conn);
+                state.available = true;
+                info!("Redis reachable again; trace publishing resumed");
+                return;
+            }
+        }
+    });
+}
+
 /// Initialize the trace publisher.
 ///
 /// Must be called before publishing spans. Checks if tracing is enabled
@@ -84,84 +265,41 @@ fn get_publisher() -> Arc<RwLock<TracePublisherState>> {
 /// true if tracing is enabled and Redis is available, false otherwise.
 pub async fn init_trace_publisher() -> bool {
     let publisher = get_publisher();
-    let mut state = publisher.write().await;
 
-    // Check if tracing is enabled
-    state.enabled = is_tracing_enabled();
-    if !state.enabled {
-        debug!("Distributed tracing: disabled");
-        return false;
+    let enabled = is_tracing_enabled();
+    let redis_url = get_redis_url();
+
+    {
+        let mut state = publisher.write().await;
+        state.enabled = enabled;
+        state.redis_url = redis_url.clone();
+        if !enabled {
+            debug!("Distributed tracing: disabled");
+            return false;
+        }
     }
 
     info!("Distributed tracing: enabled");
 
-    // Get Redis URL
-    state.redis_url = get_redis_url();
-
-    // Initialize the reconnecting connection once; publishes clone it.
-    //
-    // Bound the initial connect: ConnectionManager's DEFAULTS retry the
-    // first connection 6 times with exponential backoff and no connect
-    // timeout, which turns a down Redis into a multi-second agent-startup
-    // stall inside init (the previous per-span code failed fast). The bounded
-    // config below (2 retries × 500ms per-attempt connect timeout, hard-wrapped
-    // by the 3s `tokio::time::timeout` further down) keeps a down or
-    // blackholed Redis from stalling startup.
-    //
-    // The response timeout bounds every subsequent command too (the XADD
-    // on the drain task): without it, a black-holed Redis (accepts
-    // connections, never replies) would stall publishes forever — the
-    // manager only triggers a reconnect when a command actually errors.
-    match redis::Client::open(state.redis_url.as_str()) {
-        Ok(client) => {
-            let cm_config = ConnectionManagerConfig::new()
-                .set_number_of_retries(2)
-                .set_connection_timeout(Duration::from_millis(500))
-                .set_response_timeout(Duration::from_secs(2));
-
-            // Hard outer bound on the whole connect + PING (issue #1363).
-            // `set_connection_timeout` above does NOT reliably bound the very
-            // first `new_with_config` dial for every failure mode: a
-            // black-holed Redis (a host that silently drops the SYN) was
-            // observed stalling this init ~118s — the OS TCP connect timeout —
-            // despite the 500ms per-attempt setting, because that per-attempt
-            // timeout isn't applied to the initial connection in the redis
-            // crate version in use. This `tokio::time::timeout` guarantees init
-            // can never stall startup (or any caller) past the budget; on
-            // timeout we soft-fail (available=false, log a warn) and continue
-            // with tracing effectively no-op'd until the lazy re-probe.
-            const INIT_CONNECT_BUDGET: Duration = Duration::from_secs(3);
-            let connect = async {
-                let mut conn = ConnectionManager::new_with_config(client, cm_config).await?;
-                // Ping to verify
-                let _: String = redis::cmd("PING").query_async(&mut conn).await?;
-                Ok::<ConnectionManager, redis::RedisError>(conn)
-            };
-            match tokio::time::timeout(INIT_CONNECT_BUDGET, connect).await {
-                Ok(Ok(conn)) => {
-                    debug!("Redis connection established for tracing");
-                    state.conn = Some(conn);
-                    state.available = true;
-                    true
-                }
-                Ok(Err(e)) => {
-                    warn!("Failed to connect to Redis for tracing: {}", e);
-                    state.available = false;
-                    false
-                }
-                Err(_) => {
-                    warn!(
-                        "Redis connect for tracing exceeded {}s budget; tracing paused (will re-probe)",
-                        INIT_CONNECT_BUDGET.as_secs()
-                    );
-                    state.available = false;
-                    false
-                }
-            }
+    // Connect off the lock so the healthy read path is never blocked behind a
+    // startup dial, and store the result under a brief write lock.
+    match connect_and_verify(&redis_url).await {
+        Some(conn) => {
+            let mut state = publisher.write().await;
+            state.conn = Some(conn);
+            state.available = true;
+            true
         }
-        Err(e) => {
-            warn!("Failed to create Redis client: {}", e);
-            state.available = false;
+        None => {
+            {
+                let mut state = publisher.write().await;
+                state.available = false;
+            }
+            // Redis was down/unreachable at startup (`conn` stays None). Kick
+            // the background re-prober so a Redis-down-at-startup agent recovers
+            // when Redis later comes up (issue #1364 facet 2) — connect_and_verify
+            // constructs a brand-new manager, no existing connection required.
+            spawn_reprober(publisher.clone());
             false
         }
     }
@@ -180,57 +318,36 @@ pub async fn init_trace_publisher() -> bool {
 pub async fn publish_span(span_data: HashMap<String, String>) -> bool {
     let publisher = get_publisher();
 
-    // Clone the shared connection under a short lock, then publish without
+    // Request path — never pays a Redis reconnect (issue #1364).
+    //
+    // Clone the shared connection under a READ lock only, then publish without
     // holding the lock. `ConnectionManager` clones share the same underlying
     // multiplexed connection — no per-span TCP dial.
     //
-    // Fast-paths (issue #1363 RC2):
+    // Fast-paths:
     //   * tracing disabled or no connection → drop silently.
-    //   * Redis previously marked unavailable → short-circuit instantly (no
-    //     per-span Redis timeout) until the re-probe cooldown elapses, then
-    //     let exactly ONE span through to re-test the connection.
-    // `was_available` records which path we took so the healthy path never
-    // pays a write lock: the flag is only toggled on a state *transition*.
-    let (mut conn, was_available) = {
+    //   * Redis marked unavailable → short-circuit INSTANTLY (read-lock only).
+    //     The background re-prober is the only thing that dials Redis while
+    //     unavailable, so no request ever stalls on a reconnect.
+    let mut conn = {
         let state = publisher.read().await;
         if !state.enabled {
             return false;
         }
-        if state.available {
-            match &state.conn {
-                Some(c) => (c.clone(), true),
-                None => return false,
-            }
-        } else {
-            // Unavailable: gate a single re-probe per cooldown under the write
-            // lock so concurrent spans don't all pay the timeout together.
+        if !state.available {
+            // Short-circuit INSTANTLY (read-lock only) — never dial Redis on the
+            // request path. Self-heal (issue #1364 W1): re-kick the single-flight
+            // re-prober in case a prior one died (panic/cancellation). This is
+            // idempotent — a no-op failed CAS while a prober is already running —
+            // so the per-span cost here is just `Handle::try_current` + one
+            // atomic CAS; spawn_reprober itself takes no lock and does no I/O.
             drop(state);
-            let mut state = publisher.write().await;
-            if !state.enabled {
-                return false;
-            }
-            // Another span may have re-probed successfully while we waited.
-            if state.available {
-                match &state.conn {
-                    Some(c) => (c.clone(), true),
-                    None => return false,
-                }
-            } else {
-                let due = state
-                    .last_failure
-                    .map(|t| t.elapsed() >= REPROBE_COOLDOWN)
-                    .unwrap_or(true);
-                if !due {
-                    return false;
-                }
-                // Reserve this cooldown window for our probe; other spans that
-                // race in now see the fresh timestamp and short-circuit.
-                state.last_failure = Some(Instant::now());
-                match &state.conn {
-                    Some(c) => (c.clone(), false),
-                    None => return false,
-                }
-            }
+            spawn_reprober(publisher.clone());
+            return false;
+        }
+        match &state.conn {
+            Some(c) => c.clone(),
+            None => return false,
         }
     };
 
@@ -256,37 +373,23 @@ pub async fn publish_span(span_data: HashMap<String, String>) -> bool {
         .await;
     match result {
         Ok(_msg_id) => {
-            if was_available {
-                debug!("Published trace span to Redis stream");
-            } else {
-                // Re-probe succeeded: Redis is back. Flip `available` on so
-                // the fast healthy path resumes for subsequent spans.
-                let mut state = publisher.write().await;
-                state.available = true;
-                state.last_failure = None;
-                debug!("Redis reachable again; trace publishing resumed");
-            }
+            debug!("Published trace span to Redis stream");
             true
         }
         Err(e) => {
-            // Non-blocking - never fail agent operations (issue #1363 RC2):
+            // Non-blocking - never fail agent operations (issue #1364):
             // flip `available` off so subsequent spans short-circuit instantly
             // instead of each paying the full Redis timeout for the whole
-            // outage. The manager reconnects in the background; the lazy
-            // re-probe (one span per cooldown) flips it back on once Redis is
-            // reachable again (this span is dropped).
-            //
-            // NB: this recovery only covers a MID-LIFE outage — Redis was
-            // reachable at init (so `conn` is `Some`) and later dropped; the
-            // re-probe clones that live `ConnectionManager`, which reconnects.
-            // A STARTUP outage (Redis never reachable at init → `conn` is
-            // `None`) does NOT recover: the re-probe branch hits `None` and
-            // returns without ever re-establishing a connection. Tracked in
-            // issue #1364.
-            let mut state = publisher.write().await;
-            state.available = false;
-            state.last_failure = Some(Instant::now());
-            debug!("Failed to publish trace span: {} (tracing paused; will re-probe)", e);
+            // outage, then KICK the single-flight background re-prober which is
+            // the ONLY thing that dials Redis on the unhealthy path. The
+            // reconnect rebuilds a fresh `ConnectionManager`, so this recovers
+            // regardless of whether the socket died mid-life or was never up.
+            {
+                let mut state = publisher.write().await;
+                state.available = false;
+            }
+            spawn_reprober(publisher.clone());
+            debug!("Failed to publish trace span: {} (tracing paused; re-prober kicked)", e);
             false
         }
     }
@@ -364,7 +467,20 @@ pub fn is_trace_publisher_available_py(py: Python<'_>) -> PyResult<bool> {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Instant;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Reset the process-global re-probe state so prober-sensitive tests are
+    /// order-independent (issue #1364 W3). Each `#[tokio::test]` gets its own
+    /// runtime, so a leaked immortal prober from a prior test is cancelled when
+    /// that runtime drops (and the RAII [`ReproberGuard`] clears the guard on
+    /// the way out) — but we reset the static atomics explicitly here so tests
+    /// never depend on that drop timing. Call at the START of any test that
+    /// asserts on `REPROBE_RUNNING`, connection counts, or recovery.
+    fn reset_reprober_state() {
+        REPROBE_RUNNING.store(false, Ordering::SeqCst);
+        REPROBE_COOLDOWN_MS.store(5_000, Ordering::SeqCst);
+    }
 
     #[test]
     fn test_trace_stream_name() {
@@ -381,6 +497,11 @@ mod tests {
     /// CI, matching the other env-mutating tests in this crate.
     #[tokio::test]
     async fn publisher_reuses_connection_across_publishes() {
+        // Order-independence (issue #1364 W3): clear any leaked re-probe guard
+        // so this test's connection-count assertion isn't perturbed by a prober
+        // spawned in a prior test.
+        reset_reprober_state();
+
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind fake redis");
@@ -469,6 +590,12 @@ mod tests {
     /// runs --test-threads=1 in CI, matching the other env-mutating tests.
     #[tokio::test]
     async fn init_bounds_blackholed_redis_connect() {
+        // Order-independence (issue #1364 W3): this test's failed init spawns an
+        // immortal prober toward the black-holed host that leaks
+        // REPROBE_RUNNING=true until the runtime drops; reset up front so a
+        // leaked guard from a prior test can't suppress this init's own prober.
+        reset_reprober_state();
+
         std::env::set_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED", "true");
         std::env::set_var("REDIS_URL", "redis://192.0.2.1:6379");
 
@@ -492,6 +619,152 @@ mod tests {
             elapsed
         );
 
+        std::env::remove_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED");
+        std::env::remove_var("REDIS_URL");
+    }
+
+    /// Issue #1364: after a Redis-down-at-startup init fails, the single-flight
+    /// background re-prober must construct a fresh connection when Redis comes
+    /// up and flip `available` back on — WITHOUT any request paying the
+    /// reconnect. Fake RESP server that rejects (closes immediately) the first
+    /// two TCP connections, then serves PONG: init's connect is rejected
+    /// (available=false, prober spawned), the prober's first attempt is
+    /// rejected, and its second attempt succeeds — proving recovery from a cold
+    /// start (`conn == None` at init) within a bounded number of cooldowns.
+    ///
+    /// NB: mutates process env + the global publisher singleton + the shared
+    /// re-probe cooldown/guard; the suite runs --test-threads=1 in CI.
+    #[tokio::test]
+    async fn reprober_recovers_from_cold_start() {
+        use std::sync::atomic::AtomicUsize;
+
+        // Order-independence (issue #1364 W3): a prior test may have left the
+        // single-flight guard set when its runtime was torn down mid-probe;
+        // clear it (and restore the default cooldown) so this test's init can
+        // spawn a prober. Then shrink the cooldown for a fast, deterministic
+        // recovery assertion.
+        reset_reprober_state();
+        REPROBE_COOLDOWN_MS.store(50, Ordering::SeqCst);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fake redis");
+        let addr = listener.local_addr().unwrap();
+        let accepted = Arc::new(AtomicUsize::new(0));
+        let accepted_srv = accepted.clone();
+
+        // Reject the first N connections (close immediately → fast connect
+        // failure), then serve PONG so the prober's later attempt succeeds.
+        //
+        // W2: init's connect_and_verify uses set_number_of_retries(2), so a
+        // rejecting server can see up to 1 initial + 2 retries = 3 connection
+        // attempts from init alone. REJECT_FIRST must STRICTLY exceed that so
+        // init can never stumble onto a served socket and succeed (which would
+        // break `assert!(!inited)` and the whole cold-start premise). 4 > 3
+        // guarantees every one of init's attempts is rejected regardless of how
+        // many it actually makes; the prober's attempt #5 is the first served.
+        const REJECT_FIRST: usize = 4;
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                let n = accepted_srv.fetch_add(1, Ordering::SeqCst) + 1;
+                if n <= REJECT_FIRST {
+                    // Drop the socket to force a fast connect/handshake failure.
+                    drop(sock);
+                    continue;
+                }
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 8192];
+                    loop {
+                        match sock.read(&mut buf).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(rn) => {
+                                let req = String::from_utf8_lossy(&buf[..rn]);
+                                let ncmds = req
+                                    .split("\r\n")
+                                    .filter(|line| line.starts_with('*'))
+                                    .count()
+                                    .max(1);
+                                let resp = "+PONG\r\n".repeat(ncmds);
+                                if sock.write_all(resp.as_bytes()).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        std::env::set_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED", "true");
+        std::env::set_var("REDIS_URL", format!("redis://{}", addr));
+
+        // Init's connect is rejected → soft-fail, prober spawned.
+        let inited = tokio::time::timeout(Duration::from_secs(8), init_trace_publisher())
+            .await
+            .expect("init must not hang");
+        assert!(!inited, "init must fail while the fake server rejects connects");
+        assert!(
+            !is_trace_publisher_available().await,
+            "publisher must be unavailable right after the rejected init"
+        );
+        assert!(
+            REPROBE_RUNNING.load(Ordering::SeqCst),
+            "a background re-prober must be running after a failed init"
+        );
+
+        // W2: assert on the OBSERVED attempt count rather than assuming init
+        // makes exactly one. Read before the prober's first ~50ms cooldown
+        // elapses, so this reflects init's attempts alone: at least one dial,
+        // and all of them within the rejected window (init never reached a
+        // served socket — it soft-failed, exactly as the cold-start test needs).
+        let init_attempts = accepted.load(Ordering::SeqCst);
+        assert!(
+            init_attempts >= 1,
+            "init must have made at least one connection attempt, saw {init_attempts}"
+        );
+        assert!(
+            init_attempts <= REJECT_FIRST,
+            "init must not have reached a served socket, saw {init_attempts} (> {REJECT_FIRST})"
+        );
+
+        // The prober rebuilds a fresh ConnectionManager each attempt; once the
+        // server starts serving it must flip `available` back on within a
+        // bounded number of ~50ms cooldowns.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut recovered = false;
+        while Instant::now() < deadline {
+            if is_trace_publisher_available().await {
+                recovered = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            recovered,
+            "re-prober must reconnect (cold start) and flip available=true"
+        );
+        assert!(
+            !REPROBE_RUNNING.load(Ordering::SeqCst),
+            "the re-prober must clear its single-flight guard on success"
+        );
+        assert!(
+            accepted.load(Ordering::SeqCst) > REJECT_FIRST,
+            "recovery must have required more than the rejected connects"
+        );
+
+        // A publish now succeeds against the recovered connection.
+        let span: HashMap<String, String> =
+            HashMap::from([("span".to_string(), "recovered".to_string())]);
+        let published = tokio::time::timeout(Duration::from_secs(5), publish_span(span))
+            .await
+            .expect("publish must not hang");
+        assert!(published, "publish must succeed after recovery");
+
+        // Restore shared state for other tests.
+        REPROBE_COOLDOWN_MS.store(5_000, Ordering::SeqCst);
         std::env::remove_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED");
         std::env::remove_var("REDIS_URL");
     }

--- a/src/runtime/python/_mcp_mesh/tracing/redis_metadata_publisher.py
+++ b/src/runtime/python/_mcp_mesh/tracing/redis_metadata_publisher.py
@@ -31,10 +31,17 @@ class RedisTracePublisher:
             logger.debug("Distributed tracing: disabled")
 
     def publish_execution_trace(self, trace_data: dict[str, Any]) -> None:
-        """Publish execution trace data to Redis Stream via Rust core (non-blocking)."""
-        if not self._available:
-            return  # Silent no-op when Redis unavailable
+        """Publish execution trace data to Redis Stream via Rust core (non-blocking).
 
+        Issue #1364: does NOT gate on the cached ``self._available`` flag
+        (latched at construction). The Rust sync binding (``publish_span_py``) is
+        the single source of truth — it short-circuits internally in microseconds
+        while Redis is unavailable and resumes automatically once the Rust
+        background re-prober reconnects, so a stale Python latch must never keep
+        skipping a recovered connection (mirrors ``publish_execution_trace_async``
+        and the async un-gating). This is the SYNC path: it runs on an anyio
+        worker thread (off the event loop), so the binding's block_on is harmless.
+        """
         try:
             # Convert trace data to strings for Redis storage
             from .utils import add_timestamp_if_missing, convert_for_redis_storage
@@ -59,10 +66,14 @@ class RedisTracePublisher:
         async-tool wrapper and @mesh.route middleware) must use this instead of
         the sync ``publish_execution_trace`` so a stalled/unreachable telemetry
         Redis yields the loop rather than blocking every concurrent request.
-        """
-        if not self._available:
-            return  # Silent no-op when Redis unavailable
 
+        Issue #1364: does NOT gate on the cached ``self._available`` flag
+        (latched at construction). The Rust async binding is now the single
+        source of truth — it short-circuits internally in microseconds while
+        Redis is unavailable and resumes automatically once the Rust background
+        re-prober reconnects, so a stale Python latch must never block a
+        recovered connection.
+        """
         try:
             from .utils import add_timestamp_if_missing, convert_for_redis_storage
 

--- a/src/runtime/python/_mcp_mesh/tracing/utils.py
+++ b/src/runtime/python/_mcp_mesh/tracing/utils.py
@@ -106,6 +106,17 @@ def publish_trace_with_fallback(
     Attempts to publish trace data to Redis, silently handling failures
     to ensure trace publishing never breaks application execution.
 
+    Issue #1364: does NOT gate on the cached ``publisher.is_available`` flag
+    (latched at construction). Always delegate to the Rust sync binding
+    (``publish_span_py``), which is the single source of truth — it short-
+    circuits internally in microseconds while Redis is unavailable and resumes
+    automatically once the Rust background re-prober reconnects, so a stale
+    Python latch must never keep skipping a recovered connection. This is the
+    SYNC path: it runs on an anyio worker thread (off the event loop), so the
+    binding's block_on is harmless here. ``get_trace_publisher()`` is used
+    (constructing) on purpose — off-loop construction is fine; the request event
+    loop uses the non-constructing ``get_initialized_trace_publisher`` instead.
+
     Args:
         trace_data: Trace metadata to publish
         logger_instance: Logger for debug messages
@@ -114,11 +125,7 @@ def publish_trace_with_fallback(
         from .redis_metadata_publisher import get_trace_publisher
 
         publisher = get_trace_publisher()
-        if publisher.is_available:
-            publisher.publish_execution_trace(trace_data)
-            pass
-        else:
-            pass
+        publisher.publish_execution_trace(trace_data)
     except Exception:
         # Never fail agent operations due to trace publishing
         pass
@@ -147,8 +154,17 @@ async def publish_trace_with_fallback_async(
         # that would freeze concurrent request coroutines. The singleton is
         # built off the request path at agent startup
         # (init_trace_publisher_at_startup); if it isn't set yet, drop the span.
+        # Issue #1364: do NOT gate on the cached ``publisher.is_available`` flag
+        # (latched at construction). Always delegate to the Rust async binding,
+        # which short-circuits internally in microseconds while Redis is
+        # unavailable and resumes automatically once the Rust background
+        # re-prober reconnects — a stale Python latch must never keep skipping a
+        # recovered connection. Still uses the NON-constructing
+        # get_initialized_trace_publisher() so no sync block_on init ever runs on
+        # the event loop (RC4 preserved); if the singleton isn't built yet the
+        # span is simply dropped.
         publisher = get_initialized_trace_publisher()
-        if publisher is not None and publisher.is_available:
+        if publisher is not None:
             await publisher.publish_execution_trace_async(trace_data)
     except Exception:
         # Never fail agent operations due to trace publishing


### PR DESCRIPTION
## Summary

Follow-up to #1363. That fix kept the steady-state tracing publish off the event loop, but the RC2 re-probe was still **inline**: once per cooldown, one request cloned the connection and drove the reconnect, stalling that request **22–30s+** during an outage (surfaced by a live mid-life chaos test). It also could only re-test an *existing* connection, so a telemetry Redis that was **unreachable at agent startup never recovered** — the original scope of #1364.

This replaces the inline re-probe with a **background, single-flight, bounded** re-prober:

- **`publish_span`** — healthy path stays read-lock-only. On an `XADD` failure it flips `available=false` and spawns the prober. When unavailable, the request path short-circuits instantly and **idempotently self-heals** (CAS-guarded `spawn_reprober`) — it never dials Redis on the request path.
- **Background prober** — single-flight via a `static AtomicBool` + CAS, spawned on the current runtime handle. Loops on a cooldown attempting one **bounded** `connect_and_verify` (fresh `ConnectionManager` + `tokio::time::timeout(3s)`), stores the connection and flips `available=true` on success. Immortal-until-reconnect. An **RAII guard resets the single-flight flag on any task exit** (including panic/cancellation), and `init_trace_publisher` spawns the prober when the startup connect fails so a cold start recovers.
- **`connect_and_verify`** (factored out of init) handles both cold start (`conn == None`) and rebuild-after-death.
- **Python** — un-gate **both** the sync and async request paths from the stale `_available` latch so they always delegate to Rust (the single source of truth). The async path keeps the non-constructing lookup, so no sync init ever runs on the event loop.
- **`ffi.rs`** — arm the Java span queue whenever tracing is enabled (bounded, drop-on-overflow) so Java agents also recover.

TypeScript and Java inherit the recovery via the shared `publish_span`.

## Live validation (2 agents from `examples/simple`, `--dte`, local Redis)

| Scenario | before this PR | after |
|---|---|---|
| Mid-life kill, calls across ~6 cooldown windows | one call per window stalls ~30s | 27 calls all 30–50ms, zero ≥5s; re-probe runs in the background |
| Mid-life recovery (Redis back) | — | tracing resumes within a cooldown, no request stalls |
| Cold start (Redis down at boot) then up | tracing never resumes until restart | auto-recovers ~2s after Redis appears, `XLEN` 0→>0, no request stall |

## Review notes

- Independent diff review: **0 blockers, 1 warning, 2 info**; all four warnings from an earlier review round (guard-wedge-on-panic, sync-path parity, cold-start test retry assumption, test global coupling) were fixed and re-verified resolved.
- The one warning (an unused `Instant` import in non-test builds) is fixed in this PR.
- Remaining 2 infos are harmless: a shutdown-only CAS/guard window (`REPROBE_RUNNING` can stay set only if the runtime is torn down between spawn and first poll — process-lifetime runtime, so never mid-life), and a test-timing assumption safe under `--test-threads=1`.

## Verification

- `cargo check` passes for both the `python` and `typescript,simd` feature sets.
- `cargo test tracing_publish` — 4 pass, including a new `reprober_recovers_from_cold_start` (cold-start recovery) and the two preserved #1363 tests; a shared `reset_reprober_state()` makes the suite order-independent.
- Native module rebuilt (`maturin develop`); Python imports clean.
- Live before/after as tabled above.

Closes #1364

## Test plan

- [ ] CI green (Rust + Python runtime tests)
- [ ] Integration suite with tracing enabled passes
- [ ] Manual: agent with `--dte` and telemetry Redis killed mid-traffic — tool-call latency stays flat across multiple re-probe cooldown windows (no per-cooldown stall)
- [ ] Manual: agent with `--dte` and Redis down at startup, then started — tracing auto-recovers within a cooldown with no request stall


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed trace publishing recovery when Redis is unavailable.
  * Added background reconnection so application requests avoid repeated reconnect costs.
  * Trace publishing now resumes automatically after Redis connectivity is restored.
  * Prevented stale availability status from blocking trace publication attempts.
  * Ensured non-blocking trace publishing remains active even when initial setup fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->