### PR TITLE
fix(helm): order the grafana and tempo pod swap so a single-replica RWO rollout can finish

### DIFF
--- a/helm/mcp-mesh-agent/README.md
+++ b/helm/mcp-mesh-agent/README.md
@@ -102,7 +102,7 @@ helm uninstall my-agent -n mcp-mesh
 | Parameter                   | Description                            | Default                    |
 | --------------------------- | -------------------------------------- | -------------------------- |
 | `replicaCount`              | Number of replicas                     | `1`                        |
-| `strategy`                  | Deployment update strategy (unset = Kubernetes default `RollingUpdate`; set `{type: Recreate}` for ReadWriteOnce `persistence`) | `{}` |
+| `strategy`                  | Deployment update strategy (unset = Kubernetes default `RollingUpdate`; pin `rollingUpdate.maxSurge: 0` for ReadWriteOnce `persistence`) | `{}` |
 | `image.repository`          | Container image repository             | `"mcpmesh/python-runtime"` |
 | `image.pullPolicy`          | Image pull policy                      | `IfNotPresent`             |
 | `image.tag`                 | Image tag (overrides chart appVersion) | `"0.9"`                    |
@@ -111,13 +111,21 @@ helm uninstall my-agent -n mcp-mesh
 | `resources.requests.cpu`    | CPU request                            | `100m`                     |
 | `resources.requests.memory` | Memory request                         | `256Mi`                    |
 
-> **`strategy` and ReadWriteOnce volumes:** with the default `RollingUpdate`, Kubernetes starts the incoming pod before the outgoing one is gone. If the scheduler places it on another node it cannot mount a ReadWriteOnce claim the outgoing pod still holds, and the rollout deadlocks until someone deletes the old pod. Both pods landing on one node is why single-node dev clusters (kind, minikube, Docker Desktop) never see this. Set `strategy: {type: Recreate}` whenever `persistence.enabled` is true with the default `accessMode: ReadWriteOnce`.
+> **`strategy` and ReadWriteOnce volumes:** the unset default gets Kubernetes' `RollingUpdate` with `maxSurge: 25%`, which starts the incoming pod before the outgoing one is gone — correct for a stateless agent, wrong the moment one mounts a ReadWriteOnce claim. If the scheduler places the incoming pod on another node it cannot mount the claim the outgoing pod still holds, and the rollout hangs indefinitely on a `Multi-Attach` error. Both pods landing on one node is why single-node dev clusters (kind, minikube, Docker Desktop) never see this. Whenever `persistence.enabled` is true with the default `accessMode: ReadWriteOnce`, pin the surge to zero:
 >
-> `Recreate` costs a gap in service while the old pod terminates, and when `autoscaling.enabled` is true that gap covers every replica at once, since `Recreate` tears the whole set down before scheduling any replacement. Note that `persistence` creates a **single** claim for the whole release, so ReadWriteOnce is not compatible with more than one replica under either strategy: with `replicaCount > 1` or an active HPA, every replica scheduled off the claim's node stays `Pending`. `Recreate` does not fix that combination — use ReadWriteMany, or keep the agent at one replica.
+> ```yaml
+> strategy:
+>   type: RollingUpdate
+>   rollingUpdate:
+>     maxSurge: 0
+>     maxUnavailable: 1
+> ```
 >
