### PR TITLE
fix(route): discover and integrate @mesh.route handlers mounted via include_router

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,12 +282,15 @@ jobs:
           name: codecov-${{ matrix.test-group }}
           fail_ci_if_error: false
 
-      # Issue #1387/#1389: @mesh.route route integration is the one place mesh
-      # rebuilds FastAPI's cached route state, so it is the one place a FastAPI
-      # release can break us. Testing a single resolved FastAPI is how 0.140.5
-      # shipped as a silent SSE-to-JSON degradation. The run above uses whatever
-      # pip resolves (latest); re-run the route-integration tests against an
-      # older FastAPI so both ends of the supported range are covered.
+      # Issue #1387/#1389/#1396: @mesh.route route handling is the one place
+      # mesh reads and rebuilds FastAPI's own route state, so it is the one
+      # place a FastAPI release can break us. Testing a single resolved FastAPI
+      # is how 0.140.5 shipped as a silent SSE-to-JSON degradation, and how
+      # 0.139's include_router() change shipped as silently-undiscovered
+      # routes. The run above uses whatever pip resolves (latest); re-run the
+      # route files against an older FastAPI so both ends of the supported
+      # range are covered — 0.136.1 still flattens included routers, latest
+      # does not, and the same code must handle both.
       # Runs last so it cannot perturb coverage/test-result artifacts.
       - name: Route integration tests against older FastAPI
         if: matrix.test-group == 'unit' && matrix.python-version == '3.11'
@@ -298,6 +301,7 @@ jobs:
           pip install "fastapi==0.136.1"
           python -c "import fastapi; print('pinned fastapi:', fastapi.__version__)"
           pytest tests/unit/test_route_sse_wrapping.py \
+            tests/unit/test_route_include_router_1396.py \
             tests/unit/test_sse_strips_mcp_mesh_tool_params.py \
             tests/unit/test_stream_settle.py -q
 

--- a/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/fastapi_discovery.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/fastapi_discovery.py
@@ -16,6 +16,7 @@ to the registry.
 import logging
 from typing import Any
 
+from ...shared.fastapi_routes import iter_app_routes
 from ...shared.server_discovery import ServerDiscoveryUtil
 from ..shared import PipelineResult, PipelineStatus, PipelineStep
 
@@ -90,9 +91,14 @@ class A2AFastAPIDiscoveryStep(PipelineStep):
                 app = app_info.get("instance")
                 if app is None:
                     continue
-                app_route_paths = {
-                    getattr(r, "path", None) for r in app.router.routes
-                }
+                # Walk everything the app serves, not just its top-level
+                # list: routes mounted with include_router() are no longer
+                # flattened into it (issue #1396). ``mesh.a2a.mount()``
+                # registers its surfaces top-level, so this filter is not
+                # broken today — but it is a "does this app host the surface"
+                # question, and answering it off a partial view is how the
+                # multi-app mystery this filter exists to prevent comes back.
+                app_route_paths = {ref.path for ref in iter_app_routes(app)}
                 if app_route_paths & wanted_paths:
                     filtered_apps[app_id] = app_info
 

--- a/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
@@ -38,6 +38,35 @@ _SSE_HEADERS = {
 }
 
 
+def _methods_overlap(route_methods: Any, call_methods: Any) -> bool:
+    """True when a route's verbs and the verbs being integrated intersect.
+
+    The two sides come from independent places — ``RouteRef.methods`` is
+    whatever FastAPI stored on the route (a set on an ``APIRoute``, a list on
+    an effective-route context), while the integration call's ``methods``
+    comes from ``route_info["methods"]`` — so they can differ in container
+    type, order and (for a hand-built route registration) case. Both are
+    normalised to upper-case sets before comparing.
+
+    Intersection, not equality: a single registration may serve several verbs
+    (``methods=["GET", "POST"]``) and must still be rebuilt when integrating
+    a handler discovered under one of them. Intersection is also immune to
+    FastAPI/Starlette adding ``HEAD`` alongside ``GET`` — an extra verb on
+    the route side can never turn a real match into a miss, and cannot create
+    one either, since ``HEAD`` never appears alone on the call side.
+
+    An empty collection on either side means "unconstrained" and matches, so
+    route objects that carry no ``methods`` at all (websocket routes, which
+    the ``APIRoute`` guard below rejects by design) keep reaching that guard
+    instead of being silently skipped.
+    """
+    route_verbs = {str(m).upper() for m in route_methods or ()}
+    call_verbs = {str(m).upper() for m in call_methods or ()}
+    if not route_verbs or not call_verbs:
+        return True
+    return not route_verbs.isdisjoint(call_verbs)
+
+
 def _resolve_user_function(handler: Any) -> Any:
     """Return the user-authored function underneath a possibly wrapped handler.
 
@@ -673,6 +702,13 @@ class RouteIntegrationStep(PipelineStep):
         dispatch state instead of mesh hand-patching it through private
         internals.
 
+        Every registration of ``original_handler`` at ``path`` whose verbs
+        this call covers is rebuilt, not just the first one found: the same
+        function can be registered twice at one path under different verbs
+        (``add_api_route(..., methods=["GET"])`` then ``methods=["POST"]``),
+        which produces two ``APIRoute`` objects that are indistinguishable by
+        path and endpoint alone.
+
         Args:
             app: FastAPI application instance
             path: Route path to find
@@ -681,9 +717,9 @@ class RouteIntegrationStep(PipelineStep):
             wrapped_handler: New wrapped handler function
 
         Returns:
-            True if the route was found and rebuilt. False only when no
-            matching route exists — nothing was modified in that case, so
-            the caller reports the route as not integrated.
+            True if at least one matching route was found and rebuilt. False
+            only when no matching route exists — nothing was modified in that
+            case, so the caller reports the route as not integrated.
 
         Raises:
             RouteRebuildError: The route was found but could not be rebuilt,
@@ -696,17 +732,29 @@ class RouteIntegrationStep(PipelineStep):
         from ...shared.fastapi_routes import invalidate_route_caches, iter_app_routes
 
         try:
-            # Find the matching route among everything the app serves.
+            # Find the matching routes among everything the app serves.
             #
             # ``iter_app_routes`` also reaches routes mounted with
             # ``include_router()``, which stopped being flattened into
             # ``app.router.routes`` in FastAPI 0.139 (issue #1396). It reports
             # each route's EFFECTIVE path, matching what discovery recorded in
             # ``route_info["path"]``, and the mutable list that owns it.
-            for ref in iter_app_routes(app):
-                if ref.path != path or ref.endpoint is not original_handler:
-                    continue
+            #
+            # Matching on the verbs as well as path+endpoint is what keeps a
+            # GET integration from wrapping a same-path POST registration of
+            # the same function (which route it hit was iteration-order
+            # dependent). The walk is snapshotted first, because rebuilding
+            # assigns into the very lists it reads.
+            matches = [
+                ref
+                for ref in iter_app_routes(app)
+                if ref.path == path
+                and ref.endpoint is original_handler
+                and _methods_overlap(ref.methods, methods)
+            ]
 
+            rebuilt = 0
+            for ref in matches:
                 route = ref.route
                 if not isinstance(route, APIRoute):
                     raise RouteRebuildError(
@@ -752,6 +800,10 @@ class RouteIntegrationStep(PipelineStep):
                 # original registration options (response_model,
                 # status_code, tags, dependencies, response_class,
                 # name/unique_id, ...) unchanged.
+                #
+                # The rebuild reads ``ref.route`` — the pre-swap object the
+                # ref captured — so a route reachable twice through the walk
+                # cannot be wrapped on top of its own wrapper.
                 new_route = self._rebuild_api_route(route, wrapped_handler)
                 ref.container[ref.index] = new_route
 
@@ -774,6 +826,9 @@ class RouteIntegrationStep(PipelineStep):
                         f"not be dispatched"
                     )
 
+                rebuilt += 1
+
+            if rebuilt:
                 return True
 
             # If we get here, we didn't find the route

--- a/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
@@ -686,74 +686,95 @@ class RouteIntegrationStep(PipelineStep):
             the caller reports the route as not integrated.
 
         Raises:
-            RouteRebuildError: The route was found but could not be rebuilt.
-                Never reported as success: the route is live and its dispatch
-                state would contradict the installed handler (issue #1387).
+            RouteRebuildError: The route was found but could not be rebuilt,
+                or the rebuild did not take effect. Never reported as
+                success: the route is live and its dispatch state would
+                contradict the installed handler (issue #1387).
         """
         from fastapi.routing import APIRoute
 
