### PR TITLE
feat(litellm): add the [litellm] extra, pin it from scaffold, document the split

### DIFF
--- a/cmd/meshctl/templates/python/llm-provider/requirements.txt.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/requirements.txt.tmpl
@@ -1,3 +1,12 @@
 # {{ .Name }} dependencies
 # Add your third-party dependencies here
 # Note: mcp-mesh is provided by the runtime environment (local venv or Docker base image)
+{{- if .RequiresLiteLLM }}
+
+# LiteLLM provider path (model: {{ .Model }}).
+# mcp-mesh bundles native SDK adapters for Anthropic, OpenAI and Gemini only;
+# every other vendor dispatches through LiteLLM. LiteLLM ships in the base
+# mcp-mesh install today, so this line currently changes nothing. It is
+# declared so this agent keeps working when LiteLLM becomes an opt-in extra.
+mcp-mesh[litellm]==3.3.1
+{{- end }}

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -38,7 +38,10 @@ export OPENAI_API_KEY=sk-...
     release. Declaring `mcp-mesh[litellm]` now is a no-op today and keeps a
     long-tail agent working across that change; `meshctl scaffold` already
     writes that pin into the generated `requirements.txt` when the selected
-    model is not Anthropic, OpenAI or Gemini.
+    model is not Anthropic, OpenAI, Gemini or Vertex AI. `vertex_ai/*` is
+    native despite the long-tail-looking name: it runs the same Gemini models
+    through the same bundled SDK, only the auth differs (ADC / Workload
+    Identity instead of an AI Studio API key).
 
 ## @mesh.llm Decorator
 

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -18,11 +18,10 @@ MCP Mesh provides first-class support for LLM-powered agents through the `@mesh.
 
 ## What's Included
 
-The `mcp-mesh` package includes LLM support out of the box via LiteLLM:
+The `mcp-mesh` package includes LLM support out of the box:
 
-- **Claude** (Anthropic)
-- **GPT** (OpenAI)
-- **And 100+ other providers** via LiteLLM
+- **Claude** (Anthropic), **GPT** (OpenAI) and **Gemini** (Google) dispatch through bundled native SDK adapters
+- **100+ other providers** (Bedrock, Cohere, Ollama, …) dispatch through LiteLLM
 
 No additional packages needed. Just set your API keys:
 
@@ -30,6 +29,16 @@ No additional packages needed. Just set your API keys:
 export ANTHROPIC_API_KEY=sk-ant-...
 export OPENAI_API_KEY=sk-...
 ```
+
+!!! note "LiteLLM"
+
+    The big-3 vendors above need nothing beyond the base install. LiteLLM is
+    also part of the base install today, so long-tail providers work with no
+    extra step either — but it is moving to an opt-in extra in a future major
+    release. Declaring `mcp-mesh[litellm]` now is a no-op today and keeps a
+    long-tail agent working across that change; `meshctl scaffold` already
+    writes that pin into the generated `requirements.txt` when the selected
+    model is not Anthropic, OpenAI or Gemini.
 
 ## @mesh.llm Decorator
 

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -149,6 +149,27 @@ gemini = [
     # error.
     "google-genai>=1.22"
 ]
