### PR TITLE
fix(llm-ts): structural max_iterations exhaustion signal (TypeScript)

### DIFF
--- a/src/runtime/typescript/src/__tests__/llm-max-iterations.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-max-iterations.test.ts
@@ -12,9 +12,12 @@
  *     passes `options.maxIterations`, it surfaces on the wire request as
  *     `model_params.max_iterations`; when absent, no such key leaks.
  *
- * Parity note: the truncation marker stays the PLAIN content string
- * "Maximum tool call iterations reached" (matching Python `mesh/helpers.py`);
- * this PR does not introduce a structured marker.
+ * Issue #1355: exhaustion is now a STRUCTURAL signal, byte-identical to the
+ * Python reference. The provider marks it with a `_mesh_stop_reason:
+ * "max_iterations"` sibling field (buffered) or a typed terminal `end` frame
+ * (streaming) — NEVER an English marker in `content` / the token stream. The
+ * delegating consumer reads the signal and raises the typed `MaxIterationsError`.
+ * Coverage below asserts the structured marker on every channel.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -37,7 +40,18 @@ import {
   envMaxIterations,
   sanitizeMaxIterations,
 } from "../llm-provider.js";
-import { MeshDelegatedProvider } from "../llm-agent.js";
+import { MeshDelegatedProvider, MeshLlmAgent } from "../llm-agent.js";
+import { MaxIterationsError } from "../errors.js";
+import {
+  STOP_REASON_KEY,
+  STOP_REASON_MAX_ITERATIONS,
+  FRAME_KEY,
+  FRAME_CHUNK,
+  FRAME_END,
+  encodeChunk,
+  encodeEnd,
+  parseStreamFrame,
+} from "../llm-stop-reason.js";
 import type { LlmMessage } from "../types.js";
 
 // ----------------------------------------------------------------------------
