### PR TITLE
fix(release): stop bump_version.py rewriting dated provenance claims

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -216,7 +216,7 @@ Designed for containers and Kubernetes.
 
 ## Multimodal Pipeline
 
-MCP Mesh v3.3.1 adds a media pipeline that lets tools produce and LLMs consume binary content:
+MCP Mesh v1.0.0 adds a media pipeline that lets tools produce and LLMs consume binary content:
 
 ```
 Tool produces media

--- a/docs/concepts/stateful-agents.md
+++ b/docs/concepts/stateful-agents.md
@@ -48,7 +48,7 @@ mcp-mesh runs your agent across two event loops:
 
 The two-loop split means a long-running tool body (LLM call, slow registry hop, multi-minute MeshJob) holds the user loop, but never the framework loop — your K8s liveness/readiness probes stay responsive.
 
-**What this fixes**: loop-bound resources work as expected when created in `lifespan` startup. `asyncpg.Pool`, `redis.asyncio.Redis`, and `aiohttp.ClientSession` are all loop-affine — they bind to the asyncio loop that created them and fail if reused from a different one. Because v3.3.1 runs your `lifespan` AND your tools on the same user loop, the canonical FastMCP idiom is straightforward:
+**What this fixes**: loop-bound resources work as expected when created in `lifespan` startup. `asyncpg.Pool`, `redis.asyncio.Redis`, and `aiohttp.ClientSession` are all loop-affine — they bind to the asyncio loop that created them and fail if reused from a different one. Because v2.2.4 runs your `lifespan` AND your tools on the same user loop, the canonical FastMCP idiom is straightforward:
 
 ```python
 # Module-level — FastMCP's `lifespan` parameter receives a FastMCP server
@@ -104,7 +104,7 @@ long-running work. From mesh's perspective it's an ordinary CRUD
 agent — every tool call is short, idempotent where possible, and
 returns. The pool lives inside the agent process — created in
 `lifespan` startup, stored in a module-level global, and closed in
