### PR TITLE
fix(llm-java): unwrap _mesh_frame envelope in the Java streaming consumer

### DIFF
--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshLlmStopReason.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/types/MeshLlmStopReason.java
@@ -14,12 +14,35 @@ package io.mcpmesh.types;
  * interoperates with a Python/TypeScript provider and vice versa because the
  * string tokens match exactly.
  *
+ * <p>Two channels carry the signal:
+ *
  * <p><b>Buffered</b> reply envelope: a namespaced sibling field
  * {@code _mesh_stop_reason: "max_iterations"} (sibling of {@code content} /
  * {@code _mesh_usage}). Absent on normal completion.
  *
- * <p>The Java runtime has no provider-side streaming producer (deferred, see
- * #1223), so only the buffered vocabulary is defined here.
+ * <p><b>Streaming</b>: the MCP stream channel is strictly stringly-typed
+ * (FastMCP progress notifications carry {@code str} chunks), so a structured
+ * object cannot ride it directly. We adopt the Anthropic Messages API streaming
+ * discipline: the discriminator is the frame <em>type</em>, never the text
+ * content. EVERY chunk is a typed frame — a JSON <em>string</em> keyed by a
+ * RESERVED {@code _mesh_}-namespaced discriminator — so text can never be
+ * misread as a control signal:
+ *
+ * <ul>
+ *   <li>text delta            → {@code {"_mesh_frame":"chunk","content":"<delta>"}}</li>
+ *   <li>terminal, normal      → {@code {"_mesh_frame":"end"}}</li>
+ *   <li>terminal, exhaustion  → {@code {"_mesh_frame":"end","stop_reason":"max_iterations"}}</li>
+ * </ul>
+ *
+ * <p>The Java runtime has no provider-side streaming <b>producer</b> (deferred,
+ * see #1223), so no frame encoder is defined here. But the streaming
+ * <b>consumer</b> ({@code MeshLlmAgentProxy.streamGenerate()}) DOES decode these
+ * frames when talking to a Python/TypeScript streaming provider (#1369): it
+ * unwraps {@code chunk} content to the caller, completes on a plain {@code end}
+ * frame, and raises {@link MeshMaxIterationsException} on an {@code end} frame
+ * carrying {@code stop_reason == "max_iterations"}. The frame parser lives with
+ * the consumer (mirroring the buffered {@code extractStopReason} JSON unwrap);
+ * only the shared frame vocabulary is defined here.
  */
 public final class MeshLlmStopReason {
 
@@ -30,4 +53,17 @@ public final class MeshLlmStopReason {
 
     /** Reserved sibling key on the buffered reply envelope. */
     public static final String STOP_REASON_KEY = "_mesh_stop_reason";
+
+    /**
+     * Reserved discriminator key on every streaming frame. Byte-identical to
+     * Python's {@code FRAME_KEY} and TypeScript's {@code FRAME_KEY}. Namespaced
+     * under {@code _mesh_} so raw model text can never satisfy the frame check.
+     */
+    public static final String FRAME_KEY = "_mesh_frame";
+
+    /** Frame type for a text delta ({@code {"_mesh_frame":"chunk","content":...}}). */
+    public static final String FRAME_CHUNK = "chunk";
+
+    /** Frame type for a terminal frame ({@code {"_mesh_frame":"end", ...}}). */
+    public static final String FRAME_END = "end";
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -715,7 +715,15 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                     provider.endpoint(), provider.functionName(),
                     llmMessages.size(), toolDefs.size());
 
-                return mcpClient.streamTool(provider.endpoint(), provider.functionName(), params, null);
+                // Issue #1369: a Python/TS streaming provider frames EVERY chunk as
+                // a typed _mesh_frame envelope (chunk/end). Decode it so the caller
+                // sees plain text, a plain `end` completes the stream, and an
+                // exhaustion `end` terminates with onError(MeshMaxIterationsException)
+                // — mirroring the buffered path's typed exhaustion. A non-frame chunk
+                // (unframed/old provider) passes through verbatim.
+                return StreamFrameDecoder.decode(
+                    mcpClient.streamTool(provider.endpoint(), provider.functionName(), params, null),
+                    maxIterations);
             } finally {
                 // Clear the ThreadLocal invocationContext on return so it does not
                 // leak across pooled-thread reuse (Spring/Tomcat). The ThreadLocal

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/StreamFrameDecoder.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/StreamFrameDecoder.java
@@ -1,0 +1,233 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.core.MeshObjectMappers;
+import io.mcpmesh.types.MeshLlmStopReason;
+import io.mcpmesh.types.MeshMaxIterationsException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Decodes the typed {@code _mesh_frame} streaming envelope (issue #1369) on the
+ * consumer side of a mesh-delegated LLM stream.
+ *
+ * <p>After #1355 a Python/TypeScript streaming provider frames EVERY chunk as a
+ * typed JSON string keyed by the reserved {@code _mesh_frame} discriminator:
+ * <ul>
+ *   <li>text delta            → {@code {"_mesh_frame":"chunk","content":"<delta>"}}</li>
+ *   <li>terminal, normal      → {@code {"_mesh_frame":"end"}}</li>
+ *   <li>terminal, exhaustion  → {@code {"_mesh_frame":"end","stop_reason":"max_iterations"}}</li>
+ * </ul>
+ *
+ * <p>This mirrors Python's {@code _stream_mesh_delegated} unwrap and TypeScript's
+ * {@code stream()}: {@link #decode} wraps the raw upstream {@code Flow.Publisher<String>}
+ * (from {@link McpHttpClient#streamTool}) and transforms it so the caller sees
+ * plain text — never raw frame JSON — and observes streaming exhaustion as a
+ * typed {@code onError(MeshMaxIterationsException)} terminal signal.
+ *
+ * <p>Java has no streaming <b>producer</b> (deferred, #1223); this is
+ * consumer-side only, so only the frame parser + decode transform live here (no
+ * encoder). The parser mirrors how {@code MeshLlmAgentProxy.extractStopReason}
+ * unwraps the buffered envelope's JSON.
+ */
+final class StreamFrameDecoder {
+
+    private static final Logger log = LoggerFactory.getLogger(StreamFrameDecoder.class);
+    private static final ObjectMapper objectMapper = MeshObjectMappers.create();
+
+    private StreamFrameDecoder() {}
+
+    /**
+     * Parse a stream chunk into a typed frame map, or {@code null}.
+     *
+     * <p>Reserved-key guard, byte-for-byte equivalent to Python's
+     * {@code parse_stream_frame} and TypeScript's {@code parseStreamFrame}: a
+     * well-formed frame is a JSON object carrying the reserved
+     * {@code _mesh_frame} discriminator set to a recognized frame type
+     * ({@code "chunk"} or {@code "end"}). Anything else — {@code null}, invalid
+     * JSON, a JSON value that isn't an object, an object missing
+     * {@code _mesh_frame}, or one whose {@code _mesh_frame} is unrecognized —
+     * returns {@code null} so the consumer can apply a defensive passthrough
+     * fallback. Because the discriminator is {@code _mesh_}-namespaced, an
+     * UNFRAMED raw model delta that merely looks frame-ish (e.g. a literal
+     * {@code {"type":"end"}} in the model's own text) does NOT match and is
+     * passed through verbatim rather than misread as a control/text frame.
+     */
+    @SuppressWarnings("unchecked")
+    static Map<String, Object> parseStreamFrame(String chunk) {
+        if (chunk == null) {
+            return null;
+        }
+        Object obj;
+        try {
+            obj = objectMapper.readValue(chunk, Object.class);
+        } catch (JacksonException e) {
+            return null;
+        }
+        if (!(obj instanceof Map)) {
+            return null;
+        }
+        Map<String, Object> map = (Map<String, Object>) obj;
+        Object type = map.get(MeshLlmStopReason.FRAME_KEY);
+        if (!MeshLlmStopReason.FRAME_CHUNK.equals(type)
+                && !MeshLlmStopReason.FRAME_END.equals(type)) {
+            return null;
+        }
+        return map;
+    }
+
+    /**
+     * Wrap {@code upstream} so downstream subscribers observe the decoded stream:
+     * {@code chunk} frames unwrapped to their {@code content} text (null/non-string
+     * coerced to {@code ""}), a plain {@code end} frame as {@code onComplete}, an
+     * exhaustion {@code end} frame as {@code onError(MeshMaxIterationsException)},
+     * and any non-frame chunk passed through verbatim (defensive fallback for an
+     * unframed/old provider).
+     *
+     * <p>The frame→text mapping is 1:1 for every non-terminal frame and terminal
+     * {@code end} frames end the stream, so downstream demand maps directly onto
+     * upstream demand (1:1), preserving backpressure and ordering without
+     * rebuffering. Downstream never touches the upstream {@code Subscription}
+     * directly: it is handed a thin interposing {@code Subscription} so the decoder
+     * remains the sole, serialized owner of the upstream (Reactive Streams §2.7).
+     *
+     * @param upstream      the raw String-chunk publisher (e.g. {@code streamTool})
+     * @param maxIterations the configured loop cap, carried into the typed error
+     */
+    static Flow.Publisher<String> decode(Flow.Publisher<String> upstream, int maxIterations) {
+        return subscriber -> upstream.subscribe(new DecodingSubscriber(subscriber, maxIterations));
+    }
+
+    /**
+     * Interposing subscriber: decodes each upstream frame and re-signals to the
+     * downstream subscriber.
+     *
+     * <p>Reactive Streams §2.7 requires the Subscriber to be the sole, serialized
+     * caller of its upstream {@code Subscription}. To honor that, downstream is
+     * handed a thin interposing {@code Subscription} (built in {@link #onSubscribe})
+     * rather than the raw upstream one, so downstream {@code request}/{@code cancel}
+     * and the decoder's own swallow-{@code end} cancel all funnel through a single
+     * point. Cancel is idempotently serialized via {@link #cancelled}; the terminal
+     * transition is serialized via {@link #terminated} (an {@link AtomicBoolean}, so
+     * a downstream-thread §3.9 error can't race an upstream terminal). The terminal
+     * flag is set before any downstream {@code onError}/{@code onComplete}, and
+     * post-terminal upstream signals are ignored.
+     */
+    private static final class DecodingSubscriber implements Flow.Subscriber<String> {
+
+        private final Flow.Subscriber<? super String> downstream;
+        private final int maxIterations;
+        private volatile Flow.Subscription upstream;
+        private final AtomicBoolean terminated = new AtomicBoolean(false);
+        private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+        DecodingSubscriber(Flow.Subscriber<? super String> downstream, int maxIterations) {
+            this.downstream = downstream;
+            this.maxIterations = maxIterations;
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription subscription) {
+            this.upstream = subscription;
+            // Interpose a thin Subscription so downstream never touches the upstream
+            // directly (§2.7). Non-terminal frames map 1:1 to text, so downstream
+            // demand forwards straight to upstream demand, preserving backpressure.
+            downstream.onSubscribe(new Flow.Subscription() {
+                @Override
+                public void request(long n) {
+                    if (n <= 0) {
+                        // §3.9: a non-positive request must signal onError with an
+                        // IllegalArgumentException; do not forward it upstream.
+                        if (terminated.compareAndSet(false, true)) {
+                            cancelUpstream();
+                            downstream.onError(new IllegalArgumentException(
+                                "Reactive Streams §3.9: request amount must be positive, was " + n));
+                        }
+                        return;
+                    }
+                    if (!cancelled.get()) {
+                        subscription.request(n);
+                    }
+                }
+
+                @Override
+                public void cancel() {
+                    cancelUpstream();
+                }
+            });
+        }
+
+        /** Single, idempotent, serialized cancel path to the upstream (§2.7). */
+        private void cancelUpstream() {
+            Flow.Subscription u = upstream;
+            if (u != null && cancelled.compareAndSet(false, true)) {
+                u.cancel();
+            }
+        }
+
+        @Override
+        public void onNext(String chunk) {
+            if (terminated.get()) {
+                return;
+            }
+            Map<String, Object> frame = parseStreamFrame(chunk);
+            if (frame == null) {
+                // Not a well-formed frame — a provider that isn't yet framing
+                // (older provider mid-rollout, or a bug). Degrade to plain
+                // passthrough rather than crashing.
+                downstream.onNext(chunk);
+                return;
+            }
+            if (MeshLlmStopReason.FRAME_END.equals(frame.get(MeshLlmStopReason.FRAME_KEY))) {
+                if (!terminated.compareAndSet(false, true)) {
+                    return;
+                }
+                // Route through the single serialized cancel path so downstream and
+                // the decoder never contend on the upstream Subscription.
+                cancelUpstream();
+                if (MeshLlmStopReason.STOP_REASON_MAX_ITERATIONS.equals(frame.get("stop_reason"))) {
+                    log.warn("stream(mesh): provider signaled max_iterations exhaustion (max={})",
+                        maxIterations);
+                    downstream.onError(new MeshMaxIterationsException(maxIterations, maxIterations));
+                } else {
+                    // Normal terminal frame — complete cleanly, never forward it.
+                    downstream.onComplete();
+                }
+                return;
+            }
+            // Text delta: unwrap and forward the plain content. Coerce a null /
+            // non-string content to "" so a malformed frame can't leak a
+            // non-String into the stream.
+            Object content = frame.get("content");
+            if (content instanceof String s) {
+                downstream.onNext(s);
+            } else {
+                log.debug("stream(mesh): chunk frame content missing or non-string ({}); "
+                        + "coercing to empty string",
+                    content == null ? "null" : content.getClass().getSimpleName());
+                downstream.onNext("");
+            }
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            if (!terminated.compareAndSet(false, true)) {
+                return;
+            }
+            downstream.onError(throwable);
+        }
+
+        @Override
+        public void onComplete() {
+            if (!terminated.compareAndSet(false, true)) {
+                return;
+            }
+            downstream.onComplete();
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/StreamFrameDecoderTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/StreamFrameDecoderTest.java
@@ -1,0 +1,308 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.types.MeshLlmStopReason;
+import io.mcpmesh.types.MeshMaxIterationsException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * First Java streaming-frame coverage (issue #1369).
+ *
+ * <p>Exercises {@link StreamFrameDecoder#decode} — the consumer-side unwrap of the
+ * typed {@code _mesh_frame} streaming envelope emitted by a Python/TypeScript
+ * streaming provider after #1355. Mirrors the Python {@code _stream_mesh_delegated}
+ * and TypeScript {@code stream()} consumer tests:
+ * <ul>
+ *   <li>{@code chunk} frames → unwrapped {@code content} strings, in order</li>
+ *   <li>exhaustion {@code end} frame → {@code onError(MeshMaxIterationsException)};
+ *       frame NOT emitted</li>
+ *   <li>plain {@code end} frame → {@code onComplete}; frame NOT emitted</li>
+ *   <li>collision: a {@code chunk} whose {@code content} is literally the
+ *       end-frame JSON is emitted as text and does NOT terminate</li>
+ *   <li>unframed passthrough: a raw non-frame chunk (and one frame-shaped under a
+ *       DIFFERENT scheme, e.g. {@code {"type":"end"}}) is emitted verbatim</li>
+ * </ul>
+ */
+@DisplayName("StreamFrameDecoder — _mesh_frame consumer unwrap (issue #1369)")
+class StreamFrameDecoderTest {
+
+    // Wire shapes — byte-match the Python/TS producer.
+    private static final String CHUNK_HELLO = "{\"_mesh_frame\":\"chunk\",\"content\":\"Hello\"}";
+    private static final String CHUNK_WORLD = "{\"_mesh_frame\":\"chunk\",\"content\":\", world!\"}";
+    private static final String CHUNK_TRAILING = "{\"_mesh_frame\":\"chunk\",\"content\":\"trailing\"}";
+    private static final String END_NORMAL = "{\"_mesh_frame\":\"end\"}";
+    private static final String END_EXHAUSTION =
+        "{\"_mesh_frame\":\"end\",\"stop_reason\":\"max_iterations\"}";
+
+    private static final int MAX_ITERATIONS = 7;
+
+    // -------------------------------------------------------------------------
+    // Test helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * A cold, synchronous, single-subscriber {@code Flow.Publisher<String>} that
+     * emits {@code items} respecting demand — stands in for
+     * {@link McpHttpClient#streamTool}'s upstream.
+     */
+    private static Flow.Publisher<String> source(List<String> items) {
+        return source(items, new AtomicBoolean(false));
+    }
+
+    /**
+     * As {@link #source(List)} but records upstream cancellation into
+     * {@code cancelledFlag} so a test can assert the decoder invoked
+     * {@code cancel()} on the upstream (e.g. the swallow-{@code end} path).
+     */
+    private static Flow.Publisher<String> source(List<String> items, AtomicBoolean cancelledFlag) {
+        return subscriber -> subscriber.onSubscribe(new Flow.Subscription() {
+            private int idx = 0;
+            private boolean completed = false;
+
+            @Override
+            public void request(long n) {
+                if (cancelledFlag.get() || completed) {
+                    return;
+                }
+                for (long i = 0; i < n && idx < items.size(); i++) {
+                    subscriber.onNext(items.get(idx++));
+                    if (cancelledFlag.get()) {
+                        return;
+                    }
+                }
+                if (idx >= items.size() && !completed) {
+                    completed = true;
+                    subscriber.onComplete();
+                }
+            }
+
+            @Override
+            public void cancel() {
+                cancelledFlag.set(true);
+            }
+        });
+    }
+
+    /** Collect Flow.Publisher chunks blocking, throwing on onError. */
+    private static List<String> collect(Flow.Publisher<String> publisher) throws Exception {
+        ConcurrentLinkedQueue<String> chunks = new ConcurrentLinkedQueue<>();
+        CompletableFuture<Throwable> done = new CompletableFuture<>();
+        publisher.subscribe(new Flow.Subscriber<>() {
+            @Override public void onSubscribe(Flow.Subscription s) { s.request(Long.MAX_VALUE); }
+            @Override public void onNext(String item) { chunks.add(item); }
+            @Override public void onError(Throwable t) { done.complete(t); }
+            @Override public void onComplete() { done.complete(null); }
+        });
+        Throwable err = done.get(10, TimeUnit.SECONDS);
+        if (err != null) {
+            if (err instanceof RuntimeException re) throw re;
+            throw new RuntimeException(err);
+        }
+        return new ArrayList<>(chunks);
+    }
+
+    private Flow.Publisher<String> decoded(String... frames) {
+        return StreamFrameDecoder.decode(source(List.of(frames)), MAX_ITERATIONS);
+    }
+
+    // -------------------------------------------------------------------------
+    // Constant parity
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("frame constants byte-match Python/TypeScript")
+    void frameConstantsByteMatch() {
+        assertEquals("_mesh_frame", MeshLlmStopReason.FRAME_KEY);
+        assertEquals("chunk", MeshLlmStopReason.FRAME_CHUNK);
+        assertEquals("end", MeshLlmStopReason.FRAME_END);
+        assertEquals("max_iterations", MeshLlmStopReason.STOP_REASON_MAX_ITERATIONS);
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("chunk frames → unwrapped content strings, in order; end frame not emitted")
+    void chunkFramesUnwrappedInOrder() throws Exception {
+        List<String> out = collect(decoded(CHUNK_HELLO, CHUNK_WORLD, END_NORMAL));
+        assertEquals(List.of("Hello", ", world!"), out);
+    }
+
+    @Test
+    @DisplayName("exhaustion end frame → onError(MeshMaxIterationsException); frame not emitted")
+    void exhaustionFrameTerminatesWithTypedError() {
+        MeshMaxIterationsException ex = assertThrows(
+            MeshMaxIterationsException.class,
+            () -> collect(decoded(CHUNK_HELLO, END_EXHAUSTION))
+        );
+        assertEquals(MAX_ITERATIONS, ex.getMaxAllowed());
+        assertEquals(MAX_ITERATIONS, ex.getIterationCount());
+    }
+
+    @Test
+    @DisplayName("exhaustion end frame: chunks before it are still delivered, then error")
+    void exhaustionDeliversPriorChunksThenErrors() {
+        ConcurrentLinkedQueue<String> chunks = new ConcurrentLinkedQueue<>();
+        CompletableFuture<Throwable> done = new CompletableFuture<>();
+        decoded(CHUNK_HELLO, CHUNK_WORLD, END_EXHAUSTION).subscribe(new Flow.Subscriber<>() {
+            @Override public void onSubscribe(Flow.Subscription s) { s.request(Long.MAX_VALUE); }
+            @Override public void onNext(String item) { chunks.add(item); }
+            @Override public void onError(Throwable t) { done.complete(t); }
+            @Override public void onComplete() { done.complete(null); }
+        });
+        Throwable err = done.join();
+        assertInstanceOf(MeshMaxIterationsException.class, err);
+        assertEquals(List.of("Hello", ", world!"), new ArrayList<>(chunks),
+            "prior chunk content is delivered; the exhaustion frame itself is never emitted");
+    }
+
+    @Test
+    @DisplayName("plain end frame → completes normally; frame not emitted")
+    void plainEndCompletesNormally() throws Exception {
+        List<String> out = collect(decoded(CHUNK_HELLO, END_NORMAL));
+        assertEquals(List.of("Hello"), out);
+    }
+
+    @Test
+    @DisplayName("collision: a chunk whose content IS the end-frame JSON is emitted as text, no throw")
+    void collisionChunkContentLooksLikeEndFrame() throws Exception {
+        // A framed text delta whose content is literally an exhaustion end-frame
+        // JSON string. Parsed as a `chunk`, its content is yielded verbatim — the
+        // reserved _mesh_frame discriminator (chunk) wins; no control collision.
+        String innerEnd = END_EXHAUSTION;
+        String collisionChunk = "{\"_mesh_frame\":\"chunk\",\"content\":"
+            + jsonString(innerEnd) + "}";
+
+        List<String> out = collect(decoded(collisionChunk, END_NORMAL));
+        assertEquals(List.of(innerEnd), out,
+            "the inner end-frame JSON is delivered as plain text, NOT interpreted as a control frame");
+    }
+
+    @Test
+    @DisplayName("unframed passthrough: raw text and a DIFFERENT-scheme frame are emitted verbatim")
+    void unframedChunksPassThroughVerbatim() throws Exception {
+        // 1. Plain raw text (not JSON at all).
+        // 2. A JSON object that is frame-shaped under a DIFFERENT scheme
+        //    ({"type":"end"}) — it lacks the reserved _mesh_frame key, so it is
+        //    NOT a control frame and must be forwarded verbatim.
+        String rawText = "just some raw text";
+        String otherScheme = "{\"type\":\"end\"}";
+
+        List<String> out = collect(decoded(rawText, otherScheme, END_NORMAL));
+        assertEquals(List.of(rawText, otherScheme), out);
+    }
+
+    @Test
+    @DisplayName("chunk frame with null content coerces to empty string")
+    void nullContentCoercedToEmpty() throws Exception {
+        String chunkNullContent = "{\"_mesh_frame\":\"chunk\",\"content\":null}";
+        List<String> out = collect(decoded(chunkNullContent, END_NORMAL));
+        assertEquals(List.of(""), out);
+    }
+
+    @Test
+    @DisplayName("bounded demand: request(1) yields exactly one item at a time (1:1 backpressure)")
+    void boundedDemandYieldsOneAtATime() {
+        // All other tests request Long.MAX_VALUE; this proves demand maps 1:1 so
+        // downstream backpressure is actually honored through the interposed sub.
+        List<String> chunks = new ArrayList<>();
+        AtomicReference<Flow.Subscription> subRef = new AtomicReference<>();
+        CompletableFuture<Throwable> done = new CompletableFuture<>();
+
+        StreamFrameDecoder.decode(source(List.of(CHUNK_HELLO, CHUNK_WORLD, END_NORMAL)), MAX_ITERATIONS)
+            .subscribe(new Flow.Subscriber<>() {
+                @Override public void onSubscribe(Flow.Subscription s) { subRef.set(s); }
+                @Override public void onNext(String item) { chunks.add(item); }
+                @Override public void onError(Throwable t) { done.complete(t); }
+                @Override public void onComplete() { done.complete(null); }
+            });
+
+        Flow.Subscription sub = subRef.get();
+        assertNotNull(sub, "downstream received an interposed subscription");
+        assertTrue(chunks.isEmpty(), "no items before any demand is signaled");
+
+        sub.request(1);
+        assertEquals(List.of("Hello"), chunks, "exactly one item after request(1)");
+        assertFalse(done.isDone(), "stream not yet terminated after one bounded request");
+
+        sub.request(1);
+        assertEquals(List.of("Hello", ", world!"), chunks, "exactly one more item after next request(1)");
+
+        // Drain the terminal end frame.
+        sub.request(1);
+        assertNull(done.getNow(new RuntimeException("not done")),
+            "plain end frame completes normally after the final request");
+        assertEquals(List.of("Hello", ", world!"), chunks, "end frame itself is never emitted");
+    }
+
+    @Test
+    @DisplayName("trailing items after an exhaustion end frame are dropped; upstream is cancelled")
+    void trailingItemsAfterExhaustionEndAreDropped() {
+        AtomicBoolean upstreamCancelled = new AtomicBoolean(false);
+        List<String> items = List.of(CHUNK_HELLO, CHUNK_WORLD, END_EXHAUSTION, CHUNK_TRAILING);
+
+        ConcurrentLinkedQueue<String> chunks = new ConcurrentLinkedQueue<>();
+        CompletableFuture<Throwable> done = new CompletableFuture<>();
+        StreamFrameDecoder.decode(source(items, upstreamCancelled), MAX_ITERATIONS)
+            .subscribe(new Flow.Subscriber<>() {
+                @Override public void onSubscribe(Flow.Subscription s) { s.request(Long.MAX_VALUE); }
+                @Override public void onNext(String item) { chunks.add(item); }
+                @Override public void onError(Throwable t) { done.complete(t); }
+                @Override public void onComplete() { done.complete(null); }
+            });
+
+        Throwable err = done.join();
+        assertInstanceOf(MeshMaxIterationsException.class, err);
+        assertEquals(List.of("Hello", ", world!"), new ArrayList<>(chunks),
+            "leading chunks delivered in order; trailing chunk after end is NOT emitted");
+        assertTrue(upstreamCancelled.get(), "decoder cancelled the upstream when it swallowed the end frame");
+    }
+
+    @Test
+    @DisplayName("trailing items after a plain end frame are dropped; upstream is cancelled")
+    void trailingItemsAfterPlainEndAreDropped() throws Exception {
+        AtomicBoolean upstreamCancelled = new AtomicBoolean(false);
+        List<String> items = List.of(CHUNK_HELLO, END_NORMAL, CHUNK_TRAILING);
+
+        ConcurrentLinkedQueue<String> chunks = new ConcurrentLinkedQueue<>();
+        CompletableFuture<Throwable> done = new CompletableFuture<>();
+        StreamFrameDecoder.decode(source(items, upstreamCancelled), MAX_ITERATIONS)
+            .subscribe(new Flow.Subscriber<>() {
+                @Override public void onSubscribe(Flow.Subscription s) { s.request(Long.MAX_VALUE); }
+                @Override public void onNext(String item) { chunks.add(item); }
+                @Override public void onError(Throwable t) { done.complete(t); }
+                @Override public void onComplete() { done.complete(null); }
+            });
+
+        assertNull(done.get(10, TimeUnit.SECONDS), "plain end frame completes normally");
+        assertEquals(List.of("Hello"), new ArrayList<>(chunks),
+            "one chunk then onComplete; trailing chunk after end is NOT emitted");
+        assertTrue(upstreamCancelled.get(), "decoder cancelled the upstream when it swallowed the end frame");
+    }
+
+    /** Minimal JSON string encoder (quotes + escapes) for building collision fixtures. */
+    private static String jsonString(String s) {
+        StringBuilder sb = new StringBuilder("\"");
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                default -> sb.append(c);
+            }
+        }
+        return sb.append('"').toString();
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to the #1355 exhaustion signal — the **streaming half** of Java's participation. After #1355, a Python streaming provider frames every stream chunk as a typed `_mesh_frame` JSON string. The Java streaming consumer (`MeshLlmAgentProxy.streamGenerate()`) was a raw `Flow.Publisher<String>` passthrough, so it would leak the frame JSON to callers and never surface streaming exhaustion.

- **`MeshLlmStopReason`** — adds the streaming frame constants (`_mesh_frame`, `"chunk"`, `"end"`), byte-matching Python/TypeScript.
- **New `StreamFrameDecoder`** — `parseStreamFrame(String) → Map|null` (reserved-key guard, null for non-frames) + a `decode(Flow.Publisher<String>, maxIterations)` transform:
  - `chunk` → emit `content` (null/non-string coerced to `""`, with a debug breadcrumb)
  - `end` + `stop_reason == "max_iterations"` → terminate with `onError(MeshMaxIterationsException)` (not emitted)
  - plain `end` → `onComplete` (not emitted)
  - non-frame → **defensive raw passthrough** (an unframed/old provider degrades to plain text; existing streaming tests exercise this path unchanged)
- **`MeshLlmAgentProxy.streamGenerate()`** now wraps `mcpClient.streamTool(...)` with the decoder. Public signature unchanged.

Java still has no streaming **producer** (deferred, #1223) — this is consumer-side only.

## Review notes

- Independent diff review (with Reactive-Streams scrutiny): **0 blockers, 1 warning, 4 info**. Core reactive logic confirmed correct (terminal guard, demand accounting, `parseStreamFrame` matches Python/TS, collision-safety, backward-compat, constants byte-match).
- **Warning fixed in this PR:** the decoder now interposes its **own serializing `Subscription`** rather than exposing the raw upstream — downstream never touches the upstream directly, and `request`/`cancel` funnel through one serialized point (Reactive Streams §2.7), with §3.9 handling for `request(n<=0)` and an `AtomicBoolean` terminal guard. Backpressure/ordering preserved 1:1 for non-terminal frames.
- **Info hardening folded in:** a bounded-demand test (`request(1)` → one item at a time), trailing-items-after-`end` tests (leading chunks emitted, terminal fires, trailing dropped, upstream cancelled) for both exhaustion and plain-`end`, and a debug log on non-string-content coercion. (The iteration-count-equals-cap info is intentional — matches the buffered path, since the wire frame carries no count.)

## Verification

- Full suites: `mcp-mesh-sdk` **117** + `mcp-mesh-spring-boot-starter` **677** = **794 tests, 0 failures** (`StreamFrameDecoderTest`: 11).
- Frame constants asserted equal to the Python/TS reference.

## Test plan

- [ ] CI green (Java build + full module suites)
- [ ] Integration: a Java streaming consumer against a Python streaming provider that hits `max_iterations` surfaces `MeshMaxIterationsException` via `onError` (frame not forwarded); a normal stream unwraps text and completes
- [ ] Integration: a Java streaming consumer against an unframed/legacy provider still receives plain text (defensive passthrough)

Closes #1369

Related: #1355


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for typed streaming frames, including content chunks and stream completion signals.
  * Streams now surface maximum-iteration exhaustion as a clear error.
  * Legacy and unframed streaming responses continue to work unchanged.

* **Bug Fixes**
  * Improved handling of malformed, empty, and trailing streaming data.
  * Ensured stream completion and cancellation behave consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->