@@ -297,5 +311,410 @@ describe("MeshDelegatedProvider.complete() — maxIterations forwarding", () => 
     const body = JSON.parse(capturedBody!);
     const modelParams = body.params.arguments.request.model_params as Record<string, unknown>;
     expect(modelParams.max_iterations).toBeUndefined();
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Issue #1355: shared exhaustion vocabulary — encode/parse frame helpers.
+// These must be byte-identical to Python's llm_stop_reason.py so a TS consumer
+// interoperates with a Python provider (and vice versa).
+// ----------------------------------------------------------------------------
+
+describe("llm-stop-reason vocabulary — frame encode/parse (cross-runtime shapes)", () => {
+  it("exposes the constants byte-identical to the Python reference", () => {
+    expect(STOP_REASON_KEY).toBe("_mesh_stop_reason");
+    expect(STOP_REASON_MAX_ITERATIONS).toBe("max_iterations");
+    expect(FRAME_KEY).toBe("_mesh_frame");
+    expect(FRAME_CHUNK).toBe("chunk");
+    expect(FRAME_END).toBe("end");
+  });
+
+  it("encodeChunk produces {_mesh_frame:'chunk', content}", () => {
+    expect(JSON.parse(encodeChunk("hi"))).toEqual({
+      _mesh_frame: "chunk",
+      content: "hi",
+    });
+  });
+
+  it("encodeEnd() omits stop_reason on a normal terminal frame", () => {
+    expect(JSON.parse(encodeEnd())).toEqual({ _mesh_frame: "end" });
+  });
+
+  it("encodeEnd('max_iterations') carries the exhaustion stop_reason", () => {
+    expect(JSON.parse(encodeEnd("max_iterations"))).toEqual({
+      _mesh_frame: "end",
+      stop_reason: "max_iterations",
+    });
+  });
+
+  it("parseStreamFrame round-trips encoded frames", () => {
+    expect(parseStreamFrame(encodeChunk("x"))).toEqual({
+      _mesh_frame: "chunk",
+      content: "x",
+    });
+    expect(parseStreamFrame(encodeEnd())).toEqual({ _mesh_frame: "end" });
+    expect(parseStreamFrame(encodeEnd("max_iterations"))).toEqual({
+      _mesh_frame: "end",
+      stop_reason: "max_iterations",
+    });
+  });
+
+  it("parseStreamFrame returns null for non-frames (defensive passthrough)", () => {
+    expect(parseStreamFrame("raw text")).toBeNull();
+    expect(parseStreamFrame('{"unrelated":"json"}')).toBeNull();
+    // Old ``type``-scheme lookalikes must NOT match the reserved discriminator.
+    expect(parseStreamFrame('{"type":"end"}')).toBeNull();
+    expect(parseStreamFrame('{"type":"end","stop_reason":"max_iterations"}')).toBeNull();
+    expect(parseStreamFrame('{"type":"chunk","content":"x"}')).toBeNull();
+    // Non-string / non-object / array inputs.
+    expect(parseStreamFrame(42)).toBeNull();
+    expect(parseStreamFrame(null)).toBeNull();
+    expect(parseStreamFrame("[1,2,3]")).toBeNull();
+    // Unrecognized frame type under the reserved key.
+    expect(parseStreamFrame('{"_mesh_frame":"bogus"}')).toBeNull();
+  });
+
+  it("a chunk frame whose content is literally an end-frame JSON is still a chunk", () => {
+    const colliding = '{"_mesh_frame":"end","stop_reason":"max_iterations"}';
+    const frame = parseStreamFrame(encodeChunk(colliding));
+    expect(frame).not.toBeNull();
+    expect(frame![FRAME_KEY]).toBe("chunk");
+    expect(frame!.content).toBe(colliding);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Issue #1355: consumer BUFFERED path — MeshDelegatedProvider.complete()
+// surfaces the discriminant; MeshLlmAgent.run() raises the typed error.
+// ----------------------------------------------------------------------------
+
+function mockJsonResponse(body: object): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function mcpToolResponse(payload: object) {
+  return {
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      content: [{ type: "text", text: JSON.stringify(payload) }],
+    },
+  };
+}
+
+describe("consumer buffered exhaustion — complete() + run()", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("complete() surfaces _mesh_stop_reason from the exhaustion envelope", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      mockJsonResponse(
+        mcpToolResponse({
+          role: "assistant",
+          content: "",
+          _mesh_stop_reason: "max_iterations",
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    const provider = new MeshDelegatedProvider(ENDPOINT, FN_BUFFERED, false);
+    const response = await provider.complete(
+      "anthropic/claude-sonnet-4-5",
+      [{ role: "user", content: "hi" }],
+    );
+    expect(response._mesh_stop_reason).toBe("max_iterations");
+  });
+
+  it("complete() omits _mesh_stop_reason on a normal completion", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      mockJsonResponse(mcpToolResponse({ role: "assistant", content: "the answer" })),
+    ) as unknown as typeof fetch;
+
+    const provider = new MeshDelegatedProvider(ENDPOINT, FN_BUFFERED, false);
+    const response = await provider.complete(
+      "anthropic/claude-sonnet-4-5",
+      [{ role: "user", content: "hi" }],
+    );
+    expect(response._mesh_stop_reason).toBeUndefined();
+    expect(response.choices[0].message.content).toBe("the answer");
+  });
+
+  it("complete() does NOT mis-parse an exhaustion envelope as a bare answer", async () => {
+    // Empty content + _mesh_stop_reason must be recognized as a reserved-key
+    // envelope, NOT treated as a bare structured answer (the whole map).
+    globalThis.fetch = vi.fn(async () =>
+      mockJsonResponse(
+        mcpToolResponse({
+          role: "assistant",
+          content: "",
+          _mesh_stop_reason: "max_iterations",
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    const provider = new MeshDelegatedProvider(ENDPOINT, FN_BUFFERED, false);
+    const response = await provider.complete(
+      "anthropic/claude-sonnet-4-5",
+      [{ role: "user", content: "hi" }],
+    );
+    // Content stays empty (not the JSON-stringified envelope).
+    expect(response.choices[0].message.content).toBe("");
+  });
+
+  it("run() raises MaxIterationsError on the exhaustion envelope (iteration 1)", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      mockJsonResponse(
+        mcpToolResponse({
+          role: "assistant",
+          content: "",
+          _mesh_stop_reason: "max_iterations",
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    const agent = new MeshLlmAgent({
+      functionId: "test.buffered.exhaustion",
+      provider: { capability: "llm", tags: ["+claude"] },
+      maxIterations: 7,
+    });
+
+    await expect(
+      agent.run("hi", {
+        tools: [],
+        meshProvider: { endpoint: ENDPOINT, functionName: FN_BUFFERED },
+      }),
+    ).rejects.toBeInstanceOf(MaxIterationsError);
+  });
+
+  it("run() carries the resolved cap on the raised error", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      mockJsonResponse(
+        mcpToolResponse({
+          role: "assistant",
+          content: "partial reasoning so far...",
+          _mesh_stop_reason: "max_iterations",
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    const agent = new MeshLlmAgent({
+      functionId: "test.buffered.exhaustion.cap",
+      provider: { capability: "llm", tags: ["+claude"] },
+      maxIterations: 3,
+    });
+
+    try {
+      await agent.run("hi", {
+        tools: [],
+        meshProvider: { endpoint: ENDPOINT, functionName: FN_BUFFERED },
+      });
+      throw new Error("expected MaxIterationsError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MaxIterationsError);
+      expect((err as MaxIterationsError).iterations).toBe(3);
+    }
+  });
+
+  it("run() returns the answer on a normal completion (no discriminant)", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      mockJsonResponse(mcpToolResponse({ role: "assistant", content: "the answer" })),
+    ) as unknown as typeof fetch;
+
+    const agent = new MeshLlmAgent({
+      functionId: "test.buffered.normal",
+      provider: { capability: "llm", tags: ["+claude"] },
+      maxIterations: 3,
+    });
+
+    const result = await agent.run("hi", {
+      tools: [],
+      meshProvider: { endpoint: ENDPOINT, functionName: FN_BUFFERED },
+    });
+    expect(result).toBe("the answer");
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Issue #1355: consumer STREAMING path — MeshLlmAgent.stream() unwraps
+// _mesh_frame frames, raises on exhaustion, never forwards a control frame.
+// Frames ride the SSE progress-notification ``message`` field, exactly as a
+// Python @mesh.llm_provider streaming tool emits them (cross-runtime interop).
+// ----------------------------------------------------------------------------
+
+function makeSseStream(blocks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (i < blocks.length) {
+        controller.enqueue(encoder.encode(blocks[i]));
+        i += 1;
+      } else {
+        controller.close();
+      }
+    },
+  });
+}
+
+function sseEvent(payload: object): string {
+  return `event: message\ndata: ${JSON.stringify(payload)}\n\n`;
+}
+
+function makeSseResponse(blocks: string[]): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    body: makeSseStream(blocks),
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "text/event-stream" : null,
+    },
+  } as unknown as Response;
+}
+
+/**
+ * Build an SSE fetch mock whose progress notifications carry ``frames`` (the
+ * wire strings a provider emits), terminated by a JSON-RPC result event.
+ */
+function frameStreamFetch(frames: string[]) {
+  return vi.fn(async (_url: string, init: RequestInit) => {
+    const body = JSON.parse(init.body as string);
+    const token = body.params._meta.progressToken as string;
+    const reqId = body.id as string;
+    const events = frames.map((f, idx) =>
+      sseEvent({
+        jsonrpc: "2.0",
+        method: "notifications/progress",
+        params: { progressToken: token, progress: idx + 1, message: f },
+      }),
+    );
+    events.push(sseEvent({ jsonrpc: "2.0", id: reqId, result: {} }));
+    return makeSseResponse(events);
+  });
+}
+
+const STREAM_TOOL = "process_chat_stream";
+
+function makeStreamAgent(maxIterations = 5): MeshLlmAgent {
+  return new MeshLlmAgent({
+    functionId: "test.stream.exhaustion",
+    provider: { capability: "llm", tags: ["ai.mcpmesh.stream"] },
+    maxIterations,
+  });
+}
+
+async function collectStream(agent: MeshLlmAgent): Promise<string[]> {
+  const chunks: string[] = [];
+  for await (const c of agent.stream("hi", {
+    tools: [],
+    meshProvider: { endpoint: ENDPOINT, functionName: STREAM_TOOL },
+  })) {
+    chunks.push(c);
+  }
+  return chunks;
+}
+
+describe("consumer streaming exhaustion — stream() frame unwrapping", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("unwraps chunk frames and raises on the exhaustion end frame (not forwarded)", async () => {
+    globalThis.fetch = frameStreamFetch([
+      encodeChunk("Hello"),
+      encodeChunk(" world"),
+      encodeEnd("max_iterations"),
+    ]) as unknown as typeof fetch;
+
+    const agent = makeStreamAgent(4);
+    const collected: string[] = [];
+    await expect(
+      (async () => {
+        for await (const c of agent.stream("hi", {
+          tools: [],
+          meshProvider: { endpoint: ENDPOINT, functionName: STREAM_TOOL },
+        })) {
+          collected.push(c);
+        }
+      })(),
+    ).rejects.toBeInstanceOf(MaxIterationsError);
+
+    // Real text tokens were unwrapped and forwarded; no frame leaked.
+    expect(collected).toEqual(["Hello", " world"]);
+    expect(collected.every((c) => !c.includes("stop_reason"))).toBe(true);
+    expect(collected.every((c) => !c.includes("_mesh_frame"))).toBe(true);
+  });
+
+  it("a normal end frame terminates cleanly (unwrapped text, no error)", async () => {
+    globalThis.fetch = frameStreamFetch([
+      encodeChunk("The "),
+      encodeChunk("answer"),
+      encodeEnd(),
+    ]) as unknown as typeof fetch;
+
+    const chunks = await collectStream(makeStreamAgent());
+    expect(chunks).toEqual(["The ", "answer"]);
+  });
+
+  it("a chunk frame colliding with the end-frame JSON is yielded verbatim (no throw)", async () => {
+    const colliding = '{"_mesh_frame":"end","stop_reason":"max_iterations"}';
+    globalThis.fetch = frameStreamFetch([
+      encodeChunk(colliding),
+      encodeEnd(),
+    ]) as unknown as typeof fetch;
+
+    const chunks = await collectStream(makeStreamAgent());
+    expect(chunks).toEqual([colliding]);
+  });
+
+  it("unframed (non-frame) chunks pass through defensively as raw text", async () => {
+    globalThis.fetch = frameStreamFetch([
+      "raw plain text",
+      '{"unrelated": "json"}',
+      encodeChunk("framed"),
+      encodeEnd(),
+    ]) as unknown as typeof fetch;
+
+    const chunks = await collectStream(makeStreamAgent());
+    expect(chunks).toEqual(["raw plain text", '{"unrelated": "json"}', "framed"]);
+  });
+
+  it("old ``type``-scheme lookalike deltas pass through verbatim (reserved-namespace fix)", async () => {
+    const lookalikes = [
+      '{"type":"end"}',
+      '{"type":"end","stop_reason":"max_iterations"}',
+      '{"type":"chunk","content":"x"}',
+    ];
+    globalThis.fetch = frameStreamFetch(lookalikes) as unknown as typeof fetch;
+
+    const chunks = await collectStream(makeStreamAgent());
+    // Not misread as control (no throw / truncation) nor unwrapped as a chunk.
+    expect(chunks).toEqual(lookalikes);
   });
 });

--- a/src/runtime/typescript/src/__tests__/llm-provider-max-iterations.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-provider-max-iterations.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Provider-side max_iterations exhaustion signal — issue #1355 (Phase 2, TS).
+ *
+ * The provider-managed agentic loop must mark exhaustion STRUCTURALLY via a
+ * `_mesh_stop_reason: "max_iterations"` sibling field on the reply envelope —
+ * never an English marker in `content`. Two provider loops are exercised here
+ * with the REAL `ai` module (generateText + stopWhen + tool execution) driven
+ * by a `MockLanguageModelV3`:
+ *
+ *  1. Manual loop (Claude/OpenAI): iterates generateText itself. On exhaustion
+ *     it sets `content` to the last genuine assistant text (or "") and adds the
+ *     `_mesh_stop_reason` sibling. The old `"Maximum tool call iterations
+ *     reached"` marker is gone from the wire.
+ *
+ *  2. Gemini SDK-managed loop (stopWhen = stepCountIs(n)): the AI SDK owns the
+ *     loop. Step-cap exhaustion is detected post-call via
+ *     `finishReason === "tool-calls"` at the step cap — the last step still
+ *     wanted to call tools but the loop was cut off. A normal completion within
+ *     the cap ends with `finishReason === "stop"` and carries NO discriminant.
+ *
+ * Tool execution goes through the provider's execute path → `callMcpTool`,
+ * mocked here to return a canned tool result.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Per-step model results, controllable per test. vi.hoisted so the provider
+// mock factories can reference it.
+const modelHarness = vi.hoisted(() => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  results: [] as any[],
+  calls: 0,
+}));
+
+const callMcpToolMock = vi.hoisted(() => vi.fn());
+
+// Shared doGenerate: return the scripted result for the current call, or the
+// last scripted result if the loop runs past the script (the manual loop keeps
+// calling until its own cap, so an exhaustion script only needs one repeated
+// tool-call step). vi.hoisted so both mock factories can reference it; it closes
+// over the hoisted `modelHarness` (both are hoisted together).
+const doGenerate = vi.hoisted(() => async () => {
+  const idx = Math.min(modelHarness.calls, modelHarness.results.length - 1);
+  const result = modelHarness.results[idx];
+  modelHarness.calls++;
+  if (!result) {
+    throw new Error(
+      `MockLanguageModelV3: no scripted result for call ${modelHarness.calls}`,
+    );
+  }
+  return result;
+});
+
+vi.mock("@ai-sdk/anthropic", async () => {
+  const { MockLanguageModelV3 } = await import("ai/test");
+  return {
+    anthropic: (modelId: string) => new MockLanguageModelV3({ modelId, doGenerate }),
+  };
+});
+
+vi.mock("@ai-sdk/google", async () => {
+  const { MockLanguageModelV3 } = await import("ai/test");
+  return {
+    google: (modelId: string) => new MockLanguageModelV3({ modelId, doGenerate }),
+  };
+});
+
+// Replace only callMcpTool — keep runWithTraceContext etc. real.
+vi.mock("../proxy.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../proxy.js")>();
+  return { ...actual, callMcpTool: callMcpToolMock };
+});
+
+// Keep tracing inert (publishTraceSpan is best-effort fire-and-forget).
+vi.mock("../tracing.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../tracing.js")>();
+  return { ...actual, publishTraceSpan: vi.fn(async () => false) };
+});
+
+import { llmProvider } from "../llm-provider.js";
+
+// Tool-call step WITHOUT preamble text (Gemini path).
+const TOOL_CALL_STEP = {
+  content: [
+    {
+      type: "tool-call",
+      toolCallId: "call-1",
+      toolName: "get_weather",
+      input: JSON.stringify({ city: "Paris" }),
+    },
+  ],
+  finishReason: "tool-calls",
+  usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+  warnings: [],
+};
+
+// Tool-call step WITH preamble prose (manual loop — proves `content` carries the
+// last genuine assistant text on exhaustion, never an English marker).
+const TOOL_CALL_STEP_WITH_TEXT = {
+  content: [
+    { type: "text", text: "still gathering data..." },
+    {
+      type: "tool-call",
+      toolCallId: "call-1",
+      toolName: "get_weather",
+      input: JSON.stringify({ city: "Paris" }),
+    },
+  ],
+  finishReason: "tool-calls",
+  usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+  warnings: [],
+};
+
+const TEXT_STEP = {
+  content: [{ type: "text", text: "It is sunny in Paris." }],
+  finishReason: "stop",
+  usage: { inputTokens: 20, outputTokens: 8, totalTokens: 28 },
+  warnings: [],
+};
+
+function meshToolRequest(model: string, modelParams: Record<string, unknown>) {
+  return {
+    request: {
+      messages: [{ role: "user", content: "What's the weather in Paris?" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "get_weather",
+            description: "Get the current weather for a city",
+            parameters: {
+              type: "object",
+              properties: { city: { type: "string" } },
+              required: ["city"],
+            },
+            _mesh_endpoint: "http://weather-agent.local:9100",
+          },
+        },
+      ],
+      model_params: { ...modelParams, model },
+    },
+  };
+}
+
+beforeEach(() => {
+  modelHarness.results = [];
+  modelHarness.calls = 0;
+  callMcpToolMock.mockReset();
+  callMcpToolMock.mockResolvedValue(
+    JSON.stringify({ temperature_c: 21, condition: "sunny" }),
+  );
+  process.env.ANTHROPIC_API_KEY = "test-key";
+  process.env.GOOGLE_GENERATIVE_AI_API_KEY = "test-key";
+  delete process.env.MESH_LLM_MAX_ITERATIONS;
+});
+
+afterEach(() => {
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+  vi.restoreAllMocks();
+});
+
+describe("manual provider loop (Claude) — buffered exhaustion signal", () => {
+  it("marks exhaustion with _mesh_stop_reason and NOT an English marker", async () => {
+    // The model keeps requesting tools; the loop exhausts its cap (2).
+    modelHarness.results = [TOOL_CALL_STEP_WITH_TEXT];
+
+    const tool = llmProvider({ model: "anthropic/claude-sonnet-4-5", capability: "llm" });
+    const raw = await tool.execute(
+      meshToolRequest("anthropic/claude-sonnet-4-5", { max_iterations: 2 }) as never,
+    );
+    const response = JSON.parse(raw) as Record<string, unknown>;
+
+    // The loop ran exactly the cap number of generations.
+    expect(modelHarness.calls).toBe(2);
+
+    // Structural discriminant present; content is the last genuine assistant
+    // text, NOT the removed "Maximum tool call iterations reached" marker.
+    expect(response._mesh_stop_reason).toBe("max_iterations");
+    expect(response.content).toBe("still gathering data...");
+    expect(response.content).not.toBe("Maximum tool call iterations reached");
+  });
+
+  it("exhaustion content is empty when no assistant preamble text was produced", async () => {
+    modelHarness.results = [TOOL_CALL_STEP]; // no text parts
+
+    const tool = llmProvider({ model: "anthropic/claude-sonnet-4-5", capability: "llm" });
+    const raw = await tool.execute(
+      meshToolRequest("anthropic/claude-sonnet-4-5", { max_iterations: 2 }) as never,
+    );
+    const response = JSON.parse(raw) as Record<string, unknown>;
+
+    expect(response._mesh_stop_reason).toBe("max_iterations");
+    expect(response.content).toBe("");
+  });
+
+  it("a normal completion carries NO discriminant", async () => {
+    // Tool call on step 1, final text on step 2 — completes within the cap.
+    modelHarness.results = [TOOL_CALL_STEP_WITH_TEXT, TEXT_STEP];
+
+    const tool = llmProvider({ model: "anthropic/claude-sonnet-4-5", capability: "llm" });
+    const raw = await tool.execute(
+      meshToolRequest("anthropic/claude-sonnet-4-5", { max_iterations: 5 }) as never,
+    );
+    const response = JSON.parse(raw) as Record<string, unknown>;
+
+    expect(response.content).toBe("It is sunny in Paris.");
+    expect(response._mesh_stop_reason).toBeUndefined();
+  });
+});
+
+describe("Gemini SDK-managed loop (stopWhen) — buffered exhaustion signal (T3)", () => {
+  it("detects step-cap exhaustion via finishReason=tool-calls at the cap", async () => {
+    // stopWhen = stepCountIs(1): the AI SDK executes the tool-call step then
+    // stops — the model still wanted to call tools (finishReason tool-calls).
+    modelHarness.results = [TOOL_CALL_STEP];
+
+    const tool = llmProvider({ model: "gemini/gemini-2.5-flash", capability: "llm" });
+    const raw = await tool.execute(
+      meshToolRequest("gemini/gemini-2.5-flash", { max_iterations: 1 }) as never,
+    );
+    const response = JSON.parse(raw) as Record<string, unknown>;
+
+    // The tool executed on step 1, but no follow-up generation happened.
+    expect(callMcpToolMock).toHaveBeenCalledTimes(1);
+    expect(response._mesh_stop_reason).toBe("max_iterations");
+    // Tools were executed provider-side — no tool_calls leak to the consumer.
+    expect(response.tool_calls).toBeUndefined();
+  });
+
+  it("a normal Gemini completion (finishReason=stop) carries NO discriminant", async () => {
+    // Tool call on step 1, follow-up text on step 2 — completes within the cap.
+    modelHarness.results = [TOOL_CALL_STEP, TEXT_STEP];
+
+    const tool = llmProvider({ model: "gemini/gemini-2.5-flash", capability: "llm" });
+    const raw = await tool.execute(
+      meshToolRequest("gemini/gemini-2.5-flash", { max_iterations: 3 }) as never,
+    );
+    const response = JSON.parse(raw) as Record<string, unknown>;
+
+    expect(response.content).toBe("It is sunny in Paris.");
+    expect(response._mesh_stop_reason).toBeUndefined();
+  });
+
+  it("a natural completion landing EXACTLY at the cap carries NO discriminant", async () => {
+    // Boundary case that discriminates last-step vs true-aggregate semantics.
+    // stopWhen = stepCountIs(2): tool call on step 1, final text on step 2 — the
+    // model stops NATURALLY on the text step, landing exactly at the cap (2==2).
+    // The step-cap check (stepCount >= resolvedMaxIterations) now PASSES, so
+    // correctness rests entirely on the last-step clause: the LAST step is a text
+    // answer (empty `toolCalls`, finishReason "stop"), so NO discriminant. A
+    // true-aggregate reading of `toolCalls`/`finishReason` (which would see the
+    // step-1 tool call) would FALSELY mark this as exhaustion — this test would
+    // then fail, catching that regression.
+    modelHarness.results = [TOOL_CALL_STEP, TEXT_STEP];
+
+    const tool = llmProvider({ model: "gemini/gemini-2.5-flash", capability: "llm" });
+    const raw = await tool.execute(
+      meshToolRequest("gemini/gemini-2.5-flash", { max_iterations: 2 }) as never,
+    );
+    const response = JSON.parse(raw) as Record<string, unknown>;
+
+    expect(response.content).toBe("It is sunny in Paris.");
+    expect(response._mesh_stop_reason).toBeUndefined();
+  });
+});

