### PR TITLE
fix(man): style list items, and protect code spans from the bold/italic passes

### DIFF
--- a/src/core/cli/man/renderer.go
+++ b/src/core/cli/man/renderer.go
@@ -2,6 +2,7 @@ package man
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -42,6 +43,12 @@ var (
 	inlineLinkRe   = regexp.MustCompile(`\[([^\]]+)\]\([^)]+\)`)
 	numberedListRe = regexp.MustCompile(`^\d+\. `)
 )
+
+// placeholderSentinel wraps the index of an already-styled span while the
+// remaining inline passes run. NUL is stripped from the input first, so a
+// placeholder can never be forged by real content, and it matches none of the
+// bold/italic/link patterns (no backtick, underscore, asterisk, or brackets).
+const placeholderSentinel = "\x00"
 
 // Renderer handles guide content rendering.
 type Renderer struct {
@@ -126,19 +133,22 @@ func (r *Renderer) renderStyled(guide *Guide, content string) string {
 			continue
 		}
 
-		// Handle bullet points
+		// Handle bullet points. Only the content is styled; the marker keeps its
+		// own colouring so styleInline cannot disturb or swallow it. Code fences
+		// are handled above, so a "- " line inside a fenced block never reaches
+		// here and stays literal.
 		if strings.HasPrefix(line, "- ") {
-			sb.WriteString(yellow + "  • " + reset + strings.TrimPrefix(line, "- ") + "\n")
+			sb.WriteString(yellow + "  • " + reset + r.styleInline(strings.TrimPrefix(line, "- ")) + "\n")
 			continue
 		}
 		if strings.HasPrefix(line, "  - ") {
-			sb.WriteString(yellow + "    ◦ " + reset + strings.TrimPrefix(line, "  - ") + "\n")
+			sb.WriteString(yellow + "    ◦ " + reset + r.styleInline(strings.TrimPrefix(line, "  - ")) + "\n")
 			continue
 		}
 
 		// Handle numbered lists
-		if numberedListRe.MatchString(line) {
-			sb.WriteString(yellow + "  " + reset + line + "\n")
+		if marker := numberedListRe.FindString(line); marker != "" {
+			sb.WriteString(yellow + "  " + reset + marker + r.styleInline(strings.TrimPrefix(line, marker)) + "\n")
 			continue
 		}
 
@@ -159,8 +169,30 @@ func (r *Renderer) renderStyled(guide *Guide, content string) string {
 // styleInline applies inline styling for bold, italic, code, etc.
 // Uses pre-compiled regex patterns for performance.
 func (r *Renderer) styleInline(line string) string {
+	// Code spans and links are styled first and stashed behind placeholders so
+	// the bold/italic passes cannot reach their contents. Without this, a line
+	// carrying two snake_case code spans (e.g. `dependency_resolved` and
+	// `dependency_unresolved`) has its underscores paired across the spans by
+	// the italic pass, and a link URL containing underscores gets ANSI injected
+	// mid-URL. Reordering alone cannot fix this: running italic first would
+	// instead corrupt the text inside the code spans.
+	line = strings.ReplaceAll(line, placeholderSentinel, "")
+
+	var stashed []string
+	stash := func(styled string) string {
+		stashed = append(stashed, styled)
+		return placeholderSentinel + strconv.Itoa(len(stashed)-1) + placeholderSentinel
+	}
+
 	// Inline code: `code`
-	line = inlineCodeRe.ReplaceAllString(line, green+"$1"+reset)
+	line = inlineCodeRe.ReplaceAllStringFunc(line, func(match string) string {
+		return stash(green + inlineCodeRe.FindStringSubmatch(match)[1] + reset)
+	})
+
+	// Links: [text](url) - show as underlined text
+	line = inlineLinkRe.ReplaceAllStringFunc(line, func(match string) string {
+		return stash(underline + cyan + inlineLinkRe.FindStringSubmatch(match)[1] + reset)
+	})
 
 	// Bold: **text** or __text__
 	line = inlineBoldRe.ReplaceAllString(line, bold+"$1$2"+reset)
@@ -168,8 +200,12 @@ func (r *Renderer) styleInline(line string) string {
 	// Italic: *text* or _text_
 	line = inlineItalicRe.ReplaceAllString(line, italic+"$1$2"+reset)
 
-	// Links: [text](url) - show as underlined text
-	line = inlineLinkRe.ReplaceAllString(line, underline+cyan+"$1"+reset)
+	// Restore highest index first: a link may have stashed a code placeholder
+	// inside its text, and that code span always holds a lower index.
+	for i := len(stashed) - 1; i >= 0; i-- {
+		token := placeholderSentinel + strconv.Itoa(i) + placeholderSentinel
+		line = strings.ReplaceAll(line, token, stashed[i])
+	}
 
 	return line
 }

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -1,0 +1,349 @@
+package man
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStyleInline(t *testing.T) {
+	r := NewRenderer(false)
+
+	testCases := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			// Regression: audit.md:7. Two snake_case code spans on one line had
+			// their underscores paired across the spans by the italic pass.
+			name: "two snake_case code spans keep their underscores",
+			line: "records it as a `dependency_resolved` (or `dependency_unresolved`) event",
+			want: "records it as a " + green + "dependency_resolved" + reset +
+				" (or " + green + "dependency_unresolved" + reset + ") event",
+		},
+		{
+			name: "single snake_case code span keeps its underscore",
+			line: "the `agent_id` field",
+			want: "the " + green + "agent_id" + reset + " field",
+		},
+		{
+			name: "underscore italic outside code still italicises",
+			line: "this is _emphasised_ text",
+			want: "this is " + italic + "emphasised" + reset + " text",
+		},
+		{
+			name: "asterisk italic outside code still italicises",
+			line: "this is *emphasised* text",
+			want: "this is " + italic + "emphasised" + reset + " text",
+		},
+		{
+			name: "bold still bolds",
+			line: "this is **strong** text",
+			want: "this is " + bold + "strong" + reset + " text",
+		},
+		{
+			name: "underscore bold still bolds",
+			line: "this is __strong__ text",
+			want: "this is " + bold + "strong" + reset + " text",
+		},
+		{
+			name: "italic outside code coexists with snake_case code spans",
+			line: "_note_: `agent_id` and `agent_name` differ",
+			want: italic + "note" + reset + ": " + green + "agent_id" + reset +
+				" and " + green + "agent_name" + reset + " differ",
+		},
+		{
+			name: "link with underscores in url still renders as a link",
+			line: "see [the docs](https://example.com/a_b_c/d_e) for more",
+			want: "see " + underline + cyan + "the docs" + reset + " for more",
+		},
+		{
+			name: "link with underscores in text still renders as a link",
+			line: "see [dependency_injection](https://example.com/di) for more",
+			want: "see " + underline + cyan + "dependency_injection" + reset + " for more",
+		},
+		{
+			name: "code span containing an asterisk is not mangled",
+			line: "the `a*b` expression",
+			want: "the " + green + "a*b" + reset + " expression",
+		},
+		{
+			name: "two code spans containing asterisks are not mangled",
+			line: "compare `a*b` with `c*d`",
+			want: "compare " + green + "a*b" + reset + " with " + green + "c*d" + reset,
+		},
+		{
+			name: "code span containing double asterisks is not bolded",
+			line: "the `**literal**` token",
+			want: "the " + green + "**literal**" + reset + " token",
+		},
+		{
+			name: "code span containing markdown link syntax is not linkified",
+			line: "write `[text](url)` verbatim",
+			want: "write " + green + "[text](url)" + reset + " verbatim",
+		},
+		{
+			name: "code and bold and italic combine",
+			line: "**bold** `snake_case_name` _italic_",
+			want: bold + "bold" + reset + " " + green + "snake_case_name" + reset +
+				" " + italic + "italic" + reset,
+		},
+		{
+			name: "plain line is untouched",
+			line: "nothing to style here",
+			want: "nothing to style here",
+		},
+		{
+			name: "raw NUL in content cannot forge a placeholder",
+			line: "spooky \x000\x00 `agent_id`",
+			want: "spooky 0 " + green + "agent_id" + reset,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := r.styleInline(tc.line)
+			if got != tc.want {
+				t.Errorf("styleInline(%q)\n got: %q\nwant: %q", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStyleInlineNoStrayItalicBetweenCodeSpans guards the specific corruption
+// signature: an italic escape emitted between two code spans on the same line.
+func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
+	r := NewRenderer(false)
+
+	lines := []string{
+		"as a `dependency_resolved` (or `dependency_unresolved`) event in the log",
+		"set `MCP_MESH_LOG_LEVEL` and `MCP_MESH_DEBUG_MODE` together",
+		"`retry_on` accepts the same values as `max_duration`",
+		"fields `agent_id`, `capability_name`, and `resolved_at`",
+	}
+
+	for _, line := range lines {
+		t.Run(line, func(t *testing.T) {
+			got := r.styleInline(line)
+			if strings.Contains(got, italic) {
+				t.Errorf("stray italic escape in styleInline(%q): %q", line, got)
+			}
+			// Every underscore in the source must survive into the output.
+			if want, have := strings.Count(line, "_"), strings.Count(got, "_"); want != have {
+				t.Errorf("styleInline(%q) dropped underscores: want %d, have %d (%q)",
+					line, want, have, got)
+			}
+		})
+	}
+}
+
+// TestStyleInlineCorpus renders every shipped man page and asserts that the
+// content of every source code span survives verbatim into the output. Any
+// bold/italic/link escape injected into a code span breaks this.
+func TestStyleInlineCorpus(t *testing.T) {
+	r := NewRenderer(false)
+	checked := 0
+
+	for _, guide := range ListGuides() {
+		_, content, err := GetGuide(guide.Name)
+		if err != nil {
+			t.Fatalf("GetGuide(%q) failed: %v", guide.Name, err)
+		}
+
+		inCodeBlock := false
+		for i, line := range strings.Split(content, "\n") {
+			// Only inline-formatted prose reaches styleInline; code blocks,
+			// headers and tables take other branches in renderStyled.
+			if strings.HasPrefix(line, "```") {
+				inCodeBlock = !inCodeBlock
+				continue
+			}
+			if inCodeBlock || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "|") {
+				continue
+			}
+
+			styled := r.styleInline(line)
+			for _, m := range inlineCodeRe.FindAllStringSubmatch(line, -1) {
+				checked++
+				if !strings.Contains(styled, green+m[1]+reset) {
+					t.Errorf("%s:%d code span %q corrupted\n src: %q\n out: %q",
+						guide.Name, i+1, m[1], line, styled)
+				}
+			}
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no inline code spans found in man corpus; test is not exercising anything")
+	}
+	t.Logf("verified %d inline code spans across the man corpus", checked)
+}
+
+const (
+	bulletMarker       = yellow + "  • " + reset
+	nestedBulletMarker = yellow + "    ◦ " + reset
+	numberedMarker     = yellow + "  " + reset
+)
+
+// TestRenderStyledListItems covers list content reaching the inline passes.
+// Bullet and numbered branches used to write their remainder raw, so markup in
+// a list item rendered literally.
+func TestRenderStyledListItems(t *testing.T) {
+	r := NewRenderer(false)
+	guide := &Guide{Name: "t", Title: "T"}
+
+	testCases := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "bullet with inline code",
+			content: "- For `dependency_resolved`:",
+			want:    bulletMarker + "For " + green + "dependency_resolved" + reset + ":",
+		},
+		{
+			name:    "bullet with bold",
+			content: "- **Orphan reroute.** A job whose owner died",
+			want:    bulletMarker + bold + "Orphan reroute." + reset + " A job whose owner died",
+		},
+		{
+			name:    "bullet with two snake_case code spans",
+			content: "- `agent_id` and `agent_name` differ",
+			want: bulletMarker + green + "agent_id" + reset + " and " +
+				green + "agent_name" + reset + " differ",
+		},
+		{
+			name:    "nested bullet with inline code",
+			content: "  - the `retry_on` field",
+			want:    nestedBulletMarker + "the " + green + "retry_on" + reset + " field",
+		},
+		{
+			name:    "nested bullet with bold and italic",
+			content: "  - **note:** _see_ below",
+			want:    nestedBulletMarker + bold + "note:" + reset + " " + italic + "see" + reset + " below",
+		},
+		{
+			name:    "numbered item with inline code",
+			content: "1. Run `meshctl start` first",
+			want:    numberedMarker + "1. Run " + green + "meshctl start" + reset + " first",
+		},
+		{
+			name:    "numbered item with bold, multi-digit marker",
+			content: "12. **Deploy** the agent",
+			want:    numberedMarker + "12. " + bold + "Deploy" + reset + " the agent",
+		},
+		{
+			name:    "bullet with a markdown link",
+			content: "- see [the docs](https://example.com/a_b_c)",
+			want:    bulletMarker + "see " + underline + cyan + "the docs" + reset,
+		},
+		{
+			name:    "plain bullet is unchanged",
+			content: "- nothing to style",
+			want:    bulletMarker + "nothing to style",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := r.Render(guide, tc.content)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("Render(%q)\n got: %q\nwant to contain: %q", tc.content, got, tc.want)
+			}
+			// Markup must be consumed, not left literal.
+			body := strings.TrimPrefix(got, renderedHeader(guide))
+			if strings.Contains(body, "`") || strings.Contains(body, "**") {
+				t.Errorf("Render(%q) left literal markdown: %q", tc.content, body)
+			}
+		})
+	}
+}
+
+// TestRenderStyledFencedListItemsStayLiteral is the critical negative case:
+// bullet- and numbered-looking lines inside a fenced code block must NOT be
+// styled, or code samples would be corrupted. Code fences are handled before
+// the list branches in renderStyled, which is what protects them.
+func TestRenderStyledFencedListItemsStayLiteral(t *testing.T) {
+	r := NewRenderer(false)
+	guide := &Guide{Name: "t", Title: "T"}
+
+	content := strings.Join([]string{
+		"```yaml",
+		"- name: `literal_backticks`",
+		"  - nested: **not bold**",
+		"1. numbered: `stays_literal`",
+		"```",
+	}, "\n")
+
+	got := r.Render(guide, content)
+
+	for _, literal := range []string{
+		"- name: `literal_backticks`",
+		"  - nested: **not bold**",
+		"1. numbered: `stays_literal`",
+	} {
+		if !strings.Contains(got, literal) {
+			t.Errorf("fenced line %q was altered; output: %q", literal, got)
+		}
+	}
+	if strings.Contains(got, bulletMarker) || strings.Contains(got, nestedBulletMarker) {
+		t.Errorf("fenced lines were turned into bullets: %q", got)
+	}
+	// The title block legitimately uses bold, so inspect only the body.
+	if body := strings.TrimPrefix(got, renderedHeader(guide)); strings.Contains(body, bold) {
+		t.Errorf("fenced ** was bolded: %q", body)
+	}
+}
+
+// TestRenderStyledCorpusListItems asserts that code spans on list lines of the
+// shipped man pages survive verbatim into the fully rendered page. The earlier
+// styleInline-only corpus test could not catch renderStyled skipping the inline
+// passes for list items.
+func TestRenderStyledCorpusListItems(t *testing.T) {
+	r := NewRenderer(false)
+	checked := 0
+
+	for _, guide := range ListGuides() {
+		g, content, err := GetGuide(guide.Name)
+		if err != nil {
+			t.Fatalf("GetGuide(%q) failed: %v", guide.Name, err)
+		}
+		rendered := r.Render(g, content)
+
+		inCodeBlock := false
+		for i, line := range strings.Split(content, "\n") {
+			if strings.HasPrefix(line, "```") {
+				inCodeBlock = !inCodeBlock
+				continue
+			}
+			if inCodeBlock {
+				continue
+			}
+			if !strings.HasPrefix(line, "- ") && !strings.HasPrefix(line, "  - ") &&
+				!numberedListRe.MatchString(line) {
+				continue
+			}
+
+			for _, m := range inlineCodeRe.FindAllStringSubmatch(line, -1) {
+				checked++
+				if !strings.Contains(rendered, green+m[1]+reset) {
+					t.Errorf("%s:%d list-item code span %q not styled\n src: %q",
+						guide.Name, i+1, m[1], line)
+				}
+			}
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no list-item code spans found in man corpus; test is not exercising anything")
+	}
+	t.Logf("verified %d list-item inline code spans across the man corpus", checked)
+}
+
+// renderedHeader reproduces the fixed title block Render emits, so tests can
+// inspect only the body.
+func renderedHeader(guide *Guide) string {
+	bar := strings.Repeat("━", 78)
+	return cyan + bold + bar + "\n  " + guide.Title + "\n" + bar + "\n" + reset
+}


### PR DESCRIPTION
## Summary

Two rendering defects in `meshctl man`. Source markdown was correct in every case — the renderer mangled it.

### 1. Inline code corrupted by the italic pass

`styleInline` ran code → bold → italic → link. Once `inlineCodeRe` strips the backticks, span content is ordinary text, so `_([^_]+)_` pairs the underscore in one code span with the one in the next. Since mcp-mesh uses snake_case capabilities everywhere, this was pervasive.

```
source:   ... as a `dependency_resolved` (or `dependency_unresolved`) event ...
rendered: ... as a ^[[32mdependency^[[3mresolved^[[0m (or ^[[32mdependency^[[0munresolved^[[0m) ...
```

Same cause hit links (URL underscores got ANSI injected, after which the link regex no longer matched). A second instance surfaced in `llm.md:61`, where the bold pass emitted `\x1b[1m` and the literal `[1m` was then swallowed as link text.

**Fix:** style code spans and links first, stash them behind NUL-delimited placeholders matching none of the remaining patterns, run bold/italic, restore highest-index-first so a code span nested in link text still restores correctly. Input NULs are stripped up front so content can't forge a placeholder.

### 2. List items were never styled at all

The `- `, nested `  - `, and numbered branches in `renderStyled` wrote the line raw and `continue`d — `styleInline` was never reached, so markup rendered literally.

```
source:     - **Orphan reroute.** A job whose owner replica is gone
before:       • **Orphan reroute.** A job whose owner replica is gone
after:        • [bold]Orphan reroute.[/] A job whose owner replica is gone
```

**774 list lines across 65 files** carried `code` or `**bold**` — the larger of the two defects.

**Fix:** route the three branches through `styleInline` for their **content only**; the coloured marker is emitted separately, so markers stay byte-identical.

## Fences are safe — verified, not assumed

The fence toggle and `inCodeBlock` guard both `continue` **before** the list branches, so a `- ` or `1. ` line inside a fenced block never reaches them and stays literal. This was the main regression risk and it's now pinned by `TestRenderStyledFencedListItemsStayLiteral`.

## Verification

| scan | before | after |
|---|---|---|
| corrupted code spans (italic inside code) | 83 | **0** |
| unstyled list lines — default variant | 432 | **0** |
| unstyled list lines — `--typescript` | — | **0** |
| unstyled list lines — `--java` | — | **0** |

Marker counts are identical per-topic before/after, confirming no line changed branch. Indentation preserved.

**Tests:** the package previously had none. Added 6 tests / 35 subtests — including a corpus test verifying **1582 code spans** and **475 list-item spans** against full `Render()` output, and the fenced-list negative case.

Proven to be genuine regression guards, not tautologies: reverting only the inline fix yields 182 corrupted spans and 7 failing subtests; reverting only the list fix yields 363 unstyled corpus spans.

`go build ./...` · `go vet` · `gofmt` · `go test ./src/core/cli/man/...` **35 PASS / 0 FAIL** · `go test ./src/core/...` 10 ok packages.

## Deliberately out of scope

Table (577 lines), blockquote (56), and header (39) branches still bypass `styleInline`. They wrap the **whole line** in a colour, and since `styleInline` emits `reset` after every span, routing them through as-is would kill the wrapper colour mid-line — trading one defect for another. That needs reset-aware styling (a colour stack or re-applying the base after each span), which is a change to `styleInline`'s contract rather than a routing fix. Detailed in #1392; tables are the biggest remaining win.

Closes #1392

## Test plan

- [ ] CI green
- [ ] Manual: `meshctl man audit`, `man jobs`, `man environment` — code spans keep underscores, bullets styled, fenced samples still literal