### PR TITLE
test(llm): integration coverage for max_iterations exhaustion + forwarding

### DIFF
--- a/tests/integration/suites/uc04_llm_integration/tc48_max_iterations_typed_error_py/artifacts/ticket-agent-typed/main.py
+++ b/tests/integration/suites/uc04_llm_integration/tc48_max_iterations_typed_error_py/artifacts/ticket-agent-typed/main.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+ticket-agent-typed - Python @mesh.llm consumer that CATCHES the typed
+buffered-exhaustion error (issue #1355).
+
+WHAT #1355 CHANGED
+------------------
+Before #1355 the Python provider-managed agentic loop signalled exhaustion by
+returning a synthetic assistant string ("Maximum tool call iterations reached").
+#1355 removed that sentinel: the loop now surfaces a STRUCTURAL discriminant
+(``_mesh_stop_reason == "max_iterations"``) and the consumer's MeshLlmAgent
+RAISES a typed ``mesh.MaxIterationsError`` (see
+_mcp_mesh/engine/mesh_llm_agent.py). The failure is NEVER carried in ``content``.
+
+WHAT THIS AGENT PROVES
+----------------------
+That a capped buffered call raises ``mesh.MaxIterationsError`` (the public
+export) rather than returning a completed answer or the old sentinel text. The
+handler catches the type and re-emits a machine-checkable sentinel that names
+the exception CLASS and its ``max_allowed`` attribute:
+
+    EXHAUSTED_TYPED type=MaxIterationsError max=1
+
+The tc asserts on that class name — deliberately NOT on the removed
+"Maximum tool call iterations reached" string.
+
+DETERMINISM (shared with tc45/tc46/tc47)
+----------------------------------------
+Configured with an explicit ``max_iterations=1`` and filtered to the single
+``iteration_probe`` capability (advance_ticket) on iteration-probe-agent. The
+probe ticket needs FOUR advance_ticket rounds to reach COMPLETE, so a cap of 1
+forces the loop to exhaust after exactly one tool round. The tc reads the
+probe's out-of-band invocation counter to prove one round ran (PROBE_INVOCATIONS
+=[1]); a [0] count would mean the model answered without the tool and nothing
+was measured.
+"""
+
+from fastmcp import FastMCP
+from pydantic import BaseModel, Field
+
+import mesh
+
+app = FastMCP("TicketAgentTyped")
+
+
+class TicketContext(BaseModel):
+    """Context for the ticket-processing request."""
+
+    instruction: str = Field(
+        ..., description="Instruction describing the multi-step ticket to process"
+    )
+
+
+@app.tool()
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["+claude", "+provider"]},
+    # Only advance_ticket is exposed to the model. probe_count / probe_reset sit
+    # on DIFFERENT capabilities so the model can neither read nor reset the
+    # counter it is being measured with.
+    filter={"capability": "iteration_probe"},
+    # Explicit cap -> forwarded as model_params.max_iterations. Combined with the
+    # 4-step ticket this forces the provider-managed loop to exhaust.
+    max_iterations=1,
+    system_prompt=(
+        "You are a ticket-processing agent. You MUST use the advance_ticket "
+        "tool to make progress on a ticket; never guess, fabricate or predict a "
+        "token, a step number or a final_code. Call advance_ticket AT MOST ONCE "
+        "per turn and wait for its result before calling it again — the token "
+        "for the next call only exists in the previous call's response. Keep "
+        "going until the tool reports status COMPLETE, then reply with the "
+        "final_code it returned."
+    ),
+    context_param="ctx",
+)
+@mesh.tool(
+    capability="run_ticket",
+    description="Drive the probe ticket to completion using the advance_ticket tool",
+    version="1.0.0",
+    tags=["llm", "ticket", "iteration"],
+)
+async def run_ticket(
+    ctx: TicketContext,
+    llm: mesh.MeshLlmAgent = None,
+) -> str:
+    """Hand the ticket to the mesh LLM provider and catch typed exhaustion.
+
+    A capped provider-managed loop RAISES ``mesh.MaxIterationsError`` (issue
+    #1355) — the failure is structural and never appears in the returned text.
+    We convert it to a sentinel that names the exception class so the test can
+    assert on the TYPE rather than any (removed) sentinel string.
+    """
+    if llm is None:
+        raise RuntimeError("Mesh provider not resolved for run_ticket")
+
+    try:
+        return await llm(ctx.instruction)
+    except mesh.MaxIterationsError as e:
+        return f"EXHAUSTED_TYPED type={type(e).__name__} max={e.max_allowed}"
+
+
+@mesh.agent(
+    name="ticket-agent-typed",
+    version="1.0.0",
+    description="Consumer that catches typed buffered exhaustion (issue #1355)",
+    http_port=9048,
+    enable_http=True,
+    auto_run=True,
+)
+class TicketAgentTypedConfig:
+    """Consumer agent for the buffered typed-exhaustion tc."""
+
+    pass

--- a/tests/integration/suites/uc04_llm_integration/tc48_max_iterations_typed_error_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc48_max_iterations_typed_error_py/test.yaml
@@ -1,0 +1,197 @@
+# Test Case: buffered exhaustion RAISES a typed error - Python (issue #1355)
+#
+# Issue: https://github.com/dhyansraj/mcp-mesh/issues/1355
+#
+# WHAT #1355 CHANGED
+#   The Python provider-managed agentic loop used to signal exhaustion by
+#   RETURNING a synthetic assistant string ("Maximum tool call iterations
+#   reached"). #1355 removed that sentinel: exhaustion is now STRUCTURAL
+#   (_mesh_stop_reason == "max_iterations", carried in _mesh_frame — never in
+#   `content`), and the consumer's MeshLlmAgent RAISES a typed
+#   mesh.MaxIterationsError.
+#
+# WHAT THIS TC PROVES
+#   A buffered (non-streaming) capped call raises mesh.MaxIterationsError — the
+#   public export — rather than returning a completed answer or the removed
+#   sentinel string. The consumer (ticket-agent-typed) catches the type and
+#   re-emits a machine-checkable sentinel naming the CLASS and its max_allowed:
+#       EXHAUSTED_TYPED type=MaxIterationsError max=1
+#   The assertion targets the class name, NOT the old "Maximum tool call
+#   iterations reached" text (which this PR removed).
+#
+# DETERMINISM (shared with tc45/tc46/tc47)
+#   Consumer configured with an explicit max_iterations=1 and filtered to the
+#   single iteration_probe capability (advance_ticket on iteration-probe-agent).
+#   The probe ticket needs FOUR advance_ticket rounds to reach COMPLETE, so the
+#   cap of 1 forces exhaustion after exactly one tool round. The probe's
+#   out-of-band invocation counter (probe_count / probe_reset — capabilities the
+#   consumer filter never matches, so the model can neither read nor reset them)
+#   is the structural observable:
+#       cap honored (=1)  -> PROBE_INVOCATIONS=[1]  + typed error   PASS
+#       model answered w/o tool -> PROBE_INVOCATIONS=[0]            infra miss
+#   Claude (temperature 0.0, parallel_tool_calls OFF) most reliably invokes the
+#   tool and honors "one call per turn"; advance_ticket's unguessable random
+#   next_token enforces that serialization structurally.
+
+name: "Buffered exhaustion raises typed MaxIterationsError - Py"
+description: "Issue #1355: a capped buffered @mesh.llm call raises mesh.MaxIterationsError (structural _mesh_stop_reason signal), not the removed exhaustion sentinel string"
+tags:
+  - llm
+  - claude
+  - python
+  - tools
+  - max-iterations
+  - issue-1355
+timeout: 300
+# LLM test: needs a real ANTHROPIC_API_KEY and the tsuite-mesh:local image.
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+test:
+  # --- Copy artifacts ---
+  - name: "Copy Claude provider to workspace"
+    handler: shell
+    command: "cp -rL /uc-artifacts/claude-provider /workspace/"
+    capture: copy_provider_output
+  - name: "Copy iteration-probe-agent to workspace"
+    handler: shell
+    command: "cp -rL /uc-artifacts/iteration-probe-agent /workspace/"
+    capture: copy_probe_output
+  - name: "Copy ticket-agent-typed to workspace"
+    handler: shell
+    command: "cp -rL /artifacts/ticket-agent-typed /workspace/"
+    capture: copy_consumer_output
+  - name: "Create env file with secrets"
+    handler: secrets
+    target: /workspace/.env
+  - name: "Verify workspace files"
+    handler: shell
+    command: "ls -la /workspace/"
+    capture: ls_output
+
+  # --- Start the probe tool provider ---
+  - name: "Start iteration-probe-agent"
+    handler: shell
+    command: "meshctl start iteration-probe-agent/main.py -d"
+    workdir: /workspace
+    capture: start_probe_output
+  - name: "Wait for probe agent to register"
+    handler: wait
+    seconds: 5
+
+  # --- Start the LLM provider (NO MESH_LLM_MAX_ITERATIONS: the provider default
+  #     is 10, so any cap observed below can ONLY have come from the consumer's
+  #     explicitly-forwarded max_iterations=1). ---
+  - name: "Start Claude provider (no provider-side cap)"
+    handler: shell
+    command: "meshctl start claude-provider/main.py --env-file .env -d"
+    workdir: /workspace
+    capture: start_provider_output
+  - name: "Wait for provider to register"
+    handler: wait
+    seconds: 15
+
+  # --- Start the consumer (max_iterations=1, catches the typed error) ---
+  - name: "Start ticket-agent-typed (max_iterations=1)"
+    handler: shell
+    command: "meshctl start ticket-agent-typed/main.py -d --debug"
+    workdir: /workspace
+    capture: start_consumer_output
+  - name: "Wait for consumer to register and resolve dependencies"
+    handler: wait
+    seconds: 15
+  - name: "Verify all agents running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: all_list_output
+  - name: "List available tools"
+    handler: shell
+    command: "meshctl list -t"
+    workdir: /workspace
+    capture: tools_output
+
+  # --- Zero the counter right before the measured call ---
+  - name: "Reset the probe invocation counter"
+    handler: shell
+    command: "meshctl call probe_reset '{}'"
+    workdir: /workspace
+    capture: reset_output
+
+  # --- THE MEASURED CALL (exactly one; never retried) ---
+  - name: "Call run_ticket (single measured call)"
+    handler: shell
+    command: |
+      meshctl call run_ticket '{"ctx": {"instruction": "Process ticket ABC-1 to completion. Begin by calling advance_ticket with token \"START\". Each response gives you a next_token; call advance_ticket again with it. Keep going until the tool reports status COMPLETE, then reply with the final_code."}}'
+    workdir: /workspace
+    capture: ticket_response
+    timeout: 180
+
+  # --- Read the counter: proves one provider-managed tool round ran ---
+  - name: "Read the probe invocation counter"
+    handler: shell
+    command: "meshctl call probe_count '{}'"
+    workdir: /workspace
+    capture: probe_count_output
+
+  - name: "Capture consumer log tail (diagnostics)"
+    handler: shell
+    command: "meshctl logs ticket-agent-typed 2>/dev/null | tail -80 || true"
+    workdir: /workspace
+    capture: consumer_log
+    ignore_errors: true
+
+  - name: "Stop all agents"
+    handler: shell
+    command: "meshctl stop"
+    workdir: /workspace
+    ignore_errors: true
+
+assertions:
+  # --- Infrastructure (must hold for the measurement to mean anything) ---
+  - expr: ${captured.all_list_output} contains 'iteration-probe-agent'
+    message: "iteration-probe-agent should be registered"
+  - expr: ${captured.all_list_output} contains 'claude-provider'
+    message: "claude-provider should be registered"
+  - expr: ${captured.all_list_output} contains 'ticket-agent-typed'
+    message: "ticket-agent-typed should be registered"
+  - expr: ${captured.tools_output} contains 'run_ticket'
+    message: "run_ticket tool should be listed"
+  - expr: ${captured.tools_output} contains 'advance_ticket'
+    message: "advance_ticket tool should be listed"
+  - expr: ${captured.reset_output} contains 'PROBE_RESET_OK'
+    message: "Counter should be reset before the measured call"
+
+  # --- THE OBSERVABLE: buffered exhaustion raised the TYPED error ---
+  - expr: ${captured.ticket_response} contains 'EXHAUSTED_TYPED type=MaxIterationsError'
+    message: "A capped buffered call must raise mesh.MaxIterationsError (issue #1355), which the consumer catches and reports by class name"
+  # Guard against the removed sentinel leaking back as text.
+  - expr: ${captured.ticket_response} not contains 'Maximum tool call iterations reached'
+    message: "The removed exhaustion sentinel string must NOT appear — the signal is structural, not text in content (issue #1355)"
+
+  # --- Exactly one provider-managed tool round ran ---
+  - expr: ${captured.probe_count_output} contains 'PROBE_INVOCATIONS=[1]'
+    message: "The provider-managed loop should have executed advance_ticket EXACTLY ONCE before exhausting (max_iterations=1)"
+  - expr: ${captured.probe_count_output} not contains 'PROBE_INVOCATIONS=[0]'
+    message: "advance_ticket should have run at least once (a zero count means the model never called the tool, so nothing was measured)"
+
+  # --- Secondary, sentinel-independent evidence the loop stopped early:
+  #     the final_code only exists after the 4th round, so a capped run cannot
+  #     have seen it. ---
+  - expr: ${captured.ticket_response} not contains 'PROBE-COMPLETE-9F3A'
+    message: "A run capped at 1 iteration cannot have driven the ticket to completion (final_code must be absent)"
+
+  # --- No infrastructure failure masquerading as the typed error ---
+  - expr: ${captured.ticket_response} not contains 'Mesh provider not resolved'
+    message: "The consumer's LLM provider should have been resolved"
+  - expr: ${captured.ticket_response} not contains 'timed out'
+    message: "The measured call should not time out"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc04_llm_integration/tc49_max_iterations_ts_forwarding_py/artifacts/ticket-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc49_max_iterations_ts_forwarding_py/artifacts/ticket-consumer-ts/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ticket-consumer-ts",
+  "version": "1.0.0",
+  "description": "MCP Mesh TS consumer with unset maxIterations (issue #1360)",
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "@mcpmesh/sdk": "^3.2.3",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/tests/integration/suites/uc04_llm_integration/tc49_max_iterations_ts_forwarding_py/artifacts/ticket-consumer-ts/src/index.ts
+++ b/tests/integration/suites/uc04_llm_integration/tc49_max_iterations_ts_forwarding_py/artifacts/ticket-consumer-ts/src/index.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env npx tsx
+/**
+ * ticket-consumer-ts - TypeScript @mesh.llm consumer that forwards NOTHING
+ * (issue #1360) and catches the typed exhaustion error (issue #1355).
+ *
+ * WHAT #1360 FIXED (the fix site is THIS consumer)
+ * ------------------------------------------------
+ * Before #1360 the TS consumer unconditionally forwarded `max_iterations: 10`
+ * on the wire even when the user configured nothing, which SHADOWED any
+ * provider-side MESH_LLM_MAX_ITERATIONS and made the provider's env inert.
+ * After #1360 an UNSET `maxIterations` forwards no `max_iterations` at all, so
+ * the provider's own MESH_LLM_MAX_ITERATIONS governs the loop.
+ *
+ * This consumer therefore declares NO `maxIterations`. In the tc the Python
+ * provider is started with MESH_LLM_MAX_ITERATIONS=1 (on a private --env, not
+ * the shared .env, so it can never leak to this consumer). If the fix holds,
+ * the provider's env caps the loop at ONE tool round (PROBE_INVOCATIONS=[1]);
+ * the pre-#1360 regression would forward 10, shadow the provider env, and let
+ * the 4-step ticket run to completion (PROBE_INVOCATIONS=[4]).
+ *
+ * WHAT #1355 ADDED (observed here)
+ * --------------------------------
+ * On exhaustion the provider signals `_mesh_stop_reason == "max_iterations"`
+ * (structural, never in `content`) and the TS MeshLlmAgent throws
+ * `MaxIterationsError`. We catch it and return a sentinel naming the class so
+ * the tc asserts on the TYPE, not the removed "Maximum tool call iterations
+ * reached" string.
+ */
+
+import { FastMCP, mesh, MaxIterationsError } from "@mcpmesh/sdk";
+import { z } from "zod";
+
+const server = new FastMCP({
+  name: "Ticket Consumer TS",
+  version: "1.0.0",
+});
+
+const runTicketTs = mesh.llm({
+  name: "run_ticket_ts",
+  capability: "run_ticket_ts",
+  description: "Drive the probe ticket using the advance_ticket tool (TS consumer)",
+  tags: ["llm", "ticket", "iteration", "typescript"],
+  version: "1.0.0",
+
+  // Mesh delegation to the Python Claude provider.
+  provider: { capability: "llm", tags: ["+claude", "+provider"] },
+
+  // Only advance_ticket (capability "iteration_probe") is exposed to the model.
+  // probe_count / probe_reset sit on different capabilities so the model can
+  // neither read nor reset the counter it is being measured with.
+  filter: [{ capability: "iteration_probe" }],
+  filterMode: "all",
+
+  // THE THING UNDER TEST (#1360): NO maxIterations. An unset cap must forward
+  // NOTHING so the provider's MESH_LLM_MAX_ITERATIONS governs the loop.
+  // (Do NOT add maxIterations here — that would defeat the regression guard.)
+
+  // Plain string result; the tool catches exhaustion before any parse.
+  returns: z.string(),
+
+  parameters: z.object({
+    ctx: z.object({
+      instruction: z.string().describe("Multi-step ticket instruction"),
+    }),
+  }),
+  contextParam: "ctx",
+
+  systemPrompt:
+    "You are a ticket-processing agent. You MUST use the advance_ticket tool " +
+    "to make progress on a ticket; never guess, fabricate or predict a token, " +
+    "a step number or a final_code. Call advance_ticket AT MOST ONCE per turn " +
+    "and wait for its result before calling it again - the token for the next " +
+    "call only exists in the previous call's response. Keep going until the " +
+    "tool reports status COMPLETE, then reply with the final_code it returned.",
+
+  execute: async ({ ctx }, { llm }) => {
+    try {
+      return await llm(ctx.instruction);
+    } catch (e) {
+      if (e instanceof MaxIterationsError) {
+        // Typed exhaustion (#1355) — name the class so the tc asserts on TYPE.
+        return `EXHAUSTED_TYPED type=${e.name}`;
+      }
+      throw e;
+    }
+  },
+});
+
+server.addTool(runTicketTs);
+
+const agent = mesh(server, {
+  name: "ticket-consumer-ts",
+  version: "1.0.0",
+  description:
+    "TS consumer with UNSET maxIterations — defers to provider env (issue #1360)",
+  httpPort: 9049,
+});
+
+console.log(
+  "ticket-consumer-ts initialized. Waiting for mesh connections..."
+);

--- a/tests/integration/suites/uc04_llm_integration/tc49_max_iterations_ts_forwarding_py/artifacts/ticket-consumer-ts/tsconfig.json
+++ b/tests/integration/suites/uc04_llm_integration/tc49_max_iterations_ts_forwarding_py/artifacts/ticket-consumer-ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/integration/suites/uc04_llm_integration/tc49_max_iterations_ts_forwarding_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc49_max_iterations_ts_forwarding_py/test.yaml
@@ -1,0 +1,207 @@
+# Test Case: TS consumer forwarding parity - an UNSET cap defers to provider env
+#
+# Issue: https://github.com/dhyansraj/mcp-mesh/issues/1360
+#
+# WHAT #1360 FIXED (the fix site is the TS CONSUMER)
+#   Before #1360 the TypeScript consumer unconditionally put max_iterations=10
+#   on the wire even when the user configured NOTHING. That defaulted value
+#   SHADOWED any provider-side MESH_LLM_MAX_ITERATIONS, making the provider env
+#   inert. After #1360 an UNSET maxIterations forwards no max_iterations at all,
+#   so the provider's own MESH_LLM_MAX_ITERATIONS governs the loop.
+#
+# SETUP (mirrors tc46, but the consumer is TypeScript)
+#   Consumer (ticket-consumer-ts): declares NO maxIterations, filters in exactly
+#     the iteration_probe capability (advance_ticket).
+#   Provider (claude-provider, Python): started with MESH_LLM_MAX_ITERATIONS=1 in
+#     its OWN environment, passed via --env (NOT the shared .env) so the cap can
+#     only ever reach the provider process, never the TS consumer (the
+#     load-bearing isolation from tc46).
+#
+# WHY THE ASSERTION REALLY DISCRIMINATES
+#   The observable is the probe agent's tool-invocation counter (out-of-band on
+#   probe_count / probe_reset, which the consumer filter never matches). The
+#   ticket needs FOUR advance_ticket rounds to reach COMPLETE, so:
+#       fix applied: TS forwards nothing -> provider env (1) caps -> [1]   PASS
+#       pre-#1360:   TS forwards 10 -> shadows provider env -> ticket runs
+#                    to completion -> [4]                                  FAIL
+#   So [1] vs [4] cleanly separates "unset forwards nothing" from the exact
+#   regression #1360 fixed. On exhaustion the TS MeshLlmAgent also RAISES the
+#   typed MaxIterationsError (issue #1355), which the consumer catches and
+#   reports by class name.
+#
+# WHY CLAUDE: tool-calling determinism (temperature 0.0, parallel_tool_calls
+#   OFF). advance_ticket's unguessable random next_token enforces one-call-
+#   per-turn serialization structurally; Claude makes it reliable in practice.
+
+name: "Unset TS consumer cap defers to provider env - TS->Py"
+description: "Issue #1360: a TS @mesh.llm consumer with NO maxIterations forwards nothing, so the Python provider's MESH_LLM_MAX_ITERATIONS=1 caps the provider-managed loop at one tool round (pre-fix it forwarded 10 and shadowed the env)"
+tags:
+  - llm
+  - claude
+  - typescript
+  - python
+  - cross-runtime
+  - tools
+  - max-iterations
+  - issue-1360
+timeout: 300
+# LLM test: needs a real ANTHROPIC_API_KEY and the tsuite-mesh:local image.
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+  - routine: global.setup_for_typescript_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+test:
+  # --- Copy artifacts ---
+  - name: "Copy Claude provider to workspace"
+    handler: shell
+    command: "cp -rL /uc-artifacts/claude-provider /workspace/"
+    capture: copy_provider_output
+  - name: "Copy iteration-probe-agent to workspace"
+    handler: shell
+    command: "cp -rL /uc-artifacts/iteration-probe-agent /workspace/"
+    capture: copy_probe_output
+  - name: "Copy ticket-consumer-ts to workspace"
+    handler: shell
+    command: "cp -rL /artifacts/ticket-consumer-ts /workspace/"
+    capture: copy_consumer_output
+  - name: "Create env file with secrets"
+    handler: secrets
+    target: /workspace/.env
+  - name: "Verify workspace files"
+    handler: shell
+    command: "ls -la /workspace/"
+    capture: ls_output
+
+  # --- Install TS consumer deps ---
+  - name: "Install npm dependencies for the TS consumer"
+    handler: npm-install
+    path: /workspace/ticket-consumer-ts
+
+  # --- Start the probe tool provider ---
+  - name: "Start iteration-probe-agent"
+    handler: shell
+    command: "meshctl start iteration-probe-agent/main.py -d"
+    workdir: /workspace
+    capture: start_probe_output
+  - name: "Wait for probe agent to register"
+    handler: wait
+    seconds: 5
+
+  # --- Start the Python LLM provider WITH its own cap in the environment. The
+  #     cap is passed via --env (NOT the shared .env) so it can only ever reach
+  #     the provider process, never the TS consumer. ---
+  - name: "Start Claude provider with MESH_LLM_MAX_ITERATIONS=1 (private --env)"
+    handler: shell
+    command: "meshctl start claude-provider/main.py --env-file .env --env MESH_LLM_MAX_ITERATIONS=1 -d"
+    workdir: /workspace
+    capture: start_provider_output
+  - name: "Wait for provider to register"
+    handler: wait
+    seconds: 15
+
+  # --- Start the TS consumer that configures NO cap ---
+  - name: "Start ticket-consumer-ts (no configured cap)"
+    handler: shell
+    command: "meshctl start ticket-consumer-ts/src/index.ts --env MCP_MESH_HTTP_PORT=9049 -d"
+    workdir: /workspace
+    capture: start_consumer_output
+  - name: "Wait for consumer to register and resolve dependencies"
+    handler: wait
+    seconds: 20
+  - name: "Verify all agents running"
+    handler: shell
+    command: "meshctl list"
+    workdir: /workspace
+    capture: all_list_output
+  - name: "List available tools"
+    handler: shell
+    command: "meshctl list -t"
+    workdir: /workspace
+    capture: tools_output
+
+  # --- Zero the counter right before the measured call ---
+  - name: "Reset the probe invocation counter"
+    handler: shell
+    command: "meshctl call probe_reset '{}'"
+    workdir: /workspace
+    capture: reset_output
+
+  # --- THE MEASURED CALL (exactly one; never retried) ---
+  - name: "Call run_ticket_ts (single measured call)"
+    handler: shell
+    command: |
+      meshctl call run_ticket_ts '{"ctx": {"instruction": "Process ticket ABC-1 to completion. Begin by calling advance_ticket with token \"START\". Each response gives you a next_token; call advance_ticket again with it. Keep going until the tool reports status COMPLETE, then reply with the final_code."}}'
+    workdir: /workspace
+    capture: ticket_response
+    timeout: 180
+
+  # --- Read the counter: THE observable ---
+  - name: "Read the probe invocation counter"
+    handler: shell
+    command: "meshctl call probe_count '{}'"
+    workdir: /workspace
+    capture: probe_count_output
+
+  - name: "Capture consumer log tail (diagnostics)"
+    handler: shell
+    command: "meshctl logs ticket-consumer-ts 2>/dev/null | tail -80 || true"
+    workdir: /workspace
+    capture: consumer_log
+    ignore_errors: true
+
+  - name: "Stop all agents"
+    handler: shell
+    command: "meshctl stop"
+    workdir: /workspace
+    ignore_errors: true
+
+assertions:
+  # --- Infrastructure ---
+  - expr: ${captured.all_list_output} contains 'iteration-probe-agent'
+    message: "iteration-probe-agent should be registered"
+  - expr: ${captured.all_list_output} contains 'claude-provider'
+    message: "claude-provider should be registered"
+  - expr: ${captured.all_list_output} contains 'ticket-consumer-ts'
+    message: "ticket-consumer-ts should be registered"
+  - expr: ${captured.tools_output} contains 'run_ticket_ts'
+    message: "run_ticket_ts tool should be listed"
+  - expr: ${captured.tools_output} contains 'advance_ticket'
+    message: "advance_ticket tool should be listed"
+  - expr: ${captured.reset_output} contains 'PROBE_RESET_OK'
+    message: "Counter should be reset before the measured call"
+
+  # --- THE OBSERVABLE: the PROVIDER's env cap took effect ---
+  # [1] = the TS consumer forwarded nothing, so the provider's env (1) governed.
+  # [4] = the ticket ran to completion, meaning the TS consumer forwarded a
+  #       default (10) that shadowed the provider env — the pre-#1360 regression.
+  - expr: ${captured.probe_count_output} contains 'PROBE_INVOCATIONS=[1]'
+    message: "Provider's MESH_LLM_MAX_ITERATIONS=1 should cap the loop at exactly one tool round (an unset TS consumer must forward nothing)"
+  - expr: ${captured.probe_count_output} not contains 'PROBE_INVOCATIONS=[0]'
+    message: "advance_ticket should have run at least once (a zero count means the model never called the tool, so nothing was measured)"
+
+  # --- The TS consumer surfaced the typed exhaustion error (issue #1355) ---
+  - expr: ${captured.ticket_response} contains 'EXHAUSTED_TYPED type=MaxIterationsError'
+    message: "On exhaustion the TS MeshLlmAgent must raise MaxIterationsError, which the consumer catches and reports by class name"
+
+  # --- Secondary, sentinel-independent evidence the loop stopped early ---
+  - expr: ${captured.ticket_response} not contains 'PROBE-COMPLETE-9F3A'
+    message: "A run capped at 1 iteration cannot have driven the ticket to completion (final_code must be absent)"
+
+  # --- No infrastructure failure masquerading as a small count ---
+  - expr: ${captured.ticket_response} not contains 'timed out'
+    message: "The measured call should not time out"
+  - expr: "${captured.ticket_response} not contains '\"isError\":true'"
+    message: "The measured call should not return an MCP error envelope"
+  - expr: "${captured.ticket_response} not contains '\"isError\": true'"
+    message: "The measured call should not return an MCP error envelope (spaced form)"
+
+post_run:
+  - handler: shell
+    command: "meshctl stop 2>/dev/null || true"
+    workdir: /workspace
+    ignore_errors: true
+  - routine: global.cleanup_workspace

--- a/tests/integration/suites/uc04_llm_integration/tc50_max_iterations_streaming_java_py/artifacts/stream-gateway-java/pom.xml
+++ b/tests/integration/suites/uc04_llm_integration/tc50_max_iterations_streaming_java_py/artifacts/stream-gateway-java/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>stream-gateway-java</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Streaming Max-Iterations Java Gateway (issue #1369)</name>
+    <description>Java @MeshLlm streaming consumer + SSE gateway; forwards MeshSse over a capped streaming loop to surface MeshMaxIterationsException (issue #1369)</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>4.0.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <!-- maven-install handler aligns this from the container's ~/.m2 repo -->
+        <mcp-mesh.version>3.2.3</mcp-mesh.version>
+    </properties>
+
+    <dependencies>
+        <!-- MCP Mesh Spring Boot Starter (provides @MeshAgent, MeshSse, MeshHealthController) -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-boot-starter</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- MCP Mesh Spring AI Integration (provides @MeshLlm + MeshLlmAgent) -->
+        <dependency>
+            <groupId>io.mcp-mesh</groupId>
+            <artifactId>mcp-mesh-spring-ai</artifactId>
+            <version>${mcp-mesh.version}</version>
+        </dependency>
+
+        <!-- Spring Boot Web (HTTP server + SseEmitter) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <mainClass>com.example.streamgateway.StreamGatewayApplication</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>spring-milestones</id>
+            <name>Spring Milestones</name>
+            <url>https://repo.spring.io/milestone</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+</project>

--- a/tests/integration/suites/uc04_llm_integration/tc50_max_iterations_streaming_java_py/artifacts/stream-gateway-java/src/main/java/com/example/streamgateway/StreamGatewayApplication.java
+++ b/tests/integration/suites/uc04_llm_integration/tc50_max_iterations_streaming_java_py/artifacts/stream-gateway-java/src/main/java/com/example/streamgateway/StreamGatewayApplication.java
@@ -1,0 +1,258 @@
+package com.example.streamgateway;
+
+import io.mcpmesh.FilterMode;
+import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshLlm;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+import io.mcpmesh.spring.web.MeshSse;
+import io.mcpmesh.types.MeshLlmAgent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Streaming max-iterations Java gateway — issue #1369 (PR #1371).
+ *
+ * <p>WHAT #1369 FIXED (the streaming half of Java's #1355 participation): a
+ * Python streaming provider frames every stream chunk as a typed
+ * {@code _mesh_frame} JSON string. The Java streaming consumer
+ * ({@code MeshLlmAgentProxy.streamGenerate()}) used to be a raw
+ * {@code Flow.Publisher<String>} passthrough, so it (a) leaked the frame JSON to
+ * callers and (b) never surfaced streaming exhaustion. #1371 wraps the stream in
+ * {@code StreamFrameDecoder}, which unwraps {@code chunk} frames to plain
+ * content and, on an {@code end} frame carrying
+ * {@code stop_reason == "max_iterations"}, terminates the publisher with
+ * {@code onError(MeshMaxIterationsException)} — which {@link MeshSse#forward}
+ * renders as {@code event: error\ndata: {"type":"MeshMaxIterationsException"}}
+ * and OMITS {@code data: [DONE]}.
+ *
+ * <p>WHY A CAPTURE-INTO-HOLDER SHAPE: the mesh {@code MeshLlmAgent} proxy is
+ * only injected by the framework into a {@code @MeshTool}+{@code @MeshLlm}
+ * method's parameter — {@code @MeshRoute}/{@code @MeshDependency} inject
+ * {@code McpMeshTool} proxies (mesh tools/producers), NOT a {@code MeshLlmAgent}
+ * (Java has no streaming <em>producer</em>, deferred #1223). So the single
+ * {@code @MeshLlm} bind tool captures its injected proxy into a shared holder
+ * and the plain SSE routes forward {@code proxy.stream(...)} through
+ * {@code MeshSse.forward}. This still exercises the exact #1369 code path
+ * ({@code streamGenerate} → {@code StreamFrameDecoder} → {@code MeshSse}).
+ *
+ * <p>SINGLE {@code @MeshLlm} (issue #1141): the gateway declares EXACTLY ONE
+ * {@code @MeshLlm} function so its per-funcId proxy binds reliably (multiple
+ * {@code @MeshLlm} on one agent bind unreliably, #1141). Both routes share that
+ * one proxy: the CAPPED route uses the annotation's {@code maxIterations = 1}
+ * (forces exhaustion against the 4-step probe ticket); the NORMAL route raises
+ * the cap per-call via {@code modelParams("max_iterations", 10)} so the loop can
+ * complete and terminate with {@code [DONE]}.
+ */
+@MeshAgent(
+    name = "stream-gateway-java",
+    version = "1.0.0",
+    description = "Java streaming @MeshLlm consumer + SSE gateway (issue #1369)",
+    port = 9060
+)
+@SpringBootApplication
+public class StreamGatewayApplication {
+
+    private static final Logger log = LoggerFactory.getLogger(StreamGatewayApplication.class);
+
+    public static void main(String[] args) {
+        log.info("Starting Streaming Max-Iterations Java Gateway (single @MeshLlm)...");
+        SpringApplication.run(StreamGatewayApplication.class, args);
+    }
+
+    /** Ticket context record (the bind tool ignores it; present so @MeshLlm has a contextParam). */
+    public record TicketContext(String instruction) {}
+}
+
+/**
+ * Process-wide holder for the single injected {@link MeshLlmAgent} proxy.
+ *
+ * <p>Shared between {@link TicketLlmBinder} (which captures the framework-
+ * injected proxy) and {@link StreamController} (which forwards its stream).
+ */
+@Component
+class LlmProxyHolder {
+    private final AtomicReference<MeshLlmAgent> ref = new AtomicReference<>();
+
+    void set(MeshLlmAgent agent) {
+        ref.set(agent);
+    }
+
+    MeshLlmAgent get() {
+        return ref.get();
+    }
+
+    boolean isBound() {
+        MeshLlmAgent a = ref.get();
+        return a != null && a.isAvailable();
+    }
+}
+
+/**
+ * The gateway's ONLY {@code @MeshLlm} function: a readiness/bind tool.
+ *
+ * <p>Called by the test via {@code meshctl call bindProxy} until it returns
+ * {@code PROXY_BOUND}. On each call it captures the framework-injected
+ * {@link MeshLlmAgent} proxy into {@link LlmProxyHolder} so the SSE routes can
+ * forward its stream. It does NOT invoke the LLM, so it never increments the
+ * probe counter (the counter is reset right before the measured capped call).
+ */
+@Component
+class TicketLlmBinder {
+
+    private static final Logger log = LoggerFactory.getLogger(TicketLlmBinder.class);
+
+    /** Returned until the LLM proxy has bound — the test's readiness poll keys off this. */
+    static final String UNAVAILABLE = "LLM_UNAVAILABLE";
+
+    private final LlmProxyHolder holder;
+
+    TicketLlmBinder(LlmProxyHolder holder) {
+        this.holder = holder;
+    }
+
+    @MeshLlm(
+        // Streaming provider variant: the ai.mcpmesh.stream tag is REQUIRED in
+        // Java to resolve the Python provider's auto-generated
+        // process_chat_stream tool.
+        providerSelector = @Selector(capability = "llm", tags = {"+claude", "+provider", "ai.mcpmesh.stream"}),
+        // Annotation cap = 1 -> forwarded as model_params.max_iterations on the
+        // streaming path. The CAPPED route uses this directly; the NORMAL route
+        // overrides it up via per-call modelParams.
+        maxIterations = 1,
+        systemPrompt = "You are a ticket-processing agent. You MUST use the advance_ticket "
+            + "tool to make progress on a ticket; never guess, fabricate or predict a token, "
+            + "a step number or a final_code. Call advance_ticket AT MOST ONCE per turn and "
+            + "wait for its result before calling it again - the token for the next call only "
+            + "exists in the previous call's response. Keep going until the tool reports status "
+            + "COMPLETE, then reply with the final_code it returned.",
+        contextParam = "ctx",
+        filter = @Selector(capability = "iteration_probe"),
+        filterMode = FilterMode.ALL,
+        maxTokens = 2048,
+        temperature = 0.0
+    )
+    @MeshTool(
+        capability = "bindProxy",
+        description = "Bind (capture) the streaming LLM proxy; returns PROXY_BOUND once resolved",
+        tags = {"llm", "stream", "iteration", "java"}
+    )
+    public String bindProxy(
+        @Param(value = "ctx", description = "Ticket context (unused by the bind tool)")
+        StreamGatewayApplication.TicketContext ctx,
+        MeshLlmAgent llm
+    ) {
+        if (llm == null || !llm.isAvailable()) {
+            log.warn("Streaming LLM proxy not available yet");
+            return UNAVAILABLE;
+        }
+        holder.set(llm);
+        log.info("Captured streaming LLM proxy@{} into holder", System.identityHashCode(llm));
+        return "PROXY_BOUND";
+    }
+}
+
+/**
+ * SSE gateway: forwards the captured streaming LLM proxy over Spring
+ * {@link SseEmitter} via {@link MeshSse#forward}.
+ *
+ * <ul>
+ *   <li>{@code POST /stream/capped} — annotation {@code maxIterations = 1}
+ *       governs → the 4-step probe ticket forces exhaustion →
+ *       {@code event: error} + {@code MeshMaxIterationsException}, no
+ *       {@code [DONE]}.</li>
+ *   <li>{@code POST /stream/normal} — per-call {@code max_iterations = 10}
+ *       lets the loop complete → text chunks + {@code data: [DONE]}, no
+ *       error frame.</li>
+ * </ul>
+ */
+@RestController
+class StreamController {
+
+    private static final Logger log = LoggerFactory.getLogger(StreamController.class);
+
+    /** Standard 4-round probe-ticket instruction (matches tc45/tc46/tc47). */
+    private static final String DEFAULT_INSTRUCTION =
+        "Process ticket ABC-1 to completion. Begin by calling advance_ticket with token "
+        + "\"START\". Each response gives you a next_token; call advance_ticket again with it. "
+        + "Keep going until the tool reports status COMPLETE, then reply with the final_code.";
+
+    private final LlmProxyHolder holder;
+
+    StreamController(LlmProxyHolder holder) {
+        this.holder = holder;
+    }
+
+    private static String instructionFrom(Map<String, Object> body) {
+        if (body != null && body.get("instruction") instanceof String s && !s.isBlank()) {
+            return s;
+        }
+        return DEFAULT_INSTRUCTION;
+    }
+
+    private void emitUnavailable(SseEmitter emitter) {
+        try {
+            emitter.send(SseEmitter.event()
+                .name("error")
+                .data("{\"error\":\"LLM proxy not bound\",\"type\":\"ProxyUnavailable\"}"));
+            emitter.complete();
+        } catch (Exception e) {
+            emitter.completeWithError(e);
+        }
+    }
+
+    /**
+     * CAPPED stream: uses the annotation's maxIterations=1. Against the 4-step
+     * probe ticket the provider-managed streaming loop exhausts after one tool
+     * round; #1369 surfaces that as MeshMaxIterationsException → SSE error frame.
+     */
+    @PostMapping("/stream/capped")
+    public SseEmitter streamCapped(@RequestBody(required = false) Map<String, Object> body) {
+        SseEmitter emitter = new SseEmitter(0L);
+        MeshLlmAgent llm = holder.get();
+        if (llm == null || !llm.isAvailable()) {
+            emitUnavailable(emitter);
+            return emitter;
+        }
+        String instruction = instructionFrom(body);
+        log.info("Forwarding /stream/capped (max_iterations=1)");
+        // stream(prompt) forwards the annotation cap (=1) on the wire.
+        MeshSse.forward(emitter, llm.stream(instruction));
+        return emitter;
+    }
+
+    /**
+     * NORMAL stream: raises the cap per-call to 10 via the model_params escape
+     * hatch so the loop can drive the ticket to COMPLETE and terminate cleanly
+     * with [DONE] (regression control for the error-frame path).
+     */
+    @PostMapping("/stream/normal")
+    public SseEmitter streamNormal(@RequestBody(required = false) Map<String, Object> body) {
+        SseEmitter emitter = new SseEmitter(0L);
+        MeshLlmAgent llm = holder.get();
+        if (llm == null || !llm.isAvailable()) {
+            emitUnavailable(emitter);
+            return emitter;
+        }
+        String instruction = instructionFrom(body);
+        log.info("Forwarding /stream/normal (max_iterations=10)");
+        MeshSse.forward(
+            emitter,
+            llm.request()
+                .user(instruction)
+                .modelParams(Map.of("max_iterations", 10))
+                .streamGenerate());
+        return emitter;
+    }
+}

--- a/tests/integration/suites/uc04_llm_integration/tc50_max_iterations_streaming_java_py/artifacts/stream-gateway-java/src/main/resources/application.yml
+++ b/tests/integration/suites/uc04_llm_integration/tc50_max_iterations_streaming_java_py/artifacts/stream-gateway-java/src/main/resources/application.yml
@@ -1,0 +1,30 @@
+# Streaming Max-Iterations Java Gateway Configuration (issue #1369)
+#
+# Overridable via environment variables:
+#   MCP_MESH_REGISTRY_URL - Registry URL
+#   MCP_MESH_HTTP_PORT    - Agent HTTP port (also serves the SSE routes)
+#   MCP_MESH_AGENT_NAME   - Agent name
+
+spring:
+  application:
+    name: stream-gateway-java
+
+server:
+  # The @MeshAgent HTTP port also serves the @RestController SSE routes.
+  port: ${MCP_MESH_HTTP_PORT:9060}
+
+mesh:
+  registry:
+    url: ${MCP_MESH_REGISTRY_URL:http://localhost:8000}
+  agent:
+    name: ${MCP_MESH_AGENT_NAME:stream-gateway-java}
+    namespace: ${MCP_MESH_NAMESPACE:default}
+  llm:
+    default-provider:
+      capability: llm
+    timeout: 60000
+
+logging:
+  level:
+    io.mcpmesh: DEBUG
+    com.example: DEBUG

--- a/tests/integration/suites/uc04_llm_integration/tc50_max_iterations_streaming_java_py/test.yaml
+++ b/tests/integration/suites/uc04_llm_integration/tc50_max_iterations_streaming_java_py/test.yaml
@@ -1,0 +1,327 @@
+# Test Case: Java streaming frame unwrap + streaming exhaustion over SSE
+#
+# Issue: https://github.com/dhyansraj/mcp-mesh/issues/1369  (PR #1371)
+#
+# WHAT #1369 FIXED (the streaming half of Java's #1355 participation)
+#   A Python streaming provider frames every stream chunk as a typed
+#   _mesh_frame JSON string. The Java streaming consumer
+#   (MeshLlmAgentProxy.streamGenerate()) was a raw Flow.Publisher<String>
+#   passthrough, so it (a) LEAKED the frame JSON to callers and (b) never
+#   surfaced streaming exhaustion. #1371 wraps the stream in StreamFrameDecoder:
+#     - "chunk" frame        -> emit plain content (unwrapped)
+#     - "end" + stop_reason  == "max_iterations" -> terminate the publisher with
+#                               onError(MeshMaxIterationsException) (NOT emitted)
+#     - plain "end"          -> onComplete (NOT emitted)
+#   MeshSse.forward renders that onError as
+#     event: error\ndata: {"error":"...","type":"MeshMaxIterationsException"}
+#   and OMITS data: [DONE]; a normal completion writes data: [DONE].
+#
+# GATEWAY SHAPE (see stream-gateway-java/StreamGatewayApplication.java)
+#   A single @MeshLlm bind tool (issue #1141: exactly ONE @MeshLlm so the
+#   per-funcId proxy binds reliably) captures the framework-injected
+#   MeshLlmAgent proxy into a shared holder; two plain SSE routes forward
+#   proxy.stream(...) via MeshSse.forward. (@MeshRoute/@MeshDependency inject
+#   McpMeshTool proxies, not a MeshLlmAgent — Java has no streaming producer,
+#   #1223 — so the LLM proxy is captured from the @MeshLlm tool instead.)
+#     POST /stream/capped  -> annotation maxIterations=1 governs; the 4-step
+#                             probe ticket forces exhaustion -> error frame.
+#     POST /stream/normal  -> per-call modelParams(max_iterations=10) lets the
+#                             loop complete -> text chunks + [DONE].
+#
+# THE OBSERVABLE
+#   Wire-format assertions on each captured SSE body (event: error + the typed
+#   exception class name for capped; data: chunks + [DONE] for normal), plus the
+#   probe agent's out-of-band invocation counter for the capped route
+#   (PROBE_INVOCATIONS=[1], never [0]). Chunk counts are asserted via a
+#   PASS/FAIL verdict token, never numeric substrings.
+#
+# WHY CLAUDE + temperature 0.0 + parallel_tool_calls OFF: tool-calling
+#   determinism; advance_ticket's unguessable random next_token serializes the
+#   loop structurally (one tool round == one counter increment).
+
+name: "Java streaming exhaustion frame unwrap over SSE - Java->Py"
+description: "Issue #1369: a Java @MeshLlm streaming consumer unwraps the Python provider's _mesh_frame envelope; a capped streaming loop surfaces MeshMaxIterationsException as an SSE error frame (no [DONE]), while a normal loop completes with [DONE]"
+tags:
+  - llm
+  - claude
+  - java
+  - python
+  - cross-runtime
+  - tools
+  - streaming
+  - sse
+  - max-iterations
+  - issue-1369
+  - slow
+# Java build + slow Spring Boot startup: the tc-level budget matches every other
+# Java tc (tc47 / uc18-tc05 = 600). The design's "streaming 240" is applied as
+# the per-SSE-call step timeout, not the total (a maven build cannot fit in 240).
+timeout: 600
+# LLM test: needs a real ANTHROPIC_API_KEY and the tsuite-mesh:local image.
+pre_run:
+  - routine: global.setup_for_python_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+      mcpmesh_version: "${config.packages.sdk_python_version}"
+  - routine: global.setup_for_java_agent
+    params:
+      meshctl_version: "${config.packages.cli_version}"
+test:
+  # --- Copy artifacts ---
+  - name: "Copy Python Claude provider to workspace"
+    handler: shell
+    command: "cp -rL /uc-artifacts/claude-provider /workspace/"
+    capture: copy_provider
+  - name: "Copy iteration-probe-agent to workspace"
+    handler: shell
+    command: "cp -rL /uc-artifacts/iteration-probe-agent /workspace/"
+    capture: copy_probe
+  - name: "Copy Java streaming gateway to workspace"
+    handler: shell
+    command: "cp -rL /artifacts/stream-gateway-java /workspace/"
+    capture: copy_gateway
+  - name: "Create env file with secrets"
+    handler: secrets
+    target: /workspace/.env
+
+  # --- Build the Java gateway ---
+  - name: "Install Maven dependencies for the Java gateway"
+    handler: maven-install
+    path: /workspace/stream-gateway-java
+    timeout: 600
+
+  # --- Start the probe tool provider (Python) ---
+  - name: "Start iteration-probe-agent"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start iteration-probe-agent/main.py -d"
+    capture: start_probe
+  - name: "Wait for probe agent to register"
+    handler: wait
+    seconds: 5
+
+  # --- Start the Python LLM provider. NO MESH_LLM_MAX_ITERATIONS here: its own
+  #     default is 10, so the capped route's exhaustion can ONLY come from the
+  #     Java consumer's forwarded annotation cap (=1). ---
+  - name: "Start Python Claude provider (no provider-side cap)"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl start claude-provider/main.py --env-file .env -d"
+    capture: start_provider
+  - name: "Wait for provider to register (streaming variant auto-generated)"
+    handler: wait
+    seconds: 15
+  - name: "Verify probe agent and provider are running"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: pre_agent_list
+  - name: "Confirm the provider streaming variant registered"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list -t"
+    capture: pre_tools
+
+  # --- Start the Java streaming gateway (@MeshAgent HTTP port 9060 also serves
+  #     the @RestController SSE routes) ---
+  - name: "Start Java streaming gateway"
+    handler: shell
+    workdir: /workspace
+    command: |
+      meshctl start /workspace/stream-gateway-java --env MCP_MESH_HTTP_PORT=9060 --env MCP_MESH_SETTLE_TIMEOUT=60 -d
+    capture: start_gateway
+  - name: "Wait for stream-gateway-java to register"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "Waiting for stream-gateway-java agent..."
+      for i in $(seq 1 45); do
+        AGENTS=$(meshctl list 2>/dev/null || echo "")
+        if echo "$AGENTS" | grep -q "stream-gateway-java"; then
+          echo "stream-gateway-java registered after $((i*2))s"
+          exit 0
+        fi
+        if [ $((i % 10)) -eq 0 ]; then
+          echo "Still waiting... ($((i*2))s)"
+          echo "$AGENTS"
+        fi
+        sleep 2
+      done
+      echo "WARNING: stream-gateway-java not registered within 90s"
+      meshctl list 2>/dev/null || true
+      meshctl logs stream-gateway-java 2>/dev/null | tail -50 || true
+      exit 1
+    capture: wait_gateway
+    timeout: 120
+
+  # --- Poll /health so the HTTP listener (which also serves the SSE routes) is
+  #     confirmed up before we hit /stream/*. ---
+  - name: "Wait for gateway /health to respond"
+    handler: shell
+    command: |
+      for i in $(seq 1 45); do
+        if curl -sf http://localhost:9060/health 2>/dev/null | grep -q '"status":"healthy"'; then
+          echo "gateway /health healthy after $((i*2))s"
+          exit 0
+        fi
+        sleep 2
+      done
+      echo "WARNING: gateway /health did not report healthy within 90s"
+      curl -s http://localhost:9060/health 2>/dev/null || true
+      exit 1
+    capture: wait_health
+    timeout: 120
+
+  - name: "Verify all agents running"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list"
+    capture: all_list
+  - name: "List available tools"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl list -t"
+    capture: tools_output
+
+  # --- READINESS: poll the bind tool until the Java @MeshLlm proxy has bound
+  #     (i.e. it stops returning LLM_UNAVAILABLE). bindProxy does NOT invoke the
+  #     LLM, so it never bumps the probe counter. It captures the proxy into the
+  #     holder that the SSE routes read. ---
+  - name: "Poll bindProxy until the streaming LLM proxy has bound (readiness)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      for i in $(seq 1 12); do
+        RESP=$(meshctl call bindProxy '{"ctx": {"instruction": "bind"}}' 2>/dev/null || echo "")
+        if [ -n "$RESP" ] && echo "$RESP" | grep -q "PROXY_BOUND"; then
+          echo "PROXY_BOUND after attempt $i"
+          exit 0
+        fi
+        echo "Attempt $i: proxy not bound yet, retrying in 5s..." >&2
+        sleep 5
+      done
+      echo "ERROR: bindProxy still LLM_UNAVAILABLE after 12 attempts" >&2
+      meshctl logs stream-gateway-java 2>/dev/null | tail -80 >&2 || true
+      exit 1
+    capture: readiness_output
+    timeout: 120
+
+  # --- NORMAL route: capture headers + full SSE body in one call. max_iterations
+  #     is raised to 10 per-call so the loop completes and terminates with
+  #     data: [DONE]. This runs the ticket to completion (bumps the probe), so it
+  #     is done BEFORE the counter reset below. ---
+  - name: "POST /stream/normal and capture headers + SSE body"
+    handler: shell
+    # SSE over `curl -N` can exit non-zero (e.g. 18 "partial transfer") when the
+    # stream closes; the captured body is what matters, so force a 0 exit and
+    # ignore the curl status.
+    command: |
+      curl -s -N -D - -X POST http://localhost:9060/stream/normal \
+        -H "Content-Type: application/json" \
+        -d '{"instruction": "Process ticket ABC-1 to completion. Begin by calling advance_ticket with token \"START\". Each response gives you a next_token; call advance_ticket again with it. Keep going until the tool reports status COMPLETE, then reply with the final_code."}' 2>&1 || true
+    capture: normal_sse
+    timeout: 240
+    ignore_errors: true
+
+  # --- Zero the counter right before the single measured CAPPED call ---
+  - name: "Reset the probe invocation counter"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl call probe_reset '{}'"
+    capture: reset_output
+
+  # --- CAPPED route (the measured call): annotation maxIterations=1 forces the
+  #     provider-managed streaming loop to exhaust after one tool round. #1369
+  #     surfaces that as MeshMaxIterationsException -> SSE error frame, no
+  #     [DONE]. Exactly one call; never retried. ---
+  - name: "POST /stream/capped and capture the SSE body"
+    handler: shell
+    # The exhaustion path ends with an SSE error frame and an abnormal close, so
+    # `curl -N` returns non-zero (typically 18 "partial transfer"). That is the
+    # expected shape here — capture the body and force a 0 exit; the assertions
+    # below inspect the captured frames.
+    command: |
+      curl -s -N -X POST http://localhost:9060/stream/capped \
+        -H "Content-Type: application/json" \
+        -d '{"instruction": "Process ticket ABC-1 to completion. Begin by calling advance_ticket with token \"START\". Each response gives you a next_token; call advance_ticket again with it. Keep going until the tool reports status COMPLETE, then reply with the final_code."}' 2>&1 || true
+    capture: capped_sse
+    timeout: 240
+    ignore_errors: true
+
+  # --- Read the counter: proves the capped route ran exactly one tool round ---
+  - name: "Read the probe invocation counter"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl call probe_count '{}'"
+    capture: probe_count_output
+
+  - name: "Capture gateway log tail (diagnostics)"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl logs stream-gateway-java 2>/dev/null | tail -120 || true"
+    capture: gateway_log
+    ignore_errors: true
+
+  - name: "Stop all agents"
+    handler: shell
+    workdir: /workspace
+    command: "meshctl stop"
+    ignore_errors: true
+
+assertions:
+  # --- Infrastructure ---
+  - expr: "${captured.pre_agent_list} contains 'iteration-probe-agent'"
+    message: "iteration-probe-agent should be registered"
+  - expr: "${captured.pre_agent_list} contains 'claude-provider'"
+    message: "Python claude-provider should be registered"
+  - expr: "${captured.pre_tools} contains 'claude_provider_stream'"
+    message: "Provider must expose the auto-generated streaming variant (ai.mcpmesh.stream)"
+  - expr: "${captured.all_list} contains 'stream-gateway-java'"
+    message: "Java streaming gateway should be registered"
+  - expr: "${captured.tools_output} contains 'advance_ticket'"
+    message: "advance_ticket tool should be available"
+  - expr: "${captured.readiness_output} contains 'PROXY_BOUND'"
+    message: "The Java @MeshLlm streaming proxy should have bound before the measured calls"
+  - expr: "${captured.reset_output} contains 'PROBE_RESET_OK'"
+    message: "Counter should be reset after the normal call and before the capped measured call"
+
+  # --- CAPPED route: #1369 surfaces streaming exhaustion as a typed SSE error ---
+  # Note: Spring writes the event-name line as `event:error` (no space), unlike
+  # the space-padded `data: ` lines MeshSse emits deliberately.
+  - expr: "${captured.capped_sse} contains 'event:error'"
+    message: "The capped streaming loop must emit an SSE error frame on exhaustion (MeshSse.forward onError path)"
+  - expr: "${captured.capped_sse} contains '\"type\":\"MeshMaxIterationsException\"'"
+    message: "The SSE error frame must name the typed exception class MeshMaxIterationsException (issue #1369 / #1355)"
+  - expr: "${captured.capped_sse} not contains 'data: [DONE]'"
+    message: "A stream that exhausted must NOT terminate with data: [DONE] (the error path omits the terminator)"
+  # The unwrapped stream must not leak the raw frame envelope to the caller.
+  - expr: "${captured.capped_sse} not contains '_mesh_frame'"
+    message: "The Java consumer must UNWRAP the _mesh_frame envelope, never leak it to the SSE client (issue #1369)"
+
+  # --- NORMAL route: completes cleanly with [DONE], no error frame ---
+  - expr: "${captured.normal_sse} contains 'text/event-stream'"
+    message: "POST /stream/normal response Content-Type must be text/event-stream"
+  - expr: "${captured.normal_sse} contains 'data: '"
+    message: "The normal streaming loop must emit at least one data: chunk"
+  - expr: "${captured.normal_sse} contains 'data: [DONE]'"
+    message: "A normally-completing stream must terminate with data: [DONE]"
+  - expr: "${captured.normal_sse} not contains 'event:error'"
+    message: "A normally-completing stream must NOT emit an error frame"
+  - expr: "${captured.normal_sse} not contains '_mesh_frame'"
+    message: "The normal stream must also be unwrapped (no raw frame envelope leaks) - proves the Java consumer unwrapped the typed frames to text (issue #1369)"
+
+  # --- Probe counter (capped route): exactly one provider-managed tool round ---
+  - expr: "${captured.probe_count_output} contains 'PROBE_INVOCATIONS=[1]'"
+    message: "The capped streaming loop should have executed advance_ticket EXACTLY ONCE before exhausting (Java maxIterations=1 forwarded on the streaming path)"
+  - expr: "${captured.probe_count_output} not contains 'PROBE_INVOCATIONS=[0]'"
+    message: "advance_ticket should have run at least once on the capped route (a zero count means the model never called the tool, so nothing was measured)"
+
+post_run:
+  - handler: shell
+    workdir: /workspace
+    command: |
+      meshctl stop 2>/dev/null || true
+      pkill -f "spring-boot:run" 2>/dev/null || true
+      pkill -f "java.*stream-gateway" 2>/dev/null || true
+    ignore_errors: true
+  - routine: global.cleanup_workspace


### PR DESCRIPTION
## Summary

The LLM `max_iterations` exhaustion signal (#1355), the `MESH_LLM_MAX_ITERATIONS` consumer-forwarding parity (#1360), and the Java streaming-consumer `_mesh_frame` unwrap (#1369) shipped with unit coverage but **no integration coverage** — the gap that let those behaviors go unguarded. This adds three deterministic, cross-runtime tsuite integration tests in `uc04_llm_integration`, **all passing on a real cluster** (real Anthropic key + `tsuite-mesh:local`).

- **`tc48_max_iterations_typed_error_py`** (#1355) — a Python `@mesh.llm` consumer capped at `max_iterations=1` surfaces the typed `mesh.MaxIterationsError` on exhaustion (not a fabricated answer). Asserts the typed class present, the removed English sentinel absent, the fabricated final code absent, and `PROBE_INVOCATIONS=[1]`.
- **`tc49_max_iterations_ts_forwarding_py`** (#1360) — an **unset** TypeScript consumer against a Python provider started with a private `--env MESH_LLM_MAX_ITERATIONS=1`: the provider env governs the loop cap (`[1]`), proving the TS consumer no longer forwards a default unconditionally (pre-fix would be `[4]`).
- **`tc50_max_iterations_streaming_java_py`** (#1369) — a Java streaming gateway consuming a Python streaming LLM provider: the capped SSE route terminates with a typed `MeshMaxIterationsException` error frame (no `[DONE]`); the normal route unwraps chunks to text (no raw `_mesh_frame` leaked) and completes with `[DONE]`.

## Determinism

All three reuse the existing `iteration-probe-agent` — `advance_ticket` returns an unguessable random `next_token`, so the model cannot batch tool rounds (1 round == 1 counter increment), and a 4-step ticket capped at 1 deterministically forces exhaustion. Each guards the one nondeterminism risk (`PROBE_INVOCATIONS=[0]` = model skipped the tool) as an infra miss, not a contract pass. Shared `claude-provider` / `iteration-probe-agent` are reused from the uc-level artifacts (`cp -rL`); only the consumers-under-test are new.

## Review notes

- Independent test-quality review: **0 blockers, 1 warning, 4 info**. No spurious-pass path found; the `[0]` infra-miss guard is present in all three; `PROBE_INVOCATIONS=[1]` is bracket-terminated so it can't match `[10]`/`[4]`; wire formats verified against `MeshSse` (`event:error`, `"type":"MeshMaxIterationsException"`).
- **Warning fixed:** tc50 previously string-interpolated the multi-line SSE body into a shell `grep -c` verdict step (fragile on shell/JSON-significant chars, and redundant). Removed it; the normal route now proves unwrapping directly via `not contains '_mesh_frame'` alongside `data: [DONE]` / `text/event-stream` / `not event:error`. tc50 re-run on the cluster after the change: **PASS**.
- Info items left as-is (tests pass on-cluster): TS sentinel uses `e.name` (set by the SDK class); tc48/tc49 use a fixed readiness `wait` guarded by loud-fail assertions.

## Verification

- `tsuite --dry-run` parses all three.
- Consumers compile: Python `py_compile`, TS `tsc --noEmit`, Java `mvn compile`.
- **Real cluster run:** tc48 (56.9s), tc49 (80.6s), tc50 (133.8s) — all PASS. Captured wire output confirms the designed behavior (e.g. capped Java stream: `event:error` / `data: {"error":"Exceeded maximum 1 iterations without reaching final response","type":"MeshMaxIterationsException"}`, no `[DONE]`).

## Note (potential follow-up)

tc50's Java gateway uses a bind-tool "holder" to capture the injected `MeshLlmAgent` proxy for its `@PostMapping` SSE routes, because Java's `@MeshRoute`/`@MeshDependency` inject `McpMeshTool` proxies, not a `MeshLlmAgent` (which only injects into a `@MeshLlm`+`@MeshTool` method). The test exercises the real `streamGenerate` → `StreamFrameDecoder` → `MeshSse` path, but the inability to inject `MeshLlmAgent` directly into an SSE route is a real Java ergonomic gap worth a separate follow-up.

## Test plan

- [ ] CI green (suite parses; non-`llm` gating unaffected)
- [ ] Keyed cluster run of the three tcs remains green (validated once here)

Closes #1373

Guards #1355, #1360, #1369.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python, TypeScript, and Java integration scenarios for LLM iteration limits.
  * Added typed `MaxIterationsError` reporting when provider-managed loops reach their cap.
  * Added Java streaming endpoints for capped and normal LLM responses.
  * Added SSE handling that delivers plain text chunks and reports streaming errors clearly.

* **Tests**
  * Added coverage for cross-runtime iteration-limit forwarding, tool-round counts, incomplete ticket handling, and streaming completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->