+        from ...shared.fastapi_routes import invalidate_route_caches, iter_app_routes
+
         try:
-            # Find the matching route in FastAPI's router.
+            # Find the matching route among everything the app serves.
             #
-            # ``app.routes`` IS ``app.router.routes`` (same list object), and
-            # Starlette resolves requests by walking that list per request —
-            # no route is cached by identity anywhere, and nothing in
-            # _mcp_mesh holds a route object (only ``route.endpoint``
-            # functions and path/method strings). So substituting a rebuilt
-            # route in place is equivalent to mutating the existing one.
-            for index, route in enumerate(app.router.routes):
-                if (
-                    hasattr(route, "endpoint")
-                    and hasattr(route, "path")
-                    and hasattr(route, "methods")
-                ):
+            # ``iter_app_routes`` also reaches routes mounted with
+            # ``include_router()``, which stopped being flattened into
+            # ``app.router.routes`` in FastAPI 0.139 (issue #1396). It reports
+            # each route's EFFECTIVE path, matching what discovery recorded in
+            # ``route_info["path"]``, and the mutable list that owns it.
+            for ref in iter_app_routes(app):
+                if ref.path != path or ref.endpoint is not original_handler:
+                    continue
 
-                    # Match by path and endpoint function
-                    if route.path == path and route.endpoint is original_handler:
+                route = ref.route
+                if not isinstance(route, APIRoute):
+                    raise RouteRebuildError(
+                        f"Route {methods} {path} is a "
+                        f"{type(route).__name__}, not a FastAPI "
+                        f"APIRoute; @mesh.route handlers must be "
+                        f"registered through FastAPI's decorators "
+                        f"(@app.post/@app.get/...) so their dispatch "
+                        f"state can be rebuilt after wrapping"
+                    )
 
-                        if not isinstance(route, APIRoute):
-                            raise RouteRebuildError(
-                                f"Route {methods} {path} is a "
-                                f"{type(route).__name__}, not a FastAPI "
-                                f"APIRoute; @mesh.route handlers must be "
-                                f"registered through FastAPI's decorators "
-                                f"(@app.post/@app.get/...) so their dispatch "
-                                f"state can be rebuilt after wrapping"
-                            )
+                if ref.container is None or ref.index is None:
+                    raise RouteRebuildError(
+                        f"Route {methods} {path} is served through an "
+                        f"include_router() mount, but the router list that "
+                        f"owns it could not be located, so its dispatch "
+                        f"state cannot be rebuilt after wrapping"
+                    )
 
-                        # FastAPI dispatches via a per-route ASGI handler
-                        # closure (route.app) built from state APIRoute.__init__
-                        # derives from the endpoint: the Dependant, the
-                        # flattened dependant, the embed-body-fields decision,
-                        # the body field model, the response field, and (since
-                        # 0.136) the is_json_stream / is_sse_stream
-                        # auto-streaming flags. Assigning route.endpoint alone
-                        # leaves ALL of that pointing at the original function.
-                        #
-                        # Critical for SSE wrapping, where the wrapper returns
-                        # a StreamingResponse: without a rebuild FastAPI keeps
-                        # calling the original async-generator function and
-                        # JSON-encodes (or JSONL-streams) the result, so the
-                        # response comes back as application/jsonl instead of
-                        # text/event-stream. Harmless-but-correct for plain DI
-                        # wrapping, where the closure already targeted the
-                        # wrapper.
-                        #
-                        # Rather than hand-recomputing that state through
-                        # private FastAPI internals — which is how the 0.140.5
-                        # rename of ``get_body_field`` broke SSE silently
-                        # (issues #1387/#1389) — construct a fresh APIRoute
-                        # around the wrapper and let FastAPI derive everything
-                        # itself. Every APIRoute.__init__ parameter is
-                        # round-trippable off the existing route, so the new
-                        # route carries the user's original registration
-                        # options (response_model, status_code, tags,
-                        # dependencies, response_class, name/unique_id, ...)
-                        # unchanged.
-                        new_route = self._rebuild_api_route(route, wrapped_handler)
-                        app.router.routes[index] = new_route
+                # FastAPI dispatches from state APIRoute.__init__ derives
+                # from the endpoint: the Dependant, the flattened dependant,
+                # the embed-body-fields decision, the body field model, the
+                # response field, and (since 0.136) the is_json_stream /
+                # is_sse_stream auto-streaming flags. Assigning
+                # route.endpoint alone leaves ALL of that pointing at the
+                # original function.
+                #
+                # Critical for SSE wrapping, where the wrapper returns a
+                # StreamingResponse: without a rebuild FastAPI keeps calling
+                # the original async-generator function and JSON-encodes (or
+                # JSONL-streams) the result, so the response comes back as
+                # application/jsonl instead of text/event-stream.
+                # Harmless-but-correct for plain DI wrapping, where the
+                # dispatch state already targeted the wrapper.
+                #
+                # Rather than hand-recomputing that state through private
+                # FastAPI internals — which is how the 0.140.5 rename of
+                # ``get_body_field`` broke SSE silently (issues
+                # #1387/#1389) — construct a fresh APIRoute around the
+                # wrapper and let FastAPI derive everything itself. Every
+                # APIRoute.__init__ parameter is round-trippable off the
+                # existing route, so the new route carries the user's
+                # original registration options (response_model,
+                # status_code, tags, dependencies, response_class,
+                # name/unique_id, ...) unchanged.
+                new_route = self._rebuild_api_route(route, wrapped_handler)
+                ref.container[ref.index] = new_route
 