-> Set it at install time if you can. Switching an **already-installed** release from `RollingUpdate` to `Recreate` is rejected by the API server — it defaulted `.spec.strategy.rollingUpdate` on the live object, and `rollingUpdate` "may not be specified when strategy `type` is 'Recreate'". Under **Helm 4** the default server-side apply does not clear it and `--force-conflicts` does not help, so run that one switch with `helm upgrade --server-side=false`; **Helm 3** patches client-side and needs no flag. Deleting the Deployment and letting Helm recreate it also works.
+> `maxUnavailable` must stay non-zero — the API server rejects `maxSurge` and `maxUnavailable` both being `0`. This applies cleanly to an already-installed release under both Helm 3 and Helm 4, with no extra flags, because it replaces the API-defaulted `rollingUpdate` block rather than trying to remove it. It costs a gap in service while the old pod terminates, plus one transient `FailedAttachVolume`/`Multi-Attach` event per rollout — the scale-down and the scale-up are issued in the same second, so the replacement is created while the CSI driver is still detaching. It clears once the detach completes and the rollout converges without intervention. (This is what `mcp-mesh-grafana` and `mcp-mesh-tempo` ship as their default, since both are single-replica with a ReadWriteOnce claim enabled out of the box.)
+>
+> This only makes ReadWriteOnce safe at one replica. `persistence` creates a **single** claim for the whole release, so with `replicaCount > 1` or an active HPA, every replica scheduled off the claim's node stays `Pending` no matter what strategy is set — use ReadWriteMany, or keep the agent at one replica.
 
-> **Upgrade note:** `podSecurityContext` (runAsNonRoot, uid/gid 999, fsGroup 999, RuntimeDefault seccomp) is now always applied — it was previously gated behind the removed `podSecurityPolicy.enabled` flag and never rendered. It covers user-supplied `initContainers` (an init container that must run as root needs its own `securityContext`, which overrides the pod level), and `fsGroup: 999` changes group ownership of mounted volumes, including PVCs from `extraVolumes`.
+> **Upgrade note:** `podSecurityContext` (runAsNonRoot, uid/gid 999, fsGroup 999, RuntimeDefault seccomp) is now always applied — it was previously gated behind the removed `podSecurityPolicy.enabled` flag and never rendered. It covers user-supplied `initContainers` (an init container that must run as root needs both `runAsUser: 0` and `runAsNonRoot: false` in its own `securityContext`, because a container-level context overrides only the fields it sets — `runAsUser: 0` alone still inherits the pod's `runAsNonRoot: true`, and the kubelet refuses to start it with `container has runAsNonRoot and image will run as root` — and only where the namespace's Pod Security Standards level and any cluster policy permit running as root), and `fsGroup: 999` changes group ownership of mounted volumes, including PVCs from `extraVolumes`.
 
 ### Agent Code Configuration
 

--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -135,33 +135,37 @@ autoscaling:
   targetMemoryUtilizationPercentage: 80
 
 # Deployment update strategy. Empty leaves the field unset, so Kubernetes
-# applies its own default (RollingUpdate) — right for the stateless default.
-# Set Recreate when the agent mounts a ReadWriteOnce volume (see persistence
-# below, whose accessMode defaults to ReadWriteOnce). RollingUpdate starts the
-# incoming pod before the outgoing one is gone; if the scheduler places it on
-# another node it cannot mount a ReadWriteOnce claim the outgoing pod still
-# holds, and the rollout deadlocks until someone deletes the old pod. Both
-# pods landing on one node is why single-node dev clusters never see this.
+# applies its own default (RollingUpdate with maxSurge 25%) — right for the
+# stateless default, where surging a replica ahead of the old one is exactly
+# what you want.
 #
-# Recreate trades that for a gap in service while the old pod terminates, and
-# with autoscaling.enabled the gap covers every replica at once, because
-# Recreate tears the whole set down before scheduling any replacement. Note
-# that persistence creates a single claim for the whole release, so
-# ReadWriteOnce is not compatible with more than one replica under either
-# strategy: with replicaCount > 1 or an active HPA, every replica scheduled
-# off the claim's node stays Pending. Recreate does not fix that combination —
-# use ReadWriteMany, or keep the agent at one replica.
+# It is wrong as soon as the agent mounts a ReadWriteOnce volume (see
+# persistence below, whose accessMode defaults to ReadWriteOnce). Any maxSurge
+# starts the incoming pod before the outgoing one is gone; if the scheduler
+# places it on another node it cannot mount the claim the outgoing pod still
+# holds, and the rollout hangs indefinitely on a Multi-Attach error. Both pods
+# landing on one node is why single-node dev clusters never see this. For that
+# case pin the surge to zero, which orders the swap without giving up the
+# ability to change .spec.strategy on later upgrades:
 #
