### PR TITLE
ci: run the chart and bump-guard checks that already existed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,136 @@ jobs:
             tests/unit/test_sse_strips_mcp_mesh_tool_params.py \
             tests/unit/test_stream_settle.py -q
 
+  # Issue #1399: scripts/test_bump_version.py was referenced by nothing — not a
+  # workflow, not the Makefile, not the docs. It is the only regression net for
+  # two defect classes bump_version.py's own guards structurally cannot see
+  # (prefix corruption of our own pins, and provenance prose being rewritten),
+  # and the guards it covers only run during a release bump. So a weakened guard
+  # would have surfaced at the same moment #1379 did: mid-release.
+  #
+  # Discovers the whole directory rather than naming one file, so the next
+  # scripts/test_*.py is enforced the day it lands instead of the day someone
+  # remembers to add a line here. It is stdlib-only and finishes in well under a
+  # second; the job cost is almost entirely the Python setup.
+  scripts-test:
+    name: Repo Script Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run scripts/ tests
+        run: python3 -m pytest scripts/ -v
+
+      # The file documents `python scripts/test_bump_version.py` as a supported
+      # entry point, and that __main__ runner collects tests by a different rule
+      # than pytest does. Run it too so it cannot rot into a no-op.
+      - name: Run the direct entry point
+        run: python3 scripts/test_bump_version.py
+
+  # Issue #1421: helm lint and the PSS render used to run in exactly one place —
+  # helm-release.yml, on a `v*` tag — so a chart change met its first automated
+  # check during the release that published it. Six chart PRs merged with green
+  # walls containing zero chart validation; every defect in them was caught by
+  # hand.
+  #
+  # No `paths:` filter, deliberately. The job takes under a minute, and a
+  # skipped job reports the same green check as a passing one — a status wall
+  # that cannot distinguish "validated" from "not looked at" is the exact
+  # failure this job exists to fix. A filter would also have to enumerate every
+  # input to the render (helm/**, observability/grafana/dashboards/**, and the
+  # scripts/ checkers themselves), and would go quietly inert the day something
+  # new feeds the render and nobody updates the list.
+  helm-charts:
+    name: Helm Charts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The render diff needs the merge base, so it needs history and the
+          # base branch ref.
+          fetch-depth: 0
+
+      # Same version helm-release.yml packages with: this job is only worth
+      # having if it renders what the release will render.
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.13.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install PyYAML
+        run: pip install pyyaml==6.0.3
+
+      # Mirrors helm-release.yml. The dashboard ConfigMap only renders when the
+      # JSON is present, so without this step CI would validate a variant of the
+      # chart that is never released.
+      - name: Sync observability configs to Helm charts
+        run: |
+          mkdir -p helm/mcp-mesh-grafana/files/dashboards
+          cp observability/grafana/dashboards/*.json \
+             helm/mcp-mesh-grafana/files/dashboards/
+          ls -la helm/mcp-mesh-grafana/files/dashboards/
+
+      # helm/*/charts/*.tgz is gitignored, so a fresh checkout has no subchart
+      # archives at all and the umbrella cannot render until they are built.
+      - name: Update Helm chart dependencies
+        run: helm dependency update helm/mcp-mesh-core
+
+      - name: Lint Helm charts
+        run: |
+          for chart in helm/mcp-mesh-*; do
+            if [ -f "$chart/Chart.yaml" ]; then
+              echo "Linting $chart..."
+              helm lint "$chart"
+            fi
+          done
+
+      # lint parses templates; it says nothing about what they render. This
+      # renders every chart and asserts the PSS "restricted" profile, which is
+      # what catches valid-but-wrong YAML.
+      - name: Check Pod Security Standards compliance
+        run: python3 scripts/check_helm_pss.py
+
+      # ...and the PSS check renders defaults only. Template-time guards are
+      # inert on the default path by construction, so a deleted or inverted
+      # guard stays green through both steps above. This one renders each
+      # guard's fail path and the pass path next to it.
+      - name: Render chart guards with non-default values
+        run: python3 scripts/check_helm_render_matrix.py
+
+      # Reviewer aid, not a gate — see the header of the script for why CI
+      # cannot decide whether a chart delta is intended.
+      - name: Diff the rendered umbrella against the merge base
+        run: |
+          if [ -n "${{ github.base_ref }}" ]; then
+            BASE="origin/${{ github.base_ref }}"
+          else
+            BASE="HEAD^"
+          fi
+          scripts/helm_render_diff.sh "$BASE" | tee /tmp/render-diff.txt
+          {
+            echo '### Rendered umbrella diff'
+            echo
+            echo '```diff'
+            head -n 400 /tmp/render-diff.txt
+            if [ "$(wc -l < /tmp/render-diff.txt)" -gt 400 ]; then
+              echo "... truncated; see the step log for the full diff"
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   security-scan:
     name: Security Scanning
     runs-on: ubuntu-latest
@@ -388,6 +518,8 @@ jobs:
         typescript-test,
         java-test,
         ui-test,
+        scripts-test,
+        helm-charts,
         build-and-package,
       ]
     if: always()
@@ -403,6 +535,8 @@ jobs:
           echo "TypeScript Tests: ${{ needs.typescript-test.result }}"
           echo "Java Tests: ${{ needs.java-test.result }}"
           echo "UI Dashboard Tests: ${{ needs.ui-test.result }}"
+          echo "Repo Script Tests: ${{ needs.scripts-test.result }}"
+          echo "Helm Charts: ${{ needs.helm-charts.result }}"
           echo "Build and Package: ${{ needs.build-and-package.result }}"
 
           # Allow skipped status for temporarily disabled jobs
@@ -412,6 +546,8 @@ jobs:
              [[ "${{ needs.typescript-test.result }}" != "success" ]] || \
              [[ "${{ needs.java-test.result }}" != "success" ]] || \
              [[ "${{ needs.ui-test.result }}" != "success" ]] || \
+             [[ "${{ needs.scripts-test.result }}" != "success" ]] || \
+             [[ "${{ needs.helm-charts.result }}" != "success" ]] || \
              [[ "${{ needs.build-and-package.result }}" != "success" ]]; then
             echo "❌ CI pipeline failed"
             exit 1

--- a/scripts/check_helm_render_matrix.py
+++ b/scripts/check_helm_render_matrix.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Render the helm/ charts with NON-DEFAULT values and assert every template-time
+guard still behaves: each guard's fail path fails with its own message, and the
+pass path next to it still renders.
+
+scripts/check_helm_pss.py renders defaults only, and a guard is by construction
+inert on the default path — `mcp-mesh-core.validateNamespaceResourcePolicy` and
+`mcp-mesh-grafana.validateCredentialSource` both emit nothing at all until a
+values file trips them. A defaults-only render therefore cannot tell a working
+guard from a broken one, or from one that was deleted: every one of these
+`fail` calls would stay green forever.
+
+Each case declares the values that reach the guard and what must happen:
+
+  expect_fail="<substring>"  helm template must exit non-zero AND say this
+  expect_fail=None           helm template must succeed (the pass path)
+
+The substring matters as much as the exit code. A guard rewritten to fire on
+the wrong condition still fails the render, just with someone else's message.
+
+Usage: python3 scripts/check_helm_render_matrix.py  (run from anywhere)
+Exit code 0 = every case behaved as declared.
+"""
+
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_helm_pss import HELM_DIR, build_dependencies  # noqa: E402
+
+# The five entries the v2.4.0 chart shipped as agent.environment defaults. A
+# values file copied from that release carries them without user intent, so the
+# removed-key guard tolerates them verbatim and only fails on divergence.
+V240_AGENT_ENVIRONMENT = {
+    "MCP_MESH_DISTRIBUTED_TRACING_ENABLED": "true",
+    "REDIS_URL": "redis://mcp-core-mcp-mesh-redis:6379",
+    "TELEMETRY_ENDPOINT": "mcp-core-mcp-mesh-tempo:4317",
+    "MCP_MESH_TRACING_ENABLED": "true",
+    "MCP_MESH_METRICS_ENABLED": "true",
+}
+
+
+@dataclass(frozen=True)
+class Case:
+    chart: str
+    name: str
+    values: dict
+    expect_fail: str | None = None
+    extra_args: tuple[str, ...] = field(default_factory=tuple)
+
+
+CASES: list[Case] = [
+    # --- mcp-mesh-core: Namespace resource-policy guard -------------------
+    Case(
+        "mcp-mesh-core",
+        "commonAnnotations may not override the Namespace's keep policy",
+        {"commonAnnotations": {"helm.sh/resource-policy": "delete"}},
+        expect_fail="blast radius",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "an explicit keep is a tolerated no-op",
+        {"commonAnnotations": {"helm.sh/resource-policy": "keep"}},
+    ),
+    # --- mcp-mesh-core: removed-key guards --------------------------------
+    Case(
+        "mcp-mesh-core",
+        "networkPolicies.enabled was removed",
+        {"networkPolicies": {"enabled": True}},
+        expect_fail="networkPolicies.enabled was never consumed",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "serviceMonitors.enabled was removed",
+        {"serviceMonitors": {"enabled": True}},
+        expect_fail="serviceMonitors.enabled was never consumed",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "global.coreReleaseName was removed",
+        {"global": {"coreReleaseName": "platform"}},
+        expect_fail="global.coreReleaseName was documentation-only",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "the shipped coreReleaseName default is grandfathered",
+        {"global": {"coreReleaseName": "mcp-core"}},
+    ),
+    # --- mcp-mesh-grafana (through the umbrella): credential source -------
+    Case(
+        "mcp-mesh-core",
+        "grafana generatedSecret=false with no credential",
+        {"mcp-mesh-grafana": {"grafana": {"config": {"generatedSecret": False}}}},
+        expect_fail="grafana.config.generatedSecret=false requires",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "grafana generatedSecret=false with existingSecret",
+        {
+            "mcp-mesh-grafana": {
+                "grafana": {
+                    "config": {"generatedSecret": False, "existingSecret": "gf-admin"}
+                }
+            }
+        },
+    ),
+    Case(
+        "mcp-mesh-core",
+        "grafana generatedSecret=false with an inline adminPassword",
+        {
+            "mcp-mesh-grafana": {
+                "grafana": {
+                    "config": {"generatedSecret": False, "adminPassword": "s3cret"}
+                }
+            }
+        },
+    ),
+    # --- mcp-mesh-grafana: securityContext migration + image tag ----------
+    Case(
+        "mcp-mesh-core",
+        "pod-only fields rejected in grafana.securityContext",
+        {"mcp-mesh-grafana": {"grafana": {"securityContext": {"fsGroup": 472}}}},
+        expect_fail="belong in grafana.podSecurityContext",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "the same field is accepted in grafana.podSecurityContext",
+        {"mcp-mesh-grafana": {"grafana": {"podSecurityContext": {"fsGroup": 472}}}},
+    ),
+    Case(
+        "mcp-mesh-core",
+        "an emptied grafana image tag",
+        {"mcp-mesh-grafana": {"grafana": {"image": {"tag": ""}}}},
+        expect_fail="grafana.image.tag must not be empty",
+    ),
+    # --- mcp-mesh-postgres (through the umbrella) -------------------------
+    Case(
+        "mcp-mesh-core",
+        "postgres generatedSecret=false with no credential",
+        {"global": {"postgres": {"generatedSecret": False}}},
+        expect_fail="global.postgres.generatedSecret=false requires",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "postgres generatedSecret=false with an inline password",
+        {"global": {"postgres": {"generatedSecret": False, "password": "pw"}}},
+    ),
+    Case(
+        "mcp-mesh-core",
+        "a full-DSN existing secret with no bare password key",
+        {
+            "global": {
+                "postgres": {"existingSecret": "pg", "existingSecretUrlKey": "dsn"}
+            }
+        },
+        expect_fail="existingSecretUrlKey cannot be combined",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "...and the same secret once a password key is named",
+        {
+            "global": {
+                "postgres": {
+                    "existingSecret": "pg",
+                    "existingSecretUrlKey": "dsn",
+                    "existingSecretPasswordKey": "password",
+                }
+            }
+        },
+    ),
+    Case(
+        "mcp-mesh-core",
+        "a name override that renames the generated postgres secret",
+        {"mcp-mesh-postgres": {"nameOverride": "db"}},
+        expect_fail="generatedSecretName",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "...and the same override once generatedSecretName follows it",
+        {
+            "mcp-mesh-postgres": {"nameOverride": "db"},
+            "global": {"postgres": {"generatedSecretName": "mcp-core-db-credentials"}},
+        },
+    ),
+    Case(
+        "mcp-mesh-core",
+        "an external postgres with the bundled subchart disabled",
+        {
+            "postgres": {"enabled": False},
+            "global": {
+                "postgres": {
+                    "host": "pg.example.internal",
+                    "password": "pw",
+                    "sslmode": "require",
+                }
+            },
+        },
+    ),
+    # --- mcp-mesh-redis (through the umbrella) ----------------------------
+    Case(
+        "mcp-mesh-core",
+        "redis credentials against the AUTH-less bundled server",
+        {"global": {"redis": {"password": "pw"}}},
+        expect_fail="cannot be combined with the bundled Redis chart",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "...and the same credentials once redis points somewhere external",
+        {
+            "redis": {"enabled": False},
+            "global": {"redis": {"host": "redis.example.internal", "password": "pw"}},
+        },
+    ),
+    # --- mcp-mesh-ui (through the umbrella) -------------------------------
+    Case(
+        "mcp-mesh-core",
+        "an unrecognised postgres sslmode",
+        {"ui": {"enabled": True}, "global": {"postgres": {"sslmode": "yes-please"}}},
+        expect_fail="global.postgres.sslmode must be one of",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "a recognised postgres sslmode",
+        {"ui": {"enabled": True}, "global": {"postgres": {"sslmode": "verify-full"}}},
+    ),
+    # --- mcp-mesh-agent (standalone chart) --------------------------------
+    Case(
+        "mcp-mesh-agent",
+        "an agent.environment entry that was never consumed",
+        {"agent": {"environment": {"MY_API_KEY": "abc"}}},
+        expect_fail="agent.environment was never consumed",
+    ),
+    Case(
+        "mcp-mesh-agent",
+        "an agent.environment default carried forward with a changed value",
+        {"agent": {"environment": {"MCP_MESH_TRACING_ENABLED": "false"}}},
+        expect_fail="diverges from the old shipped default",
+    ),
+    Case(
+        "mcp-mesh-agent",
+        "the v2.4.0 agent.environment defaults verbatim",
+        {"agent": {"environment": dict(V240_AGENT_ENVIRONMENT)}},
+    ),
+    # --- mcp-mesh-ingress (standalone chart) ------------------------------
+    Case(
+        "mcp-mesh-ingress",
+        "neither ingress pattern enabled",
+        {
+            "patterns": {
+                "hostBased": {"enabled": False},
+                "pathBased": {"enabled": False},
+            }
+        },
+        expect_fail="At least one ingress pattern",
+    ),
+    Case(
+        "mcp-mesh-ingress",
+        "a host-based ingress",
+        {
+            "patterns": {
+                "hostBased": {"enabled": True},
+                "pathBased": {"enabled": False},
+            }
+        },
+    ),
+]
+
+
+def run_case(case: Case, values_file: Path) -> str | None:
+    """Return None when the case behaved as declared, else a failure reason."""
+    values_file.write_text(yaml.safe_dump(case.values))
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "render-matrix",
+            str(HELM_DIR / case.chart),
+            "--values",
+            str(values_file),
+            *case.extra_args,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    output = result.stdout + result.stderr
+
+    if case.expect_fail is None:
+        if result.returncode != 0:
+            return f"expected a clean render, helm template failed:\n{_indent(output)}"
+        if not result.stdout.strip():
+            return "expected a clean render, helm template produced no manifests"
+        return None
+
+    if result.returncode == 0:
+        return (
+            f"expected the render to fail with {case.expect_fail!r}, "
+            "but it succeeded — the guard is gone or no longer reachable"
+        )
+    if case.expect_fail not in output:
+        return (
+            f"render failed, but not with {case.expect_fail!r} — a different "
+            f"guard (or a template error) fired:\n{_indent(output)}"
+        )
+    return None
+
+
+def _indent(text: str) -> str:
+    lines = text.strip().splitlines()
+    return "\n".join(f"      {line}" for line in lines[:12])
+
+
+def main() -> int:
+    for chart in sorted({c.chart for c in CASES}):
+        build_dependencies(chart)
+
+    failures = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        values_file = Path(tmp) / "values.yaml"
+        for case in CASES:
+            reason = run_case(case, values_file)
+            verdict = "fails" if case.expect_fail else "renders"
+            if reason is None:
+                print(f"OK   {case.chart}: {case.name} ({verdict})")
+            else:
+                failures += 1
+                print(f"FAIL {case.chart}: {case.name} ({verdict})")
+                print(f"  -> {reason}")
+
+    print(f"\n{len(CASES) - failures}/{len(CASES)} render cases behaved as declared")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/helm_render_diff.sh
+++ b/scripts/helm_render_diff.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Render the mcp-mesh-core umbrella at HEAD and at a base revision and print the
+# diff between the two manifest streams.
+#
+# This is a REVIEWER AID, not a gate: it always exits 0 when both sides render.
+# "Is this delta expected?" is a judgement about intent that CI cannot make — a
+# chart PR is supposed to change the render, and the guards recently added to
+# these charts change nothing at all on the default path. A job that went red on
+# any delta would be red on every chart PR; a job that went red on an empty
+# delta would have been red on the PRs that added those guards. What CI can do
+# is put a trustworthy diff in front of the reviewer, which is the part that is
+# tedious and easy to get wrong by hand:
+#
+#   * The baseline is rendered from a throwaway `git worktree`, never from the
+#     working tree. helm/*/charts/*.tgz is gitignored, so a baseline rendered in
+#     place would reuse whatever subchart archives happen to be lying around and
+#     silently compare HEAD's subcharts against themselves. A fresh worktree has
+#     no archives at all, so `helm dependency update` has to build them from
+#     that revision's sources.
+#
+#   * `helm dependency update` runs on BOTH sides. Subchart archives are not
+#     rebuilt just because a template changed (no version bump is involved), so
+#     without this the umbrella renders stale subcharts on the head side too.
+#
+#   * The generated credentials are pinned. mcp-mesh-grafana's admin-password
+#     and mcp-mesh-postgres's password are `randAlphaNum` when no cluster lookup
+#     answers, so an unpinned render differs from itself on every invocation and
+#     the diff is never clean.
+#
+#   * The grafana dashboards are synced from observability/ on both sides, the
+#     same way helm-release.yml does it before packaging, so the diff covers the
+#     manifests that are actually released rather than a dashboard-less variant.
+#
+# Usage: scripts/helm_render_diff.sh [BASE_REF]   (default: origin/main)
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE_REF="${1:-origin/main}"
+CHART="helm/mcp-mesh-core"
+
+# Applied identically to both sides. ui.enabled mirrors check_helm_pss.py: the
+# UI pod is optional and would otherwise never appear in the diff at all.
+RENDER_ARGS=(
+  --set ui.enabled=true
+  --set global.postgres.password=render-diff-pinned
+  --set mcp-mesh-grafana.grafana.config.adminPassword=render-diff-pinned
+)
+
+WORKDIR="$(mktemp -d)"
+cleanup() {
+  git -C "$REPO_ROOT" worktree remove --force "$WORKDIR/base" >/dev/null 2>&1
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+# Render the umbrella of the tree rooted at $1 into $2.
+render_tree() {
+  local tree="$1" out="$2"
+  if [ -d "$tree/observability/grafana/dashboards" ]; then
+    mkdir -p "$tree/helm/mcp-mesh-grafana/files/dashboards"
+    cp "$tree"/observability/grafana/dashboards/*.json \
+       "$tree/helm/mcp-mesh-grafana/files/dashboards/" 2>/dev/null || true
+  fi
+  helm dependency update "$tree/$CHART" >"$out.deps" 2>&1 || {
+    echo "helm dependency update failed for $tree:" >&2
+    cat "$out.deps" >&2
+    return 1
+  }
+  helm template mcp-core "$tree/$CHART" "${RENDER_ARGS[@]}" >"$out" 2>"$out.err"
+}
+
+BASE_SHA="$(git -C "$REPO_ROOT" merge-base HEAD "$BASE_REF" 2>/dev/null)"
+if [ -z "$BASE_SHA" ]; then
+  echo "helm-render-diff: no merge base with '$BASE_REF' — skipping the diff."
+  echo "(Fetch the base branch, or pass a revision: scripts/helm_render_diff.sh <ref>)"
+  exit 0
+fi
+
+echo "helm-render-diff: HEAD $(git -C "$REPO_ROOT" rev-parse --short HEAD)" \
+     "vs merge-base $(git -C "$REPO_ROOT" rev-parse --short "$BASE_SHA") ($BASE_REF)"
+
+if ! git -C "$REPO_ROOT" worktree add --detach "$WORKDIR/base" "$BASE_SHA" >/dev/null 2>&1; then
+  echo "helm-render-diff: could not create a worktree at $BASE_SHA — skipping the diff."
+  exit 0
+fi
+
+if ! render_tree "$WORKDIR/base" "$WORKDIR/base.yaml"; then
+  echo "helm-render-diff: the BASE revision does not render — nothing to compare against."
+  exit 0
+fi
+if [ ! -s "$WORKDIR/base.yaml" ]; then
+  echo "helm-render-diff: the BASE revision rendered nothing:"
+  cat "$WORKDIR/base.err"
+  exit 0
+fi
+
+# HEAD renders from the working tree so uncommitted edits are visible locally.
+if ! render_tree "$REPO_ROOT" "$WORKDIR/head.yaml" || [ ! -s "$WORKDIR/head.yaml" ]; then
+  echo "helm-render-diff: HEAD does not render:"
+  cat "$WORKDIR/head.yaml.err" 2>/dev/null
+  echo "(the lint and PSS steps own this failure — not reporting it twice)"
+  exit 0
+fi
+
+if diff -u "$WORKDIR/base.yaml" "$WORKDIR/head.yaml" \
+     --label "base ($(git -C "$REPO_ROOT" rev-parse --short "$BASE_SHA"))" \
+     --label "head" >"$WORKDIR/diff"; then
+  echo "No change to the rendered umbrella manifests."
+else
+  echo "Rendered umbrella manifests changed ($(grep -c '^[+-][^+-]' "$WORKDIR/diff") line(s)):"
+  echo
+  cat "$WORKDIR/diff"
+  echo
+  echo "Review the delta above against the intent of this change."
+fi
+
+exit 0

--- a/scripts/test_bump_version.py
+++ b/scripts/test_bump_version.py
@@ -630,6 +630,97 @@ def test_anchored_patterns_skip_third_party_pins():
         assert out == expected, f"{name}: got\n{out}"
 
 
+# Characters that can legally continue a PEP 440 version. `3.3.1` followed by
+# any of these is a DIFFERENT version (`3.3.10`, `3.3.1rc1`, `3.3.1.post1`,
+# `3.3.1-1`, `3.3.1+local`), never a stale copy of ours.
+_VERSION_CONTINUATION = "0123456789abcrpostABC_.-+"
+
+
+def _version_continuations_admitted(pattern: str) -> list[str]:
+    """Which continuation characters the pattern would still let follow OLD.
+
+    Everything after the OLD placeholder is the terminal boundary, so compile
+    that tail on its own and ask it to match each continuation character. A
+    boundary that is doing its job cannot match one: `(?![\\w.\\-+])` fails the
+    lookahead, and a literal delimiter like `(")` or `(</version>)` fails on the
+    first character. A pattern with no boundary at all leaves an EMPTY tail,
+    which matches zero-width against anything — so every character comes back,
+    which is exactly the prefix over-match this list is here to forbid."""
+    tail = pattern.split("OLD", 1)[1]
+    compiled = re.compile(tail)
+    return [c for c in _VERSION_CONTINUATION if compiled.match(c)]
+
+
+def test_pep440_handlers_terminally_bound_the_version():
+    """Every pep440 handler must terminate its version match.
+
+    The four pip-pin handlers carry `(?![\\w.\\-+])` because someone remembered
+    to add it after `==3.3.10` was rewritten into the nonexistent `==3.3.20`;
+    the other three end at a closing quote, which bounds it just as well. Both
+    are fine — what must not happen is a NEW pep440 handler, or a refactor of an
+    old one, that ends the pattern at OLD and re-opens prefix matching. Nothing
+    else notices: the handler still bumps our pin correctly, and the corruption
+    only appears in whichever release first sits next to a longer version.
+
+    Scoped to pep440 because that is the projection used for pip requirements,
+    where a longer version genuinely coexists. The `raw` image-tag handlers
+    carry a deliberately narrower `(?![\\d.\\-+])` boundary and are left alone
+    here."""
+    offenders = {}
+    for h in bv.HANDLERS:
+        if h.version_format != "pep440":
+            continue
+        admitted = _version_continuations_admitted(h.pattern)
+        if admitted:
+            offenders[h.name] = (h.pattern, admitted)
+    assert not offenders, (
+        "pep440 handler(s) match a PREFIX of a longer version — add the "
+        "terminal boundary `(?![\\w.\\-+])` after OLD (or end the pattern at a "
+        f"delimiter that cannot appear in a version): {offenders}"
+    )
+
+
+def test_terminal_boundary_check_bites():
+    """The check above is only worth having if it goes red when the boundary
+    goes away, so exercise it against the shapes it exists to reject: no
+    boundary at all, and a boundary narrowed until it stops covering the
+    alphabetic suffixes PEP 440 allows."""
+    real = r"(mcp-mesh\[litellm\]==)OLD(?![\w.\-+])"
+    assert _version_continuations_admitted(real) == []
+
+    for broken, why in [
+        (r"(mcp-mesh\[litellm\]==)OLD", "boundary deleted"),
+        (r"(mcp-mesh\[litellm\]==)OLD(?!\d)", "digits only"),
+        (r"(mcp-mesh\[litellm\]==)OLD(?![\d.\-+])", "the image-tag boundary"),
+        (r"(mcp-mesh\[litellm\]==)OLD(\d*)", "a trailing wildcard"),
+    ]:
+        assert _version_continuations_admitted(broken), why
+
+    # ...and the whole-handler assertion must fail with such a handler present,
+    # not just the helper.
+    original = list(bv.HANDLERS)
+    try:
+        bv.HANDLERS.append(
+            bv.Handler(
+                name="unbounded probe",
+                globs=["does/not/exist"],
+                pattern=r"(mcp-mesh>=)OLD",
+                replacement=r"\g<1>NEW",
+                version_format="pep440",
+            )
+        )
+        try:
+            test_pep440_handlers_terminally_bound_the_version()
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError(
+                "the boundary check accepted a handler with no terminal boundary"
+            )
+    finally:
+        bv.HANDLERS[:] = original
+
+
 if __name__ == "__main__":
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     for fn in fns:


### PR DESCRIPTION
## Summary

Two issues, one defect: **a check exists in the repo and CI never runs it.**

- **#1421** — `helm lint` and `scripts/check_helm_pss.py` run only in `helm-release.yml`, on a release tag. `grep helm .github/workflows/ci.yml` returned nothing. Six chart PRs merged in the last two days (#1410, #1413, #1415, #1417, #1418, #1426) with green check walls containing zero chart validation.
- **#1399** — `scripts/test_bump_version.py` is the sole regression net for two defect classes the bump guards structurally cannot see, and CI never ran it.

CI configuration plus one test. No chart, no `bump_version.py`, no version changed — `git diff main HEAD -- helm/` and `-- scripts/bump_version.py` are both empty.

## What was added

Two jobs in `ci.yml`, both wired into `integration-status`'s `needs`, echo block and failure condition — otherwise a red job would not block the aggregate:

- **`scripts-test`** — `pytest scripts/` plus the direct `python3 scripts/test_bump_version.py` entry point.
- **`helm-charts`** — observability sync → `helm dependency update` → `helm lint` → PSS render → guard matrix → render diff.

Plus `scripts/check_helm_render_matrix.py` (28 non-default cases), `scripts/helm_render_diff.sh`, and two tests in `test_bump_version.py`.

## Every new check was proven to fail before being trusted

A job only ever observed passing is indistinguishable from one that cannot fail — which is the failure mode this repo has hit repeatedly. Each break was made in a throwaway worktree, confirmed red, then restored:

| Deliberate break | `helm lint` | PSS | matrix | bump tests |
|---|---|---|---|---|
| `{{- if` → `{{- fi` in registry deployment | **RED** (`function "fi" not defined`) | — | — | — |
| Removed `runAsNonRoot` from registry pod securityContext | green | **RED** (4 findings) | — | — |
| Emptied `validateNamespaceResourcePolicy`, inverted grafana `generatedSecret` | green | green | **RED 25/28** | — |
| Deleted the litellm handler's `(?![\w.\-+])` | — | — | — | **RED** |
| Added a *new* pep440 handler with no boundary | — | — | — | **RED** — only the meta-test caught it |

Two rows are the point of the whole PR. The `runAsNonRoot` break reproduces #1421's claim exactly: **lint exits 0, the render exits 1** — lint does not see valid-but-wrong YAML. And the guard break is green through **both** lint and PSS; only the matrix catches it, in both directions (the guard's fail path stopped failing *and* its pass path started failing).

Worth noting a break that correctly did **not** go red: the first `runAsNonRoot` removal left the pod-level `securityContext` supplying it, so the check was right and both had to be removed.

## Judgement calls

**No `paths:` filter, deliberately.** A skipped job reports the same green check as a passing one, which reintroduces the exact "green wall that validates nothing" this issue is about. And the render has inputs *outside* `helm/` — demonstrated: editing `observability/grafana/dashboards/mcp-mesh-overview.json`, touching no `helm/` file, changed 14 lines of rendered umbrella manifest, because `helm-release.yml` copies that JSON into the chart before packaging. A `paths: helm/**` filter would have skipped the job on that PR.

**Render diff implemented but non-gating.** "Fail only on unexpected deltas" has no CI-computable definition: a chart PR is *supposed* to change the render, and the two guards named above change nothing on the default path — so a must-be-non-empty gate would have gone red on the very PRs that added them, and a must-be-empty gate red on every chart PR. It prints to the step log and job summary and always exits 0. It is a step *inside* the gating helm job rather than its own job, so it does not add a second always-green check to the wall.

**A script rather than inline YAML** for the matrix — 28 declarative cases would be unmaintainable as a shell loop and unrunnable locally. It follows `check_helm_pss.py`'s shape and imports its `build_dependencies`.

## Both mechanical traps confirmed live, then handled

- **Determinism**: unpinned back-to-back umbrella renders differ on exactly two lines (`admin-password`, `password`); pinned, byte-identical.
- **Stale `.tgz`**: appended a probe line to `helm/mcp-mesh-grafana/templates/configmap.yaml` — the umbrella render showed it **0 times before** `helm dependency update` and **1 time after**. The render-diff baseline is built in a throwaway `git worktree` with its own dependency update; a fresh worktree has no `charts/` directory at all and `helm template` there errors outright.

## Version parity

Ran lint, PSS, matrix and render-diff under **helm v3.13.0** — what `azure/setup-helm` pins and what `helm-release.yml` packages with — not just the local 4.0.1. All green. The full `helm-charts` job was also replayed step-by-step in a pristine worktree (no `charts/*.tgz`, no `files/dashboards/`) under 3.13.0: six steps green, and the dashboard JSON confirmed present inside the packaged subchart archive, verifying the sync must run before `helm dependency update` — it does, in both the workflow and the script.

## Tallies

`python3 scripts/test_bump_version.py` 30 → **32**; `pytest -q` 30 → **32**. `actionlint`: 2 findings before, 2 after — both pre-existing `if: false` on the disabled `lint-and-format`/`type-check` jobs. No new findings.

## Found while doing this, not fixed here

**The `raw` image-tag handlers use a narrower boundary than the pep440 ones.** Eight handlers carry `(?![\d.\-+])`, which admits letters — so a docker tag `mcpmesh/cli:3.3.1rc1` would be rewritten by a 3.3.1 bump. `test_bump_version.py:69` already asserts the *guard* ignores that form, so **guard and handler disagree**. The meta-test here is deliberately scoped to pep440 as #1399 specifies, and no behaviour was changed; widening it changes what those handlers rewrite, so it belongs with the release-tooling work (#1407/#1409) rather than here.

Closes #1399
Closes #1421
