### PR TITLE
fix(helm): add Deployment strategy passthrough to agent, grafana, tempo, redis

### DIFF
--- a/helm/mcp-mesh-agent/README.md
+++ b/helm/mcp-mesh-agent/README.md
@@ -102,6 +102,7 @@ helm uninstall my-agent -n mcp-mesh
 | Parameter                   | Description                            | Default                    |
 | --------------------------- | -------------------------------------- | -------------------------- |
 | `replicaCount`              | Number of replicas                     | `1`                        |
+| `strategy`                  | Deployment update strategy (unset = Kubernetes default `RollingUpdate`; set `{type: Recreate}` for ReadWriteOnce `persistence`) | `{}` |
 | `image.repository`          | Container image repository             | `"mcpmesh/python-runtime"` |
 | `image.pullPolicy`          | Image pull policy                      | `IfNotPresent`             |
 | `image.tag`                 | Image tag (overrides chart appVersion) | `"0.9"`                    |
@@ -109,6 +110,12 @@ helm uninstall my-agent -n mcp-mesh
 | `resources.limits.memory`   | Memory limit                           | `1Gi`                      |
 | `resources.requests.cpu`    | CPU request                            | `100m`                     |
 | `resources.requests.memory` | Memory request                         | `256Mi`                    |
+
+> **`strategy` and ReadWriteOnce volumes:** with the default `RollingUpdate`, Kubernetes starts the incoming pod before the outgoing one is gone. If the scheduler places it on another node it cannot mount a ReadWriteOnce claim the outgoing pod still holds, and the rollout deadlocks until someone deletes the old pod. Both pods landing on one node is why single-node dev clusters (kind, minikube, Docker Desktop) never see this. Set `strategy: {type: Recreate}` whenever `persistence.enabled` is true with the default `accessMode: ReadWriteOnce`.
+>
+> `Recreate` costs a gap in service while the old pod terminates, and when `autoscaling.enabled` is true that gap covers every replica at once, since `Recreate` tears the whole set down before scheduling any replacement. Note that `persistence` creates a **single** claim for the whole release, so ReadWriteOnce is not compatible with more than one replica under either strategy: with `replicaCount > 1` or an active HPA, every replica scheduled off the claim's node stays `Pending`. `Recreate` does not fix that combination — use ReadWriteMany, or keep the agent at one replica.
+>
+> Set it at install time if you can. Switching an **already-installed** release from `RollingUpdate` to `Recreate` is rejected by the API server — it defaulted `.spec.strategy.rollingUpdate` on the live object, and `rollingUpdate` "may not be specified when strategy `type` is 'Recreate'". Under **Helm 4** the default server-side apply does not clear it and `--force-conflicts` does not help, so run that one switch with `helm upgrade --server-side=false`; **Helm 3** patches client-side and needs no flag. Deleting the Deployment and letting Helm recreate it also works.
 
 > **Upgrade note:** `podSecurityContext` (runAsNonRoot, uid/gid 999, fsGroup 999, RuntimeDefault seccomp) is now always applied — it was previously gated behind the removed `podSecurityPolicy.enabled` flag and never rendered. It covers user-supplied `initContainers` (an init container that must run as root needs its own `securityContext`, which overrides the pod level), and `fsGroup: 999` changes group ownership of mounted volumes, including PVCs from `extraVolumes`.
 

--- a/helm/mcp-mesh-agent/templates/deployment.yaml
+++ b/helm/mcp-mesh-agent/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mcp-mesh-agent.selectorLabels" . | nindent 6 }}

--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -134,6 +134,35 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
 
