### PR TITLE
fix(llm-ts): forward max_iterations only when the consumer configured it

### DIFF
--- a/src/runtime/typescript/src/__tests__/llm-max-iterations.test.ts
+++ b/src/runtime/typescript/src/__tests__/llm-max-iterations.test.ts
@@ -315,6 +315,132 @@ describe("MeshDelegatedProvider.complete() — maxIterations forwarding", () => 
 });
 
 // ----------------------------------------------------------------------------
+// Issue #1360: consumer-level forwarding through MeshLlmAgent.run().
+//
+// The complete()-level tests above prove the wire guard omits the key when the
+// caller passes no maxIterations. These assert the END-TO-END consumer path:
+// run() resolves the cap, and only an EXPLICITLY configured one (runtime option
+// / consumer env / user-supplied config) reaches the wire. A consumer that
+// configured NOTHING must send no max_iterations key so the provider's own
+// MESH_LLM_MAX_ITERATIONS governs — mirroring the Python/Java tests from #1356.
+//
+// The consumer's OWN loop cap must still default to 10 when unset (the #1355
+// exhaustion path), which the last test asserts via the raised error's cap.
+// ----------------------------------------------------------------------------
+
+describe("MeshLlmAgent forwarding — explicit vs unset (issue #1360)", () => {
+  let originalFetch: typeof fetch;
+  const ORIGINAL_ENV = process.env.MESH_LLM_MAX_ITERATIONS;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.MESH_LLM_MAX_ITERATIONS;
+    } else {
+      process.env.MESH_LLM_MAX_ITERATIONS = ORIGINAL_ENV;
+    }
+  });
+
+  /**
+   * Run the agent through a fetch mock returning a normal completion, and
+   * return the wire request's model_params (undefined when the request carried
+   * no model_params block at all — e.g. a consumer that configured nothing).
+   */
+  async function captureRunModelParams(
+    agent: MeshLlmAgent,
+    options?: { maxIterations?: number },
+  ): Promise<Record<string, unknown> | undefined> {
+    let capturedBody: string | undefined;
+    globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) => {
+      capturedBody = init.body as string;
+      return mockJsonResponse(mcpToolResponse({ role: "assistant", content: "ok" }));
+    }) as unknown as typeof fetch;
+
+    await agent.run("hi", {
+      tools: [],
+      meshProvider: { endpoint: ENDPOINT, functionName: FN_BUFFERED },
+      options,
+    });
+
+    const body = JSON.parse(capturedBody!);
+    return body.params.arguments.request.model_params as
+      | Record<string, unknown>
+      | undefined;
+  }
+
+  function unsetAgent(): MeshLlmAgent {
+    // No maxIterations configured at all — the crux of #1360.
+    return new MeshLlmAgent({
+      functionId: "test.1360.unset",
+      provider: { capability: "llm", tags: ["+claude"] },
+    });
+  }
+
+  it("omits max_iterations when the consumer configured nothing (provider env governs)", async () => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    const modelParams = await captureRunModelParams(unsetAgent());
+    expect(modelParams?.max_iterations).toBeUndefined();
+  });
+
+  it("forwards an explicit runtime option", async () => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    const modelParams = await captureRunModelParams(unsetAgent(), {
+      maxIterations: 25,
+    });
+    expect(modelParams?.max_iterations).toBe(25);
+  });
+
+  it("forwards the consumer-side MESH_LLM_MAX_ITERATIONS env", async () => {
+    process.env.MESH_LLM_MAX_ITERATIONS = "15";
+    const modelParams = await captureRunModelParams(unsetAgent());
+    expect(modelParams?.max_iterations).toBe(15);
+  });
+
+  it("forwards an explicit user-supplied config value", async () => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    const agent = new MeshLlmAgent({
+      functionId: "test.1360.explicit-config",
+      provider: { capability: "llm", tags: ["+claude"] },
+      maxIterations: 8,
+    });
+    const modelParams = await captureRunModelParams(agent);
+    expect(modelParams?.max_iterations).toBe(8);
+  });
+
+  it("still caps the consumer's own loop at 10 when unset (default local cap preserved)", async () => {
+    delete process.env.MESH_LLM_MAX_ITERATIONS;
+    // Provider signals exhaustion structurally; the raised error must carry the
+    // default local cap of 10, proving the consumer loop is still bounded even
+    // though nothing is forwarded to the provider.
+    globalThis.fetch = vi.fn(async () =>
+      mockJsonResponse(
+        mcpToolResponse({
+          role: "assistant",
+          content: "",
+          _mesh_stop_reason: "max_iterations",
+        }),
+      ),
+    ) as unknown as typeof fetch;
+
+    try {
+      await unsetAgent().run("hi", {
+        tools: [],
+        meshProvider: { endpoint: ENDPOINT, functionName: FN_BUFFERED },
+      });
+      throw new Error("expected MaxIterationsError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MaxIterationsError);
+      expect((err as MaxIterationsError).iterations).toBe(10);
+    }
+  });
+});
+
+// ----------------------------------------------------------------------------
 // Issue #1355: shared exhaustion vocabulary — encode/parse frame helpers.
 // These must be byte-identical to Python's llm_stop_reason.py so a TS consumer
 // interoperates with a Python provider (and vice versa).

