### PR TITLE
docs+test(di): restate the positional contract, fix Java examples, pin position stability

### DIFF
--- a/docs/concepts/schema-matching.md
+++ b/docs/concepts/schema-matching.md
@@ -163,7 +163,8 @@ For Spring web routes (`@MeshRoute(dependencies = @MeshDependency(...))`):
     )
 })
 @PostMapping("/report")
-public ResponseEntity<Report> report(McpMeshTool<Employee> employeeLookup) { ... }
+public ResponseEntity<Report> report(
+        @MeshInject("lookup_employee") McpMeshTool<Employee> employeeLookup) { ... }
 ```
 
 ## Cross-language convention

--- a/docs/java/annotations.md
+++ b/docs/java/annotations.md
@@ -269,11 +269,11 @@ public class ClaudeProviderApplication {
 Enables mesh dependency injection in REST endpoint handlers.
 
 ```java
-@MeshRoute(dependencies = @Selector(capability = "avatar_chat"))
+@MeshRoute(dependencies = @MeshDependency(capability = "avatar_chat"))
 @PostMapping("/chat")
 public ResponseEntity<ChatResponse> chat(
         @RequestBody ChatRequest request,
-        McpMeshTool<String> avatarChat) {
+        @MeshInject("avatar_chat") McpMeshTool<String> avatarChat) {
     if (avatarChat == null || !avatarChat.isAvailable()) {
         return ResponseEntity.status(503)
             .body(new ChatResponse("Service unavailable"));

--- a/docs/java/capabilities-tags.md
+++ b/docs/java/capabilities-tags.md
@@ -33,7 +33,7 @@ record WeatherResponse(String city, int temp, String conditions) {}
 
 ## Capability Selector Syntax
 
-MCP Mesh uses the `@Selector` annotation for selecting capabilities. This same pattern appears in `dependencies`, `@MeshLlm` provider/filter, and `@MeshRoute`.
+MCP Mesh uses the `@Selector` annotation for selecting capabilities. This same pattern appears in `@MeshTool` `dependencies` and in the `@MeshLlm` provider/filter. Spring web routes use `@MeshDependency` instead, with the same `capability` / `tags` / `version` fields.
 
 ### Selector Fields
 
@@ -73,7 +73,7 @@ dependencies = @Selector(capability = "api_client", version = ">=2.0.0")
 | `@MeshTool` dependencies  | `dependencies = @Selector(capability = "svc")`                 |
 | `@MeshLlm` provider       | `providerSelector = @Selector(capability = "llm")`             |
 | `@MeshLlm` filter         | `filter = @Selector(tags = {"tools"})`                         |
-| `@MeshRoute` dependencies | `dependencies = @Selector(capability = "api", tags = {"+v2"})` |
+| `@MeshRoute` dependencies | `dependencies = @MeshDependency(capability = "api", tags = {"+v2"})` |
 
 ### Tag Operators
 

--- a/docs/java/dependency-injection.md
+++ b/docs/java/dependency-injection.md
@@ -459,7 +459,8 @@ public Report generateReport(McpMeshTool<Data> dataService) {
 ```java
 @GetMapping("/report")
 @MeshRoute(dependencies = @MeshDependency(capability = "data_service", required = true))
-public ResponseEntity<Report> report(McpMeshTool<Data> dataService) {
+public ResponseEntity<Report> report(
+        @MeshInject("data_service") McpMeshTool<Data> dataService) {
     return ResponseEntity.ok(new Report(dataService.call()));
 }
 ```

--- a/docs/typescript/dependency-injection.md
+++ b/docs/typescript/dependency-injection.md
@@ -48,7 +48,7 @@ agent.addTool({
 });
 ```
 
-**Important**: Dependencies are injected **positionally** as parameters after the first `args` parameter, in declaration order (`dependencies[0]`, `dependencies[1]`, ...). They may be `null` if unavailable.
+**How pairing works**: Dependencies are injected positionally as parameters after the first `args` parameter, in declaration order (`dependencies[0]`, `dependencies[1]`, ...), and arrive as `null` if unavailable. Parameter names are yours to choose; pick whatever reads best.
 
 ### Dependencies with Filters
 
@@ -197,7 +197,7 @@ agent.addTool({
     { capability: "formatter" }, // optional (default)
   ],
   parameters: z.object({}),
-  // Tool deps inject POSITIONALLY as McpMeshTool params after args
+  // Tool deps inject positionally as McpMeshTool params after args
   // (dependencies[0], dependencies[1], ...).
   execute: async (
     {},

--- a/docs/typescript/getting-started/index.md
+++ b/docs/typescript/getting-started/index.md
@@ -99,7 +99,7 @@ agent.addTool({
   parameters: z.object({ name: z.string() }),
   execute: async (
     { name },
-    greeting: McpMeshTool | null = null, // Injected positionally!
+    greeting: McpMeshTool | null = null, // Injected positionally, in declaration order
   ) => {
     if (greeting) {
       const baseGreeting = await greeting({ name });

--- a/docs/typescript/mesh-functions.md
+++ b/docs/typescript/mesh-functions.md
@@ -77,7 +77,7 @@ agent.addTool({
 });
 ```
 
-**Note**: Dependencies are injected **positionally** as `McpMeshTool | null` parameters after the first `args` parameter, in declaration order (`dependencies[0]`, `dependencies[1]`, ...). They may be `null` if unavailable.
+**Note**: Dependencies are injected positionally as `McpMeshTool | null` parameters after the first `args` parameter, in declaration order, and parameter names are yours to choose. See the [Dependency Injection](dependency-injection.md) guide for the full pairing rule.
 
 ### Dependency Injection Types
 

--- a/src/core/cli/man/content/capabilities_java.md
+++ b/src/core/cli/man/content/capabilities_java.md
@@ -25,7 +25,7 @@ record WeatherResponse(String city, int temp, String conditions) {}
 
 ## Capability Selector Syntax
 
-MCP Mesh uses the `@Selector` annotation for selecting capabilities. This same pattern appears in `dependencies`, `@MeshLlm` provider/filter, and `@MeshRoute`.
+MCP Mesh uses the `@Selector` annotation for selecting capabilities. This same pattern appears in `@MeshTool` `dependencies` and in the `@MeshLlm` provider/filter. Spring web routes use `@MeshDependency` instead, with the same `capability` / `tags` / `version` fields.
 
 ### Selector Fields
 
@@ -65,7 +65,7 @@ dependencies = @Selector(capability = "api_client", version = ">=2.0.0")
 | `@MeshTool` dependencies  | `dependencies = @Selector(capability = "svc")`                 |
 | `@MeshLlm` provider       | `providerSelector = @Selector(capability = "llm")`             |
 | `@MeshLlm` filter         | `filter = @Selector(tags = {"tools"})`                         |
-| `@MeshRoute` dependencies | `dependencies = @Selector(capability = "api", tags = {"+v2"})` |
+| `@MeshRoute` dependencies | `dependencies = @MeshDependency(capability = "api", tags = {"+v2"})` |
 
 ### Tag Operators
 

--- a/src/core/cli/man/content/decorators.md
+++ b/src/core/cli/man/content/decorators.md
@@ -217,7 +217,7 @@ async def chat_endpoint(
 
 **Note**: `@mesh.route` is for FastAPI backends that _consume_ mesh capabilities. Use `@mesh.tool` for MCP agents that _provide_ capabilities.
 
-**Note**: Both `@mesh.tool` and `@mesh.route` inject dependencies POSITIONALLY into `McpMeshTool`-typed parameters — pairing the order of `McpMeshTool` parameters in the function signature against the order of `dependencies=[...]` (the runtime takes `mesh_positions[: len(dependencies)]`). Parameter names like `date_service` in examples are reader-friendly only — they don't match against the dependency capability name. The same rule applies in TypeScript (`addTool({ dependencies: [...] })`, injected positionally) and Java (`@MeshTool(dependencies = @Selector(...))`, parameter order). A `MeshJob` slot (one per tool) is detected by parameter type but counts as an eligible position in this same positional pairing — it pairs with its own `dependencies=[...]` entry, and that dependency is bound as the job's submitter — see `meshctl man jobs`.
+**Note**: In both `@mesh.tool` and `@mesh.route`, `dependencies=[...]` pairs with your `McpMeshTool`-typed parameters in declaration order, and parameter names are yours to choose. See `meshctl man dependency-injection` for the full pairing rule, including where a `MeshJob` parameter fits.
 
 See `meshctl man api` for complete FastAPI integration guide.
 

--- a/src/core/cli/man/content/decorators_java.md
+++ b/src/core/cli/man/content/decorators_java.md
@@ -78,6 +78,8 @@ public GreetingResponse greet(
 
 **Note**: Dependencies are injected as `McpMeshTool<T>` parameters on the method. They may be `null` if unavailable.
 
+**Note**: `dependencies` entries pair with the method's `McpMeshTool<T>` (and `MeshJob`) parameters in declaration order, and parameter names are yours to choose. See `meshctl man dependency-injection --java` for the full pairing rule, including where a `MeshJob` parameter fits and how `@MeshRoute` differs.
+
 ### Schema-aware capabilities (issue #547)
 
 The mesh can match producers and consumers by their canonical response schemas, not just by capability name. This is opt-in per tool/selector.
@@ -125,7 +127,8 @@ public Report hrReport(McpMeshTool<Employee> employeeLookup) { ... }
     )
 })
 @PostMapping("/report")
-public ResponseEntity<Report> report(McpMeshTool<Employee> employeeLookup) { ... }
+public ResponseEntity<Report> report(
+        @MeshInject("lookup_employee") McpMeshTool<Employee> employeeLookup) { ... }
 ```
 
 **Per-tool strict knob** — set `outputSchemaStrict = false` on `@MeshTool` to demote a BLOCK schema verdict to a WARN for that one tool. Wins even when the cluster-wide `MCP_MESH_SCHEMA_STRICT=true` env var promotes WARN→BLOCK.
@@ -357,11 +360,11 @@ public class ClaudeProviderApplication {
 Enables mesh dependency injection in REST endpoint handlers.
 
 ```java
-@MeshRoute(dependencies = @Selector(capability = "avatar_chat"))
+@MeshRoute(dependencies = @MeshDependency(capability = "avatar_chat"))
 @PostMapping("/chat")
 public ResponseEntity<ChatResponse> chat(
         @RequestBody ChatRequest request,
-        McpMeshTool<String> avatarChat) {
+        @MeshInject("avatar_chat") McpMeshTool<String> avatarChat) {
     if (avatarChat == null || !avatarChat.isAvailable()) {
         return ResponseEntity.status(503)
             .body(new ChatResponse("Service unavailable"));

--- a/src/core/cli/man/content/dependency-injection.md
+++ b/src/core/cli/man/content/dependency-injection.md
@@ -96,7 +96,7 @@ async def greet(name: str, date_service: mesh.McpMeshTool = None) -> str:
 
 **Important**: Functions with dependencies must be `async def` and calls must use `await`.
 
-**Note**: Both `@mesh.tool` and `@mesh.route` inject dependencies POSITIONALLY into `McpMeshTool`-typed parameters — pairing the order of `McpMeshTool` parameters in the function signature against the order of `dependencies=[...]` (the runtime takes `mesh_positions[: len(dependencies)]`). Parameter names like `date_service` in examples are reader-friendly only — they don't match against the dependency capability name. The same rule applies in TypeScript (`addTool({ dependencies: [...] })`, injected positionally) and Java (`@MeshTool(dependencies = @Selector(...))`, parameter order). A `MeshJob` slot (one per tool) is detected by parameter type but counts as an eligible position in this same positional pairing — it pairs with its own `dependencies=[...]` entry, and that dependency is bound as the job's submitter — see `meshctl man jobs`.
+**How pairing works**: In both `@mesh.tool` and `@mesh.route`, `dependencies=[...]` pairs with your `McpMeshTool`-typed parameters in declaration order — the first dependency fills the first such parameter, and so on. Parameter names are yours to choose; pick whatever reads best. The same order-based rule applies in TypeScript (`addTool({ dependencies: [...] })`) and Java (`@MeshTool(dependencies = @Selector(...))`). A `MeshJob` parameter (at most one per tool) occupies a position in this same ordering and binds its paired dependency as the job's submitter — see `meshctl man jobs`.
 
 ### Dependencies with Filters
 

--- a/src/core/cli/man/content/dependency-injection_java.md
+++ b/src/core/cli/man/content/dependency-injection_java.md
@@ -55,6 +55,40 @@ public GreetingResponse smartGreet(
 
 **Important**: Dependencies are injected as `McpMeshTool<T>` parameters on the method. They may be `null` if unavailable.
 
+**How pairing works**: On `@MeshTool`, the `dependencies` entries pair with the method's dependency-typed parameters — `McpMeshTool<T>` and, where present, `MeshJob` — in declaration order: the first `@Selector` fills the first such parameter, the second fills the second, and so on. `@Param`-annotated business parameters take no part in the pairing. Parameter names are yours to choose; pick whatever reads best. Declare more than one dependency as an array:
+
+```java
+@MeshTool(capability = "report",
+          dependencies = {@Selector(capability = "data_service"),
+                          @Selector(capability = "formatter")})
+public Report generateReport(
+        @Param(value = "query", description = "Report query") String query,
+        McpMeshTool<Data> data,        // ← data_service
+        McpMeshTool<String> format) {  // ← formatter
+    ...
+}
+```
+
+A `MeshJob` parameter (at most one per method) occupies a position in this same ordering and binds its paired dependency as the job's submitter — see `meshctl man jobs --java`. The same order-based rule applies in Python (`dependencies=[...]`) and TypeScript (`addTool({ dependencies: [...] })`).
+
+`@MeshRoute` handlers bind **by name**, not by order. Each handler parameter contributes one match key — its `@MeshInject("...")` value when present, otherwise the Java parameter name — and binds to the `@MeshDependency` whose capability or injection name equals that key. The injection name is `name()` when you set it, and otherwise the capability with kebab hyphens folded to camelCase (`pdf-tool` becomes `pdfTool`); a capability containing no hyphen is left exactly as written. A snake_case capability therefore never matches a camelCase parameter on its own — name the binding explicitly, at whichever end reads better:
+
+```java
+// At the parameter: @MeshInject supplies the key directly.
+@MeshRoute(dependencies = @MeshDependency(capability = "lookup_employee"))
+@PostMapping("/a")
+public ResponseEntity<Report> a(
+        @MeshInject("lookup_employee") McpMeshTool<Employee> employeeLookup) { ... }
+
+// At the dependency: name() declares the parameter it should land on.
+@MeshRoute(dependencies = @MeshDependency(capability = "lookup_employee",
+                                          name = "employeeLookup"))
+@PostMapping("/b")
+public ResponseEntity<Report> b(McpMeshTool<Employee> employeeLookup) { ... }
+```
+
+Falling back to the bare Java parameter name also requires compiling with `-parameters`; `@MeshInject` does not. `@MeshDependsOn` beans bind by `@Qualifier`, by name as well.
+
 ### Dependencies with Filters
 
 Use the `@Selector` annotation with tags or version to filter providers:
@@ -106,7 +140,8 @@ For Spring web routes, the equivalent annotation is `@MeshDependency` (used insi
     )
 })
 @PostMapping("/report")
-public ResponseEntity<Report> report(McpMeshTool<Employee> employeeLookup) { ... }
+public ResponseEntity<Report> report(
+        @MeshInject("lookup_employee") McpMeshTool<Employee> employeeLookup) { ... }
 ```
 
 > Note: Use `@NotNull` (`jakarta.validation.constraints`) on required fields. Java reference types are nullable by default; `@NotNull` is required for cross-language `STRICT` matching with Python/TypeScript counterparts.
@@ -498,7 +533,8 @@ public Report generateReport(McpMeshTool<Data> dataService) { ... }
     @MeshDependency(capability = "data_service", required = true)
 })
 @PostMapping("/report")
-public ResponseEntity<Report> report(McpMeshTool<Data> dataService) { ... }
+public ResponseEntity<Report> report(
+        @MeshInject("data_service") McpMeshTool<Data> dataService) { ... }
 ```
 
 `required` defaults to `false` and combines with the other selector fields (`tags`, `version`, `expectedType`). It is carried on the wire only when `true`.

--- a/src/core/cli/man/content/dependency-injection_typescript.md
+++ b/src/core/cli/man/content/dependency-injection_typescript.md
@@ -57,7 +57,7 @@ agent.addTool({
 });
 ```
 
-**Important**: Dependencies are injected **positionally** as parameters after the first `args` parameter, in declaration order (`dependencies[0]`, `dependencies[1]`, ...). They may be `null` if unavailable.
+**How pairing works**: Dependencies are injected positionally as parameters after the first `args` parameter, in declaration order (`dependencies[0]`, `dependencies[1]`, ...), and arrive as `null` if unavailable. Parameter names are yours to choose; pick whatever reads best.
 
 ### Dependencies with Filters
 
@@ -236,7 +236,7 @@ agent.addTool({
     { capability: "formatter" }, // optional (default)
   ],
   parameters: z.object({}),
-  // Tool deps inject POSITIONALLY as McpMeshTool params after args
+  // Tool deps inject positionally as McpMeshTool params after args
   // (dependencies[0], dependencies[1], ...).
   execute: async (
     {},

--- a/src/core/cli/man/content/schema-matching.md
+++ b/src/core/cli/man/content/schema-matching.md
@@ -161,7 +161,8 @@ For Spring web routes (`@MeshRoute(dependencies = @MeshDependency(...))`):
     )
 })
 @PostMapping("/report")
-public ResponseEntity<Report> report(McpMeshTool<Employee> employeeLookup) { ... }
+public ResponseEntity<Report> report(
+        @MeshInject("lookup_employee") McpMeshTool<Employee> employeeLookup) { ... }
 ```
 
 ## Cross-language convention

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperUnresolvedDepPositionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperUnresolvedDepPositionTest.java
@@ -1,0 +1,273 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Positional-injection safety property: an UNRESOLVED dependency must not
+ * shift the other dependencies into the wrong parameter slots.
+ *
+ * <p>mcp-mesh injects dependencies positionally — {@code dependencies[i]}
+ * pairs with the i-th dependency-typed parameter in declaration order. The
+ * property pinned here is what makes that safe to ship:
+ *
+ * <blockquote>An unresolved dependency leaves ITS OWN slot null, and every
+ * other dependency still lands in its own slot.</blockquote>
+ *
+ * <p>Without it, one provider going down would silently rewire every
+ * downstream parameter (cap_c's proxy arriving as the {@code depB}
+ * parameter) — a much worse failure than a null.
+ *
+ * <p>Cross-runtime seam — the same property is pinned by:
+ * <ul>
+ *   <li>Python: {@code test_12_dependency_injector.py ::
+ *       TestUnifiedPositionalInjection ::
+ *       test_unresolved_middle_dependency_does_not_shift} (+ the mixed
+ *       MeshJob variant).</li>
+ *   <li>TypeScript: {@code src/__tests__/unresolved-dep-no-shift.spec.ts}.</li>
+ * </ul>
+ *
+ * <p>In Java the property holds by construction — {@code updateDependency}
+ * writes {@code injectedDeps[depIndexToSlot[depIndex]]} (a fixed index map
+ * built at wrapper construction) and {@code buildFullArgs} reads slot ordinal
+ * {@code i} into {@code meshToolPositions.get(i)}. Neither step consults
+ * resolution STATE, so an unresolved slot cannot compress the others. These
+ * tests exercise that through the real invoke path (and through the
+ * composite-key registry path the heartbeat events actually use) so a future
+ * refactor that compacts the slot array fails here.
+ */
+class MeshToolWrapperUnresolvedDepPositionTest {
+
+    /** Consumer with THREE McpMeshTool dependencies in declaration order. */
+    public static class FanOutBean {
+        final List<McpMeshTool<?>> received = new ArrayList<>();
+
+        @MeshTool(capability = "fan_out", dependencies = {
+            @Selector(capability = "cap_a"),
+            @Selector(capability = "cap_b"),
+            @Selector(capability = "cap_c")})
+        public Object fanOut(
+                @Param("user_id") String userId,
+                McpMeshTool<String> depA,
+                McpMeshTool<String> depB,
+                McpMeshTool<String> depC) {
+            received.clear();
+            received.add(depA);
+            received.add(depB);
+            received.add(depC);
+            return Map.of("user_id", userId);
+        }
+    }
+
+    /**
+     * Consumer mixing a MeshJob dependency with McpMeshTool dependencies —
+     * the declared-index / slot-ordinal spaces skew here, so an unresolved
+     * McpMeshTool in the middle is the sharpest form of the property.
+     */
+    public static class MixedBean {
+        final List<Object> received = new ArrayList<>();
+
+        @MeshTool(capability = "mixed", dependencies = {
+            @Selector(capability = "run_workflow"),
+            @Selector(capability = "missing_tool"),
+            @Selector(capability = "cap_c")})
+        public Object mixed(
+                @Param("user_id") String userId,
+                MeshJob job,                  // declared index 0
+                McpMeshTool<String> missing,  // declared index 1 — unresolved
+                McpMeshTool<String> present) { // declared index 2
+            received.clear();
+            received.add(job);
+            received.add(missing);
+            received.add(present);
+            return Map.of("user_id", userId);
+        }
+    }
+
+    /** Available stub proxy that reports the capability it is bound to. */
+    static class StubProxy implements McpMeshTool<String> {
+        private final String capability;
+        StubProxy(String capability) { this.capability = capability; }
+        @Override public String call() { return capability; }
+        @Override public String call(Map<String, Object> params) { return capability; }
+        @Override public String call(Object... args) { return capability; }
+        @Override public CompletableFuture<String> callAsync() { return CompletableFuture.completedFuture(capability); }
+        @Override public CompletableFuture<String> callAsync(Map<String, Object> params) { return CompletableFuture.completedFuture(capability); }
+        @Override public CompletableFuture<String> callAsync(Object... keyValuePairs) { return CompletableFuture.completedFuture(capability); }
+        @Override public String getCapability() { return capability; }
+        @Override public String getEndpoint() { return "http://" + capability; }
+        @Override public String getFunctionName() { return capability; }
+        @Override public boolean isAvailable() { return true; }
+    }
+
+    private static String capabilityOf(Object dep) {
+        return dep == null ? null : ((McpMeshTool<?>) dep).getCapability();
+    }
+
+    private static MeshToolWrapper fanOutWrapper(FanOutBean bean) throws Exception {
+        Method m = FanOutBean.class.getMethod("fanOut",
+            String.class, McpMeshTool.class, McpMeshTool.class, McpMeshTool.class);
+        return new MeshToolWrapper(
+            "FanOutBean.fanOut",
+            "fan_out",
+            "test",
+            bean,
+            m,
+            List.of("cap_a", "cap_b", "cap_c"),
+            JsonMapper.builder().build());
+    }
+
+    private static MeshToolWrapper mixedWrapper(MixedBean bean) throws Exception {
+        Method m = MixedBean.class.getMethod("mixed",
+            String.class, MeshJob.class, McpMeshTool.class, McpMeshTool.class);
+        return new MeshToolWrapper(
+            "MixedBean.mixed",
+            "mixed",
+            "test",
+            bean,
+            m,
+            List.of("run_workflow", "missing_tool", "cap_c"),
+            JsonMapper.builder().build());
+    }
+
+    // ---- the property -------------------------------------------------------
+
+    @Test
+    void unresolvedMiddleDependency_doesNotShift() throws Exception {
+        FanOutBean bean = new FanOutBean();
+        MeshToolWrapper wrapper = fanOutWrapper(bean);
+
+        // Resolve ONLY dependency 0 and dependency 2. Dependency 1 (cap_b)
+        // never resolves — the exact "provider went down" shape.
+        wrapper.updateDependency(0, new StubProxy("cap_a"));
+        wrapper.updateDependency(2, new StubProxy("cap_c"));
+
+        Object result = wrapper.invoke(Map.of("user_id", "alice"));
+
+        assertFalse(result instanceof io.modelcontextprotocol.spec.McpSchema.CallToolResult,
+            "optional unresolved deps must not produce a refusal envelope");
+        assertEquals(3, bean.received.size(),
+            "every declared dependency slot must be materialised — the array is "
+                + "never compacted");
+        assertEquals("cap_a", capabilityOf(bean.received.get(0)),
+            "position 0 must keep its own proxy");
+        assertNull(bean.received.get(1),
+            "the UNRESOLVED dependency must leave its OWN slot null — it must not "
+                + "slide up and consume cap_c's proxy");
+        assertEquals("cap_c", capabilityOf(bean.received.get(2)),
+            "position 2 must still receive cap_c, not shift down to position 1");
+    }
+
+    @Test
+    void unresolvedLeadingAndTrailingDependencies_holdTheirOwnSlots() throws Exception {
+        FanOutBean bean = new FanOutBean();
+        MeshToolWrapper wrapper = fanOutWrapper(bean);
+
+        // Only the MIDDLE dependency resolves.
+        wrapper.updateDependency(1, new StubProxy("cap_b"));
+
+        wrapper.invoke(Map.of("user_id", "bob"));
+
+        assertNull(bean.received.get(0), "unresolved leading dep must stay null in slot 0");
+        assertEquals("cap_b", capabilityOf(bean.received.get(1)),
+            "the single resolved dep must land in ITS slot (1), not slot 0");
+        assertNull(bean.received.get(2), "unresolved trailing dep must stay null in slot 2");
+    }
+
+    @Test
+    void dependencyGoingUnavailable_nullsOnlyItsOwnSlot() throws Exception {
+        FanOutBean bean = new FanOutBean();
+        MeshToolWrapper wrapper = fanOutWrapper(bean);
+
+        wrapper.updateDependency(0, new StubProxy("cap_a"));
+        wrapper.updateDependency(1, new StubProxy("cap_b"));
+        wrapper.updateDependency(2, new StubProxy("cap_c"));
+
+        wrapper.invoke(Map.of("user_id", "carol"));
+        assertEquals(List.of("cap_a", "cap_b", "cap_c"),
+            bean.received.stream().map(MeshToolWrapperUnresolvedDepPositionTest::capabilityOf).toList(),
+            "baseline: all three resolved deps land in declaration order");
+
+        // The middle provider drops out (dependency_unavailable → null proxy).
+        wrapper.updateDependency(1, null);
+        wrapper.invoke(Map.of("user_id", "carol"));
+
+        assertEquals("cap_a", capabilityOf(bean.received.get(0)));
+        assertNull(bean.received.get(1),
+            "the dropped dependency nulls its own slot only");
+        assertEquals("cap_c", capabilityOf(bean.received.get(2)),
+            "the surviving trailing dependency must NOT shift into the freed slot");
+    }
+
+    @Test
+    void unresolvedMiddleDependency_doesNotShift_viaRegistryCompositeKey() throws Exception {
+        // The heartbeat path applies resolutions through
+        // MeshToolWrapperRegistry with a `funcId:dep_N` composite key. Pin the
+        // property on that path too — the key carries the declared index, so a
+        // gap must survive the parse.
+        FanOutBean bean = new FanOutBean();
+        MeshToolWrapper wrapper = fanOutWrapper(bean);
+
+        MeshToolWrapperRegistry registry =
+            new MeshToolWrapperRegistry(new McpMeshToolProxyFactory(new McpHttpClient()));
+        registry.registerWrapper(wrapper);
+
+        registry.updateDependency(
+            MeshToolWrapperRegistry.buildDependencyKey("FanOutBean.fanOut", 0),
+            "http://provider-a:9001", "fn_a", "agent-a");
+        // dep_1 is deliberately never applied.
+        registry.updateDependency(
+            MeshToolWrapperRegistry.buildDependencyKey("FanOutBean.fanOut", 2),
+            "http://provider-c:9003", "fn_c", "agent-c");
+
+        wrapper.invoke(Map.of("user_id", "dave"));
+
+        assertNotNull(bean.received.get(0));
+        assertEquals("http://provider-a:9001", bean.received.get(0).getEndpoint(),
+            "slot 0 must hold the dep_0 proxy");
+        assertNull(bean.received.get(1),
+            "the never-applied dep_1 must leave its own slot null");
+        assertNotNull(bean.received.get(2),
+            "slot 2 must be populated — the gap at dep_1 must not compact it away");
+        assertEquals("http://provider-c:9003", bean.received.get(2).getEndpoint(),
+            "slot 2 must hold the dep_2 proxy, not dep_0's or a shifted one");
+    }
+
+    @Test
+    void unresolvedMeshToolBesideMeshJob_doesNotShift() throws Exception {
+        // Declared-index → slot-ordinal skew: with a MeshJob at declared index
+        // 0, "missing_tool" is declared index 1 / slot 0 and "cap_c" is
+        // declared index 2 / slot 1. Resolving ONLY cap_c must fill the
+        // `present` parameter — never the `missing` one.
+        MixedBean bean = new MixedBean();
+        MeshToolWrapper wrapper = mixedWrapper(bean);
+
+        wrapper.updateDependency(2, new StubProxy("cap_c"));
+
+        wrapper.invoke(Map.of("user_id", "erin"));
+
+        // No consumer-side submitter is wired in this unit context (staying
+        // below the FFI boundary), so the MeshJob slot is null — the point is
+        // that it is the JOB parameter that is null, not a shifted proxy.
+        assertNull(bean.received.get(0),
+            "the MeshJob slot must stay its own slot (no submitter wired here)");
+        assertNull(bean.received.get(1),
+            "the unresolved McpMeshTool must leave its own slot null");
+        assertEquals("cap_c", capabilityOf(bean.received.get(2)),
+            "cap_c must land in ITS parameter — not shift into the unresolved "
+                + "'missing_tool' slot");
+    }
+}

--- a/src/runtime/typescript/src/__tests__/unresolved-dep-no-shift.spec.ts
+++ b/src/runtime/typescript/src/__tests__/unresolved-dep-no-shift.spec.ts
@@ -1,0 +1,362 @@
+/**
+ * Positional-injection safety property: an UNRESOLVED dependency must not
+ * shift the other dependencies into the wrong parameter slots.
+ *
+ * mcp-mesh injects dependencies positionally — `dependencies[i]` pairs with
+ * the i-th dependency-typed parameter in declaration order. The property this
+ * file pins is the one that makes positional injection safe to ship:
+ *
+ *   An unresolved dependency leaves ITS OWN slot null and every other
+ *   dependency still lands in its own slot.
+ *
+ * If this did not hold, a single provider going down would silently rewire
+ * every downstream parameter (dep 2's proxy arriving as parameter `depB`),
+ * which is a far worse failure than a null.
+ *
+ * Cross-runtime seam — the same property is pinned by:
+ *   - Python: `test_12_dependency_injector.py::TestUnifiedPositionalInjection::
+ *     test_unresolved_middle_dependency_does_not_shift` (and the mixed
+ *     MeshJob variant).
+ *   - Java: `MeshToolWrapperUnresolvedDepPositionTest`.
+ *
+ * In TypeScript the property holds by construction: `_buildDepSlots` is an
+ * index-preserving `depSlots.map()` reading `resolvedDeps.get(
+ * `${toolName}:dep_${edgeIndex}`) ?? null`, and the dependency events are
+ * keyed by `depIndex` (never by "next free position"). These tests exercise
+ * that end-to-end through the real `addTool` wrapper so a future refactor
+ * that filters/compacts the slot array (e.g. `.filter(Boolean)`) fails here.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { z } from "zod";
+import { MeshAgent, __resetUnwiredSlotWarnedForTests } from "../agent.js";
+import { PROXY_DISPATCH_META } from "../proxy.js";
+import { MeshJobSubmitter } from "../mesh-job-submitter.js";
+import { RouteRegistry } from "../route.js";
+import { resetSettleStateForTests } from "../settle.js";
+
+function makeFastMCPStub() {
+  return {
+    addTool: vi.fn(),
+    start: vi.fn(),
+    getApp: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+/** Capability a resolved proxy is bound to, read off its dispatch meta. */
+function capabilityOf(dep: unknown): string | null {
+  if (dep === null || dep === undefined) return null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const meta = (dep as any)[PROXY_DISPATCH_META];
+  return meta ? (meta.capability as string) : null;
+}
+
+let autoStartSpy: ReturnType<typeof vi.spyOn> | null = null;
+let warnSpy: ReturnType<typeof vi.spyOn> | null = null;
+let logSpy: ReturnType<typeof vi.spyOn> | null = null;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  autoStartSpy = vi
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .spyOn(MeshAgent.prototype as any, "_autoStart")
+    .mockImplementation(async () => {
+      /* no-op */
+    });
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    /* swallow the #1231 unwired-slot warning */
+  });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {
+    /* swallow dependency-available chatter */
+  });
+  savedEnv.MCP_MESH_SETTLE_TIMEOUT = process.env.MCP_MESH_SETTLE_TIMEOUT;
+  savedEnv.MCP_MESH_TOOL_ISOLATION = process.env.MCP_MESH_TOOL_ISOLATION;
+  savedEnv.MCP_MESH_REGISTRY_URL = process.env.MCP_MESH_REGISTRY_URL;
+  // Inline execution so the user function receives the REAL proxy objects
+  // (the worker-isolation path re-creates proxies inside the worker).
+  process.env.MCP_MESH_TOOL_ISOLATION = "false";
+  // No settle grace — the middle dep is genuinely unresolved, not late.
+  process.env.MCP_MESH_SETTLE_TIMEOUT = "0";
+  resetSettleStateForTests();
+  RouteRegistry.reset();
+  __resetUnwiredSlotWarnedForTests();
+});
+
+afterEach(() => {
+  autoStartSpy?.mockRestore();
+  autoStartSpy = null;
+  warnSpy?.mockRestore();
+  warnSpy = null;
+  logSpy?.mockRestore();
+  logSpy = null;
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetSettleStateForTests();
+  RouteRegistry.reset();
+  __resetUnwiredSlotWarnedForTests();
+});
+
+describe("unresolved middle dependency does not shift", () => {
+  it("inbound path: positions 0 and 2 keep their proxies, position 1 stays null", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, {
+      name: "no-shift-agent",
+      httpPort: 0,
+    });
+
+    const received: unknown[] = [];
+    agent.addTool({
+      name: "fan_out",
+      parameters: z.object({}),
+      dependencies: [
+        { capability: "cap_a" },
+        { capability: "cap_b" },
+        { capability: "cap_c" },
+      ],
+      execute: async (
+        _args: unknown,
+        dep0: unknown,
+        dep1: unknown,
+        dep2: unknown,
+      ) => {
+        // Capture arity too: a compacted array would arrive as
+        // (args, proxyA, proxyC) — dep2 undefined, not null.
+        received.push(dep0, dep1, dep2);
+        return "ok";
+      },
+    });
+
+    // Resolve ONLY dep 0 and dep 2. dep 1 (cap_b) never resolves.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).handleDependencyAvailable(
+      "cap_a",
+      "http://provider-a:9001",
+      "fn_a",
+      "agent-a",
+      "fan_out",
+      0,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).handleDependencyAvailable(
+      "cap_c",
+      "http://provider-c:9003",
+      "fn_c",
+      "agent-c",
+      "fan_out",
+      2,
+    );
+
+    const execute = fastmcp.addTool.mock.calls[0][0].execute as (
+      args: unknown,
+    ) => Promise<string>;
+    expect(await execute({})).toBe("ok");
+
+    const [dep0, dep1, dep2] = received;
+    expect(capabilityOf(dep0)).toBe("cap_a");
+    // The unresolved dep leaves its OWN slot null — it does not consume
+    // cap_c's proxy by sliding up.
+    expect(dep1).toBeNull();
+    expect(capabilityOf(dep2)).toBe("cap_c");
+    // Explicitly rule out compaction: dep2 must be a real value, and the
+    // slot count must equal the declared dependency count.
+    expect(dep2).not.toBeUndefined();
+    expect(received).toHaveLength(3);
+  });
+
+  it("inbound path: leading and trailing unresolved deps hold their own slots", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, {
+      name: "edges-agent",
+      httpPort: 0,
+    });
+
+    const received: unknown[] = [];
+    agent.addTool({
+      name: "edges",
+      parameters: z.object({}),
+      dependencies: [
+        { capability: "cap_a" },
+        { capability: "cap_b" },
+        { capability: "cap_c" },
+      ],
+      execute: async (
+        _args: unknown,
+        dep0: unknown,
+        dep1: unknown,
+        dep2: unknown,
+      ) => {
+        received.push(dep0, dep1, dep2);
+        return "ok";
+      },
+    });
+
+    // Only the MIDDLE dep resolves — the first and last stay null.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).handleDependencyAvailable(
+      "cap_b",
+      "http://provider-b:9002",
+      "fn_b",
+      "agent-b",
+      "edges",
+      1,
+    );
+
+    const execute = fastmcp.addTool.mock.calls[0][0].execute as (
+      args: unknown,
+    ) => Promise<string>;
+    await execute({});
+
+    expect(received[0]).toBeNull();
+    expect(capabilityOf(received[1])).toBe("cap_b");
+    expect(received[2]).toBeNull();
+  });
+
+  it("a dependency going unavailable nulls only its own slot", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, {
+      name: "flap-agent",
+      httpPort: 0,
+    });
+
+    const received: unknown[] = [];
+    agent.addTool({
+      name: "flap",
+      parameters: z.object({}),
+      dependencies: [
+        { capability: "cap_a" },
+        { capability: "cap_b" },
+        { capability: "cap_c" },
+      ],
+      execute: async (
+        _args: unknown,
+        dep0: unknown,
+        dep1: unknown,
+        dep2: unknown,
+      ) => {
+        received.length = 0;
+        received.push(dep0, dep1, dep2);
+        return "ok";
+      },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const a = agent as any;
+    a.handleDependencyAvailable("cap_a", "http://a:9001", "fn_a", "agent-a", "flap", 0);
+    a.handleDependencyAvailable("cap_b", "http://b:9002", "fn_b", "agent-b", "flap", 1);
+    a.handleDependencyAvailable("cap_c", "http://c:9003", "fn_c", "agent-c", "flap", 2);
+
+    const execute = fastmcp.addTool.mock.calls[0][0].execute as (
+      args: unknown,
+    ) => Promise<string>;
+    await execute({});
+    expect(received.map(capabilityOf)).toEqual(["cap_a", "cap_b", "cap_c"]);
+
+    // The middle provider drops out mid-flight.
+    a.handleDependencyUnavailable("cap_b", "flap", 1);
+    await execute({});
+
+    expect(capabilityOf(received[0])).toBe("cap_a");
+    expect(received[1]).toBeNull();
+    expect(capabilityOf(received[2])).toBe("cap_c");
+  });
+
+  it("claim-dispatch path: unresolved middle dep does not shift either", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, {
+      name: "claim-no-shift-agent",
+      httpPort: 0,
+    });
+
+    const received: unknown[] = [];
+    agent.addTool({
+      name: "task_fan_out",
+      task: true,
+      parameters: z.object({}),
+      dependencies: [
+        { capability: "cap_a" },
+        { capability: "cap_b" },
+        { capability: "cap_c" },
+      ],
+      execute: async (
+        _args: unknown,
+        dep0: unknown,
+        dep1: unknown,
+        dep2: unknown,
+      ) => {
+        received.push(dep0, dep1, dep2);
+        return "ok";
+      },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const a = agent as any;
+    a.handleDependencyAvailable("cap_a", "http://a:9001", "fn_a", "agent-a", "task_fan_out", 0);
+    a.handleDependencyAvailable("cap_c", "http://c:9003", "fn_c", "agent-c", "task_fan_out", 2);
+
+    // The claim path builds its own deps array (`liveDeps`) — assert it
+    // preserves positions identically to the inbound path.
+    const { handler } = a._taskHandlers.get("task_fan_out");
+    expect(await handler({}, {} as never)).toBe("ok");
+
+    expect(capabilityOf(received[0])).toBe("cap_a");
+    expect(received[1]).toBeNull();
+    expect(capabilityOf(received[2])).toBe("cap_c");
+  });
+
+  it("mixed MeshJob + unresolved McpMeshTool: submitter keeps its own slot", async () => {
+    // Mirrors Python's `test_unresolved_mixed_mesh_tool_with_mesh_job`: a
+    // MeshJob slot is built locally (never resolved by an event), so an
+    // unresolved McpMeshTool sibling must not disturb it — and vice versa.
+    // The MeshJob slot builds a submitter bound to the resolved registry URL,
+    // which comes from the environment (not AgentConfig).
+    process.env.MCP_MESH_REGISTRY_URL = "http://registry.local:8000";
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, {
+      name: "mixed-agent",
+      httpPort: 0,
+    });
+
+    const received: unknown[] = [];
+    agent.addTool({
+      name: "mixed",
+      parameters: z.object({}),
+      dependencies: [
+        { capability: "run_workflow" }, // dep 0 → MeshJob slot
+        { capability: "missing_tool" }, // dep 1 → unresolved McpMeshTool
+        { capability: "cap_c" }, // dep 2 → resolved McpMeshTool
+      ],
+      meshJobDepIndex: 0,
+      execute: async (
+        _args: unknown,
+        job: unknown,
+        tool: unknown,
+        dep2: unknown,
+      ) => {
+        received.push(job, tool, dep2);
+        return "ok";
+      },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).handleDependencyAvailable(
+      "cap_c",
+      "http://c:9003",
+      "fn_c",
+      "agent-c",
+      "mixed",
+      2,
+    );
+
+    const execute = fastmcp.addTool.mock.calls[0][0].execute as (
+      args: unknown,
+    ) => Promise<string>;
+    await execute({});
+
+    expect(received[0]).toBeInstanceOf(MeshJobSubmitter);
+    expect((received[0] as MeshJobSubmitter).capability).toBe("run_workflow");
+    expect(received[1]).toBeNull();
+    expect(capabilityOf(received[2])).toBe("cap_c");
+  });
+});


