### PR TITLE
fix(release): stop bump_version.py rewriting third-party plugin pins (#1379)

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -305,6 +305,12 @@ HANDLERS: list[Handler] = [
         replacement=r"\g<1>\g<2>NEW\3",
     ),
     # --- Category 5: Java Parent/Module POMs ------------------------------
+    # Only rewrite the mcp-mesh-owned <version>, i.e. the one that directly
+    # follows an `io.mcp-mesh` <groupId>/<artifactId> pair (the project coords
+    # or a <parent> block). A blind `<version>OLD</version>` replace also
+    # catches coincidental third-party plugin/dependency pins that happen to
+    # sit at the same version (e.g. maven-jar-plugin 3.3.0), which broke the
+    # 3.3.1 release when it bumped them to a nonexistent 3.3.1 plugin.
     Handler(
         name="Java Parent/Module POMs",
         globs=[
@@ -316,7 +322,10 @@ HANDLERS: list[Handler] = [
             "src/runtime/java/mcp-mesh-spring-ai/pom.xml",
             "src/runtime/java/mcp-mesh-native/pom.xml",
         ],
-        pattern=r"(<version>)OLD(</version>)",
+        pattern=(
+            r"(<groupId>io\.mcp-mesh</groupId>\s*"
+            r"<artifactId>[^<]+</artifactId>\s*<version>)OLD(</version>)"
+        ),
         replacement=r"\g<1>NEW\2",
     ),
     # --- Category 6: Java Example POMs ------------------------------------

--- a/src/runtime/java/pom.xml
+++ b/src/runtime/java/pom.xml
@@ -177,17 +177,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

The `v3.3.1` release's `publish-java-sdk` job failed because the version bump rewrote three **third-party** Maven plugins that were coincidentally pinned at `3.3.0` in `src/runtime/java/pom.xml` up to `3.3.1`. `maven-jar-plugin:3.3.1` doesn't exist on Maven Central (404), so `mvn` couldn't resolve it and the Java build died before publishing.

- **`src/runtime/java/pom.xml`** — revert `maven-surefire-plugin`, `maven-jar-plugin`, `maven-source-plugin` from `3.3.1` back to `3.3.0` (all three are real, existing versions; `maven-jar-plugin:3.3.1` never existed).
- **`scripts/bump_version.py`** — the root cause. The Category-5 (Java POM) handler used a blind `<version>OLD</version>` regex. It's now anchored to the `io.mcp-mesh` coordinate, so only the mesh-owned `<version>` (project coords / `<parent>`) is ever rewritten — never a coincidental third-party plugin/dependency pin.

Artifacts stay **3.3.1** — this is a build-config correction, not a new version. PyPI/npm/crates 3.3.1 were already published from the tag and are correct (the plugin bug only affected the Java build). This unblocks the **Java SDK + Docker** publish for v3.3.1.

## Audit

Full `git diff v3.3.0..v3.3.1` audit: the over-match was **contained to those 3 plugin lines** — no other third-party pin (npm/Cargo/Actions/helm/Docker) was affected. `maven-resources-plugin` in `mcp-mesh-native` was already `3.3.1` before this bump and is untouched.

## Validation

- `mvn -o -q validate` (offline) → exit 0: poms parse, plugin coordinates resolve.
- `scripts/test_bump_version.py` → 4 passed.
- Simulated bump with the new regex: each mesh pom bumps exactly its one mesh version; the `maven-resources-plugin` pin is correctly left alone.

Closes #1379

## Test plan

- [ ] CI green
- [ ] After merge: re-trigger the v3.3.1 Release publish (Java build resolves `maven-jar-plugin:3.3.0`, `publish-java-sdk` + `build-docker` complete; already-published jobs skip idempotently)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version updates for Java projects to modify only the intended project versions, preventing unrelated version values from being changed.

* **Chores**
  * Adjusted Maven plugin versions for improved build compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->