-# Set it at install time if you can. Switching an already-installed release
-# from RollingUpdate to Recreate is rejected by the API server, which
-# defaulted .spec.strategy.rollingUpdate on the live object: rollingUpdate
-# "may not be specified when strategy `type` is 'Recreate'". Under Helm 4 the
-# default server-side apply does not clear it and --force-conflicts does not
-# help, so run that one switch with `helm upgrade --server-side=false`; Helm 3
-# patches client-side and needs no flag. Deleting the Deployment and letting
-# Helm recreate it also works.
+#   strategy:
+#     type: RollingUpdate
+#     rollingUpdate:
+#       maxSurge: 0
+#       maxUnavailable: 1
+#
+# maxUnavailable must stay non-zero — the API server rejects both being 0. The
+# cost is a gap in service while the old pod terminates, plus one transient
+# FailedAttachVolume/Multi-Attach event per rollout, because the scale-down and
+# the scale-up are issued in the same second and the replacement is created
+# while the CSI driver is still detaching. It clears once the detach completes
+# and the rollout converges on its own.
+#
+# This only makes ReadWriteOnce safe at one replica. persistence creates a
+# single claim for the whole release, so with replicaCount > 1 or an active HPA
+# every replica scheduled off the claim's node stays Pending no matter what
+# strategy is set — use ReadWriteMany, or keep the agent at one replica.
 strategy: {}
-  # type: Recreate
 
 nodeSelector: {}
 

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -271,14 +271,11 @@ mcp-mesh-grafana:
       enabled: true
       size: 2Gi
 
-    # This claim is ReadWriteOnce and Grafana runs a single replica, so on a
-    # multi-node cluster you want the Deployment replaced rather than rolled —
-    # otherwise the incoming pod can land on another node and hang waiting for
-    # a claim the outgoing pod still holds. Set it at install time; see
-    # mcp-mesh-grafana/values.yaml for the migration path on an existing
-    # release. Full path: mcp-mesh-grafana.grafana.strategy
-    # strategy:
-    #   type: Recreate
+    # This claim is ReadWriteOnce and Grafana runs a single replica, so the
+    # subchart already defaults to a strategy that terminates the outgoing pod
+    # before scheduling its replacement (RollingUpdate, maxSurge: 0). Nothing
+    # to set here — see mcp-mesh-grafana/values.yaml before overriding.
+    # Full path: mcp-mesh-grafana.grafana.strategy
 
     resources:
       requests:
@@ -303,14 +300,11 @@ mcp-mesh-tempo:
       enabled: true
       size: 5Gi
 
-    # This claim is ReadWriteOnce and Tempo runs a single replica, so on a
-    # multi-node cluster you want the Deployment replaced rather than rolled —
-    # otherwise the incoming pod can land on another node and hang waiting for
-    # a claim the outgoing pod still holds. Set it at install time; see
-    # mcp-mesh-tempo/values.yaml for the migration path on an existing release.
+    # This claim is ReadWriteOnce and Tempo runs a single replica, so the
+    # subchart already defaults to a strategy that terminates the outgoing pod
+    # before scheduling its replacement (RollingUpdate, maxSurge: 0). Nothing
+    # to set here — see mcp-mesh-tempo/values.yaml before overriding.
     # Full path: mcp-mesh-tempo.tempo.strategy
-    # strategy:
-    #   type: Recreate
 
     resources:
       requests:

--- a/helm/mcp-mesh-grafana/templates/deployment.yaml
+++ b/helm/mcp-mesh-grafana/templates/deployment.yaml
@@ -18,10 +18,25 @@ metadata:
     {{- include "mcp-mesh-grafana.labels" . | nindent 4 }}
 spec:
   replicas: 1
