### PR TITLE
feat(java): DI arity validation and the @MeshRoute/@MeshA2A legacy-shape detector

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshDiValidator.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshDiValidator.java
@@ -1,0 +1,211 @@
+package io.mcpmesh.spring;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
+
+/**
+ * Dependency-injection validation for the positional pairing contract
+ * (issue #1401).
+ *
+ * <p>Positional pairing is only safe when a dependency-count / slot-count
+ * mismatch is <i>reported</i>. Without that, declaring one dependency too many
+ * silently drops it ({@code depIndexToSlot = -1}) and declaring one too few
+ * silently injects {@code null} — the two failure modes that make a reordered
+ * declaration list indistinguishable from a correct one. Python has had this
+ * check since {@code validate_mesh_dependencies}; this is its Java counterpart,
+ * with the same default posture and the same opt-in knob.
+ *
+ * <h2>Posture</h2>
+ * <ul>
+ *   <li><b>Default: WARN.</b> Mesh DI is permissive by design — a mismatched
+ *       arity still boots, still registers, and still serves.</li>
+ *   <li><b>{@code MCP_MESH_STRICT_DI=true}: boot failure.</b> Same env var,
+ *       same truthy spellings and the same message text as Python, so a team
+ *       that wants rigor gets it in every runtime with one variable.</li>
+ * </ul>
+ *
+ * <h2>Three things this deliberately does not count</h2>
+ * <ul>
+ *   <li><b>Non-pairable declared dependencies.</b> Arity is measured against
+ *       {@link MeshPositionalBinder.Binding#pairableDepCount()}, never
+ *       {@code capabilities.size()}. A {@code @MeshTool}'s declared list is the
+ *       explicit {@code @Selector} prefix <i>plus</i> the RFC-1280
+ *       {@code @MeshService} view-edge suffix, and view edges own no injectable
+ *       parameter by construction. Counting the full list would report every
+ *       view edge as a phantom excess dependency.</li>
+ *   <li><b>{@code MeshLlmAgent} parameters.</b> They are invisible to arity
+ *       checking <i>by construction, not by oversight</i>: {@code @MeshLlm} has
+ *       no {@code dependencies} member, so an LLM agent slot lives in a
+ *       separate index space and consumes nothing from the declared list. It is
+ *       correct that neither side of this comparison counts it.</li>
+ *   <li><b>The producer-side {@code MeshJob} parameter, which is OPTIONALLY
+ *       declared.</b> {@code MeshJob} is two different things depending on
+ *       {@code @MeshTool(task = ...)}. On a <i>consumer</i> it is a submitter
+ *       proxy for a remote {@code task = true} capability and must be backed by
+ *       a declared dependency — that capability is what the submitter binds to.
+ *       On the <i>producer</i> — the {@code task = true} tool itself — it is the
+ *       inbound job's controller, filled by the dispatch path, and
+ *       {@code JobsRuntimeManager.wireConsumers} skips it outright
+ *       ({@code if (meta.task()) continue}). Producers therefore usually declare
+ *       nothing for it, yet a producer <i>may</i> still declare a capability at
+ *       the job slot's index, and the pairing table honours the resulting index
+ *       skew. Both counts are sound, so the caller passes a
+ *       {@code minSlots}/{@code maxSlots} range rather than an exact count.</li>
+ * </ul>
+ *
+ * @see MeshPositionalBinder
+ */
+public final class MeshDiValidator {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshDiValidator.class);
+
+    /** Opt-in strictness knob, shared with Python and TypeScript. */
+    public static final String STRICT_DI_ENV = "MCP_MESH_STRICT_DI";
+
+    private MeshDiValidator() {}
+
+    /**
+     * Whether {@code MCP_MESH_STRICT_DI} is truthy.
+     *
+     * <p>Truthy spellings match {@link MeshSchemaSupport#clusterStrictEnabled()}
+     * ({@code 1} / {@code true} / {@code yes}, case- and whitespace-insensitive)
+     * so mesh's two strictness knobs never disagree about what "on" means.
+     *
+     * @return true when strict DI is enabled
+     */
+    public static boolean strictDiEnabled() {
+        String v = System.getenv(STRICT_DI_ENV);
+        if (v == null) {
+            return false;
+        }
+        String lc = v.trim().toLowerCase(Locale.ROOT);
+        return "1".equals(lc) || "true".equals(lc) || "yes".equals(lc);
+    }
+
+    /**
+     * Report a dependency-count / injectable-slot-count mismatch, applying the
+     * ambient {@link #strictDiEnabled()} policy.
+     *
+     * @param site     the declaration site, e.g. {@code "@MeshTool"}
+     * @param binding  the pairing table produced by {@link MeshPositionalBinder}
+     * @param minSlots lowest sound declared-dependency count
+     * @param maxSlots highest sound declared-dependency count; equals
+     *                 {@code minSlots} unless the site has an optionally-declared
+     *                 slot (see the class javadoc on {@code MeshJob})
+     * @throws IllegalStateException when the count is out of range and strict DI
+     *         is on
+     */
+    public static void checkArity(
+            String site, MeshPositionalBinder.Binding binding, int minSlots, int maxSlots) {
+        checkArity(site, binding, minSlots, maxSlots, strictDiEnabled());
+    }
+
+    /**
+     * Report a dependency-count / injectable-slot-count mismatch under an
+     * explicit policy (the seam tests use — env vars are not settable in-process).
+     *
+     * @param site     the declaration site, e.g. {@code "@MeshTool"}
+     * @param binding  the pairing table produced by {@link MeshPositionalBinder}
+     * @param minSlots lowest sound declared-dependency count
+     * @param maxSlots highest sound declared-dependency count
+     * @param strict   true to throw instead of warning
+     * @return the diagnostic that was emitted, or null when the arity is sound
+     * @throws IllegalStateException when the count is out of range and
+     *         {@code strict}
+     */
+    public static String checkArity(
+            String site,
+            MeshPositionalBinder.Binding binding,
+            int minSlots,
+            int maxSlots,
+            boolean strict) {
+
+        int declared = binding.pairableDepCount();
+        int min = Math.max(0, Math.min(minSlots, maxSlots));
+        int max = Math.max(min, maxSlots);
+        if (declared >= min && declared <= max) {
+            return null;
+        }
+
+        String message = arityMessage(site, binding, declared, min, max, strict);
+        if (strict) {
+            throw new IllegalStateException(message);
+        }
+        log.warn("{}", message);
+        return message;
+    }
+
+    /**
+     * Build the mismatch diagnostic. Modelled on Python's
+     * {@code validate_mesh_dependencies} message: name the counts, name each
+     * slot, state the positional rule explicitly, and prescribe the fix.
+     */
+    private static String arityMessage(
+            String site,
+            MeshPositionalBinder.Binding binding,
+            int declared,
+            int min,
+            int max,
+            boolean strict) {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(site).append(' ').append(signatureOf(binding))
+            .append(" declares ").append(plural(declared, "dependency", "dependencies"))
+            .append(" but has ")
+            .append(plural(max, "dependency-backed injectable parameter",
+                "dependency-backed injectable parameters"));
+        if (min != max) {
+            sb.append(", of which ").append(max - min)
+                .append(" need not be declared");
+        }
+        sb.append(". Each injectable slot needs a corresponding dependency; ")
+            .append("dependencies[i] pairs with the i-th injectable parameter in signature order ")
+            .append("(parameter names are never matched). ");
+
+        if (declared > max) {
+            sb.append("The surplus declared ")
+                .append(declared - max == 1 ? "dependency is" : "dependencies are")
+                .append(" resolved and advertised but injected nowhere. ");
+        } else {
+            sb.append("The surplus ")
+                .append(min - declared == 1 ? "parameter is" : "parameters are")
+                .append(" injected null. ");
+        }
+
+        sb.append("Fix: declare ");
+        if (min == max) {
+            sb.append("exactly ").append(plural(max, "entry", "entries"));
+        } else {
+            sb.append(min).append(" or ").append(plural(max, "entry", "entries"));
+        }
+        sb.append(" in dependencies = {...}, or add/remove injectable parameters ")
+            .append("(McpMeshTool / MeshJob) so the counts match.\n")
+            .append(binding.describe());
+
+        if (!strict) {
+            sb.append("\n  Set ").append(STRICT_DI_ENV)
+                .append("=true to fail startup on this instead of warning.");
+        }
+        return sb.toString();
+    }
+
+    private static String signatureOf(MeshPositionalBinder.Binding binding) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(binding.method().getDeclaringClass().getName()).append('.')
+            .append(binding.method().getName()).append('(');
+        Class<?>[] types = binding.method().getParameterTypes();
+        for (int i = 0; i < types.length; i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(types[i].getSimpleName());
+        }
+        return sb.append(')').toString();
+    }
+
+    private static String plural(int n, String singular, String pluralForm) {
+        return n + " " + (n == 1 ? singular : pluralForm);
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -399,6 +399,25 @@ public class MeshToolWrapper implements McpToolHandler {
         this.slotToDepIndex = binding.slotToDepIndex();
         this.meshJobDepIndex = binding.jobDepIndex();
 
+        // Issue #1401: arity check at parity with Python's
+        // validate_mesh_dependencies. WARN by default, boot failure under
+        // MCP_MESH_STRICT_DI. The binding carries explicitDepCount as its
+        // pairable count, so @MeshService view edges — which own no injectable
+        // parameter — cannot read as phantom excess dependencies. MeshLlmAgent
+        // parameters are absent from both sides by construction: @MeshLlm has
+        // no dependencies member, so an LLM slot consumes no declared index.
+        //
+        // A MeshJob parameter on a task=true tool is the PRODUCER's inbound job
+        // controller, filled by the dispatch path — JobsRuntimeManager.wireConsumers
+        // skips task() tools outright, so a producer normally declares nothing for
+        // it. It MAY still declare a capability at the job slot's index (the
+        // pairing table honours the resulting skew), so both counts are sound and
+        // the check takes a range. A CONSUMER's MeshJob slot is a submitter proxy
+        // and must be backed: the declared capability is what it binds to.
+        int slotCount = binding.slots().size();
+        int minSlots = (task && meshJobParamIndex != null) ? slotCount - 1 : slotCount;
+        MeshDiValidator.checkArity("@MeshTool", binding, minSlots, slotCount);
+
         // Generate input schema (excluding injected params)
         this.inputSchema = generateInputSchema();
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ABeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ABeanPostProcessor.java
@@ -70,6 +70,11 @@ public class MeshA2ABeanPostProcessor implements BeanPostProcessor {
                 deps.add(MeshRouteRegistry.DependencySpec.fromAnnotation(dep));
             }
 
+            // Issue #1401: report handlers whose bindings would change when
+            // @MeshA2A moves from name-based to positional pairing. Warning
+            // only — this PR changes no binding behaviour.
+            MeshLegacyBindingDetector.inspectA2A(method, deps);
+
             String handlerMethodId = targetClass.getName() + "." + method.getName();
             MeshA2ARegistry.SurfaceMetadata metadata = new MeshA2ARegistry.SurfaceMetadata(
                 annotation.path(),

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
@@ -620,7 +620,10 @@ public class MeshA2ADispatcher {
         for (int i = 0; i < params.length; i++) {
             Parameter p = params[i];
             MeshInject inj = p.getAnnotation(MeshInject.class);
-            if (inj != null || McpMeshTool.class.isAssignableFrom(p.getType())) {
+            // Slot classification lives in MeshInjectableSlots (issue #1401)
+            // so the boot-time legacy-shape detector sees exactly the set of
+            // parameters this loop treats as dependency slots.
+            if (MeshInjectableSlots.isA2AInjectable(p)) {
                 args[i] = resolveDependency(surface, p, inj);
             } else if (MeshJobSubmitter.class.isAssignableFrom(p.getType())) {
                 // Issue #936: framework-injected MeshJobSubmitter for

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshInjectArgumentResolver.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshInjectArgumentResolver.java
@@ -54,8 +54,11 @@ public class MeshInjectArgumentResolver implements HandlerMethodArgumentResolver
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        // Support McpMeshTool parameters - with or without @MeshInject
-        return McpMeshTool.class.isAssignableFrom(parameter.getParameterType());
+        // Support McpMeshTool parameters - with or without @MeshInject.
+        // The predicate lives in MeshInjectableSlots (issue #1401) so the
+        // boot-time legacy-shape detector classifies parameters exactly the
+        // way this resolver does, rather than re-deriving the rule.
+        return MeshInjectableSlots.isRouteInjectable(parameter.getParameterType());
     }
 
     @Override

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshInjectableSlots.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshInjectableSlots.java
@@ -1,0 +1,124 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.spring.MeshPositionalBinder;
+import io.mcpmesh.types.McpMeshTool;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * "Is this parameter an injectable dependency slot?" for the two web
+ * injection sites — {@code @MeshRoute} and {@code @MeshA2A} — in one place
+ * (issue #1401).
+ *
+ * <h2>Why this exists as its own component</h2>
+ *
+ * <p>{@link MeshPositionalBinder} deliberately does not classify parameters:
+ * it takes an already-enumerated slot list, because the {@code @MeshTool} rules
+ * live inside {@code MeshToolWrapper.analyzeParameters} tangled with
+ * {@code @Param} validation, generic extraction and boot-time
+ * {@code @A2AConsumer} checks. Re-deriving them in the binder would duplicate
+ * that classification.
+ *
+ * <p>The legacy-shape detector ({@link MeshLegacyBindingDetector}) needs the
+ * same question answered for route and A2A handlers at boot, and the live
+ * resolvers answer it at request time. Writing the predicate twice is exactly
+ * the drift surface #1401 exists to close, so it is written once — here — and
+ * the live resolvers call it:
+ *
+ * <ul>
+ *   <li>{@link MeshInjectArgumentResolver#supportsParameter} →
+ *       {@link #isRouteInjectable(Class)}</li>
+ *   <li>{@code MeshA2ADispatcher.invokeHandler}'s dependency branch →
+ *       {@link #isA2AInjectable(Parameter)}</li>
+ * </ul>
+ *
+ * <h2>The two rules genuinely differ</h2>
+ *
+ * <p>They are not accidentally different, so this class exposes two methods
+ * rather than pretending one rule covers both:
+ *
+ * <ul>
+ *   <li><b>Route</b> keys purely off the parameter <i>type</i>. Spring MVC asks
+ *       {@code supportsParameter} before it knows anything else, and a
+ *       {@code @MeshInject} on a non-{@code McpMeshTool} parameter must fall
+ *       through to Spring's own resolvers rather than being claimed here.</li>
+ *   <li><b>A2A</b> additionally treats {@code @MeshInject} on <i>any</i>
+ *       parameter type as a dependency slot: the dispatcher owns the whole
+ *       argument array (there is no Spring MVC resolver chain behind it), so
+ *       the annotation is the user's unambiguous statement of intent.</li>
+ * </ul>
+ *
+ * <p>A2A's message-fallback rule ("the parameter at index 0 takes the message
+ * if nothing else claimed it") does not compete with these slots: the
+ * dependency branch is evaluated <i>first</i> in {@code invokeHandler}, so a
+ * slot always wins index 0. Neither does {@code MeshJobSubmitter}, which is
+ * framework-constructed from the surface rather than paired with a declared
+ * dependency — it is not a slot here, and it consumes no declared index.
+ *
+ * @see MeshLegacyBindingDetector
+ * @see MeshPositionalBinder
+ */
+public final class MeshInjectableSlots {
+
+    private MeshInjectableSlots() {}
+
+    /**
+     * Whether a {@code @MeshRoute} handler parameter of this type is a mesh
+     * dependency slot.
+     *
+     * @param parameterType the declared parameter type
+     * @return true when the framework injects a mesh proxy here
+     */
+    public static boolean isRouteInjectable(Class<?> parameterType) {
+        return McpMeshTool.class.isAssignableFrom(parameterType);
+    }
+
+    /**
+     * Whether a {@code @MeshA2A} handler parameter is a mesh dependency slot.
+     *
+     * @param param the handler parameter
+     * @return true when the dispatcher fills this slot from a declared
+     *         {@code @MeshDependency}
+     */
+    public static boolean isA2AInjectable(Parameter param) {
+        return param.getAnnotation(MeshInject.class) != null
+            || McpMeshTool.class.isAssignableFrom(param.getType());
+    }
+
+    /**
+     * Injectable slots of a {@code @MeshRoute} handler, in signature order.
+     *
+     * @param method the handler method
+     * @return proxy slots in signature order (possibly empty)
+     */
+    public static List<MeshPositionalBinder.Slot> routeSlots(Method method) {
+        List<MeshPositionalBinder.Slot> slots = new ArrayList<>();
+        Parameter[] params = method.getParameters();
+        for (int i = 0; i < params.length; i++) {
+            if (isRouteInjectable(params[i].getType())) {
+                slots.add(new MeshPositionalBinder.Slot(i, MeshPositionalBinder.SlotRole.PROXY));
+            }
+        }
+        return slots;
+    }
+
+    /**
+     * Injectable slots of a {@code @MeshA2A} handler, in signature order.
+     *
+     * @param method the handler method
+     * @return proxy slots in signature order (possibly empty)
+     */
+    public static List<MeshPositionalBinder.Slot> a2aSlots(Method method) {
+        List<MeshPositionalBinder.Slot> slots = new ArrayList<>();
+        Parameter[] params = method.getParameters();
+        for (int i = 0; i < params.length; i++) {
+            if (isA2AInjectable(params[i])) {
+                slots.add(new MeshPositionalBinder.Slot(i, MeshPositionalBinder.SlotRole.PROXY));
+            }
+        }
+        return slots;
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshLegacyBindingDetector.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshLegacyBindingDetector.java
@@ -1,0 +1,411 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.spring.MeshDiValidator;
+import io.mcpmesh.spring.MeshPositionalBinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The migration instrument for issue #1401: at boot, tell a user whether their
+ * {@code @MeshRoute} / {@code @MeshA2A} handler means something different once
+ * those sites move from name-based to positional dependency binding.
+ *
+ * <h2>What it compares</h2>
+ *
+ * <p>For each handler it enumerates the injectable slots in signature order
+ * ({@link MeshInjectableSlots}) and pairs them positionally with the declared
+ * {@code @MeshDependency} list — the binding of the future. Against that it puts
+ * the binding of today: the capability name each slot resolves through, which is
+ * {@code @MeshInject}'s value when non-empty and the parameter name otherwise.
+ * Four outcomes per slot:
+ *
+ * <ul>
+ *   <li><b>Agrees</b> — the name resolves to the same dependency the position
+ *       would. Positional and by-name binding are identical here; nothing
+ *       changes, and nothing is reported (DEBUG).</li>
+ *   <li><b>Reordered</b> — the name resolves to a <i>different</i> declared
+ *       dependency. The handler was written under name-binding with an order
+ *       positional binding would change. <b>WARN</b> today; the conversion PR
+ *       makes it fatal.</li>
+ *   <li><b>Undeclared</b> — the name matches nothing declared. This is
+ *       <i>already</i> broken: {@code MeshInjectArgumentResolver} warns and
+ *       injects null at request time. Reported as an <b>ERROR</b>, because a
+ *       boot-time error beats a per-request warning.</li>
+ *   <li><b>No name available</b> — no {@code @MeshInject} value and the class
+ *       was compiled without {@code -parameters}. Spring's
+ *       {@code MethodParameter.getParameterName()} returns null (verified: the
+ *       reflection {@code Parameter.getName()} yields {@code arg0}, and Spring's
+ *       {@code StandardReflectionParameterNameDiscoverer} refuses to use it), so
+ *       the route resolver already logs an error and injects null, and the A2A
+ *       dispatcher already matches {@code "arg0"} against nothing. <b>There is
+ *       no working code in this shape</b> — which is what makes the conversion
+ *       safe. Reported as an <b>ERROR</b>.</li>
+ * </ul>
+ *
+ * <h2>What it deliberately does not check</h2>
+ *
+ * <p><b>Arity.</b> Unlike {@code @MeshTool} (see
+ * {@link MeshDiValidator#checkArity}), a route or A2A surface with more declared
+ * dependencies than injectable parameters is <i>legitimate and documented</i>:
+ * {@code MeshRouteUtils.getDependencies(request)} hands the whole resolved map
+ * to the handler, and a dependency-declaring surface with zero parameters is the
+ * canonical way to publish a capability edge that a constructor-injected
+ * {@code @Qualifier} bean consumes. Reporting arity here would fire on correct
+ * code. Every slot that actually goes unbound is caught by the per-slot analysis
+ * above instead.
+ *
+ * @see MeshInjectableSlots
+ * @see MeshDiValidator
+ */
+public final class MeshLegacyBindingDetector {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshLegacyBindingDetector.class);
+
+    private MeshLegacyBindingDetector() {}
+
+    /** How bad a handler's shape is. */
+    public enum Severity {
+        /** Positional and by-name binding agree — nothing changes. */
+        OK,
+        /** At least one slot's binding changes under positional pairing. */
+        WARN,
+        /** At least one slot binds to nothing today — already broken. */
+        ERROR
+    }
+
+    /**
+     * The verdict for one handler.
+     *
+     * @param severity worst per-slot outcome
+     * @param message  the human-readable diagnostic; empty when {@code OK}
+     */
+    public record Finding(Severity severity, String message) {}
+
+    /** Per-slot outcome. */
+    private enum SlotVerdict { AGREES, REORDERED, UNDECLARED, NO_NAME }
+
+    /**
+     * Inspect a {@code @MeshRoute} handler and report through the logger,
+     * honouring {@code MCP_MESH_STRICT_DI}.
+     *
+     * @param method the handler method
+     * @param deps   the declared dependency specs in declaration order
+     * @throws IllegalStateException when the shape is not {@code OK} and strict
+     *         DI is enabled
+     */
+    public static void inspectRoute(Method method, List<MeshRouteRegistry.DependencySpec> deps) {
+        report(analyze("@MeshRoute", method, MeshInjectableSlots.routeSlots(method), deps),
+            MeshDiValidator.strictDiEnabled());
+    }
+
+    /**
+     * Inspect a {@code @MeshA2A} handler and report through the logger,
+     * honouring {@code MCP_MESH_STRICT_DI}.
+     *
+     * @param method the handler method
+     * @param deps   the declared dependency specs in declaration order
+     * @throws IllegalStateException when the shape is not {@code OK} and strict
+     *         DI is enabled
+     */
+    public static void inspectA2A(Method method, List<MeshRouteRegistry.DependencySpec> deps) {
+        report(analyze("@MeshA2A", method, MeshInjectableSlots.a2aSlots(method), deps),
+            MeshDiValidator.strictDiEnabled());
+    }
+
+    /**
+     * Apply the reporting policy to a finding. Package-private with an explicit
+     * strictness flag because {@code MCP_MESH_STRICT_DI} cannot be set
+     * in-process, so this is the seam tests drive.
+     */
+    static void report(Finding finding, boolean strict) {
+        switch (finding.severity()) {
+            case OK -> {
+                if (log.isDebugEnabled() && !finding.message().isEmpty()) {
+                    log.debug("{}", finding.message());
+                }
+            }
+            case WARN -> {
+                if (strict) {
+                    throw new IllegalStateException(finding.message());
+                }
+                log.warn("{}", finding.message());
+            }
+            case ERROR -> {
+                if (strict) {
+                    throw new IllegalStateException(finding.message());
+                }
+                log.error("{}", finding.message());
+            }
+        }
+    }
+
+    /**
+     * The pure analysis, with no logging and no strictness policy — the seam
+     * tests use.
+     *
+     * @param site   the declaration site, e.g. {@code "@MeshRoute"}
+     * @param method the handler method
+     * @param slots  injectable slots in signature order
+     * @param deps   the declared dependency specs in declaration order
+     * @return the verdict; {@link Severity#OK} with a DEBUG-grade message when
+     *         today's and tomorrow's bindings are identical
+     */
+    public static Finding analyze(
+            String site,
+            Method method,
+            List<MeshPositionalBinder.Slot> slots,
+            List<MeshRouteRegistry.DependencySpec> deps) {
+
+        List<MeshRouteRegistry.DependencySpec> declared = deps == null ? List.of() : deps;
+        Parameter[] params = method.getParameters();
+
+        SlotVerdict[] verdicts = new SlotVerdict[slots.size()];
+        String[] nameKeys = new String[slots.size()];
+        boolean[] fromAnnotation = new boolean[slots.size()];
+        int[] nameTarget = new int[slots.size()];
+
+        Severity severity = Severity.OK;
+        for (int k = 0; k < slots.size(); k++) {
+            Parameter p = params[slots.get(k).parameterPosition()];
+            MeshInject inject = p.getAnnotation(MeshInject.class);
+            String key;
+            if (inject != null && !inject.value().isEmpty()) {
+                key = inject.value();
+                fromAnnotation[k] = true;
+            } else if (p.isNamePresent()) {
+                key = p.getName();
+            } else {
+                key = null;
+            }
+            nameKeys[k] = key;
+            nameTarget[k] = key == null ? -1 : matchIndex(declared, key);
+
+            if (key == null) {
+                verdicts[k] = SlotVerdict.NO_NAME;
+            } else if (nameTarget[k] < 0) {
+                verdicts[k] = SlotVerdict.UNDECLARED;
+            } else if (nameTarget[k] == k) {
+                verdicts[k] = SlotVerdict.AGREES;
+            } else {
+                verdicts[k] = SlotVerdict.REORDERED;
+            }
+
+            severity = switch (verdicts[k]) {
+                case AGREES -> severity;
+                case REORDERED -> severity == Severity.ERROR ? Severity.ERROR : Severity.WARN;
+                case UNDECLARED, NO_NAME -> Severity.ERROR;
+            };
+        }
+
+        return new Finding(severity,
+            buildMessage(site, method, slots, declared, verdicts, nameKeys, fromAnnotation,
+                nameTarget, severity));
+    }
+
+    /**
+     * The declared dependency a name key resolves to today.
+     *
+     * <p>Mirrors both live lookups: the route path's map is double-keyed by
+     * capability AND by {@code DependencySpec.getParameterName()}
+     * ({@code MeshRouteHandlerInterceptor:155-157}); the A2A path scans the same
+     * two fields in declaration order ({@code MeshA2ADispatcher:779-784}).
+     * First declaration wins on a collision.
+     */
+    private static int matchIndex(List<MeshRouteRegistry.DependencySpec> deps, String key) {
+        for (int i = 0; i < deps.size(); i++) {
+            MeshRouteRegistry.DependencySpec dep = deps.get(i);
+            if (key.equals(dep.getCapability()) || key.equals(dep.getParameterName())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static String buildMessage(
+            String site,
+            Method method,
+            List<MeshPositionalBinder.Slot> slots,
+            List<MeshRouteRegistry.DependencySpec> deps,
+            SlotVerdict[] verdicts,
+            String[] nameKeys,
+            boolean[] fromAnnotation,
+            int[] nameTarget,
+            Severity severity) {
+
+        String signature = signatureOf(method);
+        if (severity == Severity.OK) {
+            return site + " " + signature + ": name-based and positional dependency binding "
+                + "agree for all " + slots.size() + " injectable parameter(s) — issue #1401 will "
+                + "not change this handler.";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(site).append(' ').append(signature).append(": ");
+        if (severity == Severity.ERROR) {
+            sb.append("at least one injectable parameter resolves to NO declared dependency and "
+                + "is injected null today.");
+        } else {
+            sb.append("declaration order disagrees with parameter names, so this handler's "
+                + "bindings WILL CHANGE.");
+        }
+
+        sb.append("\n  ").append(site).append(" binds mesh dependencies BY NAME today. mcp-mesh is "
+            + "aligning every injection site on the positional contract (issue #1401): the Nth "
+            + "declared dependency binds to the Nth injectable parameter, and names are not "
+            + "consulted. @MeshTool already works this way, as does every Python and TypeScript "
+            + "site.");
+
+        sb.append("\n  ").append(deps.size())
+            .append(deps.size() == 1 ? " declared dependency: " : " declared dependencies: ")
+            .append(renderDeps(deps));
+
+        Parameter[] params = method.getParameters();
+        for (int k = 0; k < slots.size(); k++) {
+            Parameter p = params[slots.get(k).parameterPosition()];
+            sb.append("\n    slot ").append(k)
+                .append(" = parameter ").append(slots.get(k).parameterPosition())
+                .append(" (").append(p.getType().getSimpleName()).append(' ')
+                .append(p.isNamePresent() ? p.getName() : "<unnamed>").append(')');
+            sb.append("\n        ").append(pad("today (" + todayLabel(nameKeys[k], fromAnnotation[k]) + "):"))
+                .append(todayTarget(deps, nameTarget[k], verdicts[k]));
+            sb.append("\n        ").append(pad("after alignment (by position):"))
+                .append(positionalTarget(deps, k));
+        }
+
+        appendPrescription(sb, slots, deps, verdicts, nameTarget);
+
+        if (!MeshDiValidator.strictDiEnabled()) {
+            sb.append("\n  Set ").append(MeshDiValidator.STRICT_DI_ENV)
+                .append("=true to fail startup on this instead of logging it.");
+        }
+        return sb.toString();
+    }
+
+    private static void appendPrescription(
+            StringBuilder sb,
+            List<MeshPositionalBinder.Slot> slots,
+            List<MeshRouteRegistry.DependencySpec> deps,
+            SlotVerdict[] verdicts,
+            int[] nameTarget) {
+
+        boolean anyUnbound = false;
+        boolean anyReordered = false;
+        for (SlotVerdict v : verdicts) {
+            anyUnbound |= v == SlotVerdict.UNDECLARED || v == SlotVerdict.NO_NAME;
+            anyReordered |= v == SlotVerdict.REORDERED;
+        }
+
+        if (anyUnbound) {
+            sb.append("\n  Fix the unbound parameter(s) first: give each one a @MeshInject value "
+                + "naming a declared capability, or declare the capability it names in "
+                + "dependencies = {...}. A parameter that binds to nothing today will bind to "
+                + "whatever sits at its position after the alignment.");
+        }
+
+        if (!anyReordered) {
+            return;
+        }
+
+        // A reorder can only express the current bindings when each slot names a
+        // distinct dependency and every slot has a position to sit at.
+        Set<Integer> targets = new LinkedHashSet<>();
+        boolean injective = slots.size() <= deps.size();
+        for (int k = 0; k < slots.size() && injective; k++) {
+            if (nameTarget[k] < 0 || !targets.add(nameTarget[k])) {
+                injective = false;
+            }
+        }
+
+        sb.append("\n  Fix now — behaviour-preserving today, correct after the alignment.");
+        if (injective) {
+            List<String> reordered = new ArrayList<>();
+            for (int k = 0; k < slots.size(); k++) {
+                reordered.add(deps.get(nameTarget[k]).getCapability());
+            }
+            for (int i = 0; i < deps.size(); i++) {
+                if (!targets.contains(i)) {
+                    reordered.add(deps.get(i).getCapability());
+                }
+            }
+            sb.append(" Reorder dependencies = {...} to: ");
+            for (int i = 0; i < reordered.size(); i++) {
+                sb.append(i == 0 ? "" : ", ")
+                    .append('[').append(i).append("] '").append(reordered.get(i)).append('\'');
+            }
+            sb.append("\n      (move each whole @MeshDependency — keep its tags, version, "
+                + "required and schema attributes with its capability), or reorder the "
+                + "parameters to match the current declaration order.");
+        } else {
+            sb.append(" Reorder dependencies = {...} so declaration order matches parameter "
+                + "order, or reorder the parameters to match the declaration.");
+        }
+        sb.append("\n      Once the two agree, name-based and positional binding are identical "
+            + "and this stops being reported.");
+    }
+
+    private static String todayLabel(String key, boolean fromAnnotation) {
+        if (key == null) {
+            return "no @MeshInject value, and no parameter name is available — "
+                + "compiled without -parameters";
+        }
+        return fromAnnotation
+            ? "by name, @MeshInject(\"" + key + "\")"
+            : "by name, parameter name '" + key + "'";
+    }
+
+    private static String todayTarget(
+            List<MeshRouteRegistry.DependencySpec> deps, int target, SlotVerdict verdict) {
+        return switch (verdict) {
+            case NO_NAME -> "injected null (already broken today)";
+            case UNDECLARED -> "NO MATCH among the declared dependencies — "
+                + "injected null (already broken today)";
+            default -> "dependency[" + target + "] '" + deps.get(target).getCapability() + "'";
+        };
+    }
+
+    private static String positionalTarget(List<MeshRouteRegistry.DependencySpec> deps, int k) {
+        if (k >= deps.size()) {
+            return "no dependency declared at index " + k + " — injected null";
+        }
+        return "dependency[" + k + "] '" + deps.get(k).getCapability() + "'";
+    }
+
+    private static String renderDeps(List<MeshRouteRegistry.DependencySpec> deps) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < deps.size(); i++) {
+            sb.append(i == 0 ? "" : ", ")
+                .append('[').append(i).append("] '").append(deps.get(i).getCapability()).append('\'');
+        }
+        return deps.isEmpty() ? "(none)" : sb.toString();
+    }
+
+    /** Left-pad a label to a fixed width so the two comparison lines line up. */
+    private static String pad(String label) {
+        int width = 48;
+        if (label.length() >= width) {
+            return label + " ";
+        }
+        return label + " ".repeat(width - label.length());
+    }
+
+    private static String signatureOf(Method method) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(method.getDeclaringClass().getName()).append('.')
+            .append(method.getName()).append('(');
+        Class<?>[] types = method.getParameterTypes();
+        for (int i = 0; i < types.length; i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(types[i].getSimpleName());
+        }
+        return sb.append(')').toString();
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteBeanPostProcessor.java
@@ -73,6 +73,11 @@ public class MeshRouteBeanPostProcessor implements BeanPostProcessor {
             // Enrich dependency specs with generic return type info from method parameters
             enrichDependencyReturnTypes(method, deps);
 
+            // Issue #1401: report handlers whose bindings would change when
+            // @MeshRoute moves from name-based to positional pairing. Warning
+            // only — this PR changes no binding behaviour.
+            MeshLegacyBindingDetector.inspectRoute(method, deps);
+
             // Register each HTTP method/path combination
             String handlerMethodId = targetClass.getName() + "." + method.getName();
             MeshRouteRegistry.RouteMetadata metadata = new MeshRouteRegistry.RouteMetadata(

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDiValidatorTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshDiValidatorTest.java
@@ -1,0 +1,323 @@
+package io.mcpmesh.spring;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.mcpmesh.MeshJob;
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Selector;
+import io.mcpmesh.types.McpMeshTool;
+import io.mcpmesh.types.MeshLlmAgent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link MeshDiValidator} — Java's dependency-count / slot-count
+ * check, at parity with Python's {@code validate_mesh_dependencies}
+ * (issue #1401).
+ *
+ * <p>Strictness is passed explicitly rather than read from the environment:
+ * {@code MCP_MESH_STRICT_DI} cannot be set in-process, and the ambient overload
+ * is a one-line delegation to the explicit one.
+ */
+@DisplayName("MeshDiValidator: @MeshTool arity validation (issue #1401)")
+class MeshDiValidatorTest {
+
+    @SuppressWarnings("unused")
+    static class Shapes {
+        void matched(@io.mcpmesh.Param("x") String x, McpMeshTool a, McpMeshTool b) {}
+
+        void tooFewParams(@io.mcpmesh.Param("x") String x, McpMeshTool only) {}
+
+        void tooManyParams(McpMeshTool a, McpMeshTool b, McpMeshTool c) {}
+
+        void withJob(McpMeshTool a, MeshJob job) {}
+
+        void viewShape(@io.mcpmesh.Param("x") String x, McpMeshTool explicitDep) {}
+
+        void withLlmAgent(McpMeshTool a, MeshLlmAgent llm) {}
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Sound arity
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Counts match: nothing reported, nothing thrown, in either mode")
+    void matchedArityIsSilent() {
+        MeshPositionalBinder.Binding binding = bind("matched", List.of(1, 2), null,
+            List.of("cap_a", "cap_b"), 2);
+
+        assertNull(MeshDiValidator.checkArity("@MeshTool", binding, binding.slots().size(), binding.slots().size(), false));
+        assertNull(MeshDiValidator.checkArity("@MeshTool", binding, binding.slots().size(), binding.slots().size(), true));
+    }
+
+    @Test
+    @DisplayName("CONSUMER MeshJob slot consumes a declared dependency and counts toward arity")
+    void consumerJobSlotCountsAsAnInjectableSlot() {
+        MeshPositionalBinder.Binding binding = bind("withJob", List.of(0), 1,
+            List.of("cap_a", "job_cap"), 2);
+
+        assertNull(MeshDiValidator.checkArity("@MeshTool", binding, binding.slots().size(), binding.slots().size(), true));
+    }
+
+    @Test
+    @DisplayName("TRAP 3: a PRODUCER's MeshJob controller slot is OPTIONALLY declared")
+    void producerJobControllerSlotIsOptional() {
+        // On a task=true tool the MeshJob parameter is the inbound job's
+        // controller — the dispatch path fills it, and JobsRuntimeManager
+        // explicitly skips task() tools when wiring submitters. Producers
+        // normally declare nothing for it (counting it would flag every
+        // long-running producer in the ecosystem), yet declaring a capability
+        // at its index is also supported and skews the pairing table. Both
+        // counts must pass.
+        MeshPositionalBinder.Binding undeclared = bind("withJob", List.of(0), 1,
+            List.of("cap_a"), 1);
+        assertNull(MeshDiValidator.checkArity("@MeshTool", undeclared, 1, 2, true),
+            "the producer's controller slot must not demand a declared dependency");
+
+        MeshPositionalBinder.Binding declared = bind("withJob", List.of(0), 1,
+            List.of("job_cap", "cap_a"), 2);
+        assertNull(MeshDiValidator.checkArity("@MeshTool", declared, 1, 2, true),
+            "a producer MAY declare a capability at the job slot's index");
+
+        // ...but the same shape read as a CONSUMER must be backed exactly.
+        assertNotNull(MeshDiValidator.checkArity("@MeshTool", undeclared, 2, 2, false));
+    }
+
+    @Test
+    @DisplayName("TRAP 1: @MeshService view edges are not phantom excess dependencies")
+    void viewEdgesAreNotCountedAsExcess() {
+        // The declared list is the explicit @Selector prefix plus RFC-1280 view
+        // edges; only the prefix is pairable. Counting capabilities.size() here
+        // would report two phantom excess dependencies.
+        MeshPositionalBinder.Binding binding = bind("viewShape", List.of(1), null,
+            List.of("explicit_cap", "view_edge_one", "view_edge_two"), 1);
+
+        assertEquals(3, binding.capabilities().size());
+        assertEquals(1, binding.pairableDepCount());
+        assertNull(MeshDiValidator.checkArity("@MeshTool", binding, binding.slots().size(), binding.slots().size(), true),
+            "view edges own no injectable parameter by construction");
+    }
+
+    @Test
+    @DisplayName("TRAP 2: MeshLlmAgent parameters are invisible to arity checking by construction")
+    void llmAgentParametersAreNotSlots() {
+        // MeshToolWrapper.analyzeParameters puts MeshLlmAgent positions in a
+        // separate index space (@MeshLlm has no dependencies member), so the
+        // agent parameter is neither a slot nor backed by a declared entry.
+        MeshPositionalBinder.Binding binding = bind("withLlmAgent", List.of(0), null,
+            List.of("cap_a"), 1);
+
+        assertNull(MeshDiValidator.checkArity("@MeshTool", binding, binding.slots().size(), binding.slots().size(), true));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Mismatched arity
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("More dependencies than slots: WARN by default, naming both counts and the fix")
+    void surplusDependenciesWarnByDefault() {
+        MeshPositionalBinder.Binding binding = bind("tooFewParams", List.of(1), null,
+            List.of("cap_a", "cap_b"), 2);
+
+        String message = MeshDiValidator.checkArity("@MeshTool", binding, binding.slots().size(), binding.slots().size(), false);
+
+        assertNotNull(message, "a dep/slot mismatch must be reported, never silently dropped");
+        assertTrue(message.contains("declares 2 dependencies"), message);
+        assertTrue(message.contains("has 1 dependency-backed injectable parameter"), message);
+        assertTrue(message.contains("injected nowhere"), message);
+        assertTrue(message.contains("dependencies[i] pairs with the i-th injectable parameter"),
+            "the message must state the positional rule, as Python's does");
+        assertTrue(message.contains("declare exactly 1 entry"), message);
+        assertTrue(message.contains("(no injectable parameter — dropped)"),
+            "the binder's own pairing table must be part of the diagnostic");
+        assertTrue(message.contains("MCP_MESH_STRICT_DI=true"),
+            "the non-strict message must point at the knob that hardens it");
+    }
+
+    @Test
+    @DisplayName("More slots than dependencies: WARN naming the null-injected surplus")
+    void surplusParametersWarnByDefault() {
+        MeshPositionalBinder.Binding binding = bind("tooManyParams", List.of(0, 1, 2), null,
+            List.of("cap_a"), 1);
+
+        String message = MeshDiValidator.checkArity("@MeshTool", binding, binding.slots().size(), binding.slots().size(), false);
+
+        assertNotNull(message);
+        assertTrue(message.contains("declares 1 dependency"), message);
+        assertTrue(message.contains("has 3 dependency-backed injectable parameters"), message);
+        assertTrue(message.contains("injected null"), message);
+        assertTrue(message.contains("declare exactly 3 entries"), message);
+    }
+
+    @Test
+    @DisplayName("MCP_MESH_STRICT_DI: the same diagnostic becomes a boot failure")
+    void strictModeFailsBoot() {
+        MeshPositionalBinder.Binding binding = bind("tooFewParams", List.of(1), null,
+            List.of("cap_a", "cap_b"), 2);
+
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+            () -> MeshDiValidator.checkArity("@MeshTool", binding, binding.slots().size(), binding.slots().size(), true));
+
+        assertTrue(e.getMessage().contains("declares 2 dependencies"), e.getMessage());
+        assertTrue(e.getMessage().contains("has 1 dependency-backed injectable parameter"), e.getMessage());
+        assertTrue(!e.getMessage().contains("Set MCP_MESH_STRICT_DI=true"),
+            "the strict message must not tell the user to enable what is already enabled");
+    }
+
+    @Test
+    @DisplayName("The declaration site is named so a multi-site agent knows where to look")
+    void siteLabelIsCarriedIntoTheMessage() {
+        MeshPositionalBinder.Binding binding = bind("tooFewParams", List.of(1), null,
+            List.of("cap_a", "cap_b"), 2);
+
+        String message = MeshDiValidator.checkArity("@MeshTool", binding, binding.slots().size(), binding.slots().size(), false);
+        assertTrue(message.startsWith("@MeshTool io.mcpmesh.spring.MeshDiValidatorTest$Shapes"
+            + ".tooFewParams("), message);
+    }
+
+    @Test
+    @DisplayName("Default posture is permissive: MCP_MESH_STRICT_DI is off unless set")
+    void strictIsOptIn() {
+        // The suite does not set the variable; DI stays soft-fail by default.
+        assertEquals(System.getenv(MeshDiValidator.STRICT_DI_ENV) != null
+                && List.of("1", "true", "yes")
+                    .contains(System.getenv(MeshDiValidator.STRICT_DI_ENV).trim().toLowerCase()),
+            MeshDiValidator.strictDiEnabled());
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // At the real call site: MeshToolWrapper
+    // ─────────────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unused")
+    static class Tools {
+        @MeshTool(capability = "produce_report", task = true)
+        public String producer(@io.mcpmesh.Param("x") String x, MeshJob job) {
+            return "";
+        }
+
+        @MeshTool(capability = "consume", dependencies = @Selector(capability = "remote_task"))
+        public String consumer(@io.mcpmesh.Param("x") String x, MeshJob job) {
+            return "";
+        }
+
+        @MeshTool(capability = "mismatched",
+            dependencies = {@Selector(capability = "a"), @Selector(capability = "b")})
+        public String mismatched(@io.mcpmesh.Param("x") String x, McpMeshTool only) {
+            return "";
+        }
+
+        /** The skew shape: a producer that DOES declare at the job slot's index. */
+        @MeshTool(capability = "skew", task = true,
+            dependencies = {@Selector(capability = "job_cap"), @Selector(capability = "db_cap")})
+        public String skewProducer(MeshJob job, McpMeshTool db) {
+            return "";
+        }
+    }
+
+    @Test
+    @DisplayName("Real wrapper: a task=true producer with a MeshJob parameter warns about nothing")
+    void wrapperDoesNotWarnForTaskProducers() {
+        assertEquals(List.of(), warningsFromWrapper("producer", List.of(), true));
+    }
+
+    @Test
+    @DisplayName("Real wrapper: a producer that DOES declare at the job slot's index is also silent")
+    void wrapperDoesNotWarnForSkewedProducers() {
+        assertEquals(List.of(),
+            warningsFromWrapper("skewProducer", List.of("job_cap", "db_cap"), true));
+    }
+
+    @Test
+    @DisplayName("Real wrapper: a consumer MeshJob slot backed by its declared dependency is silent")
+    void wrapperDoesNotWarnForWiredConsumers() {
+        assertEquals(List.of(), warningsFromWrapper("consumer", List.of("remote_task"), false));
+    }
+
+    @Test
+    @DisplayName("Real wrapper: a genuine mismatch still warns, and the wrapper still builds")
+    void wrapperWarnsButStillBuilds() {
+        List<String> warnings = warningsFromWrapper("mismatched", List.of("a", "b"), false);
+
+        assertEquals(1, warnings.size(), warnings.toString());
+        assertTrue(warnings.get(0).contains("declares 2 dependencies"), warnings.get(0));
+        assertTrue(warnings.get(0).contains("has 1 dependency-backed injectable parameter"),
+            warnings.get(0));
+    }
+
+    /** Build a real {@link MeshToolWrapper} and collect what the validator logged. */
+    private static List<String> warningsFromWrapper(
+            String methodName, List<String> dependencies, boolean task) {
+
+        Method method = null;
+        for (Method m : Tools.class.getDeclaredMethods()) {
+            if (m.getName().equals(methodName)) {
+                method = m;
+            }
+        }
+        if (method == null) {
+            throw new AssertionError("No such tool: " + methodName);
+        }
+
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger)
+            org.slf4j.LoggerFactory.getLogger(MeshDiValidator.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            new MeshToolWrapper(
+                "test." + methodName,
+                "cap",
+                "",
+                new Tools(),
+                method,
+                dependencies,
+                JsonMapper.builder().build(),
+                task,
+                new Class[0],
+                List.of());
+        } finally {
+            logger.detachAppender(appender);
+        }
+        return appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Harness
+    // ─────────────────────────────────────────────────────────────────
+
+    private static MeshPositionalBinder.Binding bind(
+            String methodName,
+            List<Integer> proxyPositions,
+            Integer jobPosition,
+            List<String> capabilities,
+            int pairableDepCount) {
+
+        return MeshPositionalBinder.bind(
+            methodOf(methodName),
+            MeshPositionalBinder.slots(proxyPositions, jobPosition),
+            capabilities,
+            pairableDepCount);
+    }
+
+    private static Method methodOf(String name) {
+        for (Method m : Shapes.class.getDeclaredMethods()) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+        throw new AssertionError("No such shape: " + name);
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherDependencyBindingCharacterizationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherDependencyBindingCharacterizationTest.java
@@ -1,0 +1,260 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.spring.MeshDependencyInjector;
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Characterization tests for {@code MeshA2ADispatcher.resolveDependency}'s
+ * {@link McpMeshTool} branch — the {@code @MeshA2A} injection path (issue
+ * #1401).
+ *
+ * <p><b>Why these exist.</b> Only the {@code MeshJobSubmitter} branch of the
+ * dispatcher's argument binding had coverage;
+ * {@link A2ATestFixtures} even carries a comment noting that "most tests don't
+ * exercise {@code @MeshInject} parameter resolution". The conversion of
+ * {@code @MeshA2A} from name-based to positional binding rewrites exactly this
+ * code, so today's behaviour is pinned first — the rewrite of this file then
+ * <b>is</b> the semantic change, made visible in a diff.
+ *
+ * <p><b>The contract being pinned:</b> the dispatcher derives a capability
+ * <i>string</i> — {@code @MeshInject}'s value when non-empty, otherwise the raw
+ * reflective parameter name — and linearly scans the surface's declared
+ * dependencies for one whose capability or {@code DependencySpec} name equals
+ * it. The parameter's position in the signature is never consulted.
+ *
+ * <p>Tests drive the real {@code tasks/send} dispatch path rather than calling
+ * the private resolver, so what is pinned is the behaviour a user observes.
+ */
+@DisplayName("MeshA2ADispatcher: today's by-NAME dependency binding (issue #1401 characterization)")
+class MeshA2ADispatcherDependencyBindingCharacterizationTest {
+
+    private MeshA2ARegistry registry;
+    private MeshA2ATaskStore taskStore;
+    private ObjectMapper mapper;
+
+    private McpMeshTool alphaProxy;
+    private McpMeshTool betaProxy;
+
+    @BeforeEach
+    void setUp() {
+        registry = new MeshA2ARegistry();
+        taskStore = new MeshA2ATaskStore();
+        mapper = A2ATestFixtures.objectMapper();
+        alphaProxy = mock(McpMeshTool.class, "alpha-proxy");
+        betaProxy = mock(McpMeshTool.class, "beta-proxy");
+        CapturingBean.ARGS.remove();
+    }
+
+    @AfterEach
+    void tearDown() {
+        CapturingBean.ARGS.remove();
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // The pins
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("@MeshInject values agreeing with declaration order: each parameter gets its own proxy")
+    void agreeingInjectValuesResolveToTheirOwnCapability() {
+        dispatch("agreeing", List.of(dep("alpha"), dep("beta")));
+
+        assertSame(alphaProxy, CapturingBean.ARGS.get().get(0));
+        assertSame(betaProxy, CapturingBean.ARGS.get().get(1));
+    }
+
+    @Test
+    @DisplayName("PIN: @MeshInject value WINS over parameter position — declaration order is ignored")
+    void nameBeatsPositionToday() {
+        // Declaration order is [alpha, beta]; positional binding would give the
+        // first injectable parameter the alpha proxy. Today the name decides.
+        dispatch("disagreeing", List.of(dep("alpha"), dep("beta")));
+
+        assertSame(betaProxy, CapturingBean.ARGS.get().get(0),
+            "parameter annotated @MeshInject(\"beta\") must receive the beta proxy today");
+        assertSame(alphaProxy, CapturingBean.ARGS.get().get(1),
+            "parameter annotated @MeshInject(\"alpha\") must receive the alpha proxy today");
+    }
+
+    @Test
+    @DisplayName("@MeshInject value matching no declared capability: null, dispatch still succeeds")
+    void undeclaredInjectValueResolvesToNull() {
+        dispatch("undeclared", List.of(dep("alpha"), dep("beta")));
+
+        assertNull(CapturingBean.ARGS.get().get(0),
+            "an unmatched capability is a debug-and-inject-null, not a failure");
+    }
+
+    @Test
+    @DisplayName("No @MeshInject: the PARAMETER NAME is the lookup key")
+    void parameterNameIsTheFallbackKey() {
+        dispatch("parameterNameFallback", List.of(dep("alpha")));
+
+        assertSame(alphaProxy, CapturingBean.ARGS.get().get(0));
+    }
+
+    @Test
+    @DisplayName("No @MeshInject, kebab-case capability: the camelCased DependencySpec name matches")
+    void camelCasedDependencySpecNameMatches() {
+        // DependencySpec.fromAnnotation defaults the spec name to the camelCased
+        // capability, and the dispatcher scans that field too.
+        when(injector().getToolProxy("base-cap")).thenReturn(alphaProxy);
+        dispatch("camelCasedParameterName",
+            List.of(new MeshRouteRegistry.DependencySpec(
+                "base-cap", new String[0], "", "baseCap")));
+
+        assertSame(alphaProxy, CapturingBean.ARGS.get().get(0));
+    }
+
+    @Test
+    @DisplayName("Declared dependency with no parameter naming it: simply unbound, no error")
+    void surplusDeclaredDependencyIsIgnored() {
+        dispatch("parameterNameFallback", List.of(dep("alpha"), dep("beta")));
+
+        assertEquals(1, CapturingBean.ARGS.get().size(),
+            "handler has one injectable slot; the second declared dependency binds nowhere");
+        assertSame(alphaProxy, CapturingBean.ARGS.get().get(0));
+    }
+
+    @Test
+    @DisplayName("@MeshInject on a NON-McpMeshTool parameter is also a dependency slot on the A2A path")
+    void meshInjectOnNonProxyTypeIsStillASlot() {
+        // Divergence from @MeshRoute: the dispatcher owns the whole argument
+        // array, so @MeshInject claims any parameter type. The injector returns
+        // an McpMeshTool, which is then assigned into an Object slot.
+        dispatch("injectOnObjectParam", List.of(dep("alpha")));
+
+        assertSame(alphaProxy, CapturingBean.ARGS.get().get(0));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Harness
+    // ─────────────────────────────────────────────────────────────────
+
+    private MeshDependencyInjector injectorMock;
+
+    private MeshDependencyInjector injector() {
+        if (injectorMock == null) {
+            injectorMock = mock(MeshDependencyInjector.class);
+            when(injectorMock.getToolProxy(anyString())).thenReturn(null);
+            when(injectorMock.getToolProxy("alpha")).thenReturn(alphaProxy);
+            when(injectorMock.getToolProxy("beta")).thenReturn(betaProxy);
+        }
+        return injectorMock;
+    }
+
+    private void dispatch(String handlerMethod, List<MeshRouteRegistry.DependencySpec> deps) {
+        MeshDependencyInjector injector = injector();
+        registry.register(surfaceFor("/svc", "skill-" + handlerMethod, handlerMethod, deps));
+        MeshA2ADispatcher dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper, provider(injector));
+        dispatcher.dispatch("/svc", A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+            Map.of("id", "t1", "message", Map.of("text", "hi"))));
+    }
+
+    private static MeshA2ARegistry.SurfaceMetadata surfaceFor(
+            String path, String skillId, String handlerMethod,
+            List<MeshRouteRegistry.DependencySpec> deps) {
+
+        Method method = null;
+        for (Method m : CapturingBean.class.getDeclaredMethods()) {
+            if (m.getName().equals(handlerMethod)) {
+                method = m;
+            }
+        }
+        if (method == null) {
+            throw new AssertionError("No such handler: " + handlerMethod);
+        }
+        return new MeshA2ARegistry.SurfaceMetadata(
+            path, skillId, skillId, "", List.of(), deps, "",
+            "CapturingBean." + handlerMethod, new CapturingBean(), method);
+    }
+
+    private static MeshRouteRegistry.DependencySpec dep(String capability) {
+        return new MeshRouteRegistry.DependencySpec(
+            capability, new String[0], "", capability);
+    }
+
+    private static ObjectProvider<MeshDependencyInjector> provider(MeshDependencyInjector injector) {
+        return new ObjectProvider<>() {
+            @Override public MeshDependencyInjector getObject() { return injector; }
+            @Override public MeshDependencyInjector getObject(Object... args) { return injector; }
+            @Override public MeshDependencyInjector getIfAvailable() { return injector; }
+            @Override public MeshDependencyInjector getIfUnique() { return injector; }
+        };
+    }
+
+    /**
+     * Handler bean recording exactly what landed in each injectable slot, in
+     * signature order.
+     */
+    @SuppressWarnings("unused")
+    public static class CapturingBean {
+
+        static final ThreadLocal<List<Object>> ARGS = new ThreadLocal<>();
+
+        public Object agreeing(
+                Map<String, Object> message,
+                @MeshInject("alpha") McpMeshTool a,
+                @MeshInject("beta") McpMeshTool b) {
+            return capture(a, b);
+        }
+
+        public Object disagreeing(
+                Map<String, Object> message,
+                @MeshInject("beta") McpMeshTool first,
+                @MeshInject("alpha") McpMeshTool second) {
+            return capture(first, second);
+        }
+
+        public Object undeclared(
+                Map<String, Object> message,
+                @MeshInject("nope") McpMeshTool ghost) {
+            return capture(ghost);
+        }
+
+        public Object parameterNameFallback(Map<String, Object> message, McpMeshTool alpha) {
+            return capture(alpha);
+        }
+
+        public Object camelCasedParameterName(Map<String, Object> message, McpMeshTool baseCap) {
+            return capture(baseCap);
+        }
+
+        public Object injectOnObjectParam(
+                Map<String, Object> message,
+                @MeshInject("alpha") Object anything) {
+            return capture(anything);
+        }
+
+        private static Object capture(Object... args) {
+            List<Object> captured = new ArrayList<>();
+            for (Object arg : args) {
+                captured.add(arg);
+            }
+            ARGS.set(captured);
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("ok", true);
+            return result;
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshInjectArgumentResolverCharacterizationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshInjectArgumentResolverCharacterizationTest.java
@@ -1,0 +1,254 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.core.MethodParameter;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Characterization tests for {@link MeshInjectArgumentResolver} — the
+ * {@code @MeshRoute} injection path (issue #1401).
+ *
+ * <p><b>Why these exist.</b> Before this PR there was no unit test anywhere for
+ * this resolver; its only coverage was end-to-end integration fixtures. The
+ * conversion of {@code @MeshRoute} from name-based to positional binding touches
+ * exactly this code, so today's behaviour is pinned <i>first</i>. These tests
+ * describe what the resolver does now, not what it should do — when the
+ * conversion lands, the rewrite of this file <b>is</b> the semantic change, made
+ * visible in a diff.
+ *
+ * <p><b>The contract being pinned:</b> the resolver derives a capability
+ * <i>string</i> — {@code @MeshInject}'s value when non-empty, otherwise the
+ * parameter name — and looks it up in the map the interceptor put on the
+ * request. Declaration order of {@code dependencies = {...}} is never consulted,
+ * so a parameter's position in the signature is irrelevant.
+ *
+ * <p><b>On the no-{@code -parameters} case.</b> The test harness reproduces it
+ * by not installing a {@code ParameterNameDiscoverer} on the
+ * {@link MethodParameter}, which is the same null that Spring's
+ * {@code StandardReflectionParameterNameDiscoverer} returns for a class compiled
+ * without {@code -parameters} (it refuses to fall back on the synthetic
+ * {@code arg0} names). This module compiles <i>with</i> {@code -parameters}, so
+ * the real bytecode shape cannot be produced in-tree.
+ */
+@DisplayName("MeshInjectArgumentResolver: today's by-NAME binding (issue #1401 characterization)")
+class MeshInjectArgumentResolverCharacterizationTest {
+
+    private final MeshInjectArgumentResolver resolver = new MeshInjectArgumentResolver();
+
+    // ─────────────────────────────────────────────────────────────────
+    // Handlers under characterization
+    // ─────────────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unused")
+    static class Handlers {
+
+        /** @MeshInject values agree with declaration order [alpha, beta]. */
+        String agreeing(
+                @MeshInject("alpha") McpMeshTool a,
+                @MeshInject("beta") McpMeshTool b) {
+            return "";
+        }
+
+        /**
+         * @MeshInject values are the REVERSE of declaration order
+         * [alpha, beta]. Under name binding this is correct code; under
+         * positional binding the two parameters swap.
+         */
+        String disagreeing(
+                @MeshInject("beta") McpMeshTool first,
+                @MeshInject("alpha") McpMeshTool second) {
+            return "";
+        }
+
+        /** @MeshInject names a capability that is not declared anywhere. */
+        String undeclared(@MeshInject("nope") McpMeshTool ghost) {
+            return "";
+        }
+
+        /** No annotation — the parameter NAME is the lookup key. */
+        String parameterNameFallback(McpMeshTool alpha) {
+            return "";
+        }
+
+        /**
+         * No annotation, and the capability is kebab-case: the interceptor also
+         * keys the map by {@code DependencySpec.getParameterName()}, which
+         * defaults to the camelCased capability.
+         */
+        String camelCasedParameterName(McpMeshTool baseCap) {
+            return "";
+        }
+
+        /** @MeshInject present but with an empty value — falls back to the name. */
+        String emptyInjectValue(@MeshInject McpMeshTool alpha) {
+            return "";
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // The pins
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("@MeshInject value agreeing with declaration order: each parameter gets its own proxy")
+    void agreeingInjectValuesResolveToTheirOwnCapability() {
+        McpMeshTool alpha = stub("alpha");
+        McpMeshTool beta = stub("beta");
+        ServletWebRequest request = requestWith(deps(alpha, beta));
+
+        assertSame(alpha, resolve("agreeing", 0, request));
+        assertSame(beta, resolve("agreeing", 1, request));
+    }
+
+    @Test
+    @DisplayName("PIN: @MeshInject value WINS over parameter position — declaration order is ignored")
+    void nameBeatsPositionToday() {
+        McpMeshTool alpha = stub("alpha");
+        McpMeshTool beta = stub("beta");
+        ServletWebRequest request = requestWith(deps(alpha, beta));
+
+        // Declaration order is [alpha, beta]; positional binding would give
+        // parameter 0 the alpha proxy. Today the @MeshInject value decides.
+        assertSame(beta, resolve("disagreeing", 0, request),
+            "parameter 0 is annotated @MeshInject(\"beta\") and must receive the beta proxy today");
+        assertSame(alpha, resolve("disagreeing", 1, request),
+            "parameter 1 is annotated @MeshInject(\"alpha\") and must receive the alpha proxy today");
+    }
+
+    @Test
+    @DisplayName("@MeshInject value matching no declared capability: null, no exception")
+    void undeclaredInjectValueResolvesToNull() {
+        ServletWebRequest request = requestWith(deps(stub("alpha"), stub("beta")));
+
+        assertNull(resolve("undeclared", 0, request),
+            "an unmatched capability is a warn-and-inject-null, not a failure");
+    }
+
+    @Test
+    @DisplayName("No @MeshInject: the PARAMETER NAME is the lookup key")
+    void parameterNameIsTheFallbackKey() {
+        McpMeshTool alpha = stub("alpha");
+        ServletWebRequest request = requestWith(deps(alpha));
+
+        assertSame(alpha, resolve("parameterNameFallback", 0, request));
+    }
+
+    @Test
+    @DisplayName("No @MeshInject, kebab-case capability: the camelCased DependencySpec name matches")
+    void camelCasedParameterNameKeyMatches() {
+        // The interceptor double-keys the map: capability AND
+        // DependencySpec.getParameterName(), which camelCases "base-cap".
+        McpMeshTool baseCap = stub("base-cap");
+        Map<String, McpMeshTool> map = new LinkedHashMap<>();
+        map.put("base-cap", baseCap);
+        map.put("baseCap", baseCap);
+        ServletWebRequest request = requestWith(map);
+
+        assertSame(baseCap, resolve("camelCasedParameterName", 0, request));
+    }
+
+    @Test
+    @DisplayName("@MeshInject with an empty value falls back to the parameter name")
+    void emptyInjectValueFallsBackToParameterName() {
+        McpMeshTool alpha = stub("alpha");
+        ServletWebRequest request = requestWith(deps(alpha));
+
+        assertSame(alpha, resolve("emptyInjectValue", 0, request));
+    }
+
+    @Test
+    @DisplayName("No @MeshInject and no parameter name (compiled without -parameters): null")
+    void noNameSignalResolvesToNull() {
+        ServletWebRequest request = requestWith(deps(stub("alpha")));
+
+        // A class compiled without -parameters cannot be produced in-tree (this
+        // module compiles WITH it), so the shape is reproduced at the resolver's
+        // seam: MethodParameter.getParameterName() returns null. Verified against
+        // Spring 7.0.7 — for a class compiled without -parameters it returns null
+        // both with and without a ParameterNameDiscoverer installed, because
+        // StandardReflectionParameterNameDiscoverer refuses the synthetic argN
+        // names.
+        MethodParameter parameter = mock(MethodParameter.class);
+        when(parameter.getParameterAnnotation(MeshInject.class)).thenReturn(null);
+        when(parameter.getParameterName()).thenReturn(null);
+
+        assertNull(resolver.resolveArgument(parameter, null, request, null),
+            "a parameter with no @MeshInject value and no discoverable name binds to nothing today");
+    }
+
+    @Test
+    @DisplayName("No mesh dependencies on the request (not a @MeshRoute handler): null")
+    void noDependencyAttributeResolvesToNull() {
+        ServletWebRequest request = new ServletWebRequest(new MockHttpServletRequest());
+
+        assertNull(resolve("agreeing", 0, request));
+    }
+
+    @Test
+    @DisplayName("supportsParameter claims McpMeshTool parameters with or without @MeshInject")
+    void supportsMcpMeshToolParameters() {
+        assertTrue(resolver.supportsParameter(named(methodOf("agreeing"), 0)));
+        assertTrue(resolver.supportsParameter(named(methodOf("parameterNameFallback"), 0)));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Harness
+    // ─────────────────────────────────────────────────────────────────
+
+    private Object resolve(String methodName, int index, ServletWebRequest request) {
+        return resolver.resolveArgument(named(methodOf(methodName), index), null, request, null);
+    }
+
+    /**
+     * A {@link MethodParameter} with name discovery installed — mirroring what
+     * Spring MVC's {@code InvocableHandlerMethod} does before calling a resolver.
+     */
+    private static MethodParameter named(Method method, int index) {
+        MethodParameter parameter = new MethodParameter(method, index);
+        parameter.initParameterNameDiscovery(new DefaultParameterNameDiscoverer());
+        return parameter;
+    }
+
+    private static Method methodOf(String name) {
+        for (Method m : Handlers.class.getDeclaredMethods()) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+        throw new AssertionError("No such handler: " + name);
+    }
+
+    private static ServletWebRequest requestWith(Map<String, McpMeshTool> dependencies) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(MeshRouteHandlerInterceptor.MESH_DEPENDENCIES_ATTR, dependencies);
+        return new ServletWebRequest(request);
+    }
+
+    /** Build the interceptor's map keyed by capability (names equal capabilities here). */
+    private static Map<String, McpMeshTool> deps(McpMeshTool... tools) {
+        Map<String, McpMeshTool> map = new LinkedHashMap<>();
+        for (McpMeshTool tool : tools) {
+            map.put(tool.toString(), tool);
+        }
+        return map;
+    }
+
+    /** An identity-bearing {@link McpMeshTool} — the mock's name is its capability. */
+    private static McpMeshTool stub(String capability) {
+        return mock(McpMeshTool.class, capability);
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshLegacyBindingDetectorTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshLegacyBindingDetectorTest.java
@@ -1,0 +1,367 @@
+package io.mcpmesh.spring.web;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.mcpmesh.spring.MeshPositionalBinder;
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Tests for {@link MeshLegacyBindingDetector} — the issue #1401 migration
+ * instrument.
+ *
+ * <p>The detector must fire on exactly the handler shapes whose meaning changes
+ * when {@code @MeshRoute} / {@code @MeshA2A} move to positional binding, and on
+ * nothing else. Both halves matter: a false positive in the instrument that is
+ * meant to make the migration trustworthy is as damaging as a miss.
+ */
+@DisplayName("MeshLegacyBindingDetector: legacy-shape detection (issue #1401)")
+class MeshLegacyBindingDetectorTest {
+
+    @SuppressWarnings("unused")
+    static class Routes {
+
+        String agreeing(
+                String body,
+                @MeshInject("alpha") McpMeshTool a,
+                @MeshInject("beta") McpMeshTool b) {
+            return "";
+        }
+
+        String disagreeing(
+                String body,
+                @MeshInject("beta") McpMeshTool first,
+                @MeshInject("alpha") McpMeshTool second) {
+            return "";
+        }
+
+        String undeclared(@MeshInject("nope") McpMeshTool ghost) {
+            return "";
+        }
+
+        String parameterNames(McpMeshTool alpha, McpMeshTool beta) {
+            return "";
+        }
+
+        String parameterNamesSwapped(McpMeshTool beta, McpMeshTool alpha) {
+            return "";
+        }
+
+        String camelCased(McpMeshTool baseCap) {
+            return "";
+        }
+
+        /** Declares dependencies but injects none — reads them off the request. */
+        String mapAccessOnly(String body) {
+            return "";
+        }
+
+        /** One more parameter than there are dependencies to pair with. */
+        String moreSlotsThanDeps(
+                @MeshInject("alpha") McpMeshTool a,
+                @MeshInject("alpha") McpMeshTool alsoAlpha) {
+            return "";
+        }
+
+        String a2aInjectOnObject(Map<String, Object> message, @MeshInject("alpha") Object anything) {
+            return "";
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Shapes that do NOT change meaning — the detector must stay quiet
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("@MeshInject values in declaration order: OK, nothing changes")
+    void agreeingInjectValuesAreOk() {
+        MeshLegacyBindingDetector.Finding finding =
+            analyzeRoute("agreeing", deps("alpha", "beta"));
+
+        assertEquals(MeshLegacyBindingDetector.Severity.OK, finding.severity());
+        assertTrue(finding.message().contains("agree"), finding.message());
+    }
+
+    @Test
+    @DisplayName("Parameter names in declaration order: OK")
+    void agreeingParameterNamesAreOk() {
+        assertEquals(MeshLegacyBindingDetector.Severity.OK,
+            analyzeRoute("parameterNames", deps("alpha", "beta")).severity());
+    }
+
+    @Test
+    @DisplayName("Kebab-case capability matched by its camelCased spec name: OK")
+    void camelCasedSpecNameIsOk() {
+        assertEquals(MeshLegacyBindingDetector.Severity.OK,
+            analyzeRoute("camelCased",
+                List.of(new MeshRouteRegistry.DependencySpec(
+                    "base-cap", new String[0], "", "baseCap"))).severity());
+    }
+
+    @Test
+    @DisplayName("NO FALSE POSITIVE: dependencies declared with zero injectable parameters is OK")
+    void mapAccessStyleIsNotAnArityError() {
+        // MeshRouteUtils.getDependencies(request) is a documented access style,
+        // and a zero-parameter declaring route is the canonical way to publish a
+        // capability edge for a constructor-injected @Qualifier bean. Arity is
+        // deliberately not checked on this path.
+        assertEquals(MeshLegacyBindingDetector.Severity.OK,
+            analyzeRoute("mapAccessOnly", deps("alpha", "beta")).severity());
+    }
+
+    @Test
+    @DisplayName("A handler with no dependencies and no slots is OK")
+    void emptyHandlerIsOk() {
+        assertEquals(MeshLegacyBindingDetector.Severity.OK,
+            analyzeRoute("mapAccessOnly", List.of()).severity());
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Shapes that DO change meaning
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Reversed @MeshInject values: WARN printing both orderings and the reorder")
+    void reversedInjectValuesWarn() {
+        MeshLegacyBindingDetector.Finding finding =
+            analyzeRoute("disagreeing", deps("alpha", "beta"));
+
+        assertEquals(MeshLegacyBindingDetector.Severity.WARN, finding.severity());
+        String m = finding.message();
+        assertTrue(m.contains("bindings WILL CHANGE"), m);
+        // Both orderings, for both slots.
+        assertTrue(m.contains("today (by name, @MeshInject(\"beta\")):"), m);
+        assertTrue(m.contains("dependency[1] 'beta'"), m);
+        assertTrue(m.contains("after alignment (by position):"), m);
+        assertTrue(m.contains("dependency[0] 'alpha'"), m);
+        // The prescription, in the order that preserves today's bindings.
+        assertTrue(m.contains("Reorder dependencies = {...} to: [0] 'beta', [1] 'alpha'"), m);
+        assertTrue(m.contains("MCP_MESH_STRICT_DI=true"), m);
+    }
+
+    @Test
+    @DisplayName("Reversed parameter NAMES (no @MeshInject) warn identically")
+    void reversedParameterNamesWarn() {
+        MeshLegacyBindingDetector.Finding finding =
+            analyzeRoute("parameterNamesSwapped", deps("alpha", "beta"));
+
+        assertEquals(MeshLegacyBindingDetector.Severity.WARN, finding.severity());
+        assertTrue(finding.message().contains("by name, parameter name 'beta'"),
+            finding.message());
+    }
+
+    @Test
+    @DisplayName("@MeshInject naming nothing declared: ERROR — already broken today")
+    void undeclaredInjectValueIsAnError() {
+        MeshLegacyBindingDetector.Finding finding =
+            analyzeRoute("undeclared", deps("alpha"));
+
+        assertEquals(MeshLegacyBindingDetector.Severity.ERROR, finding.severity());
+        String m = finding.message();
+        assertTrue(m.contains("resolves to NO declared dependency"), m);
+        assertTrue(m.contains("already broken today"), m);
+        assertTrue(m.contains("Fix the unbound parameter(s) first"), m);
+    }
+
+    @Test
+    @DisplayName("Two parameters naming one dependency: WARN, and no reorder is prescribed")
+    void nonInjectiveNamingCannotBeFixedByReordering() {
+        MeshLegacyBindingDetector.Finding finding =
+            analyzeRoute("moreSlotsThanDeps", deps("alpha"));
+
+        assertEquals(MeshLegacyBindingDetector.Severity.WARN, finding.severity());
+        String m = finding.message();
+        assertFalse(m.contains("Reorder dependencies = {...} to:"),
+            "no reordering can give two parameters the same dependency: " + m);
+        assertTrue(m.contains("no dependency declared at index 1"), m);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // The load-bearing blind spot: no @MeshInject, no -parameters
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("LOAD-BEARING: without -parameters there is no name signal, so no working code exists")
+    void withoutParameterNamesThereIsNoBinding() throws Exception {
+        Method handler = compiledWithoutParameterNames();
+        assumeTrue(handler != null, "system Java compiler unavailable");
+
+        // The whole migration rests on this: a handler in this shape cannot be
+        // working today, so it cannot regress from working to misbinding.
+        // MeshInjectArgumentResolver logs an error and injects null (Spring's
+        // MethodParameter.getParameterName() returns null — the reflection name
+        // is the synthetic 'arg0', which the discoverer refuses); the A2A
+        // dispatcher matches 'arg0' against nothing.
+        assertFalse(handler.getParameters()[0].isNamePresent(),
+            "fixture precondition: compiled without -parameters");
+        assertEquals("arg0", handler.getParameters()[0].getName());
+
+        MeshLegacyBindingDetector.Finding finding = MeshLegacyBindingDetector.analyze(
+            "@MeshRoute", handler, MeshInjectableSlots.routeSlots(handler),
+            deps("alpha", "beta"));
+
+        assertEquals(MeshLegacyBindingDetector.Severity.ERROR, finding.severity());
+        assertTrue(finding.message().contains("compiled without -parameters"),
+            finding.message());
+        assertTrue(finding.message().contains("already broken today"), finding.message());
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Reporting policy
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Default posture: a changed binding is a WARN, a broken one an ERROR — never fatal")
+    void defaultPostureIsPermissive() {
+        List<ILoggingEvent> events = capture(() -> {
+            MeshLegacyBindingDetector.report(
+                analyzeRoute("disagreeing", deps("alpha", "beta")), false);
+            MeshLegacyBindingDetector.report(
+                analyzeRoute("undeclared", deps("alpha")), false);
+            MeshLegacyBindingDetector.report(
+                analyzeRoute("agreeing", deps("alpha", "beta")), false);
+        });
+
+        assertEquals(List.of(Level.WARN, Level.ERROR),
+            events.stream().map(ILoggingEvent::getLevel).toList(),
+            "an agreeing handler must not be reported at all above DEBUG");
+    }
+
+    @Test
+    @DisplayName("MCP_MESH_STRICT_DI: a changed binding becomes a boot failure")
+    void strictModeFailsBoot() {
+        assertThrows(IllegalStateException.class, () ->
+            MeshLegacyBindingDetector.report(
+                analyzeRoute("disagreeing", deps("alpha", "beta")), true));
+        assertThrows(IllegalStateException.class, () ->
+            MeshLegacyBindingDetector.report(analyzeRoute("undeclared", deps("alpha")), true));
+
+        // ...but an agreeing handler still boots under strict.
+        MeshLegacyBindingDetector.report(analyzeRoute("agreeing", deps("alpha", "beta")), true);
+    }
+
+    private static List<ILoggingEvent> capture(Runnable body) {
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger)
+            org.slf4j.LoggerFactory.getLogger(MeshLegacyBindingDetector.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            body.run();
+        } finally {
+            logger.detachAppender(appender);
+        }
+        return appender.list;
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Slot classification, per path
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Route slots are McpMeshTool parameters only; A2A slots also include @MeshInject")
+    void slotClassificationDiffersPerPathAsTheResolversDo() {
+        Method method = methodOf("a2aInjectOnObject");
+
+        assertTrue(MeshInjectableSlots.routeSlots(method).isEmpty(),
+            "Spring MVC must not claim a non-McpMeshTool parameter");
+        assertEquals(List.of(1),
+            MeshInjectableSlots.a2aSlots(method).stream()
+                .map(MeshPositionalBinder.Slot::parameterPosition).toList(),
+            "the dispatcher owns the whole argument array, so @MeshInject claims any type");
+
+        // And the detector follows each path's own rule.
+        assertEquals(MeshLegacyBindingDetector.Severity.OK,
+            MeshLegacyBindingDetector.analyze("@MeshA2A", method,
+                MeshInjectableSlots.a2aSlots(method), deps("alpha")).severity());
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Harness
+    // ─────────────────────────────────────────────────────────────────
+
+    private static MeshLegacyBindingDetector.Finding analyzeRoute(
+            String methodName, List<MeshRouteRegistry.DependencySpec> deps) {
+        Method method = methodOf(methodName);
+        return MeshLegacyBindingDetector.analyze(
+            "@MeshRoute", method, MeshInjectableSlots.routeSlots(method), deps);
+    }
+
+    private static Method methodOf(String name) {
+        for (Method m : Routes.class.getDeclaredMethods()) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+        throw new AssertionError("No such route shape: " + name);
+    }
+
+    private static List<MeshRouteRegistry.DependencySpec> deps(String... capabilities) {
+        return java.util.Arrays.stream(capabilities)
+            .map(c -> new MeshRouteRegistry.DependencySpec(c, new String[0], "", c))
+            .toList();
+    }
+
+    /**
+     * Compile a handler <b>without</b> {@code -parameters} at test time — the
+     * one shape this module cannot express in its own sources, since the build
+     * passes {@code -parameters} to javac.
+     *
+     * @return the compiled handler method, or null when no system compiler is
+     *         available (a JRE-only run)
+     */
+    private static Method compiledWithoutParameterNames() throws Exception {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            return null;
+        }
+        Path dir = Files.createTempDirectory("mesh1401-noparams");
+        dir.toFile().deleteOnExit();
+        Path source = dir.resolve("NoParameterNames.java");
+        Files.writeString(source, """
+            import io.mcpmesh.types.McpMeshTool;
+
+            public class NoParameterNames {
+                public String handler(McpMeshTool first, McpMeshTool second) {
+                    return "";
+                }
+            }
+            """);
+
+        String classpath = new File(McpMeshTool.class.getProtectionDomain()
+            .getCodeSource().getLocation().toURI()).getAbsolutePath();
+        int rc = compiler.run(null, null, null,
+            "-classpath", classpath,
+            "-d", dir.toString(),
+            source.toString());
+        if (rc != 0) {
+            return null;
+        }
+
+        try (URLClassLoader loader = new URLClassLoader(
+                new URL[]{dir.toUri().toURL()},
+                MeshLegacyBindingDetectorTest.class.getClassLoader())) {
+            Class<?> compiled = loader.loadClass("NoParameterNames");
+            return compiled.getDeclaredMethod("handler", McpMeshTool.class, McpMeshTool.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**PR A of the #1401 sequence. Non-breaking — warnings only, no binding behaviour changes.**

PR B will convert Java `@MeshRoute` and `@MeshA2A` from name-based to positional binding. Both key on names today, so they *cannot* silently misbind. Converting removes that safety, so this PR builds the net first.

Three things: arity validation for `@MeshTool` (Java had none), the legacy-shape detector that tells a user their bindings will change, and characterization tests for two paths that had **zero** unit coverage.

## The claim the whole migration rests on — verified, not assumed

The detector has one blind spot: a user compiled without `-parameters`, where there is no name to compare against. The migration is only safe if that blind spot contains no *working* code.

Probed Spring 7.0.7 directly: for a class compiled without `-parameters`, `MethodParameter.getParameterName()` returns `null` **with or without** a `ParameterNameDiscoverer` installed — `StandardReflectionParameterNameDiscoverer` refuses the synthetic `arg0`. The route path then logs an error and injects null; the A2A path matches `"arg0"` against nothing.

**No working code exists in that shape**, so nobody can regress from working to misbinding. Now pinned in CI: `MeshLegacyBindingDetectorTest` compiles a handler without `-parameters` at test time via `ToolProvider.getSystemJavaCompiler()` and asserts both `isNamePresent()==false` and the detector's ERROR.

## Detector output across the tree

Compiled all **102** in-tree Java modules and ran a throwaway reflective scanner using the real components. Coverage cross-checked against source grep: **14/14 `@MeshRoute`, 7/7 `@MeshA2A`, 179/179 `@MeshTool`, 0 skipped.**

- Default: **0 findings.**
- `MCP_MESH_STRICT_DI=true`: **0 findings** — every in-tree Java app boots identically under strict today. That is the no-behaviour-change proof.
- Break test: reordering `@MeshInject` values in `rest-api-consumer` → exactly 1 WARN. Adding a phantom `@Selector` to `java-dual-consumer` → exactly 1 arity WARN, and a boot failure under strict. Both restored.

Sample output from the deliberate break:

```
@MeshRoute ...ApiController.getEmployee(int, McpMeshTool, McpMeshTool): declaration order
disagrees with parameter names, so this handler's bindings WILL CHANGE.
  2 declared dependencies: [0] 'get_employee', [1] 'employee_count'
    slot 0 = parameter 1 (McpMeshTool statsTool)
        today (by name, @MeshInject("employee_count")): dependency[1] 'employee_count'
        after alignment (by position):                  dependency[0] 'get_employee'
  Fix now — behaviour-preserving today, correct after the alignment. Reorder to:
    [0] 'employee_count', [1] 'get_employee'
```

## The classifier judgement call

#1434 established that the binder cannot answer "is this parameter injectable?" — the rules live in `analyzeParameters` and the A2A rules genuinely differ.

Resolved with **one new file, `MeshInjectableSlots`, exposing two per-path methods**, and both live resolvers refactored to call it. The rules differ for a real reason — Spring MVC asks `supportsParameter` before anything else, so the route path must not claim non-`McpMeshTool` params, while A2A owns the whole argument array and lets `@MeshInject` claim any type — so a fake-shared single rule would be a lie. But writing the predicate twice is the drift surface this issue exists to close. Two methods, one file, and **the live resolvers call it**, so the detector cannot diverge from what actually binds. It is also the seam PR B rewrites.

## Characterization tests — the largest gap in the sequence

There was **no unit test anywhere** for `MeshInjectArgumentResolver`, and `MeshA2ADispatcher.resolveDependency`'s McpMeshTool branch was likewise untested (`web/A2ATestFixtures.java:17` carries a comment saying so).

Added 9 + 7 cases pinning today's by-name behaviour — agreeing, disagreeing, `@MeshInject` matching nothing, and the parameter-name fallback — the A2A set driven through real `tasks/send` dispatch. PR B rewrites these, and that rewrite diff *is* the semantic change made visible.

## The design fought back twice, both on `MeshJob`

**19 false positives on the first attempt.** Counting every slot flagged every long-running producer. `MeshJob` is two different things: on a consumer it is a submitter proxy that must be backed by a declared capability; on a `task = true` producer it is the inbound job's controller, filled by the dispatch path. `JobsRuntimeManager.wireConsumers` already encodes this (`if (meta.task()) continue`).

Worth noting Python has the same latent shape — `validate_mesh_dependencies` would flag these too, and is only saved by `heartbeat_preparation.py:109` gating the whole check on `if dependencies:`, which is a coarser dodge rather than a real distinction.

**One more, found only by running the SDK's own suite.** `MeshServiceToolParamTest$SkewProcessor` is a `task = true` producer that *does* declare a capability at the job slot's index, and the suite pins the resulting skew. So a producer's job slot is **optionally** declared, not never-declared. Fixed by giving `checkArity` a `minSlots`/`maxSlots` range.

After both, the only warnings anywhere are 3 pre-existing SDK test fixtures, all deliberately skewed and all genuine: `UnpairedMeshJobConsumer` (#1231's fixture), `NoDepConsumer`, and `DupCapProcessor`.

## One finding for your decision — deliberately not fixed here

**A `task = true` producer whose `MeshJob` parameter precedes an `McpMeshTool` parameter silently nulls the proxy.** Verified:

```
jobBeforeProxy(MeshJob job, McpMeshTool db), dependencies = {@Selector("db_cap")}
  dependency[0] 'db_cap' -> parameter 0 (MeshJob job) [job slot]   <- consumed by an INERT slot
  (no declared dependency) -> parameter 1 (McpMeshTool db) — injected null
```

`proxyBeforeJob` — the shape every in-tree example happens to use — binds correctly. The counts are legitimately in range, so arity checking is blind to it: this is an *ordering* defect, not an arity one.

The discriminator is ready and six lines (`task && binding.jobDepIndex() >= 0 && any PROXY slot with slotToDepIndex == -1`), with provably zero in-tree hits. It is not in this PR because it implies an answer to a question #1401 is itself about — whether a producer's controller slot should consume a declared index at all — and that wants an explicit decision rather than a silent guard. Fold into this PR or PR B, either works.

## Validation

`mvn -o test` green. **native 15 / core 117 / starter 739 / spring-ai 211 = 1082**, up 43 from the 1039 baseline — exactly the four new test classes (14+13+9+7), no existing test edited. `MeshToolWrapperUnresolvedDepPositionTest` 5/5 and `MeshPositionalBinderTest` 12/12 pass **unedited**. `go build ./...` clean.

Refs #1401
