### PR TITLE
fix(llm): make LiteLLM optional for big-3 vendors and fail loudly when missing

### DIFF
--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -39,6 +39,58 @@ logger = logging.getLogger(__name__)
 _MAX_ITERATIONS_UNSET = object()
 
 
+def _require_litellm(model: str | None = None, vendor: str | None = None) -> Any:
+    """Import and return the ``litellm`` module, or raise actionable guidance.
+
+    LiteLLM is an OPTIONAL dependency (issue #1383). The big-3 vendors
+    (Anthropic / OpenAI / Gemini) dispatch through the bundled native SDK
+    adapters and never reach this helper; only the long-tail
+    GenericHandler/LiteLLM path genuinely needs the package. Call this at the
+    point of genuine use — never at function top — so a big-3-only install
+    stays fully functional without litellm present.
+    """
+    try:
+        import litellm
+
+        return litellm
+    except ModuleNotFoundError as e:
+        # Only the top-level 'litellm' package being absent is an optional-dep
+        # problem. A failing transitive import (e.g. 'tokenizers') or any other
+        # ImportError (ABI mismatch, circular import) must propagate untouched —
+        # mislabelling those sends users to an install command that is already
+        # satisfied and cannot fix anything, while hiding the real cause.
+        if e.name != "litellm":
+            raise
+
+        try:
+            from mesh import __version__ as mesh_version
+        except Exception:  # pragma: no cover - version lookup is best-effort
+            mesh_version = None
+
+        pin = (
+            f"mcp-mesh[litellm]=={mesh_version}"
+            if mesh_version
+            else "mcp-mesh[litellm]"
+        )
+        target = ""
+        if model and vendor and vendor != "unknown":
+            target = f" for model '{model}' (vendor '{vendor}')"
+        elif model:
+            target = f" for model '{model}'"
+        elif vendor and vendor != "unknown":
+            target = f" for vendor '{vendor}'"
+
+        raise ImportError(
+            f"This request{target} requires the optional LiteLLM provider path, "
+            "but the 'litellm' package is not installed. mcp-mesh bundles native "
+            "SDK adapters for Anthropic, OpenAI and Gemini; every other "
+            "vendor/model dispatches through LiteLLM.\n"
+            f"  Install it with:  pip install '{pin}'\n"
+            f"  Containerized agents: add  {pin}  to your agent's "
+            "requirements.txt so the image build includes it."
+        ) from e
+
+
 def _sanitize_max_iterations(value: Any) -> int | None:
     """Coerce an arbitrary value to a positive integer iteration cap.
 
@@ -539,10 +591,6 @@ async def _run_response_format_retry(
         },
     }
     fallback_args["request_timeout"] = fallback_timeout
-    # Lazy import keeps this module importable in environments without
-    # litellm (e.g., during static analysis); both call sites already
-    # import litellm before invoking this helper.
-    import litellm
 
     # Native dispatch (issue #834, PR 1): if the vendor handler ships a
     # native SDK adapter and the feature flag is on, route through it.
@@ -571,6 +619,9 @@ async def _run_response_format_retry(
             base_url=fallback_args.get("base_url"),
         )
     else:
+        # LiteLLM is optional (#1383) — resolve it only on the branch that
+        # actually calls into it.
+        litellm = _require_litellm(model=fb_model, vendor=fb_vendor)
         fallback_response = await asyncio.to_thread(
             litellm.completion, **fallback_args
         )
@@ -767,10 +818,10 @@ async def _maybe_retry_synthetic_on_validation_failure(
     tools: list[dict],
     completion_args_template: dict,
     native_handler,
-    litellm_module,
     effective_model: str,
     vendor: str | None,
     loop_logger: logging.Logger | None,
+    litellm_module=None,
 ) -> tuple[str, dict | None]:
     """Validate synthetic-tool args against the schema; retry once on failure.
 
@@ -932,8 +983,13 @@ async def _maybe_retry_synthetic_on_validation_failure(
                 base_url=retry_args.get("base_url"),
             )
         else:
+            # LiteLLM is optional (#1383) — resolve it only on the branch that
+            # actually calls into it.
+            _litellm = litellm_module
+            if _litellm is None:
+                _litellm = _require_litellm(model=effective_model, vendor=vendor)
             retry_response = await asyncio.to_thread(
-                litellm_module.completion, **retry_args
+                _litellm.completion, **retry_args
             )
     except Exception as retry_exc:  # noqa: BLE001 - any retry failure falls back
         effective_logger.warning(
@@ -1435,10 +1491,11 @@ async def _dispatch_completion(
     native_handler: Any,
     completion_args: dict[str, Any],
     effective_model: str,
-    litellm_module: Any,
+    litellm_module: Any = None,
     *,
     stream: bool,
     native_exclude_keys: tuple[str, ...],
+    vendor: str | None = None,
 ) -> Any:
     """Dispatch one completion call, native-SDK or LiteLLM.
 
@@ -1449,6 +1506,10 @@ async def _dispatch_completion(
     explicit kwargs, and the streaming path additionally excludes
     ``stream``/``stream_options``). The buffered path uses the buffered
     native/LiteLLM calls; the streaming path uses the streaming variants.
+
+    ``litellm_module`` is optional (#1383): callers on the native path must
+    not import litellm just to reach this function. When omitted, the module
+    is imported lazily on the LiteLLM branch only.
 
     Returns the buffered response object (``stream=False``) or the stream
     async iterator (``stream=True``), matching what each loop inlined.
@@ -1473,6 +1534,8 @@ async def _dispatch_completion(
             base_url=completion_args.get("base_url"),
         )
 
+    if litellm_module is None:
+        litellm_module = _require_litellm(model=effective_model, vendor=vendor)
     if stream:
         return await litellm_module.acompletion(**completion_args)
     return await asyncio.to_thread(litellm_module.completion, **completion_args)
@@ -1509,8 +1572,6 @@ async def _provider_agentic_loop(
     Returns:
         Message dict with role, content, and optionally _mesh_usage.
     """
-    import litellm
-
     iteration = 0
     current_messages = list(messages)
     # Issue #1355: last genuine assistant text seen on a tool-call turn, used
@@ -1596,9 +1657,9 @@ async def _provider_agentic_loop(
             _native_handler,
             completion_args,
             effective_model,
-            litellm,
             stream=False,
             native_exclude_keys=("model", "api_key", "base_url"),
+            vendor=vendor,
         )
         message = response.choices[0].message
 
@@ -1667,7 +1728,6 @@ async def _provider_agentic_loop(
                                 tools=tools,
                                 completion_args_template=retry_template,
                                 native_handler=_native_handler,
-                                litellm_module=litellm,
                                 effective_model=effective_model,
                                 vendor=vendor,
                                 loop_logger=loop_logger,
@@ -2044,8 +2104,7 @@ async def _provider_agentic_loop_stream(
     # same way the main iteration does — see the buffered loop's
     # ``retry_template`` construction for the keys to strip.
     # Tracking issue: https://github.com/dhyanraj/mcp-mesh/issues/961.
-    import litellm
-
+    #
     # Imported here to avoid a circular import: ``_mcp_mesh.engine`` imports
     # this module via the @mesh.llm_provider decorator path.
     from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
@@ -2124,7 +2183,6 @@ async def _provider_agentic_loop_stream(
             _native_handler,
             completion_args,
             effective_model,
-            litellm,
             stream=True,
             native_exclude_keys=(
                 "model",
@@ -2133,6 +2191,7 @@ async def _provider_agentic_loop_stream(
                 "stream",
                 "stream_options",
             ),
+            vendor=vendor,
         )
 
         chunks: list[Any] = []
@@ -2636,7 +2695,10 @@ def llm_provider(
 
     Raises:
         RuntimeError: If FastMCP 'app' not found in module
-        ImportError: If litellm not installed
+        ImportError: At call time, if the model routes to the LiteLLM
+            long-tail path and ``litellm`` is not installed. Anthropic,
+            OpenAI and Gemini models dispatch through the bundled native SDK
+            adapters and do not require it.
     """
 
     def decorator(func):
@@ -2896,8 +2958,6 @@ def llm_provider(
             Returns:
                 Full message dict with content, role, and tool_calls (if present)
             """
-            import litellm
-
             (
                 effective_model,
                 messages,
@@ -3011,6 +3071,11 @@ def llm_provider(
                         base_url=completion_args.get("base_url"),
                     )
                 else:
+                    # LiteLLM is optional (#1383) — import it only here, on
+                    # the long-tail branch that actually calls into it.
+                    litellm = _require_litellm(
+                        model=effective_model, vendor=vendor
+                    )
                     response = await asyncio.to_thread(
                         litellm.completion, **completion_args
                     )
@@ -3282,8 +3347,6 @@ def llm_provider(
             # which only runs when ``output_schema`` is set in
             # ``model_params``); the buffered legacy path's HINT branch is
             # preserved exactly as-is in ``process_chat``.
-            import litellm
-
             completion_args: dict[str, Any] = {
                 "model": effective_model,
                 "messages": messages,
@@ -3347,6 +3410,9 @@ def llm_provider(
                     base_url=completion_args.get("base_url"),
                 )
             else:
+                # LiteLLM is optional (#1383) — import it only here, on the
+                # long-tail branch that actually calls into it.
+                litellm = _require_litellm(model=effective_model, vendor=vendor)
                 stream_iter = await litellm.acompletion(**completion_args)
             chunks: list[Any] = []
             stream_completed = False


### PR DESCRIPTION
## Summary

Implements items 1 and 2 of #1383. **Neither is breaking** — item 1 only improves an error message, item 2 makes the big-3 vendors work *without* LiteLLM. The breaking change (moving `litellm` out of the base install behind an extra) is item 3 and stays on a version boundary; this PR does not touch `pyproject.toml`.

LiteLLM is not functionally required for Anthropic / OpenAI / Gemini — they dispatch through the bundled native SDK adapters, and native dispatch is default-ON (`MCP_MESH_NATIVE_LLM=0` is the opt-out). It was unavoidable only because several `import litellm` statements sat at **function-top** in the provider entry points and executed before native dispatch was ever consulted.

Separately, when LiteLLM is genuinely missing, the failure was a bare `ModuleNotFoundError` raised at the **first LLM call** — after install, import, and decoration all succeed. That escapes build and deploy entirely and surfaces only in production.

## Changes

All in `src/runtime/python/mesh/helpers.py`.

- **New `_require_litellm(model=None, vendor=None)`** — imports at the point of genuine use; on failure raises `ImportError` naming the model and resolved vendor, the `pip install 'mcp-mesh[litellm]==<version>'` command, and the `requirements.txt` guidance for containerized agents, chained from the original error via `raise ... from e`. `ImportError` is what the `llm_provider` docstring already declared, so no new public exception type was introduced.
- **Six function-top imports relocated** to the LiteLLM fallback branches (~545, ~1512, ~2047, ~2899, ~3285, plus `_maybe_retry_synthetic_on_validation_failure`, which took the module as a required kwarg and was a transitive blocker).
- `_dispatch_completion` and `_maybe_retry_synthetic_on_validation_failure` now resolve the module lazily; both are private with no external callers.
- **The decorator's vendor detection is deliberately unchanged.** It stays soft-fail — `try/except (ImportError, ...)` falling through to `_extract_vendor_from_model` / `_infer_big3_vendor_from_bare_name` — because that path has a correct non-LiteLLM fallback and must not start raising.

No dispatch logic or control flow was altered; only where the name is bound.

## Verification

- **Full unit suite: 1774 passed** (`tests/unit/` + `provider_handlers/tests/`), 0 failures.
- **Big-3 without LiteLLM.** In a venv with `anthropic` installed and `litellm` uninstalled (precondition asserted via `importlib.util.find_spec`), a bare-name `claude-sonnet-4-5` provider dispatches native and reaches the Anthropic API — 401 on a bogus key, and a normal completion with a real one. Buffered and streaming paths both verified. Pre-fix this raised `ModuleNotFoundError` at function entry.
- **Long-tail vendor.** `cohere-command` and `llama-3` now produce the actionable `ImportError` on both paths instead of a bare `ModuleNotFoundError`.
- Bare-name vendor inference still resolves with LiteLLM absent: logs `using 'unknown'` then `Inferred big-3 vendor 'anthropic' ... normalized to 'anthropic/claude-sonnet-4-5'`.

Refs #1383

## Test plan

- [ ] CI green
- [ ] Manual: an agent using only a big-3 vendor functions with `litellm` uninstalled
- [ ] Manual: a long-tail vendor without `litellm` surfaces the guidance, not a bare import error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * LiteLLM is now loaded only when a non-native (“long-tail”) execution path is used, so native provider workflows run even when it isn’t installed.
  * Improved ImportError messaging explains when LiteLLM is required and how to proceed.
  * Retry/fallback and both buffered and streaming completion flows now route providers more reliably.
* **Documentation**
  * Updated provider guidance to reflect LiteLLM’s optional, long-tail behavior and improved error expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->