-  {{- with .Values.grafana.strategy }}
+  {{- /* One replica against a ReadWriteOnce claim: the incoming pod must not
+         start before the outgoing one has released the volume, or it hangs on
+         Multi-Attach when the scheduler picks another node. maxSurge: 0 gets
+         that ordering while leaving type as RollingUpdate, so there is no
+         API-defaulted .rollingUpdate block to clear on upgrade (which is what
+         makes a switch to Recreate fail). Defaults are derived here rather
+         than in values.yaml because strategy is deep-merged: an operator who
+         sets only type would otherwise inherit rollingUpdate too and be
+         rejected with "may not be specified when strategy `type` is
+         'Recreate'". */}}
+  {{- $st := .Values.grafana.strategy | default dict }}
+  {{- $type := $st.type | default "RollingUpdate" }}
   strategy:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    type: {{ $type }}
+    {{- if eq $type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ dig "rollingUpdate" "maxSurge" 0 $st }}
+      maxUnavailable: {{ dig "rollingUpdate" "maxUnavailable" 1 $st }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "mcp-mesh-grafana.selectorLabels" . | nindent 6 }}

--- a/helm/mcp-mesh-grafana/values.yaml
+++ b/helm/mcp-mesh-grafana/values.yaml
@@ -31,30 +31,32 @@ grafana:
     accessModes:
       - ReadWriteOnce
 
-  # Deployment update strategy. Empty leaves the field unset, so Kubernetes
-  # applies its own default (RollingUpdate).
+  # Deployment update strategy. Empty gets the chart's default: RollingUpdate
+  # with maxSurge: 0 and maxUnavailable: 1, which terminates the outgoing pod
+  # before scheduling its replacement. That ordering is required, not tuning —
+  # this chart runs a single replica against the ReadWriteOnce volume above, and
+  # with any maxSurge the incoming pod can be scheduled to another node, where
+  # it hangs indefinitely on a Multi-Attach error waiting for a claim the
+  # outgoing pod still holds. On a single-node cluster it mounts instead, which
+  # is worse rather than better: two Grafana processes briefly write the same
+  # SQLite database. At one replica there is no availability to preserve, so the
+  # only cost of ordering the swap is a gap in dashboards while the old pod
+  # terminates. `type: Recreate` is redundant here — maxSurge: 0 already orders
+  # the swap, and leaving type as RollingUpdate keeps .spec.strategy freely
+  # transitionable on later upgrades.
   #
-  # On a multi-node cluster you almost certainly want Recreate here, because
-  # this chart runs a single replica against the ReadWriteOnce volume above.
-  # RollingUpdate starts the incoming pod before the outgoing one is gone; if
-  # the scheduler places it on another node it cannot mount a ReadWriteOnce
-  # claim the outgoing pod still holds, and the rollout deadlocks until someone
-  # deletes the old pod. Both pods landing on one node is why single-node dev
-  # clusters never see this — and in that case it is still wrong, because two
-  # Grafana processes would write the same SQLite database. With replicas fixed
-  # at 1 there is no availability to preserve either way, so Recreate costs
-  # only a gap in dashboards while the old pod terminates.
+  # Expect one transient FailedAttachVolume/Multi-Attach event per pod-template
+  # change: Kubernetes issues the scale-down and the scale-up in the same
+  # second, so the replacement is created while the CSI driver is still
+  # detaching the volume from the old node. It clears once the detach completes
+  # — under a minute in practice, bounded by terminationGracePeriodSeconds plus
+  # detach time — and the rollout converges with no intervention. The event is
+  # logged, not silent.
   #