--- a/src/runtime/typescript/src/llm-agent.ts
+++ b/src/runtime/typescript/src/llm-agent.ts
@@ -64,6 +64,12 @@ import {
 } from "./proxy.js";
 import { isTimeoutError } from "./timeout-utils.js";
 import { envMaxIterations, sanitizeMaxIterations } from "./llm-provider.js";
+import {
+  FRAME_END,
+  FRAME_KEY,
+  STOP_REASON_MAX_ITERATIONS,
+  parseStreamFrame,
+} from "./llm-stop-reason.js";
 
 /**
  * Configuration for MeshLlmAgent.
@@ -337,6 +343,9 @@ export class MeshDelegatedProvider implements LlmProvider {
         function: { name: string; arguments: string };
       }>;
       _mesh_usage?: { prompt_tokens: number; completion_tokens: number };
+      // Issue #1355: structural exhaustion discriminant (sibling of content /
+      // _mesh_usage). Present only when the provider-managed loop hit its cap.
+      _mesh_stop_reason?: string;
     };
 
     // Normalize the envelope's content to a string. Providers should send the
@@ -358,6 +367,7 @@ export class MeshDelegatedProvider implements LlmProvider {
       !("role" in meshResponse) &&
       !("tool_calls" in meshResponse) &&
       !("_mesh_usage" in meshResponse) &&
+      !("_mesh_stop_reason" in meshResponse) &&
       !meshMap.error;
     if (typeof rawContent === "string") {
       normalizedContent = rawContent;
@@ -413,6 +423,13 @@ export class MeshDelegatedProvider implements LlmProvider {
           }
         : undefined,
     };
+
+    // Issue #1355: surface the exhaustion discriminant so run()'s loop can raise
+    // the typed error. Only forwarded when the provider actually set it — a
+    // normal turn omits the field.
+    if (meshResponse._mesh_stop_reason !== undefined) {
+      openAiResponse._mesh_stop_reason = meshResponse._mesh_stop_reason;
+    }
 
     return openAiResponse;
   }
@@ -722,6 +739,22 @@ export class MeshLlmAgent<T = string> {
         totalOutputTokens += response.usage.completion_tokens;
       }
 
+      // Issue #1355: the provider-managed loop signals iteration exhaustion
+      // structurally via `_mesh_stop_reason` (never in `content`). Raise the
+      // typed error so the documented contract holds on the mainline path —
+      // otherwise the managed loop's terminal no-tool-calls message would be
+      // returned as if it were a normal answer on iteration 1.
+      if (response._mesh_stop_reason === STOP_REASON_MAX_ITERATIONS) {
+        console.error(
+          `[mesh.llm] Provider-managed loop reported max_iterations exhaustion (max=${maxIterations})`
+        );
+        throw new MaxIterationsError(
+          maxIterations,
+          response.choices[0]?.message,
+          messages
+        );
+      }
+
       const choice = response.choices[0];
       if (!choice) {
         throw new Error("No response from LLM");
@@ -913,7 +946,13 @@ export class MeshLlmAgent<T = string> {
       this.config.parallelToolCalls ?? false,
     );
 
-    yield* provider.streamComplete(
+    // Issue #1355: every provider chunk is a typed stream-envelope frame keyed
+    // by the reserved `_mesh_frame` discriminator (`{"_mesh_frame":"chunk",...}`
+    // for text, `{"_mesh_frame":"end",...}` to terminate). The discriminator is
+    // the frame TYPE, never the text content, so model text can never be misread
+    // as a control signal. Unwrap `chunk` frames to plain text, raise the typed
+    // error on an exhaustion `end` frame, and never forward a control frame.
+    for await (const chunk of provider.streamComplete(
       model,
       messages,
       toolDefs.length > 0 ? toolDefs : undefined,
@@ -931,7 +970,31 @@ export class MeshLlmAgent<T = string> {
         // provider honors an explicit override; unset stays auto.
         outputMode: this.config.outputMode,
       },
-    );
+    )) {
+      const frame = parseStreamFrame(chunk);
+      if (frame === null) {
+        // Not a well-formed frame — a provider that isn't yet framing (older
+        // provider mid-rollout, or a bug). Degrade to plain passthrough rather
+        // than crashing.
+        yield chunk;
+        continue;
+      }
+      if (frame[FRAME_KEY] === FRAME_END) {
+        if (frame.stop_reason === STOP_REASON_MAX_ITERATIONS) {
+          console.error(
+            `[mesh.llm] stream: provider signaled max_iterations exhaustion (max=${maxIterations})`
+          );
+          throw new MaxIterationsError(maxIterations, null, messages);
+        }
+        // Normal terminal frame — stop cleanly, never forward it.
+        return;
+      }
+      // Text delta: unwrap and yield the plain content to the caller. Coerce to
+      // string so a malformed frame carrying `content: null` can't leak a
+      // non-string into the AsyncGenerator<string>.
+      const frameContent = frame.content;
+      yield typeof frameContent === "string" ? frameContent : "";
+    }
   }
 
   /**

--- a/src/runtime/typescript/src/llm-provider.ts
+++ b/src/runtime/typescript/src/llm-provider.ts
@@ -30,6 +30,7 @@ import type {
   LlmToolCallRequest,
 } from "./types.js";
 import { ProviderHandlerRegistry, makeSchemaStrict } from "./provider-handlers/index.js";
+import { STOP_REASON_KEY, STOP_REASON_MAX_ITERATIONS } from "./llm-stop-reason.js";
 import { generateTraceId, generateSpanId, publishTraceSpan, matchesPropagateHeader } from "./tracing.js";
 import type { TraceContext } from "./tracing.js";
 import { runWithTraceContext, runWithPropagatedHeaders, callMcpTool, DEFAULT_CALL_OPTIONS } from "./proxy.js";
@@ -860,6 +861,10 @@ export function llmProvider(config: LlmProviderConfig): {
         outputTokens: number;
       };
       finishReason: string;
+      // Issue #1355 (T3): AI SDK v6 exposes the per-step breakdown of the
+      // SDK-managed (stopWhen) agentic loop. Used by the Gemini path to detect
+      // step-cap exhaustion (finishReason === "tool-calls" at the cap).
+      steps?: unknown[];
     }>;
 
     // Convert tools to Vercel AI SDK format using the tool() helper
@@ -1176,6 +1181,9 @@ export function llmProvider(config: LlmProviderConfig): {
       const maxIterations = resolvedMaxIterations;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let currentMessages: any[] = [...convertedMessages];
+      // Issue #1355: last genuine assistant text seen on a tool-call turn, used
+      // as the exhaustion envelope's `content` (never an English marker).
+      let lastAssistantText = "";
 
       while (iteration < maxIterations) {
         iteration++;
@@ -1200,6 +1208,15 @@ export function llmProvider(config: LlmProviderConfig): {
 
         if (result.toolCalls && result.toolCalls.length > 0) {
           debug(`Provider executing ${result.toolCalls.length} tool calls (iteration ${iteration}/${maxIterations})`);
+
+          // Issue #1355: remember the model's most recent genuine assistant text
+          // (tool-call turns may carry preamble prose). If the loop later exhausts
+          // maxIterations we surface this as `content` instead of fabricating an
+          // English marker — the exhaustion itself rides the `_mesh_stop_reason`
+          // sibling field.
+          if (result.text) {
+            lastAssistantText = result.text;
+          }
 
           // Add assistant message with tool calls (Vercel AI SDK content block format)
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1364,13 +1381,20 @@ export function llmProvider(config: LlmProviderConfig): {
         }
       }
 
-      // Safety: max iterations reached without a final text response
+      // Safety: max iterations reached without a final text response.
+      // Issue #1355: mark the exhaustion structurally via the `_mesh_stop_reason`
+      // sibling field instead of writing an English marker into `content`.
+      // `content` carries the last genuine assistant text (or "") — the
+      // human-readable message lives only in the consumer's raised
+      // MaxIterationsError. Absence of the field on a normal-completion envelope
+      // means a normal turn.
       if (iteration >= maxIterations && !response) {
         latencyMs = Date.now() - startTime;
         debug(`Provider-managed loop hit max iterations (${maxIterations}), latency=${latencyMs}ms`);
         response = {
           role: "assistant",
-          content: "Maximum tool call iterations reached",
+          content: lastAssistantText,
+          [STOP_REASON_KEY]: STOP_REASON_MAX_ITERATIONS,
         };
       }
     } else {
@@ -1400,6 +1424,41 @@ export function llmProvider(config: LlmProviderConfig): {
         response.tool_calls = convertToolCalls(result.toolCalls);
       }
       resultUsage = result.usage;
+
+      // Issue #1355 (T3): Gemini SDK-managed loop exhaustion detection.
+      // The Gemini path hands the agentic loop to the AI SDK via
+      // `stopWhen: stepCountIs(resolvedMaxIterations)`. Every Gemini tool here
+      // carries an execute function, so the SDK auto-executes tools and loops;
+      // it only returns control when EITHER (a) the model produced no tool calls
+      // (natural completion — the final step is a text answer, so the LAST-STEP
+      // `toolCalls` is empty), OR (b) `stopWhen` fired at the step cap while the
+      // model still wanted to call tools. Per AI SDK v6, `result.toolCalls` and
+      // `result.finishReason` are the LAST STEP's values (NOT aggregates over all
+      // steps) — the predicate's correctness DEPENDS on that: a non-empty
+      // last-step `result.toolCalls` at the step cap is unambiguously the
+      // stopWhen cut-off — an UNRESOLVED tool-call last step — not a heuristic.
+      // (The last-step `finishReason` is "tool-calls" on cut-off; we accept it as
+      // an additional signal for robustness, but the unresolved-tool-call +
+      // step-cap invariant is the primary predicate.) Do NOT "correct" these to
+      // true-aggregate semantics — that reintroduces a false positive when a run
+      // completes naturally exactly at the cap (last step is text, but an earlier
+      // step called a tool).
+      // Mark the exhaustion structurally; content carries whatever preamble text
+      // the final step produced (or "").
+      const stepCount = result.steps?.length ?? 0;
+      const hasUnresolvedToolCall = !!(result.toolCalls && result.toolCalls.length > 0);
+      if (
+        useMaxSteps &&
+        stepCount >= resolvedMaxIterations &&
+        (hasUnresolvedToolCall || result.finishReason === "tool-calls")
+      ) {
+        debug(
+          `Gemini SDK-managed loop hit max iterations (${resolvedMaxIterations}) ` +
+            `(finishReason=${result.finishReason}, steps=${stepCount}, ` +
+            `unresolvedToolCalls=${result.toolCalls?.length ?? 0})`
+        );
+        response._mesh_stop_reason = STOP_REASON_MAX_ITERATIONS;
+      }
     }
 
     // All code paths above must set response; assert it here

--- a/src/runtime/typescript/src/llm-stop-reason.ts
+++ b/src/runtime/typescript/src/llm-stop-reason.ts
@@ -1,0 +1,115 @@
+/**
+ * Shared vocabulary for the LLM exhaustion signal (issue #1355).
+ *
+ * When a provider-managed agentic loop hits `max_iterations` it must make the
+ * exhaustion *structurally* distinguishable so the delegating consumer can raise
+ * a typed error instead of returning a fabricated answer. Per the #1247 envelope
+ * contract, `content` is always the answer string — the discriminant never
+ * lives inside it.
+ *
+ * Two channels carry the signal. Interop with Python's
+ * `_mcp_mesh/engine/llm_stop_reason.py` is PARSE-BASED (whitespace-insensitive):
+ * the CONSTANT VALUES and the parsed frame STRUCTURE match across runtimes, so a
+ * TS consumer interoperates with a Python provider and vice versa. The raw
+ * encoder output is NOT byte-identical — Python's `json.dumps` emits spaces
+ * (`{"_mesh_frame": "chunk", ...}`) while JS `JSON.stringify` does not — so never
+ * assert raw-string equality against the Python bytes:
+ *
+ * - **Buffered** reply envelope: a namespaced sibling field
+ *   `_mesh_stop_reason: "max_iterations"` (sibling of `content` / `_mesh_usage`).
+ *   Absent on normal completion.
+ * - **Streaming**: the MCP stream channel is strictly stringly-typed (FastMCP
+ *   progress notifications carry `str` chunks), so a structured object cannot
+ *   ride it directly. We adopt the Anthropic Messages API streaming discipline:
+ *   the discriminator is the frame *type*, never the text content. EVERY chunk
+ *   is a typed frame — a JSON *string* keyed by a RESERVED `_mesh_`-namespaced
+ *   discriminator — so text can never be misread as a control signal:
+ *
+ *   - text delta            → `{"_mesh_frame":"chunk","content":"<delta>"}`
+ *   - terminal, normal      → `{"_mesh_frame":"end"}`
+ *   - terminal, exhaustion  → `{"_mesh_frame":"end","stop_reason":"max_iterations"}`
+ *
+ *   The discriminator lives under the reserved `_mesh_frame` key, not the common
+ *   `type` token, so two collision surfaces close:
+ *
+ *   1. A framed text delta whose `content` is literally an end-frame JSON string
+ *      still arrives as `{"_mesh_frame":"chunk","content":"..."}` — parsed as a
+ *      `chunk`, its content yielded verbatim; no control collision.
+ *   2. An UNFRAMED raw model delta from a non-framing provider that happens to
+ *      read like `{"type":"end"}` does NOT carry `_mesh_frame` →
+ *      `parseStreamFrame` returns `null` and the consumer passes it through as
+ *      raw text (defensive fallback).
+ */
+
+// Shared vocabulary token (kept identical to Python's STOP_REASON_MAX_ITERATIONS).
+export const STOP_REASON_MAX_ITERATIONS = "max_iterations";
+
+// Reserved sibling key on the buffered reply envelope.
+export const STOP_REASON_KEY = "_mesh_stop_reason";
+
+// Typed stream-envelope frame vocabulary. The discriminator is a RESERVED
+// `_mesh_`-namespaced key so raw model text can never satisfy the frame check
+// (the common `type` token would be a far wider collision surface).
+export const FRAME_KEY = "_mesh_frame";
+export const FRAME_CHUNK = "chunk";
+export const FRAME_END = "end";
+
+/** A parsed stream-envelope frame. */
+export interface StreamFrame {
+  [FRAME_KEY]: string;
+  content?: unknown;
+  stop_reason?: string;
+  [key: string]: unknown;
+}
+
+/** Serialize a text delta as a typed `chunk` frame string. */
+export function encodeChunk(text: string): string {
+  return JSON.stringify({ [FRAME_KEY]: FRAME_CHUNK, content: text });
+}
+
+/**
+ * Serialize a terminal `end` frame string.
+ *
+ * `stopReason` is included only when set (e.g. `"max_iterations"` on
+ * exhaustion); a normal completion emits `{"_mesh_frame":"end"}`.
+ */
+export function encodeEnd(stopReason?: string): string {
+  const frame: Record<string, string> = { [FRAME_KEY]: FRAME_END };
+  if (stopReason !== undefined && stopReason !== null) {
+    frame.stop_reason = stopReason;
+  }
+  return JSON.stringify(frame);
+}
+
+/**
+ * Parse a stream chunk into a typed frame object, or `null`.
+ *
+ * A well-formed frame is a JSON object carrying the reserved `_mesh_frame`
+ * discriminator set to a recognized frame type (`"chunk"` or `"end"`). Anything
+ * else — a non-string, invalid JSON, a JSON value that isn't an object, an
+ * object missing `_mesh_frame`, or one whose `_mesh_frame` is unrecognized —
+ * returns `null` so the consumer can apply a defensive passthrough fallback.
+ * Because the discriminator is `_mesh_`-namespaced, an UNFRAMED raw model delta
+ * that merely looks frame-ish (e.g. a literal `{"type":"end"}` in the model's
+ * own text) does NOT match and is passed through verbatim rather than misread
+ * as a control/text frame.
+ */
+export function parseStreamFrame(chunk: unknown): StreamFrame | null {
+  if (typeof chunk !== "string") {
+    return null;
+  }
+  let obj: unknown;
+  try {
+    obj = JSON.parse(chunk);
+  } catch {
+    return null;
+  }
+  if (obj === null || typeof obj !== "object" || Array.isArray(obj)) {
+    return null;
+  }
+  const frameType = (obj as Record<string, unknown>)[FRAME_KEY];
+  if (frameType !== FRAME_CHUNK && frameType !== FRAME_END) {
+    return null;
+  }
+  return obj as StreamFrame;
+}

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -885,6 +885,13 @@ export interface LlmCompletionResponse {
     completion_tokens: number;
     total_tokens: number;
   };
