### PR TITLE
docs(helm): rewrite every core install recipe to a form that works

### DIFF
--- a/docs/00-why-mcp-mesh/index.md
+++ b/docs/00-why-mcp-mesh/index.md
@@ -121,7 +121,8 @@ meshctl scaffold --compose --observability
 
 # Or deploy to Kubernetes (OCI registry)
 helm install my-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.3.2 -n mcp-mesh --create-namespace
+  --version 3.3.2 -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false
 ```
 
 ### 5. Built-in Observability

--- a/docs/04-kubernetes-basics.md
+++ b/docs/04-kubernetes-basics.md
@@ -16,18 +16,21 @@
 The `mcp-mesh-core` chart deploys registry + PostgreSQL + Redis + Grafana + Tempo:
 
 ```bash
-# Create namespace
-kubectl create namespace mcp-mesh
-
 # Deploy core (OCI registry - no "helm repo add" needed)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
-  --namespace mcp-mesh
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false
 
 # Wait for registry
 kubectl wait --for=condition=available deployment/mcp-core-mcp-mesh-registry \
   -n mcp-mesh --timeout=120s
 ```
+
+`--create-namespace` creates the namespace; `--set namespaceCreate=false` stops
+the chart from also rendering one, which would collide with it. Both are
+required — see [Namespace handling](https://github.com/dhyansraj/mcp-mesh/blob/main/helm/mcp-mesh-core/README.md#namespace-handling)
+for why, and for what applies to a release that already exists.
 
 ### 2. Build Your Agent Image
 
@@ -139,7 +142,8 @@ resources:
 # Core without Grafana/Tempo (lighter footprint)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
-  --namespace mcp-mesh \
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 ```
@@ -155,15 +159,15 @@ helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
 
 ### Custom Namespace
 
-By default, examples use `mcp-mesh` as the namespace. You can deploy into any namespace —
-just match `-n` with `--set global.namespace`:
+By default, examples use `mcp-mesh` as the namespace. You can deploy into any
+namespace — change `-n` and nothing else:
 
 ```bash
 # Deploy core to a custom namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
   -n my-namespace --create-namespace \
-  --set global.namespace=my-namespace
+  --set namespaceCreate=false
 
 # Deploy agent to the same namespace
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
@@ -175,24 +179,18 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 Service hostnames use short names (e.g., `mcp-core-mcp-mesh-registry`) that resolve
 within the same namespace automatically. No FQDN changes needed.
 
-Matching the two matters: `-n` is where every component is deployed, while
-`global.namespace` names the `Namespace` object the core chart renders
-(`namespaceCreate`, default `true`). Leave them mismatched and you get a stray,
-empty `mcp-mesh` namespace alongside the one you deployed into — and multiple
-core releases will contend for that one shared object.
-
 For **multi-tenant** clusters (separate core per team), deploy each core to its own namespace:
 
 ```bash
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
-  -n team-a --create-namespace --set global.namespace=team-a
+  -n team-a --create-namespace --set namespaceCreate=false
 
 # Team B — same values, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
-  -n team-b --create-namespace --set global.namespace=team-b
+  -n team-b --create-namespace --set namespaceCreate=false
 ```
 
 For **cross-namespace** access (agent in one namespace, core in another), use FQDNs:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -17,7 +17,10 @@ Opens the dashboard at [http://localhost:3080](http://localhost:3080).
 The published `mcpmesh/ui` image serves at `/ops/dashboard` by default. Enable it in your Helm values:
 
 ```bash
-helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core --set ui.enabled=true
+helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false \
+  --set ui.enabled=true
 ```
 
 See `meshctl man deployment` for ingress routing and custom basePath configuration.

--- a/docs/dev-to-production.md
+++ b/docs/dev-to-production.md
@@ -85,7 +85,8 @@ The [TSuite](https://github.com/dhyansraj/mcp-mesh-test-suite) integration testi
 
     ```bash
     helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-      --version 3.3.2 -n mcp-mesh --create-namespace
+      --version 3.3.2 -n mcp-mesh --create-namespace \
+      --set namespaceCreate=false
 
     helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
       --version 3.3.2 -n mcp-mesh -f helm-values.yaml

--- a/docs/index.md
+++ b/docs/index.md
@@ -394,7 +394,8 @@ A `kubectl`-style command-line tool that follows you from first agent to product
 === "Helm Charts"
 
     ```bash
-    helm install mcp-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core
+    helm install mcp-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+      -n mcp-mesh --create-namespace --set namespaceCreate=false
     ```
 
     Kubernetes deployment with the umbrella chart.

--- a/docs/python/getting-started/prerequisites.md
+++ b/docs/python/getting-started/prerequisites.md
@@ -146,7 +146,8 @@ Available from OCI registry (no `helm repo add` needed):
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
-  -n mcp-mesh --create-namespace
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \

--- a/docs/tutorial/day-09-kubernetes.md
+++ b/docs/tutorial/day-09-kubernetes.md
@@ -218,6 +218,10 @@ $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
     --wait --timeout 5m
 ```
 
+`values-core.yaml` sets `namespaceCreate: false`, which is what lets the chart
+install into the namespace `kubectl` created in Part 2. Without it the install
+fails with `invalid ownership metadata`.
+
 Wait for the registry to become available:
 
 ```shell

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -168,13 +168,22 @@ helm get values <release>
   `commonAnnotations` value would override it on last-wins, so the chart fails
   the render when the key is set to anything but `keep` — remove it from
   `commonAnnotations`, or set it to `keep`, before upgrading.