-  # It is not the default because switching an already-installed release from
-  # RollingUpdate to Recreate is rejected by the API server, which defaulted
-  # .spec.strategy.rollingUpdate on the live object: rollingUpdate "may not be
-  # specified when strategy `type` is 'Recreate'". Under Helm 4 the default
-  # server-side apply does not clear it and --force-conflicts does not help, so
-  # run that one switch with `helm upgrade --server-side=false`; Helm 3 patches
-  # client-side and needs no flag. Deleting the Deployment and letting Helm
-  # recreate it also works. Setting it at install time avoids all of this.
+  # Overrides are deep-merged into the above, so set only the keys you mean to
+  # change. Note that maxUnavailable must stay non-zero while maxSurge is 0:
+  # the API server rejects both being 0.
   strategy: {}
-    # type: Recreate
 
   service:
     type: ClusterIP

--- a/helm/mcp-mesh-redis/values.yaml
+++ b/helm/mcp-mesh-redis/values.yaml
@@ -44,22 +44,25 @@ persistence:
 # and there is no reason to change this.
 #
 # The key is a passthrough for the case where you have pointed this Deployment
-# at a ReadWriteOnce volume yourself — set Recreate there. RollingUpdate starts
-# the incoming pod before the outgoing one is gone; if the scheduler places it
-# on another node it cannot mount a ReadWriteOnce claim the outgoing pod still
-# holds, and the rollout deadlocks until someone deletes the old pod. Both pods
-# landing on one node is why single-node dev clusters never see this.
+# at a ReadWriteOnce volume yourself. Any maxSurge starts the incoming pod
+# before the outgoing one is gone; if the scheduler places it on another node it
+# cannot mount the claim the outgoing pod still holds, and the rollout hangs
+# indefinitely on a Multi-Attach error. Both pods landing on one node is why
+# single-node dev clusters never see this. For that case pin the surge to zero:
 #
-# Set it at install time if you can. Switching an already-installed release
-# from RollingUpdate to Recreate is rejected by the API server, which
-# defaulted .spec.strategy.rollingUpdate on the live object: rollingUpdate
-# "may not be specified when strategy `type` is 'Recreate'". Under Helm 4 the
-# default server-side apply does not clear it and --force-conflicts does not
-# help, so run that one switch with `helm upgrade --server-side=false`; Helm 3
-# patches client-side and needs no flag. Deleting the Deployment and letting
-# Helm recreate it also works.
+#   strategy:
+#     type: RollingUpdate
+#     rollingUpdate:
+#       maxSurge: 0
+#       maxUnavailable: 1
+#
+# maxUnavailable must stay non-zero — the API server rejects both being 0. This
+# applies cleanly to an already-installed release under both Helm 3 and Helm 4
+# with no extra flags, because it replaces the API-defaulted rollingUpdate block
+# rather than trying to remove it. Expect one transient
+# FailedAttachVolume/Multi-Attach event per rollout while the CSI driver
+# detaches; it clears on its own.
 strategy: {}
-  # type: Recreate
 
 # Resource limits
 resources:

--- a/helm/mcp-mesh-tempo/templates/deployment.yaml
+++ b/helm/mcp-mesh-tempo/templates/deployment.yaml
@@ -17,10 +17,25 @@ metadata:
     {{- include "mcp-mesh-tempo.labels" . | nindent 4 }}
 spec:
   replicas: 1
-  {{- with .Values.tempo.strategy }}
+  {{- /* One replica against a ReadWriteOnce claim: the incoming pod must not
+         start before the outgoing one has released the volume, or it hangs on
+         Multi-Attach when the scheduler picks another node. maxSurge: 0 gets
+         that ordering while leaving type as RollingUpdate, so there is no
+         API-defaulted .rollingUpdate block to clear on upgrade (which is what
+         makes a switch to Recreate fail). Defaults are derived here rather
+         than in values.yaml because strategy is deep-merged: an operator who
+         sets only type would otherwise inherit rollingUpdate too and be
+         rejected with "may not be specified when strategy `type` is
+         'Recreate'". */}}
+  {{- $st := .Values.tempo.strategy | default dict }}
+  {{- $type := $st.type | default "RollingUpdate" }}
   strategy:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    type: {{ $type }}
