### PR TITLE
fix(registry): bound telemetry aggregates and decouple the event cap from retention

### DIFF
--- a/cmd/mcp-mesh-ui/main.go
+++ b/cmd/mcp-mesh-ui/main.go
@@ -167,7 +167,10 @@ func main() {
 			BatchSize:     100,
 			BlockTimeout:  2 * time.Second,
 			TraceTimeout:  5 * time.Minute,
-			TempoQueryURL: resolveTempoURL(tempoURL),
+			// meshui honours MCP_MESH_TRACE_RETENTION too, so stream trimming
+			// does not depend on the registry process being alive (#1424).
+			TraceRetention: tracing.TraceRetentionFromEnv(),
+			TempoQueryURL:  resolveTempoURL(tempoURL),
 		}
 
 		metricsProc = ui.NewMetricsProcessor()

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -60,7 +60,10 @@ export TEMPO_URL=http://localhost:3200
 | `TELEMETRY_PROTOCOL` | `grpc` | OTLP protocol: `grpc` or `http` |
 | `TRACE_EXPORTER_TYPE` | `otlp` | Exporter: `otlp`, `console`, or `json` |
 | `TEMPO_URL` | `http://localhost:3200` | Tempo query URL for the trace API |
-| `MCP_MESH_TRACE_RETENTION` | `24h` | Redis `mesh:trace` stream retention (`0` disables trimming) |
+| `MCP_MESH_TRACE_RETENTION` | `24h` | Redis `mesh:trace` stream retention (`0` disables trimming). Honoured by both the registry and meshui, so trimming survives either being down |
+| `MCP_MESH_TRACE_STREAM_MAXLEN` | `100000` | Producer-side `XADD MAXLEN ~` ceiling on `mesh:trace`, applied by every agent runtime. Bounds the stream even with no consumer alive (`0` disables) |
+| `MCP_MESH_TELEMETRY_AGGREGATE_RETENTION` | `24h` | Age-out window for the in-memory per-agent / per-model / per-edge dashboard aggregates (`0` disables age pruning) |
+| `MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES` | `10000` | Hard key ceiling per aggregate map, evicting least-recently-seen first (`0` disables the ceiling) |
 
 See the [environment variables reference](environment-variables.md) for the full list.
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -273,14 +273,23 @@ export DEFAULT_EVICTION_THRESHOLD=60
 ```bash
 # How long unhealthy/unknown agents are kept in the registry before the
 # sweep job purges them. Go duration string (e.g. "30m", "2h", "48h").
-# Default: 1h. Set to "0" to disable the sweep entirely (forensic mode —
-# keeps all rows). Affects `meshctl list` (purged agents disappear from
-# output), the underlying RegistryEvent table (event rows are governed
-# by a separate hardcoded 100,000 rolling cap, not by this variable),
-# and orphan schema_entries (rows in the content-addressed schema store
-# that are no longer referenced by any capability — purged when both
-# orphan and older than this retention window; #842).
+# Default: 1h. Set to "0" to disable the agent/schema sweep (forensic
+# mode — keeps all agent and schema rows). Affects `meshctl list` (purged
+# agents disappear from output) and orphan schema_entries (rows in the
+# content-addressed schema store that are no longer referenced by any
+# capability — purged when both orphan and older than this retention
+# window; #842). It does NOT govern the registry_events table: that has
+# its own row cap, MCP_MESH_EVENT_MAX_ROWS, which stays enforced even
+# with the sweep disabled.
 export MCP_MESH_RETENTION=1h
+
+# registry_events row cap — a table-size safety limit, not a retention
+# policy. When the table exceeds this many rows the oldest are deleted
+# until it is back under the cap. Enforced independently of
+# MCP_MESH_RETENTION, so disabling the sweep does not unbound this table.
+# Default: 100000. Set to "0" to disable the cap deliberately (logged as
+# a removed bound at startup).
+export MCP_MESH_EVENT_MAX_ROWS=100000
 
 # How often the periodic job/agent sweep runs (reaping, lease recovery,
 # retention purges). Go duration string (e.g. "30s", "5m", "1m30s").
@@ -310,7 +319,9 @@ export MCP_MESH_JOB_STALE_TIMEOUT=2h
   `1m` with the default 5m sweep) will not speed up the purge cadence —
   it only affects when an agent becomes eligible for purge. Lower
   `MCP_MESH_SWEEP_INTERVAL` to tighten the cadence.
-- Internal constant: event hard cap = 100,000 rows.
+- `MCP_MESH_RETENTION=0` disables only the agent/schema/job phases. The
+  `registry_events` row cap keeps running on the same schedule; use
+  `MCP_MESH_EVENT_MAX_ROWS=0` to turn that off too.
 
 ### Logging and Debug
 
@@ -456,10 +467,25 @@ export TRACE_EXPORTER_TYPE=otlp
 export TRACE_BATCH_SIZE=100
 export TRACE_TIMEOUT=5m
 
-# Redis trace stream retention — registry trims mesh:trace entries older
-# than this on connect and periodically. Go duration string. Default: 24h.
+# Redis trace stream retention — the registry AND meshui both trim mesh:trace
+# entries older than this on connect and periodically, so trimming does not
+# depend on a single process being alive. Go duration string. Default: 24h.
 # Set to "0" to disable trimming entirely.
 export MCP_MESH_TRACE_RETENTION=24h
+
+# Producer-side ceiling on the mesh:trace stream. Every agent runtime publishes
+# with XADD MAXLEN ~ <n>, so the stream stays bounded even when no consumer is
+# running. This is a safety ceiling, not a retention policy — time-based
+# retention stays with MCP_MESH_TRACE_RETENTION. Default: 100000. "0" disables.
+export MCP_MESH_TRACE_STREAM_MAXLEN=100000
+
+# In-memory telemetry aggregates (dashboard per-agent, per-model and per-edge
+# stats). Keyed by name, so they grow with agent/model name cardinality rather
+# than trace volume. A key not written to within the retention window ages out;
+# the max-entries ceiling is a backstop for name churn, evicting the
+# least-recently-seen key first. "0" disables the respective bound.
+export MCP_MESH_TELEMETRY_AGGREGATE_RETENTION=24h
+export MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES=10000
 
 # Trace output options
 export TRACE_PRETTY_OUTPUT=false

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -185,7 +185,9 @@ mcp-mesh-registry:
         enabled: true
         # mesh:trace Redis stream retention (XTRIM MINID on connect and
         # periodically); "0" disables trimming. The stream is a transport
-        # buffer — long-term trace history lives in Tempo.
+        # buffer — long-term trace history lives in Tempo. meshui trims to the
+        # same window (see mcp-mesh-ui.ui.tracing.retention below), so trimming
+        # does not depend on the registry being alive.
         retention: "24h"
       telemetryEndpoint: "mcp-core-mcp-mesh-tempo:4317"
 
@@ -323,6 +325,12 @@ mcp-mesh-tempo:
 mcp-mesh-ui:
   ui:
     registryURL: "http://mcp-core-mcp-mesh-registry:8000"
+    tracing:
+      enabled: true
+      # Keep equal to mcp-mesh-registry.registry.observability.distributedTracing.retention
+      # above: both processes trim mesh:trace, so trimming survives either
+      # being down, but only if they agree on the window.
+      retention: "24h"
     basePath: "/ops/dashboard"  # default; override with custom image for different path
     tempo:
       url: "http://mcp-core-mcp-mesh-tempo:3200"

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -271,10 +271,11 @@ registry:
   observability:
     distributedTracing:
       enabled: true
-      # How long span events stay in the mesh:trace Redis stream before the
-      # registry trims them (XTRIM MINID on connect and every 5m). The stream
-      # is a transport buffer — long-term trace history lives in Tempo. Go
-      # duration string; "0" disables trimming entirely.
+      # How long span events stay in the mesh:trace Redis stream before it is
+      # trimmed (XTRIM MINID on connect and every 5m). meshui trims to the same
+      # window, so keep this equal to the meshui chart's ui.tracing.retention.
+      # The stream is a transport buffer — long-term trace history lives in
+      # Tempo. Go duration string; "0" disables trimming entirely.
       retention: "24h"
     telemetryEndpoint: "mcp-core-mcp-mesh-tempo:4317"
     # Exporter type: console (default), otlp (for Tempo/Jaeger), json

--- a/helm/mcp-mesh-ui/templates/configmap.yaml
+++ b/helm/mcp-mesh-ui/templates/configmap.yaml
@@ -10,6 +10,11 @@ data:
   MCP_MESH_REGISTRY_URL: {{ .Values.ui.registryURL | quote }}
   MCP_MESH_LOG_LEVEL: {{ .Values.ui.logLevel | default "INFO" | quote }}
   MCP_MESH_DISTRIBUTED_TRACING_ENABLED: {{ .Values.ui.tracing.enabled | default "true" | quote }}
+  {{- /* hasKey instead of `default` so retention: 0 (disable) is not treated
+         as unset. meshui trims the mesh:trace stream too, so this must be
+         kept equal to registry.observability.distributedTracing.retention or
+         the two processes trim to different windows. */}}
+  MCP_MESH_TRACE_RETENTION: {{ hasKey .Values.ui.tracing "retention" | ternary .Values.ui.tracing.retention "24h" | toString | quote }}
   TEMPO_URL: {{ .Values.ui.tempo.url | quote }}
   TELEMETRY_ENDPOINT: {{ .Values.ui.tempo.telemetryEndpoint | quote }}
   {{- if .Values.ui.basePath }}

--- a/helm/mcp-mesh-ui/values.yaml
+++ b/helm/mcp-mesh-ui/values.yaml
@@ -78,6 +78,11 @@ ui:
     url: ""
   tracing:
     enabled: true
+    # mesh:trace Redis stream retention. meshui trims the stream alongside
+    # the registry so trimming survives either process being down, which
+    # means this must match registry.observability.distributedTracing.retention.
+    # Go duration string; "0" disables trimming from meshui.
+    retention: "24h"
   redis:
     # Full Redis URL. When empty, composed from global.redis.* (rediss:// when
     # global.redis.tls.enabled); an explicit value here always wins. When

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -349,9 +349,21 @@ export TELEMETRY_PROTOCOL=grpc                  # OTLP protocol: grpc or http
 # Trace exporter type: otlp, console, json (default: otlp)
 export TRACE_EXPORTER_TYPE=otlp
 
-# Redis trace stream retention — registry trims mesh:trace entries older
-# than this on connect and periodically (default: 24h; 0 disables trimming)
+# Redis trace stream retention — the registry AND meshui trim mesh:trace
+# entries older than this on connect and periodically, so trimming survives
+# either process being down (default: 24h; 0 disables trimming)
 export MCP_MESH_TRACE_RETENTION=24h
+
+# Producer-side XADD MAXLEN ~ ceiling on mesh:trace, applied by every agent
+# runtime so the stream stays bounded with no consumer alive
+# (default: 100000; 0 disables the producer-side cap)
+export MCP_MESH_TRACE_STREAM_MAXLEN=100000
+
+# In-memory dashboard aggregates (per-agent, per-model, per-edge). Keyed by
+# name, so bounded by age first and by a key ceiling as a backstop against
+# name churn (0 disables the respective bound)
+export MCP_MESH_TELEMETRY_AGGREGATE_RETENTION=24h
+export MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES=10000
 
 # Header propagation across agents (comma-separated prefixes)
 export MCP_MESH_PROPAGATE_HEADERS=x-request-id,x-trace
@@ -534,9 +546,16 @@ export DEFAULT_EVICTION_THRESHOLD=60  # Evict stale agents (seconds)
 # orphan schema_entries (content-addressed schemas no longer referenced
 # by any capability; #842) are retained before the periodic sweep job
 # purges them. Go duration string (e.g. "30m", "2h"). Default: 1h.
-# Set to "0" to disable the sweep entirely (forensic mode — keeps all
-# rows). Event rows are governed by a separate hardcoded 100k row cap.
+# Set to "0" to disable the agent/schema sweep (forensic mode — keeps
+# all agent and schema rows). The registry_events table has its own row
+# cap, MCP_MESH_EVENT_MAX_ROWS, which stays enforced either way.
 export MCP_MESH_RETENTION=1h
+
+# registry_events row cap — a table-size safety limit, not a retention
+# policy. Oldest rows are deleted once the table exceeds this many rows.
+# Enforced independently of MCP_MESH_RETENTION. Default: 100000.
+# Set to "0" to disable the cap deliberately.
+export MCP_MESH_EVENT_MAX_ROWS=100000
 
 # Registry sweep cadence — how often the periodic job/agent sweep runs
 # (reaping, lease recovery, retention purges). Go duration string (e.g.

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -103,6 +103,9 @@ Default credentials: `admin` / `admin`
 | `TELEMETRY_PROTOCOL`                   | Protocol        | `grpc`                  |
 | `TEMPO_URL`                            | Tempo query URL | `http://localhost:3200` |
 | `MCP_MESH_TRACE_RETENTION`             | Redis trace stream retention (`0` = no trimming) | `24h` |
+| `MCP_MESH_TRACE_STREAM_MAXLEN`         | Producer-side `XADD MAXLEN ~` ceiling on `mesh:trace` (`0` = no cap) | `100000` |
+| `MCP_MESH_TELEMETRY_AGGREGATE_RETENTION` | Age-out window for in-memory dashboard aggregates (`0` = no age pruning) | `24h` |
+| `MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES` | Key ceiling per aggregate map, LRU eviction (`0` = no ceiling) | `10000` |
 
 ## Troubleshooting
 

--- a/src/core/registry/sweep.go
+++ b/src/core/registry/sweep.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -22,9 +23,7 @@ import (
 	"mcp-mesh/src/core/logger"
 )
 
-// Internal sweep tunables. Operators get a single env-var knob
-// (MCP_MESH_RETENTION); these are deliberately not configurable so the
-// surface area stays small.
+// Internal sweep tunables.
 //
 // Exception: sweepInterval is overridable via MCP_MESH_SWEEP_INTERVAL so
 // integration tests that exercise crash-recovery and total_deadline expiry