--- a/src/runtime/typescript/src/llm-agent.ts
+++ b/src/runtime/typescript/src/llm-agent.ts
@@ -85,8 +85,14 @@ export interface MeshLlmAgentConfig {
   systemPrompt?: string;
   /** Parameter name for template context */
   contextParam?: string;
-  /** Max agentic loop iterations */
-  maxIterations: number;
+  /**
+   * Max agentic loop iterations. Issue #1360: `undefined` = the consumer
+   * configured nothing — the local loop still caps at 10 (applied in run()/
+   * stream()), but no `max_iterations` is forwarded to the provider, so the
+   * provider's MESH_LLM_MAX_ITERATIONS governs. Any defined value is an
+   * explicit consumer cap and IS forwarded.
+   */
+  maxIterations?: number;
   /** Max tokens */
   maxOutputTokens?: number;
   /** Temperature */
@@ -655,6 +661,26 @@ export class MeshLlmAgent<T = string> {
   }
 
   /**
+   * Issue #1360: single-source the max-iterations resolution shared by run() and
+   * stream(). `forwarded` is the EXPLICIT cap the consumer configured (runtime
+   * option → consumer env → user config), or undefined when nothing is set — in
+   * which case the delegation request omits `max_iterations` and the provider's
+   * own MESH_LLM_MAX_ITERATIONS governs (parity with Python/Java). `localCap` is
+   * the concrete bound the consumer's own loop always needs (#1355), defaulting
+   * to 10 when nothing is configured.
+   */
+  private resolveForwardedMaxIterations(options?: LlmCallOptions): {
+    forwarded: number | undefined;
+    localCap: number;
+  } {
+    const forwarded =
+      sanitizeMaxIterations(options?.maxIterations) ??
+      envMaxIterations() ??
+      this.config.maxIterations;
+    return { forwarded, localCap: forwarded ?? 10 };
+  }
+
+  /**
    * Run the agentic loop.
    *
    * @param messageInput - User message string or multi-turn message array
@@ -687,11 +713,13 @@ export class MeshLlmAgent<T = string> {
       includeOutputSchemaHint: !isMeshDelegated,
     });
 
-    // Get effective options (runtime options > MESH_LLM_* env > config)
-    const maxIterations =
-      sanitizeMaxIterations(context.options?.maxIterations) ??
-      envMaxIterations() ??
-      this.config.maxIterations;
+    // Get effective options (runtime options > MESH_LLM_* env > config).
+    // Issue #1360: `forwardedMaxIterations` is the EXPLICIT cap the consumer
+    // configured (undefined = omit from the delegation request so the provider's
+    // MESH_LLM_MAX_ITERATIONS governs); `maxIterations` is the concrete local
+    // exhaustion bound (#1355), default 10 when nothing is configured.
+    const { forwarded: forwardedMaxIterations, localCap: maxIterations } =
+      this.resolveForwardedMaxIterations(context.options);
     const maxTokens = context.options?.maxOutputTokens ?? this.config.maxOutputTokens;
     const temperature = context.options?.temperature ?? this.config.temperature;
 
@@ -725,8 +753,10 @@ export class MeshLlmAgent<T = string> {
           outputSchema,
           // Issue #1019: forward caller-supplied escape-hatch kwargs
           modelParams: context.options?.modelParams,
-          // Issue #1116: forward the resolved provider-managed loop cap.
-          maxIterations,
+          // Issue #1116/#1360: forward the provider-managed loop cap ONLY when
+          // the consumer explicitly configured one (undefined = omit the key so
+          // the provider's MESH_LLM_MAX_ITERATIONS / default of 10 applies).
+          maxIterations: forwardedMaxIterations,
           // Issue #1112: forward the RAW (possibly-undefined) output_mode so the
           // provider honors an explicit override; unset stays auto.
           outputMode: this.config.outputMode,
@@ -924,11 +954,11 @@ export class MeshLlmAgent<T = string> {
       includeOutputSchemaHint: false,
     });
 
-    // Effective options (runtime > env > config)
-    const maxIterations =
-      sanitizeMaxIterations(context.options?.maxIterations) ??
-      envMaxIterations() ??
-      this.config.maxIterations;
+    // Effective options (runtime > env > config). Issue #1360: forward only an
+    // explicitly configured cap (undefined = omit; provider env governs); the
+    // local exhaustion cap still defaults to 10.
+    const { forwarded: forwardedMaxIterations, localCap: maxIterations } =
+      this.resolveForwardedMaxIterations(context.options);
     const maxTokens = context.options?.maxOutputTokens ?? this.config.maxOutputTokens;
     const temperature = context.options?.temperature ?? this.config.temperature;
 
@@ -964,8 +994,10 @@ export class MeshLlmAgent<T = string> {
         outputSchema,
         // Issue #1019: forward caller-supplied escape-hatch kwargs
         modelParams: context.options?.modelParams,
-        // Issue #1116: forward the resolved provider-managed loop cap.
-        maxIterations,
+        // Issue #1116/#1360: forward the provider-managed loop cap ONLY when
+        // the consumer explicitly configured one (undefined = omit the key so
+        // the provider's MESH_LLM_MAX_ITERATIONS / default of 10 applies).
+        maxIterations: forwardedMaxIterations,
         // Issue #1112: forward the RAW (possibly-undefined) output_mode so the
         // provider honors an explicit override; unset stays auto.
         outputMode: this.config.outputMode,

--- a/src/runtime/typescript/src/llm-provider.ts
+++ b/src/runtime/typescript/src/llm-provider.ts
@@ -369,10 +369,10 @@ export function envMaxIterations(): number | undefined {
  *
  * Note: a *present* paramValue (even if invalid) never falls through to the
  * env branch — invalid param → default. The env branch is consulted only when
- * the param is ABSENT. For TS consumers this means the provider-host env only
- * applies when the consumer does not forward a cap: run()/stream() always
- * forward one, so provider-side MESH_LLM_MAX_ITERATIONS primarily affects
- * non-forwarding / other-language / raw callers.
+ * the param is ABSENT. Since #1360, run()/stream() forward max_iterations only
+ * when the consumer explicitly configured it (runtime option → consumer env →
+ * user config); when unset, no cap is forwarded and this provider-side
+ * MESH_LLM_MAX_ITERATIONS governs — parity with Python/Java.
  */
 export function resolveMaxIterations(paramValue: unknown): number {
   const DEFAULT = 10;

--- a/src/runtime/typescript/src/llm.ts
+++ b/src/runtime/typescript/src/llm.ts
@@ -161,7 +161,12 @@ export interface LlmToolConfig {
   tags: string[];
   provider: LlmProviderSpec;
   model?: string;
-  maxIterations: number;
+  // Issue #1360: `undefined` = the consumer configured NOTHING (no decorator
+  // arg). Preserved (not defaulted to 10 here) so the forwarding path can tell
+  // "user asked for 10" from "user said nothing" and only forward an explicit
+  // cap — leaving an unset cap lets the provider's MESH_LLM_MAX_ITERATIONS
+  // govern. Local-use sites apply `?? 10`.
+  maxIterations?: number;
   systemPrompt?: string;
   contextParam?: string;
   filter?: LlmFilterSpec[];
@@ -231,7 +236,12 @@ export function llm<
     tags: config.tags ?? [],
     provider: config.provider,
     model: config.model,
-    maxIterations: config.maxIterations ?? 10,
+    // Issue #1360: preserve the RAW user value (undefined when unset). The
+    // default of 10 is applied only at LOCAL-use sites (the consumer's own loop
+    // cap, the Rust core spec). Defaulting here would make "unset" look explicit
+    // and forward a defaulted 10 onto the wire, shadowing the provider's
+    // MESH_LLM_MAX_ITERATIONS (parity gap with Python/Java).
+    maxIterations: config.maxIterations,
     systemPrompt: config.systemPrompt,
     contextParam: config.contextParam,
     filter: config.filter,
@@ -481,8 +491,9 @@ export function buildLlmAgentSpecs(): Array<{
     const resolvedFilterMode =
       process.env.MESH_LLM_FILTER_MODE || config.filterMode;
 
-    // MESH_LLM_MAX_ITERATIONS: Override max iterations
-    const resolvedMaxIterations = envMaxIterations() ?? config.maxIterations;
+    // MESH_LLM_MAX_ITERATIONS: Override max iterations. Local-use site — the
+    // Rust core spec needs a concrete cap, so default to 10 when unset (#1360).
+    const resolvedMaxIterations = envMaxIterations() ?? config.maxIterations ?? 10;
 
     specs.push({
       functionId: config.functionId,


### PR DESCRIPTION
## Summary

A TypeScript LLM consumer forwarded `model_params.max_iterations` to the provider **unconditionally**, so a provider operator's `MESH_LLM_MAX_ITERATIONS` env was permanently inert for TS consumers. Python and Java forward it **only when explicitly configured**, letting the provider env govern an unset consumer — TS was the outlier.

Root cause: `llm.ts` built config with `maxIterations: config.maxIterations ?? 10`, erasing the "user set nothing" distinction at build time, so the downstream resolution always yielded a number and the forwarding guard always fired.

- **`llm.ts` / `llm-agent.ts`:** `maxIterations` config is now `number | undefined` (undefined = user configured nothing); the `?? 10` default moved from build time to the **local-use sites** — mirroring Python's `Optional[int] = None` + effective-default and Java's `MAX_ITERATIONS_UNSET` sentinel.
- **`run()` / `stream()`** resolve a forwarded value (runtime option → consumer env → user config; `undefined` otherwise) and derive the local loop cap as `forwarded ?? 10`. The wire guard **omits `max_iterations`** when the forwarded value is `undefined`, so the provider's `MESH_LLM_MAX_ITERATIONS` governs an unconfigured TS consumer.
- **No #1355 regression:** the consumer's own loop cap still defaults to 10 — the `while (iteration < maxIterations)` bound, the exhaustion `MaxIterationsError`, and the Rust-core spec all still receive a concrete number.
- Precedence single-sourced in a `resolveForwardedMaxIterations()` helper.

## Review notes

- Independent diff review: **0 blockers, 1 warning, 1 info**. The reviewer traced the core omit property and confirmed no default (10) leaks onto the wire, no #1355 regression, and that the tests genuinely prove key-absence (the request round-trips through `JSON.stringify`/`parse`, so an `undefined`-valued key can't survive).
- **Warning fixed:** a stale `resolveMaxIterations` docstring in `llm-provider.ts` stated the exact inverse of the new behavior — rewritten to describe the current forwarding contract.
- **Info folded in:** the duplicated resolution chain in `run()`/`stream()` is extracted into a shared `resolveForwardedMaxIterations()` helper so the precedence is single-sourced.
- Benign semantics refinement noted by the reviewer: an *invalid* explicit option (e.g. `0`/`-1`/`0.5`) now sanitizes to `undefined` and defers to env/config/omit, rather than forwarding the old defaulted `10` — the intended "invalid = not an explicit cap" behavior.

## Verification

- `tsc` clean; full TS suite **1208 tests, 0 failures** (`llm-max-iterations.test.ts`: 63, incl. 5 new — omit-when-unset, explicit option/env/config forwarding, and local-cap-preserved).

## Test plan

- [ ] CI green (TypeScript build + full test suite)
- [ ] Manual: a TS consumer with nothing configured, against a provider whose host sets `MESH_LLM_MAX_ITERATIONS=N`, runs the provider-managed loop with cap N (not 10)
- [ ] Manual: a TS consumer with an explicit `maxIterations` (option/env/config) still forwards that value

Closes #1360