+    {{- if eq $type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ dig "rollingUpdate" "maxSurge" 0 $st }}
+      maxUnavailable: {{ dig "rollingUpdate" "maxUnavailable" 1 $st }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "mcp-mesh-tempo.selectorLabels" . | nindent 6 }}

--- a/helm/mcp-mesh-tempo/values.yaml
+++ b/helm/mcp-mesh-tempo/values.yaml
@@ -31,31 +31,32 @@ tempo:
     accessModes:
       - ReadWriteOnce
 
-  # Deployment update strategy. Empty leaves the field unset, so Kubernetes
-  # applies its own default (RollingUpdate).
+  # Deployment update strategy. Empty gets the chart's default: RollingUpdate
+  # with maxSurge: 0 and maxUnavailable: 1, which terminates the outgoing pod
+  # before scheduling its replacement. That ordering is required, not tuning —
+  # this chart runs a single replica against the ReadWriteOnce volume above, and
+  # with any maxSurge the incoming pod can be scheduled to another node, where
+  # it hangs indefinitely on a Multi-Attach error waiting for a claim the
+  # outgoing pod still holds. On a single-node cluster it mounts instead, which
+  # is worse rather than better: two single-binary Tempo processes briefly write
+  # the same WAL and blocks directory. At one replica there is no availability to
+  # preserve, so the only cost of ordering the swap is a gap in trace ingestion
+  # while the old pod terminates. `type: Recreate` is redundant here — maxSurge:
+  # 0 already orders the swap, and leaving type as RollingUpdate keeps
+  # .spec.strategy freely transitionable on later upgrades.
   #
-  # On a multi-node cluster you almost certainly want Recreate here, because
-  # this chart runs a single replica against the ReadWriteOnce volume above.
-  # RollingUpdate starts the incoming pod before the outgoing one is gone; if
-  # the scheduler places it on another node it cannot mount a ReadWriteOnce
-  # claim the outgoing pod still holds, and the rollout deadlocks until someone
-  # deletes the old pod. Both pods landing on one node is why single-node dev
-  # clusters never see this — and in that case it is still wrong, because two
-  # single-binary Tempo processes would write the same WAL and blocks
-  # directory. With replicas fixed at 1 there is no availability to preserve
-  # either way, so Recreate costs only a gap in trace ingestion while the old
-  # pod terminates.
+  # Expect one transient FailedAttachVolume/Multi-Attach event per pod-template
+  # change: Kubernetes issues the scale-down and the scale-up in the same
+  # second, so the replacement is created while the CSI driver is still
+  # detaching the volume from the old node. It clears once the detach completes
+  # — under a minute in practice, bounded by terminationGracePeriodSeconds plus
+  # detach time — and the rollout converges with no intervention. The event is
+  # logged, not silent.
   #
-  # It is not the default because switching an already-installed release from
-  # RollingUpdate to Recreate is rejected by the API server, which defaulted
-  # .spec.strategy.rollingUpdate on the live object: rollingUpdate "may not be
-  # specified when strategy `type` is 'Recreate'". Under Helm 4 the default
-  # server-side apply does not clear it and --force-conflicts does not help, so
-  # run that one switch with `helm upgrade --server-side=false`; Helm 3 patches
-  # client-side and needs no flag. Deleting the Deployment and letting Helm
-  # recreate it also works. Setting it at install time avoids all of this.
+  # Overrides are deep-merged into the above, so set only the keys you mean to
+  # change. Note that maxUnavailable must stay non-zero while maxSurge is 0:
+  # the API server rejects both being 0.
   strategy: {}
-    # type: Recreate
 
   service:
     type: ClusterIP


### PR DESCRIPTION
## Summary

`mcp-mesh-grafana` and `mcp-mesh-tempo` ship a `Deployment` with `replicas: 1` hardcoded and a `ReadWriteOnce` PVC **enabled by default**. With the API-default `maxSurge: 25%`, `RollingUpdate` starts the incoming pod before the outgoing one is gone, so on a multi-node cluster it cannot mount the claim and the rollout never finishes. Both charts are in the default `mcp-mesh-core` path, so a standard install carries two workloads that deadlock on any pod-template change.