@@ -33,7 +32,12 @@ import (
 const (
 	defaultSweepInterval = 5 * time.Minute
 	defaultRetention     = 1 * time.Hour
-	eventMaxRows         = 100_000
+
+	// defaultEventMaxRows caps the registry_events table. This is a
+	// table-size safety limit, NOT a retention policy: it is enforced
+	// independently of MCP_MESH_RETENTION (#1425) and tunable via
+	// MCP_MESH_EVENT_MAX_ROWS.
+	defaultEventMaxRows = 100_000
 )
 
 // sweepInterval is read once at package init from MCP_MESH_SWEEP_INTERVAL.
@@ -77,10 +81,24 @@ func readSweepIntervalFromEnv() time.Duration {
 
 // SweepConfig holds the configuration for the registry sweep job.
 //
-// Set Retention to 0 to disable the sweep entirely (forensic escape hatch:
-// no goroutine is launched, no agents or events are purged).
+// Set Retention to 0 to disable the agent/schema sweep (forensic escape
+// hatch: no agents or schema entries are purged). The registry_events row
+// cap is NOT affected by that — it has its own knob, EventMaxRows.
 type SweepConfig struct {
 	Retention time.Duration
+
+	// EventMaxRows caps the registry_events table. It is a table-size safety
+	// limit, not a retention policy, so it is enforced whether or not the
+	// agent/schema sweep is running (#1425): an operator who sets
+	// MCP_MESH_RETENTION=0 to preserve agent history no longer silently
+	// unbounds an unrelated table.
+	//
+	// 0 means "unset" and resolves to defaultEventMaxRows. Use the
+	// EventCapDisabled sentinel to turn the cap off deliberately — the zero
+	// value of a struct field must not be able to silently remove a bound.
+	// LoadSweepConfigFromEnv maps MCP_MESH_EVENT_MAX_ROWS=0 to that sentinel
+	// and logs it.
+	EventMaxRows int
 
 	// JobStaleTimeout is a DEFAULT total-runtime ceiling applied to jobs that
 	// did NOT set their own total_deadline, measured from submitted_at. The
@@ -92,17 +110,30 @@ type SweepConfig struct {
 	JobStaleTimeout time.Duration
 }
 
+// EventCapDisabled is the SweepConfig.EventMaxRows sentinel meaning "the
+// registry_events row cap is deliberately off". A plain 0 means "unset" and
+// resolves to defaultEventMaxRows, so a zero-valued config can never silently
+// remove the bound.
+const EventCapDisabled = -1
+
 // LoadSweepConfigFromEnv reads sweep configuration from the environment.
 //
-// Only MCP_MESH_RETENTION is honored:
+// MCP_MESH_RETENTION (agent/schema purge window):
 //   - unset / empty: defaults to 1h
 //   - any positive time.ParseDuration value (e.g. "2h", "30m"): use that value
-//   - "0" / "0s": disables the sweep job entirely
+//   - "0" / "0s": disables the agent/schema sweep (the registry_events row cap
+//     keeps running — see MCP_MESH_EVENT_MAX_ROWS)
 //   - negative (e.g. "-1h"): warn and fall back to default (likely a typo;
 //     0 is the documented disable mechanism)
 //   - invalid: warn and fall back to default
+//
+// MCP_MESH_EVENT_MAX_ROWS (registry_events table-size cap):
+//   - unset / empty: defaults to 100000
+//   - positive integer: use that value
+//   - "0": disables the cap — logged as a removed bound
+//   - negative / invalid: warn and fall back to default
 func LoadSweepConfigFromEnv(log *logger.Logger) SweepConfig {
-	cfg := SweepConfig{Retention: defaultRetention}
+	cfg := SweepConfig{Retention: defaultRetention, EventMaxRows: defaultEventMaxRows}
 
 	if v := os.Getenv("MCP_MESH_RETENTION"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
@@ -115,6 +146,27 @@ func LoadSweepConfigFromEnv(log *logger.Logger) SweepConfig {
 			}
 		} else if log != nil {
 			log.Warning("Invalid MCP_MESH_RETENTION %q, using default %s: %v", v, cfg.Retention, err)
+		}
+	}
+
+	if v := os.Getenv("MCP_MESH_EVENT_MAX_ROWS"); v != "" {
+		n, err := strconv.Atoi(v)
+		switch {
+		case err != nil:
+			if log != nil {
+				log.Warning("Invalid MCP_MESH_EVENT_MAX_ROWS %q, using default %d: %v", v, defaultEventMaxRows, err)
+			}
+		case n < 0:
+			if log != nil {
+				log.Warning("Invalid MCP_MESH_EVENT_MAX_ROWS %q: negative values are not allowed (use 0 to disable); using default %d", v, defaultEventMaxRows)
+			}
+		case n == 0:
+			if log != nil {
+				log.Warning("MCP_MESH_EVENT_MAX_ROWS=0: the registry_events row cap is DISABLED; the table will grow without bound")
+			}
+			cfg.EventMaxRows = EventCapDisabled
+		default:
+			cfg.EventMaxRows = n
 		}
 	}
 
@@ -169,9 +221,10 @@ func parseJobStaleTimeoutEnv() (time.Duration, error) {
 //     than Retention. Before deleting, dependency_resolution rows where
 //     the purged agent is a provider are flipped to status=unavailable so
 //     consumer-side state stays consistent.
-//  2. If the event row count exceeds the internal hard cap (100,000),
-//     delete oldest rows until back under the cap. Events are governed
-//     solely by row count, not age.
+//  2. If the event row count exceeds the row cap (MCP_MESH_EVENT_MAX_ROWS,
+//     default 100,000), delete oldest rows until back under the cap. Events
+//     are governed solely by row count, not age. This phase runs even when
+//     MCP_MESH_RETENTION=0 disables everything else (#1425).
 //  3. Purge orphan schema_entries (no capability still references the
 //     hash) older than Retention. Runs after step 1 so newly-orphaned
 //     schemas (whose last referencing capability got cascade-deleted)
@@ -193,17 +246,36 @@ type SweepJob struct {
 
 // NewSweepJob constructs a SweepJob with the given configuration.
 //
-// The clock and eventMaxRows are injectable for tests; production callers
-// should leave them unset so they default to time.Now (UTC) and the
-// internal eventMaxRows constant respectively.
+// The clock is injectable for tests; production callers should leave it unset
+// so it defaults to time.Now (UTC). eventMaxRows comes from cfg.EventMaxRows;
+// a zero-valued SweepConfig (as used by several tests) falls back to the
+// package default rather than silently disabling the cap — only an explicit
+// MCP_MESH_EVENT_MAX_ROWS=0 does that, and LoadSweepConfigFromEnv logs it.
+//
+// Only the EventCapDisabled sentinel turns the cap off. Any OTHER negative
+// value is a typo or an arithmetic slip, not an intent to unbound the table,
+// so it warns and falls back to the package default — matching how
+// LoadSweepConfigFromEnv treats bad env input.
 func NewSweepJob(cfg SweepConfig, entDB *database.EntDatabase, service *EntService, log *logger.Logger) *SweepJob {
+	maxRows := cfg.EventMaxRows
+	switch {
+	case maxRows == EventCapDisabled:
+		maxRows = 0 // explicit disable
+	case maxRows == 0:
+		maxRows = defaultEventMaxRows
+	case maxRows < 0:
+		if log != nil {
+			log.Warning("Invalid SweepConfig.EventMaxRows %d: negative values other than the EventCapDisabled sentinel (%d) are not allowed; using default %d", cfg.EventMaxRows, EventCapDisabled, defaultEventMaxRows)
+		}
+		maxRows = defaultEventMaxRows
+	}
 	return &SweepJob{
 		cfg:          cfg,
 		entDB:        entDB,
 		service:      service,
 		logger:       log,
 		clock:        func() time.Time { return time.Now().UTC() },
-		eventMaxRows: eventMaxRows,
+		eventMaxRows: maxRows,
 	}
 }
 
@@ -212,15 +284,20 @@ func NewSweepJob(cfg SweepConfig, entDB *database.EntDatabase, service *EntServi
 // runs every sweepInterval until the goroutine's context is cancelled or
 // Stop is called.
 //
-// If cfg.Retention is zero or negative the job is treated as disabled
-// and Start is a no-op.
+// MCP_MESH_RETENTION=0 disables the agent/schema/job phases but NOT the
+// registry_events row cap (#1425): the cap is a table-size safety limit, not
+// a retention policy, so the goroutine still starts and runs the cap-only
+// tick. Start is a full no-op only when BOTH bounds are off.
 func (s *SweepJob) Start(ctx context.Context) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.cfg.Retention <= 0 {
+	sweepEnabled := s.cfg.Retention > 0
+	capEnabled := s.eventMaxRows > 0
+
+	if !sweepEnabled && !capEnabled {
 		if s.logger != nil {
-			s.logger.Info("🧹 Registry sweep job disabled (MCP_MESH_RETENTION=0)")
+			s.logger.Warning("🧹 Registry sweep job fully disabled (MCP_MESH_RETENTION=0 and MCP_MESH_EVENT_MAX_ROWS=0): agents/schemas are never purged AND registry_events is not capped")
 		}
 		return
 	}
@@ -236,14 +313,29 @@ func (s *SweepJob) Start(ctx context.Context) {
 	s.running = true
 	s.wg.Add(1)
 
+	// Pick the tick body. With the sweep disabled we still run the event-cap
+	// phase on the same schedule, so disabling one bound never removes the
+	// other.
+	tick := s.tick
+	if !sweepEnabled {
+		tick = s.tickEventCapOnly
+	}
+
 	go func() {
 		defer s.wg.Done()
 		if s.logger != nil {
-			s.logger.Info("🧹 Starting registry sweep job (retention=%s)", s.cfg.Retention)
+			switch {
+			case sweepEnabled && capEnabled:
+				s.logger.Info("🧹 Starting registry sweep job (retention=%s, registry_events cap=%d rows)", s.cfg.Retention, s.eventMaxRows)
+			case sweepEnabled:
+				s.logger.Info("🧹 Starting registry sweep job (retention=%s); registry_events row cap DISABLED (MCP_MESH_EVENT_MAX_ROWS=0)", s.cfg.Retention)
+			default:
+				s.logger.Info("🧹 Registry sweep job disabled (MCP_MESH_RETENTION=0): agents and schemas are never purged. The registry_events row cap (%d rows, MCP_MESH_EVENT_MAX_ROWS) is still enforced every %s", s.eventMaxRows, sweepInterval)
+			}
 		}
 
 		// Run once at startup to catch missed sweeps after downtime.
-		s.tick(jobCtx)
+		tick(jobCtx)
 
 		ticker := time.NewTicker(sweepInterval)
 		defer ticker.Stop()
@@ -251,7 +343,7 @@ func (s *SweepJob) Start(ctx context.Context) {
 		for {
 			select {
 			case <-ticker.C:
-				s.tick(jobCtx)
+				tick(jobCtx)
 			case <-jobCtx.Done():
 				if s.logger != nil {
 					s.logger.Info("🛑 Registry sweep job stopped")
@@ -322,6 +414,32 @@ func (s *SweepJob) tick(ctx context.Context) {
 				res.jobsDeadlined, res.jobsStaled, res.jobEventsPurged, took)
 		} else {
 			s.logger.Debug("sweep: nothing to purge (took %s)", took)
+		}
+	}
+}
+
+// tickEventCapOnly is the tick body used when MCP_MESH_RETENTION=0. It runs
+// ONLY the registry_events row cap — the agent, schema and job phases stay
+// disabled, exactly as the operator asked for. It exists so that turning off
+// the retention sweep cannot also turn off an unrelated table-size bound
+// (#1425).
+func (s *SweepJob) tickEventCapOnly(ctx context.Context) {
+	start := s.clock()
+	n, err := s.enforceEventCap(ctx)
+	took := time.Since(start)
+
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("sweep: event cap enforcement failed (took %s): %v", took, err)
+		}
+		return
+	}
+
+	if s.logger != nil {
+		if n > 0 {
+			s.logger.Info("sweep: purged %d events over the %d-row cap (took %s)", n, s.eventMaxRows, took)
+		} else {
+			s.logger.Debug("sweep: registry_events under the %d-row cap (took %s)", s.eventMaxRows, took)
 		}
 	}
 }
@@ -577,10 +695,17 @@ func (s *SweepJob) purgeOneAgent(ctx context.Context, a *ent.Agent, threshold ti
 	return deleted, nil
 }
 
-// enforceEventCap deletes the oldest events when the table exceeds the
-// internal hard cap (s.eventMaxRows, defaulting to the package constant).
-// Events are governed solely by row count, not age.
+// enforceEventCap deletes the oldest events when the table exceeds the row
+// cap (s.eventMaxRows, from MCP_MESH_EVENT_MAX_ROWS, defaulting to the package
+// constant). Events are governed solely by row count, not age.
+//
+// A non-positive cap means the operator deliberately disabled it; without this
+// guard a cap of 0 would delete every row rather than keeping none bounded.
 func (s *SweepJob) enforceEventCap(ctx context.Context) (int, error) {
+	if s.eventMaxRows <= 0 {
+		return 0, nil
+	}
+
 	count, err := s.entDB.Client.RegistryEvent.Query().Count(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("count events: %w", err)

--- a/src/core/registry/sweep_event_cap_test.go
+++ b/src/core/registry/sweep_event_cap_test.go
@@ -1,0 +1,264 @@
+package registry
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"mcp-mesh/src/core/config"
+	"mcp-mesh/src/core/ent/agent"
+	"mcp-mesh/src/core/logger"
+)
+
+// waitForEventCount polls the registry_events row count until it reaches want
+// or the deadline expires, returning the last observed count. Used because the
+// sweep's startup tick runs in its own goroutine.
+func waitForEventCount(t *testing.T, job *SweepJob, want int, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	last := -1
+	for time.Now().Before(deadline) {
+		n, err := job.entDB.Client.RegistryEvent.Query().Count(context.Background())
+		if err != nil {
+			t.Fatalf("count events: %v", err)
+		}
+		last = n
+		if n == want {
+			return n
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return last
+}
+
+// TestEventCapEnforcedWithRetentionZero is issue #1425.
+//
+// BEFORE: SweepJob.Start returned immediately when Retention <= 0, so
+// enforceEventCap — which only ever ran inside runOnce, inside the sweep loop
+// — never executed. Disabling the agent/schema sweep silently unbounded
+// registry_events.
+//
+// AFTER: Start launches a cap-only tick, so the row cap holds regardless of
+// the retention setting. This test fails against the pre-fix code (the row
+// count stays at 5).
+func TestEventCapEnforcedWithRetentionZero(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 0} // sweep disabled — the forensic escape hatch
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	job.eventMaxRows = 3
+
+	seedAgent(t, client, "host", agent.StatusHealthy, now)
+	for i := 0; i < 5; i++ {
+		seedEvent(t, client, "host", now.Add(-time.Duration(5-i)*time.Minute))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	job.Start(ctx)
+	defer job.Stop()
+
+	if got := waitForEventCount(t, job, 3, 3*time.Second); got != 3 {
+		t.Fatalf("registry_events count = %d, want 3: the row cap is not enforced with MCP_MESH_RETENTION=0", got)
+	}
+
+	// The agent purge must remain OFF — the operator asked for that.
+	agents, err := client.Agent.Query().Count(ctx)
+	if err != nil {
+		t.Fatalf("count agents: %v", err)
+	}
+	if agents != 1 {
+		t.Fatalf("agent count = %d, want 1: the cap-only tick must not purge agents", agents)
+	}
+}
+
+// TestEventCapOnlyTickLeavesStaleAgentsAlone proves the cap-only path really
+// is cap-only: a stale unhealthy agent that the full sweep WOULD purge must
+// survive, because the operator disabled that on purpose.
+func TestEventCapOnlyTickLeavesStaleAgentsAlone(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 0}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	job.eventMaxRows = 2
+
+	// Long-dead unhealthy agent — prime purge material for the real sweep.
+	seedAgent(t, client, "long-dead", agent.StatusUnhealthy, now.Add(-30*24*time.Hour))
+	for i := 0; i < 6; i++ {
+		seedEvent(t, client, "long-dead", now.Add(-time.Duration(6-i)*time.Minute))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	job.Start(ctx)
+	defer job.Stop()
+
+	if got := waitForEventCount(t, job, 2, 3*time.Second); got != 2 {
+		t.Fatalf("registry_events count = %d, want 2", got)
+	}
+
+	agents, err := client.Agent.Query().Count(ctx)
+	if err != nil {
+		t.Fatalf("count agents: %v", err)
+	}
+	if agents != 1 {
+		t.Fatalf("agent count = %d, want 1: a 30-day-stale agent was purged despite MCP_MESH_RETENTION=0", agents)
+	}
+}
+
+// TestSweepFullyDisabledWhenBothBoundsOff verifies the only remaining no-op
+// path: both knobs explicitly off. Nothing runs, and (checked by reading the
+// code path, logged as a Warning) the operator is told both bounds are gone.
+func TestSweepFullyDisabledWhenBothBoundsOff(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 0, EventMaxRows: EventCapDisabled}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	if job.eventMaxRows != 0 {
+		t.Fatalf("eventMaxRows = %d, want 0 for the EventCapDisabled sentinel", job.eventMaxRows)
+	}
+
+	seedAgent(t, client, "host", agent.StatusHealthy, now)
+	for i := 0; i < 5; i++ {
+		seedEvent(t, client, "host", now.Add(-time.Duration(5-i)*time.Minute))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	job.Start(ctx)
+	defer job.Stop()
+
+	time.Sleep(200 * time.Millisecond)
+
+	n, err := client.RegistryEvent.Query().Count(ctx)
+	if err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if n != 5 {
+		t.Fatalf("registry_events count = %d, want 5: nothing should run with both bounds off", n)
+	}
+
+	job.mu.Lock()
+	running := job.running
+	job.mu.Unlock()
+	if running {
+		t.Error("sweep goroutine started even though both bounds are disabled")
+	}
+}
+
+// TestEnforceEventCapDisabledDoesNotDeleteEverything is the guard against the
+// obvious way to get this wrong: with the cap at 0, "count > cap" would be
+// true for every row and the excess would be the whole table.
+func TestEnforceEventCapDisabledDoesNotDeleteEverything(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: time.Hour, EventMaxRows: EventCapDisabled}
+	client, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	seedAgent(t, client, "host", agent.StatusHealthy, now)
+	for i := 0; i < 5; i++ {
+		seedEvent(t, client, "host", now.Add(-time.Duration(5-i)*time.Minute))
+	}
+
+	res, err := job.runOnce(context.Background())
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res.eventsPurged != 0 {
+		t.Errorf("eventsPurged = %d, want 0 with the cap disabled", res.eventsPurged)
+	}
+
+	n, err := client.RegistryEvent.Query().Count(context.Background())
+	if err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if n != 5 {
+		t.Fatalf("registry_events count = %d, want 5: a disabled cap deleted rows", n)
+	}
+}
+
+// TestNewSweepJobEventMaxRowsResolution pins the zero-vs-sentinel semantics:
+// a zero-valued struct field must NOT be able to silently remove the bound.
+func TestNewSweepJobEventMaxRowsResolution(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  int
+		want int
+	}{
+		{"unset_uses_default", 0, defaultEventMaxRows},
+		{"explicit_value", 42, 42},
+		{"sentinel_disables", EventCapDisabled, 0},
+		// A stray negative must NOT unbound the table. Only the -1 sentinel
+		// disables the cap; every other negative is a typo and falls back to
+		// the default (warned, not silently corrected).
+		{"non_sentinel_negative_falls_back", -2, defaultEventMaxRows},
+		{"large_negative_falls_back", -100_000, defaultEventMaxRows},
+		{"min_int_negative_falls_back", math.MinInt, defaultEventMaxRows},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+			_, _, job, cleanup := newSweepTestEnv(t, SweepConfig{Retention: time.Hour, EventMaxRows: tc.cfg}, now)
+			defer cleanup()
+			if job.eventMaxRows != tc.want {
+				t.Fatalf("eventMaxRows = %d, want %d", job.eventMaxRows, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoadSweepConfigEventMaxRowsFromEnv covers the MCP_MESH_EVENT_MAX_ROWS
+// knob, including that a bad value falls back to the default instead of
+// silently unbounding the table.
+func TestLoadSweepConfigEventMaxRowsFromEnv(t *testing.T) {
+	testLogger := logger.New(&config.Config{LogLevel: "ERROR"})
+
+	cases := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"unset_uses_default", "", defaultEventMaxRows},
+		{"positive_override", "5000", 5000},
+		{"zero_disables", "0", EventCapDisabled},
+		{"negative_falls_back", "-1", defaultEventMaxRows},
+		{"garbage_falls_back", "many", defaultEventMaxRows},
+		{"float_falls_back", "1e5", defaultEventMaxRows},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MCP_MESH_EVENT_MAX_ROWS", tc.env)
+			cfg := LoadSweepConfigFromEnv(testLogger)
+			if cfg.EventMaxRows != tc.want {
+				t.Fatalf("EventMaxRows = %d, want %d", cfg.EventMaxRows, tc.want)
+			}
+		})
+	}
+}
+
+// TestRetentionZeroDoesNotChangeEventCapConfig is the acceptance criterion
+// stated in #1425: "Disabling the agent/schema sweep does not change whether
+// registry_events is capped."
+func TestRetentionZeroDoesNotChangeEventCapConfig(t *testing.T) {
+	testLogger := logger.New(&config.Config{LogLevel: "ERROR"})
+
+	t.Setenv("MCP_MESH_EVENT_MAX_ROWS", "")
+
+	t.Setenv("MCP_MESH_RETENTION", "1h")
+	withSweep := LoadSweepConfigFromEnv(testLogger)
+
+	t.Setenv("MCP_MESH_RETENTION", "0")
+	withoutSweep := LoadSweepConfigFromEnv(testLogger)
+
+	if withoutSweep.Retention != 0 {
+		t.Fatalf("Retention = %s, want 0", withoutSweep.Retention)
+	}
+	if withoutSweep.EventMaxRows != withSweep.EventMaxRows {
+		t.Fatalf("MCP_MESH_RETENTION=0 changed the event cap: %d vs %d",
+			withoutSweep.EventMaxRows, withSweep.EventMaxRows)
+	}
+}

--- a/src/core/registry/sweep_test.go
+++ b/src/core/registry/sweep_test.go
@@ -249,7 +249,7 @@ func TestSweepEventMaxRowsOverCap(t *testing.T) {
 // event is well under the 100k cap, not because enforceEventCap is gated
 // (it always runs regardless of Retention).
 //
-// Note: Start() bails out before launching the goroutine when retention=0;
+// Note: with retention=0 Start() runs only the event-cap tick (#1425);
 // runOnce here is invoked directly to confirm the agent path is gated.
 func TestSweepDisabledRetention(t *testing.T) {
 	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
@@ -277,22 +277,50 @@ func TestSweepDisabledRetention(t *testing.T) {
 	}
 }
 
-// TestSweepDisabledStartIsNoop verifies that Start() with retention=0 does
-// not launch the goroutine (the operator's forensic escape hatch).
+// TestSweepDisabledStartIsNoop verifies that Start() launches nothing only
+// when BOTH bounds are off.
+//
+// Retention=0 alone is the operator's forensic escape hatch for agent/schema
+// history, but it no longer takes the registry_events row cap down with it
+// (#1425): the goroutine still runs, executing only the cap-only tick. See
+// TestEventCapEnforcedWithRetentionZero and
+// TestEventCapOnlyTickLeavesStaleAgentsAlone for what does and does not run.
 func TestSweepDisabledStartIsNoop(t *testing.T) {
 	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
-	cfg := SweepConfig{Retention: 0}
+	cfg := SweepConfig{Retention: 0, EventMaxRows: EventCapDisabled}
 	_, _, job, cleanup := newSweepTestEnv(t, cfg, now)
 	defer cleanup()
 
 	job.Start(context.Background())
+	defer job.Stop()
 
 	job.mu.Lock()
 	running := job.running
 	job.mu.Unlock()
 
 	if running {
-		t.Errorf("expected sweep job to NOT be running when Retention=0, but running=true")
+		t.Errorf("expected sweep job to NOT be running with Retention=0 and the event cap disabled, but running=true")
+	}
+}
+
+// TestSweepRetentionZeroStillRunsForEventCap is the counterpart: with only
+// Retention=0 the goroutine DOES start, because the registry_events row cap is
+// an independent bound (#1425).
+func TestSweepRetentionZeroStillRunsForEventCap(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	cfg := SweepConfig{Retention: 0}
+	_, _, job, cleanup := newSweepTestEnv(t, cfg, now)
+	defer cleanup()
+
+	job.Start(context.Background())
+	defer job.Stop()
+
+	job.mu.Lock()
+	running := job.running
+	job.mu.Unlock()
+
+	if !running {
+		t.Errorf("expected the sweep goroutine to run for the event cap with Retention=0, but running=false")
 	}
 }
 

--- a/src/core/registry/tracing/accumulator.go
+++ b/src/core/registry/tracing/accumulator.go
@@ -54,8 +54,11 @@ type TraceAccumulator struct {
 	// Active (in-progress) traces keyed by trace ID
 	activeTraces map[string]*activeTrace
 
-	// Per-edge stats keyed by "source -> target"
-	edgeStats map[string]*edgeAccum
+	// Per-edge stats keyed by "source -> target". Bounded by edgeBounds:
+	// each entry carries a LastSeen stamp so idle edges age out, and the
+	// number of keys is capped as a backstop against name churn (#1424).
+	edgeStats  map[string]*edgeAccum
+	edgeBounds AggregateBounds
 
 	// Total number of finalized traces (never resets)
 	totalFinalized int
@@ -99,10 +102,19 @@ type edgeAccum struct {
 	TotalMs     int64
 	MaxMs       int64
 	MinMs       int64
+	LastSeen    time.Time // last observation, drives age-based pruning
 }
 
-// NewTraceAccumulator creates a new accumulator with the given ring buffer size.
+// NewTraceAccumulator creates a new accumulator with the given ring buffer
+// size and the process-wide aggregate bounds (see DefaultAggregateBounds).
 func NewTraceAccumulator(ringSize int, logger *log.Logger) *TraceAccumulator {
+	return NewTraceAccumulatorWithBounds(ringSize, logger, DefaultAggregateBounds())
+}
+
+// NewTraceAccumulatorWithBounds is NewTraceAccumulator with explicit edge-stat
+// bounds. Production callers should use NewTraceAccumulator so the operator's
+// env configuration applies; this exists for tests.
+func NewTraceAccumulatorWithBounds(ringSize int, logger *log.Logger, bounds AggregateBounds) *TraceAccumulator {
 	if ringSize <= 0 {
 		ringSize = 200
 	}
@@ -111,6 +123,7 @@ func NewTraceAccumulator(ringSize int, logger *log.Logger) *TraceAccumulator {
 		ringSize:     ringSize,
 		activeTraces: make(map[string]*activeTrace),
 		edgeStats:    make(map[string]*edgeAccum),
+		edgeBounds:   bounds,
 		liveClients:  make(map[chan *LiveTraceEvent]struct{}),
 		dirtyTraces:  make(map[string]bool),
 		logger:       logger,
@@ -210,6 +223,47 @@ func (ta *TraceAccumulator) recordEdge(source, target string, durationMs int64, 
 	if success != nil && !*success {
 		ea.ErrorCount++
 	}
+	ea.LastSeen = time.Now()
+
+	// Hard key ceiling. Age pruning (pruneEdgeStats) is the primary bound;
+	// this only trips when new edge names appear faster than the retention
+	// window retires them, and it evicts least-recently-seen first.
+	if evicted := EnforceMaxEntries(ta.edgeStats, edgeLastSeen, ta.edgeBounds.MaxEntries); evicted > 0 && ta.logger != nil {
+		ta.logger.Printf("TraceAccumulator: edge-stat key cap (%d) reached, evicted %d least-recently-seen edges "+
+			"(raise MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES or shorten MCP_MESH_TELEMETRY_AGGREGATE_RETENTION)",
+			ta.edgeBounds.MaxEntries, evicted)
+	}
+}
+
+// edgeLastSeen adapts edgeAccum to the PruneOlderThan/EnforceMaxEntries
+// accessor signature.
+func edgeLastSeen(ea *edgeAccum) time.Time { return ea.LastSeen }
+
+// pruneEdgeStats removes edge entries not observed within the retention
+// window. Mirrors SpanCorrelator.pruneExpiredCompletedTraces: age-based, with
+// a retention <= 0 no-op. Called from cleanupLoop.
+func (ta *TraceAccumulator) pruneEdgeStats() {
+	if ta.edgeBounds.Retention <= 0 {
+		return
+	}
+
+	cutoff := time.Now().Add(-ta.edgeBounds.Retention)
+
+	ta.mu.Lock()
+	removed := PruneOlderThan(ta.edgeStats, edgeLastSeen, cutoff)
+	ta.mu.Unlock()
+
+	if removed > 0 && ta.logger != nil {
+		ta.logger.Printf("TraceAccumulator: pruned %d edge stats idle longer than %s", removed, ta.edgeBounds.Retention)
+	}
+}
+
+// EdgeStatCount returns the current number of tracked edge keys. Exposed for
+// tests and diagnostics.
+func (ta *TraceAccumulator) EdgeStatCount() int {
+	ta.mu.RLock()
+	defer ta.mu.RUnlock()
+	return len(ta.edgeStats)
 }
 
 // finalizeTrace converts an active trace into a RecentTraceSummary and pushes
@@ -523,7 +577,7 @@ func (ta *TraceAccumulator) Stop() {
 
 func (ta *TraceAccumulator) cleanupLoop() {
 	defer ta.wg.Done()
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(AggregatePruneInterval)
 	defer ticker.Stop()
 
 	for {
@@ -532,6 +586,7 @@ func (ta *TraceAccumulator) cleanupLoop() {
 			return
 		case <-ticker.C:
 			ta.cleanupStaleTraces()
+			ta.pruneEdgeStats()
 		}
 	}
 }

--- a/src/core/registry/tracing/accumulator_bounds_test.go
+++ b/src/core/registry/tracing/accumulator_bounds_test.go
@@ -1,0 +1,168 @@
+package tracing
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"testing"
+	"time"
+)
+
+// feedEdgeTrace drives one two-agent trace through the accumulator's real
+// entry points (ProcessTraceEvent + FinalizeAllActive), producing exactly one
+// "source -> target" edge key. This is the live path — no direct map writes.
+func feedEdgeTrace(ta *TraceAccumulator, traceID, source, target string) {
+	_ = ta.ProcessTraceEvent(makeEndEvent(traceID, "root-"+traceID, "", source, 10, true))
+	_ = ta.ProcessTraceEvent(makeEndEvent(traceID, "child-"+traceID, "root-"+traceID, target, 5, true))
+	ta.FinalizeAllActive()
+}
+
+// TestEdgeStatsUnboundedWithoutBounds is the "before" half of the #1424
+// contrast: with both bounds off (the pre-fix behaviour), the edge map grows
+// one key per distinct agent-name pair, forever.
+func TestEdgeStatsUnboundedWithoutBounds(t *testing.T) {
+	ta := NewTraceAccumulatorWithBounds(16, log.New(io.Discard, "", 0), AggregateBounds{})
+
+	const churn = 2000
+	for i := 0; i < churn; i++ {
+		feedEdgeTrace(ta, fmt.Sprintf("t%04d", i), fmt.Sprintf("caller-pod-%04d", i), "backend")
+	}
+
+	if got := ta.EdgeStatCount(); got != churn {
+		t.Fatalf("unbounded accumulator: edge keys = %d, want %d (this test documents the pre-fix growth)", got, churn)
+	}
+}
+
+// TestEdgeStatsKeyCapBoundsGrowth is the "after" half: the same churn under
+// the default-shaped bounds never exceeds the cap, checked after EVERY trace
+// rather than only at the end.
+func TestEdgeStatsKeyCapBoundsGrowth(t *testing.T) {
+	const cap = 50
+	ta := NewTraceAccumulatorWithBounds(16, log.New(io.Discard, "", 0),
+		AggregateBounds{Retention: 24 * time.Hour, MaxEntries: cap})
+
+	const churn = 2000
+	for i := 0; i < churn; i++ {
+		feedEdgeTrace(ta, fmt.Sprintf("t%04d", i), fmt.Sprintf("caller-pod-%04d", i), "backend")
+		if got := ta.EdgeStatCount(); got > cap {
+			t.Fatalf("after trace %d: edge keys = %d exceeds cap %d", i, got, cap)
+		}
+	}
+
+	if got := ta.EdgeStatCount(); got == 0 {
+		t.Fatal("edge map emptied entirely; the cap is evicting too aggressively")
+	}
+
+	// GetEdgeStats must still work off the bounded map.
+	edges := ta.GetEdgeStats()
+	if len(edges) == 0 {
+		t.Fatal("GetEdgeStats returned nothing after 2000 traces")
+	}
+	if len(edges) > cap {
+		t.Fatalf("GetEdgeStats returned %d edges, exceeds cap %d", len(edges), cap)
+	}
+}
+
+// TestEdgeStatsAgePrune proves the PRIMARY bound: an edge that stopped
+// reporting ages out, while a still-active edge survives. Dropping a live edge
+// would be worse than holding a dead one, so both directions are asserted.
+func TestEdgeStatsAgePrune(t *testing.T) {
+	ta := NewTraceAccumulatorWithBounds(16, log.New(io.Discard, "", 0),
+		AggregateBounds{Retention: time.Hour, MaxEntries: 1000})
+
+	feedEdgeTrace(ta, "t1", "retired-agent", "backend")
+	feedEdgeTrace(ta, "t2", "live-agent", "backend")
+
+	if got := ta.EdgeStatCount(); got != 2 {
+		t.Fatalf("edge keys = %d, want 2 before pruning", got)
+	}
+
+	// Age the retired edge past the window; leave the live one fresh.
+	ta.mu.Lock()
+	ta.edgeStats["retired-agent -> backend"].LastSeen = time.Now().Add(-2 * time.Hour)
+	ta.mu.Unlock()
+
+	ta.pruneEdgeStats()
+
+	if got := ta.EdgeStatCount(); got != 1 {
+		t.Fatalf("edge keys = %d after prune, want 1", got)
+	}
+	ta.mu.RLock()
+	_, liveOK := ta.edgeStats["live-agent -> backend"]
+	_, deadOK := ta.edgeStats["retired-agent -> backend"]
+	ta.mu.RUnlock()
+	if !liveOK {
+		t.Error("still-active edge was pruned")
+	}
+	if deadOK {
+		t.Error("idle edge survived the prune")
+	}
+}
+
+// TestEdgeStatsAgePruneDisabled proves retention=0 is an honest no-op rather
+// than a silent surprise, matching pruneExpiredCompletedTraces' contract.
+func TestEdgeStatsAgePruneDisabled(t *testing.T) {
+	ta := NewTraceAccumulatorWithBounds(16, log.New(io.Discard, "", 0),
+		AggregateBounds{Retention: 0, MaxEntries: 1000})
+
+	feedEdgeTrace(ta, "t1", "ancient", "backend")
+	ta.mu.Lock()
+	ta.edgeStats["ancient -> backend"].LastSeen = time.Now().Add(-1000 * time.Hour)
+	ta.mu.Unlock()
+
+	ta.pruneEdgeStats()
+
+	if got := ta.EdgeStatCount(); got != 1 {
+		t.Fatalf("edge keys = %d, want 1 (retention=0 must not prune)", got)
+	}
+}
+
+// TestEdgeStatsDefaultPathUnchanged is the no-regression guard: a normally
+// sized mesh (a handful of agents, repeated calls) sees byte-identical edge
+// stats under the shipped defaults. The dashboard must show what it shows
+// today.
+func TestEdgeStatsDefaultPathUnchanged(t *testing.T) {
+	bounded := newTestAccumulator(t, 16) // ships with DefaultAggregateBounds
+	unbounded := NewTraceAccumulatorWithBounds(16, log.New(io.Discard, "", 0), AggregateBounds{})
+
+	agents := []string{"frontend", "auth", "billing", "search"}
+	for i := 0; i < 500; i++ {
+		src := agents[i%len(agents)]
+		dst := agents[(i+1)%len(agents)]
+		id := fmt.Sprintf("t%04d", i)
+		feedEdgeTrace(bounded, id, src, dst)
+		feedEdgeTrace(unbounded, id, src, dst)
+	}
+
+	// Compare as a keyed set: GetEdgeStats sorts by CallCount with an
+	// unstable sort, so equal-count edges have never had a deterministic
+	// order. The invariant that matters is that every edge and every number
+	// is identical.
+	index := func(edges []EdgeStats) map[string]EdgeStats {
+		m := make(map[string]EdgeStats, len(edges))
+		for _, e := range edges {
+			m[e.Source+" -> "+e.Target] = e
+		}
+		return m
+	}
+	bEdges := index(bounded.GetEdgeStats())
+	uEdges := index(unbounded.GetEdgeStats())
+	if len(bEdges) != len(uEdges) {
+		t.Fatalf("edge count differs under defaults: bounded=%d unbounded=%d", len(bEdges), len(uEdges))
+	}
+	if len(bEdges) == 0 {
+		t.Fatal("no edges recorded; the test did not exercise the aggregate path")
+	}
+	for key, want := range uEdges {
+		got, ok := bEdges[key]
+		if !ok {
+			t.Fatalf("edge %q missing under the shipped defaults", key)
+		}
+		if got != want {
+			t.Fatalf("edge %q differs under defaults:\n bounded=%+v\n   plain=%+v", key, got, want)
+		}
+	}
+	if bounded.GetTotalFinalized() != unbounded.GetTotalFinalized() {
+		t.Fatalf("totals differ: %d vs %d", bounded.GetTotalFinalized(), unbounded.GetTotalFinalized())
+	}
+}

--- a/src/core/registry/tracing/aggregates.go
+++ b/src/core/registry/tracing/aggregates.go
@@ -1,0 +1,180 @@
+package tracing
+
+import (
+	"log"
+	"os"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// Bounds for the in-memory telemetry AGGREGATE maps that sit on top of the
+// trace stream: TraceAccumulator.edgeStats and the UI MetricsProcessor's
+// per-agent / per-model maps. The stream itself is bounded by
+// MCP_MESH_TRACE_RETENTION; these maps are keyed by agent / model / edge name
+// and, before #1424, were written on every event and never pruned.
+//
+// Cardinality here is names, not volume, so the primary bound is AGE: a key
+// that has not been written to within the retention window has stopped
+// reporting and ages out. MaxEntries is a hard ceiling for the pathological
+// case (name churn faster than the retention window can absorb); it evicts
+// least-recently-seen first, so it only ever degrades into LRU once age
+// pruning has already failed to keep up.
+const (
+	defaultAggregateRetention  = 24 * time.Hour
+	defaultAggregateMaxEntries = 10000
+
+	// AggregatePruneInterval is how often age pruning runs. The accumulator
+	// piggybacks its existing 10s cleanup loop; the MetricsProcessor gates its
+	// inline prune on the same interval so both maps age out at the same rate.
+	AggregatePruneInterval = 10 * time.Second
+)
+
+// AggregateBounds bounds a telemetry aggregate map.
+//
+// Retention is the age-out window for a key that has stopped being written to
+// (0 disables age pruning). MaxEntries is the hard per-map key ceiling
+// (0 disables the ceiling). Both are set from the environment by
+// LoadAggregateBoundsFromEnv; tests inject values directly.
+type AggregateBounds struct {
+	Retention  time.Duration
+	MaxEntries int
+}
+
+// defaultAggregateBounds is read once at package init, mirroring the
+// sweepInterval convention in the registry package: the env read has to happen
+// before any structured logger exists, and the value cannot change at runtime.
+var defaultAggregateBounds = LoadAggregateBoundsFromEnv()
+
+// DefaultAggregateBounds returns the process-wide aggregate bounds derived
+// from the environment at init time. Both the registry and meshui construct
+// their aggregate maps from this.
+func DefaultAggregateBounds() AggregateBounds {
+	return defaultAggregateBounds
+}
+
+// LoadAggregateBoundsFromEnv reads the aggregate bounds from the environment.
+//
+// MCP_MESH_TELEMETRY_AGGREGATE_RETENTION (Go duration):
+//   - unset / empty: 24h
+//   - positive: use it
+//   - "0" / "0s": age pruning disabled — logged as a removed bound
+//   - negative / unparseable: warn and fall back to the default
+//
+// MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES (integer):
+//   - unset / empty: 10000
+//   - positive: use it
+//   - "0": key ceiling disabled — logged as a removed bound
+//   - negative / unparseable: warn and fall back to the default
+//
+// Uses the stdlib log package because it runs at package init, before any
+// manager (and therefore any manager logger) exists.
+func LoadAggregateBoundsFromEnv() AggregateBounds {
+	b := AggregateBounds{
+		Retention:  defaultAggregateRetention,
+		MaxEntries: defaultAggregateMaxEntries,
+	}
+
+	if raw := os.Getenv("MCP_MESH_TELEMETRY_AGGREGATE_RETENTION"); raw != "" {
+		d, err := time.ParseDuration(raw)
+		switch {
+		case err != nil:
+			log.Printf("[TRACE-AGGREGATES] Invalid MCP_MESH_TELEMETRY_AGGREGATE_RETENTION %q, using default %s: %v",
+				raw, defaultAggregateRetention, err)
+		case d < 0:
+			log.Printf("[TRACE-AGGREGATES] Invalid MCP_MESH_TELEMETRY_AGGREGATE_RETENTION %q: negative durations are not allowed (use 0 to disable); using default %s",
+				raw, defaultAggregateRetention)
+		case d == 0:
+			log.Printf("[TRACE-AGGREGATES] MCP_MESH_TELEMETRY_AGGREGATE_RETENTION=0: per-agent/model/edge aggregates will NOT age out; only the MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES ceiling bounds them")
+			b.Retention = 0
+		default:
+			b.Retention = d
+		}
+	}
+
+	if raw := os.Getenv("MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		switch {
+		case err != nil:
+			log.Printf("[TRACE-AGGREGATES] Invalid MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES %q, using default %d: %v",
+				raw, defaultAggregateMaxEntries, err)
+		case n < 0:
+			log.Printf("[TRACE-AGGREGATES] Invalid MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES %q: negative values are not allowed (use 0 to disable); using default %d",
+				raw, defaultAggregateMaxEntries)
+		case n == 0:
+			log.Printf("[TRACE-AGGREGATES] MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES=0: per-agent/model/edge aggregate maps have NO key ceiling; only MCP_MESH_TELEMETRY_AGGREGATE_RETENTION bounds them")
+			b.MaxEntries = 0
+		default:
+			b.MaxEntries = n
+		}
+	}
+
+	if b.Retention == 0 && b.MaxEntries == 0 {
+		log.Printf("[TRACE-AGGREGATES] WARNING: both MCP_MESH_TELEMETRY_AGGREGATE_RETENTION and MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES are 0 — in-memory telemetry aggregates are UNBOUNDED and will grow with agent/model name cardinality")
+	}
+
+	return b
+}
+
+// PruneOlderThan removes every entry from m whose lastSeen timestamp is before
+// cutoff, returning the number removed. No-op on a nil/empty map.
+//
+// Exported so the UI package's MetricsProcessor can share the accumulator's
+// pruning semantics rather than reimplementing them.
+func PruneOlderThan[V any](m map[string]V, lastSeen func(V) time.Time, cutoff time.Time) int {
+	removed := 0
+	for k, v := range m {
+		if lastSeen(v).Before(cutoff) {
+			delete(m, k)
+			removed++
+		}
+	}
+	return removed
+}
+
+// EnforceMaxEntries drops the least-recently-seen entries when m exceeds max,
+// returning the number evicted. max <= 0 disables the ceiling.
+//
+// Eviction is batched: once the cap is breached we drop down to ~90% of it
+// (always at least one entry) so the O(n log n) sort is amortised over many
+// subsequent inserts instead of being paid on every insert past the cap. The
+// post-condition callers rely on is len(m) <= max.
+func EnforceMaxEntries[V any](m map[string]V, lastSeen func(V) time.Time, max int) int {
+	if max <= 0 || len(m) <= max {
+		return 0
+	}
+
+	target := max - max/10
+	if target >= max {
+		// max < 10, so the 10% batch rounded to zero. Evict one entry so the
+		// call always makes progress.
+		target = max - 1
+	}
+	if target < 1 {
+		// Never empty the map: with max == 1 the newest entry must survive.
+		target = 1
+	}
+
+	type entry struct {
+		key  string
+		seen time.Time
+	}
+	entries := make([]entry, 0, len(m))
+	for k, v := range m {
+		entries = append(entries, entry{key: k, seen: lastSeen(v)})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].seen.Equal(entries[j].seen) {
+			// Stable tiebreak so eviction is deterministic when many keys
+			// share a timestamp (common in tests and in bursty churn).
+			return entries[i].key < entries[j].key
+		}
+		return entries[i].seen.Before(entries[j].seen)
+	})
+
+	evict := len(m) - target
+	for i := 0; i < evict && i < len(entries); i++ {
+		delete(m, entries[i].key)
+	}
+	return evict
+}

--- a/src/core/registry/tracing/aggregates_test.go
+++ b/src/core/registry/tracing/aggregates_test.go
@@ -1,0 +1,160 @@
+package tracing
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestLoadAggregateBoundsFromEnv covers every branch of the #1424 knobs,
+// including the disable values and the requirement that a BAD value falls back
+// to the default rather than silently removing the bound.
+func TestLoadAggregateBoundsFromEnv(t *testing.T) {
+	cases := []struct {
+		name         string
+		retention    string
+		maxEntries   string
+		wantRetain   time.Duration
+		wantMaxEntry int
+	}{
+		{"unset_uses_defaults", "", "", defaultAggregateRetention, defaultAggregateMaxEntries},
+		{"retention_override", "1h", "", time.Hour, defaultAggregateMaxEntries},
+		{"max_entries_override", "", "250", defaultAggregateRetention, 250},
+		{"both_overridden", "30m", "7", 30 * time.Minute, 7},
+		{"retention_zero_disables_age_prune", "0", "", 0, defaultAggregateMaxEntries},
+		{"max_entries_zero_disables_cap", "", "0", defaultAggregateRetention, 0},
+		{"both_zero_fully_unbounded", "0", "0", 0, 0},
+
+		// Bad values must FALL BACK, never disable. A typo must not silently
+		// unbound the map.
+		{"retention_negative_falls_back", "-1h", "", defaultAggregateRetention, defaultAggregateMaxEntries},
+		{"retention_garbage_falls_back", "not-a-duration", "", defaultAggregateRetention, defaultAggregateMaxEntries},
+		{"max_entries_negative_falls_back", "", "-5", defaultAggregateRetention, defaultAggregateMaxEntries},
+		{"max_entries_garbage_falls_back", "", "lots", defaultAggregateRetention, defaultAggregateMaxEntries},
+		{"max_entries_float_falls_back", "", "1e4", defaultAggregateRetention, defaultAggregateMaxEntries},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("MCP_MESH_TELEMETRY_AGGREGATE_RETENTION", tc.retention)
+			t.Setenv("MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES", tc.maxEntries)
+
+			got := LoadAggregateBoundsFromEnv()
+			if got.Retention != tc.wantRetain {
+				t.Errorf("Retention = %s, want %s", got.Retention, tc.wantRetain)
+			}
+			if got.MaxEntries != tc.wantMaxEntry {
+				t.Errorf("MaxEntries = %d, want %d", got.MaxEntries, tc.wantMaxEntry)
+			}
+		})
+	}
+}
+
+// TestDefaultAggregateBoundsAreBounded is the regression guard for #1424: the
+// out-of-the-box configuration must bound both dimensions. If someone changes
+// a default to 0 this fails loudly.
+func TestDefaultAggregateBoundsAreBounded(t *testing.T) {
+	b := DefaultAggregateBounds()
+	if b.Retention <= 0 {
+		t.Errorf("default aggregate retention must be positive, got %s", b.Retention)
+	}
+	if b.MaxEntries <= 0 {
+		t.Errorf("default aggregate max entries must be positive, got %d", b.MaxEntries)
+	}
+}
+
+type stamped struct{ seen time.Time }
+
+func stampedSeen(s *stamped) time.Time { return s.seen }
+
+func TestPruneOlderThan(t *testing.T) {
+	now := time.Now()
+	m := map[string]*stamped{
+		"fresh":    {seen: now},
+		"recent":   {seen: now.Add(-30 * time.Second)},
+		"stale":    {seen: now.Add(-2 * time.Hour)},
+		"ancient":  {seen: now.Add(-48 * time.Hour)},
+		"zerotime": {}, // never stamped — must be treated as infinitely old
+	}
+
+	removed := PruneOlderThan(m, stampedSeen, now.Add(-time.Hour))
+	if removed != 3 {
+		t.Fatalf("removed = %d, want 3", removed)
+	}
+	if len(m) != 2 {
+		t.Fatalf("len(m) = %d, want 2", len(m))
+	}
+	for _, k := range []string{"fresh", "recent"} {
+		if _, ok := m[k]; !ok {
+			t.Errorf("key %q should have survived the prune", k)
+		}
+	}
+}
+
+// TestEnforceMaxEntriesBoundsGrowth drives the map far past its cap and proves
+// the length never exceeds it — the actual bound, not just that the function
+// is callable.
+func TestEnforceMaxEntriesBoundsGrowth(t *testing.T) {
+	const cap = 100
+	base := time.Now()
+	m := make(map[string]*stamped)
+
+	maxSeen := 0
+	for i := 0; i < 5000; i++ {
+		m[fmt.Sprintf("key-%05d", i)] = &stamped{seen: base.Add(time.Duration(i) * time.Millisecond)}
+		EnforceMaxEntries(m, stampedSeen, cap)
+		if len(m) > maxSeen {
+			maxSeen = len(m)
+		}
+		if len(m) > cap {
+			t.Fatalf("after insert %d: len(m) = %d exceeds cap %d", i, len(m), cap)
+		}
+	}
+
+	if maxSeen == 0 {
+		t.Fatal("map never grew; test did not exercise the cap")
+	}
+	// The survivors must be the most recently seen keys, i.e. eviction is LRU
+	// and not arbitrary — dropping a recently-active key would be the bad
+	// failure mode for a dashboard.
+	if _, ok := m["key-04999"]; !ok {
+		t.Error("most recently inserted key was evicted; eviction is not least-recently-seen")
+	}
+	if _, ok := m["key-00000"]; ok {
+		t.Error("oldest key survived 5000 inserts past a cap of 100")
+	}
+}
+
+// TestEnforceMaxEntriesDisabled proves 0 really means "no ceiling" so the knob's
+// disable value is honest.
+func TestEnforceMaxEntriesDisabled(t *testing.T) {
+	m := make(map[string]*stamped)
+	for i := 0; i < 1000; i++ {
+		m[fmt.Sprintf("k%d", i)] = &stamped{seen: time.Now()}
+		if n := EnforceMaxEntries(m, stampedSeen, 0); n != 0 {
+			t.Fatalf("cap of 0 evicted %d entries; it must be a no-op", n)
+		}
+	}
+	if len(m) != 1000 {
+		t.Fatalf("len(m) = %d, want 1000 with the cap disabled", len(m))
+	}
+}
+
+// TestEnforceMaxEntriesTinyCap covers cap values small enough that the 10%
+// batch rounds to zero.
+func TestEnforceMaxEntriesTinyCap(t *testing.T) {
+	for _, cap := range []int{1, 2, 3} {
+		m := make(map[string]*stamped)
+		base := time.Now()
+		for i := 0; i < 50; i++ {
+			m[fmt.Sprintf("k%02d", i)] = &stamped{seen: base.Add(time.Duration(i) * time.Millisecond)}
+			EnforceMaxEntries(m, stampedSeen, cap)
+			if len(m) > cap {
+				t.Fatalf("cap=%d: len(m) = %d after insert %d", cap, len(m), i)
+			}
+		}
+		if len(m) == 0 {
+			t.Fatalf("cap=%d: map emptied entirely", cap)
+		}
+	}
+}

--- a/src/core/registry/tracing/consumer.go
+++ b/src/core/registry/tracing/consumer.go
@@ -123,6 +123,50 @@ type StreamConsumerConfig struct {
 	Retention time.Duration
 }
 
+// Consumer-group housekeeping thresholds (#1424).
+//
+// These are timing thresholds for a reclamation loop that runs
+// unconditionally, not retention/memory trade-offs, so they are internal
+// constants rather than env knobs — the bound itself (the PEL does not grow,
+// dead consumers do not accumulate) is never off.
+//
+//   - pelMinIdle: how long a delivered-but-unacked entry must sit in the
+//     Pending Entries List before another read may reclaim it. In-band
+//     processing is sub-millisecond and the slowest path (a blocking OTLP
+//     export) is seconds, so 5 minutes cannot reclaim genuinely in-flight
+//     work; a spurious reclaim would cost a duplicate export, never a lost
+//     span.
+//   - pelMaxDeliveries: after this many delivery attempts an entry is treated
+//     as a poison pill — ACKed and logged instead of being retried forever.
+//   - pelReclaimBatch: entries examined per pass. A large backlog drains at
+//     pelReclaimBatch per maintenanceTickInterval, which is deliberate: the
+//     stream trim retires the underlying entries anyway, so there is no reason
+//     to spend an unbounded pass reclaiming them.
+//   - consumerIdleTimeout: how long a consumer entry may sit with zero pending
+//     messages and no reads before XGROUP DELCONSUMER removes it. This is what
+//     retires the `registry-<hostname>-<pid>` entry left behind by every pod
+//     restart.
+//   - maintenanceTickInterval: how often the housekeeping pass runs.
+//   - pelAckTimeout: bounds a single per-message ACK. Each successfully
+//     reprocessed message gets its own ACK deadline instead of sharing the
+//     pass-wide one — a pass reclaims up to pelReclaimBatch messages with a
+//     processMessage between every ACK, so a slow batch would exhaust a shared
+//     deadline and strand already-processed messages unACKed in the PEL, to be
+//     reclaimed and reprocessed forever.
+const (
+	pelMinIdle              = 5 * time.Minute
+	pelMaxDeliveries        = 5
+	pelReclaimBatch         = 100
+	consumerIdleTimeout     = 1 * time.Hour
+	maintenanceTickInterval = 1 * time.Minute
+	pelAckTimeout           = 5 * time.Second
+)
+
+// pelBatchTimeout bounds one reclaim pass's Redis round-trips (XPENDING,
+// XCLAIM, the poison-pill ACK). var rather than const only so tests can shrink
+// it; production never reassigns it.
+var pelBatchTimeout = 10 * time.Second
+
 // NewStreamConsumer creates a new Redis Streams consumer for trace events
 // This never fails - it stores config and attempts connection in background
 func NewStreamConsumer(config *StreamConsumerConfig, processor TraceEventProcessor) (*StreamConsumer, error) {
@@ -198,8 +242,220 @@ func (sc *StreamConsumer) Start() error {
 	sc.wg.Add(1)
 	go sc.connectionManager()
 
+	// Consumer-group housekeeping (PEL reclaim + dead-consumer reap). Runs
+	// independently of retention/trimming so it is never disabled.
+	sc.wg.Add(1)
+	go sc.maintenanceLoop()
+
 	sc.logger.Println("Consumer started (connection manager running in background)")
 	return nil
+}
+
+// maintenanceLoop periodically reclaims stuck PEL entries and removes
+// consumer-group entries left behind by previous processes. Both operations
+// no-op when disconnected; the next tick retries.
+func (sc *StreamConsumer) maintenanceLoop() {
+	defer sc.wg.Done()
+
+	ticker := time.NewTicker(maintenanceTickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-sc.ctx.Done():
+			return
+		case <-ticker.C:
+			sc.runMaintenance()
+		}
+	}
+}
+
+// runMaintenance performs one housekeeping pass. Ordered so PEL entries are
+// reclaimed off dead consumers BEFORE those consumers are deleted — deleting a
+// consumer that still owns pending entries discards them.
+func (sc *StreamConsumer) runMaintenance() {
+	if reclaimed, dropped, err := sc.ReclaimPending(); err != nil {
+		sc.logger.Printf("Warning: PEL reclaim failed: %v (will retry in %s)", err, maintenanceTickInterval)
+	} else if reclaimed > 0 || dropped > 0 {
+		sc.logger.Printf("PEL maintenance: reclaimed %d stuck entries, dropped %d past %d delivery attempts",
+			reclaimed, dropped, pelMaxDeliveries)
+	}
+
+	if reaped, err := sc.ReapIdleConsumers(); err != nil {
+		sc.logger.Printf("Warning: idle-consumer reap failed: %v (will retry in %s)", err, maintenanceTickInterval)
+	} else if reaped > 0 {
+		sc.logger.Printf("Removed %d consumer-group entries idle longer than %s", reaped, consumerIdleTimeout)
+	}
+}
+
+// ReclaimPending re-processes entries stuck in the group's Pending Entries
+// List for longer than pelMinIdle, and permanently ACKs (dropping) any that
+// have already been delivered pelMaxDeliveries times.
+//
+// Without this, an entry whose processing fails is logged, skipped, never
+// ACKed and never re-read — XREADGROUP with ">" only ever returns
+// never-delivered entries — so it sits in the PEL forever (#1424).
+//
+// Returns (reclaimed, dropped, err). No-ops when disconnected.
+func (sc *StreamConsumer) ReclaimPending() (int, int, error) {
+	return sc.reclaimPendingWithIdle(pelMinIdle)
+}
+
+// reclaimPendingWithIdle is ReclaimPending with an explicit idle threshold, so
+// tests can exercise the reclaim path without waiting pelMinIdle.
+func (sc *StreamConsumer) reclaimPendingWithIdle(minIdle time.Duration) (int, int, error) {
+	sc.mu.RLock()
+	client := sc.client
+	state := sc.connectionState
+	sc.mu.RUnlock()
+
+	if !sc.enabled || client == nil || state != StateConnected {
+		return 0, 0, nil
+	}
+
+	ctx, cancel := context.WithTimeout(sc.ctx, pelBatchTimeout)
+	defer cancel()
+
+	pending, err := client.XPendingExt(ctx, &redis.XPendingExtArgs{
+		Stream: sc.streamName,
+		Group:  sc.consumerGroup,
+		Idle:   minIdle,
+		Start:  "-",
+		End:    "+",
+		Count:  pelReclaimBatch,
+	}).Result()
+	if err != nil {
+		if err == redis.Nil {
+			return 0, 0, nil
+		}
+		return 0, 0, fmt.Errorf("XPENDING on %s/%s: %w", sc.streamName, sc.consumerGroup, err)
+	}
+	if len(pending) == 0 {
+		return 0, 0, nil
+	}
+
+	var (
+		retryIDs []string
+		dropIDs  []string
+	)
+	for _, p := range pending {
+		if p.RetryCount >= pelMaxDeliveries {
+			dropIDs = append(dropIDs, p.ID)
+			continue
+		}
+		retryIDs = append(retryIDs, p.ID)
+	}
+
+	// Poison pills: acknowledge and log rather than leaving them pending
+	// forever. The entry itself stays in the stream until XTRIM retires it,
+	// so it is still visible to an operator inspecting the stream.
+	dropped := 0
+	if len(dropIDs) > 0 {
+		if err := client.XAck(ctx, sc.streamName, sc.consumerGroup, dropIDs...).Err(); err != nil {
+			return 0, 0, fmt.Errorf("XACK poison-pill entries: %w", err)
+		}
+		dropped = len(dropIDs)
+		sc.logger.Printf("Dropped %d trace entries after %d failed delivery attempts (IDs: %v)",
+			dropped, pelMaxDeliveries, dropIDs)
+	}
+
+	reclaimed := 0
+	if len(retryIDs) > 0 {
+		msgs, err := client.XClaim(ctx, &redis.XClaimArgs{
+			Stream:   sc.streamName,
+			Group:    sc.consumerGroup,
+			Consumer: sc.consumerName,
+			MinIdle:  minIdle,
+			Messages: retryIDs,
+		}).Result()
+		if err != nil && err != redis.Nil {
+			return 0, dropped, fmt.Errorf("XCLAIM stuck entries: %w", err)
+		}
+
+		for _, m := range msgs {
+			if perr := sc.processMessage(m); perr != nil {
+				// Leave it pending; the delivery counter was just bumped by
+				// XCLAIM, so it converges on the poison-pill path above.
+				sc.logger.Printf("ERROR: reclaimed message %s failed again: %v", m.ID, perr)
+				continue
+			}
+			// Deliberately NOT the pass-wide ctx: this ACK is downstream of
+			// processMessage, so on a slow batch the shared deadline would
+			// already be spent and the message would stay in the PEL despite
+			// having been processed — reclaimed and reprocessed on every
+			// subsequent pass, forever.
+			ackCtx, ackCancel := context.WithTimeout(sc.ctx, pelAckTimeout)
+			aerr := client.XAck(ackCtx, sc.streamName, sc.consumerGroup, m.ID).Err()
+			ackCancel()
+			if aerr != nil {
+				sc.logger.Printf("WARN: failed to acknowledge reclaimed message %s: %v", m.ID, aerr)
+				continue
+			}
+			reclaimed++
+		}
+	}
+
+	return reclaimed, dropped, nil
+}
+
+// ReapIdleConsumers removes consumer-group entries that hold no pending
+// messages and have been idle longer than consumerIdleTimeout. The consumer
+// name embeds hostname+PID, so without this every process restart leaves a
+// permanent entry in the group (#1424).
+//
+// Consumers with pending entries are left alone — deleting them would discard
+// those entries. ReclaimPending runs first and moves them to this consumer, so
+// a genuinely dead consumer drains to zero pending and is reaped on a later
+// pass. This consumer never reaps itself.
+//
+// Returns the number of consumers removed. No-ops when disconnected.
+func (sc *StreamConsumer) ReapIdleConsumers() (int, error) {
+	return sc.reapIdleConsumersWithTimeout(consumerIdleTimeout)
+}
+
+// reapIdleConsumersWithTimeout is ReapIdleConsumers with an explicit idle
+// threshold, so tests can exercise the reap path without waiting an hour.
+func (sc *StreamConsumer) reapIdleConsumersWithTimeout(idleTimeout time.Duration) (int, error) {
+	sc.mu.RLock()
+	client := sc.client
+	state := sc.connectionState
+	sc.mu.RUnlock()
+
+	if !sc.enabled || client == nil || state != StateConnected {
+		return 0, nil
+	}
+
+	ctx, cancel := context.WithTimeout(sc.ctx, 10*time.Second)
+	defer cancel()
+
+	consumers, err := client.XInfoConsumers(ctx, sc.streamName, sc.consumerGroup).Result()
+	if err != nil {
+		if err == redis.Nil {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("XINFO CONSUMERS on %s/%s: %w", sc.streamName, sc.consumerGroup, err)
+	}
+
+	reaped := 0
+	for _, c := range consumers {
+		if c.Name == sc.consumerName {
+			continue
+		}
+		if c.Pending > 0 {
+			continue
+		}
+		if c.Idle < idleTimeout {
+			continue
+		}
+		if err := client.XGroupDelConsumer(ctx, sc.streamName, sc.consumerGroup, c.Name).Err(); err != nil {
+			sc.logger.Printf("WARN: failed to delete idle consumer %s: %v", c.Name, err)
+			continue
+		}
+		sc.logger.Printf("Deleted consumer-group entry %s (idle %s, 0 pending)", c.Name, c.Idle)
+		reaped++
+	}
+
+	return reaped, nil
 }
 
 // connectionManager handles Redis connection with retry logic
@@ -632,7 +888,9 @@ func (sc *StreamConsumer) processNextBatch() error {
 		return fmt.Errorf("not connected")
 	}
 
-	// Read from consumer group (pending messages first, then new ones)
+	// Read NEVER-DELIVERED messages only (">"). Entries already delivered to
+	// some consumer live in the group's PEL and are recovered by
+	// ReclaimPending on the maintenance loop, not here.
 	args := &redis.XReadGroupArgs{
 		Group:    sc.consumerGroup,
 		Consumer: sc.consumerName,

--- a/src/core/registry/tracing/consumer_maintenance_test.go
+++ b/src/core/registry/tracing/consumer_maintenance_test.go
@@ -1,0 +1,443 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// redisURLForTest returns the Redis URL to exercise the consumer-group
+// housekeeping against, or skips the test. Set MCP_MESH_TEST_REDIS_URL to a
+// throwaway Redis (e.g. redis://localhost:6399) to run these; they are skipped
+// by default so `go test ./...` needs no external service.
+func redisURLForTest(t *testing.T) string {
+	t.Helper()
+	url := os.Getenv("MCP_MESH_TEST_REDIS_URL")
+	if url == "" {
+		t.Skip("set MCP_MESH_TEST_REDIS_URL to run consumer-group housekeeping tests against a real Redis")
+	}
+
+	opts, err := redis.ParseURL(url)
+	if err != nil {
+		t.Fatalf("bad MCP_MESH_TEST_REDIS_URL %q: %v", url, err)
+	}
+	c := redis.NewClient(opts)
+	defer c.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := c.Ping(ctx).Err(); err != nil {
+		t.Skipf("Redis at %s unreachable: %v", url, err)
+	}
+	return url
+}
+
+// failingProcessor fails the first n ProcessTraceEvent calls for a given span
+// ID, then succeeds. Models the "processing failed, entry stuck in the PEL"
+// case from #1424.
+type failingProcessor struct {
+	failuresLeft int
+	seen         []string
+}
+
+func (fp *failingProcessor) ProcessTraceEvent(event *TraceEvent) error {
+	fp.seen = append(fp.seen, event.SpanID)
+	if fp.failuresLeft > 0 {
+		fp.failuresLeft--
+		return fmt.Errorf("simulated processing failure for %s", event.SpanID)
+	}
+	return nil
+}
+
+// newConnectedConsumer builds a StreamConsumer wired to a real Redis on a
+// per-test stream/group, with the connection established synchronously (no
+// background connectionManager, so the test drives everything).
+func newConnectedConsumer(t *testing.T, url string, processor TraceEventProcessor) (*StreamConsumer, *redis.Client, string) {
+	t.Helper()
+
+	stream := fmt.Sprintf("test:trace:%s:%d", t.Name(), time.Now().UnixNano())
+	group := "test-group"
+
+	sc, err := NewStreamConsumer(&StreamConsumerConfig{
+		RedisURL:      url,
+		StreamName:    stream,
+		ConsumerGroup: group,
+		ConsumerName:  "live-consumer",
+		BatchSize:     10,
+		BlockTimeout:  100 * time.Millisecond,
+		Enabled:       true,
+	}, processor)
+	if err != nil {
+		t.Fatalf("NewStreamConsumer: %v", err)
+	}
+
+	opts, err := redis.ParseURL(url)
+	if err != nil {
+		t.Fatalf("ParseURL: %v", err)
+	}
+	client := redis.NewClient(opts)
+
+	sc.mu.Lock()
+	sc.client = client
+	sc.connectionState = StateConnected
+	sc.mu.Unlock()
+
+	ctx := context.Background()
+	if err := client.XGroupCreateMkStream(ctx, stream, group, "0").Err(); err != nil {
+		t.Fatalf("XGroupCreateMkStream: %v", err)
+	}
+
+	t.Cleanup(func() {
+		client.Del(context.Background(), stream)
+		client.Close()
+		sc.cancel()
+	})
+
+	return sc, client, stream
+}
+
+func xaddTraceEvent(t *testing.T, client *redis.Client, stream, traceID, spanID string) string {
+	t.Helper()
+	id, err := client.XAdd(context.Background(), &redis.XAddArgs{
+		Stream: stream,
+		Values: map[string]interface{}{
+			"trace_id":    traceID,
+			"span_id":     spanID,
+			"agent_name":  "test-agent",
+			"operation":   "test_op",
+			"timestamp":   fmt.Sprintf("%d", time.Now().Unix()),
+			"duration_ms": "5",
+		},
+	}).Result()
+	if err != nil {
+		t.Fatalf("XADD: %v", err)
+	}
+	return id
+}
+
+// TestReclaimPendingRecoversStuckEntry proves the PEL does not grow forever:
+// an entry whose processing failed (delivered, never ACKed) is reclaimed,
+// reprocessed and ACKed, dropping group pending back to zero.
+//
+// Before #1424 the entry was unreachable: XREADGROUP uses ">" (new messages
+// only) and nothing in the repo issued XCLAIM/XAUTOCLAIM/XPENDING.
+func TestReclaimPendingRecoversStuckEntry(t *testing.T) {
+	url := redisURLForTest(t)
+	fp := &failingProcessor{failuresLeft: 1}
+	sc, client, stream := newConnectedConsumer(t, url, fp)
+	ctx := context.Background()
+
+	msgID := xaddTraceEvent(t, client, stream, "trace-1", "span-1")
+
+	// First delivery: processMessage fails, so processNextBatch logs and skips
+	// the ACK — exactly the pre-existing behaviour that stranded the entry.
+	if err := sc.processNextBatch(); err != nil {
+		t.Fatalf("processNextBatch: %v", err)
+	}
+
+	pending, err := client.XPending(ctx, stream, "test-group").Result()
+	if err != nil {
+		t.Fatalf("XPENDING: %v", err)
+	}
+	if pending.Count != 1 {
+		t.Fatalf("group pending = %d, want 1 (entry should be stuck in the PEL)", pending.Count)
+	}
+
+	// A second XREADGROUP must NOT see it — this is the "never re-read" half
+	// of the bug, asserted rather than assumed.
+	if err := sc.processNextBatch(); err != nil {
+		t.Fatalf("processNextBatch (2nd): %v", err)
+	}
+	if len(fp.seen) != 1 {
+		t.Fatalf("processor saw %d deliveries, want 1: XREADGROUP \">\" must not redeliver", len(fp.seen))
+	}
+
+	// Now reclaim. Drop the idle threshold to zero for the test so we don't
+	// have to wait pelMinIdle.
+	reclaimed, dropped, err := sc.reclaimPendingWithIdle(0)
+	if err != nil {
+		t.Fatalf("ReclaimPending: %v", err)
+	}
+	if reclaimed != 1 || dropped != 0 {
+		t.Fatalf("reclaimed=%d dropped=%d, want 1 and 0", reclaimed, dropped)
+	}
+
+	pending, err = client.XPending(ctx, stream, "test-group").Result()
+	if err != nil {
+		t.Fatalf("XPENDING after reclaim: %v", err)
+	}
+	if pending.Count != 0 {
+		t.Fatalf("group pending = %d after reclaim, want 0", pending.Count)
+	}
+	if len(fp.seen) != 2 {
+		t.Fatalf("processor saw %d deliveries, want 2 (original + reclaim)", len(fp.seen))
+	}
+	_ = msgID
+}
+
+// TestReclaimPendingDropsPoisonPill proves a permanently-failing entry does
+// not sit in the PEL forever either: after pelMaxDeliveries attempts it is
+// ACKed and logged rather than retried indefinitely.
+func TestReclaimPendingDropsPoisonPill(t *testing.T) {
+	url := redisURLForTest(t)
+	fp := &failingProcessor{failuresLeft: 1000} // always fails
+	sc, client, stream := newConnectedConsumer(t, url, fp)
+	ctx := context.Background()
+
+	xaddTraceEvent(t, client, stream, "trace-poison", "span-poison")
+
+	if err := sc.processNextBatch(); err != nil {
+		t.Fatalf("processNextBatch: %v", err)
+	}
+
+	// Each reclaim pass bumps the delivery counter. Converge on the drop.
+	totalDropped := 0
+	for i := 0; i < pelMaxDeliveries+3; i++ {
+		_, dropped, err := sc.reclaimPendingWithIdle(0)
+		if err != nil {
+			t.Fatalf("ReclaimPending pass %d: %v", i, err)
+		}
+		totalDropped += dropped
+		if totalDropped > 0 {
+			break
+		}
+	}
+
+	if totalDropped != 1 {
+		t.Fatalf("dropped = %d, want 1: a permanently-failing entry must not stay pending forever", totalDropped)
+	}
+
+	pending, err := client.XPending(ctx, stream, "test-group").Result()
+	if err != nil {
+		t.Fatalf("XPENDING: %v", err)
+	}
+	if pending.Count != 0 {
+		t.Fatalf("group pending = %d after the poison-pill drop, want 0", pending.Count)
+	}
+}
+
+// slowProcessor succeeds, but takes `delay` per message. Models a reclaim pass
+// whose per-message work (a blocking OTLP export, a slow DB write) is slow
+// enough to burn the pass-wide deadline.
+type slowProcessor struct {
+	delay time.Duration
+	seen  []string
+}
+
+func (sp *slowProcessor) ProcessTraceEvent(event *TraceEvent) error {
+	time.Sleep(sp.delay)
+	sp.seen = append(sp.seen, event.SpanID)
+	return nil
+}
+
+// TestReclaimPendingAcksAfterBatchDeadlineExpires proves a slow reclaim pass
+// still ACKs what it processed. The pass-wide context is shared across up to
+// pelReclaimBatch messages with a processMessage between each ACK; when a
+// shared deadline was used for the ACKs too, every message after the deadline
+// expired was processed and then left in the PEL — reclaimed and reprocessed
+// on every later pass, forever.
+func TestReclaimPendingAcksAfterBatchDeadlineExpires(t *testing.T) {
+	url := redisURLForTest(t)
+
+	// Shrink the pass-wide deadline so the third message's ACK is guaranteed to
+	// fall outside it (3 x 150ms of processing against a 250ms pass budget).
+	origBatchTimeout := pelBatchTimeout
+	pelBatchTimeout = 250 * time.Millisecond
+	t.Cleanup(func() { pelBatchTimeout = origBatchTimeout })
+
+	sp := &slowProcessor{delay: 150 * time.Millisecond}
+	sc, client, stream := newConnectedConsumer(t, url, sp)
+	ctx := context.Background()
+
+	// Strand three entries in the PEL under a dead consumer.
+	for i := 0; i < 3; i++ {
+		xaddTraceEvent(t, client, stream, fmt.Sprintf("trace-slow-%d", i), fmt.Sprintf("span-slow-%d", i))
+	}
+	if err := client.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    "test-group",
+		Consumer: "registry-dead-slow",
+		Streams:  []string{stream, ">"},
+		Count:    3,
+		Block:    10 * time.Millisecond,
+	}).Err(); err != nil && err != redis.Nil {
+		t.Fatalf("seed pending entries: %v", err)
+	}
+
+	pending, err := client.XPending(ctx, stream, "test-group").Result()
+	if err != nil {
+		t.Fatalf("XPENDING: %v", err)
+	}
+	if pending.Count != 3 {
+		t.Fatalf("group pending = %d before reclaim, want 3", pending.Count)
+	}
+
+	reclaimed, dropped, err := sc.reclaimPendingWithIdle(0)
+	if err != nil {
+		t.Fatalf("ReclaimPending: %v", err)
+	}
+	if len(sp.seen) != 3 {
+		t.Fatalf("processor saw %d messages, want 3", len(sp.seen))
+	}
+	if reclaimed != 3 || dropped != 0 {
+		t.Fatalf("reclaimed=%d dropped=%d, want 3 and 0: a message processed after the pass deadline expired must still be ACKed", reclaimed, dropped)
+	}
+
+	pending, err = client.XPending(ctx, stream, "test-group").Result()
+	if err != nil {
+		t.Fatalf("XPENDING after reclaim: %v", err)
+	}
+	if pending.Count != 0 {
+		t.Fatalf("group pending = %d after reclaim, want 0: processed-but-unacked entries stay in the PEL and are reprocessed forever", pending.Count)
+	}
+}
+
+// TestReapIdleConsumersRemovesDeadEntry proves the group does not accumulate a
+// permanent entry per pod restart. Consumer names embed hostname+PID, so a
+// restarted registry leaves the old name behind forever without
+// XGROUP DELCONSUMER.
+func TestReapIdleConsumersRemovesDeadEntry(t *testing.T) {
+	url := redisURLForTest(t)
+	sc, client, stream := newConnectedConsumer(t, url, &failingProcessor{})
+	ctx := context.Background()
+
+	// Simulate three prior pod incarnations plus the live one.
+	xaddTraceEvent(t, client, stream, "t", "s")
+	for _, dead := range []string{"registry-pod-a-11", "registry-pod-b-22", "registry-pod-c-33"} {
+		if err := client.XReadGroup(ctx, &redis.XReadGroupArgs{
+			Group:    "test-group",
+			Consumer: dead,
+			Streams:  []string{stream, ">"},
+			Count:    1,
+			Block:    10 * time.Millisecond,
+		}).Err(); err != nil && err != redis.Nil {
+			t.Fatalf("seed consumer %s: %v", dead, err)
+		}
+	}
+	if err := sc.processNextBatch(); err != nil {
+		t.Fatalf("processNextBatch: %v", err)
+	}
+
+	consumers, err := client.XInfoConsumers(ctx, stream, "test-group").Result()
+	if err != nil {
+		t.Fatalf("XINFO CONSUMERS: %v", err)
+	}
+	if len(consumers) != 4 {
+		t.Fatalf("consumers = %d, want 4 (3 dead + 1 live)", len(consumers))
+	}
+
+	// Reclaim first (as runMaintenance does) so any dead consumer's pending
+	// entries move to us and it can be safely deleted.
+	if _, _, err := sc.reclaimPendingWithIdle(0); err != nil {
+		t.Fatalf("ReclaimPending: %v", err)
+	}
+
+	// Zero idle threshold for the test rather than waiting an hour.
+	reaped, err := sc.reapIdleConsumersWithTimeout(0)
+	if err != nil {
+		t.Fatalf("ReapIdleConsumers: %v", err)
+	}
+	if reaped != 3 {
+		t.Fatalf("reaped = %d, want 3", reaped)
+	}
+
+	consumers, err = client.XInfoConsumers(ctx, stream, "test-group").Result()
+	if err != nil {
+		t.Fatalf("XINFO CONSUMERS after reap: %v", err)
+	}
+	if len(consumers) != 1 {
+		t.Fatalf("consumers = %d after reap, want 1", len(consumers))
+	}
+	if consumers[0].Name != "live-consumer" {
+		t.Fatalf("surviving consumer = %q, want the live one", consumers[0].Name)
+	}
+}
+
+// TestReapIdleConsumersSkipsSelfAndPendingHolders guards the two ways this
+// could destroy data: reaping ourselves, or reaping a consumer that still owns
+// PEL entries (XGROUP DELCONSUMER discards them).
+func TestReapIdleConsumersSkipsSelfAndPendingHolders(t *testing.T) {
+	url := redisURLForTest(t)
+	sc, client, stream := newConnectedConsumer(t, url, &failingProcessor{failuresLeft: 1000})
+	ctx := context.Background()
+
+	xaddTraceEvent(t, client, stream, "t1", "s1")
+	// A dead consumer that still holds a pending entry.
+	if err := client.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    "test-group",
+		Consumer: "registry-dead-with-pending",
+		Streams:  []string{stream, ">"},
+		Count:    1,
+		Block:    10 * time.Millisecond,
+	}).Err(); err != nil && err != redis.Nil {
+		t.Fatalf("seed pending holder: %v", err)
+	}
+	// The live consumer reads (and fails), so it also has pending work.
+	xaddTraceEvent(t, client, stream, "t2", "s2")
+	if err := sc.processNextBatch(); err != nil {
+		t.Fatalf("processNextBatch: %v", err)
+	}
+
+	reaped, err := sc.reapIdleConsumersWithTimeout(0)
+	if err != nil {
+		t.Fatalf("ReapIdleConsumers: %v", err)
+	}
+	if reaped != 0 {
+		t.Fatalf("reaped = %d, want 0: consumers holding PEL entries must be left alone", reaped)
+	}
+
+	consumers, err := client.XInfoConsumers(ctx, stream, "test-group").Result()
+	if err != nil {
+		t.Fatalf("XINFO CONSUMERS: %v", err)
+	}
+	if len(consumers) != 2 {
+		t.Fatalf("consumers = %d, want 2 (nothing reaped)", len(consumers))
+	}
+
+	pending, err := client.XPending(ctx, stream, "test-group").Result()
+	if err != nil {
+		t.Fatalf("XPENDING: %v", err)
+	}
+	if pending.Count != 2 {
+		t.Fatalf("group pending = %d, want 2: no PEL entry may be discarded by the reap", pending.Count)
+	}
+}
+
+// TestMaintenanceNoOpsWhenDisconnected verifies both housekeeping entry points
+// are safe to call with no Redis connection — the maintenance loop runs on a
+// timer regardless of connection state.
+func TestMaintenanceNoOpsWhenDisconnected(t *testing.T) {
+	sc, err := NewStreamConsumer(&StreamConsumerConfig{
+		RedisURL:      "redis://127.0.0.1:1",
+		StreamName:    "mesh:trace",
+		ConsumerGroup: "g",
+		Enabled:       true,
+	}, &failingProcessor{})
+	if err != nil {
+		t.Fatalf("NewStreamConsumer: %v", err)
+	}
+	defer sc.cancel()
+
+	reclaimed, dropped, err := sc.ReclaimPending()
+	if err != nil || reclaimed != 0 || dropped != 0 {
+		t.Fatalf("ReclaimPending while disconnected = (%d, %d, %v), want (0, 0, nil)", reclaimed, dropped, err)
+	}
+	reaped, err := sc.ReapIdleConsumers()
+	if err != nil || reaped != 0 {
+		t.Fatalf("ReapIdleConsumers while disconnected = (%d, %v), want (0, nil)", reaped, err)
+	}
+
+	// Also safe on a disabled consumer (tracing off).
+	off, err := NewStreamConsumer(&StreamConsumerConfig{Enabled: false}, &failingProcessor{})
+	if err != nil {
+		t.Fatalf("NewStreamConsumer(disabled): %v", err)
+	}
+	if _, _, err := off.ReclaimPending(); err != nil {
+		t.Fatalf("ReclaimPending on disabled consumer: %v", err)
+	}
+	if _, err := off.ReapIdleConsumers(); err != nil {
+		t.Fatalf("ReapIdleConsumers on disabled consumer: %v", err)
+	}
+}

--- a/src/core/registry/tracing/manager.go
+++ b/src/core/registry/tracing/manager.go
@@ -558,6 +558,14 @@ func DefaultTracingConfig() *TracingConfig {
 	}
 }
 
+// TraceRetentionFromEnv returns the configured mesh:trace stream retention.
+// Exported so processes that build a TracingConfig by hand (meshui) get the
+// same value as the registry — trimming must not depend on one process being
+// alive (#1424).
+func TraceRetentionFromEnv() time.Duration {
+	return parseTraceRetentionFromEnv()
+}
+
 // parseTraceRetentionFromEnv parses MCP_MESH_TRACE_RETENTION following the
 // same conventions as MCP_MESH_RETENTION (registry sweep):
 //   - unset / empty: defaults to 24h

--- a/src/core/registry/tracing/manager_ui.go
+++ b/src/core/registry/tracing/manager_ui.go
@@ -44,7 +44,12 @@ func NewAccumulatorOnlyManager(config *TracingConfig, extraProcessors ...TraceEv
 	}
 	manager.processor = processor
 
-	// Create consumer with UI-specific consumer group
+	// Create consumer with UI-specific consumer group.
+	//
+	// Retention is passed through so trimming does not depend on the registry
+	// being alive (#1424): meshui reads the same stream through its own
+	// consumer group and trims it to the same window. XTRIM MINID is
+	// idempotent, so both processes trimming concurrently is harmless.
 	consumerConfig := &StreamConsumerConfig{
 		RedisURL:      config.RedisURL,
 		StreamName:    config.StreamName,
@@ -53,6 +58,7 @@ func NewAccumulatorOnlyManager(config *TracingConfig, extraProcessors ...TraceEv
 		BatchSize:     config.BatchSize,
 		BlockTimeout:  config.BlockTimeout,
 		Enabled:       config.Enabled,
+		Retention:     config.TraceRetention,
 	}
 
 	consumer, err := NewStreamConsumer(consumerConfig, manager.processor)
@@ -78,5 +84,11 @@ func NewAccumulatorOnlyManager(config *TracingConfig, extraProcessors ...TraceEv
 
 	manager.logger.Printf("UI tracing: enabled (accumulator-only), redis=%s, group=%s",
 		config.RedisURL, config.ConsumerGroup)
+	if config.TraceRetention > 0 {
+		manager.logger.Printf("Trace stream retention: %s (meshui trims too, so trimming survives a registry outage; override via MCP_MESH_TRACE_RETENTION)",
+			config.TraceRetention)
+	} else {
+		manager.logger.Printf("Trace stream retention disabled (MCP_MESH_TRACE_RETENTION=0); stream %s is never trimmed by meshui either", config.StreamName)
+	}
 	return manager, nil
 }

--- a/src/core/registry/tracing/manager_ui_retention_test.go
+++ b/src/core/registry/tracing/manager_ui_retention_test.go
@@ -1,0 +1,143 @@
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// TestAccumulatorOnlyManagerPropagatesRetention is issue #1424's "trimming must
+// not depend on one process" item: meshui builds its own TracingConfig and
+// previously left Retention at zero, so it consumed the stream through its own
+// group but never trimmed it. If the registry was down, nothing bounded the
+// stream.
+func TestAccumulatorOnlyManagerPropagatesRetention(t *testing.T) {
+	tm, err := NewAccumulatorOnlyManager(&TracingConfig{
+		Enabled:        true,
+		RedisURL:       "redis://127.0.0.1:1", // never dialled; consumer connects lazily
+		StreamName:     "mesh:trace",
+		ConsumerGroup:  "mcp-mesh-ui-dashboard",
+		ConsumerName:   "ui-test",
+		BatchSize:      100,
+		BlockTimeout:   time.Second,
+		TraceRetention: 6 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewAccumulatorOnlyManager: %v", err)
+	}
+	defer func() {
+		if tm.consumer != nil {
+			tm.consumer.cancel()
+		}
+	}()
+
+	if tm.consumer == nil {
+		t.Fatal("no consumer built")
+	}
+	if tm.consumer.retention != 6*time.Hour {
+		t.Fatalf("consumer retention = %s, want 6h: meshui must honour MCP_MESH_TRACE_RETENTION", tm.consumer.retention)
+	}
+}
+
+// TestTraceRetentionFromEnvMatchesRegistry pins that meshui and the registry
+// derive retention from the same parser, so the two processes cannot drift to
+// different trim windows.
+func TestTraceRetentionFromEnvMatchesRegistry(t *testing.T) {
+	for _, v := range []string{"", "48h", "0", "-1h", "garbage"} {
+		t.Setenv("MCP_MESH_TRACE_RETENTION", v)
+		ui := TraceRetentionFromEnv()
+		registry := DefaultTracingConfig().TraceRetention
+		if ui != registry {
+			t.Fatalf("MCP_MESH_TRACE_RETENTION=%q: meshui got %s, registry got %s", v, ui, registry)
+		}
+	}
+}
+
+// TestUIConsumerTrimsStream proves the meshui-side trim actually shears the
+// stream against a real Redis: entries older than the retention window are
+// removed by the same TrimStream the registry uses.
+func TestUIConsumerTrimsStream(t *testing.T) {
+	url := redisURLForTest(t)
+
+	stream := fmt.Sprintf("test:uitrim:%d", time.Now().UnixNano())
+	tm, err := NewAccumulatorOnlyManager(&TracingConfig{
+		Enabled:        true,
+		RedisURL:       url,
+		StreamName:     stream,
+		ConsumerGroup:  "mcp-mesh-ui-dashboard",
+		ConsumerName:   "ui-test",
+		BatchSize:      100,
+		BlockTimeout:   100 * time.Millisecond,
+		TraceRetention: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("NewAccumulatorOnlyManager: %v", err)
+	}
+	sc := tm.consumer
+	defer sc.cancel()
+
+	opts, err := redis.ParseURL(url)
+	if err != nil {
+		t.Fatalf("ParseURL: %v", err)
+	}
+	client := redis.NewClient(opts)
+	defer client.Close()
+	ctx := context.Background()
+	defer client.Del(ctx, stream)
+
+	// 100 entries stamped 2h old (past the window) and 100 stamped now.
+	oldMs := time.Now().Add(-2 * time.Hour).UnixMilli()
+	nowMs := time.Now().UnixMilli()
+	for i := 0; i < 100; i++ {
+		if err := client.XAdd(ctx, &redis.XAddArgs{
+			Stream: stream,
+			ID:     strconv.FormatInt(oldMs, 10) + "-" + strconv.Itoa(i),
+			Values: map[string]interface{}{"span_id": fmt.Sprintf("old-%d", i)},
+		}).Err(); err != nil {
+			t.Fatalf("XADD old: %v", err)
+		}
+	}
+	for i := 0; i < 100; i++ {
+		if err := client.XAdd(ctx, &redis.XAddArgs{
+			Stream: stream,
+			ID:     strconv.FormatInt(nowMs, 10) + "-" + strconv.Itoa(i),
+			Values: map[string]interface{}{"span_id": fmt.Sprintf("new-%d", i)},
+		}).Err(); err != nil {
+			t.Fatalf("XADD new: %v", err)
+		}
+	}
+
+	if n, _ := client.XLen(ctx, stream).Result(); n != 200 {
+		t.Fatalf("XLEN = %d, want 200 before trimming", n)
+	}
+
+	sc.mu.Lock()
+	sc.client = client
+	sc.connectionState = StateConnected
+	sc.mu.Unlock()
+
+	removed, err := sc.TrimStream()
+	if err != nil {
+		t.Fatalf("TrimStream: %v", err)
+	}
+	if removed == 0 {
+		t.Fatal("meshui trimmed 0 entries: retention is not reaching the UI consumer")
+	}
+
+	after, err := client.XLen(ctx, stream).Result()
+	if err != nil {
+		t.Fatalf("XLEN: %v", err)
+	}
+	if after >= 200 {
+		t.Fatalf("XLEN = %d after trim, want < 200", after)
+	}
+	// XTRIM MINID ~ is approximate (whole macro-node steps), so assert the
+	// direction and that nothing recent was lost, not an exact count.
+	if after < 100 {
+		t.Fatalf("XLEN = %d after trim: entries inside the retention window were removed", after)
+	}
+}

--- a/src/core/ui/metrics_processor.go
+++ b/src/core/ui/metrics_processor.go
@@ -1,9 +1,11 @@
 package ui
 
 import (
+	"log"
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"mcp-mesh/src/core/registry/tracing"
 )
@@ -11,6 +13,13 @@ import (
 // MetricsProcessor aggregates dashboard-specific metrics from trace events.
 // It runs as a TraceEventProcessor alongside the TraceAccumulator in the UI server,
 // keeping aggregation logic out of the shared tracing package.
+//
+// Both maps are keyed by a name (agent / model), so they are bounded by
+// cardinality rather than volume (#1424). Each entry carries a lastSeen stamp:
+// entries not written to within bounds.Retention age out, and bounds.MaxEntries
+// is a hard key ceiling evicting least-recently-seen first. Pruning is driven
+// off the write path (gated to tracing.AggregatePruneInterval) rather than a
+// goroutine, so throwaway instances (see replayWindow) need no lifecycle.
 type MetricsProcessor struct {
 	mu sync.RWMutex
 
@@ -19,6 +28,10 @@ type MetricsProcessor struct {
 
 	// Per-model token usage keyed by model name
 	modelMetrics map[string]*modelMetrics
+
+	bounds      tracing.AggregateBounds
+	nextPruneAt time.Time
+	now         func() time.Time // injectable for tests
 }
 
 type agentMetrics struct {
@@ -27,13 +40,18 @@ type agentMetrics struct {
 	TotalOutputTokens  int64
 	TotalRequestBytes  int64
 	TotalResponseBytes int64
+	lastSeen           time.Time
 }
 
 type modelMetrics struct {
 	CallCount    int
 	InputTokens  int64
 	OutputTokens int64
+	lastSeen     time.Time
 }
+
+func agentLastSeen(am *agentMetrics) time.Time { return am.lastSeen }
+func modelLastSeen(mm *modelMetrics) time.Time { return mm.lastSeen }
 
 // AgentMetricsData is the JSON response for per-agent metrics.
 type AgentMetricsData struct {
@@ -55,10 +73,21 @@ type ModelMetricsData struct {
 	TotalTokens  int64  `json:"total_tokens"`
 }
 
+// NewMetricsProcessor creates a processor bounded by the process-wide
+// aggregate bounds (see tracing.DefaultAggregateBounds).
 func NewMetricsProcessor() *MetricsProcessor {
+	return NewMetricsProcessorWithBounds(tracing.DefaultAggregateBounds())
+}
+
+// NewMetricsProcessorWithBounds is NewMetricsProcessor with explicit bounds.
+// Production callers should use NewMetricsProcessor so the operator's env
+// configuration applies; this exists for tests.
+func NewMetricsProcessorWithBounds(bounds tracing.AggregateBounds) *MetricsProcessor {
 	return &MetricsProcessor{
 		agentMetrics: make(map[string]*agentMetrics),
 		modelMetrics: make(map[string]*modelMetrics),
+		bounds:       bounds,
+		now:          time.Now,
 	}
 }
 
@@ -74,6 +103,8 @@ func (mp *MetricsProcessor) ProcessTraceEvent(event *tracing.TraceEvent) error {
 		return nil
 	}
 
+	now := mp.nowFn()
+
 	// Per-agent metrics
 	if event.AgentName != "" {
 		am, exists := mp.agentMetrics[event.AgentName]
@@ -81,6 +112,7 @@ func (mp *MetricsProcessor) ProcessTraceEvent(event *tracing.TraceEvent) error {
 			am = &agentMetrics{}
 			mp.agentMetrics[event.AgentName] = am
 		}
+		am.lastSeen = now
 		am.SpanCount++
 		if event.RequestBytes != nil {
 			am.TotalRequestBytes += *event.RequestBytes
@@ -104,6 +136,7 @@ func (mp *MetricsProcessor) ProcessTraceEvent(event *tracing.TraceEvent) error {
 			mm = &modelMetrics{}
 			mp.modelMetrics[model] = mm
 		}
+		mm.lastSeen = now
 		mm.CallCount++
 		if event.LlmInputTokens != nil {
 			mm.InputTokens += *event.LlmInputTokens
@@ -113,7 +146,55 @@ func (mp *MetricsProcessor) ProcessTraceEvent(event *tracing.TraceEvent) error {
 		}
 	}
 
+	mp.enforceBoundsLocked(now)
 	return nil
+}
+
+// nowFn returns the injected clock, defaulting to time.Now so zero-valued
+// MetricsProcessor literals (none exist today, but the field is unexported and
+// easy to forget) still behave.
+func (mp *MetricsProcessor) nowFn() time.Time {
+	if mp.now != nil {
+		return mp.now()
+	}
+	return time.Now()
+}
+
+// enforceBoundsLocked applies the key ceiling on every write and the age prune
+// at most once per tracing.AggregatePruneInterval. Caller must hold mp.mu.
+//
+// The ceiling is checked unconditionally because it must hold at all times; the
+// age prune is a full map scan, so it is rate-limited rather than run per event.
+func (mp *MetricsProcessor) enforceBoundsLocked(now time.Time) {
+	if mp.bounds.Retention > 0 && !now.Before(mp.nextPruneAt) {
+		mp.nextPruneAt = now.Add(tracing.AggregatePruneInterval)
+		cutoff := now.Add(-mp.bounds.Retention)
+		agents := tracing.PruneOlderThan(mp.agentMetrics, agentLastSeen, cutoff)
+		models := tracing.PruneOlderThan(mp.modelMetrics, modelLastSeen, cutoff)
+		if agents > 0 || models > 0 {
+			log.Printf("[UI-METRICS] Pruned %d agent and %d model aggregates idle longer than %s",
+				agents, models, mp.bounds.Retention)
+		}
+	}
+
+	if n := tracing.EnforceMaxEntries(mp.agentMetrics, agentLastSeen, mp.bounds.MaxEntries); n > 0 {
+		log.Printf("[UI-METRICS] Agent aggregate key cap (%d) reached, evicted %d least-recently-seen agents "+
+			"(raise MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES or shorten MCP_MESH_TELEMETRY_AGGREGATE_RETENTION)",
+			mp.bounds.MaxEntries, n)
+	}
+	if n := tracing.EnforceMaxEntries(mp.modelMetrics, modelLastSeen, mp.bounds.MaxEntries); n > 0 {
+		log.Printf("[UI-METRICS] Model aggregate key cap (%d) reached, evicted %d least-recently-seen models "+
+			"(raise MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES or shorten MCP_MESH_TELEMETRY_AGGREGATE_RETENTION)",
+			mp.bounds.MaxEntries, n)
+	}
+}
+
+// AggregateCounts returns the current number of tracked agent and model keys.
+// Exposed for tests and diagnostics.
+func (mp *MetricsProcessor) AggregateCounts() (agents, models int) {
+	mp.mu.RLock()
+	defer mp.mu.RUnlock()
+	return len(mp.agentMetrics), len(mp.modelMetrics)
 }
 
 // GetAgentMetrics returns per-agent aggregated metrics sorted by span count.

--- a/src/core/ui/metrics_processor_bounds_test.go
+++ b/src/core/ui/metrics_processor_bounds_test.go
@@ -1,0 +1,246 @@
+package ui
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"mcp-mesh/src/core/registry/tracing"
+)
+
+// metricEvent builds a completed span event carrying both an agent name and a
+// model name, so one call feeds both MetricsProcessor maps through the real
+// ProcessTraceEvent entry point.
+func metricEvent(agent, model string) *tracing.TraceEvent {
+	dur := int64(7)
+	in := int64(11)
+	out := int64(13)
+	reqB := int64(100)
+	respB := int64(200)
+	ev := &tracing.TraceEvent{
+		TraceID:         "t-" + agent,
+		SpanID:          "s-" + agent,
+		AgentName:       agent,
+		Operation:       "call",
+		DurationMS:      &dur,
+		RequestBytes:    &reqB,
+		ResponseBytes:   &respB,
+		LlmInputTokens:  &in,
+		LlmOutputTokens: &out,
+	}
+	if model != "" {
+		m := model
+		ev.LlmModel = &m
+	}
+	return ev
+}
+
+// TestMetricsProcessorUnboundedWithoutBounds is the "before" half of #1424:
+// with both bounds off (the pre-fix behaviour) every distinct agent and model
+// name adds a permanent map entry.
+func TestMetricsProcessorUnboundedWithoutBounds(t *testing.T) {
+	mp := NewMetricsProcessorWithBounds(tracing.AggregateBounds{})
+
+	const churn = 2000
+	for i := 0; i < churn; i++ {
+		_ = mp.ProcessTraceEvent(metricEvent(
+			fmt.Sprintf("agent-pod-%04d", i),
+			fmt.Sprintf("vendor/model-%04d", i),
+		))
+	}
+
+	agents, models := mp.AggregateCounts()
+	if agents != churn || models != churn {
+		t.Fatalf("unbounded processor: agents=%d models=%d, want %d each (documents pre-fix growth)", agents, models, churn)
+	}
+}
+
+// TestMetricsProcessorKeyCapBoundsGrowth is the "after" half: the same churn
+// under a key ceiling never exceeds it, checked after EVERY event.
+func TestMetricsProcessorKeyCapBoundsGrowth(t *testing.T) {
+	const cap = 50
+	mp := NewMetricsProcessorWithBounds(tracing.AggregateBounds{
+		Retention:  24 * time.Hour,
+		MaxEntries: cap,
+	})
+
+	const churn = 2000
+	for i := 0; i < churn; i++ {
+		_ = mp.ProcessTraceEvent(metricEvent(
+			fmt.Sprintf("agent-pod-%04d", i),
+			fmt.Sprintf("vendor/model-%04d", i),
+		))
+		agents, models := mp.AggregateCounts()
+		if agents > cap {
+			t.Fatalf("after event %d: agent keys = %d exceeds cap %d", i, agents, cap)
+		}
+		if models > cap {
+			t.Fatalf("after event %d: model keys = %d exceeds cap %d", i, models, cap)
+		}
+	}
+
+	agents, models := mp.AggregateCounts()
+	if agents == 0 || models == 0 {
+		t.Fatalf("maps emptied entirely: agents=%d models=%d", agents, models)
+	}
+
+	// The read paths must still work off the bounded maps.
+	if got := len(mp.GetAgentMetrics()); got > cap {
+		t.Fatalf("GetAgentMetrics returned %d rows, exceeds cap %d", got, cap)
+	}
+	if got := len(mp.GetModelMetrics()); got > cap {
+		t.Fatalf("GetModelMetrics returned %d rows, exceeds cap %d", got, cap)
+	}
+}
+
+// TestMetricsProcessorAgePrune proves the primary bound with an injected
+// clock: an agent/model that stopped reporting ages out, while one that is
+// still reporting survives. A dashboard dropping a live agent is the failure
+// mode this asserts against.
+func TestMetricsProcessorAgePrune(t *testing.T) {
+	base := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	clock := base
+	mp := NewMetricsProcessorWithBounds(tracing.AggregateBounds{
+		Retention:  time.Hour,
+		MaxEntries: 1000,
+	})
+	mp.now = func() time.Time { return clock }
+
+	_ = mp.ProcessTraceEvent(metricEvent("retired-agent", "vendor/retired-model"))
+	_ = mp.ProcessTraceEvent(metricEvent("live-agent", "vendor/live-model"))
+
+	if agents, models := mp.AggregateCounts(); agents != 2 || models != 2 {
+		t.Fatalf("agents=%d models=%d, want 2 each before pruning", agents, models)
+	}
+
+	// Two hours later only the live agent still reports. The write itself
+	// triggers the (rate-limited) prune.
+	clock = base.Add(2 * time.Hour)
+	_ = mp.ProcessTraceEvent(metricEvent("live-agent", "vendor/live-model"))
+
+	agents, models := mp.AggregateCounts()
+	if agents != 1 || models != 1 {
+		t.Fatalf("agents=%d models=%d after prune, want 1 each", agents, models)
+	}
+	for _, a := range mp.GetAgentMetrics() {
+		if a.AgentName != "live-agent" {
+			t.Errorf("unexpected surviving agent %q", a.AgentName)
+		}
+		if a.SpanCount != 2 {
+			t.Errorf("live agent lost its counters: SpanCount=%d, want 2", a.SpanCount)
+		}
+	}
+	for _, m := range mp.GetModelMetrics() {
+		if m.Model != "vendor/live-model" {
+			t.Errorf("unexpected surviving model %q", m.Model)
+		}
+	}
+}
+
+// TestMetricsProcessorAgePruneDisabled proves retention=0 really disables age
+// pruning rather than quietly doing something else.
+func TestMetricsProcessorAgePruneDisabled(t *testing.T) {
+	base := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	clock := base
+	mp := NewMetricsProcessorWithBounds(tracing.AggregateBounds{
+		Retention:  0,
+		MaxEntries: 1000,
+	})
+	mp.now = func() time.Time { return clock }
+
+	_ = mp.ProcessTraceEvent(metricEvent("retired-agent", "vendor/retired-model"))
+
+	clock = base.Add(10000 * time.Hour)
+	_ = mp.ProcessTraceEvent(metricEvent("live-agent", "vendor/live-model"))
+
+	if agents, models := mp.AggregateCounts(); agents != 2 || models != 2 {
+		t.Fatalf("agents=%d models=%d, want 2 each (retention=0 must not prune)", agents, models)
+	}
+}
+
+// TestMetricsProcessorPruneIsRateLimited guards the write path: the age prune
+// is a full map scan, so it must not run on every event.
+func TestMetricsProcessorPruneIsRateLimited(t *testing.T) {
+	base := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	clock := base
+	mp := NewMetricsProcessorWithBounds(tracing.AggregateBounds{
+		Retention:  time.Minute,
+		MaxEntries: 1000,
+	})
+	mp.now = func() time.Time { return clock }
+
+	// First write primes nextPruneAt.
+	_ = mp.ProcessTraceEvent(metricEvent("a", ""))
+
+	// Move well past the retention window but stay inside the prune interval.
+	clock = base.Add(tracing.AggregatePruneInterval - time.Millisecond)
+	_ = mp.ProcessTraceEvent(metricEvent("b", ""))
+	if agents, _ := mp.AggregateCounts(); agents != 2 {
+		t.Fatalf("agents=%d, want 2: prune ran before the interval elapsed", agents)
+	}
+
+	// Cross the interval AND the retention window: "a" must now go.
+	clock = base.Add(tracing.AggregatePruneInterval + time.Hour)
+	_ = mp.ProcessTraceEvent(metricEvent("c", ""))
+	if agents, _ := mp.AggregateCounts(); agents != 1 {
+		t.Fatalf("agents=%d, want 1 after the interval elapsed", agents)
+	}
+}
+
+// TestMetricsProcessorDefaultPathUnchanged is the no-regression guard: a
+// normally sized mesh produces identical dashboard numbers under the shipped
+// defaults and under no bounds at all.
+func TestMetricsProcessorDefaultPathUnchanged(t *testing.T) {
+	bounded := NewMetricsProcessor() // ships with DefaultAggregateBounds
+	plain := NewMetricsProcessorWithBounds(tracing.AggregateBounds{})
+
+	agents := []string{"frontend", "auth", "billing", "search"}
+	models := []string{"anthropic/claude", "openai/gpt", "google/gemini"}
+	for i := 0; i < 1000; i++ {
+		ev := metricEvent(agents[i%len(agents)], models[i%len(models)])
+		_ = bounded.ProcessTraceEvent(ev)
+		_ = plain.ProcessTraceEvent(ev)
+	}
+
+	bAgents, bModels := bounded.GetAgentMetrics(), bounded.GetModelMetrics()
+	pAgents, pModels := plain.GetAgentMetrics(), plain.GetModelMetrics()
+
+	if len(bAgents) != len(pAgents) || len(bModels) != len(pModels) {
+		t.Fatalf("shape differs under defaults: agents %d vs %d, models %d vs %d",
+			len(bAgents), len(pAgents), len(bModels), len(pModels))
+	}
+	if len(bAgents) != len(agents) || len(bModels) != len(models) {
+		t.Fatalf("unexpected cardinality: agents=%d models=%d", len(bAgents), len(bModels))
+	}
+
+	// Compare as keyed sets: GetAgentMetrics/GetModelMetrics sort by count with
+	// an unstable sort, so equal-count rows have never had a deterministic
+	// order. What must be identical is every row and every number.
+	wantAgents := make(map[string]AgentMetricsData, len(pAgents))
+	for _, a := range pAgents {
+		wantAgents[a.AgentName] = a
+	}
+	for _, got := range bAgents {
+		want, ok := wantAgents[got.AgentName]
+		if !ok {
+			t.Fatalf("agent %q missing under the shipped defaults", got.AgentName)
+		}
+		if got != want {
+			t.Fatalf("agent %q differs under defaults:\n bounded=%+v\n   plain=%+v", got.AgentName, got, want)
+		}
+	}
+
+	wantModels := make(map[string]ModelMetricsData, len(pModels))
+	for _, m := range pModels {
+		wantModels[m.Model] = m
+	}
+	for _, got := range bModels {
+		want, ok := wantModels[got.Model]
+		if !ok {
+			t.Fatalf("model %q missing under the shipped defaults", got.Model)
+		}
+		if got != want {
+			t.Fatalf("model %q differs under defaults:\n bounded=%+v\n   plain=%+v", got.Model, got, want)
+		}
+	}
+}

--- a/src/runtime/core/src/tracing_publish.rs
+++ b/src/runtime/core/src/tracing_publish.rs
@@ -21,6 +21,66 @@ use crate::config::{get_redis_url, is_tracing_enabled};
 /// Redis stream name for trace data.
 const TRACE_STREAM_NAME: &str = "mesh:trace";
 
+/// Producer-side hard ceiling on the `mesh:trace` stream (issue #1424).
+///
+/// Time-based trimming (`XTRIM MINID`, `MCP_MESH_TRACE_RETENTION`) is done by
+/// the consumers — the registry and meshui. If both are down while agents keep
+/// publishing, nothing bounds the stream and the only backstop is Redis
+/// `allkeys-lru`, which evicts the ENTIRE `mesh:trace` key rather than shedding
+/// old entries. Capping at the producer makes the bound independent of any
+/// consumer being alive: every runtime (Python, TypeScript, Java, Go) publishes
+/// through this single call site.
+///
+/// `MAXLEN ~` is approximate — Redis trims in whole macro-node steps, so the
+/// stream may sit somewhat above the cap. That is deliberate: the exact form is
+/// O(N) per XADD, the approximate form is amortised O(1). This is a safety
+/// ceiling, not a retention policy; retention stays time-based on the consumer.
+const DEFAULT_TRACE_STREAM_MAXLEN: usize = 100_000;
+
+/// Read the producer-side stream cap from `MCP_MESH_TRACE_STREAM_MAXLEN`.
+///
+/// - unset / empty: `DEFAULT_TRACE_STREAM_MAXLEN`
+/// - positive integer: use it
+/// - `0`: no producer-side cap (plain `XADD`) — warned, since it removes a bound
+/// - negative / unparseable: warn and fall back to the default
+///
+/// Called ONCE per [`init_trace_publisher`] and cached in
+/// [`TracePublisherState::stream_maxlen`] — never from the publish path, where
+/// the env read + parse (and, on a misconfigured value, the `warn!`) would run
+/// for every span.
+fn trace_stream_maxlen() -> usize {
+    match std::env::var("MCP_MESH_TRACE_STREAM_MAXLEN") {
+        Err(_) => DEFAULT_TRACE_STREAM_MAXLEN,
+        Ok(raw) if raw.trim().is_empty() => DEFAULT_TRACE_STREAM_MAXLEN,
+        Ok(raw) => match raw.trim().parse::<i64>() {
+            Ok(0) => {
+                warn!(
+                    "MCP_MESH_TRACE_STREAM_MAXLEN=0: producer-side cap on '{}' is DISABLED; \
+                     the stream is bounded only while a registry or meshui consumer is alive",
+                    TRACE_STREAM_NAME
+                );
+                0
+            }
+            Ok(n) if n > 0 => n as usize,
+            Ok(n) => {
+                warn!(
+                    "Invalid MCP_MESH_TRACE_STREAM_MAXLEN={}: negative values are not allowed \
+                     (use 0 to disable); using default {}",
+                    n, DEFAULT_TRACE_STREAM_MAXLEN
+                );
+                DEFAULT_TRACE_STREAM_MAXLEN
+            }
+            Err(e) => {
+                warn!(
+                    "Invalid MCP_MESH_TRACE_STREAM_MAXLEN={:?}, using default {}: {}",
+                    raw, DEFAULT_TRACE_STREAM_MAXLEN, e
+                );
+                DEFAULT_TRACE_STREAM_MAXLEN
+            }
+        },
+    }
+}
+
 /// Cooldown between re-probe attempts once Redis has been marked unavailable
 /// (issue #1364). Stored as an atomic so tests can shrink it for a
 /// deterministic recovery assertion; production always uses the 5s default.
@@ -74,6 +134,12 @@ struct TracePublisherState {
     available: bool,
     /// Redis URL.
     redis_url: String,
+    /// Producer-side `MAXLEN ~` cap, resolved once at init (issue #1424).
+    /// Cached here rather than read from the environment per span: the publish
+    /// path runs for every span, and an env read + parse — plus a `warn!` on a
+    /// misconfigured value, which would be a log flood — has no business there.
+    /// 0 means "no cap": publish with a plain `XADD`.
+    stream_maxlen: usize,
 }
 
 impl Default for TracePublisherState {
@@ -83,6 +149,7 @@ impl Default for TracePublisherState {
             enabled: false,
             available: false,
             redis_url: String::new(),
+            stream_maxlen: DEFAULT_TRACE_STREAM_MAXLEN,
         }
     }
 }
@@ -277,6 +344,10 @@ pub async fn init_trace_publisher() -> bool {
             debug!("Distributed tracing: disabled");
             return false;
         }
+        // Resolve the producer-side cap here, alongside `enabled` / `redis_url`,
+        // so the publish path is a plain field read. Any warning about a
+        // misconfigured value fires once per init instead of once per span.
+        state.stream_maxlen = trace_stream_maxlen();
     }
 
     info!("Distributed tracing: enabled");
@@ -329,7 +400,7 @@ pub async fn publish_span(span_data: HashMap<String, String>) -> bool {
     //   * Redis marked unavailable → short-circuit INSTANTLY (read-lock only).
     //     The background re-prober is the only thing that dials Redis while
     //     unavailable, so no request ever stalls on a reconnect.
-    let mut conn = {
+    let (mut conn, maxlen) = {
         let state = publisher.read().await;
         if !state.enabled {
             return false;
@@ -346,7 +417,7 @@ pub async fn publish_span(span_data: HashMap<String, String>) -> bool {
             return false;
         }
         match &state.conn {
-            Some(c) => c.clone(),
+            Some(c) => (c.clone(), state.stream_maxlen),
             None => return false,
         }
     };
@@ -367,10 +438,20 @@ pub async fn publish_span(span_data: HashMap<String, String>) -> bool {
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
 
-    // Publish to stream
-    let result: Result<String, redis::RedisError> = conn
-        .xadd(TRACE_STREAM_NAME, "*", &items)
-        .await;
+    // Publish to stream, capped at the producer so the stream stays bounded
+    // even with every consumer down (issue #1424). `maxlen` was resolved once
+    // at init; 0 still means "no cap" and takes the plain `XADD` path.
+    let result: Result<String, redis::RedisError> = if maxlen > 0 {
+        conn.xadd_maxlen(
+            TRACE_STREAM_NAME,
+            redis::streams::StreamMaxlen::Approx(maxlen),
+            "*",
+            &items,
+        )
+        .await
+    } else {
+        conn.xadd(TRACE_STREAM_NAME, "*", &items).await
+    };
     match result {
         Ok(_msg_id) => {
             debug!("Published trace span to Redis stream");
@@ -487,6 +568,57 @@ mod tests {
         assert_eq!(TRACE_STREAM_NAME, "mesh:trace");
     }
 
+    /// Issue #1424: the producer-side `MAXLEN ~` cap is the only bound on the
+    /// stream when every consumer is down, so its env parsing must default
+    /// safely and must never silently unbound on a bad value.
+    ///
+    /// NB: mutates process env; `--test-threads=1` in CI keeps this serial.
+    #[test]
+    fn test_trace_stream_maxlen_env() {
+        let restore = std::env::var("MCP_MESH_TRACE_STREAM_MAXLEN").ok();
+
+        std::env::remove_var("MCP_MESH_TRACE_STREAM_MAXLEN");
+        assert_eq!(
+            trace_stream_maxlen(),
+            DEFAULT_TRACE_STREAM_MAXLEN,
+            "unset must use the default cap"
+        );
+
+        std::env::set_var("MCP_MESH_TRACE_STREAM_MAXLEN", "");
+        assert_eq!(
+            trace_stream_maxlen(),
+            DEFAULT_TRACE_STREAM_MAXLEN,
+            "empty must use the default cap"
+        );
+
+        std::env::set_var("MCP_MESH_TRACE_STREAM_MAXLEN", "500");
+        assert_eq!(trace_stream_maxlen(), 500, "positive override must apply");
+
+        std::env::set_var("MCP_MESH_TRACE_STREAM_MAXLEN", "0");
+        assert_eq!(trace_stream_maxlen(), 0, "0 must disable the producer cap");
+
+        // A bad value must fall back to the default, NOT to 0 — falling back
+        // to 0 would silently remove the bound.
+        std::env::set_var("MCP_MESH_TRACE_STREAM_MAXLEN", "-5");
+        assert_eq!(
+            trace_stream_maxlen(),
+            DEFAULT_TRACE_STREAM_MAXLEN,
+            "negative must fall back to the default, not disable"
+        );
+
+        std::env::set_var("MCP_MESH_TRACE_STREAM_MAXLEN", "not-a-number");
+        assert_eq!(
+            trace_stream_maxlen(),
+            DEFAULT_TRACE_STREAM_MAXLEN,
+            "unparseable must fall back to the default, not disable"
+        );
+
+        match restore {
+            Some(v) => std::env::set_var("MCP_MESH_TRACE_STREAM_MAXLEN", v),
+            None => std::env::remove_var("MCP_MESH_TRACE_STREAM_MAXLEN"),
+        }
+    }
+
     /// Issue #1166 MED-3: the publisher must establish ONE connection at
     /// init and reuse it across publishes — not dial Redis per span.
     /// Uses a minimal fake RESP server that counts accepted TCP
@@ -577,6 +709,242 @@ mod tests {
 
         std::env::remove_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED");
         std::env::remove_var("REDIS_URL");
+    }
+
+    /// Issue #1424: the XADD issued on the publish path must carry
+    /// `MAXLEN ~ <n>`, so the `mesh:trace` stream stays bounded even with every
+    /// consumer down. Captures the raw RESP bytes off a fake server and
+    /// asserts the cap is on the wire — the previous uncapped `XADD` left the
+    /// stream bounded only by a live registry.
+    ///
+    /// NB: mutates process env and the global publisher singleton; the suite
+    /// runs with --test-threads=1, matching the other env-mutating tests here.
+    #[tokio::test]
+    async fn publish_span_caps_stream_with_maxlen() {
+        use std::sync::Mutex;
+
+        reset_reprober_state();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fake redis");
+        let addr = listener.local_addr().unwrap();
+        let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let captured_srv = captured.clone();
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                let captured_conn = captured_srv.clone();
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 8192];
+                    loop {
+                        match sock.read(&mut buf).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => {
+                                let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                                let ncmds = req
+                                    .split("\r\n")
+                                    .filter(|line| line.starts_with('*'))
+                                    .count()
+                                    .max(1);
+                                captured_conn.lock().unwrap().push(req);
+                                let resp = "+PONG\r\n".repeat(ncmds);
+                                if sock.write_all(resp.as_bytes()).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        std::env::set_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED", "true");
+        std::env::set_var("REDIS_URL", format!("redis://{}", addr));
+        std::env::set_var("MCP_MESH_TRACE_STREAM_MAXLEN", "777");
+
+        let budget = std::time::Duration::from_secs(10);
+        assert!(
+            tokio::time::timeout(budget, init_trace_publisher())
+                .await
+                .expect("init timed out"),
+            "init must succeed against the fake server"
+        );
+
+        let span: HashMap<String, String> = HashMap::from([("span".to_string(), "s0".to_string())]);
+        assert!(
+            tokio::time::timeout(budget, publish_span(span))
+                .await
+                .expect("publish timed out"),
+            "publish must succeed"
+        );
+
+        // Give the fake server a moment to record the write.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let reqs = captured.lock().unwrap().clone();
+        let xadd = reqs
+            .iter()
+            .find(|r| r.contains("XADD"))
+            .unwrap_or_else(|| panic!("no XADD captured; requests were: {:?}", reqs))
+            .clone();
+
+        assert!(
+            xadd.contains("MAXLEN"),
+            "XADD must carry a MAXLEN cap, got: {:?}",
+            xadd
+        );
+        assert!(
+            xadd.contains("777"),
+            "XADD must carry the configured cap 777, got: {:?}",
+            xadd
+        );
+        assert!(
+            xadd.contains("\r\n~\r\n"),
+            "cap must be approximate (~) so XADD stays amortised O(1), got: {:?}",
+            xadd
+        );
+
+        std::env::remove_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED");
+        std::env::remove_var("REDIS_URL");
+        std::env::remove_var("MCP_MESH_TRACE_STREAM_MAXLEN");
+    }
+
+    /// The cap is resolved ONCE at init, not per span: the publish path runs for
+    /// every span, so an env read + parse there is pure overhead — and on a
+    /// misconfigured value the `warn!` inside `trace_stream_maxlen` becomes a
+    /// per-span log flood.
+    ///
+    /// Proven on the wire rather than by counting log lines: init with a valid
+    /// cap, then corrupt the env var and publish. A cached value keeps emitting
+    /// the init-time cap; a per-span read would parse the bad value, warn, and
+    /// fall back to the default. Also pins that `MAXLEN=0` still takes the plain
+    /// uncapped `XADD` path after caching.
+    ///
+    /// NB: mutates process env and the global publisher singleton; the suite
+    /// runs with --test-threads=1, matching the other env-mutating tests here.
+    #[tokio::test]
+    async fn publish_span_resolves_maxlen_once_at_init() {
+        use std::sync::Mutex;
+
+        reset_reprober_state();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind fake redis");
+        let addr = listener.local_addr().unwrap();
+        let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let captured_srv = captured.clone();
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                let captured_conn = captured_srv.clone();
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 8192];
+                    loop {
+                        match sock.read(&mut buf).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => {
+                                let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                                let ncmds = req
+                                    .split("\r\n")
+                                    .filter(|line| line.starts_with('*'))
+                                    .count()
+                                    .max(1);
+                                captured_conn.lock().unwrap().push(req);
+                                let resp = "+PONG\r\n".repeat(ncmds);
+                                if sock.write_all(resp.as_bytes()).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        let budget = std::time::Duration::from_secs(10);
+        let find_xadd = |reqs: Vec<String>| -> String {
+            reqs.iter()
+                .find(|r| r.contains("XADD"))
+                .unwrap_or_else(|| panic!("no XADD captured; requests were: {:?}", reqs))
+                .clone()
+        };
+
+        std::env::set_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED", "true");
+        std::env::set_var("REDIS_URL", format!("redis://{}", addr));
+        std::env::set_var("MCP_MESH_TRACE_STREAM_MAXLEN", "321");
+
+        assert!(
+            tokio::time::timeout(budget, init_trace_publisher())
+                .await
+                .expect("init timed out"),
+            "init must succeed against the fake server"
+        );
+
+        // Corrupt the env AFTER init. A per-span read would warn and fall back
+        // to DEFAULT_TRACE_STREAM_MAXLEN; the cached value must win.
+        std::env::set_var("MCP_MESH_TRACE_STREAM_MAXLEN", "not-a-number");
+
+        for i in 0..3 {
+            let span: HashMap<String, String> =
+                HashMap::from([("span".to_string(), format!("s{}", i))]);
+            assert!(
+                tokio::time::timeout(budget, publish_span(span))
+                    .await
+                    .expect("publish timed out"),
+                "publish {} must succeed",
+                i
+            );
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let xadd = find_xadd(captured.lock().unwrap().clone());
+        assert!(
+            xadd.contains("321"),
+            "XADD must carry the init-time cap 321, not a per-span re-read of the env: {:?}",
+            xadd
+        );
+        assert!(
+            !xadd.contains(&DEFAULT_TRACE_STREAM_MAXLEN.to_string()),
+            "XADD must not fall back to the default from a per-span env re-read: {:?}",
+            xadd
+        );
+
+        // maxlen == 0 must still mean a plain, uncapped XADD after caching.
+        captured.lock().unwrap().clear();
+        std::env::set_var("MCP_MESH_TRACE_STREAM_MAXLEN", "0");
+        assert!(
+            tokio::time::timeout(budget, init_trace_publisher())
+                .await
+                .expect("re-init timed out"),
+            "re-init must succeed"
+        );
+        let span: HashMap<String, String> = HashMap::from([("span".to_string(), "z".to_string())]);
+        assert!(
+            tokio::time::timeout(budget, publish_span(span))
+                .await
+                .expect("publish timed out"),
+            "publish must succeed with the cap disabled"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let xadd = find_xadd(captured.lock().unwrap().clone());
+        assert!(
+            !xadd.contains("MAXLEN"),
+            "MCP_MESH_TRACE_STREAM_MAXLEN=0 must issue a plain uncapped XADD, got: {:?}",
+            xadd
+        );
+
+        std::env::remove_var("MCP_MESH_DISTRIBUTED_TRACING_ENABLED");
+        std::env::remove_var("REDIS_URL");
+        std::env::remove_var("MCP_MESH_TRACE_STREAM_MAXLEN");
     }
 
     /// Issue #1363: a black-holed / non-accepting Redis must not stall init


### PR DESCRIPTION
## Summary

Two registry-side bounds that silently disappear. The trace *data* pipeline was already bounded; the **in-memory aggregate layer** on top of it was not, and no knob reached it. Separately, disabling the sweep also removed an unrelated table cap.

## Design: age-based prune, hard cap as backstop

Not one or the other. The cardinality here is *names*, so "has this key stopped reporting?" is the semantically correct question — an agent that stopped should age out, one still reporting should never be dropped.

A pure LRU cap gets that backwards under a churn burst: it evicts by recency-of-write regardless of liveness, so a live-but-low-traffic agent can vanish from the dashboard while a burst of ephemeral pod names fills the map. Age alone has only a soft ceiling (new-name rate × retention), so a hard cap remains — but it engages **only after age pruning has failed to keep up**, and evicts least-recently-seen first, degrading *into* LRU rather than starting there. Every eviction batch logs both knob names.

Both are knobs: `MCP_MESH_TELEMETRY_AGGREGATE_RETENTION` (24h) and `MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES` (10000). `0` disables either and is logged as a removed bound. **A negative or unparseable value falls back to the default, never to 0** — a typo must not silently unbound the map, which is the defect class this PR is fixing.

Eviction is batched to ~90% of cap so the sort amortises to `O(log n)` per insert. `MetricsProcessor` prunes off the write path on a 10s gate rather than owning a goroutine — it has no lifecycle today, and `replayWindow` constructs throwaway instances that would otherwise need Start/Stop wiring. The accumulator reuses its existing 10s `cleanupLoop`.

**No knobs on the Redis housekeeping thresholds** (`pelMinIdle` 5m, `pelMaxDeliveries` 5, `consumerIdleTimeout` 1h). Those are timing thresholds for a loop that runs unconditionally, not memory/retention trade-offs — the bound is never off, so there is nothing to trade.

## The trace-stream single point of failure — both halves fixed

Both were small:

- **meshui now trims.** `manager_ui.go` passes `Retention` through, `cmd/mcp-mesh-ui/main.go` sets it from the shared `tracing.TraceRetentionFromEnv()`. Helm wires `ui.tracing.retention` next to the registry's, with a comment in both charts that they must agree.
- **The producer now caps.** `tracing_publish.rs:372` uses `StreamMaxlen::Approx(n)` — one call site covering Python, TypeScript, Java and Go.

Previously the `XADD` was uncapped and only the registry trimmed, so with the registry down the only backstop was `allkeys-lru`, which evicts the **entire** `mesh:trace` key rather than shedding old entries.

## Validation

**Each bound proven to bound** — driven past the limit, asserted after *every* write, not just at the end:

| test | result |
|---|---|
| `TestEdgeStatsUnboundedWithoutBounds` — 2000 churned names, bounds off | **2000** keys (documents pre-fix growth) |
| `TestEdgeStatsKeyCapBoundsGrowth` — same, cap 50 | never exceeds 50 |
| `TestMetricsProcessorUnboundedWithoutBounds` | agents **2000**, models **2000** |
| `TestMetricsProcessorKeyCapBoundsGrowth` — cap 50 | never exceeds 50 |
| `TestEnforceMaxEntriesBoundsGrowth` — 5000 inserts, cap 100 | never exceeds 100; newest survives, oldest gone (proves LRU, not arbitrary) |
| age-prune tests | idle key removed **and** still-active key survives with counters intact |

**#1425 before/after, run against the actual pre-fix code** in a worktree at `b83e1b9ee`, same assertion (`MCP_MESH_RETENTION=0`, cap 3, 5 events):

```
PRE-FIX:  registry_events count -> 5    FAIL
POST-FIX: registry_events count -> 3    PASS
```

`TestEventCapOnlyTickLeavesStaleAgentsAlone` confirms the other direction — a 30-day-stale agent survives, so the cap-only tick really is cap-only. `TestEnforceEventCapDisabledDoesNotDeleteEverything` guards the obvious way to get this wrong (cap 0 ⇒ every row exceeds it ⇒ delete the table).

**Redis, against a real server** (skipped without `MCP_MESH_TEST_REDIS_URL`, so `go test ./...` needs no service): a stuck PEL entry is proven stuck first — a second `XREADGROUP` does *not* redeliver it — then reclaimed; a poison pill is dropped after `pelMaxDeliveries`; 3 dead consumer incarnations reaped down to the 1 live one; and the reap provably discards no PEL entry.

Producer `MAXLEN` on the same Redis: uncapped 20000 XADDs → `XLEN 20000`; `MAXLEN ~ 1000` → `XLEN 1000`. Asserted on the wire by `publish_span_caps_stream_with_maxlen`, which captures raw RESP and checks the `~` flag.

**Tallies** (same machine, `-count=1`): `go test ./...` 778 → **811 PASS, 0 FAIL, 0 races**; `cargo test` 473 → **475**. Same 4 pre-existing skips both sides. `pytest scripts/` 85; `helm lint` 9/9; PSS OK; render matrix 34/34.

**No default-path change**: a normally-sized mesh (4 agents / 3 models / 500–1000 traces) run through bounded and unbounded processors produces byte-identical rows and totals.

## Worth reviewer attention

- **One pre-existing test was intentionally changed.** `TestSweepDisabledStartIsNoop` asserted `running == false` at `Retention=0` — precisely the contract #1425 inverts. It now covers the only remaining no-op path (both bounds off), with `TestSweepRetentionZeroStillRunsForEventCap` as its counterpart.
- **`EventCapDisabled = -1` sentinel.** 47 existing test literals construct `SweepConfig{Retention: ...}` leaving `EventMaxRows` zero-valued; making `0` mean "disabled" would let a forgotten struct field silently remove the bound — the same defect class as the issue. So `0 = unset → default`, `-1 = deliberately off`, and env `"0"` maps to the sentinel with a warning.
- **`replayWindow` throwaway instances inherit the same bounds**, so a 1h/1d traffic window with more distinct keys than `MaxEntries` will evict. Intended and consistent, but a behaviour change at that (pathological) scale.
- **Pre-existing formatting left alone**: `sweep.go` has a `gofmt` struct-alignment violation and `tracing_publish.rs` has 6 `rustfmt` hunks, both predating this branch. Verified zero new violations added (rustfmt hunks 6 → 6); unrelated lines not reformatted.
- **Noted, deliberately out of scope**: `MCP_MESH_RETENTION=0` also disables the orphan-job reroute, expired-lease reclaim and total-deadline expiry, which sit unguarded inside `runOnce`. Arguably the same bug class as #1425, but fixing it changes job-lifecycle behaviour well beyond what either issue asked for. Happy to file separately.

Closes #1424
Closes #1425


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for trace stream size, event-table rows, and dashboard telemetry aggregates.
  * UI tracing now continues trimming trace data during registry outages.
  * Added automatic recovery of stalled tracing messages and cleanup of inactive consumers.
  * Registry event limits can now be configured independently from general retention settings.

* **Documentation**
  * Expanded observability, environment-variable, and Helm configuration guidance, including defaults and disable options.

* **Bug Fixes**
  * Improved protection against unbounded telemetry growth and stuck trace-processing entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->