### PR TITLE
refactor(java): extract the positional dependency binder from MeshToolWrapper

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshPositionalBinder.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshPositionalBinder.java
@@ -1,0 +1,360 @@
+package io.mcpmesh.spring;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * The positional dependency-pairing rule, in one place.
+ *
+ * <p><b>The contract.</b> Declared dependencies pair positionally with a
+ * method's injectable parameters in <i>signature order</i>: the Nth declared
+ * dependency binds to the Nth injectable slot. Parameter names are never
+ * consulted. This is the same contract as Python and TypeScript.
+ *
+ * <p>The two index spaces differ whenever a non-proxy injectable slot sits in
+ * the middle of the signature — today, a {@code MeshJob} parameter. For
+ * example {@code dependencies = ["job_cap", "db_cap"]} against
+ * {@code (MeshJob job, McpMeshTool db)} puts {@code db_cap} at DECLARED index
+ * 1 but at proxy SLOT ordinal 0. Registry events carry the declared index
+ * while a wrapper's proxy arrays are slot-ordinal arrays, so the two
+ * translation tables produced here — {@link Binding#depIndexToSlot()} and
+ * {@link Binding#slotToDepIndex()} — are what let one side talk to the other.
+ *
+ * <p><b>Slack in both directions is tolerated, not an error</b> (today):
+ * declared dependencies beyond the available slots map to {@code -1} and are
+ * dropped; slots beyond the declared list map to {@code -1} and receive
+ * {@code null}. {@link Binding#describe()} renders both cases explicitly — it
+ * exists so a future arity/order validator (issue #1401) has a ready-made,
+ * human-readable statement of what the pairing actually did.
+ *
+ * <p><b>Role assignment belongs to the caller.</b> This class deliberately
+ * does NOT classify parameters. Each injection site decides for itself which
+ * parameters are injectable and what kind they are, and those rules genuinely
+ * differ:
+ * <ul>
+ *   <li>{@code @MeshTool} ({@link MeshToolWrapper}) treats {@code McpMeshTool}
+ *       parameters as proxy slots and a {@code MeshJob} parameter as a job
+ *       slot, while exempting {@code A2AClient} and {@code @MeshService} view
+ *       parameters, which are bound by other means.</li>
+ *   <li>The {@code @MeshA2A} dispatch path additionally treats
+ *       {@code @MeshInject} on a <i>non-</i>{@code McpMeshTool} parameter as
+ *       an injectable slot, and carries a message-fallback rule ("the
+ *       parameter at index 0 takes the message if nothing else claimed it")
+ *       that can compete for index 0 with a genuine slot. That competition is
+ *       a role-assignment decision, so it stays with the caller: the caller
+ *       simply does not emit a {@link Slot} for a position it wants to hand
+ *       the message. Feeding the surviving slots here then yields the same
+ *       pairing tables the tool path uses.</li>
+ * </ul>
+ * Callers therefore hand in an already-enumerated {@link Slot} list; this
+ * class only orders it and pairs it.
+ *
+ * @see MeshToolWrapper
+ * @see MeshJobResolver
+ */
+public final class MeshPositionalBinder {
+
+    private MeshPositionalBinder() {}
+
+    /** What an injectable slot is for. */
+    public enum SlotRole {
+        /**
+         * A dependency-proxy slot ({@code McpMeshTool}). Consumes one declared
+         * dependency index AND owns a proxy slot ordinal.
+         */
+        PROXY,
+        /**
+         * A job slot ({@code MeshJob}). Consumes one declared dependency index
+         * — so the capability the user typed {@code MeshJob} for is known —
+         * but owns no proxy slot: it is filled by the dispatch path
+         * (submitter or controller), never by a resolution event.
+         */
+        JOB
+    }
+
+    /**
+     * One injectable parameter.
+     *
+     * @param parameterPosition signature position of the parameter
+     * @param role              what the slot is for
+     */
+    public record Slot(int parameterPosition, SlotRole role) {
+        public Slot {
+            if (parameterPosition < 0) {
+                throw new IllegalArgumentException(
+                    "parameterPosition must be >= 0, got " + parameterPosition);
+            }
+            if (role == null) {
+                throw new IllegalArgumentException("role is required");
+            }
+        }
+    }
+
+    /**
+     * The pairing table for one method.
+     *
+     * <p>The {@code int[]} accessors expose the binder's own arrays rather
+     * than copies — {@link #bind} builds them fresh per call, so the caller
+     * that receives a {@code Binding} owns them. Treat them as read-only if
+     * the {@code Binding} is shared.
+     *
+     * @param method          the bound method (diagnostics only)
+     * @param capabilities    the FULL declared dependency list, in declaration
+     *                        order
+     * @param pairableDepCount how many leading entries of {@code capabilities}
+     *                        take part in positional pairing; the remainder
+     *                        (e.g. {@code @MeshService} view edges) always map
+     *                        to {@code -1}
+     * @param slots           injectable slots in signature order
+     * @param depIndexToSlot  declared dep index → proxy slot ordinal; -1 = no
+     *                        proxy slot (job-backed, non-pairable, or excess).
+     *                        Length = {@code capabilities.size()}
+     * @param slotToDepIndex  proxy slot ordinal → declared dep index; -1 = no
+     *                        declared dependency backs the slot. Length =
+     *                        {@link #proxySlotCount()}
+     * @param jobDepIndex     declared dep index paired with the {@code JOB}
+     *                        slot, or -1 when there is no job slot or nothing
+     *                        declared reaches it
+     */
+    public record Binding(
+        Method method,
+        List<String> capabilities,
+        int pairableDepCount,
+        List<Slot> slots,
+        int[] depIndexToSlot,
+        int[] slotToDepIndex,
+        int jobDepIndex
+    ) {
+        public Binding {
+            capabilities = List.copyOf(capabilities);
+            slots = List.copyOf(slots);
+        }
+
+        /** Number of {@code PROXY} slots — the length of {@link #slotToDepIndex()}. */
+        public int proxySlotCount() {
+            return slotToDepIndex.length;
+        }
+
+        /** Signature positions of the injectable slots, in signature order. */
+        public List<Integer> slotPositions() {
+            return slots.stream().map(Slot::parameterPosition).toList();
+        }
+
+        /**
+         * A human-readable statement of what the pairing did: every declared
+         * dependency with the parameter it landed on, every declared
+         * dependency that found no parameter, and every injectable parameter
+         * that no declared dependency reached.
+         *
+         * <p>This is the text a dependency-count / ordering validator should
+         * print (issue #1401): it names both index spaces, so a user who
+         * reordered {@code dependencies = {...}} without reordering
+         * parameters can see the mismatch directly.
+         */
+        public String describe() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("positional dependency pairing for ").append(signature()).append('\n');
+            sb.append("  ").append(pairableDepCount)
+                .append(pairableDepCount == 1
+                    ? " declared dependency pairs with " : " declared dependencies pair with ")
+                .append(slots.size())
+                .append(slots.size() == 1 ? " injectable parameter" : " injectable parameters")
+                .append(" in signature order:");
+
+            if (pairableDepCount == 0 && slots.isEmpty()) {
+                sb.append(" (nothing to pair)");
+            }
+            for (int k = 0; k < pairableDepCount; k++) {
+                sb.append("\n    dependency[").append(k).append("] '")
+                    .append(capabilityAt(k)).append("' -> ");
+                if (k < slots.size()) {
+                    Slot slot = slots.get(k);
+                    sb.append(describeParameter(slot));
+                    if (slot.role() == SlotRole.PROXY) {
+                        sb.append(" [proxy slot ").append(depIndexToSlot[k]).append(']');
+                    } else {
+                        sb.append(" [job slot]");
+                    }
+                } else {
+                    sb.append("(no injectable parameter — dropped)");
+                }
+            }
+            for (int s = pairableDepCount; s < slots.size(); s++) {
+                Slot slot = slots.get(s);
+                sb.append("\n    (no declared dependency) -> ")
+                    .append(describeParameter(slot))
+                    .append(slot.role() == SlotRole.JOB
+                        ? " — no declared capability backs the job slot"
+                        : " — injected null");
+            }
+            int nonPairable = capabilities.size() - pairableDepCount;
+            if (nonPairable > 0) {
+                sb.append("\n  ").append(nonPairable)
+                    .append(" further declared dependenc")
+                    .append(nonPairable == 1 ? "y is" : "ies are")
+                    .append(" bound by other means (e.g. @MeshService view edges) "
+                        + "and take no part in positional pairing");
+            }
+            return sb.toString();
+        }
+
+        private String capabilityAt(int k) {
+            return k < capabilities.size() ? capabilities.get(k) : "?";
+        }
+
+        private String describeParameter(Slot slot) {
+            int pos = slot.parameterPosition();
+            Parameter[] params = method.getParameters();
+            if (pos >= params.length) {
+                return "parameter " + pos + " (out of range)";
+            }
+            Parameter p = params[pos];
+            return "parameter " + pos + " (" + p.getType().getSimpleName() + " "
+                + p.getName() + ")";
+        }
+
+        private String signature() {
+            StringBuilder sb = new StringBuilder();
+            sb.append(method.getDeclaringClass().getName()).append('.')
+                .append(method.getName()).append('(');
+            Class<?>[] types = method.getParameterTypes();
+            for (int i = 0; i < types.length; i++) {
+                if (i > 0) {
+                    sb.append(", ");
+                }
+                sb.append(types[i].getSimpleName());
+            }
+            return sb.append(')').toString();
+        }
+
+        @Override
+        public String toString() {
+            return "Binding[" + signature()
+                + ", depIndexToSlot=" + Arrays.toString(depIndexToSlot)
+                + ", slotToDepIndex=" + Arrays.toString(slotToDepIndex)
+                + ", jobDepIndex=" + jobDepIndex + "]";
+        }
+    }
+
+    /**
+     * Pair a declared dependency list with a method's injectable slots.
+     *
+     * <p>Slots are sorted by signature position (the caller may supply them in
+     * any order); the Nth slot then takes the Nth pairable declared
+     * dependency. A {@code JOB} slot consumes its declared index but yields no
+     * proxy mapping. Surplus on either side maps to {@code -1} — see the class
+     * javadoc.
+     *
+     * @param method           the method being bound; used for diagnostics
+     * @param slots            injectable slots (any order; sorted here). At
+     *                         most one {@code JOB} slot
+     * @param capabilities     the FULL declared dependency list in declaration
+     *                         order; may be empty
+     * @param pairableDepCount how many leading {@code capabilities} entries
+     *                         take part in pairing. Clamped into
+     *                         {@code [0, capabilities.size()]}
+     * @return the pairing table
+     * @throws IllegalArgumentException if {@code method}, {@code slots} or
+     *         {@code capabilities} is null, if two slots share a parameter
+     *         position, or if more than one {@code JOB} slot is supplied
+     */
+    public static Binding bind(
+            Method method,
+            List<Slot> slots,
+            List<String> capabilities,
+            int pairableDepCount) {
+
+        if (method == null) {
+            throw new IllegalArgumentException("method is required");
+        }
+        if (slots == null) {
+            throw new IllegalArgumentException("slots is required");
+        }
+        if (capabilities == null) {
+            throw new IllegalArgumentException("capabilities is required");
+        }
+
+        List<Slot> ordered = new ArrayList<>(slots);
+        ordered.sort(Comparator.comparingInt(Slot::parameterPosition));
+
+        int jobSlots = 0;
+        for (int i = 0; i < ordered.size(); i++) {
+            if (i > 0 && ordered.get(i).parameterPosition() == ordered.get(i - 1).parameterPosition()) {
+                throw new IllegalArgumentException(
+                    "duplicate injectable slot at parameter position "
+                        + ordered.get(i).parameterPosition() + " of "
+                        + method.getDeclaringClass().getName() + "." + method.getName());
+            }
+            if (ordered.get(i).role() == SlotRole.JOB && ++jobSlots > 1) {
+                throw new IllegalArgumentException(
+                    "more than one JOB slot supplied for "
+                        + method.getDeclaringClass().getName() + "." + method.getName()
+                        + "; at most one is allowed");
+            }
+        }
+
+        int depCount = capabilities.size();
+        int pairable = Math.max(0, Math.min(pairableDepCount, depCount));
+
+        int proxySlotCount = 0;
+        for (Slot slot : ordered) {
+            if (slot.role() == SlotRole.PROXY) {
+                proxySlotCount++;
+            }
+        }
+
+        int[] depIndexToSlot = new int[depCount];
+        int[] slotToDepIndex = new int[proxySlotCount];
+        Arrays.fill(depIndexToSlot, -1);
+        Arrays.fill(slotToDepIndex, -1);
+
+        int jobDepIndex = -1;
+        int proxyOrdinal = 0;
+        for (int k = 0; k < ordered.size(); k++) {
+            Slot slot = ordered.get(k);
+            boolean paired = k < pairable;
+            if (slot.role() == SlotRole.JOB) {
+                if (paired) {
+                    jobDepIndex = k;
+                }
+                continue;
+            }
+            int ordinal = proxyOrdinal++;
+            if (paired) {
+                depIndexToSlot[k] = ordinal;
+                slotToDepIndex[ordinal] = k;
+            }
+        }
+
+        return new Binding(
+            method, capabilities, pairable, ordered,
+            depIndexToSlot, slotToDepIndex, jobDepIndex);
+    }
+
+    /**
+     * Convenience for the {@code @MeshTool} slot shape: {@code McpMeshTool}
+     * parameter positions plus an optional {@code MeshJob} parameter position.
+     *
+     * @param proxyPositions   signature positions of the proxy parameters
+     * @param jobPosition      signature position of the {@code MeshJob}
+     *                         parameter, or null
+     * @return the slot list in signature order
+     */
+    public static List<Slot> slots(List<Integer> proxyPositions, Integer jobPosition) {
+        List<Slot> slots = new ArrayList<>();
+        if (proxyPositions != null) {
+            for (Integer pos : proxyPositions) {
+                slots.add(new Slot(pos, SlotRole.PROXY));
+            }
+        }
+        if (jobPosition != null) {
+            slots.add(new Slot(jobPosition, SlotRole.JOB));
+        }
+        slots.sort(Comparator.comparingInt(Slot::parameterPosition));
+        return slots;
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -126,15 +126,10 @@ public class MeshToolWrapper implements McpToolHandler {
     private volatile boolean[] dependencyRequired;
 
     // Positional pairing between the DECLARED dependency list and this
-    // method's injectable slots (issue #1193 fix round). Declared
-    // dependencies pair positionally with injectable parameters
-    // (McpMeshTool + MeshJob) in parameter order — the same contract as
-    // Python/TypeScript. The two index spaces differ whenever a MeshJob
-    // dependency is declared: e.g. dependencies = ["job_cap", "db_cap"]
-    // with params (MeshJob job, McpMeshTool db) has db_cap at DECLARED
-    // index 1 but McpMeshTool SLOT ordinal 0. Registry events carry the
-    // declared index; injectedDeps/meshToolReturnTypes are slot-ordinal
-    // arrays — these tables translate between the two.
+    // method's injectable slots (issue #1193 fix round), computed by
+    // MeshPositionalBinder — see that class for the canonical statement of
+    // the positional contract and of the declared-index / slot-ordinal skew
+    // these tables translate across.
     /** Declared dep index → McpMeshTool slot ordinal; -1 = no proxy slot (MeshJob-backed or excess). */
     private final int[] depIndexToSlot;
     /** McpMeshTool slot ordinal → declared dep index; -1 = no declared dependency backs the slot. */
@@ -144,13 +139,12 @@ public class MeshToolWrapper implements McpToolHandler {
      * position, or -1 when this method has no MeshJob slot OR the slot has no
      * declared dependency backing it. The MeshJob param consumes one declared
      * dependency index via the SAME positional pairing the McpMeshTool slots
-     * use (eligible positions = McpMeshTool + MeshJob, sorted, paired to the
-     * declared dependency list). This lets the consumer-side
-     * {@link JobsRuntimeManager} wiring bind the {@link MeshJobSubmitter} to
-     * the EXACT declared capability the user typed {@code MeshJob} for —
-     * mirroring Python, which keys the submitter off the declared dependency
-     * capability at the MeshJob param's dep_index rather than a local
-     * {@code task()} registry probe.
+     * use ({@link MeshPositionalBinder.SlotRole#JOB}). This lets the
+     * consumer-side {@link JobsRuntimeManager} wiring bind the
+     * {@link MeshJobSubmitter} to the EXACT declared capability the user typed
+     * {@code MeshJob} for — mirroring Python, which keys the submitter off the
+     * declared dependency capability at the MeshJob param's dep_index rather
+     * than a local {@code task()} registry probe.
      */
     private final int meshJobDepIndex;
 
@@ -393,30 +387,17 @@ public class MeshToolWrapper implements McpToolHandler {
         }
         this.dependencyRequired = required;
 
-        // Declared-index ↔ McpMeshTool-slot translation (see field javadoc).
-        // ONLY the explicit prefix pairs with eligible positions; view edges
+        // Declared-index ↔ McpMeshTool-slot translation (see MeshPositionalBinder).
+        // ONLY the explicit prefix pairs with injectable slots; view edges
         // (index >= explicitDepCount) keep depIndexToSlot = -1.
-        this.depIndexToSlot = new int[fullSize];
-        this.slotToDepIndex = new int[meshToolPositions.size()];
-        Arrays.fill(this.depIndexToSlot, -1);
-        Arrays.fill(this.slotToDepIndex, -1);
-        List<Integer> eligiblePositions = new ArrayList<>(meshToolPositions);
-        if (meshJobParamIndex != null) {
-            eligiblePositions.add(meshJobParamIndex);
-            Collections.sort(eligiblePositions);
-        }
-        int meshJobDep = -1;
-        for (int k = 0; k < eligiblePositions.size() && k < explicitDepCount; k++) {
-            int paramPos = eligiblePositions.get(k);
-            if (meshJobParamIndex != null && paramPos == meshJobParamIndex) {
-                meshJobDep = k;
-                continue;
-            }
-            int slot = meshToolPositions.indexOf(paramPos);
-            this.depIndexToSlot[k] = slot;
-            this.slotToDepIndex[slot] = k;
-        }
-        this.meshJobDepIndex = meshJobDep;
+        MeshPositionalBinder.Binding binding = MeshPositionalBinder.bind(
+            method,
+            MeshPositionalBinder.slots(meshToolPositions, meshJobParamIndex),
+            fullNames,
+            explicitDepCount);
+        this.depIndexToSlot = binding.depIndexToSlot();
+        this.slotToDepIndex = binding.slotToDepIndex();
+        this.meshJobDepIndex = binding.jobDepIndex();
 
         // Generate input schema (excluding injected params)
         this.inputSchema = generateInputSchema();

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshPositionalBinderTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshPositionalBinderTest.java
@@ -1,0 +1,213 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.Param;
+import io.mcpmesh.types.McpMeshTool;
+import io.mcpmesh.types.MeshLlmAgent;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pins the positional pairing rule extracted from {@link MeshToolWrapper}
+ * (issue #1401 PR 0): the Nth declared dependency binds to the Nth injectable
+ * parameter in signature order, a {@code MeshJob} slot consumes a declared
+ * index without owning a proxy slot, and surplus on either side maps to -1
+ * rather than shifting anything.
+ *
+ * <p>The end-to-end consequence of the same rule — that an unresolved
+ * dependency holds its own slot — is pinned by
+ * {@link MeshToolWrapperUnresolvedDepPositionTest} through the real invoke
+ * path.
+ */
+class MeshPositionalBinderTest {
+
+    @SuppressWarnings("unused")
+    static class Shapes {
+        public void none(@Param("a") String a) {}
+
+        public void threeProxies(@Param("a") String a, McpMeshTool<String> d0,
+                                 McpMeshTool<String> d1, McpMeshTool<String> d2) {}
+
+        public void jobFirst(@Param("a") String a, MeshJob job,
+                             McpMeshTool<String> d1, McpMeshTool<String> d2) {}
+
+        public void jobMiddle(@Param("a") String a, McpMeshTool<String> d0,
+                              MeshJob job, McpMeshTool<String> d2) {}
+
+        public void llmInterleaved(@Param("a") String a, McpMeshTool<String> d0,
+                                   MeshLlmAgent llm, McpMeshTool<String> d1) {}
+    }
+
+    private static Method method(String name, Class<?>... types) throws Exception {
+        return Shapes.class.getMethod(name, types);
+    }
+
+    private static MeshPositionalBinder.Binding bind(
+            Method m, List<Integer> proxies, Integer job, List<String> caps) {
+        return MeshPositionalBinder.bind(
+            m, MeshPositionalBinder.slots(proxies, job), caps, caps.size());
+    }
+
+    @Test
+    void noDependencies_producesEmptyTables() throws Exception {
+        MeshPositionalBinder.Binding b =
+            bind(method("none", String.class), List.of(), null, List.of());
+
+        assertArrayEquals(new int[0], b.depIndexToSlot());
+        assertArrayEquals(new int[0], b.slotToDepIndex());
+        assertEquals(-1, b.jobDepIndex());
+        assertEquals(0, b.proxySlotCount());
+    }
+
+    @Test
+    void nthDependencyBindsNthInjectableParameter() throws Exception {
+        MeshPositionalBinder.Binding b = bind(
+            method("threeProxies", String.class, McpMeshTool.class,
+                McpMeshTool.class, McpMeshTool.class),
+            List.of(1, 2, 3), null, List.of("cap_a", "cap_b", "cap_c"));
+
+        assertArrayEquals(new int[]{0, 1, 2}, b.depIndexToSlot());
+        assertArrayEquals(new int[]{0, 1, 2}, b.slotToDepIndex());
+        assertEquals(List.of(1, 2, 3), b.slotPositions(),
+            "slots are reported in signature order");
+    }
+
+    @Test
+    void nonInjectableParametersAreNotSlots() throws Exception {
+        // A MeshLlmAgent parameter lives in its own index space — it must not
+        // consume a declared dependency index or displace a proxy slot.
+        MeshPositionalBinder.Binding b = bind(
+            method("llmInterleaved", String.class, McpMeshTool.class,
+                MeshLlmAgent.class, McpMeshTool.class),
+            List.of(1, 3), null, List.of("cap_a", "cap_b"));
+
+        assertArrayEquals(new int[]{0, 1}, b.depIndexToSlot());
+        assertArrayEquals(new int[]{0, 1}, b.slotToDepIndex());
+        assertEquals(List.of(1, 3), b.slotPositions());
+    }
+
+    @Test
+    void meshJobSlotConsumesADeclaredIndexButOwnsNoProxySlot() throws Exception {
+        MeshPositionalBinder.Binding b = bind(
+            method("jobFirst", String.class, MeshJob.class,
+                McpMeshTool.class, McpMeshTool.class),
+            List.of(2, 3), 1, List.of("job_cap", "cap_b", "cap_c"));
+
+        assertEquals(0, b.jobDepIndex(), "the leading declared dep pairs with the job slot");
+        assertArrayEquals(new int[]{-1, 0, 1}, b.depIndexToSlot(),
+            "declared index 0 is job-backed; cap_b/cap_c skew down one slot");
+        assertArrayEquals(new int[]{1, 2}, b.slotToDepIndex());
+    }
+
+    @Test
+    void meshJobInterleaved_skewsOnlyTheSlotsAfterIt() throws Exception {
+        MeshPositionalBinder.Binding b = bind(
+            method("jobMiddle", String.class, McpMeshTool.class,
+                MeshJob.class, McpMeshTool.class),
+            List.of(1, 3), 2, List.of("cap_a", "job_cap", "cap_c"));
+
+        assertEquals(1, b.jobDepIndex());
+        assertArrayEquals(new int[]{0, -1, 1}, b.depIndexToSlot());
+        assertArrayEquals(new int[]{0, 2}, b.slotToDepIndex());
+    }
+
+    @Test
+    void excessDeclaredDependencies_mapToMinusOne() throws Exception {
+        MeshPositionalBinder.Binding b = bind(
+            method("threeProxies", String.class, McpMeshTool.class,
+                McpMeshTool.class, McpMeshTool.class),
+            List.of(1, 2, 3), null, List.of("a", "b", "c", "d", "e"));
+
+        assertArrayEquals(new int[]{0, 1, 2, -1, -1}, b.depIndexToSlot(),
+            "declared deps beyond the available slots are dropped, not reassigned");
+        assertArrayEquals(new int[]{0, 1, 2}, b.slotToDepIndex());
+    }
+
+    @Test
+    void excessInjectableSlots_mapToMinusOne() throws Exception {
+        MeshPositionalBinder.Binding b = bind(
+            method("threeProxies", String.class, McpMeshTool.class,
+                McpMeshTool.class, McpMeshTool.class),
+            List.of(1, 2, 3), null, List.of("a"));
+
+        assertArrayEquals(new int[]{0}, b.depIndexToSlot());
+        assertArrayEquals(new int[]{0, -1, -1}, b.slotToDepIndex(),
+            "unbacked slots keep their ordinal — they receive null, they do not compact");
+    }
+
+    @Test
+    void nonPairableSuffix_neverReachesASlot() throws Exception {
+        // @MeshService view edges are appended after the explicit @Selector
+        // deps and are bound by other means; they must never claim a slot.
+        MeshPositionalBinder.Binding b = MeshPositionalBinder.bind(
+            method("threeProxies", String.class, McpMeshTool.class,
+                McpMeshTool.class, McpMeshTool.class),
+            MeshPositionalBinder.slots(List.of(1, 2, 3), null),
+            List.of("a", "view_x", "view_y"),
+            1);
+
+        assertArrayEquals(new int[]{0, -1, -1}, b.depIndexToSlot());
+        assertArrayEquals(new int[]{0, -1, -1}, b.slotToDepIndex());
+        assertTrue(b.describe().contains("further declared dependencies are bound by other means"));
+    }
+
+    @Test
+    void describe_namesBothIndexSpacesAndEverySurplus() throws Exception {
+        String text = MeshPositionalBinder.bind(
+            method("jobMiddle", String.class, McpMeshTool.class,
+                MeshJob.class, McpMeshTool.class),
+            MeshPositionalBinder.slots(List.of(1, 3), 2),
+            List.of("cap_a", "job_cap", "cap_c", "cap_d"),
+            4).describe();
+
+        assertTrue(text.contains("dependency[0] 'cap_a' -> parameter 1"), text);
+        assertTrue(text.contains("[proxy slot 0]"), text);
+        assertTrue(text.contains("dependency[1] 'job_cap' -> parameter 2"), text);
+        assertTrue(text.contains("[job slot]"), text);
+        assertTrue(text.contains("dependency[2] 'cap_c' -> parameter 3"), text);
+        assertTrue(text.contains("[proxy slot 1]"), text);
+        assertTrue(text.contains("dependency[3] 'cap_d' -> (no injectable parameter — dropped)"), text);
+    }
+
+    @Test
+    void slotsAreOrderedBySignaturePosition_regardlessOfInputOrder() throws Exception {
+        Method m = method("jobMiddle", String.class, McpMeshTool.class,
+            MeshJob.class, McpMeshTool.class);
+
+        MeshPositionalBinder.Binding shuffled = MeshPositionalBinder.bind(m, List.of(
+            new MeshPositionalBinder.Slot(3, MeshPositionalBinder.SlotRole.PROXY),
+            new MeshPositionalBinder.Slot(2, MeshPositionalBinder.SlotRole.JOB),
+            new MeshPositionalBinder.Slot(1, MeshPositionalBinder.SlotRole.PROXY)),
+            List.of("cap_a", "job_cap", "cap_c"), 3);
+
+        assertEquals(List.of(1, 2, 3), shuffled.slotPositions());
+        assertArrayEquals(new int[]{0, -1, 1}, shuffled.depIndexToSlot());
+        assertEquals(1, shuffled.jobDepIndex());
+    }
+
+    @Test
+    void duplicateSlotPosition_isRejected() throws Exception {
+        Method m = method("threeProxies", String.class, McpMeshTool.class,
+            McpMeshTool.class, McpMeshTool.class);
+
+        assertThrows(IllegalArgumentException.class, () -> MeshPositionalBinder.bind(m, List.of(
+            new MeshPositionalBinder.Slot(1, MeshPositionalBinder.SlotRole.PROXY),
+            new MeshPositionalBinder.Slot(1, MeshPositionalBinder.SlotRole.JOB)),
+            List.of("a", "b"), 2));
+    }
+
+    @Test
+    void multipleJobSlots_areRejected() throws Exception {
+        Method m = method("threeProxies", String.class, McpMeshTool.class,
+            McpMeshTool.class, McpMeshTool.class);
+
+        assertThrows(IllegalArgumentException.class, () -> MeshPositionalBinder.bind(m, List.of(
+            new MeshPositionalBinder.Slot(1, MeshPositionalBinder.SlotRole.JOB),
+            new MeshPositionalBinder.Slot(2, MeshPositionalBinder.SlotRole.JOB)),
+            List.of("a", "b"), 2));
+    }
+}


### PR DESCRIPTION
## Summary

**PR 0 of the #1401 DI-alignment sequence. Pure refactor — zero behaviour change.**

`MeshToolWrapper`'s constructor block at `:396-419` built the declared-index ↔ injectable-slot pairing table inline. It is now `MeshPositionalBinder`, a standalone component; the wrapper's 23 lines of algorithm become 8 lines of delegation.

## Why this is its own PR

The later PRs add validation and convert `@MeshRoute` / `@MeshA2A` from name-based to positional binding. Extracting the code *inside* those PRs would produce a diff mixing moved code with changed semantics, and no reviewer could tell them apart. Move first, prove nothing changed, then change behaviour in a diff containing only the change.

## Pairing identity — proven, not asserted

A throwaway harness carrying a **verbatim copy of the pre-extraction algorithm** was diffed against the new one, then deleted (not in the commit).

- **Exhaustive sweep of the entire input domain**: every subset of parameter positions 0–5 as proxy slots (≤4), every legal `MeshJob` position or none, `explicitDepCount` 0–6, 0–2 trailing view edges — **5103 combinations, 0 differences** in `depIndexToSlot`, `slotToDepIndex`, `meshJobDepIndex`.
- **13 real method shapes** built through the actual `MeshToolWrapper` constructor with tables read back by reflection: 0 deps, 1 dep, 3 deps, deps<slots, deps>slots, `MeshJob` first/middle/last, `MeshJob` with deps<slots, `MeshLlmAgent` leading and interleaved, `A2AClient` present, and all three combined. Byte-identical throughout.

The skew-preserving cases are the interesting ones: `jobFirst` → `d2s=[-1,0,1] s2d=[1,2] job=0`; `jobMiddle` → `d2s=[0,-1,1] s2d=[0,2] job=1`.

## Suite: zero test edits

| | before | after |
|---|---|---|
| native / core / starter / spring-ai | 15 / 117 / 682 / 211 = **1025** | 15 / 117 / **694** / 211 = **1037** |

The +12 is exactly the new `MeshPositionalBinderTest`. **`MeshToolWrapperUnresolvedDepPositionTest` passes verbatim, all 5 cases, unedited** — the #1390 slot-preservation pin. No existing test needed a change, which is the point.

`MeshInjectArgumentResolver`, `MeshRouteHandlerInterceptor`, `MeshRouteBeanPostProcessor` and `MeshA2ADispatcher` are untouched — those are PR B.

## API shape

`bind()` takes an already-enumerated `List<Slot>` (`PROXY` | `JOB`) plus the declared capabilities; `Method` is passed **for diagnostics only**. Role assignment stays with the caller.

Both known A2A divergences are expressible without contorting the design: `@MeshInject` on a non-`McpMeshTool` parameter is simply a `PROXY` slot the caller chose to emit, and the message-fallback collision is resolved by the caller not emitting a slot for the position it hands the message. That reasoning is in the class javadoc, so PR B inherits the argument and not just the signature.

`Binding.describe()` produces the diagnostic that becomes PR A's validation error text:

```
positional dependency pairing for ...Shapes.jobMiddle(String, McpMeshTool, MeshJob, McpMeshTool)
  3 declared dependencies pair with 3 injectable parameters in signature order:
    dependency[0] 'cap_a' -> parameter 1 (McpMeshTool d0) [proxy slot 0]
    dependency[1] 'job_cap' -> parameter 2 (MeshJob job) [job slot]
    dependency[2] 'cap_c' -> parameter 3 (McpMeshTool d2) [proxy slot 1]
    dependency[3] 'cap_d' -> (no injectable parameter — dropped)
```

## Three things the extraction surfaced, for PR A and B

**1. Arity checking must count `pairableDepCount`, not `capabilities.size()`.** The tool path's declared list is only partly pairable — the explicit `@Selector` prefix pairs with slots, the `@MeshService` view-edge suffix never does, while `depIndexToSlot` is sized by the full list. Route and A2A have no view edges and will always pass `capabilities.size()`, so this parameter will look inert at the two new call sites. Get it wrong in PR A and view edges read as phantom excess dependencies.

**2. The binder cannot own slot enumeration, and that constrains PR A.** Three parameter kinds — `A2AClient`, `MeshLlmAgent`, `@MeshService` views — are excluded from slots by rules living inside `analyzeParameters`, tangled with `@Param` validation, generic extraction and boot-time `@A2AConsumer` checks. Re-deriving them in the binder would duplicate that classification and create exactly the drift surface #1401 exists to close. So the binder can never answer "is this parameter injectable?" — if PR A's legacy-shape detector needs that uniformly, it requires a **second** shared component, and that one is harder because the A2A rules genuinely differ.

**3. `MeshLlmAgent` is invisible to arity checking by construction, not oversight.** `llmAgentPositions` never enters the binder and is never paired, which is correct today since `@MeshLlm` has no `dependencies` member. Worth stating in PR A's scope so it does not read as a gap.

Minor: `Binding` is a record holding `int[]`, so generated `equals`/`hashCode` are array-identity based. `toString` is overridden to render them; nothing compares `Binding`s, but do not put them in a `Set` or `assertEquals` them without unpacking.

## Validation

`mvn test` per module as above; `mvn -q compile` clean; `go build ./...` exit 0, unaffected. `git diff --name-only` → exactly the three intended files.

Refs #1401


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved positional dependency binding for Spring-based MCP Mesh methods.
  * Ensured non-injectable parameters and `MeshJob` parameters are handled correctly during dependency mapping.
  * Added validation for duplicate parameter positions and multiple job slots.
  * Clarified handling of surplus dependencies and injectable parameters.

* **Tests**
  * Added comprehensive coverage for ordering, pairing, edge cases, and invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->