### PR DESCRIPTION
## Summary

Three documentation problems and one test-coverage gap, all concerning the positional dependency-injection contract.

## 1. The framing overcorrected

The rule was written in an apologetic, alarm-toned register — all-caps `POSITIONALLY`, "parameter names ... are reader-friendly only", and leaked internals (`mesh_positions[: len(dependencies)]`) in user-facing text — duplicated verbatim across several files.

Positional pairing isn't a defect; it's one side of a real fork. Name-matching introduces capability/parameter drift that no IDE or type checker can detect, because it's a string-to-string contract across a network boundary. Worth noting the project already ships **both** strategies: Java's `@MeshTool` pairs positionally while `@MeshRoute` binds by name — the apology sat oddly next to that.

Restated plainly on both surfaces and de-duplicated (canonical note in `dependency-injection.md`; others cross-reference). `MESHJOB_DDDI_CONTRACT.md` deliberately untouched — a contract spec should stay explicit.

## 2. The Java man surface never stated the rule

`dependency-injection_java.md` mentioned ordering only for service views; `decorators_java.md` not at all — while `docs/java/` did cover it. Parallel-surface drift (man content is hand-maintained, not generated). Added, including how `@MeshRoute` differs by binding on name.

## 3. Broken Java examples — verified by compiling them