+# Deployment update strategy. Empty leaves the field unset, so Kubernetes
+# applies its own default (RollingUpdate) — right for the stateless default.
+# Set Recreate when the agent mounts a ReadWriteOnce volume (see persistence
+# below, whose accessMode defaults to ReadWriteOnce). RollingUpdate starts the
+# incoming pod before the outgoing one is gone; if the scheduler places it on
+# another node it cannot mount a ReadWriteOnce claim the outgoing pod still
+# holds, and the rollout deadlocks until someone deletes the old pod. Both
+# pods landing on one node is why single-node dev clusters never see this.
+#
+# Recreate trades that for a gap in service while the old pod terminates, and
+# with autoscaling.enabled the gap covers every replica at once, because
+# Recreate tears the whole set down before scheduling any replacement. Note
+# that persistence creates a single claim for the whole release, so
+# ReadWriteOnce is not compatible with more than one replica under either
+# strategy: with replicaCount > 1 or an active HPA, every replica scheduled
+# off the claim's node stays Pending. Recreate does not fix that combination —
+# use ReadWriteMany, or keep the agent at one replica.
+#
+# Set it at install time if you can. Switching an already-installed release
+# from RollingUpdate to Recreate is rejected by the API server, which
+# defaulted .spec.strategy.rollingUpdate on the live object: rollingUpdate
+# "may not be specified when strategy `type` is 'Recreate'". Under Helm 4 the
+# default server-side apply does not clear it and --force-conflicts does not
+# help, so run that one switch with `helm upgrade --server-side=false`; Helm 3
+# patches client-side and needs no flag. Deleting the Deployment and letting
+# Helm recreate it also works.
+strategy: {}
+  # type: Recreate
+
 nodeSelector: {}
 
 tolerations: []

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -247,6 +247,15 @@ mcp-mesh-grafana:
       enabled: true
       size: 2Gi
 
+    # This claim is ReadWriteOnce and Grafana runs a single replica, so on a
+    # multi-node cluster you want the Deployment replaced rather than rolled —
+    # otherwise the incoming pod can land on another node and hang waiting for
+    # a claim the outgoing pod still holds. Set it at install time; see
+    # mcp-mesh-grafana/values.yaml for the migration path on an existing
+    # release. Full path: mcp-mesh-grafana.grafana.strategy
+    # strategy:
+    #   type: Recreate
+
     resources:
       requests:
         memory: "128Mi"
@@ -269,6 +278,15 @@ mcp-mesh-tempo:
     persistence:
       enabled: true
       size: 5Gi
+
+    # This claim is ReadWriteOnce and Tempo runs a single replica, so on a
+    # multi-node cluster you want the Deployment replaced rather than rolled —
+    # otherwise the incoming pod can land on another node and hang waiting for
+    # a claim the outgoing pod still holds. Set it at install time; see
+    # mcp-mesh-tempo/values.yaml for the migration path on an existing release.
+    # Full path: mcp-mesh-tempo.tempo.strategy
+    # strategy:
+    #   type: Recreate
 
     resources:
       requests:

--- a/helm/mcp-mesh-grafana/templates/deployment.yaml
+++ b/helm/mcp-mesh-grafana/templates/deployment.yaml
@@ -17,6 +17,10 @@ metadata:
     {{- include "mcp-mesh-grafana.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  {{- with .Values.grafana.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mcp-mesh-grafana.selectorLabels" . | nindent 6 }}

--- a/helm/mcp-mesh-grafana/values.yaml
+++ b/helm/mcp-mesh-grafana/values.yaml
@@ -31,6 +31,31 @@ grafana:
     accessModes:
       - ReadWriteOnce
 
+  # Deployment update strategy. Empty leaves the field unset, so Kubernetes
+  # applies its own default (RollingUpdate).
+  #
+  # On a multi-node cluster you almost certainly want Recreate here, because
+  # this chart runs a single replica against the ReadWriteOnce volume above.
+  # RollingUpdate starts the incoming pod before the outgoing one is gone; if
+  # the scheduler places it on another node it cannot mount a ReadWriteOnce
+  # claim the outgoing pod still holds, and the rollout deadlocks until someone
+  # deletes the old pod. Both pods landing on one node is why single-node dev
+  # clusters never see this — and in that case it is still wrong, because two
+  # Grafana processes would write the same SQLite database. With replicas fixed
+  # at 1 there is no availability to preserve either way, so Recreate costs
+  # only a gap in dashboards while the old pod terminates.
+  #
+  # It is not the default because switching an already-installed release from
+  # RollingUpdate to Recreate is rejected by the API server, which defaulted
+  # .spec.strategy.rollingUpdate on the live object: rollingUpdate "may not be
+  # specified when strategy `type` is 'Recreate'". Under Helm 4 the default
+  # server-side apply does not clear it and --force-conflicts does not help, so
+  # run that one switch with `helm upgrade --server-side=false`; Helm 3 patches
+  # client-side and needs no flag. Deleting the Deployment and letting Helm
+  # recreate it also works. Setting it at install time avoids all of this.
+  strategy: {}
+    # type: Recreate
+
   service:
     type: ClusterIP
     port: 3000

--- a/helm/mcp-mesh-redis/templates/deployment.yaml
+++ b/helm/mcp-mesh-redis/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     {{- include "mcp-mesh-redis.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mcp-mesh-redis.selectorLabels" . | nindent 6 }}

