### PR TITLE
fix(helm): keep Grafana's data volume on uninstall

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -155,6 +155,18 @@ helm get values <release>
   derived is application data: if your own workloads used the bundled PostgreSQL
   or Redis for their own storage, that data is yours to protect before you tear
   anything down.
+- **`helm uninstall` no longer reclaims Grafana's data volume.** The Grafana
+  PVC picks up a `"helm.sh/resource-policy": keep` annotation on upgrade, so
+  Helm skips it on uninstall — `grafana.persistence.enabled` defaults to `true`,
+  and the dashboards, annotations, users, and API keys in `grafana.db` are not
+  derived from anything the mesh can replay. Previously that volume was deleted
+  along with the release. A reinstall under the same release name adopts the
+  existing claim, data intact; reclaim the storage deliberately with
+  `kubectl delete pvc <release>-mcp-mesh-grafana-pvc -n <ns>`. This lands on a
+  plain `helm upgrade` with no pod restart — the claim never leaves the rendered
+  manifest, so it is a metadata-only patch. Tempo's PVC is unchanged and still
+  deleted on uninstall: it is a rolling trace buffer under active retention, not
+  durable storage.
 - **The core release owns its `Namespace`** (`namespaceCreate`, default
   `true`). Older charts let `helm uninstall` delete that namespace and cascade
   to every co-located agent, Secret, and PVC. Upgrading fixes this with no

--- a/helm/mcp-mesh-core/README.md
+++ b/helm/mcp-mesh-core/README.md
@@ -19,12 +19,12 @@ This umbrella chart deploys the core MCP Mesh infrastructure components:
 
 ```bash
 # Install core infrastructure
-helm install mcp-mesh-core ./mcp-mesh-core \
+helm install mcp-core ./mcp-mesh-core \
   -n mcp-mesh --create-namespace \
   --set namespaceCreate=false
 
 # Or with custom values
-helm install mcp-mesh-core ./mcp-mesh-core \
+helm install mcp-core ./mcp-mesh-core \
   -n mcp-mesh --create-namespace \
   --set namespaceCreate=false \
   -f my-values.yaml
@@ -43,7 +43,7 @@ that already exists, and for what applies to a release that already exists.
 
 ```bash
 # Port forward to access registry
-kubectl port-forward -n mcp-mesh svc/mcp-mesh-core-mcp-mesh-registry 8000:8000
+kubectl port-forward -n mcp-mesh svc/mcp-core-mcp-mesh-registry 8000:8000
 
 # Check health
 curl http://localhost:8000/health
@@ -98,7 +98,7 @@ and install with `--take-ownership` (Helm 3.17+ and Helm 4):
 
 ```bash
 kubectl create namespace mcp-mesh
-helm install mcp-mesh-core ./mcp-mesh-core \
+helm install mcp-core ./mcp-mesh-core \
   -n mcp-mesh --set global.namespace=mcp-mesh --take-ownership
 ```
 
@@ -127,14 +127,14 @@ was rendered by 3.4.0 or later — two separate upgrades:
 
 ```bash
 # 1. Upgrade to >= 3.4.0, leaving namespaceCreate alone.
-helm upgrade mcp-mesh-core ./mcp-mesh-core -n mcp-mesh --reuse-values
+helm upgrade mcp-core ./mcp-mesh-core -n mcp-mesh --reuse-values
 
 # Confirm the live namespace picked up the policy before going further.
 kubectl get ns mcp-mesh -o jsonpath='{.metadata.annotations}'
 #   {"helm.sh/resource-policy":"keep","meta.helm.sh/release-name":...}
 
 # 2. Only then, and only if you want it, drop the Namespace from the release.
-helm upgrade mcp-mesh-core ./mcp-mesh-core -n mcp-mesh --reuse-values \
+helm upgrade mcp-core ./mcp-mesh-core -n mcp-mesh --reuse-values \
   --set namespaceCreate=false
 ```
 
