### PR TITLE
fix(helm): stop charts advertising surfaces that cannot work

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -36,6 +36,14 @@ Kubernetes deployment charts for MCP Mesh - a distributed agent orchestration fr
 ### Installation
 
 ```bash
+# 0. Only when installing from a clone of this repository: copy the Grafana
+#    dashboards into the chart. They live in observability/ and are synced in
+#    when the charts are released, so a released chart has them and a checkout
+#    does not. Skip this and everything still installs and runs — Grafana just
+#    comes up with its datasources and no MCP Mesh dashboards.
+mkdir -p helm/mcp-mesh-grafana/files/dashboards
+cp observability/grafana/dashboards/*.json helm/mcp-mesh-grafana/files/dashboards/
+
 # 1. Install core infrastructure (registry + observability)
 #    --set namespaceCreate=false is required: see "Namespace handling" in
 #    mcp-mesh-core/README.md

--- a/helm/mcp-mesh-core/README.md
+++ b/helm/mcp-mesh-core/README.md
@@ -665,8 +665,10 @@ brings it back. Note that the bundled PostgreSQL keeps its data on a PVC created
 by the StatefulSet's volume claim template, which the release does not own, so
 `helm uninstall` leaves the volume behind; it is deleting that PVC (or the
 namespace around it) that destroys the data. Bundled Redis writes to an
-`emptyDir` unless you enable persistence against a PVC you created yourself, so
-treat its contents as ephemeral either way.
+`emptyDir` unless you point it at a PVC you created yourself
+(`mcp-mesh-redis.persistence.enabled` with `persistence.existingClaim` — the
+chart renders no claim of its own), so treat its contents as ephemeral either
+way.
 
 ### What uninstall leaves behind
 

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -136,8 +136,10 @@ mcp-mesh-redis:
     maxmemory: "256mb"
     maxmemoryPolicy: "allkeys-lru"
 
-  persistence:
-    enabled: false # Use emptyDir for cache
+  # /data is an emptyDir: this Redis is an evicting cache and a short-lived
+  # session/trace store, not durable storage. The subchart renders no PVC, so
+  # its persistence block mounts a claim you created yourself — see
+  # helm/mcp-mesh-redis/values.yaml.
 
   resources:
     limits:

--- a/helm/mcp-mesh-grafana/templates/NOTES.txt
+++ b/helm/mcp-mesh-grafana/templates/NOTES.txt
@@ -12,6 +12,19 @@ The generated value is reused on helm upgrade. Grafana applies it only on
 first start — with persistence enabled, the password set at install time
 stays in effect (reset with: grafana-cli admin reset-admin-password).
 {{- end }}
+{{- if and .Values.grafana.dashboards.enabled (not (include "mcp-mesh-grafana.dashboardsEnabled" .)) }}
+
+NOTE: the bundled MCP Mesh dashboards were NOT provisioned. Grafana starts and
+everything else (datasources, persistence, the admin password) works, but
+files/dashboards/mcp-mesh-overview.json is not in this chart — it is copied
+from observability/ when the chart is released, and is not in source control.
+Installing from a git checkout, populate it first:
+
+  mkdir -p helm/mcp-mesh-grafana/files/dashboards
+  cp observability/grafana/dashboards/*.json helm/mcp-mesh-grafana/files/dashboards/
+
+Set grafana.dashboards.enabled=false to silence this.
+{{- end }}
 {{- if .Values.grafana.persistence.enabled }}
 
 Grafana's data volume holds grafana.db — the dashboards, annotations, users,

--- a/helm/mcp-mesh-grafana/templates/_helpers.tpl
+++ b/helm/mcp-mesh-grafana/templates/_helpers.tpl
@@ -86,6 +86,57 @@ compare stringified so both spellings disable generation.
 {{- end }}
 
 {{/*
+Whether the bundled dashboards render at all. Two conditions, not one: the
+operator has to want them (grafana.dashboards.enabled) AND the dashboard JSON
+has to be present.
+
+files/dashboards/ is gitignored and populated by the dashboard-sync step in
+helm-release.yml, so it is in every released tarball and absent from every
+source checkout. The mount used to be conditional on the flag alone while the
+ConfigMap holding the dashboard was also conditional on the file — so from a
+clone the volume referenced a ConfigMap that never rendered and the kubelet
+blocked the pod indefinitely, naming the missing ConfigMap rather than the
+missing file. A mount may not be less conditional than the object backing it.
+
+Everything dashboard-shaped keys off this single helper: the dashboard
+ConfigMap, the provisioning-provider ConfigMap (a file provider pointing at a
+directory that does not exist is a startup error for Grafana, so leaving it
+behind would trade one broken pod for another), grafana.ini's
+default_home_dashboard_path, and both volume/volumeMount pairs.
+
+Released charts are unaffected — the JSON is present, so this is true exactly
+when grafana.dashboards.enabled is.
+*/}}
+{{- define "mcp-mesh-grafana.dashboardsEnabled" -}}
+{{- if and .Values.grafana.dashboards.enabled (.Files.Get "files/dashboards/mcp-mesh-overview.json") -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Removed-key guard, same convention as mcp-mesh-registry.validateNoRemovedKeys:
+a key no template ever consumed is deleted rather than left to no-op silently,
+and a values file still carrying it fails with migration guidance instead.
+Invoked unconditionally from the deployment.
+
+- grafana.dashboards.configMaps: read by nothing. It listed a ConfigMap name
+  ("mcp-mesh-dashboards") that no volume, no mount and no provider ever
+  referenced, so extra dashboards named there were never mounted. The chart
+  provisions exactly the dashboards in files/dashboards/. The old shipped
+  default is tolerated verbatim — a values file copied from the chart carries
+  it with no user intent behind it — and only a diverging list fails.
+*/}}
+{{- define "mcp-mesh-grafana.validateNoRemovedKeys" -}}
+{{- $dashboards := .Values.grafana.dashboards | default dict -}}
+{{- if hasKey $dashboards "configMaps" -}}
+{{- $shipped := list "mcp-mesh-dashboards" -}}
+{{- if ne (toString ($dashboards.configMaps | default list)) (toString $shipped) -}}
+{{- fail (printf "grafana.dashboards.configMaps was never consumed and has been removed (set to %v, diverging from the old shipped default %v, so it would silently no-op); no volume, mount or dashboard provider ever referenced the ConfigMaps named there. This chart provisions the dashboards bundled in files/dashboards/ — to add your own, mount them yourself into /var/lib/grafana/dashboards" $dashboards.configMaps $shipped) -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Render the image reference as [registry/]repository:tag. The registry prefix
 resolves as grafana.image.registry > global.imageRegistry > "" (implicit Docker Hub).
 The repository path is preserved — mirror images to the same paths in a

--- a/helm/mcp-mesh-grafana/templates/configmap-dashboard.yaml
+++ b/helm/mcp-mesh-grafana/templates/configmap-dashboard.yaml
@@ -1,6 +1,4 @@
-{{- if and .Values.grafana.enabled .Values.grafana.dashboards.enabled }}
-{{- $dashboardFile := .Files.Get "files/dashboards/mcp-mesh-overview.json" }}
-{{- if $dashboardFile }}
+{{- if and .Values.grafana.enabled (include "mcp-mesh-grafana.dashboardsEnabled" .) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,12 +7,5 @@ metadata:
     {{- include "mcp-mesh-grafana.labels" . | nindent 4 }}
 data:
   mcp-mesh-overview.json: |
-{{ $dashboardFile | indent 4 }}
-{{- else }}
-# Dashboard file not found at files/dashboards/mcp-mesh-overview.json
-# This file is copied from observability/grafana/dashboards/ during the release process
-# For local development, run:
-#   mkdir -p helm/mcp-mesh-grafana/files/dashboards
-#   cp observability/grafana/dashboards/*.json helm/mcp-mesh-grafana/files/dashboards/
-{{- end }}
+{{ .Files.Get "files/dashboards/mcp-mesh-overview.json" | indent 4 }}
 {{- end }}

--- a/helm/mcp-mesh-grafana/templates/configmap.yaml
+++ b/helm/mcp-mesh-grafana/templates/configmap.yaml
@@ -40,8 +40,11 @@ data:
     reporting_enabled = false
     check_for_updates = false
 
+    {{- if include "mcp-mesh-grafana.dashboardsEnabled" . }}
+
     [dashboards]
     default_home_dashboard_path = /var/lib/grafana/dashboards/mcp-mesh-overview.json
+    {{- end }}
 
 ---
 apiVersion: v1
@@ -74,7 +77,7 @@ data:
     {{- end }}
 
 ---
-{{- if .Values.grafana.dashboards.enabled }}
+{{- if include "mcp-mesh-grafana.dashboardsEnabled" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/mcp-mesh-grafana/templates/deployment.yaml
+++ b/helm/mcp-mesh-grafana/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.grafana.enabled }}
 {{- include "mcp-mesh-grafana.validateCredentialSource" . -}}
+{{- include "mcp-mesh-grafana.validateNoRemovedKeys" . -}}
 {{- /* Migration guard: grafana.securityContext used to be the POD security
        context (it carried fsGroup). It is now the CONTAINER security context
        and pod-level settings live under grafana.podSecurityContext — an old
@@ -98,7 +99,7 @@ spec:
         - name: datasources
           mountPath: /etc/grafana/provisioning/datasources
           readOnly: true
-        {{- if .Values.grafana.dashboards.enabled }}
+        {{- if include "mcp-mesh-grafana.dashboardsEnabled" . }}
         - name: dashboards-config
           mountPath: /etc/grafana/provisioning/dashboards
           readOnly: true
@@ -138,7 +139,11 @@ spec:
       - name: datasources
         configMap:
           name: {{ include "mcp-mesh-grafana.fullname" . }}-datasources
-      {{- if .Values.grafana.dashboards.enabled }}
+      {{- /* Gated on dashboardsEnabled, NOT on grafana.dashboards.enabled: both
+             ConfigMaps below are conditional on the dashboard JSON being
+             present, and a volume whose backing object may not render blocks
+             the pod in the kubelet forever. See the helper. */}}
+      {{- if include "mcp-mesh-grafana.dashboardsEnabled" . }}
       - name: dashboards-config
         configMap:
           name: {{ include "mcp-mesh-grafana.fullname" . }}-dashboards-config

--- a/helm/mcp-mesh-grafana/values.yaml
+++ b/helm/mcp-mesh-grafana/values.yaml
@@ -139,12 +139,23 @@ grafana:
       enabled: true
       url: "http://prometheus:9090"
 
-  # Dashboard configuration references observability/grafana/dashboards/
+  # Provision the bundled MCP Mesh dashboards into Grafana (a ConfigMap holding
+  # the JSON, plus a file provider pointing Grafana at it).
+  #
+  # The dashboard JSON lives in this chart's files/dashboards/, which is copied
+  # from observability/grafana/dashboards/ by the release workflow and is NOT in
+  # source control — so a released chart has it and a source checkout does not.
+  # With the JSON absent, dashboards stay off no matter what this flag says: the
+  # ConfigMaps, the mounts and the default home dashboard all drop out together
+  # and Grafana starts normally without them (previously the mount stayed
+  # behind and the pod never started at all). Everything else — datasources,
+  # persistence, the admin password — is unaffected either way.
+  #
+  # To provision them from a checkout:
+  #   mkdir -p helm/mcp-mesh-grafana/files/dashboards
+  #   cp observability/grafana/dashboards/*.json helm/mcp-mesh-grafana/files/dashboards/
   dashboards:
     enabled: true
-    # References to the centralized dashboard configs
-    configMaps:
-      - mcp-mesh-dashboards
 
   # Pod security context (hardened for Pod Security Standards "restricted").
   # Renamed: this key was previously called securityContext (which is now the

--- a/helm/mcp-mesh-redis/templates/_helpers.tpl
+++ b/helm/mcp-mesh-redis/templates/_helpers.tpl
@@ -69,6 +69,46 @@ deployment.
 {{- end }}
 
 {{/*
+Persistence guard + removed-key guards, same convention as
+mcp-mesh-registry.validateNoRemovedKeys: a key no template ever consumed is
+deleted rather than left to no-op silently, and a values file still carrying
+one fails with migration guidance instead. Invoked unconditionally from the
+deployment.
+
+This chart has no PVC template and never had one, so persistence.enabled used
+to render a claimName derived from the release that nothing ever created — the
+pod stayed Pending forever on a claim no controller would bind. The four
+provisioning keys beside it (storageClass, accessMode, size, annotations)
+configured that absent PVC and so were read by nothing at all.
+
+What survives is the case that actually worked: a claim created out of band and
+mounted by name. That is now spelled persistence.existingClaim (the same key
+name mcp-mesh-agent uses), and enabled without it is a template-time error
+rather than a Pending pod.
+
+The removed keys are tolerated at their old shipped values — a values file
+copied from this chart or from the v3.x mcp-mesh-core umbrella (which shipped
+mcp-mesh-redis.persistence.enabled: false) carries them with no intent behind
+them — and only a diverging value fails.
+*/}}
+{{- define "mcp-mesh-redis.validateNoRemovedKeys" -}}
+{{- $p := .Values.persistence | default dict -}}
+{{/* Old shipped defaults, verbatim from this chart's values.yaml. */}}
+{{- $shipped := dict "storageClass" "" "accessMode" "ReadWriteOnce" "size" "8Gi" -}}
+{{- range $key, $default := $shipped -}}
+{{- if and (hasKey $p $key) (ne (toString (get $p $key)) $default) -}}
+{{- fail (printf "persistence.%s was never consumed and has been removed (set to %q, diverging from the old shipped default %q, so it would silently no-op): this chart renders no PersistentVolumeClaim, so it configured nothing. Create the claim yourself with the size and class you want, then mount it with persistence.existingClaim" $key (toString (get $p $key)) $default) -}}
+{{- end -}}
+{{- end -}}
+{{- if get $p "annotations" -}}
+{{- fail "persistence.annotations was never consumed and has been removed: this chart renders no PersistentVolumeClaim to annotate. Annotate the claim you create yourself and mount it with persistence.existingClaim" -}}
+{{- end -}}
+{{- if and $p.enabled (not $p.existingClaim) -}}
+{{- fail (printf "persistence.enabled requires persistence.existingClaim: this chart renders no PersistentVolumeClaim, so enabling persistence without naming an existing claim leaves the pod Pending forever on one nothing creates. Create the claim (any size/class you want) and name it here — if you are upgrading a release that already had persistence.enabled, the claim it referenced was %q. Redis here is an evicting cache on an emptyDir by design; leave persistence.enabled false unless you deliberately want its /data to survive a restart" (include "mcp-mesh-redis.fullname" .)) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Render the image reference as [registry/]repository:tag. The registry prefix
 resolves as image.registry > global.imageRegistry > "" (implicit Docker Hub).
 The repository path is preserved — mirror images to the same paths in a

--- a/helm/mcp-mesh-redis/templates/configmap.yaml
+++ b/helm/mcp-mesh-redis/templates/configmap.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.customConfig }}
+{{- /* Backs the "config" volume in the Deployment, which mounts this key at
+       /etc/redis/redis.conf and appends `--include /etc/redis/redis.conf` to
+       the redis-server command line. The Deployment referenced this ConfigMap
+       and the chart never rendered it, so setting customConfig produced a pod
+       the kubelet blocked forever on a missing ConfigMap — the same defect as
+       the Grafana dashboards volume (#1419).
+
+       redis-server applies the include LAST, after the --appendonly /
+       --maxmemory / --maxmemory-policy flags above it, so directives here
+       override the values-driven ones. */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mcp-mesh-redis.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-mesh-redis.labels" . | nindent 4 }}
+data:
+  redis.conf: |
+    {{- .Values.customConfig | nindent 4 }}
+{{- end }}

--- a/helm/mcp-mesh-redis/templates/deployment.yaml
+++ b/helm/mcp-mesh-redis/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- include "mcp-mesh-redis.validateCredentialSource" . -}}
+{{- include "mcp-mesh-redis.validateNoRemovedKeys" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,9 +23,18 @@ spec:
         {{- with .Values.extraLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.podAnnotations .Values.customConfig }}
       annotations:
+        {{- /* Only when customConfig renders a ConfigMap: an edit to it has to
+               roll the pod, or the new directives sit in the mount unread
+               until something else restarts redis. Gated so the default
+               render carries no annotations at all. */}}
+        {{- if .Values.customConfig }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
     spec:
       {{- with include "mcp-mesh-redis.imagePullSecrets" . }}
@@ -88,9 +98,15 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
       volumes:
         - name: redis-data
+          {{- /* This chart provisions no volume — there is no PVC template and
+                 never was. persistence.enabled therefore mounts a claim you
+                 created yourself and named in persistence.existingClaim; the
+                 guard in _helpers.tpl refuses enabled without it, because the
+                 name this used to derive belonged to no object and left the
+                 pod Pending forever (#1412). */}}
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ include "mcp-mesh-redis.fullname" . }}
+            claimName: {{ .Values.persistence.existingClaim }}
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/helm/mcp-mesh-redis/values.yaml
+++ b/helm/mcp-mesh-redis/values.yaml
@@ -30,13 +30,31 @@ service:
 # Deployment configuration
 replicaCount: 1
 
-# Persistence configuration (using emptyDir for cache)
+# Storage for /data.
+#
+# The default is an emptyDir, and that is the design: this Redis is a cache and
+# a short-lived session/trace store, capped by maxmemory with allkeys-lru
+# eviction, so its contents are ephemeral. Nothing in the mesh treats them as
+# durable — see "Application data" in the mcp-mesh-core README.
+#
+# This chart provisions NO volume: it has no PVC template and never had one.
+# persistence therefore mounts a claim YOU created, named explicitly:
+#
+#   persistence:
+#     enabled: true
+#     existingClaim: my-redis-data
+#
+# enabled without existingClaim fails at template time. It used to derive a
+# claim name from the release instead, which no template ever created, so the
+# pod sat Pending forever on a claim nothing would ever bind.
+#
+# storageClass, accessMode, size and annotations are gone: they configured the
+# PVC this chart does not create, so they were read by nothing. Size and class
+# belong to whatever creates the claim. Once /data is a ReadWriteOnce volume
+# rather than an emptyDir, the strategy note below stops being hypothetical.
 persistence:
   enabled: false
-  storageClass: ""
-  accessMode: ReadWriteOnce
-  size: 8Gi
-  annotations: {}
+  existingClaim: ""
 
 # Deployment update strategy. Empty leaves the field unset, so Kubernetes
 # applies its own default (RollingUpdate), which is right for this chart: the

--- a/scripts/check_helm_render_matrix.py
+++ b/scripts/check_helm_render_matrix.py
@@ -216,6 +216,58 @@ CASES: list[Case] = [
             "global": {"redis": {"host": "redis.example.internal", "password": "pw"}},
         },
     ),
+    Case(
+        "mcp-mesh-core",
+        "redis persistence enabled with no claim to mount",
+        {"mcp-mesh-redis": {"persistence": {"enabled": True}}},
+        expect_fail="persistence.enabled requires persistence.existingClaim",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "...and the same once an existing claim is named",
+        {
+            "mcp-mesh-redis": {
+                "persistence": {"enabled": True, "existingClaim": "redis-data"}
+            }
+        },
+    ),
+    Case(
+        "mcp-mesh-core",
+        "a redis PVC size that never provisioned anything",
+        {"mcp-mesh-redis": {"persistence": {"size": "20Gi"}}},
+        expect_fail="persistence.size was never consumed",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "the shipped redis persistence defaults are grandfathered",
+        {
+            "mcp-mesh-redis": {
+                "persistence": {
+                    "enabled": False,
+                    "storageClass": "",
+                    "accessMode": "ReadWriteOnce",
+                    "size": "8Gi",
+                    "annotations": {},
+                }
+            }
+        },
+    ),
+    # --- mcp-mesh-grafana: removed dashboard key --------------------------
+    Case(
+        "mcp-mesh-core",
+        "grafana dashboards.configMaps that never mounted anything",
+        {"mcp-mesh-grafana": {"grafana": {"dashboards": {"configMaps": ["mine"]}}}},
+        expect_fail="grafana.dashboards.configMaps was never consumed",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "the shipped dashboards.configMaps default is grandfathered",
+        {
+            "mcp-mesh-grafana": {
+                "grafana": {"dashboards": {"configMaps": ["mcp-mesh-dashboards"]}}
+            }
+        },
+    ),
     # --- mcp-mesh-ui (through the umbrella) -------------------------------
     Case(
         "mcp-mesh-core",


### PR DESCRIPTION
## Summary

Two issues, one defect: **a chart exposes a surface that cannot work.** Both produce a pod the kubelet blocks forever, from values the chart itself ships.

**Default render is unchanged** — `scripts/helm_render_diff.sh` reports *"No change to the rendered umbrella manifests."* Every fix is on a path that was already broken.

## #1419 — grafana never starts from a source clone

`configmap-dashboard.yaml` builds from `files/dashboards/*.json`, which is gitignored and populated only by the release sync. From a clone the glob matches nothing, the ConfigMap renders empty — and `deployment.yaml` mounted it **unconditionally**.

Measured on a genuinely clean checkout, `helm install` with **no flags**:

| | base `22aeafb5e` | head |
|---|---|---|
| pod | `ContainerCreating` at **8m28s**, `FailedMount ×12`: `configmap "g-mcp-mesh-grafana-dashboard" not found` | **`1/1 Running` in 26s** |

**Chose option (a), gate the mount on the same condition as the content.** Option (b) — committing the JSON — removes today's divergence but not the defect: the mount stays unconditional while the ConfigMap is conditional on a file, so a rename or deletion reproduces the identical dead pod. (a) is structural, and (b) remains available on top of it.

A new `mcp-mesh-grafana.dashboardsEnabled` helper requires the flag **and** the JSON, and gates all four surfaces together. **The provider ConfigMap had to move with the rest** — a Grafana file provider pointing at a directory that does not exist is itself a startup error, so gating only the volume would have traded one broken pod for another.

The released path still works: synced the JSON exactly as `helm-release.yml` does, and the API confirms `MCP Mesh Distributed Tracing` provisioned into the `MCP Mesh` folder, `/api/dashboards/home` returning it, 3 panels. Repeated through the packaged subchart.

## #1412 — redis advertises persistence it cannot deliver

No PVC template exists, yet `persistence.enabled` mounted `claimName: <fullname>` and four provisioning keys configured a claim nothing created. Three separate reviews reached for this as a working feature.

**Not pure removal, and the reason matters.** `helm/mcp-mesh-core/README.md:667` already documents "Bundled Redis writes to an emptyDir **unless you enable persistence against a PVC you created yourself**", and #1410's `strategy` comment is written for that same BYO case. More concretely: a user who pre-created a PVC named `<release>-mcp-mesh-redis` has a **working pod today** — dropping the branch would silently move them to `emptyDir` and lose their data at the next rollout.

So the four provisioning keys are gone (they configured a PVC this chart does not create), and the surviving path is respelled `persistence.existingClaim`, matching `mcp-mesh-agent`. `enabled` without it now fails at template time **naming the claim the release used to reference**, instead of yielding a `Pending` pod.

| scenario | base | head |
|---|---|---|
| `persistence.enabled=true` | pod `Pending`, `persistentvolumeclaim "r-mcp-mesh-redis" not found` | `INSTALLATION FAILED ... requires persistence.existingClaim: the claim it referenced was "r-mcp-mesh-redis"` |
| with a real claim | — | Running; wrote a key, deleted the pod, replacement read it back |
| **existing user upgrading with old values verbatim** | — | upgrade fails naming `up-mcp-mesh-redis`; **existing release untouched and still Running**. Adding `existingClaim` → REVISION 2, *same pod, not recreated*, same volume, data intact |

Removals sit behind `mcp-mesh-redis.validateNoRemovedKeys` in the `mcp-mesh-registry` convention: values at the old shipped defaults pass through silently (a copied values file carries no intent), a diverging value fails — `persistence.size: 20Gi` → `persistence.size was never consumed and has been removed`.

## Two more surfaces of the same shape, found while fixing these

- **`mcp-mesh-redis` `customConfig` mounted `<fullname>-config`, a ConfigMap the chart never rendered** — the identical kubelet failure as #1419, in the very chart #1412 is about. Verified: `MountVolume.SetUp failed for volume "config": configmap "rc-mcp-mesh-redis-config" not found`. Added the template plus a gated `checksum/config` annotation. Head: Running, `config get maxclients` → `137`.
- **`grafana.dashboards.configMaps` was read by nothing** — no volume, mount or provider referenced it. Removed behind the same guard.

## Validation

- **Default render diff vs `22aeafb5e`: no change.** The intended delta is the *clone-shape* render, where head drops exactly the `[dashboards]` ini stanza, the provider ConfigMap, both volumeMounts, both volumes, and the comment-only `configmap-dashboard.yaml` output — every reference to a ConfigMap that never rendered.
- Umbrella from a clone: `helm install mcp-core helm/mcp-mesh-core --set namespaceCreate=false` → **5/5 pods Running, no flags**. On base, the same render carries a volume pointing at a ConfigMap that is only a YAML comment.
- `helm lint` all 9 charts, 0 failed. `check_helm_pss.py` OK on all 9. `check_helm_render_matrix.py` **34/34** — 28 pre-existing plus 6 added covering both new guards in fail and pass directions, including the grandfathered-defaults path.
- **Helm 3.19.0 and 4.0.1**: lint, both grafana shapes, the redis guard and the customConfig ConfigMap behave identically; default render base-vs-head byte-identical on both once the generated admin password is pinned.

## Known limitation, worth stating

**Subchart NOTES are not printed by Helm**, so the "dashboards were NOT provisioned" note reaches standalone `mcp-mesh-grafana` installers only. The umbrella-from-clone case is silent — the umbrella cannot call the subchart helper, since its `.Files` and `.Values` scope are wrong (the same limitation `mcp-mesh-registry.secretName`'s comment records). Covered with a step 0 in `helm/README.md`'s from-source instructions instead. It is a doc mitigation, not a runtime one.

Also noted, not touched: `helm/mcp-mesh-tempo/files/` is gitignored but read by nothing — a dead ignore entry, belonging with #1419's option (b) discussion.

## Note for reviewers

The CI helm job added in #1427 runs the **release sync step** before rendering, so it validates the shipped artifact and does **not** reproduce the clone case. Everything above was verified from clean checkouts on a live cluster; a green CI wall is not evidence for #1419 either way.

Closes #1419
Closes #1412