--- a/helm/mcp-mesh-redis/values.yaml
+++ b/helm/mcp-mesh-redis/values.yaml
@@ -38,6 +38,29 @@ persistence:
   size: 8Gi
   annotations: {}
 
+# Deployment update strategy. Empty leaves the field unset, so Kubernetes
+# applies its own default (RollingUpdate), which is right for this chart: the
+# redis-data mount is an emptyDir cache, so a pod swap contends over nothing
+# and there is no reason to change this.
+#
+# The key is a passthrough for the case where you have pointed this Deployment
+# at a ReadWriteOnce volume yourself — set Recreate there. RollingUpdate starts
+# the incoming pod before the outgoing one is gone; if the scheduler places it
+# on another node it cannot mount a ReadWriteOnce claim the outgoing pod still
+# holds, and the rollout deadlocks until someone deletes the old pod. Both pods
+# landing on one node is why single-node dev clusters never see this.
+#
+# Set it at install time if you can. Switching an already-installed release
+# from RollingUpdate to Recreate is rejected by the API server, which
+# defaulted .spec.strategy.rollingUpdate on the live object: rollingUpdate
+# "may not be specified when strategy `type` is 'Recreate'". Under Helm 4 the
+# default server-side apply does not clear it and --force-conflicts does not
+# help, so run that one switch with `helm upgrade --server-side=false`; Helm 3
+# patches client-side and needs no flag. Deleting the Deployment and letting
+# Helm recreate it also works.
+strategy: {}
+  # type: Recreate
+
 # Resource limits
 resources:
   limits:

--- a/helm/mcp-mesh-tempo/templates/deployment.yaml
+++ b/helm/mcp-mesh-tempo/templates/deployment.yaml
@@ -17,6 +17,10 @@ metadata:
     {{- include "mcp-mesh-tempo.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  {{- with .Values.tempo.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "mcp-mesh-tempo.selectorLabels" . | nindent 6 }}

--- a/helm/mcp-mesh-tempo/values.yaml
+++ b/helm/mcp-mesh-tempo/values.yaml
@@ -31,6 +31,32 @@ tempo:
     accessModes:
       - ReadWriteOnce
 
+  # Deployment update strategy. Empty leaves the field unset, so Kubernetes
+  # applies its own default (RollingUpdate).
+  #
+  # On a multi-node cluster you almost certainly want Recreate here, because
+  # this chart runs a single replica against the ReadWriteOnce volume above.
+  # RollingUpdate starts the incoming pod before the outgoing one is gone; if
+  # the scheduler places it on another node it cannot mount a ReadWriteOnce
+  # claim the outgoing pod still holds, and the rollout deadlocks until someone
+  # deletes the old pod. Both pods landing on one node is why single-node dev
+  # clusters never see this — and in that case it is still wrong, because two
+  # single-binary Tempo processes would write the same WAL and blocks
+  # directory. With replicas fixed at 1 there is no availability to preserve
+  # either way, so Recreate costs only a gap in trace ingestion while the old
+  # pod terminates.
+  #
+  # It is not the default because switching an already-installed release from
+  # RollingUpdate to Recreate is rejected by the API server, which defaulted
+  # .spec.strategy.rollingUpdate on the live object: rollingUpdate "may not be
+  # specified when strategy `type` is 'Recreate'". Under Helm 4 the default
+  # server-side apply does not clear it and --force-conflicts does not help, so
+  # run that one switch with `helm upgrade --server-side=false`; Helm 3 patches
+  # client-side and needs no flag. Deleting the Deployment and letting Helm
+  # recreate it also works. Setting it at install time avoids all of this.
+  strategy: {}
+    # type: Recreate
+
   service:
     type: ClusterIP
     ports:


### PR DESCRIPTION
## Summary

Adds a `with`-gated Deployment `strategy` passthrough so an agent (or bundled component) mounting a `ReadWriteOnce` volume can select `Recreate`. With the default `RollingUpdate`, the incoming pod cannot mount a claim the outgoing pod still holds, so the rollout never completes and the old pod is never terminated — neither side can progress.

Purely additive: 106 insertions, 0 deletions, all defaults `{}`.

## Wider than the issue as filed

#1381 reports this on `mcp-mesh-agent`, where `persistence` is **opt-in**. Two bundled charts have the same defect with persistence **enabled by default**, and both are in the standard `mcp-mesh-core` install path:

| chart | strategy | RWO PVC | replicas |
|---|---|---|---|
| `mcp-mesh-agent` | none | opt-in (`values.yaml:313`) | `replicaCount` |
| `mcp-mesh-grafana` | none | **default-on** (`values.yaml:27-32`) | `1`, hardcoded |
| `mcp-mesh-tempo` | none | **default-on** (`values.yaml:31-32`) | `1`, hardcoded |
| `mcp-mesh-redis` | none | latent (`emptyDir` unless opted in) | — |

So a default core install already ships two workloads that deadlock on any pod-template change. All four get the key.

`mcp-mesh-registry` (hardcoded strategy, stateless) and `mcp-mesh-postgres` (StatefulSet — ordered replacement makes RWO safe) are deliberately untouched.

## Why `Recreate` is NOT the default for grafana/tempo

This was implemented as a default first, on the reasoning that `RollingUpdate` + `replicas: 1` + an RWO PVC can never complete, so the shipped default is already broken. Probing the transition against a real 3-node k3s cluster (v1.34.3) reversed it.

Helm's 3-way merge cannot clear the API-server-defaulted `rollingUpdate` block:

```
Error: UPGRADE FAILED: Deployment.apps "probe" is invalid:
spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
```

| path | result |
|---|---|
| `helm upgrade`, Helm 4 default (server-side apply) | **fails** |
| `helm upgrade --force-conflicts` | **fails** — SSA still won't clear the field |
| `helm upgrade --force` | rejected: cannot combine SSA with force replace |
| `helm upgrade --server-side=false` (Helm 3 patch path) | succeeds → `{"type":"Recreate"}` |
| `kubectl apply` (client-side, `retainKeys`) | succeeds |
| rendering `rollingUpdate: null` | no effect — `toYaml` drops null keys |

It fails whether or not the prior manifest carried an explicit `strategy`, so this is not a one-time artifact of this change.

That inverts the trade. Defaulting `Recreate` would turn a **conditional** deadlock (multi-node, and only on a pod-template change) into an **unconditional** failure of the entire `mcp-mesh-core` upgrade for every Helm 4 consumer — including those running grafana/tempo with persistence disabled, who have no exposure at all. The `--server-side=false` migration path is documented in the values comments instead.

Secondary finding: a strategy-only change does **not** roll pods — `.spec.template` is unchanged, and the ReplicaSet count stayed at 1 across the attempted upgrade. The cost of defaulting it was never a rollout; it was the API rejection.

## Validation

- **`helm lint`** — all four charts plus `mcp-mesh-core`, 0 failed.
- **Default renders byte-identical to `dcbcdbd3e`** for all four charts *and* the umbrella.
  Baseline taken from a throwaway `git worktree` with its own `helm dependency update` — necessary because `helm/*/charts/*.tgz` is gitignored, so `git stash` does not revert it. A first attempt contaminated by stale `.tgz` files made a real delta look empty. Grafana's `admin-password` and postgres's `password` churn on every render independently of this change (confirmed by two consecutive renders of unmodified `HEAD`), so both were pinned via `--set` for a clean diff.
- **Overrides render at the correct indent** in all four charts, including nested `rollingUpdate: {maxSurge, maxUnavailable}` maps.
- **Umbrella flow-through** verified through the umbrella's own values file (`mcp-mesh-grafana.grafana.strategy`, `mcp-mesh-tempo.tempo.strategy`, `mcp-mesh-redis.strategy`), not just `--set` on subcharts.
- **`python3 scripts/check_helm_pss.py`** — all 9 charts OK.
- Rendered manifests additionally passed `kubectl apply --dry-run=server` against a live cluster with `Recreate` set.

## Known gap, not closed here

The grafana/tempo **defaults are still wrong out of the box** on multi-node clusters — this PR supplies the escape hatch, not the fix. The clean resolution is likely converting both to StatefulSets, as `mcp-mesh-postgres` already is, since ordered replacement makes RWO safe without the strategy-transition trap. That is a resource-kind change with a PVC ownership migration, so it needs its own issue and upgrade note. Filed separately.

Closes #1381


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Kubernetes Deployment update strategies for the agent, Grafana, Redis, and Tempo components.
  * Supports choosing `RollingUpdate` or `Recreate`, including guidance for persistent volumes using `ReadWriteOnce` storage.
  * Preserves existing default rollout behavior when no strategy is specified.

* **Documentation**
  * Added configuration guidance and rollout considerations to the Helm chart values and README files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->