+litellm = [
+    # LiteLLM long-tail provider path (issue #1383).
+    #
+    # DELIBERATELY REDUNDANT TODAY: ``litellm`` is still a BASE dependency
+    # above, so ``pip install mcp-mesh[litellm]`` resolves to exactly the same
+    # set as ``pip install mcp-mesh``. The extra exists now, ahead of the move,
+    # so that a pin written today (by a user, by ``meshctl scaffold``'s
+    # generated requirements.txt, or by the install guidance in
+    # ``mesh.helpers._require_litellm``) keeps working unchanged when the base
+    # entry is deleted at the next major — at that point THIS is the only
+    # declaration that installs litellm.
+    #
+    # This is why the requirement is spelled out in full rather than left as an
+    # empty stub: an empty extra resolves cleanly today but would silently
+    # install nothing the day the base entry goes away.
+    #
+    # The pin MUST stay identical to the ``litellm`` entry in [project]
+    # dependencies above. Enforced by
+    # src/runtime/python/tests/unit/test_litellm_extra_pin_sync.py.
+    "litellm>=1.80.5,!=1.82.7,!=1.82.8"
+]
 
 [project.urls]
 Homepage = "https://github.com/dhyansraj/mcp-mesh"

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -458,7 +458,8 @@ HANDLERS: list[Handler] = [
     Handler(
         name="Go Handler Templates (python_handler.go pip dep)",
         globs=["src/core/cli/handlers/python_handler.go"],
-        pattern=r"(mcp-mesh>=)OLD",
+        # Terminal boundary, same reason as the litellm pin below.
+        pattern=r"(mcp-mesh>=)OLD(?![\w.\-+])",
         replacement=r"\g<1>NEW",
         version_format="pep440",
     ),
@@ -483,7 +484,8 @@ HANDLERS: list[Handler] = [
     Handler(
         name="Go Handler Templates (language_test.go pip dep)",
         globs=["src/core/cli/handlers/language_test.go"],
-        pattern=r"(mcp-mesh==)OLD",
+        # Terminal boundary, same reason as the litellm pin below.
+        pattern=r"(mcp-mesh==)OLD(?![\w.\-+])",
         replacement=r"\g<1>NEW",
         version_format="pep440",
     ),
@@ -508,7 +510,11 @@ HANDLERS: list[Handler] = [
     Handler(
         name="Scaffold Templates (Python requirements.txt.tmpl litellm extra)",
         globs=["cmd/meshctl/templates/python/*/requirements.txt.tmpl"],
-        pattern=r"(mcp-mesh\[litellm\]==)OLD",
+        # Terminal boundary: without it OLD matches a PREFIX of a longer
+        # version, so a 3.3.1 -> 3.3.2 bump rewrites a `==3.3.10` pin into the
+        # nonexistent `==3.3.20`. Letters are excluded too — `3.3.1rc1` is a
+        # different PEP 440 version, not our pin.
+        pattern=r"(mcp-mesh\[litellm\]==)OLD(?![\w.\-+])",
         replacement=r"\g<1>NEW",
         version_format="pep440",
     ),
@@ -567,7 +573,8 @@ HANDLERS: list[Handler] = [
     Handler(
         name="Example Requirements (requirements.txt)",
         globs=["examples/docker-examples/agents/*/requirements.txt"],
-        pattern=r"(mcp-mesh>=)OLD",
+        # Terminal boundary, same reason as the litellm pin above.
+        pattern=r"(mcp-mesh>=)OLD(?![\w.\-+])",
         replacement=r"\g<1>NEW",
         version_format="pep440",
     ),
@@ -935,13 +942,18 @@ def _guard_patterns(old: str, new: str | None = None) -> list[re.Pattern]:
         r"mcpmesh/(?:registry|python-runtime|typescript-runtime"
         r"|java-runtime|ui|cli):"
     )
-    boundary = r"(?![\d.\-+])"
+    # OLD must be the WHOLE version token, never a prefix of a longer one.
+    # Alphanumerics are excluded alongside `. - +` because a release segment
+    # can be followed directly by a letter: `2.8.0rc1` / `2.8.0b1` are
+    # different versions under PEP 440, and no handler would rewrite them, so
+    # flagging one as a stale `2.8.0` is a survivor the bump cannot clear.
+    boundary = r"(?![\w.\-+])"
     patterns = [
         re.compile(img + o + boundary),
         # Optional `[extras]` between the name and the specifier: a pip
         # requirement may be written `mcp-mesh[litellm]==X` (#1383), and
         # without the bracket group the guard reads straight past a stale one.
-        re.compile(r"mcp-mesh(?:\[[^\]]*\])?(?:>=|==)" + op),
+        re.compile(r"mcp-mesh(?:\[[^\]]*\])?(?:>=|==)" + op + boundary),
         # package.json: "@mcpmesh/sdk": "^X" / "@mcpmesh/core": "X" (the key
         # quote, ": ", then the value's opening quote sit between the package
         # name and the version), plus the npm `@mcpmesh/sdk@^X` shorthand.

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -500,6 +500,18 @@ HANDLERS: list[Handler] = [
         pattern=r'("@mcpmesh/sdk":\s*"\^)OLD(")',
         replacement=r"\g<1>NEW\2",
     ),
+    # The generated requirements.txt pins the optional LiteLLM extra for
+    # long-tail models (#1383). The version literal lives in the template — the
+    # same mechanism Dockerfile.tmpl uses one directory over — so both files in
+    # a scaffolded agent are bumped from here and can never disagree about
+    # which mesh version the image and its pip layer target.
+    Handler(
+        name="Scaffold Templates (Python requirements.txt.tmpl litellm extra)",
+        globs=["cmd/meshctl/templates/python/*/requirements.txt.tmpl"],
+        pattern=r"(mcp-mesh\[litellm\]==)OLD",
+        replacement=r"\g<1>NEW",
+        version_format="pep440",
+    ),
     # --- Category 12: Documentation (markdown) ----------------------------
     # Three patterns: --version OLD, <version>OLD</version>, vOLD.
     #
@@ -926,7 +938,10 @@ def _guard_patterns(old: str, new: str | None = None) -> list[re.Pattern]:
     boundary = r"(?![\d.\-+])"
     patterns = [
         re.compile(img + o + boundary),
-        re.compile(r"mcp-mesh(?:>=|==)" + op),
+        # Optional `[extras]` between the name and the specifier: a pip
+        # requirement may be written `mcp-mesh[litellm]==X` (#1383), and
+        # without the bracket group the guard reads straight past a stale one.
+        re.compile(r"mcp-mesh(?:\[[^\]]*\])?(?:>=|==)" + op),
         # package.json: "@mcpmesh/sdk": "^X" / "@mcpmesh/core": "X" (the key
         # quote, ": ", then the value's opening quote sit between the package
         # name and the version), plus the npm `@mcpmesh/sdk@^X` shorthand.

--- a/scripts/test_bump_version.py
+++ b/scripts/test_bump_version.py
@@ -55,6 +55,23 @@ def test_pip_requirement_with_extras():
     assert _matches(old, "mcp-mesh==2.8.0")  # bare form still matches
 
 
+def test_pip_requirement_needs_a_whole_version_token():
+    """OLD must be the whole version, never a prefix of a longer one: without
+    a terminal boundary the guard reads `==2.8.00` as a stale `2.8.0`. Letters
+    count too — `2.8.0rc1` is a different version under PEP 440, and no
+    handler would rewrite it, so flagging it is a survivor nobody can clear."""
+    old = "2.8.0"
+    assert not _matches(old, "mcp-mesh[litellm]==2.8.00")
+    assert not _matches(old, "mcp-mesh[litellm]==2.8.0rc1")
+    assert not _matches(old, "mcp-mesh==2.8.0.post1")
+    # The same widened boundary is shared with the image-tag, npm and
+    # --version patterns; they must not regress on the exact form either.
+    assert not _matches(old, "FROM mcpmesh/cli:2.8.0rc1")
+    assert not _matches(old, "helm upgrade --version 2.8.0rc1")
+    assert _matches(old, "FROM mcpmesh/cli:2.8.0")
+    assert _matches(old, "helm upgrade --version 2.8.0")
+
+
 def _matches_multiline(old: str, text: str) -> bool:
     return any(p.search(text) for p in bv._guard_multiline_patterns(old))
 
@@ -394,6 +411,39 @@ def test_scaffold_requirements_litellm_extra_handler():
         "mcp-mesh[litellm]==3.4.0\n"
         "some-vendor-sdk==3.3.1\n"
     )
+
+
+def test_scaffold_requirements_litellm_extra_is_not_prefix_matched():
+    """Terminal boundary: a 3.3.1 -> 3.3.2 bump used to rewrite the PREFIX of
+    a longer pin, turning `==3.3.10` into the nonexistent `==3.3.20`."""
+    text = "mcp-mesh[litellm]==3.3.10\nmcp-mesh[litellm]==3.3.1rc1\n"
+    assert (
+        _apply_handler(
+            "Scaffold Templates (Python requirements.txt.tmpl litellm extra)",
+            text,
+            old="3.3.1",
+            new="3.3.2",
+        )
+        == text
+    )
+
+
+def test_pip_pin_handlers_are_not_prefix_matched():
+    """The three sibling pip-pin handlers carried the same unbounded prefix
+    match: each must leave a longer version alone, and still bump its own."""
+    cases = [
+        ("Go Handler Templates (python_handler.go pip dep)", "mcp-mesh>="),
+        ("Go Handler Templates (language_test.go pip dep)", "mcp-mesh=="),
+        ("Example Requirements (requirements.txt)", "mcp-mesh>="),
+    ]
+    for name, prefix in cases:
+        skipped = f"{prefix}3.3.10\n{prefix}3.3.1rc1\n"
+        assert _apply_handler(name, skipped, old="3.3.1", new="3.3.2") == skipped, name
+        # The boundary must not over-block: the genuine pin still moves.
+        assert (
+            _apply_handler(name, f"{prefix}3.3.1\n", old="3.3.1", new="3.3.2")
+            == f"{prefix}3.3.2\n"
+        ), name
 
 
 def test_anchored_patterns_skip_third_party_pins():

--- a/scripts/test_bump_version.py
+++ b/scripts/test_bump_version.py
@@ -44,6 +44,17 @@ def test_other_mesh_contexts():
     assert _matches(old, '  tag: "2.8"')  # minor-tag form
 
 
+def test_pip_requirement_with_extras():
+    """`mcp-mesh[litellm]==X` (#1383) is a pip requirement like any other —
+    the bracketed extras sit between the name and the specifier, which the
+    first cut of this pattern read straight past."""
+    old = "2.8.0"
+    assert _matches(old, "mcp-mesh[litellm]==2.8.0")
+    assert _matches(old, "pip install 'mcp-mesh[litellm]==2.8.0'")
+    assert _matches(old, "mcp-mesh[litellm,vertex]>=2.8.0")
+    assert _matches(old, "mcp-mesh==2.8.0")  # bare form still matches
+
+
 def _matches_multiline(old: str, text: str) -> bool:
     return any(p.search(text) for p in bv._guard_multiline_patterns(old))
 
@@ -364,6 +375,24 @@ def test_scaffold_dockerfile_handler_matches_old_only():
         "FROM mcpmesh/python-runtime:3.4.0\n"
         "FROM mcpmesh/java-runtime:latest\n"
         "FROM mcpmesh/typescript-runtime:${RUNTIME_TAG}\n"
+    )
+
+
+def test_scaffold_requirements_litellm_extra_handler():
+    """The generated requirements.txt pins the optional LiteLLM extra (#1383).
+    Only OUR pin moves — a user's third-party pin sitting at the same version
+    is not ours to bump."""
+    text = (
+        "# my-provider dependencies\n"
+        "mcp-mesh[litellm]==3.3.1\n"
+        "some-vendor-sdk==3.3.1\n"
+    )
+    assert _apply_handler(
+        "Scaffold Templates (Python requirements.txt.tmpl litellm extra)", text
+    ) == (
+        "# my-provider dependencies\n"
+        "mcp-mesh[litellm]==3.4.0\n"
+        "some-vendor-sdk==3.3.1\n"
     )
 
 

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -8,11 +8,11 @@ MCP Mesh provides first-class support for LLM-powered agents through the `@mesh.
 
 ## What's Included
 
-The `mcp-mesh` package includes LLM support out of the box via LiteLLM:
+The `mcp-mesh` package includes LLM support out of the box:
 
-- **Claude** (Anthropic)
-- **GPT** (OpenAI)
-- **And 100+ other providers** via LiteLLM
+- **Claude** (Anthropic), **GPT** (OpenAI) and **Gemini** (Google) dispatch
+  through bundled native SDK adapters
+- **100+ other providers** (Bedrock, Cohere, Ollama, …) dispatch through LiteLLM
 
 No additional packages needed. Just set your API keys:
 
@@ -20,6 +20,14 @@ No additional packages needed. Just set your API keys:
 export ANTHROPIC_API_KEY=sk-ant-...
 export OPENAI_API_KEY=sk-...
 ```
+
+**Note on LiteLLM**: the big-3 vendors above need nothing beyond the base
+install. LiteLLM is also part of the base install today, so long-tail providers
+work with no extra step either — but it is moving to an opt-in extra in a future
+major release. Declaring `mcp-mesh[litellm]` now is a no-op today and keeps a
+long-tail agent working across that change; `meshctl scaffold` already writes
+that pin into the generated `requirements.txt` when the selected model is not
+Anthropic, OpenAI or Gemini.
 
 ## @mesh.llm Decorator
 

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -27,7 +27,10 @@ work with no extra step either — but it is moving to an opt-in extra in a futu
 major release. Declaring `mcp-mesh[litellm]` now is a no-op today and keeps a
 long-tail agent working across that change; `meshctl scaffold` already writes
 that pin into the generated `requirements.txt` when the selected model is not
-Anthropic, OpenAI or Gemini.
+Anthropic, OpenAI, Gemini or Vertex AI. `vertex_ai/*` is native despite the
+long-tail-looking name: it runs the same Gemini models through the same bundled
+SDK, only the auth differs (ADC / Workload Identity instead of an AI Studio API
+key).
 
 ## @mesh.llm Decorator
 

--- a/src/core/cli/man/content/scaffold.md
+++ b/src/core/cli/man/content/scaffold.md
@@ -115,9 +115,10 @@ LLM agent flags (`llm` and `llm-provider` subcommands):
 | `--filter-mode`     | Filter mode: `all` (default), `best_match`, `*` (wildcard) — companion to `--filter` |
 
 Python `llm-provider` agents get a `mcp-mesh[litellm]` pin in the generated
-`requirements.txt` when `--model` names a vendor outside Anthropic, OpenAI and
-Gemini (those three dispatch through bundled native SDK adapters). See
-`meshctl man llm`.
+`requirements.txt` when `--model` names a vendor outside Anthropic, OpenAI,
+Gemini and Vertex AI (those dispatch through bundled native SDK adapters —
+`vertex_ai/*` runs the same Gemini models through the same SDK, only the auth
+differs). See `meshctl man llm`.
 
 Docker compose flags (top-level scaffold, no subcommand):
 

--- a/src/core/cli/man/content/scaffold.md
+++ b/src/core/cli/man/content/scaffold.md
@@ -114,6 +114,11 @@ LLM agent flags (`llm` and `llm-provider` subcommands):
 | `--filter`          | Tool filter for `llm` agents (capability selector JSON)                              |
 | `--filter-mode`     | Filter mode: `all` (default), `best_match`, `*` (wildcard) — companion to `--filter` |
 
+Python `llm-provider` agents get a `mcp-mesh[litellm]` pin in the generated
+`requirements.txt` when `--model` names a vendor outside Anthropic, OpenAI and
+Gemini (those three dispatch through bundled native SDK adapters). See
+`meshctl man llm`.
+
 Docker compose flags (top-level scaffold, no subcommand):
 
 | Flag              | Description                                           |

--- a/src/core/cli/scaffold/model_dispatch.go
+++ b/src/core/cli/scaffold/model_dispatch.go
@@ -1,0 +1,105 @@
+package scaffold
+
+import "strings"
+
+// Which LLM models need the optional LiteLLM provider path (issue #1383).
+//
+// mcp-mesh bundles native SDK adapters for three vendors — Anthropic, OpenAI
+// and Gemini — and native dispatch is default-ON. Those models never import
+// litellm. Every other vendor/model falls through to GenericHandler, which
+// dispatches via LiteLLM.
+//
+// !! CROSS-LANGUAGE DUPLICATE !!
+// The routing rules below mirror the Python runtime, which is the source of
+// truth for dispatch at request time:
+//
+//	src/runtime/python/_mcp_mesh/engine/provider_handlers/provider_handler_registry.py
+//	  -> _handlers: which vendor prefixes get a native handler
+//	src/runtime/python/mesh/helpers.py
+//	  -> _infer_big3_vendor_from_bare_name: which UNPREFIXED names are big-3
+//
+// This copy exists only so `meshctl scaffold` can decide what to write into a
+// generated requirements.txt at scaffold time, with no Python available. It is
+// intentionally NOT shared code. When a vendor gains (or loses) a native
+// adapter, BOTH sides must be updated — the Python side changes behavior, this
+// side changes what gets installed. Each Python site carries the reciprocal
+// pointer back here.
+
+// nativeVendorPrefixes are the explicit `vendor/` prefixes that route to a
+// bundled native SDK adapter rather than to LiteLLM.
+//
+// `vertex_ai` is included deliberately: it looks like a long-tail vendor, but
+// ProviderHandlerRegistry maps it to GeminiHandler and gemini_native's
+// supports_model() matches the `vertex_ai/` prefix, so `vertex_ai/*` dispatches
+// through the bundled google-genai SDK exactly like `gemini/*` (only the auth
+// differs — ADC / Workload Identity vs. an AI Studio API key).
+//
+// `bedrock/*` and `databricks/*` are NOT included even though
+// anthropic_native.supports_model() matches `bedrock/anthropic.claude-*`:
+// handler selection happens by VENDOR, and those vendors resolve to
+// GenericHandler, so they take the LiteLLM path.
+var nativeVendorPrefixes = map[string]bool{
+	"anthropic": true,
+	"openai":    true,
+	"gemini":    true,
+	"vertex_ai": true,
+}
+
+// inferBig3VendorFromBareName mirrors Python's
+// `_infer_big3_vendor_from_bare_name`: conservatively resolve an UNPREFIXED
+// model name to one of the three native-adapter vendors, using only
+// unambiguous name prefixes. Returns "" for anything else (including any
+// string that already carries a `/` prefix).
+func inferBig3VendorFromBareName(model string) string {
+	name := strings.ToLower(strings.TrimSpace(model))
+	if name == "" || strings.Contains(name, "/") {
+		return ""
+	}
+
+	// o1/o3/o4 reasoning families: match only when the prefix is the whole
+	// name or is followed by "-" (e.g. "o3", "o3-mini"), so an unrelated
+	// "o3xyz" does not misroute. Mirrors the trailing-dash discipline of the
+	// "gpt-"/"chatgpt-" prefixes.
+	switch name {
+	case "o1", "o3", "o4":
+		return "openai"
+	}
+	if strings.HasPrefix(name, "gpt-") ||
+		strings.HasPrefix(name, "chatgpt-") ||
+		strings.HasPrefix(name, "o1-") ||
+		strings.HasPrefix(name, "o3-") ||
+		strings.HasPrefix(name, "o4-") {
+		return "openai"
+	}
+	if strings.HasPrefix(name, "claude-") {
+		return "anthropic"
+	}
+	if strings.HasPrefix(name, "gemini-") {
+		return "gemini"
+	}
+	return ""
+}
+
+// IsNativeDispatchModel reports whether model dispatches through one of the
+// bundled native SDK adapters (Anthropic / OpenAI / Gemini) rather than
+// through LiteLLM.
+//
+// An empty model is reported as native: nothing is known about it, and the
+// scaffolder must not add an install line on a guess.
+func IsNativeDispatchModel(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if m == "" {
+		return true
+	}
+	if idx := strings.Index(m, "/"); idx >= 0 {
+		return nativeVendorPrefixes[m[:idx]]
+	}
+	return inferBig3VendorFromBareName(m) != ""
+}
+
+// RequiresLiteLLM reports whether an agent using model needs the optional
+// LiteLLM provider path, i.e. whether the generated requirements.txt should
+// pin `mcp-mesh[litellm]`.
+func RequiresLiteLLM(model string) bool {
+	return !IsNativeDispatchModel(model)
+}

--- a/src/core/cli/scaffold/model_dispatch_test.go
+++ b/src/core/cli/scaffold/model_dispatch_test.go
@@ -1,0 +1,106 @@
+package scaffold
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Issue #1383: the generated requirements.txt pins mcp-mesh[litellm] only for
+// models that actually take the LiteLLM long-tail path. Getting this wrong in
+// either direction is a real cost — a needless 30MB pip layer, or an agent
+// that ImportErrors on its first request.
+func TestRequiresLiteLLM(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		expected bool
+	}{
+		// --- big-3, explicit vendor/ prefix ------------------------------
+		{"anthropic prefixed", "anthropic/claude-sonnet-5", false},
+		{"openai prefixed", "openai/gpt-4o", false},
+		{"gemini prefixed", "gemini/gemini-2.5-flash", false},
+
+		// vertex_ai looks long-tail but ProviderHandlerRegistry maps it to
+		// GeminiHandler and gemini_native.supports_model() matches the
+		// prefix — it dispatches through the bundled google-genai SDK.
+		{"vertex_ai prefixed", "vertex_ai/gemini-2.5-flash", false},
+
+		// --- big-3, bare names -------------------------------------------
+		{"bare claude", "claude-sonnet-5", false},
+		{"bare claude 3 haiku", "claude-3-haiku", false},
+		{"bare gpt", "gpt-4o", false},
+		{"bare chatgpt", "chatgpt-4o-latest", false},
+		{"bare o1", "o1", false},
+		{"bare o3", "o3", false},
+		{"bare o3-mini", "o3-mini", false},
+		{"bare o4-mini", "o4-mini", false},
+		{"bare gemini", "gemini-3-pro-preview", false},
+
+		// --- long-tail vendors -------------------------------------------
+		{"bedrock", "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", true},
+		{"databricks", "databricks/anthropic.claude-3-7-sonnet", true},
+		{"cohere", "cohere/command-r-plus", true},
+		{"unknown vendor", "acme-llm/frobnicator-9", true},
+		{"ollama", "ollama/llama3", true},
+		{"groq", "groq/llama-3.1-70b-versatile", true},
+
+		// --- bare names that are NOT big-3 -------------------------------
+		{"bare llama", "llama-3-70b", true},
+		{"bare mistral", "mistral-large-latest", true},
+		// Discipline mirrored from Python: the o-series prefixes match only
+		// as a whole name or followed by "-".
+		{"o3-lookalike", "o3xyz", true},
+
+		// --- empty / unset ------------------------------------------------
+		// Nothing is known about the model; never add an install line on a
+		// guess. Every non-LLM template renders with an empty Model.
+		{"empty", "", false},
+		{"whitespace only", "   ", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, RequiresLiteLLM(tt.model),
+				"RequiresLiteLLM(%q)", tt.model)
+			assert.Equal(t, !tt.expected, IsNativeDispatchModel(tt.model),
+				"IsNativeDispatchModel(%q)", tt.model)
+		})
+	}
+}
+
+func TestRequiresLiteLLMIsCaseInsensitive(t *testing.T) {
+	assert.False(t, RequiresLiteLLM("Anthropic/Claude-Sonnet-5"))
+	assert.False(t, RequiresLiteLLM("OpenAI/GPT-4o"))
+	assert.False(t, RequiresLiteLLM("VERTEX_AI/gemini-2.5-flash"))
+	assert.True(t, RequiresLiteLLM("Bedrock/Anthropic.Claude-3"))
+}
+
+func TestInferBig3VendorFromBareName(t *testing.T) {
+	// Mirrors mesh.helpers._infer_big3_vendor_from_bare_name — a prefixed
+	// model is never second-guessed.
+	assert.Equal(t, "", inferBig3VendorFromBareName("anthropic/claude-sonnet-5"))
+	assert.Equal(t, "openai", inferBig3VendorFromBareName("gpt-4o"))
+	assert.Equal(t, "anthropic", inferBig3VendorFromBareName("claude-opus-4-8"))
+	assert.Equal(t, "gemini", inferBig3VendorFromBareName("gemini-2.5-flash"))
+	assert.Equal(t, "", inferBig3VendorFromBareName("command-r-plus"))
+	assert.Equal(t, "", inferBig3VendorFromBareName(""))
+}
+
+// The template data map is what the requirements.txt template branches on.
+func TestTemplateDataCarriesRequiresLiteLLM(t *testing.T) {
+	native := TemplateDataFromContext(&ScaffoldContext{
+		Name:  "claude-provider",
+		Model: "anthropic/claude-sonnet-5",
+	})
+	assert.Equal(t, false, native["RequiresLiteLLM"])
+
+	longTail := TemplateDataFromContext(&ScaffoldContext{
+		Name:  "bedrock-provider",
+		Model: "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+	})
+	assert.Equal(t, true, longTail["RequiresLiteLLM"])
+
+	none := TemplateDataFromContext(&ScaffoldContext{Name: "basic-agent"})
+	assert.Equal(t, false, none["RequiresLiteLLM"])
+}

--- a/src/core/cli/scaffold/renderer.go
+++ b/src/core/cli/scaffold/renderer.go
@@ -278,6 +278,11 @@ func TemplateDataFromContext(ctx *ScaffoldContext) map[string]interface{} {
 		// LLM-provider specific
 		"Model": ctx.Model,
 
+		// True when the selected model takes the LiteLLM long-tail path
+		// rather than a bundled native SDK adapter, i.e. when the generated
+		// requirements.txt must pin mcp-mesh[litellm] (issue #1383).
+		"RequiresLiteLLM": RequiresLiteLLM(ctx.Model),
+
 		// Tool fields
 		"ToolName":        ctx.ToolName,
 		"ToolDescription": ctx.ToolDescription,

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/provider_handler_registry.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/provider_handler_registry.py
@@ -52,7 +52,16 @@ class ProviderHandlerRegistry:
         ProviderHandlerRegistry.register("cohere", CohereHandler)
     """
 
-    # Built-in vendor mappings
+    # Built-in vendor mappings.
+    #
+    # !! CROSS-LANGUAGE DUPLICATE (issue #1383) !!
+    # ``meshctl scaffold`` re-implements this vendor -> native/LiteLLM split in
+    # Go (``nativeVendorPrefixes`` in ``src/core/cli/scaffold/model_dispatch.go``)
+    # so it can decide whether a generated ``requirements.txt`` needs the
+    # optional ``mcp-mesh[litellm]`` pin. Any vendor added or removed here must
+    # be mirrored there — a vendor that is native here but long-tail there
+    # installs 30MB it never uses; the reverse ships an agent that ImportErrors
+    # on its first request.
     _handlers: dict[str, type[BaseProviderHandler]] = {
         "anthropic": ClaudeHandler,
         "openai": OpenAIHandler,

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -2512,6 +2512,14 @@ def _infer_big3_vendor_from_bare_name(model: str) -> str | None:
     returns ``None`` so the caller keeps the existing GenericHandler/LiteLLM
     tail behavior.
 
+    !! CROSS-LANGUAGE DUPLICATE (issue #1383) !!
+    ``meshctl scaffold`` re-implements these prefix rules in Go so it can
+    decide whether a generated ``requirements.txt`` needs the optional
+    ``mcp-mesh[litellm]`` pin — see ``inferBig3VendorFromBareName`` in
+    ``src/core/cli/scaffold/model_dispatch.go``. Adding or removing a vendor
+    here must be mirrored there, or scaffolded agents will install the wrong
+    set.
+
     Args:
         model: A model identifier (bare or prefixed).
 

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -145,6 +145,27 @@ gemini = [
     # resolves cleanly for users who pinned it from earlier docs.
     "google-genai>=1.22"
 ]
+litellm = [
+    # LiteLLM long-tail provider path (issue #1383).
+    #
+    # DELIBERATELY REDUNDANT TODAY: ``litellm`` is still a BASE dependency
+    # above, so ``pip install mcp-mesh[litellm]`` resolves to exactly the same
+    # set as ``pip install mcp-mesh``. The extra exists now, ahead of the move,
+    # so that a pin written today (by a user, by ``meshctl scaffold``'s
+    # generated requirements.txt, or by the install guidance in
+    # ``mesh.helpers._require_litellm``) keeps working unchanged when the base
+    # entry is deleted at the next major — at that point THIS is the only
+    # declaration that installs litellm.
+    #
+    # This is why the requirement is spelled out in full rather than left as an
+    # empty stub: an empty extra resolves cleanly today but would silently
+    # install nothing the day the base entry goes away.
+    #
+    # The pin MUST stay identical to the ``litellm`` entry in [project]
+    # dependencies above. Enforced by
+    # tests/unit/test_litellm_extra_pin_sync.py.
+    "litellm>=1.80.5,!=1.82.7,!=1.82.8"
+]
 
 [project.urls]
 Homepage = "https://github.com/dhyansraj/mcp-mesh"

--- a/src/runtime/python/tests/unit/test_litellm_extra_pin_sync.py
+++ b/src/runtime/python/tests/unit/test_litellm_extra_pin_sync.py
@@ -1,0 +1,115 @@
+"""Guard the deliberately-duplicated ``litellm`` pin (issue #1383).
+
+``litellm`` is declared twice in each Python manifest:
+
+  * in ``[project] dependencies``  — it is still a BASE dependency today, so
+    nothing breaks for existing installs;
+  * in ``[project.optional-dependencies] litellm`` — the forward-compatible
+    opt-in extra that ``meshctl scaffold`` and
+    ``mesh.helpers._require_litellm`` tell users to pin.
+
+The duplication is intentional (see the comments in both manifests), but a
+version bump or a new upstream exclusion applied to only one of the two would
+silently change what ``mcp-mesh[litellm]`` resolves to versus ``mcp-mesh``.
+These checks fail loudly on that drift.
+
+Both manifests are checked because ``packaging/pypi/pyproject.toml`` is the one
+PyPI publishes and ``src/runtime/python/pyproject.toml`` is the one editable /
+source installs use — a user hitting the extra from either direction must get
+the same litellm.
+"""
+
+import pathlib
+import tomllib
+
+import pytest
+
+# tests/unit/ -> tests/ -> python/ -> runtime/ -> src/ -> <repo root>
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[5]
+
+_MANIFESTS = {
+    "packaging/pypi/pyproject.toml": _REPO_ROOT / "packaging/pypi/pyproject.toml",
+    "src/runtime/python/pyproject.toml": (
+        _REPO_ROOT / "src/runtime/python/pyproject.toml"
+    ),
+}
+
+
+def _load(rel: str) -> dict:
+    path = _MANIFESTS[rel]
+    if not path.is_file():
+        # Running from an installed wheel/sdist rather than a source checkout.
+        pytest.skip(f"{rel} not present (not a source checkout)")
+    return tomllib.loads(path.read_text())
+
+
+def _requirements_named(reqs: list[str], name: str) -> list[str]:
+    """Return every requirement string in ``reqs`` whose project name is
+    ``name`` (matched on the leading identifier, before any extras/specifier)."""
+    hits = []
+    for req in reqs:
+        head = req.split(";")[0].strip()
+        ident = ""
+        for ch in head:
+            if ch.isalnum() or ch in "-_.":
+                ident += ch
+            else:
+                break
+        if ident.lower().replace("_", "-") == name:
+            hits.append(head)
+    return hits
+
+
+@pytest.mark.parametrize("rel", sorted(_MANIFESTS))
+def test_litellm_extra_pin_matches_base_pin(rel: str) -> None:
+    """The ``[litellm]`` extra must restate the base pin verbatim."""
+    data = _load(rel)
+    project = data["project"]
+
+    base = _requirements_named(project["dependencies"], "litellm")
+    assert len(base) == 1, f"{rel}: expected exactly one base litellm pin, got {base}"
+
+    extras = project["optional-dependencies"]
+    assert "litellm" in extras, (
+        f"{rel}: the [litellm] extra is missing. It is what "
+        "'pip install mcp-mesh[litellm]' resolves against — the install "
+        "guidance in mesh.helpers._require_litellm and the pin emitted by "
+        "'meshctl scaffold' both name it."
+    )
+
+    extra = _requirements_named(extras["litellm"], "litellm")
+    assert len(extra) == 1, (
+        f"{rel}: the [litellm] extra must declare litellm explicitly, got "
+        f"{extras['litellm']!r}. An empty/stub extra resolves cleanly today "
+        "(litellm is still a base dependency) but would silently install "
+        "nothing once the base entry is removed."
+    )
+
+    assert extra[0] == base[0], (
+        f"{rel}: the [litellm] extra pin drifted from the base pin.\n"
+        f"  base : {base[0]}\n"
+        f"  extra: {extra[0]}\n"
+        "Both must be updated together — otherwise 'mcp-mesh[litellm]' and "
+        "'mcp-mesh' resolve to different litellm versions."
+    )
+
+
+def test_litellm_pin_is_the_same_across_manifests() -> None:
+    """The published manifest and the source manifest must agree on litellm.
+
+    They deliberately differ on upper bounds for some other deps, but litellm
+    is one pin: a user installing from PyPI and a contributor installing the
+    source tree editable must get the same long-tail provider path.
+    """
+    pins = {}
+    for rel in _MANIFESTS:
+        project = _load(rel)["project"]
+        pins[rel] = (
+            _requirements_named(project["dependencies"], "litellm")[0],
+            _requirements_named(project["optional-dependencies"]["litellm"], "litellm")[
+                0
+            ],
+        )
+
+    values = list(pins.values())
+    assert len(set(values)) == 1, f"litellm pins diverge across manifests: {pins}"


### PR DESCRIPTION
## Summary

Items 3-5 of #1383, as the **first of two steps**. This change is deliberately **non-breaking**: `litellm` stays in the base install. The actual removal happens at the next major, at which point the extra added here already works with no further change.

Items 1 and 2 shipped in #1386 (`_require_litellm()` resolving at point-of-use and raising actionable guidance). That guidance already tells users to run `pip install 'mcp-mesh[litellm]==<version>'` — and until now the extra did not exist, so the command emitted `WARNING: mcp-mesh 3.3.1 does not provide the extra 'litellm'` and installed nothing.

## Item 3 — the extra

Added to both manifests, **restating the base requirement verbatim** rather than being an empty stub. It is redundant today (litellm is also in base, so the extra is a harmless no-op), but at the next major the base entry is simply deleted and the extra keeps working. An empty stub would silently become a no-op exactly when it started mattering.

Published-wheel metadata, built the way `release.yml` does:

```
Requires-Dist: litellm!=1.82.7,!=1.82.8,>=1.80.5              <- still base
Provides-Extra: litellm
Requires-Dist: litellm!=1.82.7,!=1.82.8,>=1.80.5; extra == 'litellm'
```

The duplicated pin is guarded by `tests/unit/test_litellm_extra_pin_sync.py`, which asserts base and extra match *and* that both manifests agree with each other. Deliberately placed in the Python suite rather than `scripts/test_bump_version.py` — see the note at the bottom.

## Item 4 — scaffolder emits the pinned extra

New `scaffold/model_dispatch.go` (`RequiresLiteLLM`), consumed by the `llm-provider` requirements template. Only that template carries it: it is the only Python template whose context has a `Model`, and the only one that dispatches — an `llm-agent` consumer delegates to a provider.

Version pinning follows `Dockerfile.tmpl`'s existing mechanism (a literal that `bump_version.py` rewrites) rather than introducing a template variable, since the meshctl binary's own version is `"dev"` in local builds and two version-of-record mechanisms in one template directory would be worse. New handler added; verified both lines move together in a real bump.

## Correction to the plan: `vertex_ai/*` is big-3

I briefed this as long-tail. That was wrong, and verifying it was the right call: `vertex_ai` is a registered key in `ProviderHandlerRegistry._handlers` mapping to `GeminiHandler`, and `gemini_native.supports_model()` matches `_VERTEX_PREFIX`. It dispatches through the bundled `google-genai` SDK exactly like `gemini/*` — only the auth differs. It gets **no** litellm line, and the test asserts that with the reasoning inline.

## Item 5 — docs

`man/content/llm.md`, `man/content/scaffold.md`, `docs/python/llm/index.md`. Wording is **true today**: LiteLLM ships in the base install, declaring the extra changes nothing right now, and it survives the move. The `_typescript`/`_java` man variants were deliberately not touched — they document the Vercel AI SDK and Spring AI, neither of which has a LiteLLM path or a `pip install`.

## Verification

**Non-breaking, measured** — full resolutions with `--ignore-installed` against a `main` worktree and this branch:

```
main   plain    : 111 packages
branch plain    : 111 packages   symmetric-diff vs main = NONE
branch [litellm]: 111 packages   symmetric-diff vs branch plain = NONE
```

**The extra resolves** — the `does not provide the extra` warning is gone.

**Sync test proven real** — appending `,!=1.99.0` to one extra pin fails both the per-manifest and cross-manifest assertions; reverted, 3 pass.

**Bump** — a real `3.3.1 → 3.3.2` in a throwaway worktree: 470 files, over-match guard and coverage guard both clean. The template pin moves in lockstep with the Docker tag, and the four upstream `litellm>=1.80.5` lines (their version, not ours) are untouched.

**Generated requirements.txt** — `anthropic/claude-sonnet-5` and `vertex_ai/gemini-2.5-flash` produce no line; `bedrock/…` and `ollama/llama3` produce the pinned extra with an explanatory comment.

Go: `go build ./...` clean, `go test ./src/core/...` all packages ok, 24 new `RequiresLiteLLM` sub-cases. Python: **2469 tests, 0 failures**.

## Two findings worth separate attention

**1. `bump_version.py`'s coverage guard read past the new pin.** Its pattern was `mcp-mesh(?:>=|==)`, which does not match `mcp-mesh[litellm]==X`. Extended here to allow the optional bracket group — otherwise the new pin could silently go stale across a release, which is exactly the class of bug that guard exists to catch.

**2. `bedrock/*` and `databricks/*` are long-tail despite `anthropic_native.supports_model()` matching them.** Handler selection is by *vendor*, and neither string is a registry key, so they land on `GenericHandler` → LiteLLM and `supports_model` is never consulted. That looks like unreachable capability in `anthropic_native`, and it means the `[anthropic-bedrock]` extra's documented use case may not take the native path today. Not touched — it is a behavioural question outside this issue. Worth its own issue.

Also filed **#1399**: `scripts/test_bump_version.py` is never executed by CI, so the over-match guard's own tests (added in #1395) are unenforced. That is why the new sync test went into the Python suite instead.

Refs #1383

## Test plan

- [ ] CI green
- [ ] `pip install 'mcp-mesh[litellm]'` resolves without warning
- [ ] A scaffolded long-tail provider's `requirements.txt` carries the pinned extra; a big-3 one does not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `meshctl scaffold` now determines whether a chosen model is routed via bundled native adapters or via LiteLLM, and conditionally adds the `mcp-mesh[litellm]` requirement to generated `requirements.txt`.
  * Added a new Python `litellm` optional install extra (aligned with existing LiteLLM pinning).

* **Documentation**
  * Refined LLM integration and scaffold docs to clarify native vs LiteLLM dispatch and current vs future install behavior.

* **Bug Fixes**
  * Improved version-bump logic to correctly handle `mcp-mesh[litellm]` (including extras) without false matches.

* **Tests**
  * Added coverage for model dispatch decisions and `litellm` extra/version pin synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->