### PR TITLE
fix(llm-java): structural max_iterations exhaustion signal (Java)

### DIFF
--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshLlmStopReason.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshLlmStopReason.java
@@ -1,0 +1,33 @@
+package io.mcpmesh.types;
+
+/**
+ * Shared vocabulary for the LLM exhaustion signal (issue #1355).
+ *
+ * <p>When a provider-managed agentic loop hits {@code max_iterations} it must
+ * make the exhaustion <em>structurally</em> distinguishable so the delegating
+ * consumer can raise a typed error instead of returning a fabricated answer.
+ * Per the #1247 envelope contract, {@code content} is always the answer string
+ * — the discriminant never lives inside it.
+ *
+ * <p>Interop with Python's {@code _mcp_mesh/engine/llm_stop_reason.py} and
+ * TypeScript's {@code llm-stop-reason.ts} is by CONSTANT VALUE: a Java consumer
+ * interoperates with a Python/TypeScript provider and vice versa because the
+ * string tokens match exactly.
+ *
+ * <p><b>Buffered</b> reply envelope: a namespaced sibling field
+ * {@code _mesh_stop_reason: "max_iterations"} (sibling of {@code content} /
+ * {@code _mesh_usage}). Absent on normal completion.
+ *
+ * <p>The Java runtime has no provider-side streaming producer (deferred, see
+ * #1223), so only the buffered vocabulary is defined here.
+ */
+public final class MeshLlmStopReason {
+
+    private MeshLlmStopReason() {}
+
+    /** Shared vocabulary token (kept identical to Python/TypeScript). */
+    public static final String STOP_REASON_MAX_ITERATIONS = "max_iterations";
+
+    /** Reserved sibling key on the buffered reply envelope. */
+    public static final String STOP_REASON_KEY = "_mesh_stop_reason";
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshMaxIterationsException.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshMaxIterationsException.java
@@ -1,0 +1,48 @@
+package io.mcpmesh.types;
+
+/**
+ * Thrown when a provider-managed LLM agentic loop exhausts its
+ * {@code max_iterations} cap without reaching a final response (issue #1355).
+ *
+ * <p>Exhaustion is a loud, typed failure on the mainline provider-managed-loop
+ * path — never a fabricated answer returned on the success channel. Per the
+ * #1247 envelope contract, {@code content} is always the answer string, so the
+ * exhaustion discriminant rides a namespaced sibling field
+ * ({@code _mesh_stop_reason: "max_iterations"}) on the reply envelope; the
+ * consumer reads it and raises this exception instead of returning the prior
+ * assistant text. The human-readable message lives only here — never on the
+ * wire.
+ *
+ * <p>Parity: mirrors Python's {@code MaxIterationsError(iteration_count,
+ * max_allowed)} and TypeScript's {@code MaxIterationsError}. Carries the same
+ * two counts for actionable diagnostics.
+ */
+public class MeshMaxIterationsException extends RuntimeException {
+
+    private final int iterationCount;
+    private final int maxAllowed;
+
+    public MeshMaxIterationsException(int iterationCount, int maxAllowed) {
+        super("Exceeded maximum " + maxAllowed + " iterations without reaching final response");
+        this.iterationCount = iterationCount;
+        this.maxAllowed = maxAllowed;
+    }
+
+    /**
+     * Get the number of iterations that were attempted.
+     *
+     * @return The iteration count
+     */
+    public int getIterationCount() {
+        return iterationCount;
+    }
+
+    /**
+     * Get the maximum number of iterations allowed.
+     *
+     * @return The configured cap
+     */
+    public int getMaxAllowed() {
+        return maxAllowed;
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/MeshLlmProviderProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/main/java/io/mcpmesh/ai/MeshLlmProviderProcessor.java
@@ -10,6 +10,7 @@ import io.mcpmesh.ai.handlers.LlmProviderHandler.OutputSchema;
 import io.mcpmesh.ai.handlers.LlmProviderHandler.ToolDefinition;
 import io.mcpmesh.ai.handlers.LlmProviderHandlerRegistry;
 import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.types.MeshLlmStopReason;
 import io.mcpmesh.spring.McpHttpClient;
 import io.mcpmesh.spring.media.MediaResolver;
 import io.mcpmesh.spring.media.MediaStore;
@@ -525,9 +526,14 @@ public class MeshLlmProviderProcessor implements BeanPostProcessor, ApplicationC
                     }
 
                     if (!completed) {
+                        // Issue #1355: mark the exhaustion structurally via the
+                        // _mesh_stop_reason sibling field instead of writing an
+                        // English marker into content. Real usage is still reported
+                        // (usageMeta) — it does not mask the discriminant, which
+                        // rides its own field.
                         log.warn("Provider parallel loop hit max iterations ({}) without final response", maxIterations);
-                        response.put("content", "Maximum tool call iterations reached");
-                        response.put("tool_calls", List.of());
+                        applyExhaustionSignal(
+                            response, lastResponse != null ? lastResponse.content() : null);
                         usageMeta = lastResponse != null ? lastResponse.usage() : null;
                     } else if (lastResponse != null) {
                         response.put("content", lastResponse.content());
@@ -958,6 +964,26 @@ public class MeshLlmProviderProcessor implements BeanPostProcessor, ApplicationC
         }
         Integer fromEnv = sanitizeMaxIterations(envVal);
         return fromEnv != null ? fromEnv : MeshLlmDefaults.MAX_ITERATIONS;
+    }
+
+    /**
+     * Populate a provider-managed-loop exhaustion reply envelope (issue #1355).
+     *
+     * <p>Sets {@code content} to the last genuine assistant text (or {@code ""}
+     * when none — never the fabricated English marker), an empty {@code tool_calls}
+     * list, and the structural discriminant sibling field
+     * {@code _mesh_stop_reason: "max_iterations"}. The field is added ONLY on
+     * exhaustion; a normal completion omits it so absence means a normal turn. The
+     * consumer reads the discriminant and raises {@code MeshMaxIterationsException}
+     * — the human-readable message never rides the wire.
+     *
+     * <p>Byte-matches Python ({@code mesh/helpers.py}) and TypeScript
+     * ({@code llm-provider.ts}): {@code _mesh_stop_reason} / {@code max_iterations}.
+     */
+    static void applyExhaustionSignal(Map<String, Object> response, String lastAssistantText) {
+        response.put("content", lastAssistantText != null ? lastAssistantText : "");
+        response.put("tool_calls", List.of());
+        response.put(MeshLlmStopReason.STOP_REASON_KEY, MeshLlmStopReason.STOP_REASON_MAX_ITERATIONS);
     }
 
     private LlmProviderConfig findProvider(String capability) {

--- a/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/MeshLlmProviderExhaustionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-ai/src/test/java/io/mcpmesh/ai/MeshLlmProviderExhaustionTest.java
@@ -1,0 +1,78 @@
+package io.mcpmesh.ai;
+
+import io.mcpmesh.types.MeshLlmStopReason;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1355: the LLM {@code max_iterations} exhaustion signal (provider side).
+ *
+ * <p>On exhaustion the provider-managed parallel loop must mark the failure
+ * <em>structurally</em> via the {@code _mesh_stop_reason: "max_iterations"}
+ * sibling field — never by writing an English marker into {@code content}.
+ * {@code content} carries the last genuine assistant text (or {@code ""}); the
+ * discriminant is omitted on a normal completion so absence means a normal turn.
+ *
+ * <p>The parallel loop is the only mesh-owned agentic loop in the Java provider
+ * (the sequential shape delegates the tool loop to Spring AI's {@code ChatClient},
+ * which manages iterations internally and exposes no exhaustion signal). This test
+ * exercises the extracted {@link MeshLlmProviderProcessor#applyExhaustionSignal}
+ * envelope builder — the exact wire shape that path emits — following the module
+ * convention of unit-testing the extracted static helpers.
+ */
+@DisplayName("MeshLlmProviderProcessor — max_iterations exhaustion signal (#1355)")
+class MeshLlmProviderExhaustionTest {
+
+    @Test
+    @DisplayName("wire vocabulary byte-matches Python/TypeScript")
+    void wireVocabularyMatches() {
+        assertEquals("_mesh_stop_reason", MeshLlmStopReason.STOP_REASON_KEY);
+        assertEquals("max_iterations", MeshLlmStopReason.STOP_REASON_MAX_ITERATIONS);
+    }
+
+    @Test
+    @DisplayName("exhaustion sets the discriminant and drops the English marker")
+    void exhaustionSetsDiscriminant() {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("model", "anthropic/claude");
+
+        MeshLlmProviderProcessor.applyExhaustionSignal(response, "partial reasoning");
+
+        assertEquals("max_iterations", response.get(MeshLlmStopReason.STOP_REASON_KEY));
+        // content is the last genuine assistant text — never the fabricated marker.
+        assertEquals("partial reasoning", response.get("content"));
+        assertNotEquals("Maximum tool call iterations reached", response.get("content"));
+        assertEquals(List.of(), response.get("tool_calls"));
+        // Sibling fields already on the envelope are preserved.
+        assertEquals("anthropic/claude", response.get("model"));
+    }
+
+    @Test
+    @DisplayName("null last-assistant-text collapses to \"\" (never fabricated)")
+    void nullLastTextBecomesEmpty() {
+        Map<String, Object> response = new LinkedHashMap<>();
+
+        MeshLlmProviderProcessor.applyExhaustionSignal(response, null);
+
+        assertEquals("", response.get("content"));
+        assertEquals("max_iterations", response.get(MeshLlmStopReason.STOP_REASON_KEY));
+    }
+
+    @Test
+    @DisplayName("a normal-completion envelope omits the discriminant (absence == normal turn)")
+    void normalCompletionOmitsDiscriminant() {
+        // A normal completion builds the envelope WITHOUT applyExhaustionSignal.
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("content", "final answer");
+        response.put("tool_calls", List.of());
+
+        assertFalse(response.containsKey(MeshLlmStopReason.STOP_REASON_KEY),
+            "normal completion must omit _mesh_stop_reason");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -15,6 +15,8 @@ import io.mcpmesh.spring.media.MediaStore;
 import io.mcpmesh.spring.tracing.TraceContext;
 import io.mcpmesh.types.McpMeshTool;
 import io.mcpmesh.types.MeshLlmAgent;
+import io.mcpmesh.types.MeshLlmStopReason;
+import io.mcpmesh.types.MeshMaxIterationsException;
 import io.mcpmesh.types.MeshToolCallException;
 import io.mcpmesh.types.MeshToolUnavailableException;
 import org.slf4j.Logger;
@@ -891,6 +893,17 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                 // _mesh_usage contributes nothing.
                 accumulateUsage(response);
 
+                // Issue #1355: a provider-managed loop that hit its cap returns a
+                // terminal no-tool-calls reply carrying the structural exhaustion
+                // discriminant (_mesh_stop_reason == "max_iterations"). Raise a
+                // typed error instead of returning the (possibly empty) prior text
+                // — content never carries the failure, so this is the only signal.
+                if (MeshLlmStopReason.STOP_REASON_MAX_ITERATIONS.equals(extractStopReason(response))) {
+                    log.warn("Provider-managed loop reported max_iterations exhaustion (max={}) for LLM agent {}",
+                        maxIterations, functionId);
+                    throw new MeshMaxIterationsException(maxIterations, maxIterations);
+                }
+
                 // Check for tool calls
                 List<Map<String, Object>> toolCalls = extractToolCalls(response);
 
@@ -938,8 +951,12 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                 }
             }
 
+            // Issue #1355: the consumer-managed loop exhausted its cap without a
+            // final response. Raise the typed error instead of silently returning
+            // prior assistant text — exhaustion is a loud, typed failure on the
+            // mainline, matching the provider-managed path and the Python/TS SDKs.
             log.warn("Max iterations ({}) reached for LLM agent {}", maxIterations, functionId);
-            return extractLastAssistantContent(llmMessages);
+            throw new MeshMaxIterationsException(maxIterations, maxIterations);
             } finally {
                 // Publish accumulated token usage to the per-thread sink so
                 // ExecutionTracer.endSpan can stamp the CONSUMER span (parity
@@ -1281,6 +1298,45 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
         return null;
     }
 
+    /**
+     * Extract the provider's {@code _mesh_stop_reason} exhaustion discriminant
+     * from a response (issue #1355).
+     *
+     * <p>The value — {@code "max_iterations"} on a provider-managed loop that hit
+     * its cap, absent otherwise — may appear at the response top level OR inside
+     * the nested {@code content[0].text} JSON envelope. Mirrors the same unwrap
+     * path as {@link #extractUsage}. Returns {@code null} when no discriminant is
+     * present (a normal turn).
+     */
+    @SuppressWarnings("unchecked")
+    private String extractStopReason(Map<String, Object> response) {
+        Object topLevel = response.get(MeshLlmStopReason.STOP_REASON_KEY);
+        if (topLevel instanceof String s) {
+            return s;
+        }
+
+        Object content = response.get("content");
+        if (content instanceof List<?> contentList && !contentList.isEmpty()) {
+            Object first = contentList.get(0);
+            if (first instanceof Map<?, ?> block) {
+                Object text = block.get("text");
+                if (text instanceof String textStr && textStr.trim().startsWith("{")) {
+                    try {
+                        Map<String, Object> parsed = objectMapper.readValue(textStr, Map.class);
+                        Object nested = parsed.get(MeshLlmStopReason.STOP_REASON_KEY);
+                        if (nested instanceof String ns) {
+                            return ns;
+                        }
+                    } catch (JacksonException e) {
+                        log.trace("Failed to parse nested JSON for _mesh_stop_reason: {}", e.getMessage());
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
     /** Coerce a token-count field (Number or numeric String) to a long; 0 if missing/unparseable. */
     private static long toTokenCount(Object value) {
         if (value instanceof Number n) {
@@ -1328,6 +1384,7 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                 && !response.containsKey("role")
                 && !response.containsKey("tool_calls")
                 && !response.containsKey("_mesh_usage")
+                && !response.containsKey(MeshLlmStopReason.STOP_REASON_KEY)
                 && !isTruthy(response.get("error"))) {
             return serializeContent(response, "a bare structured answer without an envelope");
         }
@@ -1469,6 +1526,7 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                 // content diagnostics rather than returning the error/tool JSON.
                 if (parsed.containsKey("tool_calls")
                         || parsed.containsKey("_mesh_usage")
+                        || parsed.containsKey(MeshLlmStopReason.STOP_REASON_KEY)
                         || isTruthy(parsed.get("error"))) {
                     return "";
                 }
@@ -1623,19 +1681,6 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                 return;
             }
         }
-    }
-
-    private String extractLastAssistantContent(List<Map<String, Object>> messages) {
-        for (int i = messages.size() - 1; i >= 0; i--) {
-            Map<String, Object> msg = messages.get(i);
-            if ("assistant".equals(msg.get("role"))) {
-                Object content = msg.get("content");
-                if (content instanceof String s) {
-                    return s;
-                }
-            }
-        }
-        return "";
     }
 
     private String extractJsonFromResponse(String response) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyContentRecoveryTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyContentRecoveryTest.java
@@ -232,6 +232,13 @@ class MeshLlmAgentProxyContentRecoveryTest {
     }
 
     @Test
+    @DisplayName("nested bare _mesh_stop_reason payload → empty (diagnostics), not the wrapper JSON")
+    void nestedStopReasonOnlyDegradesToEmpty() throws Exception {
+        assertEquals("", extractFromNestedWrapper(
+            Map.of("_mesh_stop_reason", "tool_use")));
+    }
+
+    @Test
     @DisplayName("genuine nested JSON answer (no wrapper markers) passes through unchanged")
     void nestedGenuineJsonAnswerUnchanged() throws Exception {
         String result = extractFromNestedWrapper(Map.of("answer", "42"));

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyExhaustionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmAgentProxyExhaustionTest.java
@@ -1,0 +1,166 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.MeshObjectMappers;
+import io.mcpmesh.types.MeshLlmStopReason;
+import io.mcpmesh.types.MeshMaxIterationsException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Issue #1355: the LLM {@code max_iterations} exhaustion signal (consumer side).
+ *
+ * <p>A provider-managed loop that hits its cap returns a terminal no-tool-calls
+ * reply carrying the structural discriminant {@code _mesh_stop_reason:
+ * "max_iterations"} — never the failure inside {@code content}. The delegating
+ * consumer reads it and raises {@link MeshMaxIterationsException} instead of
+ * silently returning prior assistant text. A normal completion (discriminant
+ * absent) returns content as usual, and the {@code extractContent} bare-map
+ * recovery guard treats {@code _mesh_stop_reason} as diagnostic metadata.
+ *
+ * <p>Mirrors the Python ({@code mesh_llm_agent.py}) and TypeScript
+ * ({@code llm-agent.ts}) references. Wiring mirrors
+ * {@code MeshLlmAgentProxyTokenTelemetryTest}: a real {@link McpHttpClient}
+ * pointed at a {@link MockWebServer} returning the MCP tools/call shape.
+ */
+@DisplayName("MeshLlmAgentProxy — max_iterations exhaustion signal (#1355)")
+class MeshLlmAgentProxyExhaustionTest {
+
+    private MockWebServer server;
+    private McpHttpClient client;
+    private ObjectMapper mapper;
+
+    @BeforeAll
+    static void initTlsConfig() throws Exception {
+        Constructor<MeshTlsConfig> ctor = MeshTlsConfig.class.getDeclaredConstructor(
+            boolean.class, String.class, String.class, String.class, String.class);
+        ctor.setAccessible(true);
+        MeshTlsConfig disabled = ctor.newInstance(false, "off", null, null, null);
+
+        Field cachedField = MeshTlsConfig.class.getDeclaredField("cached");
+        cachedField.setAccessible(true);
+        cachedField.set(null, disabled);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        mapper = MeshObjectMappers.create();
+        client = new McpHttpClient(mapper);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (client != null) client.close();
+        server.shutdown();
+    }
+
+    private MeshLlmAgentProxy proxyWith(int maxIterations) {
+        MeshLlmAgentProxy proxy = new MeshLlmAgentProxy("test.exhaustion");
+        proxy.configure(client, null, null, null, "", "ctx", maxIterations, false);
+        proxy.updateProvider(
+            server.url("/").toString().replaceAll("/$", ""),
+            "process_chat",
+            "mesh-delegated"
+        );
+        return proxy;
+    }
+
+    /** Build the MCP envelope wrapping a JSON-encoded inner provider payload. */
+    private MockResponse envelope(Map<String, Object> innerPayload) {
+        String innerJson = mapper.writeValueAsString(innerPayload);
+        Map<String, Object> envelope = Map.of(
+            "jsonrpc", "2.0",
+            "id", System.currentTimeMillis(),
+            "result", Map.of("content", List.of(Map.of("type", "text", "text", innerJson)))
+        );
+        return new MockResponse()
+            .setBody(mapper.writeValueAsString(envelope))
+            .setHeader("Content-Type", "application/json");
+    }
+
+    /** Exhaustion reply: last assistant text (possibly "") + the discriminant sibling. */
+    private MockResponse exhaustionReply(String lastText) {
+        Map<String, Object> inner = new LinkedHashMap<>();
+        inner.put("role", "assistant");
+        inner.put("content", lastText);
+        inner.put("tool_calls", List.of());
+        inner.put(MeshLlmStopReason.STOP_REASON_KEY, MeshLlmStopReason.STOP_REASON_MAX_ITERATIONS);
+        return envelope(inner);
+    }
+
+    private MockResponse normalReply(String content) {
+        Map<String, Object> inner = new LinkedHashMap<>();
+        inner.put("role", "assistant");
+        inner.put("content", content);
+        inner.put("tool_calls", List.of());
+        return envelope(inner);
+    }
+
+    // ------------------------------------------------------------------- throws
+
+    @Test
+    @DisplayName("throws MeshMaxIterationsException on a provider exhaustion reply (empty content)")
+    void throwsOnExhaustionReply() {
+        server.enqueue(exhaustionReply(""));
+
+        MeshMaxIterationsException ex = assertThrows(MeshMaxIterationsException.class,
+            () -> proxyWith(5).request().user("hi").generate());
+
+        assertEquals(5, ex.getMaxAllowed());
+        assertEquals(5, ex.getIterationCount());
+    }
+
+    @Test
+    @DisplayName("throws even when the exhaustion reply carries prior assistant text — content is never returned")
+    void throwsAndDoesNotLeakPriorText() {
+        server.enqueue(exhaustionReply("partial reasoning so far"));
+
+        assertThrows(MeshMaxIterationsException.class,
+            () -> proxyWith(3).request().user("hi").generate());
+    }
+
+    // ------------------------------------------------------------ does NOT throw
+
+    @Test
+    @DisplayName("normal completion (discriminant absent) returns content, does not throw")
+    void doesNotThrowOnNormalCompletion() {
+        server.enqueue(normalReply("all done"));
+
+        assertEquals("all done", proxyWith(5).request().user("hi").generate());
+    }
+
+    // -------------------------------------------------------- reserved-key guard
+
+    @Test
+    @DisplayName("extractContent treats a bare _mesh_stop_reason map as diagnostic, not a bare answer")
+    void reservedKeyGuardTreatsStopReasonAsDiagnostic() throws Exception {
+        // A bare map with NO content/role, carrying only the discriminant, must not
+        // be mis-recovered as the user's answer — the guard returns "" so the
+        // exhaustion signal is never swallowed into content.
+        Map<String, Object> bare = new LinkedHashMap<>();
+        bare.put(MeshLlmStopReason.STOP_REASON_KEY, MeshLlmStopReason.STOP_REASON_MAX_ITERATIONS);
+
+        MeshLlmAgentProxy proxy = proxyWith(5);
+        Method extractContent = MeshLlmAgentProxy.class.getDeclaredMethod("extractContent", Map.class);
+        extractContent.setAccessible(true);
+        Object result = extractContent.invoke(proxy, bare);
+
+        assertEquals("", result, "a bare _mesh_stop_reason map must not be recovered as content");
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 (Java) of #1355 — **completes cross-runtime buffered parity**. Makes LLM agentic-loop `max_iterations` exhaustion structurally distinguishable in the Java runtime, mirroring the merged Python (PR #1367) and TypeScript (PR #1368) references so Java interoperates byte-for-byte with a Python/TS provider or consumer.

- **New `io.mcpmesh.types.MeshMaxIterationsException`** (extends `RuntimeException` like its siblings; carries `iterationCount`/`maxAllowed` for parity with Python `MaxIterationsError` / TS) and **`MeshLlmStopReason`** — the shared vocabulary (`_mesh_stop_reason` / `"max_iterations"`), byte-matching Python/TS (asserted in a test).
- **Provider (`MeshLlmProviderProcessor`)** — the parallel-loop exhaustion branch no longer writes the English marker into `content` or copies usage as if genuine. `applyExhaustionSignal()` sets `content` to the last assistant text (or `""`), `tool_calls=[]`, and the sibling `_mesh_stop_reason: "max_iterations"`; real usage is still reported; the field is omitted on success.
- **Consumer (`MeshLlmAgentProxy`)** — `_mesh_stop_reason` added to **both** bare-map reserved-key guards (top-level and nested); `extractStopReason()` mirrors `extractUsage`'s unwrap; **throws `MeshMaxIterationsException`** on an exhaustion reply and at consumer-loop exhaustion — the silent "return prior assistant text" path (`J1`) is removed.

### Scope notes
- **Only one mesh-owned loop exists.** The **sequential** provider path delegates its whole tool loop to Spring AI's `ChatClient`, which owns iteration internally and exposes no exhaustion signal — so there is no reachable branch there. The design's "both loop shapes" predated confirming this.
- **Buffered-only.** Java has no provider-side streaming producer (deferred, #1223). The Java streaming-**consumer** `_mesh_frame` unwrap (a latent interop item — a Java streaming consumer talking to a post-#1355 Python streaming provider would receive raw frame JSON) is tracked separately in **#1369**, intentionally out of scope here.

## Review notes

- Independent diff review: **0 blockers, 1 warning, 3 info**. The warning (reserved-key guard added to the top-level `extractContent` but not its twin in `parseNestedContent`) is fixed in this PR, with a test. Infos: the sequential-loop asymmetry (Spring-AI-owned, expected); the no-`serialVersionUID` (matches siblings); and the public behavior change below.
- **Behavior change (release note):** `MeshLlmAgentProxy.generate()` now **throws `MeshMaxIterationsException`** on exhaustion instead of returning prior assistant text. This is the intended fix — a cap is a failure — but callers that previously consumed the silent return value will now see a typed unchecked exception on the exhaustion path (normal completion is byte-identical).
- **Release sequencing (unchanged across the phases):** this changes the exhaustion wire shape; ship the #1355 phases within one release so no cross-version provider/consumer skew reaches users.

## Verification

- Full Java test suites for the affected modules: `mcp-mesh-sdk` 117, `mcp-mesh-spring-boot-starter` 666, `mcp-mesh-spring-ai` 211 — **994 tests, 0 failures** (incl. new `MeshLlmProviderExhaustionTest`, `MeshLlmAgentProxyExhaustionTest`, and the nested-guard test).
- Constants/wire shape asserted equal to the Python/TS reference.

## Test plan

- [ ] CI green (Java build + full module test suites)
- [ ] Integration suite with an LLM provider/consumer across runtimes passes
- [ ] Manual: a Java consumer against a Python/TS provider that hits `max_iterations` throws `MeshMaxIterationsException` (buffered) with correct `iterationCount`/`maxAllowed`
- [ ] Java streaming-consumer `_mesh_frame` unwrap — tracked in #1369

Closes #1355


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized handling for LLM agent loops that exceed their maximum iteration limit.
  * Exceeded iteration limits now raise a typed exception with the attempted and allowed iteration counts.
  * Added consistent stop-reason signaling across provider and consumer-managed workflows.

* **Bug Fixes**
  * Prevented exhaustion metadata and prior assistant text from being returned as user-visible content.
  * Preserved normal completion behavior without adding exhaustion indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->