-`lifespan` exit. Since v3.3.1, `lifespan` and all tool bodies share
+`lifespan` exit. Since v2.2.4, `lifespan` and all tool bodies share
 the single user loop, so a module-level pool created in `lifespan`
 startup is the supported pattern. (FastMCP's `lifespan` receives a
 FastMCP server instance — there is no `.state` namespace as there is

--- a/docs/index.md
+++ b/docs/index.md
@@ -412,7 +412,7 @@ A `kubectl`-style command-line tool that follows you from first agent to product
 
 ## :star: Project Status
 
-- **Latest Release**: v3.3.1 (March 2026)
+- **Latest Release**: v3.3.1
 - **License**: MIT
 - **Languages**: Python 3.11+, TypeScript/Node.js 18+, and Java 17+ (runtime), Go 1.23+ (registry)
 - **Status**: Production-ready, actively developed

--- a/docs/python/dependency-injection.md
+++ b/docs/python/dependency-injection.md
@@ -297,7 +297,7 @@ loop — K8s liveness/readiness probes stay responsive.
 
 ### Default `MCP_MESH_TOOL_WORKERS=1`
 
-Since v3.3.1, default tool dispatch runs on a single-user loop (was
+Since v2.2.4, default tool dispatch runs on a single-user loop (was
 `min(8, max(2, cpu_count()))`). The canonical pattern for loop-bound
 resources works as expected — `lifespan` startup creates the resource
 on the user loop; every tool body uses it on the same loop; `lifespan`

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -142,6 +142,123 @@ def record_changes(
 # ---------------------------------------------------------------------------
 
 
+# Sentences that DATE a behaviour — "Since v2.2.4, tool dispatch runs on a
+# single user loop", "MCP Mesh v1.0.0 adds a media pipeline". The version is a
+# historical fact recording when something shipped, not a coordinate that
+# tracks the current release, so rewriting it is always wrong.
+#
+# Left unprotected it also RATCHETS: every release walks the claim forward one
+# version, so it permanently reads "new in whatever you happen to be reading
+# about" and can never mark a real upgrade boundary. Four sentences ratcheted
+# this way for eight releases before #1405 caught them; one had been walking
+# since v1.0.0.
+#
+# Neither guard can catch this class. The line genuinely is mesh-related — it
+# is usually mesh prose, with "MCP Mesh" written out — so the over-match guard
+# clears it, and the coverage guard only looks for versions we MISSED. The fix
+# has to live here, in the matcher.
+#
+# Each pattern must span the version token itself: the exclusion is applied by
+# OVERLAP with the matched version (see `_sub_skipping_provenance`), not by
+# line. A line may carry both a provenance claim and a genuine current-version
+# coordinate, and only the claim is protected.
+# A version token as it appears in prose. `v` optional so a paren/hyphen form
+# still anchors when the handler's own `v` is the character being protected.
+_PV = r"v?\d+\.\d+(?:\.\d+)?"
+# Filler the lead-in phrases tolerate before the version. "Since MCP Mesh
+# v1.0.0 adds..." is the spelling docs/concepts/architecture.md actually uses,
+# and it was the longest-running corruption of the four.
+_PV_FILLER = r"(?:the\s+)?(?:mcp[-\s]?mesh\s+)?"
+
+PROVENANCE_PROSE: list[str] = [
+    # Lead-in form: a phrase introduces the version.
+    #   "Since v2.2.4, ..." / "(as of v1.4)" / "Prior to v1.4, ..."
+    #   "Since MCP Mesh v1.0.0, ..." / "As of the v3.4.0 release, ..."
+    # The `<verb> in` list mirrors the trailing verb list below — the two forms
+    # are the same claim with the version on the other side of the verb, so a
+    # verb covered in one direction and not the other is an arbitrary hole.
+    r"\b(?:since|because|as\s+of|new\s+in|prior\s+to|before|until"
+    r"|starting\s+(?:with|in|from)"
+    r"|available\s+(?:since|in|from)"
+    r"|(?:introduced|added|shipped|landed|released|removed|deprecated"
+    r"|changed|fixed|renamed|replaced|split|merged|gated|enabled|disabled"
+    r")\s+in"
+    r")\s+" + _PV_FILLER + _PV,
+    # Trailing form: the version is the subject of a "this release did X" verb.
+    #   "MCP Mesh v1.0.0 adds a media pipeline"
+    #   "Because v2.2.4 runs your lifespan AND your tools on the same loop"
+    _PV + r"\s+(?:adds|added|introduces|introduced|brings|brought|ships"
+    r"|shipped|gains|gained|changes|changed|drops|dropped|removes|removed"
+    r"|replaces|replaced|fixes|fixed|makes|made|runs|ran|moves|moved"
+    r"|switches|switched|deprecates|deprecated)\b",
+    # Availability window: "supported in v2.2 and later", "v2.2 onwards".
+    # Both readings of this form argue against bumping. As an availability
+    # claim it is provenance outright; as a minimum-requirement floor
+    # ("requires vX or newer") auto-bumping is still wrong, because it would
+    # assert that every release raises the floor. There is no reading under
+    # which the current release is the right answer, so no ambiguity to weigh.
+    _PV + r"\s+(?:and|or)\s+(?:later|newer|above|higher|greater|earlier"
+    r"|older|below)\b",
+    _PV + r"\s+onwards?\b",
+    # Hyphenated relative form: "pre-v2.2 immediate cancel-forward behavior"
+    # (docs/environment-variables.md, src/core/cli/man/content/environment.md).
+    r"\b(?:pre|post)-" + _PV,
+    # Parenthesised version label: "## Loop topology (v2.2.4+)",
+    # "### Migration note (v1.3 → v1.4)", "# Before (v1.3):",
+    # "After (v1.4, pick one):", "**Tag-Level OR** (v0.9.1+)".
+    #
+    # A version in parentheses labels WHICH release a heading, example or
+    # column applies to. That is provenance in heading form.
+    #
+    # This replaces an earlier `vX+` plus-suffix pattern that could never fire:
+    # `+` falls outside the handler's trailing character class, so `(v2.2.4+)`
+    # never produced a match to suppress. The genuinely exposed form is the
+    # BARE parenthetical — `)` and `,` are both in that class — which is live
+    # today at src/core/cli/man/content/headers.md:51 and :62 and safe only
+    # because those versions are historical.
+    #
+    # Checked against every `v\d+\.\d+` under this handler's globs: the sole
+    # live coordinate, `**Latest Release**: vX`, carries no parentheses, and
+    # coverage_guard now watches that line specifically in case it ever does.
+    r"\(\s*" + _PV,
+    # Migration arrow, whose right-hand side no paren precedes.
+    _PV + r"\s*(?:→|->)\s*" + _PV,
+]
+
+
+def _sub_skipping_provenance(
+    pattern: str,
+    replacement: str,
+    content: str,
+    flags: int,
+    line_excludes: list[str],
+) -> str:
+    """`re.sub`, except a match is left alone when an exclusion regex matches
+    the SAME characters on that line.
+
+    Overlap, not line membership, is the test. A line reading
+    ``Since v2.2.4 ... upgrade to mcp-mesh v3.3.1`` protects only the dated
+    claim; the trailing coordinate still bumps.
+    """
+    if not line_excludes:
+        return re.sub(pattern, replacement, content, flags=flags)
+
+    compiled = [re.compile(p, re.IGNORECASE) for p in line_excludes]
+
+    def _repl(m: re.Match) -> str:
+        line_start = content.rfind("\n", 0, m.start()) + 1
+        line_end = content.find("\n", m.end())
+        line = content[line_start:] if line_end == -1 else content[line_start:line_end]
+        lo, hi = m.start() - line_start, m.end() - line_start
+        for rgx in compiled:
+            for em in rgx.finditer(line):
+                if em.start() < hi and em.end() > lo:
+                    return m.group(0)
+        return m.expand(replacement)
+
+    return re.sub(pattern, _repl, content, flags=flags)
+
+
 def replace_in_file(
     filepath: Path,
     pattern: str,
@@ -149,12 +266,15 @@ def replace_in_file(
     dry_run: bool,
     flags: int = 0,
     source: str = "",
+    line_excludes: list[str] | None = None,
 ) -> bool:
     """Apply a regex replacement in a file. Returns True if changes were made."""
     if not filepath.exists():
         return False
     content = filepath.read_text()
-    new_content = re.sub(pattern, replacement, content, flags=flags)
+    new_content = _sub_skipping_provenance(
+        pattern, replacement, content, flags, line_excludes or []
+    )
     if new_content == content:
         return False
     record_changes(filepath, content, new_content, source or pattern)
@@ -181,6 +301,12 @@ class Handler:
     # when two handlers update the same file but you want to disambiguate
     # them in the report (e.g. the mcp-mesh-core dep entry in pypi).
     report_suffix: str = ""
+    # Regexes that VETO a replacement: if one of them matches the same
+    # characters as the version match, that occurrence is left alone. Only
+    # loose, prose-facing patterns need this — a handler anchored to a
+    # structural coordinate (`--version X`, `<version>X</version>`,
+    # `mcpmesh/registry:X`) cannot collide with prose in the first place.
+    line_excludes: list[str] = field(default_factory=list)
 
 
 def _glob_to_regex(pattern: str) -> re.Pattern:
@@ -307,6 +433,7 @@ def run_handler(handler: Handler, old: str, new: str, dry_run: bool) -> list[str
             dry_run,
             flags=handler.flags,
             source=handler.name,
+            line_excludes=handler.line_excludes,
         ):
             label = str(f.relative_to(PROJECT_ROOT))
             if handler.report_suffix:
@@ -568,6 +695,11 @@ HANDLERS: list[Handler] = [
         pattern=r"(?<![/:])vOLD(?=[\s,\)\]\"']|$)",
         replacement=r"vNEW",
         flags=re.MULTILINE,
+        # This is the only handler that rewrites a bare version in running
+        # prose, so it is the only one that can corrupt a dated claim (#1405).
+        # What survives is the genuine coordinate — `**Latest Release**: vX`
+        # on the docs landing page — which carries no dating phrase.
+        line_excludes=PROVENANCE_PROSE,
     ),
     # --- Category 14: Example agent requirements.txt ---------------------
     Handler(
@@ -963,6 +1095,20 @@ def _guard_patterns(old: str, new: str | None = None) -> list[re.Pattern]:
         re.compile(r"<mcp-mesh\.version>" + o + r"</mcp-mesh\.version>"),
         re.compile(r"--version\s+v?" + o + boundary),
         re.compile(r'tag:\s*"' + o + r'"'),
+        # The docs landing page's release coordinate — the one bare-prose
+        # version under docs/ that MUST track the release.
+        #
+        # PROVENANCE_PROSE (#1405) gives the matcher the power to VETO a
+        # rewrite, which converts a loud failure mode into a silent one: an
+        # over-broad veto would leave this line on the previous release while
+        # the bump completes and both guards print green. None of the patterns
+        # above matches a bare `vX` in prose, so nothing else would notice.
+        #
+        # This is the mirror image of the OVERMATCH_ALLOWLIST entry that
+        # anchors the same line from the opposite direction: that one says the
+        # rewrite is legitimate, this one says it is mandatory. Between them
+        # the new veto mechanism fails loud in both directions.
+        re.compile(r"\*\*Latest Release\*\*:\s*v?" + o + boundary),
     ]
     if new is None or to_minor(old) != to_minor(new):
         patterns.append(re.compile(r'tag:\s*"' + om + r'"'))
@@ -1127,17 +1273,20 @@ OVERMATCH_ALLOWLIST: list[Exemption] = [
             "the release, not an artifact."
         ),
     ),
-    Exemption(
-        glob="docs/concepts/stateful-agents.md",
-        pattern=r"\bvNEW\b",
-        reason=(
-            "narrative prose ('Since vX, lifespan and all tool bodies share "
-            "one loop') dating a runtime behavior change. The document is "
-            "about the mesh runtime, but these two sentences carry no "
-            "coordinate. Scoped to this one file so a bare vX anywhere else "
-            "in docs/ is still challenged."
-        ),
-    ),
+    # NOTE: there is deliberately no entry for the 'Since vX, lifespan and all
+    # tool bodies share one loop' prose in docs/concepts/stateful-agents.md.
+    # An exemption was added for it in #1395 and made things worse: the guard
+    # had correctly flagged a sentence its own reason text described as
+    # "dating a runtime behavior change" — which is precisely the signal that
+    # it must not be bumped. Silencing the guard left the handler free to keep
+    # corrupting the file, which is how the ratchet survived eight releases
+    # (#1405). The sentence is now protected in the matcher instead, by
+    # PROVENANCE_PROSE, so no exemption is needed: the line never changes.
+    #
+    # The general rule: an exemption is only ever the right answer when the
+    # rewrite is CORRECT but unprovable. If the guard fires on a rewrite that
+    # is itself wrong, fix the handler.
+    #
     # NOTE: the three sites that used to live here — the tutorial POM's own
     # <version> in docs/java/getting-started/index.md and quickstart_java.md,
     # and `your-registry/my-agent:vX` in the deployment man pages — were not

--- a/scripts/test_bump_version.py
+++ b/scripts/test_bump_version.py
@@ -110,6 +110,25 @@ def test_maven_coordinate_guard_reports_the_version_line():
     assert text.count("\n", 0, m.start("hit")) + 1 == 4
 
 
+def test_coverage_guard_catches_a_frozen_release_coordinate():
+    """#1405 gave the matcher the power to VETO a rewrite, which converts a
+    loud failure (a doc reads the wrong version) into a silent one (a
+    coordinate quietly stops tracking). An over-broad PROVENANCE_PROSE entry
+    would leave the docs landing page advertising the previous release while
+    the bump completes and both guards print green.
+
+    None of the other guard patterns matches a bare `vX` in prose, so this one
+    is the only thing standing between an over-veto and a bad release."""
+    old = "3.3.1"
+    assert _matches(old, "- **Latest Release**: v3.3.1")
+    assert _matches(old, "- **Latest Release**: 3.3.1")  # `v` optional
+    # ...and it clears once the bump has actually landed.
+    assert not _matches(old, "- **Latest Release**: v3.3.2")
+    # Whole-version token only: a longer version is not a stale 3.3.1.
+    assert not _matches(old, "- **Latest Release**: v3.3.10")
+    assert not _matches(old, "- **Latest Release**: v3.3.1rc1")
+
+
 def test_patch_bump_leaves_minor_tag():
     # The minor image tag (tag: "2.8") intentionally tracks the latest patch,
     # so a patch bump must NOT flag it as stale (to_minor unchanged)...
@@ -181,6 +200,12 @@ def test_overmatch_guard_clears_line_level_token():
     )
     # Prose form: "MCP Mesh v3.3.1 adds ..." — the space-separated spelling
     # counts, which is what keeps narrative docs out of the report.
+    #
+    # It is also why the guard is structurally blind to #1405: this exact line
+    # is a corrupted provenance claim (it read v1.0.0 when written), yet it
+    # clears, correctly, because the line really is about mesh. Ownership is
+    # not the question a dated claim raises. Only the matcher can answer it,
+    # which is why PROVENANCE_PROSE exists and no exemption was added.
     assert not _guard_on(
         "docs/concepts/architecture.md",
         "MCP Mesh v3.3.0 adds a media pipeline\n",
@@ -313,6 +338,7 @@ def _apply_handler(name: str, text: str, old="3.3.1", new="3.4.0") -> str:
             handler.replacement.replace("NEW", new_v),
             dry_run=False,
             flags=handler.flags,
+            line_excludes=handler.line_excludes,
         )
         return f.read_text()
 
@@ -370,14 +396,141 @@ def test_docs_v_prefix_handler_skips_docker_tags():
     between the slash and the v. That tag is the READER's image."""
     text = (
         "docker buildx build -t your-registry/my-agent:v3.3.1 --push .\n"
-        "MCP Mesh v3.3.1 adds a media pipeline\n"
+        "Install MCP Mesh v3.3.1 to get started\n"
         "see https://example.com/v3.3.1 for details\n"
     )
     assert _apply_handler("Documentation (vOLD)", text) == (
         "docker buildx build -t your-registry/my-agent:v3.3.1 --push .\n"
-        "MCP Mesh v3.4.0 adds a media pipeline\n"  # prose still updates
+        "Install MCP Mesh v3.4.0 to get started\n"  # undated prose still moves
         "see https://example.com/v3.3.1 for details\n"  # URL still skipped
     )
+
+
+def test_docs_v_prefix_handler_leaves_provenance_prose_alone():
+    """#1405. A sentence that DATES a behaviour states when it shipped — a
+    historical fact, not a coordinate. Bumping it is always wrong, and it
+    ratchets: four such sentences walked forward on every release for eight
+    releases, one of them since v1.0.0, until they claimed a v2.2.4 behaviour
+    had landed in whatever release was being cut."""
+    text = (
+        "Since v3.3.1, tool dispatch runs on a single-user loop.\n"
+        "Because v3.3.1 runs your lifespan on the user loop, this works.\n"
+        "### Matching semantics (as of v3.3.1)\n"
+        "Prior to v3.3.1, all entries used prefix matching.\n"
+        "The channel shipped in v3.3.1 and has not changed.\n"
+        "MCP Mesh v3.3.1 adds a media pipeline.\n"
+        "This was introduced in v3.3.1 and refined later.\n"
+        "Available since v3.3.1 on every runtime.\n"
+        "Starting with v3.3.1, the default flipped.\n"
+    )
+    assert _apply_handler("Documentation (vOLD)", text) == text
+
+
+def test_provenance_lead_in_tolerates_the_spellings_our_docs_use():
+    """The lead-in list is only useful if it matches how the docs are actually
+    written. `Since MCP Mesh vX` is the spelling docs/concepts/architecture.md
+    uses, and that file carried the longest-running corruption of the four —
+    a bare `\\s+v?\\d` lead-in would have kept right on ratcheting it.
+
+    The `<verb> in` entries mirror the trailing verb list: the two forms are
+    the same claim with the version on the other side of the verb, so a verb
+    covered in one direction and not the other is an arbitrary hole."""
+    text = (
+        # Filler between the lead-in and the version.
+        "Since MCP Mesh v3.3.1, tools share one loop.\n"
+        "Since mcp-mesh v3.3.1, tools share one loop.\n"
+        "As of the v3.3.1 release, this is the default.\n"
+        "Since the v3.3.1 release, this is the default.\n"
+        # Lead-in verbs mirrored from the trailing list.
+        "The flag was removed in v3.3.1 and has no replacement.\n"
+        "The flag was deprecated in v3.3.1.\n"
+        "The default was changed in v3.3.1.\n"
+        "The leak was fixed in v3.3.1.\n"
+        "The feature was released in v3.3.1.\n"
+        "The env var was renamed in v3.3.1.\n"
+        # Availability window.
+        "Supported in v3.3.1 and later on every runtime.\n"
+        "Supported in v3.3.1 or newer on every runtime.\n"
+        "Available from v3.3.1 onwards.\n"
+        # Hyphenated relative form (docs/environment-variables.md:421).
+        "# revert to pre-v3.3.1 immediate cancel-forward\n"
+        "This is post-v3.3.1 behaviour.\n"
+    )
+    assert _apply_handler("Documentation (vOLD)", text) == text
+
+
+def test_provenance_covers_parenthesised_version_labels():
+    """A version in parentheses labels WHICH release a heading, example or
+    column applies to — provenance in heading form.
+
+    The bare parenthetical is the genuinely exposed shape: `)` and `,` are
+    both in the handler's trailing character class. It is live today at
+    src/core/cli/man/content/headers.md:51 and :62, safe only because those
+    versions are historical. (An earlier `vX+` plus-suffix pattern could never
+    fire at all — `+` falls outside that class, so `(v3.3.1+)` never produced
+    a match to suppress.)"""
+    text = (
+        "### Migration note (v3.3.1 → v3.4.9)\n"
+        "# Before (v3.3.1):                    After (v3.4.9, pick one):\n"
+        "## Loop topology (v3.3.1+)\n"
+        "**Tag-Level OR** (v3.3.1+):\n"
+        "### Matching semantics (v3.3.1)\n"
+    )
+    assert _apply_handler("Documentation (vOLD)", text) == text
+    # The arrow's right-hand side has no preceding paren of its own, so the
+    # arrow rule is what protects it — check it in isolation.
+    assert (
+        _apply_handler("Documentation (vOLD)", "upgrade path v2.2.4 -> v3.3.1\n")
+        == "upgrade path v2.2.4 -> v3.3.1\n"
+    )
+
+
+def test_docs_v_prefix_handler_still_bumps_the_release_coordinate():
+    """The inverse risk, and the reason the exclusion tests overlap with the
+    matched version rather than the whole line: an over-broad rule would
+    silently freeze a genuine coordinate, and the docs landing page's
+    `**Latest Release**` line is exactly that — it names the CURRENT release
+    and must track every bump."""
+    assert _apply_handler(
+        "Documentation (vOLD)", "- **Latest Release**: v3.3.1\n"
+    ) == "- **Latest Release**: v3.4.0\n"
+    # Mixed line: the dated claim is pinned, the coordinate beside it is not.
+    assert _apply_handler(
+        "Documentation (vOLD)",
+        "Since v2.2.4 this is the default; upgrade to v3.3.1 to get it.\n",
+    ) == "Since v2.2.4 this is the default; upgrade to v3.4.0 to get it.\n"
+    # A dated claim naming the version being bumped is still pinned, even
+    # though the two versions are then identical.
+    assert _apply_handler(
+        "Documentation (vOLD)",
+        "Since v3.3.1 this is the default; upgrade to v3.3.1 to get it.\n",
+    ) == "Since v3.3.1 this is the default; upgrade to v3.4.0 to get it.\n"
+
+
+def test_provenance_exclusion_is_wired_to_the_prose_handler():
+    """The exclusion only works if it is actually attached. `Documentation
+    (vOLD)` is the sole handler that rewrites a bare version in running prose,
+    so it is the sole handler that can corrupt a dated claim — if a refactor
+    drops `line_excludes` from it, the ratchet silently resumes."""
+    handler = {h.name: h for h in bv.HANDLERS}["Documentation (vOLD)"]
+    assert handler.line_excludes is bv.PROVENANCE_PROSE
+    assert "docs/**/*.md" in handler.globs
+    assert "src/core/cli/man/content/**/*.md" in handler.globs
+
+
+def test_no_exemption_covers_bare_prose_versions():
+    """#1395 exempted `\\bvNEW\\b` in docs/concepts/stateful-agents.md, which
+    told the guard to stop reporting a rewrite that was itself wrong. An
+    exemption is only ever right when the rewrite is CORRECT but unprovable;
+    reaching for one to quiet a genuine mis-rewrite is what let #1405 run for
+    eight releases."""
+    for e in bv.OVERMATCH_ALLOWLIST:
+        anchor = _literal_anchor(e.pattern)
+        assert anchor not in ("v", ""), (
+            f"{e.glob}: pattern {e.pattern!r} exempts any bare prose version. "
+            "If a bare vX is being rewritten wrongly, fix the matcher "
+            "(PROVENANCE_PROSE), not the guard."
+        )
 
 
 def test_scaffold_dockerfile_handler_matches_old_only():


### PR DESCRIPTION
## Summary

`bump_version.py` rewrites **dated provenance claims** in docs — sentences of the form *"Since vX, <behaviour>"* that record when a behaviour shipped. Bumping them is always wrong: the version is a historical fact, not a coordinate tracking the current release.

Four sentences have been ratcheted forward on every release for months. Found during 3.3.2 release prep, which is paused on this.

## Corrections

| file | claimed | actual |
|---|---|---|
| `docs/concepts/stateful-agents.md` (x2) | v3.3.1 | **v2.2.4** |
| `docs/python/dependency-injection.md:300` | v3.3.1 | **v2.2.4** |
| `docs/concepts/architecture.md:219` | v3.3.1 | **v1.0.0** |

The loop-topology change landed in `bcf698d8a`, tagged as "v2.2.1" — but v2.2.1/2.2.2/2.2.3 were aborted npm-publish attempts with no GitHub release and no `RELEASE_NOTES.md` entry. The notes document the whole fix under `## v2.2.4`, and the section headings *directly above* two of these sentences already read `## Loop topology (v2.2.4+)`, as do three sibling surfaces (`docs/environment-variables.md:72`, `man/content/environment.md:95`, `man/content/dependency-injection.md:47`).

Worth recording how the drift compounded: the sentences were written as `v2.2.1`, ratcheted to `v2.2.4` by the 2.2.2/2.2.3/2.2.4 bumps, and then `828c04f77` "corrected" the *headings* from `v2.2.1+` up to `v2.2.4+` — trusting the ratcheted prose. The ratchet fed a false version into hand-maintained text and reached the right answer by accident.

`architecture.md` was not in #1405. It was written as `v1.0.0` and has ratcheted longest of the four.

## Why neither guard caught this

The `architecture.md` line is the clearest case: it contains the literal string "MCP Mesh", so the over-match guard's ownership test clears it. **Ownership is not the question a dated claim raises** — the line genuinely is ours; the bump just makes it say something false.

`stateful-agents.md` was worse. The guard *did* flag it, and #1395 added an exemption to silence it:

```python
Exemption(glob="docs/concepts/stateful-agents.md", pattern=r"\bvNEW\b",
          reason="narrative prose ('Since vX, ...') dating a runtime behavior change. ...")
```

The reason text describes the sentence accurately as *"dating a runtime behavior change"* — precisely the signal it must not be bumped. A correct alarm was read as a false positive. An exemption only quiets the guard; the handler keeps corrupting the file.

## The fix

`PROVENANCE_PROSE` is attached as `line_excludes` on the `Documentation (vOLD)` handler — **in the matcher, not the guard**. The `stateful-agents.md` exemption is removed.

The veto tests **character overlap** with the matched version rather than line membership, which preserves the inverse case: *"Since v2.2.4 this is the default; upgrade to v3.3.1 to get it"* pins the claim and still bumps the coordinate. `**Latest Release**: vX` carries no dating phrase and is unaffected.

One pattern added beyond the issue's list: `(vX+)` availability markers, of which four exist. They are safe today only because `+` falls outside the handler's trailing character class — drop the `+` while editing a heading and the ratchet restarts. `vX or later` was deliberately **not** added; the only repo hits are Python language versions, where it is plausibly a real minimum-version coordinate.

**Stale date dropped.** `docs/index.md` has read `(March 2026)` since at least v3.0.0, through every release into July. Bump-managing it would make the script's output depend on the wall clock and untestable; `RELEASE_NOTES.md` and the releases page already date every release. `**Latest Release**: vX` now stands alone.

## Validation

Real `3.3.1 -> 3.3.2` bump in a throwaway worktree:

```
Summary: 467 files updated across 37 categories
✅ Over-match guard: all 645 changed lines are provably mcp-mesh-owned.
✅ Coverage guard: no stale mesh-shaped references to 3.3.1 remain.
```

Against a control run on pre-fix `f3eccf583` (470 files / 649 lines) the delta is exactly **−3 files / −4 lines**, and a set-diff of the changed-file lists shows only the three prose files stopped bumping, with **nothing newly bumping**. `**Latest Release**` still went to `v3.3.2`.

Since the sentences now name v2.2.4, a 3.3.1 bump would leave them alone trivially — so a `2.2.4 -> 9.9.9` sentinel was run to prove the exclusion is load-bearing rather than inert. Fixed tree: `git diff --stat` on `docs/` and man content is **empty**. The same sentinel on the baseline matcher corrupts all three v2.2.4 sentences to `v9.9.9`.

Tests: **27 checks passed** (`python3` and `pytest`). This required fixing an existing test that *encoded the bug* — `test_docs_v_prefix_handler_skips_docker_tags` asserted `MCP Mesh v3.3.1 adds a media pipeline` → `v3.4.0`, commented `# prose still updates`.

## Exemption audit

All 8 remaining entries are the opposite character — the rewrite is **correct but unprovable**, not wrong-and-silenced: two `workflow_dispatch` inputs (bare YAML scalars), `docs/index.md`'s Latest Release (no mesh token within ±3), two Python `__version__` constants (import package is `mesh`, not `mcp-mesh`), three tsuite package-version blocks (keys name artifacts by role). The distinction is encoded as `test_no_exemption_covers_bare_prose_versions`.

## Flagged, not fixed (different class)

`bump_test_documentation` does a blind `content.replace(old, new)` over three test READMEs — an unanchored global string replace, the loosest operation in the script. Harmless today (no provenance prose in those files), but it is the one remaining place where any `3.3.1`-shaped string is rewritten with no pattern at all.

Closes #1405