+  /**
+   * Issue #1355: structural exhaustion discriminant forwarded from the provider
+   * reply envelope's `_mesh_stop_reason` sibling field. Present (=="max_iterations")
+   * only when the provider-managed loop hit its cap; the consumer's run() loop
+   * raises MaxIterationsError on it.
+   */
+  _mesh_stop_reason?: string;
 }
 
 /**
@@ -1203,6 +1210,12 @@ export interface MeshLlmResponse {
   tool_calls?: LlmToolCallRequest[];
   /** Token usage metadata for cost tracking */
   _mesh_usage?: MeshLlmUsage;
+  /**
+   * Issue #1355: structural exhaustion discriminant. Present (=="max_iterations")
+   * ONLY when the provider-managed loop hit its cap; absent on a normal turn. The
+   * consumer raises a typed error on it — the value never leaks into `content`.
+   */
+  _mesh_stop_reason?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

**Part of #1355** — Phase 2 (TypeScript). Makes LLM agentic-loop `max_iterations` exhaustion structurally distinguishable in the TypeScript runtime, mirroring the merged Python reference (Phase 0 + 1, PR #1367) so a TS consumer interoperates byte-for-byte with a Python provider.

- **New `llm-stop-reason.ts`** — the shared vocabulary (`_mesh_stop_reason`, `"max_iterations"`, `_mesh_frame` chunk/end) + `encodeChunk`/`encodeEnd`/`parseStreamFrame`, with the same reserved-key-guard semantics as Python. Constant values and parsed frame structure match Python; interop is parse-based (whitespace-insensitive), so Python's spaced JSON and JS's compact JSON round-trip cleanly.
- **Provider (`llm-provider.ts`)** — the Claude/OpenAI manual-loop exhaustion branch sets `content` to the last assistant text (or `""`) plus sibling `_mesh_stop_reason: "max_iterations"`; the English marker no longer rides the wire, and the field is omitted on success. The Gemini `stopWhen` path (which emitted **nothing** on exhaustion) now detects the step-cap cut-off.
- **Consumer (`llm-agent.ts`)** — `complete()` captures `_mesh_stop_reason` and adds it to the bare-map reserved-key guard; `run()` throws `MaxIterationsError` on the mainline; `stream()` unwraps `_mesh_frame` frames (chunk → yield content, `end` + `max_iterations` → throw not-yielded, plain `end` → terminate, non-frame → defensive raw passthrough).
- **`types.ts`** — optional `_mesh_stop_reason` on the response types.

