### PR TITLE
fix(packaging): reconcile published manifest with source, and cap fastapi below 0.140.5

### DIFF
--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.11"
 dependencies = [
     # Rust core runtime (required - no Python fallback)
     "mcp-mesh-core>=3.3.1",
-    "fastapi>=0.104.0,<1.0.0",
+    "fastapi>=0.104.0,<0.140.5",
     "uvicorn>=0.24.0,<1.0.0",
     "httpx>=0.25.0,<1.0.0",
     "aiohttp>=3.8.0,<4.0.0",

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "python-dateutil>=2.8.0,<3.0.0",
     "click>=8.1.0,<9.0.0",
     "rich>=13.0.0,<14.0.0",
-    "typer>=0.9.1,<1.0.0",
+    "typer>=0.9.0,<1.0.0",
     # Pinned exact (#1312): an upstream FastMCP default-flip enabling
     # DNS-rebinding Host validation drifted in on rebuild and broke every
     # k8s Service-DNS /mcp call with 421. Loose ranges hid it. Follow-up:
@@ -76,15 +76,24 @@ dependencies = [
     "mcp==1.28.1",
     "fastmcp==3.4.3",
     "litellm>=1.80.5,!=1.82.7,!=1.82.8",
-    "anthropic>=0.42",
+    "anthropic>=0.77",
     "openai>=1.60",
-    "google-genai>=0.8.0",
+    "google-genai>=1.22",
     "prometheus-client>=0.19.0,<1.0.0",
     "pyyaml>=6.0,<7.0",
     "jinja2>=3.1.0",
     "redis>=4.0.0,<7.0.0",
     "cachetools>=5.3.0",
-    "watchfiles>=1.0.0"
+    "watchfiles>=1.0.0",
+    # orjson and jsonschema are direct runtime deps, not transitive ones.
+    # ``_mcp_mesh.shared.json_fast`` prefers orjson (stdlib json is the
+    # slow fallback) and ``mesh.helpers`` imports jsonschema unguarded at
+    # module scope for synthetic-tool schema validation (#962), so
+    # ``mesh.llm_provider`` fails to import without it. jsonschema happens
+    # to arrive via mcp/litellm today and orjson does not arrive at all;
+    # declaring both directly prevents breakage if those transitives shift.
+    "orjson>=3.10.0",
+    "jsonschema>=4"
 ]
 
 [project.optional-dependencies]
@@ -97,8 +106,7 @@ dev = [
     "mypy>=1.16.0",
     "pre-commit>=4.0.0",
     "isort>=6.0.0",
-    "bandit[toml]>=1.7.0",
-    "jsonschema>=4.0.0"
+    "bandit[toml]>=1.7.0"
 ]
 docs = [
     "mkdocs>=1.5.0",
@@ -120,13 +128,13 @@ anthropic = [
     # Backward-compat alias: ``anthropic`` is now a base dependency (issue
     # #834). This entry is kept so existing ``pip install mcp-mesh[anthropic]``
     # commands continue to work without error.
-    "anthropic>=0.42"
+    "anthropic>=0.77"
 ]
 anthropic-bedrock = [
     # AWS Bedrock backend for the native Anthropic adapter. Required when
     # using ``bedrock/anthropic.claude-*`` model strings. Opt-in because
     # boto3 is a heavy dependency.
-    "anthropic[bedrock]>=0.42"
+    "anthropic[bedrock]>=0.77"
 ]
 openai = [
     # Backward-compat alias: ``openai`` is now a base dependency (issue
@@ -139,7 +147,7 @@ gemini = [
     # (issue #834 PR 3). This entry is kept so existing
     # ``pip install mcp-mesh[gemini]`` commands continue to work without
     # error.
-    "google-genai>=0.8.0"
+    "google-genai>=1.22"
 ]
 
 [project.urls]

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -57,7 +57,7 @@ requires-python = ">=3.11"
 # native google-genai SDK; without it they would silently fall back to
 # LiteLLM.
 dependencies = [
-    "fastapi>=0.104.0",
+    "fastapi>=0.104.0,<0.140.5",
     "uvicorn>=0.24.0",
     "httpx>=0.25.0",
     "aiohttp>=3.8.0",


### PR DESCRIPTION
## Summary

Two related packaging fixes. **Merge this first** — the fastapi ceiling is what unblocks CI on the other open branches, which are currently red for reasons unrelated to their own changes.

### 1. Cap fastapi below 0.140.5 (#1387) — the urgent half

FastAPI removed the private `get_body_field` from `fastapi.dependencies.utils` in **0.140.5**. `route_integration.py:682` imports it (plus `_should_embed_body_fields`, `get_dependant`, `get_flat_dependant`) to rebuild the route handler after SSE wrapping. The resulting `ImportError` is caught by a broad `except`, logged as a warning, and followed by `return True`.

Without the rebuild, FastAPI keeps JSON-encoding the original async generator, so **`@mesh.route` SSE endpoints return `application/jsonl` instead of `text/event-stream`** — with no startup failure, passing health checks, and a log line that still says `registered with SSE streaming`.

Since the manifests allowed `fastapi>=0.104.0,<1.0.0`, a fresh `pip install mcp-mesh` today resolves a broken version. This affects the current release as shipped.

Bisected on unmodified `main` against `tests/unit/test_route_sse_wrapping.py`:

| fastapi | result | `get_body_field` |
|---|---|---|
| 0.139.2 – 0.140.4 | PASS | present |
| **0.140.5** – 0.140.7 | **FAIL** | **removed** |

CI corroborates independently: the last green `main` run installed 0.139.2; the first failing run installed 0.140.7, with fastmcp/mcp/starlette identical in both.

Ceiling applied to **both** manifests — editable installs break the same way. `<0.140.5` resolves to 0.140.4, the last known-good release.

**This is a stopgap.** Depending on four private FastAPI symbols is the underlying fragility, and the swallowed ImportError is why it shipped silently. Both are tracked in #1387.

### 2. Reconcile the published manifest with the source manifest (#1385)

`packaging/pypi/pyproject.toml` is what `pip install mcp-mesh` resolves against; it had drifted from `src/runtime/python/pyproject.toml`.

- **`jsonschema` declared in base.** `mesh/helpers.py` imports it unguarded at module scope, so `mesh.llm_provider` fails without it. #962 promoted it to a runtime dep in the source manifest; the move was never mirrored here, leaving it in `[dev]`. It has been arriving transitively via mcp/litellm.
- **`orjson` declared in base.** Guarded with a stdlib fallback so there's no crash, but no first-party dep pulled it — published installs silently ran the slow path while editable dev installs ran the fast one.
- **`anthropic` floor → `>=0.77`**, which gates `_ANTHROPIC_OUTPUT_CONFIG_FLOOR` (`capabilities.py:33`). Installs resolving 0.42–0.76 silently degraded to synthetic-tool mode plus retry recovery.
- **`google-genai` floor → `>=1.22`**, gating `RESPONSE_JSON_SCHEMA` (#1102, default-ON in #1103).
- **`typer` floor → `>=0.9.0`.** The `>=0.9.1` pin traces via `git log -S` to `d092da627 "Release v0.9.1 (#531)"`, where the mesh version bump and the typer floor changed in the same hunk — a version-bump over-match, the same class as #1379. `typer` is not imported anywhere in the runtime.

Deliberately **not** done: adding `mcp-mesh-core` to the source manifest. CI builds it locally with `maturin` before `pip install -e` (`ci.yml:244-251`, with an explicit wheel-clean so the local build wins), so a hard dep would let pip satisfy it from PyPI and shadow that build.

## ⚠️ Changes dependency resolution for existing users

The `anthropic` floor and the fastapi ceiling both alter what a fresh install resolves. Warrants a release-note entry.

## Verification

- Both manifests parse (`tomllib`).
- `bump_version.py --dry-run 3.3.1 3.3.2` — output byte-identical to the pre-edit baseline; handler-regex probe matches exactly the expected `mcp-mesh-core` line and nothing else.
- `test_bump_version.py` — 4/4.
- SSE tests pass at the ceiling version (0.140.4), fail at 0.140.5.

Closes #1385

Refs #1387

## Test plan

- [ ] CI green
- [ ] After merge: rebase the other open branches; their unrelated SSE failures should clear