-- **Do not set `namespaceCreate=false` on an existing release.** The namespace
-  is already in the release manifest, so dropping it from the rendered output
-  makes the very next `helm upgrade` delete the namespace and everything in it
-  — reporting `STATUS: deployed` and exit 0 while doing so. When
-  `global.namespace` matches the namespace passed to `-n`, the change is also
-  unrecoverable: Helm keeps the release secret in the `-n` namespace, which is
-  the one being deleted, so `helm history` afterward reports `release: not
-  found`. If the two differ, the release metadata survives — but the rendered
-  namespace is deleted either way. Leave `namespaceCreate` alone on releases
-  that already have it enabled.
+- **Do not set `namespaceCreate=false` on an existing release as part of this
+  upgrade.** New installs should set it (the chart cannot create the namespace
+  it installs into — see
+  [Namespace handling](https://github.com/dhyansraj/mcp-mesh/blob/main/helm/mcp-mesh-core/README.md#namespace-handling)),
+  but on a release that already has it enabled the namespace is already in the
+  release manifest, so dropping it from the rendered output makes the very next
+  `helm upgrade` delete the namespace and everything in it — reporting
+  `STATUS: deployed` and exit 0 while doing so. When `global.namespace` matches
+  the namespace passed to `-n`, the change is also unrecoverable: Helm keeps
+  the release secret in the `-n` namespace, which is the one being deleted. A
+  retry while the namespace drains fails with `... is forbidden: ... because it
+  is being terminated`, and once it is gone `helm history` reports
+  `release: not found`.
+  The `keep` annotation above is what makes the flip safe, and Helm reads that
+  policy off the manifest of the revision being replaced — so if you want it,
+  do it as a *second*, separate upgrade, once this one has landed and
+  `kubectl get ns <ns> -o jsonpath='{.metadata.annotations}'` shows
+  `helm.sh/resource-policy: keep`. There is no need to rush it: with the
+  annotation in place, leaving `namespaceCreate` enabled is harmless.

--- a/examples/k8s/tls/README.md
+++ b/examples/k8s/tls/README.md
@@ -51,6 +51,7 @@ kubectl get secret mcp-mesh-ca-secret -n mcp-mesh --show-labels
 
 # Install MCP Mesh core with TLS enabled
 helm install mcp-core helm/mcp-mesh-core -n mcp-mesh \
+  --set namespaceCreate=false \
   -f helm-values-tls.yaml
 
 # Install an agent with TLS
@@ -131,6 +132,7 @@ kubectl label secret mcp-mesh-ca-secret -n mcp-mesh \
 
 # Install with TLS values
 helm install mcp-core helm/mcp-mesh-core -n mcp-mesh \
+  --set namespaceCreate=false \
   -f helm-values-tls.yaml
 
 helm install my-agent helm/mcp-mesh-agent -n mcp-mesh \

--- a/examples/k8s/tls/helm-values-tls.yaml
+++ b/examples/k8s/tls/helm-values-tls.yaml
@@ -8,8 +8,12 @@
 # and mcp-mesh-agent charts. Each chart ignores keys it does not recognize,
 # so it is safe to pass the same file to both:
 #
-#   helm install mcp-core helm/mcp-mesh-core  -n mcp-mesh -f helm-values-tls.yaml
+#   helm install mcp-core helm/mcp-mesh-core  -n mcp-mesh \
+#     --set namespaceCreate=false -f helm-values-tls.yaml
 #   helm install my-agent helm/mcp-mesh-agent -n mcp-mesh -f helm-values-tls.yaml
+#
+# The core install needs --set namespaceCreate=false because the namespace was
+# created out of band above; see "Namespace handling" in the core chart README.
 #
 # Secret mapping (cert-manager Certificate -> K8s Secret -> Helm value):
 #

--- a/examples/tutorial/trip-planner/day-09/helm/values-core.yaml
+++ b/examples/tutorial/trip-planner/day-09/helm/values-core.yaml
@@ -4,10 +4,11 @@
 #
 # Usage:
 #   helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-#     --version 1.2.0 -n trip-planner -f values-core.yaml
+#     --version 1.2.0 -n trip-planner --create-namespace -f values-core.yaml
 
-global:
-  namespace: trip-planner
+# install.sh creates the namespace with kubectl, so the chart must not render
+# one of its own — see "Namespace handling" in the mcp-mesh-core chart README.
+namespaceCreate: false
 
 # All components enabled
 postgres:

--- a/examples/tutorial/trip-planner/day-10/helm/values-core.yaml
+++ b/examples/tutorial/trip-planner/day-10/helm/values-core.yaml
@@ -4,10 +4,11 @@
 #
 # Usage:
 #   helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-#     --version 1.2.0 -n trip-planner -f values-core.yaml
+#     --version 1.2.0 -n trip-planner --create-namespace -f values-core.yaml
 
-global:
-  namespace: trip-planner
+# install.sh creates the namespace with kubectl, so the chart must not render
+# one of its own — see "Namespace handling" in the mcp-mesh-core chart README.
+namespaceCreate: false
 
 # All components enabled
 postgres:

--- a/examples/tutorial/trip-planner/final_product/k8s/helm/values-core.yaml
+++ b/examples/tutorial/trip-planner/final_product/k8s/helm/values-core.yaml
@@ -3,10 +3,11 @@
 #
 # Usage:
 #   helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-#     --version 1.2.0 -n trip-planner -f values-core.yaml
+#     --version 1.2.0 -n trip-planner --create-namespace -f values-core.yaml
 
-global:
-  namespace: trip-planner
+# install.sh creates the namespace with kubectl, so the chart must not render
+# one of its own — see "Namespace handling" in the mcp-mesh-core chart README.
+namespaceCreate: false
 
 # All components enabled
 postgres:
@@ -60,7 +61,10 @@ mcp-mesh-registry:
       memory: 128Mi
 
   registry:
-    # SPIRE-based TLS for registry
+    # SPIRE-based TLS for registry. spire.enabled mounts the agent socket into
+    # the registry pod on its own — adding it again through extraVolumes /
+    # extraVolumeMounts makes the Deployment invalid ("Duplicate value:
+    # spire-agent-socket").
     security:
       tls:
         mode: "auto"
@@ -69,17 +73,6 @@ mcp-mesh-registry:
         spire:
           enabled: true
           socketPath: "/run/spire/agent/sockets/agent.sock"
-
-  # Mount SPIRE agent socket into registry pod
-  extraVolumes:
-    - name: spire-agent-socket
-      hostPath:
-        path: /run/spire/agent/sockets
-        type: Directory
-  extraVolumeMounts:
-    - name: spire-agent-socket
-      mountPath: /run/spire/agent/sockets
-      readOnly: true
 
 mcp-mesh-grafana:
   grafana:

--- a/helm/README.md
+++ b/helm/README.md
@@ -36,12 +36,12 @@ Kubernetes deployment charts for MCP Mesh - a distributed agent orchestration fr
 ### Installation
 
 ```bash
-# Create namespace
-kubectl create namespace mcp-mesh
-
 # 1. Install core infrastructure (registry + observability)
+#    --set namespaceCreate=false is required: see "Namespace handling" in
+#    mcp-mesh-core/README.md
 helm dependency update helm/mcp-mesh-core
-helm install mcp-core helm/mcp-mesh-core -n mcp-mesh
+helm install mcp-core helm/mcp-mesh-core -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false
 
 # 2. Install agents (repeat for each agent)
 helm install hello-world helm/mcp-mesh-agent -n mcp-mesh \
@@ -66,12 +66,14 @@ helm install mcp-ingress helm/mcp-mesh-ingress -n mcp-mesh
 
 ```bash
 # Core without observability
-helm install mcp-core helm/mcp-mesh-core -n mcp-mesh \
+helm install mcp-core helm/mcp-mesh-core -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 
 # Core without PostgreSQL (in-memory registry)
-helm install mcp-core helm/mcp-mesh-core -n mcp-mesh \
+helm install mcp-core helm/mcp-mesh-core -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false \
   --set postgres.enabled=false
 ```
 

--- a/helm/mcp-mesh-core/README.md
+++ b/helm/mcp-mesh-core/README.md
@@ -19,34 +19,25 @@ This umbrella chart deploys the core MCP Mesh infrastructure components:
 
 ```bash
 # Install core infrastructure
-helm install mcp-mesh-core ./mcp-mesh-core -n mcp-mesh --create-namespace
+helm install mcp-mesh-core ./mcp-mesh-core \
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false
 
 # Or with custom values
-helm install mcp-mesh-core ./mcp-mesh-core -n mcp-mesh --create-namespace -f my-values.yaml
-```
-
-`--create-namespace` (or Argo CD's `syncOptions: CreateNamespace=true`) is
-**required** when the target namespace does not exist yet, and it creates that
-namespace without tying it to the release. `namespaceCreate` is not a substitute:
-Helm writes the release secret into the `-n` namespace *before* it applies the
-rendered manifest, so a chart-templated `Namespace` can never create the
-namespace its own release is installed into — the install fails with
-`create: failed to create: namespaces "<name>" not found`. It can only
-re-declare a namespace that already exists.
-
-`namespaceCreate` (default `true`) additionally renders a `Namespace` object
-into the release. It creates **`global.namespace` (default `mcp-mesh`), not the
-release namespace** — the two are independent, so installing with
-`-n my-app` while leaving `global.namespace` at its default creates a stray
-`mcp-mesh` namespace that nothing is deployed into. Keep the two matching:
-
-```bash
 helm install mcp-mesh-core ./mcp-mesh-core \
-  -n my-app --create-namespace --set global.namespace=my-app
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false \
+  -f my-values.yaml
 ```
 
-Do not flip `namespaceCreate` to `false` on an existing release — see
-"Uninstall" below.
+Deploy into any namespace by changing `-n`. Nothing else needs to change:
+every component lands in the release namespace, and short service names
+resolve within it.
+
+`--set namespaceCreate=false` is not optional decoration — without it the
+install fails on Helm 3 and on any pre-created namespace. See
+[Namespace handling](#namespace-handling) for why, for how to adopt a namespace
+that already exists, and for what applies to a release that already exists.
 
 ### Access Registry
 
@@ -66,6 +57,120 @@ After core infrastructure is running, deploy agents:
 # Deploy an agent
 helm install my-agent ../mcp-mesh-agent --set agent.script=my_script.py
 ```
+
+## Namespace handling
+
+Two unrelated mechanisms can create the namespace, and only one of them works
+for the namespace a release installs into:
+
+| Mechanism                                                              | What it does                                                                                                                              |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `helm install --create-namespace` (Argo CD: `syncOptions: CreateNamespace=true`) | Creates the `-n` namespace as a plain object that no release owns, before the manifest is applied.                                        |
+| `namespaceCreate` (chart value, default `true`)                        | Renders a `Namespace` object **named `global.namespace`, not the release namespace** into the release manifest. Nothing else reads `global.namespace`. |
+
+Helm writes the release secret into the `-n` namespace *before* it applies the
+rendered manifest, so a chart-templated `Namespace` can never create the
+namespace its own release is installed into. It can only re-declare one that
+already exists — and re-declaring an object the release does not own is exactly
+what Helm's ownership check rejects. Measured against a live cluster with the
+full chart:
+
+| Install shape                                                        | Helm 3.19.0                              | Helm 4.0.1                       |
+| ---------------------------------------------------------------------- | ------------------------------------------ | ---------------------------------- |
+| `-n <new-ns>`, no `--create-namespace`                               | fails: `namespaces "<ns>" not found`     | fails the same way               |
+| `-n <ns> --create-namespace`                                         | fails: `namespaces "<ns>" already exists` | works — Helm 4 adopts the object |
+| `kubectl create namespace` first, then install                       | fails: `invalid ownership metadata`      | fails the same way               |
+| `-n <ns> --create-namespace --set namespaceCreate=false`             | **works**                                | **works**                        |
+| `kubectl create namespace` first, `--set namespaceCreate=false`      | **works**                                | **works**                        |
+| `kubectl create namespace` first, `--take-ownership`                 | works                                    | works                            |
+
+Hence the recipe in "Installation": **new installs set `namespaceCreate=false`**
+and let `--create-namespace` (or `kubectl create namespace`, or Argo CD) create
+the namespace. With `namespaceCreate=false`, `global.namespace` is inert and can
+be left alone — there is no second name to keep in sync, and no stray namespace
+to create by getting it wrong.
+
+### Adopting a namespace that already exists
+
+If you want the release to own its `Namespace` anyway — GitOps setups that
+render the namespace from the chart, for instance — create the namespace first
+and install with `--take-ownership` (Helm 3.17+ and Helm 4):
+
+```bash
+kubectl create namespace mcp-mesh
+helm install mcp-mesh-core ./mcp-mesh-core \
+  -n mcp-mesh --set global.namespace=mcp-mesh --take-ownership
+```
+
+Helm stamps its ownership metadata plus `helm.sh/resource-policy: keep` onto the
+existing namespace. `global.namespace` must match `-n`, or the release owns a
+`Namespace` object for some *other*, empty namespace — the chart's NOTES warns
+when that happens. `--take-ownership` applies to every object in the manifest,
+not just the namespace, so use it deliberately.
+
+### Existing releases: do not flip `namespaceCreate` on its own
+
+The `Namespace` is already recorded in the release manifest. Dropping it from
+the rendered output makes the next `helm upgrade` **delete the namespace and
+everything in it** — agents, Secrets, PVCs the chart never created — while
+reporting `STATUS: deployed` and exit `0`. When `global.namespace` matches `-n`,
+that is also unrecoverable: the release secret lives in the namespace being
+deleted. While the namespace drains, a retried `helm upgrade --install` fails
+with `secrets "sh.helm.release.v1.<release>.vN" is forbidden: ... because it is
+being terminated`; once it is gone, so is the release history, and
+`helm history` reports `release: not found`.
+
+From chart 3.4.0 the rendered `Namespace` carries `helm.sh/resource-policy:
+keep`, and Helm reads that policy from the manifest of the revision it is
+replacing. So the flip becomes safe only once the release's *current* revision
+was rendered by 3.4.0 or later — two separate upgrades:
+
+```bash
+# 1. Upgrade to >= 3.4.0, leaving namespaceCreate alone.
+helm upgrade mcp-mesh-core ./mcp-mesh-core -n mcp-mesh --reuse-values
+
+# Confirm the live namespace picked up the policy before going further.
+kubectl get ns mcp-mesh -o jsonpath='{.metadata.annotations}'
+#   {"helm.sh/resource-policy":"keep","meta.helm.sh/release-name":...}
+
+# 2. Only then, and only if you want it, drop the Namespace from the release.
+helm upgrade mcp-mesh-core ./mcp-mesh-core -n mcp-mesh --reuse-values \
+  --set namespaceCreate=false
+```
+
+There is no hurry to do step 2. Once `keep` is on the namespace, leaving
+`namespaceCreate: true` is harmless — `helm uninstall` no longer deletes it (see
+"Uninstall").
+
+### Recovering from a failed `--create-namespace` install
+
+On Helm 3, `-n <ns> --create-namespace` with `namespaceCreate: true` fails
+**non-atomically**. Helm creates the namespace, then the manifest's `Namespace`
+collides with it — but the rest of the manifest has already been applied.
+Deployments, the StatefulSet, PVCs, and Secrets are all live and running under a
+release marked `failed`:
+
+```
+Error: INSTALLATION FAILED: 1 error occurred:
+	* namespaces "<ns>" already exists
+```
+
+Do **not** try to fix this with `helm upgrade --set namespaceCreate=false`. That
+reports `STATUS: deployed` and then deletes the namespace it just deployed into,
+cascading the release secret with it. Uninstall the wreckage and reinstall with
+the recipe from "Installation":
+
+```bash
+helm uninstall mcp-mesh-core -n mcp-mesh
+helm install mcp-mesh-core ./mcp-mesh-core \
+  -n mcp-mesh --set namespaceCreate=false
+```
+
+The uninstall keeps the namespace (`resource-policy: keep`), so the reinstall
+does not need `--create-namespace`. It also keeps the generated PostgreSQL and
+Grafana Secrets, and the StatefulSet's PVC — all deliberate, and all reused by
+the reinstall. Delete them by hand if you want the install to start from
+scratch.
 
 ## Configuration
 
@@ -343,7 +448,9 @@ global:
 ```
 
 ```bash
-helm install mcp-core ./mcp-mesh-core -n mcp-mesh -f values.yaml
+helm install mcp-core ./mcp-mesh-core \
+  -n mcp-mesh --create-namespace --set namespaceCreate=false \
+  -f values.yaml
 ```
 
 The separate `mcp-mesh-agent` chart is standalone (not an umbrella subchart),
@@ -450,13 +557,14 @@ single-writer local file.
 The core infrastructure follows this deployment pattern:
 
 1. **Namespace** - Creates `global.namespace` (default `mcp-mesh`) when
-   `namespaceCreate` is enabled
+   `namespaceCreate` is enabled — which new installs should not do, see
+   [Namespace handling](#namespace-handling)
 2. **PostgreSQL** - StatefulSet with persistent storage
 3. **Redis** - Deployment with emptyDir (cache-only)
 4. **Registry** - StatefulSet connected to PostgreSQL
 
 Only step 1 uses `global.namespace`. Every workload deploys into the release
-namespace (`-n`), which is why the two need to match.
+namespace (`-n`).
 
 ## Monitoring
 
@@ -550,29 +658,24 @@ namespace around it) that destroys the data. Bundled Redis writes to an
 `emptyDir` unless you enable persistence against a PVC you created yourself, so
 treat its contents as ephemeral either way.
 
-The namespace is left in place. `namespaceCreate` (default `true`) makes the
-release own a `Namespace` object, and deleting a namespace cascades to every
-resource in it — agents, Services, Secrets, and PVCs the chart never created.
-The namespace template carries `"helm.sh/resource-policy": keep`, so Helm skips
-it on uninstall and the cascade cannot happen. Releases installed with an older
-chart pick the annotation up automatically on `helm upgrade`; no other action
-is needed.
+The namespace is left in place, whichever way it was created. A release
+installed with `namespaceCreate=false` never owned the namespace in the first
+place, so there is nothing for Helm to delete. A release that does own one —
+`namespaceCreate: true`, or `--take-ownership` — renders it with
+`"helm.sh/resource-policy": keep`, so from chart 3.4.0 onward Helm skips the
+object on uninstall and the delete cannot cascade to agents, Services, Secrets,
+and PVCs the chart never created. Releases installed with an older chart pick
+the annotation up automatically on `helm upgrade`; no other action is needed.
 
-Do **not** set `namespaceCreate=false` on an existing release to get the same
-effect. The `Namespace` is already recorded in the release manifest, so
-removing it from the rendered output makes the next `helm upgrade` delete the
-namespace and everything in it — while reporting `STATUS: deployed` and exit
-`0`. When `global.namespace` matches the namespace you pass to `-n`, it is also
-unrecoverable: Helm keeps the release secret in the `-n` namespace, which is the
-one being deleted, so `helm history` afterward reports `release: not found`. If
-the two differ, the release metadata survives in the `-n` namespace — but the
-rendered namespace is still deleted, cascade included.
+Do **not** try to get the same effect by setting `namespaceCreate=false` on an
+existing release — on its own that upgrade *deletes* the namespace. See
+[Existing releases](#existing-releases-do-not-flip-namespacecreate-on-its-own).
 
 ## Values
 
 | Key                | Type   | Default      | Description                          |
 | ------------------ | ------ | ------------ | ------------------------------------ |
-| `global.namespace` | string | `"mcp-mesh"` | Name of the `Namespace` object rendered by `namespaceCreate`. Nothing else reads it — components always deploy to the release namespace (`-n`), so keep the two matching |
+| `global.namespace` | string | `"mcp-mesh"` | Name of the `Namespace` object rendered by `namespaceCreate`, and inert without it. Nothing else reads it — components always deploy to the release namespace (`-n`) |
 | `global.imageRegistry` | string | `""` | Registry prefix applied to every image (repository paths preserved — see "Air-gapped / private registry installs"); per-component `image.registry` overrides win |
 | `global.imagePullSecrets` | list | `[]` | Pull secrets (`- name: ...`) added to every pod spec, merged with each chart's own `imagePullSecrets` and deduplicated by name |
 | `global.postgres.*` | object | bundled postgres | PostgreSQL endpoint/credentials inherited by all consumers (`host`, `port`, `name`, `username`, `password`, `sslmode`, `existingSecret`, `existingSecretUrlKey`, `existingSecretPasswordKey`, `tls.caSecret`, `tls.caKey`) |
@@ -584,7 +687,7 @@ rendered namespace is still deleted, cascade included.
 | `registry.enabled` | bool   | `true`       | Enable Registry deployment           |
 | `grafana.enabled`  | bool   | `true`       | Enable Grafana deployment            |
 | `tempo.enabled`    | bool   | `true`       | Enable Tempo deployment              |
-| `namespaceCreate`  | bool   | `true`       | Render `global.namespace` as a release-owned `Namespace`, annotated `"helm.sh/resource-policy": keep` so uninstall never deletes it. Safe to disable at install time; never flip it to `false` on an existing release (see "Uninstall") |
+| `namespaceCreate`  | bool   | `true`       | Render `global.namespace` as a release-owned `Namespace`, annotated `"helm.sh/resource-policy": keep` so uninstall never deletes it. **Set `false` on new installs** — left `true`, the install fails on Helm 3 and on any pre-created namespace. Never flip it to `false` on an existing release in isolation. See [Namespace handling](#namespace-handling) |
 
 ## Service Discovery
 

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -3,10 +3,12 @@
 
 # Global configuration
 global:
-  # Name of the Namespace object rendered by namespaceCreate. Nothing else
-  # reads it: every component deploys to .Release.Namespace (the -n flag).
-  # Keep it matching -n, or namespaceCreate creates a stray namespace that
-  # nothing is deployed into.
+  # Name of the Namespace object rendered by namespaceCreate, and read by
+  # nothing else: every component deploys to .Release.Namespace (the -n flag).
+  # With the recommended namespaceCreate: false this value is inert. It only
+  # matters when the release owns its Namespace (namespaceCreate: true or
+  # --take-ownership), and then it has to match -n — otherwise the release owns
+  # a stray namespace that nothing is deployed into.
   namespace: mcp-mesh
 
   # Private/air-gapped registry prefix applied to EVERY image in the stack:
@@ -330,16 +332,26 @@ mcp-mesh-ui:
       url: "http://mcp-core-mcp-mesh-tempo:3200"
       telemetryEndpoint: "mcp-core-mcp-mesh-tempo:4317"
 
-# Render global.namespace as a release-owned Namespace object. Note this is
-# global.namespace (below), NOT the release namespace (-n) — set both to the
-# same value, or the chart creates a stray namespace alongside the one it
-# deploys into.
+# Render global.namespace (above) as a release-owned Namespace object. Note
+# that is global.namespace, NOT the release namespace (-n).
 #
-# The Namespace carries "helm.sh/resource-policy": keep, so `helm uninstall`
-# leaves it (and everything in it) alone. Do NOT flip this to false on an
-# existing release: the namespace is already in the release manifest, so
-# dropping it from the rendered output makes the next `helm upgrade` delete
-# the namespace and cascade to every resource inside it.
+# SET THIS TO false ON NEW INSTALLS. Helm writes the release secret into the -n
+# namespace before it applies the manifest, so a chart-templated Namespace can
+# never create the namespace its own release installs into — it can only
+# re-declare an existing one, which Helm's ownership check rejects. Left true,
+# the install fails on Helm 3 ("namespaces <ns> already exists") and, on any
+# client, against a pre-created namespace ("invalid ownership metadata"). Let
+# `helm install --create-namespace`, `kubectl create namespace`, or Argo CD's
+# CreateNamespace=true create the namespace instead; with namespaceCreate
+# false, global.namespace is inert.
+#
+# The default stays true because flipping it on an EXISTING release deletes the
+# namespace and everything in it: the Namespace is already in the release
+# manifest, and dropping it from the rendered output makes the next
+# `helm upgrade` garbage-collect it. The rendered Namespace carries
+# "helm.sh/resource-policy": keep, which makes `helm uninstall` skip it and
+# makes the flip safe — but only once the release's current revision came from
+# a chart that has the annotation. See "Namespace handling" in README.md.
 namespaceCreate: true
 
 # Common labels for all resources

--- a/helm/mcp-mesh-ingress/README.md
+++ b/helm/mcp-mesh-ingress/README.md
@@ -123,7 +123,8 @@ agents:
 
 ```bash
 # Deploy core infrastructure
-helm install mcp-core ./mcp-mesh-core
+helm install mcp-core ./mcp-mesh-core \
+  -n mcp-mesh --create-namespace --set namespaceCreate=false
 
 # Deploy individual agents
 helm install hello-world ./mcp-mesh-agent --set agent.name=hello-world

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -156,7 +156,8 @@ For production Kubernetes deployment, use the official Helm charts from the MCP 
 # No "helm repo add" needed - uses OCI registry directly
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
-  -n mcp-mesh --create-namespace
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false
 
 # Deploy agent using scaffold-generated helm-values.yaml
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
@@ -165,26 +166,33 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
   -f my-agent/helm-values.yaml
 ```
 
+`--create-namespace` creates the namespace, and `--set namespaceCreate=false`
+stops the core chart from rendering a second `Namespace` object that would
+collide with it. Both are required: Helm writes the release secret into the
+`-n` namespace before applying the manifest, so a chart-templated `Namespace`
+can never create the namespace its own release installs into. Left at the
+default, the install fails on Helm 3 (`namespaces "<ns>" already exists`) and,
+on any client, against a pre-created namespace (`invalid ownership metadata`).
+
+Full detail, including how to adopt an existing namespace with
+`--take-ownership` and why an existing release must not flip the value:
+https://github.com/dhyansraj/mcp-mesh/blob/main/helm/mcp-mesh-core/README.md#namespace-handling
+
 ### Custom Namespace
 
-Deploy into any namespace — just match `-n` with `--set global.namespace`:
+Deploy into any namespace — change `-n` and nothing else:
 
 ```bash
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
   -n my-namespace --create-namespace \
-  --set global.namespace=my-namespace
+  --set namespaceCreate=false
 
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
   --version 3.3.2 \
   -n my-namespace \
   -f helm-values.yaml
 ```
-
-`-n` is where every component is deployed; `global.namespace` names the
-`Namespace` object the core chart renders (`namespaceCreate`, default `true`).
-Mismatched, they leave a stray empty namespace alongside the real one, and
-multiple core releases contend for that one shared object.
 
 For cross-namespace deployments (core and agents in different namespaces),
 override service hostnames with FQDNs:
@@ -201,7 +209,7 @@ its own namespace. Short service names resolve independently within each namespa
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
-  -n team-a --create-namespace --set global.namespace=team-a
+  -n team-a --create-namespace --set namespaceCreate=false
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
   --version 3.3.2 -n team-a -f greeter/helm-values.yaml
@@ -209,7 +217,7 @@ helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 # Team B — same helm-values.yaml, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
-  -n team-b --create-namespace --set global.namespace=team-b
+  -n team-b --create-namespace --set namespaceCreate=false
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
   --version 3.3.2 -n team-b -f greeter/helm-values.yaml
@@ -280,6 +288,7 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
   -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 
@@ -287,6 +296,7 @@ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
   -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false \
   --set postgres.enabled=false
 ```
 
@@ -409,7 +419,10 @@ The published `mcpmesh/ui` image serves at `/ops/dashboard` by default.
 **Minimum setup** (everything included by default):
 
 ```bash
-helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core --set ui.enabled=true
+helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false \
+  --set ui.enabled=true
 ```
 
 This deploys the dashboard with database access (event history), distributed tracing, and Redis (live streaming) — all enabled by default.
@@ -438,6 +451,8 @@ docker run -e MCP_MESH_UI_BASE_PATH=/my/custom/path mcpmesh/ui:3.3.2
 
 # Helm
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false \
   --set ui.enabled=true \
   --set mcp-mesh-ui.ui.basePath=/my/custom/path
 ```
@@ -450,6 +465,8 @@ For prerelease versions, override the image tag (floating major-minor tags only 
 
 ```bash
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false \
   --set ui.enabled=true \
   --set mcp-mesh-ui.image.tag=2.0.0-beta.3
 ```

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -203,9 +203,11 @@ For production Kubernetes deployment:
 
 ```bash
 # Install core infrastructure
+# --set namespaceCreate=false is required — run `meshctl man deployment`
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
-  -n mcp-mesh --create-namespace
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false
 
 # Deploy Java agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -144,9 +144,11 @@ For production Kubernetes deployment:
 
 ```bash
 # Install core infrastructure
+# --set namespaceCreate=false is required — run `meshctl man deployment`
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
-  -n mcp-mesh --create-namespace
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false
 
 # Deploy TypeScript agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -66,12 +66,14 @@ docker compose up -d
 # Install core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
-  -n mcp-mesh --create-namespace
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false
 
 # Or disable observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
   -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false \
   --set tempo.enabled=false \
   --set grafana.enabled=false
 ```

--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -136,9 +136,11 @@ Available from OCI registry (no `helm repo add` needed):
 
 ```bash
 # Install core infrastructure
+# --set namespaceCreate=false is required — run `meshctl man deployment`
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
-  -n mcp-mesh --create-namespace
+  -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \

--- a/src/core/cli/man/content/registry.md
+++ b/src/core/cli/man/content/registry.md
@@ -204,6 +204,7 @@ The registry supports multiple replicas for high availability. All replicas shar
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.3.2 \
   -n mcp-mesh --create-namespace \
+  --set namespaceCreate=false \
   --set registry.replicas=3
 ```
 

--- a/src/core/cli/man/content/tutorial.md
+++ b/src/core/cli/man/content/tutorial.md
@@ -1704,6 +1704,10 @@ $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
     --wait --timeout 5m
 ```
 
+`values-core.yaml` sets `namespaceCreate: false`, which is what lets the chart
+install into the namespace `kubectl` created in Part 2. Without it the install
+fails with `invalid ownership metadata`.
+
 ## Part 4: Deploy the agents
 
 ```shell


### PR DESCRIPTION
## Summary

Every documented way to install `mcp-mesh-core` was broken. Not on an edge case — the **primary quickstart fails on both Helm 3 and Helm 4**, and the custom-namespace recipe works only on Helm 4.

This rewrites every install recipe in the repo to a form that has actually been executed, on both clients, against the full six-subchart chart.

**No behaviour change.** `namespaceCreate` stays `true`, and the default render is byte-identical to `90a6cabdb` — `values.yaml` moved only in comments (parsed values compare equal), and `templates/` is untouched.

## The measured picture

`gn` = `global.namespace`:

| shape | Helm 3.19.0 | Helm 4.0.1 |
|---|---|---|
| A: `-n NS` (absent), `gn=NS` | FAIL not-found | FAIL not-found |
| B: `-n NS --create-namespace`, `gn=NS` — **custom-ns recipe** | FAIL AlreadyExists | OK (adopts) |
| D: `kubectl create ns NS` then install, `gn=NS` — **primary quickstart** | FAIL ownership | **FAIL ownership** |
| E: `gn != -n` | OK (stray namespace) | OK (stray namespace) |
| **F: `--create-namespace --set namespaceCreate=false`** | **OK** | **OK** |
| **G: `kubectl create ns` + `--set namespaceCreate=false`** | **OK** | **OK** |
| D+: shape D plus `--take-ownership` (Helm 3.17+) | OK | OK |

The Helm 3/4 divergence is confined to one cell — the namespace Helm itself creates mid-install, which Helm 4 adopts and Helm 3 rejects. Everything else fails or succeeds identically. So #1414's framing as a Helm 3 problem was wrong.

## The canonical recipe

```bash
helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
  --version 3.3.2 \
  -n mcp-mesh --create-namespace \
  --set namespaceCreate=false
```

Custom-namespace and multi-tenant installs collapse to *the same command with a different `-n`*, because with `namespaceCreate=false` the `global.namespace` value is inert — it is read by exactly one template, `mcp-mesh-core/templates/namespace.yaml`. The whole "keep `-n` and `global.namespace` matching" instruction disappears from every install surface.

`--set namespaceCreate=false` is safe at install time precisely because a new install has no prior release, so there is no Namespace in any stored manifest and nothing to delete. That is different from flipping it on an existing release — see below.

## Why not just change the default

`helm.sh/resource-policy: keep` (#1413) is on `main` but has never shipped; 3.3.2 predates it. It reaches live objects only in 3.4.0, and only because the Namespace still renders. Flipping the default in the same release would drop the Namespace from the manifest while the live object is still unannotated — which deletes it. Measured, on both clients.

So `namespaceCreate: true` stays, and the flip is a later, optional cleanup.

## Two findings that shifted the approach

**The flip is safe once `keep` is on the prior manifest — measured on both clients.** Helm reads the policy from the revision it is *replacing*, so:

- Negative control (pre-3.4.0 manifest, single-step flip): namespace `Terminating`, Helm reports `deployed`.
- Two-step (upgrade to the 3.4.0 chart, confirm the annotation appears on the live namespace, *then* flip): namespace `Active`, 5 pods still running.

Documented as a sequenced optional procedure rather than a flat "never", with the honest note that there is no hurry — once `keep` is in place, `namespaceCreate: true` is harmless.

**A template-time guard is not viable, so none was added.** No template-visible signal separates the failing shapes from the working ones, because the discriminator is a CLI flag plus apply-time ordering. Version-keyed fires on Argo CD (repo-server bundles helm 3.19.4) and on working `--take-ownership` installs, and flips mid-lifecycle across a client change. Predicate-keyed fires on Helm 4 shape B, the one recipe that works. `lookup` is empty under `helm template`, under `--dry-run`, under Argo CD, and — in a real install — for the very namespace `--create-namespace` is about to create.

## Also documented

- **`--take-ownership`** (Helm 3.17+) as the adoption path for a pre-existing namespace with `namespaceCreate: true`. Works on both clients, documented nowhere until now.
- **The non-atomic failure.** Shape B leaves Deployments, the StatefulSet, PVCs and Secrets running under a `failed` release — a live-but-unmanaged half-install. The recovery is documented and was executed verbatim: `helm uninstall` (which now preserves the namespace via `keep`), then reinstall with `namespaceCreate=false`.
- **The wrong recovery, explicitly.** `helm upgrade --set namespaceCreate=false` on that failed release reports `STATUS: deployed` and deletes the release's own namespace, cascading the release secret. Reproduced; the retry then fails with `secrets "sh.helm.release.v1…" is forbidden: … because it is being terminated`.
- A single canonical **`## Namespace handling`** section in `helm/mcp-mesh-core/README.md`; other surfaces link to it rather than restating.

## Validation — every documented recipe was executed

22/22 PASS on k3s, full default chart, both Helm 3.19.0 and Helm 4.0.1: the canonical recipe (local chart **and the published 3.3.2 OCI chart**), with grafana/tempo disabled, with postgres disabled, with `ui.enabled=true`, with `registry.replicas=3`, the `--take-ownership` path, all three tutorial `values-core.yaml` files, the registry-only chart, and the TLS example.

The OCI row matters: **these recipes work against the currently published chart**, so the docs are correct today, not only once 3.4.0 ships.

Plus: default render byte-identical to `90a6cabdb` (NOTES included, checked via `--dry-run` since `helm template` does not render NOTES); `helm lint` clean on both clients; `check_helm_pss.py` all charts OK; `go build ./...`; man pages re-rendered from a locally built `./cmd/meshctl` rather than the npm shim, which serves a stale embedded page.

## Drive-by fix

`examples/tutorial/trip-planner/final_product/k8s/helm/values-core.yaml` re-mounted the SPIRE agent socket that `registry.security.trust.spire.enabled` already injects, so the install failed:

```
Deployment.apps "rel-mcp-mesh-registry" is invalid: [spec.template.spec.volumes[2].name:
Duplicate value: "spire-agent-socket", ...: must be unique]
```

Pre-existing at `90a6cabdb`. Found only because the recipes were executed rather than reviewed.

## Not addressed

`docs/tutorial/day-09-kubernetes.md`, `man tutorial.md`, and the tutorial `install.sh` scripts still pin `CHART_VERSION="1.2.0"` while the docs show `--version 3.3.2`. Unrelated to this issue; filed separately.

Refs #1414


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized Kubernetes Helm installation guidance around explicit namespace selection and creation.
  * Added `namespaceCreate=false` to installation examples and clarified when it is required.
  * Expanded namespace handling guidance, including custom namespaces, multi-tenant deployments, upgrades, adoption, and recovery.
  * Updated tutorials and TLS examples to prevent namespace ownership errors.
  * Clarified SPIRE socket configuration in the TripPlanner deployment example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->