-                        return True
+                # Substitution is invisible to the version counter that
+                # include_router() entries cache their effective routes on,
+                # so tell FastAPI its lists changed. (Top-level routes need
+                # no such notice — Starlette re-walks that list per request —
+                # but the call is cheap and keeps one code path.)
+                invalidate_route_caches(app)
+
+                if not any(r.route is new_route for r in iter_app_routes(app)):
+                    # FastAPI still resolves this path to the pre-rebuild
+                    # route: the swap is live in the router's list but its
+                    # dispatch state was not recomputed, which is precisely
+                    # the silent-degradation shape of #1387.
+                    raise RouteRebuildError(
+                        f"Rebuilt route {methods} {path} did not take effect: "
+                        f"FastAPI still resolves this path to the "
+                        f"pre-rebuild route, so the wrapped handler would "
+                        f"not be dispatched"
+                    )
+
+                return True
 
             # If we get here, we didn't find the route
             self.logger.warning(

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/jobs_cancel_route.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/jobs_cancel_route.py
@@ -108,6 +108,14 @@ class JobsCancelRouteStep(PipelineStep):
             )
 
             # Defensive: skip duplicate registration on hot-reload.
+            #
+            # Deliberately scans only the app's own list — not the
+            # include_router() mounts that issue #1396 made invisible here.
+            # This guard asks "did THIS step already insert its route", and
+            # that insertion is always a top-level ``routes[0]``, so the
+            # top-level list is the exact answer. Widening it to every served
+            # path would turn it into a user-collision check with no good
+            # outcome: skipping leaves MeshJob cancellation silently dead.
             existing_paths = {
                 getattr(r, "path", None) for r in app.router.routes
             }