The fix is `maxSurge: 0` / `maxUnavailable: 1`, **derived in the template**, leaving `type: RollingUpdate`.

## Why not the StatefulSet conversion this issue proposes

Measured: converting a Deployment + plain PVC to a StatefulSet with `volumeClaimTemplates` **silently destroys the data**.

```
STATUS: deployed / REVISION: 2
storage-v-mig-0   Bound   pvc-98eff722-…     <- brand-new empty volume
                                             <- v-mig-pvc: GONE
cat: can't open '/data/marker.txt': No such file or directory
```

The old PVC is dropped from the manifest with no `keep` on the live object, so Helm deletes it — reporting success. That would have shipped #1416's failure mode across 9 live installs.

Two further traps on that route, for the record: a StatefulSet with the default `podManagementPolicy: OrderedReady` **will not roll a crash-looping pod at all** (measured stuck ~2 min with `updateRevision` never applied; needs a manual pod delete), and `podManagementPolicy` is immutable, so getting it wrong at creation is unfixable in place. `volumeClaimTemplates` is immutable too — a one-way door in both directions.

The plain-PVC StatefulSet variant *does* work, and works structurally (the replacement pod has the same name, so two cannot coexist). It is simply more change than needed. Worth keeping in mind only if the transient attach warning below ever matters in the field — and then: plain PVC plus `podManagementPolicy: Parallel`, never `volumeClaimTemplates`.

## Why the default is derived in the template, not in `values.yaml`

`strategy` is a map and Helm deep-merges it. A populated default in `values.yaml` plus an operator who followed #1410's guidance and set `strategy.type: Recreate` yields *both* keys:

```
The Deployment "x" is invalid: spec.strategy.rollingUpdate: Forbidden:
may not be specified when strategy `type` is 'Recreate'
```

That is exactly the unconditional-failure class #1410 was reverted to avoid, relocated into a values merge. So `values.yaml` keeps `strategy: {}` and the template resolves the default, gating `rollingUpdate` on the resolved type.

## This fixes #1410's `Forbidden` trap rather than sidestepping it

Because the chart now **owns** `.spec.strategy.rollingUpdate` instead of leaving it to API defaulting, switching a live release to `Recreate` now succeeds under Helm 4 SSA with no flags — verified from a release whose previous revision had the block set. `--server-side=false` no longer appears anywhere in the repo.

## `maxUnavailable: 1` is load-bearing

It API-defaults to 25%, which rounds down to **0** at `replicas: 1`, and the API server rejects that:

```
spec.strategy.rollingUpdate.maxUnavailable: Invalid value: 0:
may not be 0 when 'maxSurge' is 0
```

Verified by driving it deliberately (the release went `failed`, then recovered on the next upgrade). Documented as a constraint on overrides in all five values files.

## Deadlock reproduced, then fixed

k3s, 5 nodes, `storageClassName: longhorn` pinned — the cluster has two default StorageClasses and `local-path` node-pins, which would not reproduce the bug. Cross-node move forced with a required `podAntiAffinity`.

Baseline live object confirms the trigger: `{"rollingUpdate":{"maxSurge":"25%","maxUnavailable":"25%"},"type":"RollingUpdate"}`.

**grafana**, wedged:
```
Waiting for deployment rollout to finish: 1 old replicas are pending termination...
error: timed out waiting for the condition          (180s)
…-56b9969586-qwc7d   0/1  ContainerCreating  3m55s  beelink4
…-645d7774f5-d8kr2   1/1  Running            4m32s  beelink5
Warning FailedAttachVolume  Multi-Attach error for volume "pvc-42f70115-…"
```
then `helm upgrade` to this branch, no flags → `deployed`, `{"rollingUpdate":{"maxSurge":0,"maxUnavailable":1},…}`, rolled out in **32s**, single pod.