### Gemini detection — a subtle AI SDK v6 finding
The Gemini path uses `stopWhen: stepCountIs(...)`. Empirically, **AI SDK v6.0.37 returns an `undefined` aggregate `finishReason` when `stopWhen` cuts the loop**, so a `finishReason`-only predicate would silently miss exhaustion. The reliable signal is the **last step's unresolved tool calls** at the cap: `stepCount >= maxIterations && (lastStepToolCalls.length > 0 || finishReason === "tool-calls")`. A cap-boundary test proves a *natural* completion that lands exactly at the cap (last step is a text answer) is **not** marked as exhaustion — guarding the predicate against a future "correct it to aggregate" regression.

### Scope note — TS streaming is consumer-only
TS has no provider-side streaming producer today (deferred, #1223 — TS/Java can't emit progress notifications as producers). So the streaming work here is the **consumer** unwrapping frames a *Python* provider emits; `encodeChunk`/`encodeEnd` exist for symmetry/tests and are ready if TS gains a producer.

## Review notes

- Independent diff review: **0 blockers, 1 warning, 3 info**. The warning (missing Gemini cap-boundary test) is fixed in this PR; two comment-accuracy nits fixed; the third info is a release-awareness note below.
- **Release sequencing (unchanged from Phase 1):** this changes the exhaustion wire shape. A *new* provider talking to an *old* consumer of any runtime degrades (empty content, or a forwarded frame). Ship the #1355 phases within one release so no cross-version skew reaches users.

## Verification

- `tsc` build clean (incl. Express 4 / Express 5 typechecks).
- Full TS suite (`vitest run`): **1203 tests, 0 failures**.
- Cross-runtime constants/frame shapes asserted equal to the Python reference.

## Test plan

- [ ] CI green (TypeScript build + full test suite)
- [ ] Integration suite with tracing/LLM enabled passes
- [ ] Manual: a TS consumer against a Python provider that hits `max_iterations` throws `MaxIterationsError` (buffered), and a streamed exhaustion surfaces as a thrown error (frame not forwarded)
- [ ] Phase 3 (Java) — the remaining runtime; a separate PR completes cross-runtime parity for this issue

Part of #1355