- **Did not compile:** `@MeshRoute(dependencies = @Selector(...))` in 2 files. `MeshRoute.dependencies()` is `MeshDependency[]`; `Selector[]` is `@MeshTool` only (`MeshRoute.java:91` vs `MeshTool.java:101`).
- **Did not bind:** route examples pairing capability `lookup_employee` with parameter `employeeLookup` (4 files) and `data_service`/`dataService` (2 files). `MeshRouteRegistry.toCamelCase` folds **kebab** hyphens only — `if (!kebab.contains("-")) return kebab;` — so a snake_case capability is left exactly as written and never matches a camelCase parameter. Fixed with explicit `@MeshInject(...)`.
- `@Selector` was described as the `@MeshRoute` selector surface in prose and a table (2 files).

Every corrected snippet was compiled with `javac -parameters` against the real annotations; a negative control reproduced the original `incompatible types: Selector cannot be converted to MeshDependency`.

## 4. Position stability now pinned in all three runtimes

The load-bearing safety property is: **an unresolved dependency must not shift the others** — it leaves its own slot null and every other dependency stays in place. If that didn't hold, a provider going down would silently rewire every downstream parameter, and the alarmed docs would have been justified.

It **does** hold everywhere, by the same mechanism — the slot array is index-keyed, never derived from resolution state:

| runtime | mechanism |
|---|---|
| Python | iterates positions, not resolved deps |
| TypeScript | `_buildDepSlots` — index-preserving map on `${tool}:dep_${i}` |
| Java | `injectedDeps.set(depIndexToSlot[depIndex], proxy)`, fixed `int[]` built in the constructor |

But only Python pinned it. Added 10 tests (5 TS + 5 Java) covering middle/leading/trailing unresolved, the resolved→unavailable flap, the claim-dispatch path, and the MeshJob case where declared-index and slot-ordinal spaces skew.

**Both sets were mutation-tested** — injecting the actual bug (`.filter(d => d !== null)` in TS, a compaction pass in Java) fails 5/5 in each runtime. Mutations reverted; verified clean in git.

## Verification

- TypeScript: **1213/1213** pass, `tsc --noEmit` clean.
- Java: **682/682** pass.
- `go build ./...` passes (man content is `go:embed`-ed).
- Java topics re-rendered and confirmed.

Closes #1384

## Test plan

- [ ] CI green