--- a/src/runtime/python/_mcp_mesh/shared/fastapi_routes.py
+++ b/src/runtime/python/_mcp_mesh/shared/fastapi_routes.py
@@ -1,0 +1,248 @@
+"""Version-independent traversal of the routes a FastAPI app actually serves.
+
+Historically ``app.router.routes`` was a flat list: ``include_router()``
+copied every ``APIRoute`` off the mounted ``APIRouter`` into it, so walking
+that one list saw everything the app served. FastAPI 0.139 changed the
+representation — ``include_router()`` now appends a *single* entry that keeps
+a live reference to the user's ``APIRouter`` and derives the served
+("effective") routes from it lazily. The mounted ``APIRoute`` objects are no
+longer present in ``app.router.routes`` at all.
+
+Every mesh code path that walked ``app.router.routes`` directly therefore
+stopped seeing ``@mesh.route`` handlers registered on an ``APIRouter``
+(issue #1396): discovery found nothing, so no DI wrapper was registered for
+them, no dependency ever resolved, and the handlers served as plain FastAPI
+endpoints. ``examples/simple/simple_fastapi_router.py`` is exactly that
+pattern.
+
+This module is the single place that knows how to walk an app's routes, so
+the next representation change has one site to fix rather than five.
+
+Accessor choice
+---------------
+An ``include_router()`` entry is recognised by **duck-typing on
+``original_router``** — the attribute that links the entry back to the
+``APIRouter`` the user built — never by its class name (which is private and
+would be exactly the kind of fragile coupling #1397 removed).
+
+``original_router.routes`` is the authoritative, *mutable* list that owns the
+route objects, which is what route integration needs in order to swap a
+handler. Effective paths come from the entry's ``effective_route_contexts()``
+when it exposes one, because a router included into another router keeps its
+own unprefixed path (``/inner/deep``) while the app serves it under the
+combined prefix (``/api/v1/inner/deep``); FastAPI computes that composition
+itself and mesh should not re-derive it.
+
+Both names are non-underscore members of the entry, are read through
+``getattr`` with a working fallback, and neither is imported — a FastAPI
+release that drops one degrades to the other rather than raising.
+
+Starlette ``Mount`` / ``Host`` entries are deliberately NOT traversed even
+though they expose ``.routes``: a mount is a separate ASGI application whose
+routes are not this app's ``@mesh.route`` surface, and mesh itself mounts the
+FastMCP app as a catch-all at ``""``. Requiring ``original_router`` keeps
+them out.
+
+On FastAPI < 0.139 nothing exposes ``original_router``, so the walk collapses
+to precisely the old flat iteration — no version branching anywhere.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RouteRef:
+    """One route an app will serve, plus where it lives.
+
+    Attributes:
+        route: The route object itself (``APIRoute``, or a plain Starlette
+            ``Route`` for the docs/openapi endpoints).
+        path: The path the app serves it under — the effective path, with
+            every ``include_router(prefix=...)`` already applied.
+        methods: HTTP methods, as a list.
+        endpoint: The handler callable FastAPI will dispatch to.
+        container: The mutable list that holds ``route``, or ``None`` when it
+            could not be located. Assigning ``container[index]`` swaps the
+            route; callers must follow that with
+            :func:`invalidate_route_caches`.
+        index: ``route``'s position within ``container``.
+        included: True when the route came from an ``include_router()`` mount
+            rather than from the app's own top-level list.
+    """
+
+    route: Any
+    path: str
+    methods: list[str]
+    endpoint: Any
+    container: Optional[list]
+    index: Optional[int]
+    included: bool
+
+
+def _included_routes(entry: Any) -> Optional[list]:
+    """Return the mutable route list an ``include_router()`` entry owns.
+
+    ``None`` for anything that is not such an entry — plain routes, and
+    ``Mount``/``Host`` (which expose ``.routes`` but are separate ASGI apps).
+    """
+    router = getattr(entry, "original_router", None)
+    if router is None:
+        return None
+    routes = getattr(router, "routes", None)
+    return routes if isinstance(routes, list) else None
+
+
+def _effective_contexts(entry: Any) -> Optional[list]:
+    """FastAPI's own view of what an ``include_router()`` entry serves.
+
+    Each context carries the composed path/methods for one route plus
+    ``original_route``, the object in the router's list. Returns ``None``
+    when the accessor is absent or unusable, so the caller can fall back to
+    walking the raw lists.
+    """
+    accessor = getattr(entry, "effective_route_contexts", None)
+    if not callable(accessor):
+        return None
+    try:
+        return list(accessor())
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("effective_route_contexts() unusable on %r: %s", entry, e)
+        return None
+
+
+def _is_route(entry: Any) -> bool:
+    return hasattr(entry, "endpoint") and hasattr(entry, "path")
+
+
+def _methods_of(obj: Any) -> list[str]:
+    methods = getattr(obj, "methods", None)
+    return list(methods) if methods else []
+
+
+def _index_owners(routes: list, owners: dict, seen: set) -> None:
+    """Map ``id(route) -> (owning list, index)`` over a router subtree."""
+    if id(routes) in seen:
+        return
+    seen.add(id(routes))
+    for index, entry in enumerate(routes):
+        nested = _included_routes(entry)
+        if nested is not None:
+            _index_owners(nested, owners, seen)
+        elif _is_route(entry):
+            owners.setdefault(id(entry), (routes, index))
+
+
+def _iter_included(entry: Any, nested: list, seen: set) -> Iterator[RouteRef]:
+    owners: dict = {}
+    _index_owners(nested, owners, set())
+
+    contexts = _effective_contexts(entry)
+    if contexts is None:
+        # No effective-route accessor: walk the raw lists. Paths are then the
+        # routes' own (a nested include's outer prefix is not applied), which
+        # is the best available answer and still strictly better than not
+        # seeing the routes at all.
+        yield from _iter_routes(nested, included=True, seen=seen)
+        return
+
+    for context in contexts:
+        route = getattr(context, "original_route", None)
+        if route is None or not _is_route(route):
+            # A Mount/Host context — nothing mesh can wrap.
+            continue
+        endpoint = getattr(context, "endpoint", None) or route.endpoint
+        if endpoint is None:
+            continue
+        container, index = owners.get(id(route), (None, None))
+        yield RouteRef(
+            route=route,
+            path=getattr(context, "path", "") or route.path,
+            methods=_methods_of(context) or _methods_of(route),
+            endpoint=endpoint,
+            container=container,
+            index=index,
+            included=True,
+        )
+
+
+def _iter_routes(routes: list, included: bool, seen: set) -> Iterator[RouteRef]:
+    if id(routes) in seen:
+        # Cyclic include (FastAPI guards its own traversals against this too).
+        return
+    seen.add(id(routes))
+    for index, entry in enumerate(routes):
+        nested = _included_routes(entry)
+        if nested is not None:
+            yield from _iter_included(entry, nested, seen)
+        elif _is_route(entry):
+            yield RouteRef(
+                route=entry,
+                path=entry.path,
+                methods=_methods_of(entry),
+                endpoint=entry.endpoint,
+                container=routes,
+                index=index,
+                included=included,
+            )
+
+
+def iter_app_routes(app: Any) -> Iterator[RouteRef]:
+    """Yield a :class:`RouteRef` for every route ``app`` will serve.
+
+    Covers routes registered directly on the app and routes reached through
+    any depth of ``include_router()``.
+    """
+    routes = getattr(getattr(app, "router", None), "routes", None)
+    if not isinstance(routes, list):
+        return
+    yield from _iter_routes(routes, included=False, seen=set())
+
+
+def iter_routers(app: Any) -> Iterator[Any]:
+    """Yield ``app.router`` and every ``APIRouter`` included beneath it."""
+    router = getattr(app, "router", None)
+    if router is None:
+        return
+    pending = [router]
+    seen: set = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in seen:
+            continue
+        seen.add(id(current))
+        yield current
+        for entry in getattr(current, "routes", None) or []:
+            nested = getattr(entry, "original_router", None)
+            if nested is not None:
+                pending.append(nested)
+
+
+def invalidate_route_caches(app: Any) -> None:
+    """Tell FastAPI that an app's route lists changed underneath it.
+
+    ``include_router()`` entries cache the effective routes they derive from
+    their router, keyed on a version counter the router bumps whenever a route
+    is *added or removed* through its API. Mesh swaps a route by assigning
+    into the list, which is invisible to that counter — so without this the
+    cached (pre-swap) dispatch state keeps serving whenever the cache was
+    already warm.
+
+    The bump hook is private, so it is called only if present. Losing it does
+    not degrade silently: route integration verifies afterwards that FastAPI's
+    own view picked the rebuilt route up, and fails loudly if it did not
+    (#1387's rule).
+
+    No-op on FastAPI < 0.139, which has no such cache.
+    """
+    for router in iter_routers(app):
+        mark = getattr(router, "_mark_routes_changed", None)
+        if not callable(mark):
+            continue
+        try:
+            mark()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("Could not mark routes changed on %r: %s", router, e)

--- a/src/runtime/python/_mcp_mesh/shared/server_discovery.py
+++ b/src/runtime/python/_mcp_mesh/shared/server_discovery.py
@@ -11,6 +11,8 @@ import socket
 import threading
 from typing import Any, Dict, List, Optional, Tuple
 
+from .fastapi_routes import iter_app_routes
+
 logger = logging.getLogger(__name__)
 
 
@@ -295,24 +297,29 @@ class ServerDiscoveryUtil:
 
     @staticmethod
     def _extract_route_info(app) -> List[Dict[str, Any]]:
-        """Extract route information from FastAPI app without modifying it."""
+        """Extract route information from FastAPI app without modifying it.
+
+        Walks via ``iter_app_routes`` rather than ``app.router.routes``, so
+        handlers mounted with ``include_router()`` are seen on FastAPI >=
+        0.139 (issue #1396) — they are no longer flattened into the app's own
+        list. ``path`` is the effective path the app serves, so downstream
+        consumers (route integration's match, and the ``METHOD:path`` route
+        ids the heartbeat ships to the registry) stay correct at any include
+        depth.
+        """
         routes = []
 
         try:
-            for route in app.router.routes:
-                if hasattr(route, "endpoint") and hasattr(route, "path"):
-                    route_info = {
-                        "path": route.path,
-                        "methods": (
-                            list(route.methods) if hasattr(route, "methods") else []
-                        ),
-                        "endpoint": route.endpoint,
-                        "endpoint_name": getattr(route.endpoint, "__name__", "unknown"),
-                        "has_mesh_route": hasattr(
-                            route.endpoint, "_mesh_route_metadata"
-                        ),
+            for ref in iter_app_routes(app):
+                routes.append(
+                    {
+                        "path": ref.path,
+                        "methods": ref.methods,
+                        "endpoint": ref.endpoint,
+                        "endpoint_name": getattr(ref.endpoint, "__name__", "unknown"),
+                        "has_mesh_route": hasattr(ref.endpoint, "_mesh_route_metadata"),
                     }
-                    routes.append(route_info)
+                )
 
         except Exception as e:
             logger.warning(f"Error extracting route info: {e}")

--- a/src/runtime/python/mesh/a2a.py
+++ b/src/runtime/python/mesh/a2a.py
@@ -1467,11 +1467,23 @@ def mount(
         # collision would let a hostile/typo'd route own ``card_path`` /
         # ``rpc_path`` while heartbeat still advertises the surface for
         # this agent — clients would then call the wrong handler.
+        #
+        # The scan covers include_router() mounts too (issue #1396): those
+        # stopped being flattened into ``app.router.routes`` in FastAPI 0.139,
+        # so a top-level-only scan was blind to exactly the foreign route this
+        # guard exists to catch, and ``add_api_route`` below would have added
+        # a second registration for the same path.
+        from _mcp_mesh.shared.fastapi_routes import iter_app_routes
+
         existing_endpoints: dict = {}
         for r in app.router.routes:
+            # Keeps non-route entries that still claim a path (Mount/Host),
+            # which iter_app_routes deliberately does not yield.
             r_path = getattr(r, "path", None)
             if r_path is not None:
                 existing_endpoints[r_path] = getattr(r, "endpoint", None)
+        for ref in iter_app_routes(app):
+            existing_endpoints[ref.path] = ref.endpoint
 
         card_endpoint = _make_card_endpoint(
             metadata=metadata,

--- a/src/runtime/python/tests/unit/test_route_include_router_1396.py
+++ b/src/runtime/python/tests/unit/test_route_include_router_1396.py
@@ -1,0 +1,383 @@
+"""Regression tests for issue #1396 — @mesh.route through ``include_router()``.
+
+FastAPI 0.139 stopped flattening an included ``APIRouter``'s ``APIRoute``
+objects into ``app.router.routes``; the app now holds a single entry that
+derives the served routes from the router lazily. Every mesh site that walked
+``app.router.routes`` went blind to those handlers, so ``@mesh.route`` on an
+``APIRouter`` — a documented pattern, and what
+``examples/simple/simple_fastapi_router.py`` demonstrates — was discovered as
+nothing at all: no DI wrapper registered, no dependency ever injected, the
+handler serving as a plain FastAPI endpoint.
+
+Nothing in the suite covered discovery or integration through
+``include_router()``, which is why it survived several releases. These tests
+close that gap at both ends of the range (the walk must also still work on
+0.136.x, which flattens) and at nesting depth.
+"""
+
+import inspect
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+import mesh
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+from _mcp_mesh.pipeline.api_startup.route_integration import (
+    RouteIntegrationStep,
+    RouteRebuildError,
+)
+from _mcp_mesh.shared import fastapi_routes
+from _mcp_mesh.shared.fastapi_routes import invalidate_route_caches, iter_app_routes
+from _mcp_mesh.shared.server_discovery import ServerDiscoveryUtil
+
+
+def _build_route_info(handler, path, methods=("POST",), deps=None):
+    return {
+        "endpoint": handler,
+        "endpoint_name": handler.__name__,
+        "path": path,
+        "methods": list(methods),
+        "dependencies": deps or [],
+    }
+
+
+def _paths(app):
+    return [ref.path for ref in iter_app_routes(app)]
+
+
+def _flattens_included_routers(app) -> bool:
+    """True on FastAPI < 0.139, where include_router() copies routes over."""
+    return not any(hasattr(entry, "original_router") for entry in app.router.routes)
+
+
+# ---------------------------------------------------------------------------
+# iter_app_routes — the shared walk
+# ---------------------------------------------------------------------------
+
+
+class TestIterAppRoutes:
+    def test_included_router_routes_are_reachable(self):
+        router = APIRouter(prefix="/api/v1")
+
+        @router.get("/time")
+        async def get_time():
+            return {}
+
+        app = FastAPI()
+        app.include_router(router)
+
+        assert "/api/v1/time" in _paths(app)
+
+    def test_top_level_routes_are_still_reachable(self):
+        app = FastAPI()
+
+        @app.get("/top")
+        async def top():
+            return {}
+
+        ref = next(r for r in iter_app_routes(app) if r.path == "/top")
+        assert ref.endpoint is top
+        assert ref.included is False
+        assert ref.container is app.router.routes
+        assert ref.container[ref.index] is ref.route
+
+    def test_nested_include_yields_the_composed_path(self):
+        """A router included into a router keeps its own unprefixed path; the
+        app serves it under the combined prefix, and that is what mesh must
+        record (it becomes the ``METHOD:path`` id shipped to the registry)."""
+        inner = APIRouter(prefix="/inner")
+
+        @inner.get("/deep")
+        async def deep():
+            return {}
+
+        outer = APIRouter(prefix="/api/v1")
+        outer.include_router(inner)
+
+        app = FastAPI()
+        app.include_router(outer)
+
+        assert "/api/v1/inner/deep" in _paths(app)
+        # ...and the app really serves it there.
+        assert TestClient(app).get("/api/v1/inner/deep").status_code == 200
+
+    def test_container_points_at_the_list_that_owns_an_included_route(self):
+        router = APIRouter(prefix="/api/v1")
+
+        @router.get("/time")
+        async def get_time():
+            return {}
+
+        app = FastAPI()
+        app.include_router(router)
+
+        ref = next(r for r in iter_app_routes(app) if r.path == "/api/v1/time")
+        assert ref.route.endpoint is get_time
+        assert ref.container is not None
+        assert ref.container[ref.index] is ref.route
+        if _flattens_included_routers(app):
+            assert ref.container is app.router.routes
+        else:
+            assert ref.included is True
+            assert ref.container is router.routes
+
+    def test_mounted_sub_applications_are_not_traversed(self):
+        """A Mount is a separate ASGI app — its routes are not this app's
+        @mesh.route surface, and mesh itself mounts FastMCP as a catch-all."""
+        sub = FastAPI()
+
+        @sub.get("/inside")
+        async def inside():
+            return {}
+
+        app = FastAPI()
+        app.mount("/mounted", sub)
+
+        assert not [p for p in _paths(app) if "inside" in p]
+
+    def test_methods_and_endpoint_are_reported_for_included_routes(self):
+        router = APIRouter(prefix="/api/v1")
+
+        @router.post("/echo")
+        async def echo():
+            return {}
+
+        app = FastAPI()
+        app.include_router(router)
+
+        ref = next(r for r in iter_app_routes(app) if r.path == "/api/v1/echo")
+        assert ref.methods == ["POST"]
+        assert ref.endpoint is echo
+
+    def test_app_without_a_router_is_tolerated(self):
+        assert list(iter_app_routes(object())) == []
+
+    def test_no_fastapi_import_in_the_walk(self):
+        """The walk is pure duck-typing: it recognises an include_router()
+        entry by its ``original_router`` link, never by a (private) class, and
+        never imports anything out of fastapi. That is what makes it work
+        unchanged from 0.136 through latest."""
+        source = inspect.getsource(fastapi_routes)
+        assert "import fastapi" not in source
+        assert "from fastapi" not in source
+        assert "_IncludedRouter" not in source
+
+
+# ---------------------------------------------------------------------------
+# Discovery (server_discovery._extract_route_info)
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryThroughIncludeRouter:
+    def test_mesh_route_on_a_router_is_discovered(self):
+        @mesh.route(dependencies=["time_service"])
+        async def get_time(time_agent: mesh.McpMeshTool = None) -> dict:
+            return {"dep": time_agent}
+
+        router = APIRouter(prefix="/api/v1")
+        router.get("/time")(get_time)
+
+        app = FastAPI()
+        app.include_router(router)
+
+        routes = ServerDiscoveryUtil._extract_route_info(app)
+        found = [r for r in routes if r["endpoint_name"] == "get_time"]
+        assert len(found) == 1
+        assert found[0]["path"] == "/api/v1/time"
+        assert found[0]["methods"] == ["GET"]
+        assert found[0]["has_mesh_route"] is True
+
+    def test_discovery_covers_nested_routers(self):
+        @mesh.route(dependencies=["time_service"])
+        async def deep_handler(time_agent: mesh.McpMeshTool = None) -> dict:
+            return {"dep": time_agent}
+
+        inner = APIRouter(prefix="/inner")
+        inner.get("/deep")(deep_handler)
+        outer = APIRouter(prefix="/api/v1")
+        outer.include_router(inner)
+
+        app = FastAPI()
+        app.include_router(outer)
+
+        routes = ServerDiscoveryUtil._extract_route_info(app)
+        found = next(r for r in routes if r["endpoint_name"] == "deep_handler")
+        assert found["path"] == "/api/v1/inner/deep"
+        assert found["has_mesh_route"] is True
+
+    def test_top_level_routes_are_not_regressed(self):
+        @mesh.route(dependencies=["time_service"])
+        async def plain(time_agent: mesh.McpMeshTool = None) -> dict:
+            return {"dep": time_agent}
+
+        app = FastAPI()
+        app.get("/plain")(plain)
+
+        routes = ServerDiscoveryUtil._extract_route_info(app)
+        found = next(r for r in routes if r["endpoint_name"] == "plain")
+        assert found["path"] == "/plain"
+        assert found["has_mesh_route"] is True
+
+
+# ---------------------------------------------------------------------------
+# Route integration through include_router()
+# ---------------------------------------------------------------------------
+
+
+class TestIntegrationThroughIncludeRouter:
+    @staticmethod
+    def _app_with_included_stream_route(prefix="/api/v1"):
+        async def chat(prompt: str) -> mesh.Stream[str]:
+            yield "a"
+
+        router = APIRouter(prefix=prefix)
+        router.post("/chat", response_model=None)(chat)
+        app = FastAPI()
+        app.include_router(router)
+        return app, chat
+
+    def test_included_route_handler_is_replaced_and_served(self):
+        """The endpoint swap must reach the route the app actually
+        dispatches. An SSE route proves it end to end: without the swap
+        FastAPI keeps auto-streaming the raw async generator and answers
+        ``application/jsonl``."""
+        app, chat = self._app_with_included_stream_route()
+
+        step = RouteIntegrationStep()
+        result = step._integrate_single_route(
+            app, _build_route_info(chat, "/api/v1/chat"), None
+        )
+        assert result["status"] == "integrated"
+        assert result["sse"] is True
+
+        client = TestClient(app)
+        with client.stream("POST", "/api/v1/chat?prompt=hi") as response:
+            assert response.status_code == 200
+            assert response.headers["content-type"].startswith("text/event-stream")
+            body = response.read().decode("utf-8")
+        assert body == "data: a\n\ndata: [DONE]\n\n"
+
+    def test_included_route_replacement_survives_a_warm_route_cache(self):
+        """FastAPI caches the effective routes an include_router() entry
+        serves, keyed on a counter that only add/remove bumps. Substituting
+        into the router's list is invisible to it, so a cache warmed by an
+        earlier request would keep serving the pre-wrap handler — the same
+        looks-healthy/wrong-wire-contract shape as #1387."""
+        app, chat = self._app_with_included_stream_route()
+        client = TestClient(app)
+
+        # Warm the cache before integration runs.
+        warm = client.post("/api/v1/chat?prompt=hi")
+        assert warm.status_code == 200
+
+        step = RouteIntegrationStep()
+        assert (
+            step._integrate_single_route(
+                app, _build_route_info(chat, "/api/v1/chat"), None
+            )["status"]
+            == "integrated"
+        )
+
+        with client.stream("POST", "/api/v1/chat?prompt=hi") as response:
+            assert response.headers["content-type"].startswith("text/event-stream")
+            assert response.read().decode("utf-8") == "data: a\n\ndata: [DONE]\n\n"
+
+    def test_nested_included_route_is_integrated(self):
+        async def chat(prompt: str) -> mesh.Stream[str]:
+            yield "a"
+
+        inner = APIRouter(prefix="/inner")
+        inner.post("/chat", response_model=None)(chat)
+        outer = APIRouter(prefix="/api/v1")
+        outer.include_router(inner)
+        app = FastAPI()
+        app.include_router(outer)
+
+        step = RouteIntegrationStep()
+        result = step._integrate_single_route(
+            app, _build_route_info(chat, "/api/v1/inner/chat"), None
+        )
+        assert result["status"] == "integrated"
+
+        client = TestClient(app)
+        with client.stream("POST", "/api/v1/inner/chat?prompt=hi") as response:
+            assert response.headers["content-type"].startswith("text/event-stream")
+            assert response.read().decode("utf-8") == "data: a\n\ndata: [DONE]\n\n"
+
+    def test_rebuild_that_does_not_take_effect_is_loud(self, monkeypatch):
+        """If mesh can no longer tell FastAPI its route lists changed, the
+        swap silently does not reach dispatch. That must abort startup, not
+        report a successful integration (#1387's rule)."""
+        app, chat = self._app_with_included_stream_route()
+        if _flattens_included_routers(app):
+            pytest.skip("FastAPI flattens included routers; no cache to go stale")
+
+        client = TestClient(app)
+        client.post("/api/v1/chat?prompt=hi")  # warm the cache
+
+        monkeypatch.setattr(fastapi_routes, "invalidate_route_caches", lambda app: None)
+
+        step = RouteIntegrationStep()
+        with pytest.raises(RouteRebuildError) as exc:
+            step._integrate_single_route(
+                app, _build_route_info(chat, "/api/v1/chat"), None
+            )
+        assert "did not take effect" in str(exc.value)
+
+    def test_invalidate_route_caches_is_a_noop_without_routers(self):
+        invalidate_route_caches(object())  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# The documented example: discovery -> integration -> injection
+# ---------------------------------------------------------------------------
+
+
+class TestIncludeRouterEndToEnd:
+    def test_dependency_is_injected_into_an_included_mesh_route(self):
+        """``examples/simple/simple_fastapi_router.py`` in miniature: the
+        handler is registered on an APIRouter, mounted with include_router(),
+        and must end up wired to the mesh dependency funnel."""
+        DecoratorRegistry._route_wrapper_registry.clear()
+
+        @mesh.route(dependencies=["time_service"])
+        async def get_time(time_agent: mesh.McpMeshTool = None) -> dict:
+            if time_agent is None:
+                return {"dependency_injected": False}
+            return {"dependency_injected": True, "time": await time_agent()}
+
+        router = APIRouter(prefix="/api/v1")
+        router.get("/time")(get_time)
+        app = FastAPI()
+        app.include_router(router)
+
+        discovered = ServerDiscoveryUtil._extract_route_info(app)
+        route_info = next(r for r in discovered if r["endpoint_name"] == "get_time")
+        route_info["dependencies"] = [{"capability": "time_service"}]
+
+        step = RouteIntegrationStep()
+        assert step._integrate_single_route(app, route_info, None)["status"] == (
+            "integrated"
+        )
+
+        # The wrapper is registered under the EFFECTIVE path, which is the
+        # route id the heartbeat ships to the registry.
+        wrappers = DecoratorRegistry.get_all_route_wrappers()
+        assert "GET:/api/v1/time" in wrappers
+
+        # Push a resolved dependency the way the heartbeat funnel does.
+        class FakeTool:
+            async def __call__(self, **kwargs):
+                return "2026-07-28T00:00:00Z"
+
+        wrappers["GET:/api/v1/time"]["wrapper"]._mesh_update_dependency(0, FakeTool())
+
+        response = TestClient(app).get("/api/v1/time")
+        assert response.status_code == 200
+        assert response.json() == {
+            "dependency_injected": True,
+            "time": "2026-07-28T00:00:00Z",
+        }
+
+        DecoratorRegistry._route_wrapper_registry.clear()

--- a/src/runtime/python/tests/unit/test_route_include_router_1396.py
+++ b/src/runtime/python/tests/unit/test_route_include_router_1396.py
@@ -28,8 +28,25 @@ from _mcp_mesh.pipeline.api_startup.route_integration import (
     RouteRebuildError,
 )
 from _mcp_mesh.shared import fastapi_routes
-from _mcp_mesh.shared.fastapi_routes import invalidate_route_caches, iter_app_routes
+from _mcp_mesh.shared.fastapi_routes import (
+    RouteRef,
+    invalidate_route_caches,
+    iter_app_routes,
+)
 from _mcp_mesh.shared.server_discovery import ServerDiscoveryUtil
+
+
+@pytest.fixture(autouse=True)
+def _clean_route_wrapper_registry():
+    """Keep the process-wide route-wrapper registry out of other tests.
+
+    Every ``_integrate_single_route`` call in this file registers wrappers
+    there. Clearing on the way in and out unconditionally means a failing
+    assertion cannot leak entries into whatever runs next.
+    """
+    DecoratorRegistry._route_wrapper_registry.clear()
+    yield
+    DecoratorRegistry._route_wrapper_registry.clear()
 
 
 def _build_route_info(handler, path, methods=("POST",), deps=None):
@@ -152,6 +169,9 @@ class TestIterAppRoutes:
 
     def test_app_without_a_router_is_tolerated(self):
         assert list(iter_app_routes(object())) == []
+
+    def test_invalidate_route_caches_is_a_noop_without_routers(self):
+        invalidate_route_caches(object())  # must not raise
 
     def test_no_fastapi_import_in_the_walk(self):
         """The walk is pure duck-typing: it recognises an include_router()
@@ -325,8 +345,130 @@ class TestIntegrationThroughIncludeRouter:
             )
         assert "did not take effect" in str(exc.value)
 
-    def test_invalidate_route_caches_is_a_noop_without_routers(self):
-        invalidate_route_caches(object())  # must not raise
+    def test_route_that_is_not_an_api_route_is_loud(self, monkeypatch):
+        """Only an APIRoute carries the dispatch state mesh rebuilds. Anything
+        else matched at that path must abort startup rather than be left
+        serving with a handler mesh could not install."""
+
+        class SomeOtherRoute:
+            pass
+
+        async def handler():
+            return {}
+
+        app = FastAPI()
+        ref = RouteRef(
+            route=SomeOtherRoute(),
+            path="/x",
+            methods=["POST"],
+            endpoint=handler,
+            container=[None],
+            index=0,
+            included=False,
+        )
+        monkeypatch.setattr(fastapi_routes, "iter_app_routes", lambda app: iter([ref]))
+
+        step = RouteIntegrationStep()
+        with pytest.raises(RouteRebuildError) as exc:
+            step._replace_route_handler(app, "/x", ["POST"], handler, handler)
+        message = str(exc.value)
+        assert "SomeOtherRoute" in message
+        assert "not a FastAPI" in message
+        assert "/x" in message and "POST" in message
+
+    def test_route_whose_owning_list_is_unknown_is_loud(self, monkeypatch):
+        """Without the list that owns the route there is nowhere to put the
+        rebuilt one, so the route would keep dispatching the unwrapped
+        handler — fail instead of reporting a successful integration."""
+
+        async def handler():
+            return {}
+
+        app = FastAPI()
+        app.post("/x")(handler)
+        api_route = next(r.route for r in iter_app_routes(app) if r.path == "/x")
+
+        ref = RouteRef(
+            route=api_route,
+            path="/x",
+            methods=["POST"],
+            endpoint=handler,
+            container=None,
+            index=None,
+            included=True,
+        )
+        monkeypatch.setattr(fastapi_routes, "iter_app_routes", lambda app: iter([ref]))
+
+        step = RouteIntegrationStep()
+        with pytest.raises(RouteRebuildError) as exc:
+            step._replace_route_handler(app, "/x", ["POST"], handler, handler)
+        message = str(exc.value)
+        assert "could not be located" in message
+        assert "/x" in message and "POST" in message
+
+    def test_same_handler_registered_under_two_verbs_wraps_the_right_route(self):
+        """One function registered twice at one path produces two APIRoutes
+        that path+endpoint alone cannot tell apart. Without the verbs in the
+        match, which one gets the wrapper is iteration-order dependent — a GET
+        integration could wrap the POST registration, leaving the verb mesh
+        actually registered serving the unwrapped handler."""
+
+        async def handler():
+            return {"wrapped": False}
+
+        async def wrapper():
+            return {"wrapped": True}
+
+        app = FastAPI()
+        app.add_api_route("/x", handler, methods=["GET"], response_model=None)
+        app.add_api_route("/x", handler, methods=["POST"], response_model=None)
+
+        step = RouteIntegrationStep()
+        assert step._replace_route_handler(app, "/x", ["POST"], handler, wrapper)
+
+        client = TestClient(app)
+        assert client.post("/x").json() == {"wrapped": True}
+        assert client.get("/x").json() == {"wrapped": False}
+
+    def test_every_covered_registration_of_a_handler_is_rebuilt(self):
+        """A call covering both verbs must rebuild both registrations, not
+        stop at the first match."""
+
+        async def handler():
+            return {"wrapped": False}
+
+        async def wrapper():
+            return {"wrapped": True}
+
+        app = FastAPI()
+        app.add_api_route("/x", handler, methods=["GET"], response_model=None)
+        app.add_api_route("/x", handler, methods=["POST"], response_model=None)
+
+        step = RouteIntegrationStep()
+        assert step._replace_route_handler(app, "/x", ["GET", "POST"], handler, wrapper)
+
+        client = TestClient(app)
+        assert client.get("/x").json() == {"wrapped": True}
+        assert client.post("/x").json() == {"wrapped": True}
+
+    def test_no_matching_verb_is_reported_as_not_found(self):
+        """Nothing matched means nothing was modified — the caller reports the
+        route as not integrated rather than raising."""
+
+        async def handler():
+            return {}
+
+        async def wrapper():
+            return {}
+
+        app = FastAPI()
+        app.add_api_route("/x", handler, methods=["GET"], response_model=None)
+
+        step = RouteIntegrationStep()
+        assert (
+            step._replace_route_handler(app, "/x", ["DELETE"], handler, wrapper)
+            is False
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -339,7 +481,6 @@ class TestIncludeRouterEndToEnd:
         """``examples/simple/simple_fastapi_router.py`` in miniature: the
         handler is registered on an APIRouter, mounted with include_router(),
         and must end up wired to the mesh dependency funnel."""
-        DecoratorRegistry._route_wrapper_registry.clear()
 
         @mesh.route(dependencies=["time_service"])
         async def get_time(time_agent: mesh.McpMeshTool = None) -> dict:
@@ -379,5 +520,3 @@ class TestIncludeRouterEndToEnd:
             "dependency_injected": True,
             "time": "2026-07-28T00:00:00Z",
         }
-
-        DecoratorRegistry._route_wrapper_registry.clear()


### PR DESCRIPTION
## Summary

`@mesh.route` handlers registered on an `APIRouter` and mounted with `include_router()` were **not discovered at all** on FastAPI >= 0.139.x — they served as plain endpoints with no mesh DI. This is a documented pattern with its own example file (`examples/simple/simple_fastapi_router.py`, `docs/python/fastapi-integration.md`).

Around 0.139.x, `include_router()` stopped flattening the router's `APIRoute` objects into `app.router.routes`; it now inserts a single `_IncludedRouter`. mcp-mesh walked that flat list in five places.

**Pre-existing, not caused by #1397.** The `<0.140.5` ceiling already permitted 0.139.2 and 0.140.4, both affected — and CI's "last green" was 0.139.2, so this was broken in blessed configurations without detection. No test covered discovery through `include_router`, which is why it survived several releases.

## Approach

New `_mcp_mesh/shared/fastapi_routes.py` — one place that knows how to walk an app's routes, exposing `iter_app_routes(app) -> Iterator[RouteRef]` (route, **effective** path, methods, endpoint, owning list + index, `included` flag).

**It imports nothing from fastapi at all** (asserted by a test), which is what lets it span 0.136.1 → latest with no version branching. On <0.139 nothing exposes `original_router` and the walk collapses to exactly the old flat iteration.

**Discriminator: duck-type on `original_router`, not the class name and not `.routes`.** `.routes` alone would be wrong — Starlette `Mount`/`Host` expose it, and mesh itself mounts FastMCP as a catch-all, so blanket recursion would pull a mounted sub-app's routes into discovery. `original_router` is absent on both, excluding them for free.

**Effective paths come from `effective_route_contexts()`.** This corrects an assumption: `.path` is pre-prefixed only at depth 1. With `outer(prefix="/api/v1")` including `inner`, the nested route's own `.path` is `/inner/deep` while the app serves `/api/v1/inner/deep`. That path becomes the `METHOD:path` route id sent to the registry, so getting it wrong is not cosmetic. FastAPI composes it; mesh shouldn't re-derive it.

## Correction: in-place mutation does not work either

The obvious fix — mutate the nested route in place, since replacing it in `original_router.routes` doesn't take effect — is also wrong. Measured on 0.136.1 / 0.139.2 / 0.140.13:

| strategy | cold cache | **warm cache** (one request first) |
|---|---|---|
| list replacement | wrapper serves | **original still serves** |
| in-place attribute copy | wrapper serves | **original still serves** |
| list replacement + cache invalidation | wrapper serves | **wrapper serves** |

`_IncludedRouter.effective_candidates()` caches `_EffectiveRouteContext` objects keyed on `original_router._get_routes_version()`, and `APIRoute.get_route_handler()` reads `dependant` / `body_field` / `_embed_body_fields` / `is_json_stream` **off that context** when one is in scope. On a warm cache the route object is bypassed entirely. The version counter is only bumped by `add_api_route` / `include_router`, so any list assignment is invisible to it.

Result: **one uniform strategy at every depth** — replace in the owning list (keeping #1397's rebuild), invalidate, then verify. Simpler than a split strategy.

`invalidate_route_caches` calls `_mark_routes_changed()` only if callable — the single private touch, guarded, never imported. It cannot degrade silently, because the swap is verified: if the new route isn't reachable afterwards, `RouteRebuildError` propagates past `_integrate_app_routes`' handler → `PipelineStatus.FAILED` on a `required=True` step → startup aborts. #1397's loud-failure property is preserved and extended to "found, swapped, but didn't take".

## Five call sites

| site | verdict |
|---|---|
| `server_discovery.py:302` | **fixed** — the reported bug |
| `route_integration.py:704`/`:754` | **fixed** — broken twice over: never saw the route, and its replacement wouldn't have taken on a warm cache |
| `a2a_startup/fastapi_discovery.py:94` | **fixed** — not broken today (`mesh.a2a.mount()` uses top-level `add_api_route`), but it answers "does this app host the surface", and answering from a partial view is the multi-app misrouting the filter exists to prevent |
| `mesh/a2a.py:1471` | **fixed — a fifth site not in the issue.** `mount()`'s collision guard scanned only the top level, so on ≥0.139 it was blind to a foreign `include_router` route owning `card_path`/`rpc_path` — the silent hijack its docstring says must never happen — and would then have added a second registration for the same path |
| `jobs_cancel_route.py:112` | **skipped, deliberately** — it asks "did *this step* already insert its route", and that insert is always top-level, so the top-level list is the exact answer. Widening it turns it into a user-collision check whose failure mode is silently dead MeshJob cancellation |

## Verification

**The example is the acceptance test** — driven through the real pipeline (`FastAPIAppDiscoveryStep` → `RouteIntegrationStep`) with a dependency pushed through the heartbeat funnel and a real request:

| | discovered | integrated | `GET /api/v1/time` |
|---|---|---|---|
| before, 0.136.1 | 3 | 3 | `dependency_injected: True` |
| **before, 0.140.13** | **0** | SKIPPED | **`dependency_injected: False`** |
| after, 0.136.1 | 3 | 3 | `dependency_injected: True` |
| **after, 0.140.13** | **3** | **3** | **`dependency_injected: True`** |

Also confirmed on 0.139.2, 0.140.4, 0.140.5.

**Version matrix**, route test files, counts from `--junitxml` via isolated `pip --target`:

0.136.1 (79 passed / 1 skipped), 0.139.2, 0.140.4, 0.140.5, 0.140.7, 0.140.11, 0.140.13 — **80 passed on every version above the floor**. The one skip is `test_rebuild_that_does_not_take_effect_is_loud`, guarded on 0.136.1 since it flattens and has no cache to go stale.

**Full CI-equivalent suite**: 2461 tests, 0 failures on 0.136.1, 0.140.5, and 0.140.13.

**Tests proven real, not tautological** — a detached worktree at `main` with the new test module copied in but the call sites unfixed produces **7 failures on latest** (both discovery tests, all four integration tests, the end-to-end injection test) and **0 on 0.136.1**, matching the bug's version profile exactly.

17 new tests in `test_route_include_router_1396.py`, joined to the FastAPI floor job from #1397 so both ends of the range run them.

## Follow-up

`server_discovery.py:87`'s `router_routes_count` is now inconsistent with `len(routes)` on ≥0.139 (it counts one entry per included router). It has no consumer anywhere in the repo — only ever written — so it was left rather than widen the diff. Worth deleting or renaming if anyone touches that dict.

Closes #1396

## Test plan

- [ ] CI green, including the FastAPI floor job
- [ ] Manual: `examples/simple/simple_fastapi_router.py` gets DI on latest FastAPI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for FastAPI routes registered through `include_router()`, including nested routers.
  * Fixed route discovery, A2A detection, and endpoint integration for included routes.
  * Ensured streaming routes and dependency injection continue working after integration.
  * Added safeguards to detect when route updates fail to take effect.

* **Tests**
  * Added comprehensive regression coverage for included, nested, and mounted routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->