**tempo**: same shape, `rollout status` timed out at 180s, upgrade converged in **47s**.

**Rescuing a `failed` release**: baseline `--wait --timeout 90s` wedged it to `failed rev 2`; upgrade to this branch reached `deployed rev 3` in 25s, no manual step, no `--server-side=false`.

## Operator-value matrix — rendered and applied live, Helm 3.19.0 and 4.0.1

| values | rendered | live |
|---|---|---|
| `{}` | `RollingUpdate` + `0`/`1` | deployed |
| `type: Recreate` | `Recreate`, no `rollingUpdate` | deployed, live `{"type":"Recreate"}` |
| `rollingUpdate.maxSurge: 1` | `maxSurge: 1` | deployed |
| dropping a prior `Recreate` | `RollingUpdate` + `0`/`1` | deployed |

Plus: an operator already on `strategy.type: Recreate` per #1410 upgrades cleanly keeping the override, and cleanly after dropping it. Umbrella paths render correctly through core. `strategy:` explicitly null falls back to the default. Full core umbrella server dry-run: all 20 objects accepted.

## Scope: grafana and tempo only

`mcp-mesh-agent` and `mcp-mesh-redis` also gained the `strategy` passthrough in #1410, but their persistence is opt-in, so the default path has nothing to fix. On the agent, `maxSurge: 0` would be a regression: `replicaCount` is user-settable and autoscaling is supported, so it would force a capacity dip on every rollout of a stateless multi-replica agent for no benefit. Redis mounts an `emptyDir` by default — a pod swap contends over nothing.

A conditional derivation (`persistence.enabled && replicaCount == 1 && !autoscaling.enabled`) was considered and rejected: it makes `.spec.strategy` a function of unrelated values, so flipping `persistence` would silently rewrite rollout semantics.

Their **docs** were rewritten anyway, so they no longer point at `Recreate`.

## Honest caveat, documented in every rewritten block

`maxSurge: 0` does not eliminate the transient overlap — the scale-down and scale-up are issued in the same second, so one `FailedAttachVolume` / `Multi-Attach` event is still logged per pod-template change. It converges unaided; the window is bounded by `terminationGracePeriodSeconds` plus CSI detach. Measured end to end on a forced cross-node move: grafana **27s**, tempo **50s**. The values comments say "under a minute in practice" rather than a single number.

## Validation

Default render vs `793cd16fa` is exactly two hunks (the new `strategy` block in each chart); `mcp-mesh-agent` and `mcp-mesh-redis` standalone renders byte-identical; Helm 3 and Helm 4 renders identical to each other. Baseline from two fresh detached worktrees each with its own `helm dependency update` (`helm/*/charts/*.tgz` is gitignored), passwords pinned. `helm lint` clean on grafana, tempo, agent, redis and core on both binaries; `check_helm_pss.py` all 9 charts OK.

## Pre-existing snag found while testing, not addressed

Installing `helm/mcp-mesh-grafana` **from the source tree** wedges on `MountVolume.SetUp failed for volume "dashboards": configmap "…-dashboard" not found` — `templates/configmap-dashboard.yaml` reads `files/dashboards/*.json`, which is populated only at release time, so the ConfigMap renders empty while the Deployment mounts it unconditionally. Released chart tarballs are unaffected; anyone testing from a clone hits it. Filed separately.

Closes #1411


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment rollout guidance for persistent single-writer (RWO) volumes, including when to keep the Kubernetes default strategy.
  * Clarified how to avoid rollout deadlocks by pinning `rollingUpdate.maxSurge: 0` (while keeping `maxUnavailable` non-zero) and described expected temporary `FailedAttachVolume`/Multi-Attach events.
  * Rewrote Grafana and Tempo persistence strategy explanations and tightened security context documentation.

* **Improvements**
  * Grafana and Tempo now apply safer explicit rollout defaults when using `RollingUpdate`.
  * Tempo now validates and rejects security context settings that should be configured at the correct pod level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->