@@ -161,16 +161,16 @@ cascading the release secret with it. Uninstall the wreckage and reinstall with
 the recipe from "Installation":
 
 ```bash
-helm uninstall mcp-mesh-core -n mcp-mesh
-helm install mcp-mesh-core ./mcp-mesh-core \
+helm uninstall mcp-core -n mcp-mesh
+helm install mcp-core ./mcp-mesh-core \
   -n mcp-mesh --set namespaceCreate=false
 ```
 
 The uninstall keeps the namespace (`resource-policy: keep`), so the reinstall
 does not need `--create-namespace`. It also keeps the generated PostgreSQL and
-Grafana Secrets, and the StatefulSet's PVC — all deliberate, and all reused by
-the reinstall. Delete them by hand if you want the install to start from
-scratch.
+Grafana Secrets, Grafana's data PVC, and the StatefulSet's PVC — all
+deliberate, and all reused by the reinstall. Delete them by hand if you want
+the install to start from scratch.
 
 ## Configuration
 
@@ -239,7 +239,11 @@ Lifecycle:
   secret is never applied. Reset it in place
   (`kubectl exec deploy/<release>-mcp-mesh-grafana -- grafana-cli admin
   reset-admin-password <new-password>` — use the generated value from the
-  secret to keep it in sync), or delete the Grafana PVC before upgrading.
+  secret to keep it in sync), or delete the Grafana PVC before upgrading. That
+  PVC also carries `helm.sh/resource-policy: keep`, so deleting it means an
+  explicit `kubectl delete pvc` (see
+  [Adopting `existingSecret`](#adopting-existingsecret-on-an-existing-install)
+  for the ordering) — an uninstall/reinstall cycle will not clear it.
 
 #### Explicit credentials
 
@@ -379,15 +383,21 @@ kubectl exec deploy/mcp-core-mcp-mesh-grafana -n mcp-mesh -- \
   grafana-cli admin reset-admin-password <new-password>
 ```
 
-or reprovision from an empty volume, which requires this order (the PVC is
-release-owned and its deletion blocks on the `pvc-protection` finalizer while a
-pod has it mounted, and nothing recreates the claim by itself):
+or reprovision from an empty volume, which requires this order (deleting the
+claim blocks on the `pvc-protection` finalizer while a pod has it mounted, and
+nothing recreates the claim by itself):
 
 ```bash
 kubectl scale deploy/mcp-core-mcp-mesh-grafana -n mcp-mesh --replicas=0
 kubectl delete pvc mcp-core-mcp-mesh-grafana-pvc -n mcp-mesh
 helm upgrade mcp-core helm/mcp-mesh-core -n mcp-mesh ...  # recreates PVC + pod
 ```
+
+Delete the claim explicitly, as above — `helm uninstall` does not do it for
+you. The PVC carries `helm.sh/resource-policy: keep`, so an uninstall leaves
+the volume behind and a reinstall adopts it along with the `grafana.db` that
+still holds the old password. The annotation only tells Helm to skip the
+object; `kubectl delete pvc` is unaffected.
 
 Grafana then initializes from `GF_SECURITY_ADMIN_PASSWORD`, i.e. your secret.
 All dashboards, users, and annotations stored in `grafana.db` are lost — the
@@ -632,7 +642,7 @@ mcp-mesh-registry:
 ## Uninstall
 
 ```bash
-helm uninstall mcp-mesh-core -n mcp-mesh
+helm uninstall mcp-core -n mcp-mesh
 ```
 
 This removes the core workloads — registry, PostgreSQL, Redis, and, when
@@ -657,6 +667,38 @@ by the StatefulSet's volume claim template, which the release does not own, so
 namespace around it) that destroys the data. Bundled Redis writes to an
 `emptyDir` unless you enable persistence against a PVC you created yourself, so
 treat its contents as ephemeral either way.
+
+### What uninstall leaves behind
+
+`helm uninstall` does not reclaim every volume, and the differences are
+deliberate:
+
+| Object | Kept? | Why |
+| ------ | ----- | --- |
+| `<release>-mcp-mesh-grafana-pvc` | yes (`resource-policy: keep`) | Holds `grafana.db`: dashboards, annotations, users, and API keys authored in the UI. `persistence.enabled` defaults to `true`, and a volume the chart enables by default should not be discarded by a command that reports success |
+| `<release>-mcp-mesh-grafana-secret` | yes (`resource-policy: keep`) | Only record of the admin password Grafana is actually running with — it is applied on first start and then lives in the volume above |
+| `postgres-data-<release>-mcp-mesh-postgres-0` | yes (not release-owned) | Created by the StatefulSet's claim template, so Helm never had it to delete |
+| `<release>-mcp-mesh-postgres-credentials` | yes (`resource-policy: keep`) | Must keep matching the provisioned data directory |
+| `<release>-mcp-mesh-tempo-pvc` | **no** | A rolling trace buffer, not durable storage: `retention` (default `1h`) prunes it continuously, so what it holds is minutes old and already expiring |
+| Namespace | yes (`resource-policy: keep`) | See [Namespace handling](#namespace-handling) |
+
+Reinstalling under the same release name adopts all of the kept objects, with
+their data. To reclaim the storage instead, delete the claims yourself — the
+annotation only stops Helm, not `kubectl`:
+
+```bash
+kubectl delete pvc mcp-core-mcp-mesh-grafana-pvc -n mcp-mesh
+kubectl delete pvc postgres-data-mcp-core-mcp-mesh-postgres-0 -n mcp-mesh
+```
+
+(While a release is still running, scale the owning workload to `0` first — the
+delete otherwise blocks on the `pvc-protection` finalizer until the pod releases
+the volume. Grafana's is a Deployment;
+[Adopting `existingSecret`](#adopting-existingsecret-on-an-existing-install) has
+the full ordering, including the `helm upgrade` that recreates the claim.
+PostgreSQL's is a StatefulSet, so scale
+`statefulset/mcp-core-mcp-mesh-postgres` instead — its volume claim template
+recreates the PVC by itself on the next scale-up.)
 
 The namespace is left in place, whichever way it was created. A release
 installed with `namespaceCreate=false` never owned the namespace in the first

--- a/helm/mcp-mesh-core/templates/NOTES.txt
+++ b/helm/mcp-mesh-core/templates/NOTES.txt
@@ -70,6 +70,28 @@ password retrieved above into the new secret — Grafana applies a password only
 on first start, so with persistence enabled any other value has no effect until
 the volume is reset.
 {{- end }}
+{{- $gfPersist := dig "grafana" "persistence" (dict) (index .Values "mcp-mesh-grafana" | default dict) }}
+{{- if and .Values.grafana.enabled ($gfPersist.enabled | default false) }}
+
+Grafana keeps its data (dashboards, annotations, users, and API keys authored
+in the UI) on a claim that carries resource-policy: keep:
+
+  PersistentVolumeClaim/{{ include "mcp-mesh-core.grafanaFullname" . }}-pvc
+
+So `helm uninstall` leaves it in place and does NOT reclaim the storage — a
+reinstall under the same release name picks the same volume back up, data
+intact. Reclaim it deliberately with:
+  kubectl scale deploy/{{ include "mcp-mesh-core.grafanaFullname" . }} -n {{ .Release.Namespace }} --replicas=0
+  kubectl delete pvc {{ include "mcp-mesh-core.grafanaFullname" . }}-pvc -n {{ .Release.Namespace }}
+(the scale-down is only needed while a pod still has it mounted). Helm reads
+that policy off the live object, so a release coming from a chart that predates
+the annotation is covered from the NEXT upgrade onward.
+
+The bundled PostgreSQL volume behaves the same way for a different reason: it
+is created by the StatefulSet's claim template, which the release does not own.
+Tempo's volume is NOT kept — it is a rolling trace buffer under active
+retention, so uninstall reclaims it.
+{{- end }}
 {{- /* Only fires on the real remaining hazard: namespaceCreate renders
        global.namespace, which is independent of -n. Uninstall safety itself
        needs no warning — the Namespace carries resource-policy: keep. */}}

--- a/helm/mcp-mesh-core/templates/_helpers.tpl
+++ b/helm/mcp-mesh-core/templates/_helpers.tpl
@@ -21,7 +21,8 @@ nameOverride/fullnameOverride desyncing this default derivation.
 {{- end }}
 
 {{/*
-Name of the auto-generated Grafana admin Secret, for NOTES output. The source
+Names of the Grafana objects referenced in NOTES output: the fullname (used for
+the Deployment and the data PVC) and the auto-generated admin Secret. The source
 of truth is "mcp-mesh-grafana.secretName" (+ "mcp-mesh-grafana.fullname") in
 helm/mcp-mesh-grafana/templates/_helpers.tpl; the umbrella cannot call subchart
 helpers, so this reproduces only its RELEASE-NAME branch.
@@ -33,12 +34,16 @@ NotFound. Nothing catches that — unlike postgres, this chart has neither a
 guard nor a generatedSecretName escape hatch (only NOTES text is affected, so
 no workload breaks). Keep the derivations in sync by hand when either changes.
 */}}
-{{- define "mcp-mesh-core.grafanaSecretName" -}}
+{{- define "mcp-mesh-core.grafanaFullname" -}}
 {{- if contains "mcp-mesh-grafana" .Release.Name -}}
-{{- printf "%s-secret" (.Release.Name | trunc 63 | trimSuffix "-") -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-secret" (printf "%s-mcp-mesh-grafana" .Release.Name | trunc 63 | trimSuffix "-") -}}
+{{- printf "%s-mcp-mesh-grafana" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- end }}
+
+{{- define "mcp-mesh-core.grafanaSecretName" -}}
+{{- printf "%s-secret" (include "mcp-mesh-core.grafanaFullname" .) -}}
 {{- end }}
 
 {{/*

--- a/helm/mcp-mesh-grafana/templates/NOTES.txt
+++ b/helm/mcp-mesh-grafana/templates/NOTES.txt
@@ -12,4 +12,25 @@ The generated value is reused on helm upgrade. Grafana applies it only on
 first start — with persistence enabled, the password set at install time
 stays in effect (reset with: grafana-cli admin reset-admin-password).
 {{- end }}
+{{- if .Values.grafana.persistence.enabled }}
+
+Grafana's data volume holds grafana.db — the dashboards, annotations, users,
+and API keys created in the UI:
+
+  PersistentVolumeClaim/{{ include "mcp-mesh-grafana.fullname" . }}-pvc ({{ .Values.grafana.persistence.size }})
+
+It carries "helm.sh/resource-policy": keep, so `helm uninstall` leaves it in
+place and does NOT reclaim that storage. Reinstalling under the same release
+name adopts it, data intact.
+
+To reclaim it deliberately (this destroys everything authored in the UI):
+
+  kubectl scale deploy/{{ include "mcp-mesh-grafana.fullname" . }} -n {{ .Release.Namespace }} --replicas=0
+  kubectl delete pvc {{ include "mcp-mesh-grafana.fullname" . }}-pvc -n {{ .Release.Namespace }}
+
+After an uninstall the Deployment is already gone, so only the second command
+is needed. Helm reads the policy off the live object, so a release installed
+from a chart that predates this annotation is covered from the next
+`helm upgrade` onward.
+{{- end }}
 {{- end }}

--- a/helm/mcp-mesh-grafana/templates/pvc.yaml
+++ b/helm/mcp-mesh-grafana/templates/pvc.yaml
@@ -1,3 +1,33 @@
+{{- /*
+helm.sh/resource-policy: keep — grafana.persistence.enabled defaults to true,
+and a volume the chart enables by default should not be discarded by a command
+that reports success. Without the annotation this claim is release-owned and
+`helm uninstall` deletes it, taking grafana.db with it: every dashboard,
+annotation, user, and API key authored in the UI. None of that is derived from
+anything the mesh can replay — only the datasources and the ConfigMap-mounted
+dashboards come back on reinstall.
+
+This also makes the chart internally consistent. The admin-password Secret next
+door is already `keep` (see secret.yaml), and Grafana applies
+GF_SECURITY_ADMIN_PASSWORD only on first start — so the Secret is a record of a
+password whose authoritative copy lives in the very database this volume holds.
+Keeping one and dropping the other leaves the credential without the state it
+unlocks. The bundled PostgreSQL reaches the same outcome by accident: its data
+sits on a volumeClaimTemplates PVC the release does not own, so uninstall leaves
+it behind.
+
+Consequence, stated in values.yaml and NOTES.txt: `helm uninstall` no longer
+reclaims this storage. A reinstall under the same release name adopts the
+existing claim (and its data); reclaim it deliberately with
+`kubectl delete pvc <release>-mcp-mesh-grafana-pvc -n <ns>`. The annotation only
+tells Helm to skip the object — an explicit kubectl delete still works, which is
+what the "reprovision from an empty volume" recipe in the mcp-mesh-core README
+relies on.
+
+Unlike the Namespace case, the claim is never dropped from the rendered
+manifest, so the annotation lands on a live PVC through a plain `helm upgrade`
+with no pod churn — metadata-only patch, nothing in the pod template moves.
+*/ -}}
 {{- if and .Values.grafana.enabled .Values.grafana.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -5,6 +35,8 @@ metadata:
   name: {{ include "mcp-mesh-grafana.fullname" . }}-pvc
   labels:
     {{- include "mcp-mesh-grafana.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   accessModes:
     {{- range .Values.grafana.persistence.accessModes }}

--- a/helm/mcp-mesh-grafana/values.yaml
+++ b/helm/mcp-mesh-grafana/values.yaml
@@ -24,6 +24,21 @@ grafana:
       memory: "512Mi"
       cpu: "500m"
 
+  # Persistent storage for /var/lib/grafana (grafana.db). Enabled by default, so
+  # dashboards, annotations, users, and API keys authored in the UI survive a
+  # pod restart. Disable it and Grafana runs on an emptyDir: the provisioned
+  # datasources and ConfigMap dashboards still come back, everything authored
+  # in the UI does not.
+  #
+  # The claim carries "helm.sh/resource-policy": keep, so `helm uninstall` does
+  # NOT delete it and does NOT reclaim the storage — a volume enabled by default
+  # is not something an uninstall should discard silently, and the admin-password
+  # Secret in this chart is kept for the same reason. Reinstalling under the same
+  # release name adopts the existing claim with its data intact. To reclaim the
+  # storage, delete the claim yourself (the annotation only stops Helm):
+  #   kubectl delete pvc <release>-mcp-mesh-grafana-pvc -n <namespace>
+  # Scale the Deployment to 0 first — the delete otherwise blocks on the
+  # pvc-protection finalizer while a pod has the volume mounted.
   persistence:
     enabled: true
     size: 2Gi
@@ -96,7 +111,11 @@ grafana:
     # Upgrade first (check the annotation is on the live secret), adopt second.
     # To switch to a different password, change it in Grafana afterwards
     # (grafana-cli admin reset-admin-password) or reprovision from an empty
-    # PVC — see the mcp-mesh-core README for the ordering.
+    # volume. Reprovisioning means deleting the claim explicitly — scale the
+    # Deployment to 0, `kubectl delete pvc`, then upgrade; uninstall/reinstall
+    # does NOT do it, because the claim carries resource-policy: keep and the
+    # reinstall adopts the old database (and with it the old password). See the
+    # mcp-mesh-core README for the exact ordering.
     existingSecret: ""
     existingSecretPasswordKey: "admin-password"
     # Auto-generate the admin password when neither adminPassword nor


### PR DESCRIPTION
## Summary

`helm/mcp-mesh-grafana/templates/pvc.yaml` was a plain release-owned PVC with no `helm.sh/resource-policy`, so `helm uninstall` deleted it along with `grafana.db`. The bundled PostgreSQL keeps its data on a `volumeClaimTemplates` PVC the release does not own, so its volume survives. The component holding **derived** state retained its volume; the component holding **authored** state discarded it.

This adds `keep` to the Grafana data volume and documents what uninstall now leaves behind.

## Framing

This is a contract fix, not a data-loss recovery. A survey of the live installs found **no authored Grafana state** — one ConfigMap-provisioned dashboard, one default admin user, zero annotations, an identical 1.2M `grafana.db` on each. The harm was latent.

The argument that holds regardless: `persistence.enabled` defaults to `true`, and a volume the chart enables by default should not be discarded by a command that reports success. The Secret in this same chart is already `keep`, so this makes the chart internally consistent — the credential survived while the data it unlocked did not.

## Tempo deliberately untouched

Measured on a live 25-hour-old install: **3.1M on a 5Gi claim**, oldest block **31 minutes** old, `retention: "1h"` actively pruning. It is a rolling buffer, not durable storage, so `keep` would be wrong there. Whether it should have a PVC at all is #1423.

Verified live rather than assumed — see validation (4).

## Also fixed: a recipe this change silently breaks

`helm/mcp-mesh-grafana/values.yaml` offered "reprovision from an empty PVC" as a way to reset the admin password. That recipe worked *because* uninstall deleted the volume; once the PVC is kept it stops working, with no error. Rewritten here, along with the same recipe in `helm/mcp-mesh-core/README.md`.

The README gained a **"What uninstall leaves behind"** table, since the answer is now genuinely mixed across the bundled components.

## Validation

CI runs no helm jobs on a PR (#1421), so this is local plus live cluster, on **Helm 3.19.0 and 4.0.1**.

1. **Annotation lands via plain `helm upgrade`, no pod churn.** Baseline installed from a throwaway worktree at `d385a43a8`, marker seeded into the volume, upgraded with no extra flags: same pod uid (`8998eb93…` h4, `f28b74ea…` h3), same PVC uid, live annotations gained `keep`. Unlike the Namespace case, the PVC is never dropped from the manifest, so there is nothing for SSA to clear.
2. **Survives uninstall**, both versions:
   ```
   These resources were kept due to the resource policy:
   [PersistentVolumeClaim] gf-mcp-mesh-grafana-pvc
   [Secret] gf-mcp-mesh-grafana-secret
   ```
   A scratch pod mounting the claim read the marker back, alongside a retained `grafana.db`.
3. **Re-adopted on reinstall** under the same release name, marker intact, same PVC uid.
4. **Tempo still deleted.** Full `mcp-mesh-core` install then uninstall: remaining PVCs were exactly `mcp-core-mcp-mesh-grafana-pvc` and `postgres-data-mcp-core-mcp-mesh-postgres-0`; `mcp-core-mcp-mesh-tempo-pvc` gone.
5. **Default render delta vs `d385a43a8` is two lines**, on one PVC:
   ```
   @@ -306,6 +306,8 @@  charts/mcp-mesh-grafana/templates/pvc.yaml
   +  annotations:
   +    "helm.sh/resource-policy": keep
   ```
   Tempo's PVC in the same render carries no `annotations:` block. Baseline from a fresh worktree with its own `helm dependency update` — `helm/*/charts/*.tgz` is gitignored, so a stale archive would silently mask a delta.
6. `helm lint` grafana + core: 0 failed. `check_helm_pss.py`: all 9 OK.

## Corrections made while validating

- **The postgres claim is `postgres-data-<sts>-0`, not `data-<sts>-0`** (`volumeClaimTemplates[0].metadata.name: postgres-data`). Caught against live PVCs; the README table and reclaim snippet were wrong before being corrected.
- **A first Helm 3 run produced a false PASS** — `kubectl exec` raced container start, the marker was never written, and an empty-vs-empty comparison "passed". Re-run with a retry loop, explicit `-c grafana`, and a non-empty guard. The numbers above are from the corrected run.
- `mcp-mesh-core.grafanaSecretName` had no fullname helper to build on, so NOTES could not name the PVC or Deployment. Extracted `mcp-mesh-core.grafanaFullname` rather than adding a third copy of the release-name derivation; truncation semantics are identical.

## Note for reviewers

Probes used `--set grafana.dashboards.enabled=false` — installing this chart from a source clone wedges on a missing dashboards ConfigMap, because `files/dashboards/` is gitignored and populated only at release time while the Deployment mounts it unconditionally. That is **#1419**, unrelated to this change.

Closes #1416


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grafana data is now preserved when uninstalling the Helm release, including dashboards, users, API keys, and credentials.
  * Reinstalling with the same release name can reuse the existing Grafana data.

* **Documentation**
  * Added guidance for reclaiming Grafana storage, including required scaling and PVC deletion steps.
  * Clarified which storage remains after uninstall and how to recover from failed installations.
  * Documented that Tempo storage behavior is unchanged and its PVC is still removed on uninstall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->