### PR TITLE
fix(route): rebuild routes through the public FastAPI API, drop the <0.140.5 ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,25 @@ jobs:
           name: codecov-${{ matrix.test-group }}
           fail_ci_if_error: false
 
+      # Issue #1387/#1389: @mesh.route route integration is the one place mesh
+      # rebuilds FastAPI's cached route state, so it is the one place a FastAPI
+      # release can break us. Testing a single resolved FastAPI is how 0.140.5
+      # shipped as a silent SSE-to-JSON degradation. The run above uses whatever
+      # pip resolves (latest); re-run the route-integration tests against an
+      # older FastAPI so both ends of the supported range are covered.
+      # Runs last so it cannot perturb coverage/test-result artifacts.
+      - name: Route integration tests against older FastAPI
+        if: matrix.test-group == 'unit' && matrix.python-version == '3.11'
+        env:
+          MCP_MESH_AUTO_RUN: false
+        run: |
+          python -c "import fastapi; print('resolved fastapi:', fastapi.__version__)"
+          pip install "fastapi==0.136.1"
+          python -c "import fastapi; print('pinned fastapi:', fastapi.__version__)"
+          pytest tests/unit/test_route_sse_wrapping.py \
+            tests/unit/test_sse_strips_mcp_mesh_tool_params.py \
+            tests/unit/test_stream_settle.py -q
+
   security-scan:
     name: Security Scanning
     runs-on: ubuntu-latest

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -59,7 +59,7 @@ requires-python = ">=3.11"
 dependencies = [
     # Rust core runtime (required - no Python fallback)
     "mcp-mesh-core>=3.3.1",
-    "fastapi>=0.104.0,<0.140.5",
+    "fastapi>=0.104.0,<1.0.0",
     "uvicorn>=0.24.0,<1.0.0",
     "httpx>=0.25.0,<1.0.0",
     "aiohttp>=3.8.0,<4.0.0",

--- a/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
@@ -799,4 +799,18 @@ class RouteIntegrationStep(PipelineStep):
         kwargs = {
             name: getattr(route, name) for name in init_params if hasattr(route, name)
         }
+        # Anything the constructor accepts but the route doesn't mirror as an
+        # attribute can't be round-tripped, so it falls back to the FastAPI
+        # default on the rebuilt route. That never happens on today's FastAPI
+        # (all parameters round-trip); log it so a future release that breaks
+        # the symmetry is visible instead of silently degrading.
+        skipped = [name for name in init_params if name not in kwargs]
+        if skipped:
+            logger.debug(
+                "Route rebuild for '%s' %s: APIRoute parameter(s) %s not readable "
+                "off the existing route, falling back to FastAPI defaults",
+                route.path,
+                sorted(getattr(route, "methods", None) or []),
+                ", ".join(skipped),
+            )
         return APIRoute(path=route.path, endpoint=wrapped_handler, **kwargs)

--- a/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
@@ -14,6 +14,23 @@ from ..shared import PipelineResult, PipelineStatus, PipelineStep
 logger = logging.getLogger(__name__)
 
 
+class RouteRebuildError(RuntimeError):
+    """Raised when a route's FastAPI state could not be rebuilt after wrapping.
+
+    A rebuild failure means the route is still REGISTERED AND SERVING, but
+    FastAPI's cached dispatch state (dependant, body field, per-route ASGI
+    handler) no longer matches the handler mesh installed. For an SSE route
+    that surfaces as ``application/jsonl`` instead of ``text/event-stream``
+    — a broken wire contract on a route that looks healthy.
+
+    This is deliberately fatal (issue #1387): the previous code logged a
+    warning and reported success, which is how FastAPI 0.140.5's rename of
+    ``get_body_field`` shipped as a silent SSE degradation. Route
+    integration is a ``required=True`` pipeline step, so raising here fails
+    the pipeline and aborts startup rather than serving a wrong response.
+    """
+
+
 _SSE_HEADERS = {
     "Cache-Control": "no-cache",
     "X-Accel-Buffering": "no",
@@ -412,6 +429,15 @@ class RouteIntegrationStep(PipelineStep):
                 else:
                     integration_results["error_count"] += 1
 
+            except RouteRebuildError:
+                # Do NOT absorb into error_count like other per-route
+                # failures. A rebuild failure leaves a live route whose
+                # FastAPI dispatch state contradicts the handler mesh
+                # installed (e.g. an SSE route answering application/jsonl).
+                # Let it reach execute(), which fails this required step so
+                # startup aborts instead of serving a broken contract
+                # (issue #1387).
+                raise
             except Exception as e:
                 self.logger.error(f"❌ Failed to integrate route '{route_name}': {e}")
                 integration_results["error_count"] += 1
@@ -642,6 +668,11 @@ class RouteIntegrationStep(PipelineStep):
         """
         Replace the route handler in FastAPI's router.
 
+        The matched route is swapped for a freshly-constructed ``APIRoute``
+        carrying the wrapped endpoint, so FastAPI recomputes its own cached
+        dispatch state instead of mesh hand-patching it through private
+        internals.
+
         Args:
             app: FastAPI application instance
             path: Route path to find
@@ -650,11 +681,27 @@ class RouteIntegrationStep(PipelineStep):
             wrapped_handler: New wrapped handler function
 
         Returns:
-            True if replacement was successful, False otherwise
+            True if the route was found and rebuilt. False only when no
+            matching route exists — nothing was modified in that case, so
+            the caller reports the route as not integrated.
+
+        Raises:
+            RouteRebuildError: The route was found but could not be rebuilt.
+                Never reported as success: the route is live and its dispatch
+                state would contradict the installed handler (issue #1387).
         """
+        from fastapi.routing import APIRoute
+
         try:
-            # Find the matching route in FastAPI's router
-            for route in app.router.routes:
+            # Find the matching route in FastAPI's router.
+            #
+            # ``app.routes`` IS ``app.router.routes`` (same list object), and
+            # Starlette resolves requests by walking that list per request —
+            # no route is cached by identity anywhere, and nothing in
+            # _mcp_mesh holds a route object (only ``route.endpoint``
+            # functions and path/method strings). So substituting a rebuilt
+            # route in place is equivalent to mutating the existing one.
+            for index, route in enumerate(app.router.routes):
                 if (
                     hasattr(route, "endpoint")
                     and hasattr(route, "path")
@@ -664,80 +711,47 @@ class RouteIntegrationStep(PipelineStep):
                     # Match by path and endpoint function
                     if route.path == path and route.endpoint is original_handler:
 
-                        # Replace the endpoint with our wrapped version
-                        route.endpoint = wrapped_handler
+                        if not isinstance(route, APIRoute):
+                            raise RouteRebuildError(
+                                f"Route {methods} {path} is a "
+                                f"{type(route).__name__}, not a FastAPI "
+                                f"APIRoute; @mesh.route handlers must be "
+                                f"registered through FastAPI's decorators "
+                                f"(@app.post/@app.get/...) so their dispatch "
+                                f"state can be rebuilt after wrapping"
+                            )
 
-                        # FastAPI dispatches via a per-route ASGI handler closure
-                        # (route.app) that captured the original Dependant and
-                        # response_field at registration time. Updating
-                        # route.endpoint alone is not enough — we must rebuild
-                        # the dependant AND the request_response closure so
-                        # invocation actually targets the wrapper. Critical for
-                        # SSE wrapping where the wrapper returns a
-                        # StreamingResponse; without rebuild, FastAPI keeps
-                        # calling the original async-generator function and tries
-                        # to JSON-encode the result. Harmless for plain DI
-                        # wrapping where the closure already targeted the wrapper.
-                        try:
-                            from fastapi.dependencies.utils import (
-                                _should_embed_body_fields,
-                                get_body_field,
-                                get_dependant,
-                                get_flat_dependant,
-                            )
-                            from fastapi.routing import request_response
-
-                            route.dependant = get_dependant(
-                                path=route.path_format, call=wrapped_handler
-                            )
-                            # APIRoute.__init__ caches a flattened dependant,
-                            # the embed-body-fields decision, and the body
-                            # field model based on the original endpoint.
-                            # When the original endpoint mixed a Pydantic
-                            # body model with framework-only params (e.g.
-                            # McpMeshTool, FastMCP Context), FastAPI baked
-                            # in embed-mode body parsing — request parser
-                            # then expects ``{"body": {...}}`` envelopes.
-                            # Since the SSE wrapper now exposes ONLY the
-                            # user-facing params, refresh the cached
-                            # decision from the rebuilt dependant. Issue
-                            # #645 bug 5.
-                            route._flat_dependant = get_flat_dependant(
-                                route.dependant
-                            )
-                            route._embed_body_fields = _should_embed_body_fields(
-                                route._flat_dependant.body_params
-                            )
-                            try:
-                                route.body_field = get_body_field(
-                                    flat_dependant=route._flat_dependant,
-                                    name=route.unique_id,
-                                    embed_body_fields=route._embed_body_fields,
-                                )
-                            except TypeError:
-                                # Older FastAPI signature without embed_body_fields kwarg
-                                route.body_field = get_body_field(
-                                    dependant=route._flat_dependant,
-                                    name=route.unique_id,
-                                )
-                            # FastAPI >=0.136 added auto JSONL/SSE streaming for
-                            # generator endpoints. APIRoute.__init__ caches
-                            # is_json_stream and is_sse_stream based on the
-                            # ORIGINAL endpoint's is_async_gen_callable. Our
-                            # wrapped_handler is always a coroutine returning
-                            # StreamingResponse, so those flags must be False —
-                            # otherwise FastAPI's auto-streaming path tries to
-                            # iterate our wrapper and fails with "'coroutine'
-                            # object is not iterable". Older FastAPI versions
-                            # don't have these attributes; setattr is safe.
-                            for attr in ("is_json_stream", "is_sse_stream"):
-                                if hasattr(route, attr):
-                                    setattr(route, attr, False)
-                            route.app = request_response(route.get_route_handler())
-                        except Exception as e:
-                            self.logger.warning(
-                                f"Failed to rebuild route handler for {path}: {e}"
-                            )
+                        # FastAPI dispatches via a per-route ASGI handler
+                        # closure (route.app) built from state APIRoute.__init__
+                        # derives from the endpoint: the Dependant, the
+                        # flattened dependant, the embed-body-fields decision,
+                        # the body field model, the response field, and (since
+                        # 0.136) the is_json_stream / is_sse_stream
+                        # auto-streaming flags. Assigning route.endpoint alone
+                        # leaves ALL of that pointing at the original function.
+                        #
+                        # Critical for SSE wrapping, where the wrapper returns
+                        # a StreamingResponse: without a rebuild FastAPI keeps
+                        # calling the original async-generator function and
+                        # JSON-encodes (or JSONL-streams) the result, so the
+                        # response comes back as application/jsonl instead of
+                        # text/event-stream. Harmless-but-correct for plain DI
+                        # wrapping, where the closure already targeted the
+                        # wrapper.
+                        #
+                        # Rather than hand-recomputing that state through
+                        # private FastAPI internals — which is how the 0.140.5
+                        # rename of ``get_body_field`` broke SSE silently
+                        # (issues #1387/#1389) — construct a fresh APIRoute
+                        # around the wrapper and let FastAPI derive everything
+                        # itself. Every APIRoute.__init__ parameter is
+                        # round-trippable off the existing route, so the new
+                        # route carries the user's original registration
+                        # options (response_model, status_code, tags,
+                        # dependencies, response_class, name/unique_id, ...)
+                        # unchanged.
+                        new_route = self._rebuild_api_route(route, wrapped_handler)
+                        app.router.routes[index] = new_route
 
                         return True
 
@@ -747,6 +761,42 @@ class RouteIntegrationStep(PipelineStep):
             )
             return False
 
+        except RouteRebuildError:
+            raise
         except Exception as e:
-            self.logger.error(f"❌ Error replacing route handler: {e}")
-            return False
+            raise RouteRebuildError(
+                f"Failed to rebuild route {methods} {path} after wrapping: {e}"
+            ) from e
+
+    @staticmethod
+    def _rebuild_api_route(route, wrapped_handler):
+        """Build a fresh ``APIRoute`` for ``wrapped_handler`` from ``route``.
+
+        Reads every ``APIRoute.__init__`` parameter back off the existing
+        route and re-runs the constructor with the wrapped endpoint. The
+        parameter list is read from the signature at call time, so a FastAPI
+        release that adds a registration option is carried over automatically
+        instead of being silently dropped.
+
+        This is what makes the rebuild version-independent: FastAPI computes
+        the dependant, body field, embed-body-fields decision and the
+        auto-streaming flags itself, using whatever private helpers the
+        installed version happens to have. In particular ``is_json_stream`` /
+        ``is_sse_stream`` come out False on their own, because the wrapper is
+        a coroutine rather than an async generator.
+        """
+        from fastapi.routing import APIRoute
+
+        init_params = [
+            name
+            for name, param in inspect.signature(
+                APIRoute.__init__
+            ).parameters.items()
+            if name not in ("self", "path", "endpoint")
+            and param.kind
+            in (param.POSITIONAL_OR_KEYWORD, param.KEYWORD_ONLY)
+        ]
+        kwargs = {
+            name: getattr(route, name) for name in init_params if hasattr(route, name)
+        }
+        return APIRoute(path=route.path, endpoint=wrapped_handler, **kwargs)

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -57,7 +57,7 @@ requires-python = ">=3.11"
 # native google-genai SDK; without it they would silently fall back to
 # LiteLLM.
 dependencies = [
-    "fastapi>=0.104.0,<0.140.5",
+    "fastapi>=0.104.0",
     "uvicorn>=0.24.0",
     "httpx>=0.25.0",
     "aiohttp>=3.8.0",

--- a/src/runtime/python/tests/unit/test_route_sse_wrapping.py
+++ b/src/runtime/python/tests/unit/test_route_sse_wrapping.py
@@ -31,6 +31,7 @@ import mesh
 from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
 from _mcp_mesh.pipeline.api_startup.route_integration import (
     RouteIntegrationStep,
+    RouteRebuildError,
     _build_sse_endpoint,
     _frame_chunk_as_sse,
     _resolve_user_function,
@@ -699,3 +700,278 @@ class TestSseGatewayShape:
         r = client_err.post("/api/chat", json={})
         assert r.status_code == 503
         assert "dep unavailable" in r.text
+
+
+# ---------------------------------------------------------------------------
+# Issues #1387 / #1389: version-independent route rebuild + loud failure
+# ---------------------------------------------------------------------------
+
+
+class TestRouteRebuildIsVersionIndependent:
+    """The rebuild must not reach into FastAPI's private API.
+
+    FastAPI 0.140.5 renamed ``get_body_field`` to ``_get_body_field`` and
+    changed its signature. The old hand-rebuild imported it directly, the
+    ``ImportError`` was swallowed, and every @mesh.route SSE endpoint
+    silently degraded to ``application/jsonl`` (#1387). The rebuild now
+    constructs a fresh ``APIRoute``, so FastAPI derives that state with
+    whatever internals the installed version has.
+    """
+
+    def test_no_private_fastapi_imports_in_route_integration(self):
+        import _mcp_mesh.pipeline.api_startup.route_integration as mod
+
+        source = inspect.getsource(mod)
+        # ``APIRoute`` is public (documented for custom route classes);
+        # anything else out of fastapi.dependencies/fastapi.routing is not.
+        assert "fastapi.dependencies" not in source
+        for line in source.splitlines():
+            if "from fastapi.routing import" in line:
+                assert line.strip() == "from fastapi.routing import APIRoute", line
+
+    def test_rebuild_preserves_route_registration_options(self):
+        """Every APIRoute.__init__ option the user set must survive.
+
+        The old hand-rebuild recomputed only four attributes and silently
+        dropped route-level ``dependencies=[Depends(...)]`` (FastAPI
+        re-inserts those into the dependant, the manual ``get_dependant``
+        call did not).
+        """
+        from fastapi import Depends
+        from fastapi.responses import PlainTextResponse
+
+        guard_calls: list[int] = []
+
+        async def guard():
+            guard_calls.append(1)
+
+        async def chat(prompt: str) -> mesh.Stream[str]:
+            yield "a"
+
+        app = FastAPI()
+        app.post(
+            "/api/chat",
+            response_model=None,
+            status_code=201,
+            tags=["chat-tag"],
+            name="custom_route_name",
+            dependencies=[Depends(guard)],
+            response_class=PlainTextResponse,
+            include_in_schema=False,
+        )(chat)
+
+        before = next(
+            r for r in app.router.routes if getattr(r, "path", "") == "/api/chat"
+        )
+        before_state = (
+            before.unique_id,
+            before.name,
+            before.status_code,
+            before.tags,
+            before.response_class,
+            before.include_in_schema,
+            len(before.dependencies),
+        )
+
+        step = RouteIntegrationStep()
+        result = step._integrate_single_route(
+            app, _build_route_info(chat, "/api/chat"), MagicMock()
+        )
+        assert result["status"] == "integrated"
+
+        after = next(
+            r for r in app.router.routes if getattr(r, "path", "") == "/api/chat"
+        )
+        assert (
+            after.unique_id,
+            after.name,
+            after.status_code,
+            after.tags,
+            after.response_class,
+            after.include_in_schema,
+            len(after.dependencies),
+        ) == before_state
+
+        # The route-level Depends must still run on a real request. (Status
+        # and media type come from the StreamingResponse the SSE wrapper
+        # returns explicitly, so the route's status_code/response_class do
+        # not apply to the wire — unchanged by the rebuild.)
+        client = TestClient(app)
+        with client.stream("POST", "/api/chat?prompt=hi") as response:
+            assert response.status_code == 200
+            assert response.headers["content-type"].startswith("text/event-stream")
+            body = response.read().decode("utf-8")
+        assert body == "data: a\n\ndata: [DONE]\n\n"
+        assert guard_calls == [1]
+
+    def test_non_streaming_di_route_still_works_end_to_end(self):
+        """The rebuild runs for plain (non-SSE) DI routes too — it must not
+        regress them. Ordinary params still bind, the injected McpMeshTool is
+        kept out of the HTTP-facing signature, and the JSON response is
+        unchanged.
+        """
+
+        @mesh.route(dependencies=["greeter"])
+        async def hello(name: str, greeter: mesh.McpMeshTool = None) -> dict:
+            return {"name": name, "dep": greeter}
+
+        app = FastAPI()
+        app.get("/hello")(hello)
+
+        step = RouteIntegrationStep()
+        route_info = _build_route_info(
+            hello, "/hello", methods=("GET",), deps=[{"capability": "greeter"}]
+        )
+        result = step._integrate_single_route(app, route_info, MagicMock())
+        assert result["status"] == "integrated"
+        assert result.get("sse") is not True
+
+        registered = next(
+            r for r in app.router.routes if getattr(r, "path", "") == "/hello"
+        )
+        sig = inspect.signature(registered.endpoint)
+        assert "name" in sig.parameters
+        assert "greeter" not in sig.parameters
+
+        response = TestClient(app).get("/hello?name=world")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/json")
+        assert response.json() == {"name": "world", "dep": None}
+
+    def test_auto_stream_flags_are_false_after_rebuild(self):
+        """FastAPI >=0.136 caches is_json_stream/is_sse_stream from the
+        ORIGINAL async-generator endpoint. The wrapper is a coroutine, so a
+        correct rebuild recomputes both as False — otherwise FastAPI's
+        auto-JSONL path iterates our wrapper and the response comes back as
+        application/jsonl (the #1387 symptom).
+        """
+
+        async def chat(prompt: str) -> mesh.Stream[str]:
+            yield "a"
+
+        app = FastAPI()
+        app.post("/api/chat", response_model=None)(chat)
+
+        before = next(
+            r for r in app.router.routes if getattr(r, "path", "") == "/api/chat"
+        )
+        if not hasattr(before, "is_json_stream"):
+            pytest.skip("FastAPI too old for auto-streaming flags")
+        assert before.is_json_stream is True
+
+        step = RouteIntegrationStep()
+        step._integrate_single_route(
+            app, _build_route_info(chat, "/api/chat"), MagicMock()
+        )
+
+        after = next(
+            r for r in app.router.routes if getattr(r, "path", "") == "/api/chat"
+        )
+        assert after.is_json_stream is False
+        assert after.is_sse_stream is False
+
+
+class TestRouteRebuildFailureIsLoud:
+    """A failed rebuild must never be reported as a successful integration.
+
+    Before #1387 the rebuild ran under ``except Exception`` that logged a
+    warning and then ``return True`` — the route stayed live with FastAPI
+    dispatch state pointing at the unwrapped endpoint, so SSE silently
+    became JSON while the agent looked healthy.
+    """
+
+    @staticmethod
+    def _app_with_stream_route():
+        async def chat(prompt: str) -> mesh.Stream[str]:
+            yield "a"
+
+        app = FastAPI()
+        app.post("/api/chat", response_model=None)(chat)
+        return app, chat
+
+    def test_rebuild_failure_raises_instead_of_reporting_integrated(
+        self, monkeypatch
+    ):
+        app, chat = self._app_with_stream_route()
+
+        def _boom(route, wrapped_handler):
+            raise ImportError("cannot import name 'get_body_field'")
+
+        monkeypatch.setattr(
+            RouteIntegrationStep, "_rebuild_api_route", staticmethod(_boom)
+        )
+
+        step = RouteIntegrationStep()
+        with pytest.raises(RouteRebuildError) as exc:
+            step._integrate_single_route(
+                app, _build_route_info(chat, "/api/chat"), MagicMock()
+            )
+        assert "get_body_field" in str(exc.value)
+
+    def test_rebuild_failure_is_not_absorbed_into_error_count(self, monkeypatch):
+        """``_integrate_app_routes`` swallows ordinary per-route errors into
+        ``error_count``, which ``execute()`` discards. A rebuild failure must
+        punch through that instead."""
+        app, chat = self._app_with_stream_route()
+
+        def _boom(route, wrapped_handler):
+            raise RuntimeError("nope")
+
+        monkeypatch.setattr(
+            RouteIntegrationStep, "_rebuild_api_route", staticmethod(_boom)
+        )
+
+        step = RouteIntegrationStep()
+        with pytest.raises(RouteRebuildError):
+            step._integrate_app_routes(
+                {"instance": app, "title": "t"},
+                {"chat": _build_route_info(chat, "/api/chat")},
+            )
+
+    @pytest.mark.asyncio
+    async def test_rebuild_failure_fails_the_pipeline_step(self, monkeypatch):
+        """RouteIntegrationStep is required=True, so a FAILED result aborts
+        startup (startup_orchestrator raises on a failed pipeline) rather
+        than serving a route with a broken wire contract."""
+        from _mcp_mesh.pipeline.shared import PipelineStatus
+
+        app, chat = self._app_with_stream_route()
+
+        def _boom(route, wrapped_handler):
+            raise RuntimeError("nope")
+
+        monkeypatch.setattr(
+            RouteIntegrationStep, "_rebuild_api_route", staticmethod(_boom)
+        )
+
+        step = RouteIntegrationStep()
+        assert step.required is True
+        result = await step.execute(
+            {
+                "fastapi_apps": {"app1": {"instance": app, "title": "t"}},
+                "route_mapping": {
+                    "app1": {"chat": _build_route_info(chat, "/api/chat")}
+                },
+            }
+        )
+        assert result.status == PipelineStatus.FAILED
+        assert "Failed to rebuild route" in result.message
+
+    def test_non_apiroute_match_is_a_loud_failure(self):
+        """@mesh.route on a plain Starlette route can't have its dispatch
+        state rebuilt; that must surface rather than pretend to succeed."""
+        from starlette.routing import Route as StarletteRoute
+
+        async def chat(prompt: str) -> mesh.Stream[str]:
+            yield "a"
+
+        app = FastAPI()
+        plain = StarletteRoute("/api/chat", endpoint=chat, methods=["POST"])
+        app.router.routes.append(plain)
+
+        step = RouteIntegrationStep()
+        with pytest.raises(RouteRebuildError) as exc:
+            step._integrate_single_route(
+                app, _build_route_info(chat, "/api/chat"), MagicMock()
+            )
+        assert "APIRoute" in str(exc.value)

--- a/src/runtime/python/tests/unit/test_route_sse_wrapping.py
+++ b/src/runtime/python/tests/unit/test_route_sse_wrapping.py
@@ -870,6 +870,89 @@ class TestRouteRebuildIsVersionIndependent:
         assert after.is_json_stream is False
         assert after.is_sse_stream is False
 
+    def test_no_constructor_params_are_skipped_on_installed_fastapi(self, caplog):
+        """Every APIRoute.__init__ parameter round-trips off the route today.
+
+        The rebuild can only carry over a constructor parameter that the
+        route also exposes as a same-named attribute. On the installed
+        FastAPI all of them do, so nothing is skipped and the debug line
+        never fires.
+        """
+        import logging
+
+        async def handler(prompt: str) -> dict:
+            return {"prompt": prompt}
+
+        app = FastAPI()
+        app.post("/api/plain")(handler)
+        route = next(
+            r for r in app.router.routes if getattr(r, "path", "") == "/api/plain"
+        )
+
+        with caplog.at_level(
+            logging.DEBUG, logger="_mcp_mesh.pipeline.api_startup.route_integration"
+        ):
+            RouteIntegrationStep._rebuild_api_route(route, handler)
+
+        assert not [m for m in caplog.messages if "not readable" in m]
+
+    def test_unreadable_constructor_param_is_logged(self, caplog, monkeypatch):
+        """A future FastAPI option with no matching attribute must be visible.
+
+        Such a parameter cannot be round-tripped, so the rebuilt route falls
+        back to the FastAPI default for it. That is the silent-degradation
+        class #1387/#1389 exists to eliminate, so it is logged (debug —
+        informational, and unreachable on today's FastAPI) rather than
+        dropped without a trace.
+        """
+        import logging
+
+        from fastapi.routing import APIRoute
+
+        import _mcp_mesh.pipeline.api_startup.route_integration as mod
+
+        real_signature = inspect.signature
+        patched = real_signature(APIRoute.__init__)
+        patched = patched.replace(
+            parameters=[
+                *patched.parameters.values(),
+                inspect.Parameter(
+                    "future_fastapi_option",
+                    inspect.Parameter.KEYWORD_ONLY,
+                    default=None,
+                ),
+            ]
+        )
+
+        def fake_signature(obj, *args, **kwargs):
+            if obj is APIRoute.__init__:
+                return patched
+            return real_signature(obj, *args, **kwargs)
+
+        monkeypatch.setattr(mod.inspect, "signature", fake_signature)
+
+        async def handler(prompt: str) -> dict:
+            return {"prompt": prompt}
+
+        app = FastAPI()
+        app.post("/api/plain")(handler)
+        route = next(
+            r for r in app.router.routes if getattr(r, "path", "") == "/api/plain"
+        )
+
+        with caplog.at_level(
+            logging.DEBUG, logger="_mcp_mesh.pipeline.api_startup.route_integration"
+        ):
+            # Still built, with the parameter simply left at its default.
+            rebuilt = RouteIntegrationStep._rebuild_api_route(route, handler)
+
+        assert rebuilt.path == "/api/plain"
+        skipped = [m for m in caplog.messages if "not readable" in m]
+        assert len(skipped) == 1
+        assert "future_fastapi_option" in skipped[0]
+        assert "/api/plain" in skipped[0]
+        assert "POST" in skipped[0]
+
 
 class TestRouteRebuildFailureIsLoud:
     """A failed rebuild must never be reported as a successful integration.


### PR DESCRIPTION
## Summary

Removes mcp-mesh's dependency on five private FastAPI internals, which lets the `fastapi<0.140.5` ceiling from #1387 come off. Also makes the failure loud, so the next incompatibility can't ship silently like this one did.

## The problem

`route_integration.py` replaced a route's endpoint with an SSE/DI wrapper, then hand-rebuilt FastAPI's cached route state:

```python
from fastapi.dependencies.utils import (
    _should_embed_body_fields, get_body_field, get_dependant, get_flat_dependant,
)
from fastapi.routing import request_response
```

FastAPI renamed `get_body_field` → `_get_body_field` (and reshaped its first parameter) in **0.140.5**. The `ImportError` was swallowed by a broad `except Exception` that logged a warning and then `return True` — so SSE routes silently returned `application/jsonl` instead of `text/event-stream`, with startup succeeding and health checks passing.

## The fix

Everything that block hand-computed — `dependant`, `_flat_dependant`, `_embed_body_fields`, `body_field`, `is_json_stream`, `is_sse_stream`, `app` — is **exactly what `APIRoute.__init__` computes**. So construct a fresh `APIRoute` around the wrapper and let FastAPI do it. Constructor arguments are read back off the existing route **by signature at call time**, so registration options carry over verbatim and a future FastAPI option is picked up rather than silently dropped.

Zero private imports remain; only `from fastapi.routing import APIRoute` (public, documented for custom route classes, and already used by `jobs_cancel_route.py`).

The manual `is_json_stream`/`is_sse_stream` clearing is also gone — FastAPI recomputes both as `False` from the wrapper, which is a coroutine rather than an async generator.

**Route substitution over in-place mutation**, with evidence: `app.routes is app.router.routes` on every matrix version; nothing in `_mcp_mesh/` retains an `APIRoute` (all `.routes` consumers copy out `path`/`methods`/`endpoint`); Starlette walks the list per request with no identity cache. The alternative — harvesting computed state onto the existing object — was rejected because it still reads `_flat_dependant` / `_embed_body_fields`, the same coupling in a different costume.

## Bonus: fixes a second, unreported bug

The old hand-rebuild called `get_dependant()` directly and **silently dropped route-level `dependencies=[Depends(...)]`** — FastAPI re-inserts those, the manual call didn't. Verified against `main`:

| | route-level `Depends` ran | content-type |
|---|---|---|
| old code, 0.136.1 | **False** (dropped) | text/event-stream |
| old code, 0.140.11 | True (rebuild never ran) | **application/jsonl** ← #1387 |
| new code, both | True | text/event-stream |

## Loud failure (#1387's remaining item)

`return False` alone would **not** have been loud: it becomes `{"status": "error"}` → `error_count`, which `execute()` computes and discards, so startup would still succeed. Raising alone wasn't enough either — `_integrate_app_routes` has a per-route `except Exception` that absorbed it into the same discarded counter.

So: a rebuild failure raises `RouteRebuildError`, with a targeted re-raise past that handler → `PipelineStatus.FAILED` → the step is `required=True` → startup aborts. Scope stays tight: only a *rebuild* failure is fatal. The "route not found" path is unchanged (`return False`, nothing was modified).

## Version matrix — the whole point

Passing on a single version is what let this ship. Tests run via isolated `pip --target` dirs so the venv was never modified; counts from `--junitxml` (this suite swallows pytest's stdout summary).

| fastapi | route-integration (61) | full unit suite |
|---|---|---|
| 0.136.1 | 61 passed | 2440 passed / 2 skipped |
| 0.139.2 (last green CI) | 61 passed | — |
| 0.140.4 (last pre-break) | 61 passed | — |
| **0.140.5 (the breaking one)** | **61 passed** | 2440 passed / 2 skipped |
| 0.140.7 | 61 passed | — |
| **0.140.11 (latest)** | **61 passed** | 2440 passed / 2 skipped |

Baseline before the fix on 0.140.7: 2 failures with `Failed to rebuild route handler ... cannot import name 'get_body_field'`.

**CI now pins a floor run** against 0.136.1 for the three route-integration files, placed last so it can't perturb coverage artifacts; the main run covers latest via default resolution.

## Other checks

- 4 new tests prove the loud path: rebuild raises → `RouteRebuildError`, not absorbed by `_integrate_app_routes`, `execute()` returns `FAILED`.
- A test asserts no `fastapi.dependencies` import survives and any `fastapi.routing` import is exactly `APIRoute`.
- Non-SSE DI coverage was thin (skip path only), so `test_non_streaming_di_route_still_works_end_to_end` was added.

## Note — separate pre-existing bug found, filed as #1396

`include_router()` stopped flattening `APIRoute`s into `app.router.routes` around 0.139.x, so `@mesh.route` handlers mounted on an `APIRouter` are **not discovered at all** on ≥0.139. Orthogonal to this change and **not caused by dropping the ceiling** — the `<0.140.5` ceiling already permitted 0.139.2 and 0.140.4, both affected, and CI's "last green" was 0.139.2. Deliberately out of scope; the fix belongs in `server_discovery.py::_extract_route_info`.

Closes #1389
Closes #1387

## Test plan

- [ ] CI green, including the new FastAPI floor job
- [ ] Manual: an SSE `@mesh.route` returns `text/event-stream` on latest FastAPI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded compatibility with newer FastAPI releases.
  - Improved preservation of route configuration, including dependencies, status codes, tags, response settings, and schema visibility.

- **Bug Fixes**
  - Improved reliability for streaming and SSE-enabled routes across supported FastAPI versions.
  - Route integration failures are now surfaced clearly and prevent startup from continuing with an invalid route configuration.
  - Added safeguards for unsupported route types and route rebuild errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->