### PR TITLE
fix(python): raise declared fastapi floor to 0.135.0 — >=0.104.0 is unresolvable

### DIFF
--- a/examples/docker-examples/agents/base/requirements.txt
+++ b/examples/docker-examples/agents/base/requirements.txt
@@ -2,7 +2,7 @@
 # The main mcp_mesh package is installed from source in the Dockerfile
 
 # FastAPI and HTTP server
-fastapi>=0.104.0
+fastapi>=0.135.0
 uvicorn>=0.24.0
 
 # HTTP client for inter-agent communication

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -59,7 +59,14 @@ requires-python = ">=3.11"
 dependencies = [
     # Rust core runtime (required - no Python fallback)
     "mcp-mesh-core>=3.3.1",
-    "fastapi>=0.104.0,<1.0.0",
+    # Floor raised to 0.135.0 (#1402). Anything below 0.133.0 is not merely
+    # old, it is unresolvable against our own mcp/fastmcp pins: mcp==1.28.1
+    # wants anyio>=4.5 while old FastAPI caps anyio<4.0.0, and fastmcp==3.4.3
+    # pulls starlette>=1.0.1 while FastAPI caps starlette<1.0.0 until 0.133.0.
+    # 0.133/0.134 install but the route/SSE suite is not green there
+    # (is_sse_stream, which the route rebuild keys off, lands in 0.135.0), so
+    # 0.135.0 is the lowest version we can honestly claim to support.
+    "fastapi>=0.135.0,<1.0.0",
     "uvicorn>=0.24.0,<1.0.0",
     "httpx>=0.25.0,<1.0.0",
     "aiohttp>=3.8.0,<4.0.0",

--- a/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
@@ -736,7 +736,7 @@ class RouteIntegrationStep(PipelineStep):
             #
             # ``iter_app_routes`` also reaches routes mounted with
             # ``include_router()``, which stopped being flattened into
-            # ``app.router.routes`` in FastAPI 0.139 (issue #1396). It reports
+            # ``app.router.routes`` in FastAPI 0.137.0 (issue #1396). It reports
             # each route's EFFECTIVE path, matching what discovery recorded in
             # ``route_info["path"]``, and the mutable list that owns it.
             #

--- a/src/runtime/python/_mcp_mesh/shared/fastapi_routes.py
+++ b/src/runtime/python/_mcp_mesh/shared/fastapi_routes.py
@@ -2,7 +2,7 @@
 
 Historically ``app.router.routes`` was a flat list: ``include_router()``
 copied every ``APIRoute`` off the mounted ``APIRouter`` into it, so walking
-that one list saw everything the app served. FastAPI 0.139 changed the
+that one list saw everything the app served. FastAPI 0.137.0 changed the
 representation — ``include_router()`` now appends a *single* entry that keeps
 a live reference to the user's ``APIRouter`` and derives the served
 ("effective") routes from it lazily. The mounted ``APIRoute`` objects are no
@@ -43,7 +43,7 @@ routes are not this app's ``@mesh.route`` surface, and mesh itself mounts the
 FastMCP app as a catch-all at ``""``. Requiring ``original_router`` keeps
 them out.
 
-On FastAPI < 0.139 nothing exposes ``original_router``, so the walk collapses
+On FastAPI < 0.137.0 nothing exposes ``original_router``, so the walk collapses
 to precisely the old flat iteration — no version branching anywhere.
 """
 
@@ -236,7 +236,7 @@ def invalidate_route_caches(app: Any) -> None:
     own view picked the rebuilt route up, and fails loudly if it did not
     (#1387's rule).
 
-    No-op on FastAPI < 0.139, which has no such cache.
+    No-op on FastAPI < 0.137.0, which has no such cache.
     """
     for router in iter_routers(app):
         mark = getattr(router, "_mark_routes_changed", None)

--- a/src/runtime/python/_mcp_mesh/shared/server_discovery.py
+++ b/src/runtime/python/_mcp_mesh/shared/server_discovery.py
@@ -301,7 +301,7 @@ class ServerDiscoveryUtil:
 
         Walks via ``iter_app_routes`` rather than ``app.router.routes``, so
         handlers mounted with ``include_router()`` are seen on FastAPI >=
-        0.139 (issue #1396) — they are no longer flattened into the app's own
+        0.137.0 (issue #1396) — they are no longer flattened into the app's own
         list. ``path`` is the effective path the app serves, so downstream
         consumers (route integration's match, and the ``METHOD:path`` route
         ids the heartbeat ships to the registry) stay correct at any include

--- a/src/runtime/python/mesh/a2a.py
+++ b/src/runtime/python/mesh/a2a.py
@@ -1469,7 +1469,7 @@ def mount(
         # this agent — clients would then call the wrong handler.
         #
         # The scan covers include_router() mounts too (issue #1396): those
-        # stopped being flattened into ``app.router.routes`` in FastAPI 0.139,
+        # stopped being flattened into ``app.router.routes`` in FastAPI 0.137.0,
         # so a top-level-only scan was blind to exactly the foreign route this
         # guard exists to catch, and ``add_api_route`` below would have added
         # a second registration for the same path.

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -57,7 +57,13 @@ requires-python = ">=3.11"
 # native google-genai SDK; without it they would silently fall back to
 # LiteLLM.
 dependencies = [
-    "fastapi>=0.104.0",
+    # Floor raised to 0.135.0 (#1402). Below 0.133.0 FastAPI is unresolvable
+    # against our own mcp/fastmcp pins (mcp==1.28.1 needs anyio>=4.5 vs old
+    # FastAPI's anyio<4.0.0; fastmcp==3.4.3 needs starlette>=1.0.1 vs
+    # FastAPI's starlette<1.0.0 cap, lifted in 0.133.0). 0.133/0.134 install
+    # but the route/SSE suite is not green until 0.135.0, where is_sse_stream
+    # lands.
+    "fastapi>=0.135.0",
     "uvicorn>=0.24.0",
     "httpx>=0.25.0",
     "aiohttp>=3.8.0",

--- a/src/runtime/python/tests/unit/test_route_include_router_1396.py
+++ b/src/runtime/python/tests/unit/test_route_include_router_1396.py
@@ -1,6 +1,6 @@
 """Regression tests for issue #1396 — @mesh.route through ``include_router()``.
 
-FastAPI 0.139 stopped flattening an included ``APIRouter``'s ``APIRoute``
+FastAPI 0.137.0 stopped flattening an included ``APIRouter``'s ``APIRoute``
 objects into ``app.router.routes``; the app now holds a single entry that
 derives the served routes from the router lazily. Every mesh site that walked
 ``app.router.routes`` went blind to those handlers, so ``@mesh.route`` on an
@@ -64,7 +64,7 @@ def _paths(app):
 
 
 def _flattens_included_routers(app) -> bool:
-    """True on FastAPI < 0.139, where include_router() copies routes over."""
+    """True on FastAPI < 0.137.0, where include_router() copies routes over."""
     return not any(hasattr(entry, "original_router") for entry in app.router.routes)
 
 


### PR DESCRIPTION
## Summary

The declared `fastapi>=0.104.0` floor is a compatibility claim the package cannot honour: **FastAPI below 0.133.0 is uninstallable** alongside the pinned `mcp==1.28.1` / `fastmcp==3.4.3`, which require `starlette>=1.0.1` and `anyio>=4.5` while old FastAPI caps both. Raises the floor to a version that actually resolves, and corrects a version stated wrongly in the `include_router` comments.

**This is not fallout from the route rework.** The floor was examined while validating #1397/#1398, and that code turned out to be fine everywhere — a 7-scenario end-to-end sweep across **15 FastAPI versions (0.104.0 → 0.140.13)** passed 7/7 at every one, with **no silent degradation at any version**. SSE returned `text/event-stream` with the expected body throughout, direct and via `include_router`. The defect is purely in the declared metadata, and predates both PRs.

## Changes

- **Floor → `>=0.135.0`** in `packaging/pypi/pyproject.toml` and `src/runtime/python/pyproject.toml`, each with a comment recording why. The published manifest keeps its `<1.0.0` ceiling; the source manifest still has none — that asymmetry is deliberate and unchanged.
- **`include_router` lazy shape corrected 0.139 → 0.137.0** across 8 sites in 5 files. The issue named 3; a sweep found `server_discovery.py:304` and `mesh/a2a.py:1472` as well.
- Floor swept in `examples/docker-examples/agents/base/requirements.txt`.

## Why 0.135.0 and not 0.133.0

| candidate | installable | production paths | route/SSE suite |
|---|---|---|---|
| 0.104.0 – 0.132.1 | **no** (`ResolutionImpossible`) | pass | n/a |
| 0.133.0 – 0.134.0 | yes | pass | 1 failure |
| **0.135.0+** | yes | pass | **green** |

0.133/0.134 install and work, but the regression suite isn't green there — a supported-on-paper, untested-in-CI band. It is also exactly where the auto-streaming attributes the rebuild is built around are half-present: `is_json_stream` lands in 0.134.0, `is_sse_stream` in 0.135.0. Verified directly — `is_sse_stream` is absent from `fastapi/routing.py` at 0.134.0 and present at 0.135.0.

0.135.0 sits below the 0.136.1 CI already pins, so it costs no real-world compatibility.

## Validation

- **Floor resolves**: `fastapi==0.135.0 mcp==1.28.1 fastmcp==3.4.3` installs clean in a throwaway py3.11 venv.
- **Floor is placed correctly, not arbitrarily**: the same pins with `fastapi==0.132.1` fail with `ResolutionImpossible` — `fastapi 0.132.1 depends on starlette<1.0.0` vs `fastmcp-slim[server] 3.4.3 depends on starlette>=1.0.1`.
- **Route/SSE suite**: 278 passed, 1 skipped, 0 failed. The skip is `test_route_include_router_1396.py:334` — *"FastAPI flattens included routers; no cache to go stale"* — which independently corroborates the version correction, since CI runs 0.136.1.
- **`include_router` shape probed live**: `original_router` absent at 0.136.3 (flattens), present at 0.137.0 (lazy). Confirms 0.137.0.
- **No contradicting constraints elsewhere**: swept helm values, Dockerfiles, requirements files, scaffold templates, docs and CI. Only two other FastAPI floors exist, both `>=0.104.0` and both non-contradictory (floors intersect with the package's own). CI's `fastapi==0.136.1` satisfies the new floor.
- **Not version-managed**: `scripts/bump_version.py` has no fastapi handler, so nothing needs to stay in sync.

## Deliberately not in this PR

- **`examples/observability-test/Dockerfile.dev`** still declares `fastapi>=0.104.0`. Staging it pulls the file into the `hadolint` hook, which fails on three **pre-existing** findings on lines 9 and 40 (reproducible against unmodified `HEAD`) — the file predates the `.pre-commit-config.yaml` repair that made the hook match `Dockerfile.*` at all. Fixing `DL3008` means pinning apt versions in an example image, which rots on every Debian point release. That tradeoff deserves its own PR rather than a bypass here.
- **`examples/docker-examples/agents/base/requirements.txt` is orphaned** — nothing repo-wide reads it; both sibling Dockerfiles install the runtime directly. It also lists `asyncio`, which resolves to the PyPI `asyncio` package that shadows the stdlib module. Filed separately rather than deleted here.

Closes #1402


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependency Updates**
  * Updated the minimum supported FastAPI version to 0.135.0.
  * Updated the Docker example to use a newer FastAPI release.

* **Documentation**
  * Refined documentation and compatibility notes for FastAPI router behavior and route handling.
  * Updated regression-test descriptions to reflect the applicable FastAPI version threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->