### PR TITLE
feat(java)!: bind @MeshRoute and @MeshA2A dependencies by position

### DIFF
--- a/examples/java/producer-date-agent/src/main/java/com/example/dateproducer/ProducerDateAgentApplication.java
+++ b/examples/java/producer-date-agent/src/main/java/com/example/dateproducer/ProducerDateAgentApplication.java
@@ -39,8 +39,11 @@ import java.util.Map;
  *
  * <p>The mesh dependency on {@code date_service} demonstrates DDDI
  * inside an A2A handler: at request time the framework resolves the
- * {@link McpMeshTool} proxy through {@link MeshDependency} and injects
- * it at the {@link MeshInject} parameter slot — same wiring used by
+ * {@link McpMeshTool} proxy declared by {@link MeshDependency} and injects
+ * it into the first injectable parameter — dependencies pair with
+ * parameters by POSITION, in signature order. The {@link MeshInject}
+ * annotation does not select the dependency; it asserts the one position
+ * assigns, and startup fails if the two disagree. Same wiring used by
  * {@code @MeshRoute}.
  *
  * <h2>Stack</h2>

--- a/examples/java/rest-api-consumer/src/main/java/com/example/api/RestApiConsumerApplication.java
+++ b/examples/java/rest-api-consumer/src/main/java/com/example/api/RestApiConsumerApplication.java
@@ -84,8 +84,9 @@ class ApiController {
      * Greet a user via a mesh agent.
      *
      * <p>The @MeshRoute annotation declares a dependency on the "greeting" capability.
-     * At request time, the framework resolves the dependency and injects it as a
-     * McpMeshTool parameter (matched by parameter name).
+     * At request time, the framework resolves it and injects it into the first
+     * McpMeshTool parameter: dependencies pair with McpMeshTool parameters by
+     * POSITION, in signature order. The parameter's name is irrelevant.
      */
     @GetMapping("/greet")
     @MeshRoute(dependencies = @MeshDependency(capability = "greeting"))

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -418,6 +418,14 @@ public class MeshToolWrapper implements McpToolHandler {
         int minSlots = (task && meshJobParamIndex != null) ? slotCount - 1 : slotCount;
         MeshDiValidator.checkArity("@MeshTool", binding, minSlots, slotCount);
 
+        // Issue #1401: @MeshInject is a checked assertion at EVERY injection
+        // site, not just the web ones. It was silently ignored on @MeshTool
+        // parameters — the wrapper never even imported it — which meant the
+        // annotation quietly meant two different things depending on where it
+        // was written. Here it asserts the dependency positional pairing
+        // assigns; a value that disagrees fails the boot. It never selects.
+        io.mcpmesh.spring.web.MeshLegacyBindingDetector.inspectTool(binding);
+
         // Generate input schema (excluding injected params)
         this.inputSchema = generateInputSchema();
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ABeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ABeanPostProcessor.java
@@ -70,9 +70,9 @@ public class MeshA2ABeanPostProcessor implements BeanPostProcessor {
                 deps.add(MeshRouteRegistry.DependencySpec.fromAnnotation(dep));
             }
 
-            // Issue #1401: report handlers whose bindings would change when
-            // @MeshA2A moves from name-based to positional pairing. Warning
-            // only — this PR changes no binding behaviour.
+            // Issue #1401: @MeshA2A binds positionally. Fail the boot on a
+            // @MeshInject value that contradicts the position, and warn on a
+            // handler still shaped for the pre-3.4 name-based binding.
             MeshLegacyBindingDetector.inspectA2A(method, deps);
 
             String handlerMethodId = targetClass.getName() + "." + method.getName();

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshA2ADispatcher.java
@@ -3,6 +3,7 @@ package io.mcpmesh.spring.web;
 import io.mcpmesh.JobProxy;
 import io.mcpmesh.MeshJobSubmitter;
 import io.mcpmesh.spring.MeshDependencyInjector;
+import io.mcpmesh.spring.MeshPositionalBinder;
 import io.mcpmesh.spring.MeshRuntime;
 import io.mcpmesh.types.McpMeshTool;
 import tools.jackson.databind.JsonNode;
@@ -20,6 +21,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,9 +86,13 @@ public class MeshA2ADispatcher {
      * #936: {@code @MeshA2A} handlers may declare a {@link MeshJobSubmitter}
      * parameter that the framework auto-injects at call time. Submitters
      * are stateless after construction (capability + agent id + registry
-     * URL), so one cached instance per surface is correct — we look up
-     * by {@code handlerMethodId} since the same surface can be re-resolved
-     * across requests but always points at the same skill.
+     * URL), so one cached instance per surface is correct — we look up by
+     * the resolved {@link Method}, which identifies the surface exactly.
+     * {@code handlerMethodId} does not: it omits parameter types, so two
+     * overloaded handlers share it and the second would be handed the
+     * first's submitter — targeting the first's capability, since that is
+     * derived from the surface's own dependencies / {@code skillId}. See
+     * {@link #argPlans} for why one {@code Method} backs one surface.
      *
      * <p>This map ONLY contains successfully constructed submitters; the
      * sibling {@link #unbuildableSurfaces} set tracks surfaces we have
@@ -96,17 +102,25 @@ public class MeshA2ADispatcher {
      * identity through any future getter / debug API and keeps class-load
      * independent of {@link MeshJobSubmitter}'s constructor health.
      */
-    private final Map<String, MeshJobSubmitter> jobSubmitterCache = new ConcurrentHashMap<>();
+    private final Map<Method, MeshJobSubmitter> jobSubmitterCache = new ConcurrentHashMap<>();
 
     /**
-     * Set of surface handler IDs we have determined can NEVER produce a
-     * usable {@link MeshJobSubmitter} — either because no capability can
+     * Set of surfaces we have determined can NEVER produce a usable
+     * {@link MeshJobSubmitter} — either because no capability can
      * be derived or because the dispatcher was constructed without a
      * runtime provider. This is the "permanent unbuildable" memo; transient
      * conditions (runtime not yet available, agent id empty, constructor
      * threw) are NOT recorded here so they can be retried on the next call.
+     *
+     * <p>Keyed by {@link Method} for the same reason as
+     * {@link #jobSubmitterCache}: on {@code handlerMethodId} one overload
+     * could veto its same-named sibling. Both entry points here happen to be
+     * surface-independent today (no runtime provider at all) or unreachable
+     * (empty capability — {@code skillId} is validated non-empty), so the
+     * collision is currently latent rather than observable, but the memo must
+     * not out-live a widening of either condition.
      */
-    private final Set<String> unbuildableSurfaces = ConcurrentHashMap.newKeySet();
+    private final Set<Method> unbuildableSurfaces = ConcurrentHashMap.newKeySet();
 
     public MeshA2ADispatcher(
             MeshA2ARegistry registry,
@@ -589,14 +603,152 @@ public class MeshA2ADispatcher {
     // ─────────────────────────────────────────────────────────────────
 
     /**
+     * What a {@code @MeshA2A} handler parameter is for. Roles are assigned in
+     * the order declared here — see {@link #planArguments} for why the
+     * precedence is written down rather than left to branch order.
+     */
+    private enum ParamRole {
+        /** A declared {@code @MeshDependency}, bound positionally. */
+        DEPENDENCY,
+        /** A framework-constructed {@link MeshJobSubmitter} (issue #936). */
+        JOB_SUBMITTER,
+        /** The inbound A2A message. */
+        MESSAGE,
+        /** Nothing binds here; the parameter receives null. */
+        UNBOUND
+    }
+
+    /**
+     * The fixed argument layout of one {@code @MeshA2A} surface.
+     *
+     * @param roles       per signature position
+     * @param slotOrdinal per signature position: the injectable-slot ordinal of
+     *                    a {@link ParamRole#DEPENDENCY} parameter, else -1
+     * @param binding     the positional pairing of declared dependencies with
+     *                    those slots
+     */
+    private record ArgPlan(
+        ParamRole[] roles, int[] slotOrdinal, MeshPositionalBinder.Binding binding) {}
+
+    /**
+     * Per-surface argument layout. Depends only on the handler signature and the
+     * declared dependency list, both fixed at boot.
+     *
+     * <p>Keyed by the resolved {@link Method}, NOT by
+     * {@code handlerMethodId} — that id is {@code "ClassName.methodName"} with
+     * no parameter types, so two overloaded {@code @MeshA2A} handlers collide on
+     * it, and {@link MeshA2ARegistry} dedupes surfaces by {@code path} rather
+     * than by handler id, so both overloads do register. The second overload
+     * would then be invoked with the first one's plan. One {@code Method} backs
+     * at most one surface: {@code @MeshA2A} is not {@code @Repeatable}, so the
+     * path (and the whole dependency list) is fixed by the single annotation the
+     * method carries, and a second registration of the same method is refused by
+     * the registry's path-collision guard. Matches
+     * {@link MeshInjectArgumentResolver}, which is {@code Method}-keyed already.
+     */
+    private final Map<Method, ArgPlan> argPlans = new ConcurrentHashMap<>();
+
+    /**
+     * Assign a role to every parameter of a {@code @MeshA2A} handler.
+     *
+     * <p><b>The precedence is explicit, in passes, rather than implicit in the
+     * order of an if/else chain</b> (issue #1401). The four roles genuinely
+     * compete for the same positions, and one competition is easy to miss: the
+     * message's "parameter 0 takes it if nothing else did" fallback wants index
+     * 0, and so does an {@code McpMeshTool} declared first. Writing the passes
+     * out states which wins instead of leaving it to whichever branch happens to
+     * be tested first.
+     *
+     * <ol>
+     *   <li><b>Dependency slots win outright.</b> {@link MeshInjectableSlots#isA2AInjectable}
+     *       — an {@code McpMeshTool} parameter, or <i>any</i> parameter carrying
+     *       {@link MeshInject}. The A2A rule is wider than the route rule
+     *       because the dispatcher owns the whole argument array; there is no
+     *       Spring MVC resolver chain behind it, so the annotation is an
+     *       unambiguous statement of intent whatever the parameter's type.</li>
+     *   <li><b>Then {@link MeshJobSubmitter}</b>, which is built from the
+     *       surface rather than paired with a declared dependency, and so
+     *       consumes no declared index.</li>
+     *   <li><b>Then the message</b>, at the first parameter no earlier pass
+     *       claimed whose type is a {@link Map} — or, if every {@code Map}
+     *       parameter is already claimed, at parameter 0 when <i>that</i> is
+     *       unclaimed (a handler taking a custom POJO). An occupied index 0
+     *       simply leaves the message unassigned, exactly as before.</li>
+     *   <li><b>Everything else</b> receives null.</li>
+     * </ol>
+     *
+     * <p>Dependency slots then pair with the declared list through
+     * {@link MeshPositionalBinder}: the Nth slot takes the Nth declared
+     * {@code @MeshDependency}, and parameter names are not consulted.
+     */
+    private static ArgPlan planArguments(MeshA2ARegistry.SurfaceMetadata surface) {
+        Method method = surface.method();
+        Parameter[] params = method.getParameters();
+        ParamRole[] roles = new ParamRole[params.length];
+        int[] slotOrdinal = new int[params.length];
+        Arrays.fill(slotOrdinal, -1);
+
+        // Pass 1 — dependency slots.
+        List<MeshPositionalBinder.Slot> slots = MeshInjectableSlots.a2aSlots(method);
+        for (int k = 0; k < slots.size(); k++) {
+            int position = slots.get(k).parameterPosition();
+            roles[position] = ParamRole.DEPENDENCY;
+            slotOrdinal[position] = k;
+        }
+
+        // Pass 2 — framework-constructed job submitter.
+        for (int i = 0; i < params.length; i++) {
+            if (roles[i] == null && MeshJobSubmitter.class.isAssignableFrom(params[i].getType())) {
+                roles[i] = ParamRole.JOB_SUBMITTER;
+            }
+        }
+
+        // Pass 3 — the message.
+        int messageIndex = -1;
+        for (int i = 0; i < params.length; i++) {
+            if (roles[i] == null && Map.class.isAssignableFrom(params[i].getType())) {
+                messageIndex = i;
+                break;
+            }
+        }
+        if (messageIndex < 0 && params.length > 0 && roles[0] == null) {
+            messageIndex = 0;
+        }
+        if (messageIndex >= 0) {
+            roles[messageIndex] = ParamRole.MESSAGE;
+        }
+
+        // Pass 4 — everything else.
+        for (int i = 0; i < params.length; i++) {
+            if (roles[i] == null) {
+                roles[i] = ParamRole.UNBOUND;
+            }
+        }
+
+        List<MeshRouteRegistry.DependencySpec> deps =
+            surface.dependencies() == null ? List.of() : surface.dependencies();
+        List<String> capabilities = new ArrayList<>();
+        for (MeshRouteRegistry.DependencySpec dep : deps) {
+            capabilities.add(dep.getCapability());
+        }
+        MeshPositionalBinder.Binding binding = MeshPositionalBinder.bind(
+            method, slots, capabilities, capabilities.size());
+
+        return new ArgPlan(roles, slotOrdinal, binding);
+    }
+
+    /**
      * Reflectively invoke the user's {@code @MeshA2A} handler with:
      * <ul>
-     *   <li>the A2A {@code message} at the first {@link Map} parameter slot,
-     *       OR at index 0 when none of the params is a {@code Map};</li>
-     *   <li>{@link McpMeshTool} proxies at any parameter annotated
-     *       {@link MeshInject} (or whose type is {@link McpMeshTool}),
-     *       resolved through {@link MeshDependencyInjector} — same DDDI
-     *       wiring used by {@code @MeshRoute} and {@code @A2AConsumer};</li>
+     *   <li>the A2A {@code message} at the first unclaimed {@link Map}
+     *       parameter, OR at index 0 when none of the params is an unclaimed
+     *       {@code Map};</li>
+     *   <li>{@link McpMeshTool} proxies at the dependency slots, bound
+     *       <b>positionally</b> — the Nth injectable parameter receives the Nth
+     *       declared {@code @MeshDependency}, and parameter names are never
+     *       consulted (issue #1401). Resolved through
+     *       {@link MeshDependencyInjector} — same DDDI wiring used by
+     *       {@code @MeshRoute} and {@code @A2AConsumer};</li>
      *   <li>a {@link MeshJobSubmitter} at any parameter typed
      *       {@code MeshJobSubmitter} (issue #936) — auto-constructed by the
      *       framework with the surface's task capability + the local agent
@@ -608,40 +760,26 @@ public class MeshA2ADispatcher {
      *       {@code '_'} (the canonical skill-id-to-capability mapping —
      *       matches the existing examples' usage).</li>
      * </ul>
+     *
+     * <p>The argument array is sized to the parameter count and filled by index,
+     * so an unresolvable dependency nulls its own slot and shifts nothing.
      */
-    @SuppressWarnings("unchecked")
     private Object invokeHandler(MeshA2ARegistry.SurfaceMetadata surface, Map<String, Object> message)
             throws Throwable {
         Method method = surface.method();
-        Parameter[] params = method.getParameters();
-        Object[] args = new Object[params.length];
+        ArgPlan plan = argPlans.computeIfAbsent(method, m -> planArguments(surface));
+        Object[] args = new Object[method.getParameterCount()];
 
-        boolean messageAssigned = false;
-        for (int i = 0; i < params.length; i++) {
-            Parameter p = params[i];
-            MeshInject inj = p.getAnnotation(MeshInject.class);
-            // Slot classification lives in MeshInjectableSlots (issue #1401)
-            // so the boot-time legacy-shape detector sees exactly the set of
-            // parameters this loop treats as dependency slots.
-            if (MeshInjectableSlots.isA2AInjectable(p)) {
-                args[i] = resolveDependency(surface, p, inj);
-            } else if (MeshJobSubmitter.class.isAssignableFrom(p.getType())) {
+        for (int i = 0; i < args.length; i++) {
+            args[i] = switch (plan.roles()[i]) {
+                case DEPENDENCY -> resolveDependency(surface, plan, i);
                 // Issue #936: framework-injected MeshJobSubmitter for
                 // long-running producers. Cache per surface — the submitter
                 // is stateless after construction.
-                args[i] = resolveJobSubmitter(surface);
-            } else if (Map.class.isAssignableFrom(p.getType()) && !messageAssigned) {
-                args[i] = message;
-                messageAssigned = true;
-            } else if (!messageAssigned && i == 0) {
-                // First non-DI parameter takes the message even if it's
-                // not a Map (e.g., user wants a custom POJO — out of scope
-                // for Chunk 1A, but we don't crash).
-                args[i] = message;
-                messageAssigned = true;
-            } else {
-                args[i] = null;
-            }
+                case JOB_SUBMITTER -> resolveJobSubmitter(surface);
+                case MESSAGE -> message;
+                case UNBOUND -> null;
+            };
         }
 
         try {
@@ -674,14 +812,17 @@ public class MeshA2ADispatcher {
      * </ol>
      */
     private MeshJobSubmitter resolveJobSubmitter(MeshA2ARegistry.SurfaceMetadata surface) {
+        // The Method identifies the surface; handlerMethodId is for humans
+        // reading the logs below and is NOT unique across overloads.
+        Method key = surface.method();
         String surfaceId = surface.handlerMethodId();
         // Permanent-unbuildable check first: surfaces marked here will
         // NEVER produce a submitter (no capability, or no runtime provider
         // wired) so short-circuit without touching the runtime provider.
-        if (unbuildableSurfaces.contains(surfaceId)) {
+        if (unbuildableSurfaces.contains(key)) {
             return null;
         }
-        MeshJobSubmitter cached = jobSubmitterCache.get(surfaceId);
+        MeshJobSubmitter cached = jobSubmitterCache.get(key);
         if (cached != null) {
             return cached;
         }
@@ -690,7 +831,7 @@ public class MeshA2ADispatcher {
                 + "constructed without a MeshRuntime provider — injecting null. Use the "
                 + "five-arg MeshA2ADispatcher constructor (the Spring autoconfiguration wires "
                 + "this automatically).", surfaceId);
-            unbuildableSurfaces.add(surfaceId);
+            unbuildableSurfaces.add(key);
             return null;
         }
         MeshRuntime runtime;
@@ -727,12 +868,12 @@ public class MeshA2ADispatcher {
             log.warn("@MeshA2A {} declares MeshJobSubmitter parameter but no capability can be "
                 + "derived (no @MeshDependency declared and skillId is empty) — injecting null.",
                 surfaceId);
-            unbuildableSurfaces.add(surfaceId);
+            unbuildableSurfaces.add(key);
             return null;
         }
         try {
             MeshJobSubmitter submitter = new MeshJobSubmitter(capability, agentId, registryUrl);
-            jobSubmitterCache.put(surfaceId, submitter);
+            jobSubmitterCache.put(key, submitter);
             log.info("@MeshA2A {}: auto-injected MeshJobSubmitter (capability={}, agentId={})",
                 surfaceId, capability, agentId);
             return submitter;
@@ -765,29 +906,42 @@ public class MeshA2ADispatcher {
         return skillId.replace('-', '_');
     }
 
+    /**
+     * Resolve the dependency proxy for the parameter at signature position
+     * {@code position}, which {@link #planArguments} classified as a
+     * {@link ParamRole#DEPENDENCY} slot.
+     *
+     * <p>Positional (issue #1401): the parameter's injectable-slot ordinal
+     * selects the declared {@code @MeshDependency}, through the pairing table
+     * {@link MeshPositionalBinder} built at plan time. The parameter's name and
+     * any {@link MeshInject} value take no part — the annotation is checked as
+     * an assertion at boot ({@link MeshLegacyBindingDetector}), so by the time a
+     * request arrives the two cannot disagree. Resolution goes through the
+     * injector so the proxy lifecycle matches the {@code @MeshRoute} path.
+     */
     private McpMeshTool resolveDependency(
-            MeshA2ARegistry.SurfaceMetadata surface, Parameter param, MeshInject inj) {
+            MeshA2ARegistry.SurfaceMetadata surface, ArgPlan plan, int position) {
+        int ordinal = plan.slotOrdinal()[position];
+        int[] slotToDepIndex = plan.binding().slotToDepIndex();
+        int depIndex = ordinal >= 0 && ordinal < slotToDepIndex.length
+            ? slotToDepIndex[ordinal] : -1;
+        if (depIndex < 0) {
+            log.warn("@MeshA2A {}: parameter {} is injectable slot {}, but only {} "
+                    + "@MeshDependency entr{} declared — injecting null. dependencies[i] binds "
+                    + "to the i-th injectable parameter.",
+                surface.handlerMethodId(), position, ordinal,
+                plan.binding().capabilities().size(),
+                plan.binding().capabilities().size() == 1 ? "y is" : "ies are");
+            return null;
+        }
+
         MeshDependencyInjector injector = injectorProvider.getIfAvailable();
         if (injector == null) {
             log.warn("@MeshA2A {}: MeshDependencyInjector unavailable; injecting null McpMeshTool",
                 surface.handlerMethodId());
             return null;
         }
-        String requestedCapability = (inj != null && !inj.value().isEmpty())
-            ? inj.value() : param.getName();
-        // Match against the declared dependencies — the @MeshInject value
-        // (or parameter name) must align with one of @MeshA2A's
-        // @MeshDependency entries. We resolve through the injector so the
-        // proxy lifecycle matches the @MeshRoute path.
-        for (MeshRouteRegistry.DependencySpec dep : surface.dependencies()) {
-            if (dep.getCapability().equals(requestedCapability)
-                || requestedCapability.equals(dep.getParameterName())) {
-                return injector.getToolProxy(dep.getCapability());
-            }
-        }
-        log.debug("@MeshA2A {}: no @MeshDependency matches parameter '{}'",
-            surface.handlerMethodId(), requestedCapability);
-        return null;
+        return injector.getToolProxy(plan.binding().capabilities().get(depIndex));
     }
 
     // ─────────────────────────────────────────────────────────────────

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshInject.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshInject.java
@@ -7,23 +7,32 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Injects a mesh dependency directly into a controller method parameter.
+ * Asserts which mesh dependency a handler parameter is expected to receive.
  *
- * <p>This annotation provides a cleaner alternative to accessing dependencies
- * via request attributes. It works in conjunction with {@link MeshRoute} to
- * inject resolved {@link io.mcpmesh.types.McpMeshTool} proxies.
+ * <p><b>{@code @MeshInject} no longer selects a dependency; it asserts the one
+ * positional pairing assigns</b> (issue #1401). Dependencies bind by position at
+ * every mesh injection site: the Nth declared {@code @MeshDependency} /
+ * {@code @Selector} goes to the Nth injectable parameter in signature order, and
+ * parameter names are never consulted. This annotation states which capability
+ * the author believes lands on a parameter, and the framework <b>fails the
+ * boot</b> if position says otherwise.
+ *
+ * <p>It is optional. Adding it to a correctly-ordered handler changes nothing at
+ * runtime and costs nothing per request; removing it changes nothing either.
+ * Its value is as a safety net on handlers with several same-typed slots, where
+ * an accidental reorder is otherwise type-compatible and silent.
  *
  * <h2>Example Usage</h2>
  * <pre>{@code
  * @PostMapping("/process")
  * @MeshRoute(dependencies = {
- *     @MeshDependency(capability = "pdf-tool"),
- *     @MeshDependency(capability = "ocr-service")
+ *     @MeshDependency(capability = "pdf-tool"),      // slot 0
+ *     @MeshDependency(capability = "ocr-service")    // slot 1
  * })
  * public ResponseEntity<Result> processDocument(
- *         @RequestBody DocumentRequest request,
- *         @MeshInject("pdf-tool") McpMeshTool pdfTool,
- *         @MeshInject("ocr-service") McpMeshTool ocrService) {
+ *         @RequestBody DocumentRequest request,               // not a slot
+ *         @MeshInject("pdf-tool") McpMeshTool pdfTool,        // slot 0 — asserted
+ *         @MeshInject("ocr-service") McpMeshTool ocrService) { // slot 1 — asserted
  *
  *     // Use the injected tools directly
  *     Map<String, Object> text = pdfTool.call(Map.of("url", request.getUrl()));
@@ -33,17 +42,22 @@ import java.lang.annotation.Target;
  * }
  * }</pre>
  *
- * <h2>Parameter Naming</h2>
+ * <p>Swapping the two {@code @MeshInject} values without swapping the
+ * {@code @MeshDependency} entries no longer swaps the proxies — it fails
+ * startup, naming both orderings.
  *
- * <p>The {@link #value()} specifies which capability to inject. This must
- * match a capability declared in the method's {@link MeshRoute#dependencies()}.
+ * <h2>Where it applies</h2>
  *
- * <p>If {@code value} is empty, the parameter name is used as the capability
- * name (requires compilation with {@code -parameters} flag).
+ * <p>{@code @MeshRoute}, {@code @MeshA2A} and {@code @MeshTool}, with the same
+ * meaning at all three. On the {@code @MeshA2A} path the annotation additionally
+ * marks a parameter as a dependency slot even when its type is not
+ * {@link io.mcpmesh.types.McpMeshTool} — the dispatcher owns the whole argument
+ * array there, so the annotation is an unambiguous statement of intent.
  *
  * <h2>Type Requirements</h2>
  *
- * <p>The parameter type must be assignable from {@link io.mcpmesh.types.McpMeshTool}.
+ * <p>On {@code @MeshRoute} and {@code @MeshTool} the parameter type must be
+ * assignable from {@link io.mcpmesh.types.McpMeshTool}.
  *
  * @see MeshRoute
  * @see MeshDependency
@@ -54,10 +68,15 @@ import java.lang.annotation.Target;
 public @interface MeshInject {
 
     /**
-     * The capability name to inject.
+     * The capability this parameter is expected to receive.
      *
-     * <p>Must match a capability declared in {@link MeshRoute#dependencies()}.
-     * If empty, the parameter name is used.
+     * <p>Must name the dependency that positional pairing assigns to this
+     * parameter — the declared entry at the parameter's injectable-slot index.
+     * The {@link MeshDependency#name()} alias of that same entry is accepted as
+     * a second spelling. Anything else fails startup.
+     *
+     * <p>Empty (the default) asserts nothing; the parameter still binds by
+     * position.
      *
      * @return capability name
      */

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshInjectArgumentResolver.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshInjectArgumentResolver.java
@@ -1,5 +1,6 @@
 package io.mcpmesh.spring.web;
 
+import io.mcpmesh.spring.MeshPositionalBinder;
 import io.mcpmesh.types.McpMeshTool;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
@@ -10,54 +11,71 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Resolves {@link McpMeshTool} controller method parameters for @MeshRoute handlers.
  *
- * <p>This argument resolver enables clean dependency injection in two styles:
+ * <h2>Binding is positional (issue #1401)</h2>
  *
- * <h3>Style 1: Plain McpMeshTool (recommended, matches @MeshTool pattern)</h3>
+ * <p>The Nth {@code McpMeshTool} parameter, in signature order, receives the Nth
+ * entry of {@code dependencies = {...}}. <b>Parameter names are never
+ * consulted.</b> This is the same contract as {@code @MeshTool}, and as every
+ * Python and TypeScript injection site.
+ *
  * <pre>{@code
  * @PostMapping("/process")
  * @MeshRoute(dependencies = {
- *     @MeshDependency(capability = "pdf-tool")
+ *     @MeshDependency(capability = "pdf-tool"),      // -> pdfTool
+ *     @MeshDependency(capability = "ocr-service")    // -> ocrService
  * })
  * public ResponseEntity<String> process(
- *         @RequestBody Request request,
- *         McpMeshTool<String> pdfTool) {  // Matches by parameter name
+ *         @RequestBody Request request,              // not an injectable slot
+ *         McpMeshTool<String> pdfTool,               // slot 0
+ *         McpMeshTool<String> ocrService) {          // slot 1
  *
  *     pdfTool.call(Map.of("data", request.getData()));
  * }
  * }</pre>
  *
- * <h3>Style 2: With @MeshInject annotation (explicit capability)</h3>
- * <pre>{@code
- * @PostMapping("/process")
- * @MeshRoute(dependencies = {
- *     @MeshDependency(capability = "pdf-tool")
- * })
- * public ResponseEntity<String> process(
- *         @RequestBody Request request,
- *         @MeshInject("pdf-tool") McpMeshTool<String> tool) {  // Explicit capability
+ * <p>Reordering {@code dependencies = {...}} reorders the parameters it feeds.
+ * Renaming a parameter changes nothing.
  *
- *     tool.call(Map.of("data", request.getData()));
- * }
- * }</pre>
+ * <h2>{@link MeshInject} is an assertion, not a selector</h2>
  *
- * <p>The resolver retrieves dependencies from request attributes populated
- * by {@link MeshRouteHandlerInterceptor}.
+ * <p>Annotating a parameter {@code @MeshInject("pdf-tool")} does not choose the
+ * dependency — position already did. It states which one the author expects, and
+ * {@link MeshLegacyBindingDetector} fails the boot if the two disagree. It is
+ * optional, costs nothing at request time, and is worth adding to a handler with
+ * several same-typed slots.
+ *
+ * <p>The resolver retrieves dependencies from the positional list request
+ * attribute populated by {@link MeshRouteHandlerInterceptor}; capability-keyed
+ * access remains available through {@link MeshRouteUtils}.
  */
 public class MeshInjectArgumentResolver implements HandlerMethodArgumentResolver {
 
     private static final Logger log = LoggerFactory.getLogger(MeshInjectArgumentResolver.class);
 
+    /**
+     * Per-handler map from signature position to injectable slot ordinal (-1
+     * for a parameter that is not a slot). Derived from
+     * {@link MeshInjectableSlots#routeSlots}, so it cannot disagree with what
+     * the boot-time checks enumerated; cached because Spring MVC calls this
+     * resolver once per matching parameter per request.
+     */
+    private final Map<Method, int[]> slotOrdinals = new ConcurrentHashMap<>();
+
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         // Support McpMeshTool parameters - with or without @MeshInject.
         // The predicate lives in MeshInjectableSlots (issue #1401) so the
-        // boot-time legacy-shape detector classifies parameters exactly the
-        // way this resolver does, rather than re-deriving the rule.
+        // boot-time binding checks classify parameters exactly the way this
+        // resolver does, rather than re-deriving the rule.
         return MeshInjectableSlots.isRouteInjectable(parameter.getParameterType());
     }
 
@@ -66,22 +84,24 @@ public class MeshInjectArgumentResolver implements HandlerMethodArgumentResolver
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
 
-        // Determine capability name from annotation or parameter name
-        String capability = null;
-
-        MeshInject annotation = parameter.getParameterAnnotation(MeshInject.class);
-        if (annotation != null && !annotation.value().isEmpty()) {
-            capability = annotation.value();
+        Method method = parameter.getMethod();
+        if (method == null) {
+            log.error("McpMeshTool injection is only supported on handler METHOD parameters");
+            return null;
         }
 
-        if (capability == null) {
-            // Fall back to parameter name (requires -parameters compiler flag)
-            capability = parameter.getParameterName();
-            if (capability == null) {
-                log.error("Cannot determine capability name for McpMeshTool parameter. " +
-                    "Either use @MeshInject(\"capability\") or compile with -parameters flag.");
-                return null;
-            }
+        // Which injectable slot is this parameter? That ordinal — not the
+        // parameter's name — is the declared-dependency index it binds to.
+        int ordinal = slotOrdinals
+            .computeIfAbsent(method, MeshInjectArgumentResolver::slotOrdinalsOf)
+            [parameter.getParameterIndex()];
+        if (ordinal < 0) {
+            // supportsParameter and MeshInjectableSlots agree by construction,
+            // so this is unreachable; fail loudly rather than silently if a
+            // future change breaks that.
+            log.error("McpMeshTool parameter {} of {} is not an injectable slot",
+                parameter.getParameterIndex(), method.getName());
+            return null;
         }
 
         // Get the HttpServletRequest
@@ -93,20 +113,39 @@ public class MeshInjectArgumentResolver implements HandlerMethodArgumentResolver
 
         // Retrieve dependencies from request attributes
         Object depsAttr = request.getAttribute(MeshRouteHandlerInterceptor.MESH_DEPENDENCIES_ATTR);
-        if (depsAttr == null) {
+        if (!(depsAttr instanceof List)) {
             log.debug("No mesh dependencies in request - not a @MeshRoute handler");
             return null;
         }
 
-        Map<String, McpMeshTool> dependencies = (Map<String, McpMeshTool>) depsAttr;
-
-        // Look up by capability name or parameter name
-        McpMeshTool tool = dependencies.get(capability);
-        if (tool == null) {
-            log.warn("Dependency '{}' not found in resolved dependencies. " +
-                "Make sure it's declared in @MeshRoute dependencies.", capability);
+        List<McpMeshTool> dependencies = (List<McpMeshTool>) depsAttr;
+        if (ordinal >= dependencies.size()) {
+            log.warn("@MeshRoute {}.{}: parameter {} is injectable slot {}, but only {} "
+                    + "dependenc{} declared — injecting null. Declare one @MeshDependency per "
+                    + "injectable parameter; dependencies[i] binds to the i-th one.",
+                method.getDeclaringClass().getSimpleName(), method.getName(),
+                parameter.getParameterIndex(), ordinal, dependencies.size(),
+                dependencies.size() == 1 ? "y is" : "ies are");
+            return null;
         }
 
+        McpMeshTool tool = dependencies.get(ordinal);
+        if (tool == null) {
+            log.warn("@MeshRoute {}.{}: dependency at index {} is unavailable — injecting null "
+                    + "into parameter {}. Every other parameter keeps its own dependency.",
+                method.getDeclaringClass().getSimpleName(), method.getName(), ordinal,
+                parameter.getParameterIndex());
+        }
         return tool;
+    }
+
+    private static int[] slotOrdinalsOf(Method method) {
+        int[] ordinals = new int[method.getParameterCount()];
+        Arrays.fill(ordinals, -1);
+        List<MeshPositionalBinder.Slot> slots = MeshInjectableSlots.routeSlots(method);
+        for (int k = 0; k < slots.size(); k++) {
+            ordinals[slots.get(k).parameterPosition()] = k;
+        }
+        return ordinals;
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshInjectableSlots.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshInjectableSlots.java
@@ -22,17 +22,22 @@ import java.util.List;
  * {@code @A2AConsumer} checks. Re-deriving them in the binder would duplicate
  * that classification.
  *
- * <p>The legacy-shape detector ({@link MeshLegacyBindingDetector}) needs the
- * same question answered for route and A2A handlers at boot, and the live
- * resolvers answer it at request time. Writing the predicate twice is exactly
- * the drift surface #1401 exists to close, so it is written once — here — and
- * the live resolvers call it:
+ * <p>The boot-time binding checks ({@link MeshLegacyBindingDetector}) need the
+ * same question answered for route and A2A handlers, and the live resolvers
+ * answer it at request time. Under positional binding the answer also fixes the
+ * <i>slot ordinals</i> — which declared dependency each parameter gets — so a
+ * second, subtly different predicate would not merely disagree about a
+ * diagnostic, it would misbind. That is exactly the drift surface #1401 exists
+ * to close, so it is written once — here — and the live resolvers call it:
  *
  * <ul>
  *   <li>{@link MeshInjectArgumentResolver#supportsParameter} →
- *       {@link #isRouteInjectable(Class)}</li>
- *   <li>{@code MeshA2ADispatcher.invokeHandler}'s dependency branch →
- *       {@link #isA2AInjectable(Parameter)}</li>
+ *       {@link #isRouteInjectable(Class)}; its slot ordinals →
+ *       {@link #routeSlots(Method)}</li>
+ *   <li>{@code MeshRouteBeanPostProcessor.enrichDependencyReturnTypes} →
+ *       {@link #routeSlots(Method)}, so the {@code McpMeshTool<T>} generic lands
+ *       on the dependency that parameter actually binds to</li>
+ *   <li>{@code MeshA2ADispatcher.planArguments} → {@link #a2aSlots(Method)}</li>
  * </ul>
  *
  * <h2>The two rules genuinely differ</h2>
@@ -51,12 +56,13 @@ import java.util.List;
  *       the annotation is the user's unambiguous statement of intent.</li>
  * </ul>
  *
- * <p>A2A's message-fallback rule ("the parameter at index 0 takes the message
- * if nothing else claimed it") does not compete with these slots: the
- * dependency branch is evaluated <i>first</i> in {@code invokeHandler}, so a
- * slot always wins index 0. Neither does {@code MeshJobSubmitter}, which is
- * framework-constructed from the surface rather than paired with a declared
- * dependency — it is not a slot here, and it consumes no declared index.
+ * <p>A2A's message-fallback rule ("the parameter at index 0 takes the message if
+ * nothing else claimed it") does compete for index 0 with a slot declared first,
+ * and slots win. That precedence is stated explicitly in
+ * {@code MeshA2ADispatcher.planArguments} rather than left implicit in the order
+ * of an if/else chain. {@code MeshJobSubmitter} does not compete either way: it
+ * is framework-constructed from the surface rather than paired with a declared
+ * dependency — not a slot here, and it consumes no declared index.
  *
  * @see MeshLegacyBindingDetector
  * @see MeshPositionalBinder

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshLegacyBindingDetector.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshLegacyBindingDetector.java
@@ -13,55 +13,68 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * The migration instrument for issue #1401: at boot, tell a user whether their
- * {@code @MeshRoute} / {@code @MeshA2A} handler means something different once
- * those sites move from name-based to positional dependency binding.
+ * Boot-time guard for the positional dependency contract (issue #1401): it
+ * checks {@code @MeshInject} as an <b>assertion</b>, and reports handlers still
+ * shaped for the name-based binding that {@code @MeshRoute} / {@code @MeshA2A}
+ * used before 3.4.
  *
- * <h2>What it compares</h2>
+ * <h2>The contract this enforces</h2>
+ *
+ * <p>Every mesh injection site now pairs dependencies with parameters
+ * <i>positionally</i>: the Nth declared dependency binds to the Nth injectable
+ * parameter in signature order, and <b>parameter names are never consulted</b>.
+ * {@code @MeshTool} always worked this way; as of 3.4 so do {@code @MeshRoute}
+ * and {@code @MeshA2A}, matching Python and TypeScript.
+ *
+ * <h2>Two checks, two severities</h2>
  *
  * <p>For each handler it enumerates the injectable slots in signature order
  * ({@link MeshInjectableSlots}) and pairs them positionally with the declared
- * {@code @MeshDependency} list — the binding of the future. Against that it puts
- * the binding of today: the capability name each slot resolves through, which is
- * {@code @MeshInject}'s value when non-empty and the parameter name otherwise.
- * Four outcomes per slot:
+ * dependency list ({@link MeshPositionalBinder}). Then, per slot:
  *
  * <ul>
- *   <li><b>Agrees</b> — the name resolves to the same dependency the position
- *       would. Positional and by-name binding are identical here; nothing
- *       changes, and nothing is reported (DEBUG).</li>
- *   <li><b>Reordered</b> — the name resolves to a <i>different</i> declared
- *       dependency. The handler was written under name-binding with an order
- *       positional binding would change. <b>WARN</b> today; the conversion PR
- *       makes it fatal.</li>
- *   <li><b>Undeclared</b> — the name matches nothing declared. This is
- *       <i>already</i> broken: {@code MeshInjectArgumentResolver} warns and
- *       injects null at request time. Reported as an <b>ERROR</b>, because a
- *       boot-time error beats a per-request warning.</li>
- *   <li><b>No name available</b> — no {@code @MeshInject} value and the class
- *       was compiled without {@code -parameters}. Spring's
- *       {@code MethodParameter.getParameterName()} returns null (verified: the
- *       reflection {@code Parameter.getName()} yields {@code arg0}, and Spring's
- *       {@code StandardReflectionParameterNameDiscoverer} refuses to use it), so
- *       the route resolver already logs an error and injects null, and the A2A
- *       dispatcher already matches {@code "arg0"} against nothing. <b>There is
- *       no working code in this shape</b> — which is what makes the conversion
- *       safe. Reported as an <b>ERROR</b>.</li>
+ *   <li><b>{@code @MeshInject} carries a value → ERROR unless it names the
+ *       dependency positional pairing assigns.</b> The annotation no longer
+ *       <i>selects</i> a dependency; it <i>asserts</i> the one position already
+ *       chose. Correctly-ordered code is unaffected and gains a compile-time-ish
+ *       safety net; a value that disagrees is a boot failure rather than the
+ *       silent rebinding it would otherwise be. It is deliberately NOT an
+ *       override — an override would put two matching rules back inside one
+ *       annotation family, which is the hazard #1401 exists to close.</li>
+ *   <li><b>No {@code @MeshInject}, but the parameter's NAME resolves to a
+ *       different declared dependency → WARN.</b> This is the 3.3-and-earlier
+ *       shape: the handler was written when the name decided, so it binds
+ *       differently now. It is a warning, not an error, because names carry no
+ *       meaning under the new contract and a coincidence must not fail a boot.
+ *       Adding a {@code @MeshInject} that agrees with the position silences it
+ *       and turns the slot into an asserted one. Applies only to the two sites
+ *       that <i>were</i> name-based — {@code @MeshTool} never consulted names,
+ *       so a name coincidence there is not a migration signal
+ *       ({@link #analyzeTool}).</li>
  * </ul>
+ *
+ * <h2>What is no longer reported</h2>
+ *
+ * <p>PR A (the warning-only predecessor of this class) raised an ERROR for a
+ * parameter with no {@code @MeshInject} value and no name — a class compiled
+ * without {@code -parameters}. Under name binding that parameter bound to
+ * nothing and was injected null; under positional binding it binds correctly,
+ * because names were the only thing missing. That shape is now <b>OK</b>. The
+ * same goes for a parameter whose name happens to match no declared capability.
  *
  * <h2>What it deliberately does not check</h2>
  *
  * <p><b>Arity.</b> Unlike {@code @MeshTool} (see
  * {@link MeshDiValidator#checkArity}), a route or A2A surface with more declared
  * dependencies than injectable parameters is <i>legitimate and documented</i>:
- * {@code MeshRouteUtils.getDependencies(request)} hands the whole resolved map
- * to the handler, and a dependency-declaring surface with zero parameters is the
+ * {@link MeshRouteUtils#getDependencies} hands the resolved set to the handler
+ * by capability, and a dependency-declaring surface with zero parameters is the
  * canonical way to publish a capability edge that a constructor-injected
  * {@code @Qualifier} bean consumes. Reporting arity here would fire on correct
- * code. Every slot that actually goes unbound is caught by the per-slot analysis
- * above instead.
+ * code.
  *
  * @see MeshInjectableSlots
+ * @see MeshPositionalBinder
  * @see MeshDiValidator
  */
 public final class MeshLegacyBindingDetector {
@@ -72,11 +85,18 @@ public final class MeshLegacyBindingDetector {
 
     /** How bad a handler's shape is. */
     public enum Severity {
-        /** Positional and by-name binding agree — nothing changes. */
+        /** Nothing to report: every asserted slot agrees with its position. */
         OK,
-        /** At least one slot's binding changes under positional pairing. */
+        /**
+         * A parameter's NAME points at a different declared dependency than its
+         * position does — the 3.3 shape. Logged; fatal under
+         * {@code MCP_MESH_STRICT_DI}.
+         */
         WARN,
-        /** At least one slot binds to nothing today — already broken. */
+        /**
+         * A {@code @MeshInject} value contradicts positional pairing. Always
+         * fatal.
+         */
         ERROR
     }
 
@@ -84,21 +104,28 @@ public final class MeshLegacyBindingDetector {
      * The verdict for one handler.
      *
      * @param severity worst per-slot outcome
-     * @param message  the human-readable diagnostic; empty when {@code OK}
+     * @param message  the human-readable diagnostic; a DEBUG-grade summary when
+     *                 {@code OK}
      */
     public record Finding(Severity severity, String message) {}
 
     /** Per-slot outcome. */
-    private enum SlotVerdict { AGREES, REORDERED, UNDECLARED, NO_NAME }
+    private enum SlotVerdict {
+        /** Nothing to say about this slot. */
+        OK,
+        /** {@code @MeshInject} names something other than the paired dependency. */
+        ASSERTION_VIOLATED,
+        /** The parameter name resolves to a different declared dependency. */
+        NAME_CROSSOVER
+    }
 
     /**
-     * Inspect a {@code @MeshRoute} handler and report through the logger,
-     * honouring {@code MCP_MESH_STRICT_DI}.
+     * Inspect a {@code @MeshRoute} handler and enforce the contract.
      *
      * @param method the handler method
      * @param deps   the declared dependency specs in declaration order
-     * @throws IllegalStateException when the shape is not {@code OK} and strict
-     *         DI is enabled
+     * @throws IllegalStateException on a {@code @MeshInject} assertion failure,
+     *         or on any finding when {@code MCP_MESH_STRICT_DI} is enabled
      */
     public static void inspectRoute(Method method, List<MeshRouteRegistry.DependencySpec> deps) {
         report(analyze("@MeshRoute", method, MeshInjectableSlots.routeSlots(method), deps),
@@ -106,13 +133,12 @@ public final class MeshLegacyBindingDetector {
     }
 
     /**
-     * Inspect a {@code @MeshA2A} handler and report through the logger,
-     * honouring {@code MCP_MESH_STRICT_DI}.
+     * Inspect a {@code @MeshA2A} handler and enforce the contract.
      *
      * @param method the handler method
      * @param deps   the declared dependency specs in declaration order
-     * @throws IllegalStateException when the shape is not {@code OK} and strict
-     *         DI is enabled
+     * @throws IllegalStateException on a {@code @MeshInject} assertion failure,
+     *         or on any finding when {@code MCP_MESH_STRICT_DI} is enabled
      */
     public static void inspectA2A(Method method, List<MeshRouteRegistry.DependencySpec> deps) {
         report(analyze("@MeshA2A", method, MeshInjectableSlots.a2aSlots(method), deps),
@@ -120,9 +146,24 @@ public final class MeshLegacyBindingDetector {
     }
 
     /**
+     * Inspect a {@code @MeshTool} binding. Only the {@code @MeshInject}
+     * assertion applies here — see {@link #analyzeTool}.
+     *
+     * @param binding the pairing table built by {@link MeshPositionalBinder}
+     * @throws IllegalStateException on a {@code @MeshInject} assertion failure
+     */
+    public static void inspectTool(MeshPositionalBinder.Binding binding) {
+        report(analyzeTool(binding), MeshDiValidator.strictDiEnabled());
+    }
+
+    /**
      * Apply the reporting policy to a finding. Package-private with an explicit
      * strictness flag because {@code MCP_MESH_STRICT_DI} cannot be set
      * in-process, so this is the seam tests drive.
+     *
+     * @param finding the verdict to report
+     * @param strict  whether {@code MCP_MESH_STRICT_DI} is on, promoting WARN to
+     *                a boot failure. {@link Severity#ERROR} is fatal either way
      */
     static void report(Finding finding, boolean strict) {
         switch (finding.severity()) {
@@ -137,86 +178,135 @@ public final class MeshLegacyBindingDetector {
                 }
                 log.warn("{}", finding.message());
             }
-            case ERROR -> {
-                if (strict) {
-                    throw new IllegalStateException(finding.message());
-                }
-                log.error("{}", finding.message());
-            }
+            // A @MeshInject value that contradicts the position is never a
+            // survivable shape: the annotation is an assertion, so a false one
+            // stops the boot regardless of MCP_MESH_STRICT_DI.
+            case ERROR -> throw new IllegalStateException(finding.message());
         }
     }
 
     /**
-     * The pure analysis, with no logging and no strictness policy — the seam
-     * tests use.
+     * The pure analysis for the two formerly name-based sites, with no logging
+     * and no strictness policy — the seam tests use.
      *
      * @param site   the declaration site, e.g. {@code "@MeshRoute"}
      * @param method the handler method
      * @param slots  injectable slots in signature order
      * @param deps   the declared dependency specs in declaration order
      * @return the verdict; {@link Severity#OK} with a DEBUG-grade message when
-     *         today's and tomorrow's bindings are identical
+     *         the handler is already on the positional contract
      */
     public static Finding analyze(
             String site,
             Method method,
             List<MeshPositionalBinder.Slot> slots,
             List<MeshRouteRegistry.DependencySpec> deps) {
+        return analyze(site, method, slots, deps == null ? List.of() : deps, true);
+    }
 
-        List<MeshRouteRegistry.DependencySpec> declared = deps == null ? List.of() : deps;
+    /**
+     * The pure analysis for {@code @MeshTool}.
+     *
+     * <p>Only the {@code @MeshInject} assertion is checked. The name-crossover
+     * warning is a <i>migration</i> signal for the two sites whose binding rule
+     * changed in 3.4; {@code @MeshTool} has always been positional, so a
+     * parameter whose name happens to equal another declared capability says
+     * nothing about that method's history and must not be reported.
+     *
+     * @param binding the pairing table built by {@link MeshPositionalBinder};
+     *                only its {@link MeshPositionalBinder.Binding#pairableDepCount()}
+     *                leading capabilities take part (a {@code @MeshService} view
+     *                edge owns no injectable parameter)
+     * @return the verdict
+     */
+    public static Finding analyzeTool(MeshPositionalBinder.Binding binding) {
+        List<MeshRouteRegistry.DependencySpec> specs = new ArrayList<>();
+        for (String capability : binding.capabilities().subList(0, binding.pairableDepCount())) {
+            specs.add(new MeshRouteRegistry.DependencySpec(
+                capability, new String[0], "", capability));
+        }
+        return analyze("@MeshTool", binding.method(), binding.slots(), specs, false);
+    }
+
+    private static Finding analyze(
+            String site,
+            Method method,
+            List<MeshPositionalBinder.Slot> slots,
+            List<MeshRouteRegistry.DependencySpec> deps,
+            boolean namesUsedToBind) {
+
         Parameter[] params = method.getParameters();
 
         SlotVerdict[] verdicts = new SlotVerdict[slots.size()];
+        String[] assertedKeys = new String[slots.size()];
         String[] nameKeys = new String[slots.size()];
-        boolean[] fromAnnotation = new boolean[slots.size()];
         int[] nameTarget = new int[slots.size()];
 
         Severity severity = Severity.OK;
         for (int k = 0; k < slots.size(); k++) {
             Parameter p = params[slots.get(k).parameterPosition()];
             MeshInject inject = p.getAnnotation(MeshInject.class);
-            String key;
-            if (inject != null && !inject.value().isEmpty()) {
-                key = inject.value();
-                fromAnnotation[k] = true;
-            } else if (p.isNamePresent()) {
-                key = p.getName();
-            } else {
-                key = null;
-            }
-            nameKeys[k] = key;
-            nameTarget[k] = key == null ? -1 : matchIndex(declared, key);
+            nameTarget[k] = -1;
 
-            if (key == null) {
-                verdicts[k] = SlotVerdict.NO_NAME;
-            } else if (nameTarget[k] < 0) {
-                verdicts[k] = SlotVerdict.UNDECLARED;
-            } else if (nameTarget[k] == k) {
-                verdicts[k] = SlotVerdict.AGREES;
+            if (inject != null && !inject.value().isEmpty()) {
+                assertedKeys[k] = inject.value();
+                verdicts[k] = refersTo(deps, k, inject.value())
+                    ? SlotVerdict.OK : SlotVerdict.ASSERTION_VIOLATED;
+                // The assertion diagnostic prints where the value WOULD have
+                // pointed under the old rule, so the reorder can be prescribed.
+                nameTarget[k] = matchIndex(deps, inject.value());
+            } else if (namesUsedToBind && p.isNamePresent()) {
+                nameKeys[k] = p.getName();
+                nameTarget[k] = matchIndex(deps, p.getName());
+                verdicts[k] = (nameTarget[k] >= 0 && nameTarget[k] != k)
+                    ? SlotVerdict.NAME_CROSSOVER : SlotVerdict.OK;
             } else {
-                verdicts[k] = SlotVerdict.REORDERED;
+                // No assertion and no name signal. Under positional binding
+                // this is a perfectly ordinary slot — names are not consulted,
+                // so there is nothing left to disagree about.
+                verdicts[k] = SlotVerdict.OK;
             }
 
             severity = switch (verdicts[k]) {
-                case AGREES -> severity;
-                case REORDERED -> severity == Severity.ERROR ? Severity.ERROR : Severity.WARN;
-                case UNDECLARED, NO_NAME -> Severity.ERROR;
+                case OK -> severity;
+                case NAME_CROSSOVER -> severity == Severity.ERROR ? Severity.ERROR : Severity.WARN;
+                case ASSERTION_VIOLATED -> Severity.ERROR;
             };
         }
 
         return new Finding(severity,
-            buildMessage(site, method, slots, declared, verdicts, nameKeys, fromAnnotation,
+            buildMessage(site, method, slots, deps, verdicts, assertedKeys, nameKeys,
                 nameTarget, severity));
     }
 
     /**
-     * The declared dependency a name key resolves to today.
+     * Whether {@code key} refers to the dependency positional pairing puts at
+     * slot {@code k}.
      *
-     * <p>Mirrors both live lookups: the route path's map is double-keyed by
-     * capability AND by {@code DependencySpec.getParameterName()}
-     * ({@code MeshRouteHandlerInterceptor:155-157}); the A2A path scans the same
-     * two fields in declaration order ({@code MeshA2ADispatcher:779-784}).
-     * First declaration wins on a collision.
+     * <p>The declared {@code @MeshDependency(name = ...)} alias counts as well
+     * as the capability itself: {@code name} is an explicit, user-authored
+     * second spelling of the same edge (and defaults to the camelCased
+     * capability), so accepting it keeps
+     * {@code @MeshDependency(capability = "base-cap") + @MeshInject("baseCap")}
+     * a legal assertion. It never lets the annotation point at a
+     * <i>different</i> dependency — that is the whole check.
+     */
+    private static boolean refersTo(
+            List<MeshRouteRegistry.DependencySpec> deps, int k, String key) {
+        if (k >= deps.size()) {
+            return false;
+        }
+        MeshRouteRegistry.DependencySpec dep = deps.get(k);
+        return key.equals(dep.getCapability()) || key.equals(dep.getParameterName());
+    }
+
+    /**
+     * The declared dependency a name key resolved to under the pre-3.4 rule.
+     *
+     * <p>Mirrors both former lookups: the route path's map was double-keyed by
+     * capability AND by {@code DependencySpec.getParameterName()}; the A2A path
+     * scanned the same two fields in declaration order. First declaration wins
+     * on a collision. Used for diagnostics only — nothing binds this way now.
      */
     private static int matchIndex(List<MeshRouteRegistry.DependencySpec> deps, String key) {
         for (int i = 0; i < deps.size(); i++) {
@@ -234,33 +324,32 @@ public final class MeshLegacyBindingDetector {
             List<MeshPositionalBinder.Slot> slots,
             List<MeshRouteRegistry.DependencySpec> deps,
             SlotVerdict[] verdicts,
+            String[] assertedKeys,
             String[] nameKeys,
-            boolean[] fromAnnotation,
             int[] nameTarget,
             Severity severity) {
 
         String signature = signatureOf(method);
         if (severity == Severity.OK) {
-            return site + " " + signature + ": name-based and positional dependency binding "
-                + "agree for all " + slots.size() + " injectable parameter(s) — issue #1401 will "
-                + "not change this handler.";
+            return site + " " + signature + ": positional dependency binding is consistent for all "
+                + slots.size() + " injectable parameter(s).";
         }
 
         StringBuilder sb = new StringBuilder();
         sb.append(site).append(' ').append(signature).append(": ");
         if (severity == Severity.ERROR) {
-            sb.append("at least one injectable parameter resolves to NO declared dependency and "
-                + "is injected null today.");
+            sb.append("a @MeshInject value contradicts the dependency its parameter's POSITION "
+                + "binds to.");
         } else {
-            sb.append("declaration order disagrees with parameter names, so this handler's "
-                + "bindings WILL CHANGE.");
+            sb.append("parameter names disagree with declaration order, so these parameters do "
+                + "NOT bind the way their names suggest.");
         }
 
-        sb.append("\n  ").append(site).append(" binds mesh dependencies BY NAME today. mcp-mesh is "
-            + "aligning every injection site on the positional contract (issue #1401): the Nth "
-            + "declared dependency binds to the Nth injectable parameter, and names are not "
-            + "consulted. @MeshTool already works this way, as does every Python and TypeScript "
-            + "site.");
+        sb.append("\n  ").append(site).append(" binds mesh dependencies BY POSITION (issue #1401): "
+            + "the Nth declared dependency binds to the Nth injectable parameter, and parameter "
+            + "names are never consulted. @MeshTool, and every Python and TypeScript site, work "
+            + "the same way. @MeshInject no longer SELECTS a dependency — it ASSERTS the one "
+            + "positional pairing assigns.");
 
         sb.append("\n  ").append(deps.size())
             .append(deps.size() == 1 ? " declared dependency: " : " declared dependencies: ")
@@ -273,15 +362,20 @@ public final class MeshLegacyBindingDetector {
                 .append(" = parameter ").append(slots.get(k).parameterPosition())
                 .append(" (").append(p.getType().getSimpleName()).append(' ')
                 .append(p.isNamePresent() ? p.getName() : "<unnamed>").append(')');
-            sb.append("\n        ").append(pad("today (" + todayLabel(nameKeys[k], fromAnnotation[k]) + "):"))
-                .append(todayTarget(deps, nameTarget[k], verdicts[k]));
-            sb.append("\n        ").append(pad("after alignment (by position):"))
+            if (verdicts[k] == SlotVerdict.OK) {
+                sb.append("\n        ").append(pad("binds (by position):"))
+                    .append(positionalTarget(deps, k)).append(" — OK");
+                continue;
+            }
+            sb.append("\n        ").append(pad(claimLabel(assertedKeys[k], nameKeys[k])))
+                .append(claimTarget(deps, nameTarget[k]));
+            sb.append("\n        ").append(pad("binds (by position):"))
                 .append(positionalTarget(deps, k));
         }
 
-        appendPrescription(sb, slots, deps, verdicts, nameTarget);
+        appendPrescription(sb, slots, deps, verdicts, nameTarget, severity);
 
-        if (!MeshDiValidator.strictDiEnabled()) {
+        if (severity == Severity.WARN && !MeshDiValidator.strictDiEnabled()) {
             sb.append("\n  Set ").append(MeshDiValidator.STRICT_DI_ENV)
                 .append("=true to fail startup on this instead of logging it.");
         }
@@ -293,28 +387,12 @@ public final class MeshLegacyBindingDetector {
             List<MeshPositionalBinder.Slot> slots,
             List<MeshRouteRegistry.DependencySpec> deps,
             SlotVerdict[] verdicts,
-            int[] nameTarget) {
+            int[] nameTarget,
+            Severity severity) {
 
-        boolean anyUnbound = false;
-        boolean anyReordered = false;
-        for (SlotVerdict v : verdicts) {
-            anyUnbound |= v == SlotVerdict.UNDECLARED || v == SlotVerdict.NO_NAME;
-            anyReordered |= v == SlotVerdict.REORDERED;
-        }
-
-        if (anyUnbound) {
-            sb.append("\n  Fix the unbound parameter(s) first: give each one a @MeshInject value "
-                + "naming a declared capability, or declare the capability it names in "
-                + "dependencies = {...}. A parameter that binds to nothing today will bind to "
-                + "whatever sits at its position after the alignment.");
-        }
-
-        if (!anyReordered) {
-            return;
-        }
-
-        // A reorder can only express the current bindings when each slot names a
-        // distinct dependency and every slot has a position to sit at.
+        // A reorder can only express what the names/assertions claim when each
+        // slot claims a distinct declared dependency and every slot has a
+        // position to sit at.
         Set<Integer> targets = new LinkedHashSet<>();
         boolean injective = slots.size() <= deps.size();
         for (int k = 0; k < slots.size() && injective; k++) {
@@ -323,7 +401,11 @@ public final class MeshLegacyBindingDetector {
             }
         }
 
-        sb.append("\n  Fix now — behaviour-preserving today, correct after the alignment.");
+        sb.append(severity == Severity.ERROR
+            ? "\n  Fix — pick one:"
+            : "\n  If this handler was written for mcp-mesh 3.3 or earlier (when @MeshRoute and "
+                + "@MeshA2A bound by name), fix it — pick one:");
+
         if (injective) {
             List<String> reordered = new ArrayList<>();
             for (int k = 0; k < slots.size(); k++) {
@@ -334,40 +416,49 @@ public final class MeshLegacyBindingDetector {
                     reordered.add(deps.get(i).getCapability());
                 }
             }
-            sb.append(" Reorder dependencies = {...} to: ");
+            sb.append("\n    • reorder dependencies = {...} to: ");
             for (int i = 0; i < reordered.size(); i++) {
                 sb.append(i == 0 ? "" : ", ")
                     .append('[').append(i).append("] '").append(reordered.get(i)).append('\'');
             }
             sb.append("\n      (move each whole @MeshDependency — keep its tags, version, "
-                + "required and schema attributes with its capability), or reorder the "
-                + "parameters to match the current declaration order.");
+                + "required and schema attributes with its capability)");
         } else {
-            sb.append(" Reorder dependencies = {...} so declaration order matches parameter "
-                + "order, or reorder the parameters to match the declaration.");
+            sb.append("\n    • reorder dependencies = {...} so declaration order matches "
+                + "parameter order");
         }
-        sb.append("\n      Once the two agree, name-based and positional binding are identical "
-            + "and this stops being reported.");
+        sb.append("\n    • or reorder the parameters to match the declaration order");
+
+        boolean anyAssertion = false;
+        boolean anyCrossover = false;
+        for (SlotVerdict v : verdicts) {
+            anyAssertion |= v == SlotVerdict.ASSERTION_VIOLATED;
+            anyCrossover |= v == SlotVerdict.NAME_CROSSOVER;
+        }
+        if (anyAssertion) {
+            sb.append("\n    • or correct the @MeshInject value on each parameter to name the "
+                + "dependency at that parameter's position (@MeshInject is an assertion — "
+                + "dropping it entirely is also valid, and binding is unchanged either way)");
+        }
+        if (anyCrossover) {
+            sb.append("\n    • or, if the current bindings are already what you want, add "
+                + "@MeshInject(\"<capability>\") to each parameter to assert it — that pins "
+                + "the pairing and silences this warning");
+        }
     }
 
-    private static String todayLabel(String key, boolean fromAnnotation) {
-        if (key == null) {
-            return "no @MeshInject value, and no parameter name is available — "
-                + "compiled without -parameters";
+    private static String claimLabel(String assertedKey, String nameKey) {
+        if (assertedKey != null) {
+            return "@MeshInject(\"" + assertedKey + "\") asserts:";
         }
-        return fromAnnotation
-            ? "by name, @MeshInject(\"" + key + "\")"
-            : "by name, parameter name '" + key + "'";
+        return "parameter name '" + nameKey + "' used to bind:";
     }
 
-    private static String todayTarget(
-            List<MeshRouteRegistry.DependencySpec> deps, int target, SlotVerdict verdict) {
-        return switch (verdict) {
-            case NO_NAME -> "injected null (already broken today)";
-            case UNDECLARED -> "NO MATCH among the declared dependencies — "
-                + "injected null (already broken today)";
-            default -> "dependency[" + target + "] '" + deps.get(target).getCapability() + "'";
-        };
+    private static String claimTarget(List<MeshRouteRegistry.DependencySpec> deps, int target) {
+        if (target < 0) {
+            return "NO MATCH among the declared dependencies";
+        }
+        return "dependency[" + target + "] '" + deps.get(target).getCapability() + "'";
     }
 
     private static String positionalTarget(List<MeshRouteRegistry.DependencySpec> deps, int k) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteBeanPostProcessor.java
@@ -73,9 +73,9 @@ public class MeshRouteBeanPostProcessor implements BeanPostProcessor {
             // Enrich dependency specs with generic return type info from method parameters
             enrichDependencyReturnTypes(method, deps);
 
-            // Issue #1401: report handlers whose bindings would change when
-            // @MeshRoute moves from name-based to positional pairing. Warning
-            // only — this PR changes no binding behaviour.
+            // Issue #1401: @MeshRoute binds positionally. Fail the boot on a
+            // @MeshInject value that contradicts the position, and warn on a
+            // handler still shaped for the pre-3.4 name-based binding.
             MeshLegacyBindingDetector.inspectRoute(method, deps);
 
             // Register each HTTP method/path combination
@@ -97,25 +97,33 @@ public class MeshRouteBeanPostProcessor implements BeanPostProcessor {
     }
 
     /**
-     * Extract generic type arguments from McpMeshTool parameters and set them
-     * on matching DependencySpec entries.
+     * Extract generic type arguments from {@code McpMeshTool} parameters and set
+     * them on the {@code DependencySpec} each parameter <b>positionally</b>
+     * binds to (issue #1401).
      *
-     * <p>For a parameter like {@code @MeshInject("greeting") McpMeshTool<GreetResponse> tool},
-     * this extracts {@code GreetResponse.class} and sets it on the dependency spec
-     * with capability "greeting".
+     * <p>The Nth injectable parameter's {@code McpMeshTool<T>} argument becomes
+     * the return type of the Nth declared dependency — the same pairing
+     * {@link MeshInjectArgumentResolver} uses to hand that parameter its proxy,
+     * derived from the same {@link MeshInjectableSlots} enumeration.
+     *
+     * <p>This has to move with the resolver, not after it. The type set here
+     * flows through {@code MeshRouteHandlerInterceptor} into
+     * {@code injector.getToolProxy(capability, returnType)}, so it drives
+     * response deserialization and the issue #547 schema-match payload. Matching
+     * it by name while the proxy is chosen by position would deserialize a
+     * reordered handler's response into the wrong type — silently.
      */
     private void enrichDependencyReturnTypes(Method method, List<MeshRouteRegistry.DependencySpec> deps) {
         java.lang.reflect.Type[] genericTypes = method.getGenericParameterTypes();
-        java.lang.reflect.Parameter[] params = method.getParameters();
+        List<io.mcpmesh.spring.MeshPositionalBinder.Slot> slots =
+            MeshInjectableSlots.routeSlots(method);
 
-        for (int i = 0; i < params.length; i++) {
-            if (!McpMeshTool.class.isAssignableFrom(params[i].getType())) {
-                continue;
-            }
+        for (int slot = 0; slot < slots.size(); slot++) {
+            int position = slots.get(slot).parameterPosition();
 
             // Extract generic type argument (e.g., GreetResponse from McpMeshTool<GreetResponse>)
             java.lang.reflect.Type returnType = null;
-            if (genericTypes[i] instanceof java.lang.reflect.ParameterizedType pt) {
+            if (genericTypes[position] instanceof java.lang.reflect.ParameterizedType pt) {
                 java.lang.reflect.Type[] typeArgs = pt.getActualTypeArguments();
                 if (typeArgs.length > 0) {
                     returnType = typeArgs[0];
@@ -126,27 +134,16 @@ public class MeshRouteBeanPostProcessor implements BeanPostProcessor {
                 continue;
             }
 
-            // Match to a DependencySpec by @MeshInject annotation or parameter name
-            MeshInject meshInject = params[i].getAnnotation(MeshInject.class);
-            String matchKey;
-            if (meshInject != null && !meshInject.value().isEmpty()) {
-                matchKey = meshInject.value();
-            } else {
-                matchKey = params[i].getName();
+            if (slot >= deps.size()) {
+                log.warn("@MeshRoute {}.{}: McpMeshTool parameter {} is injectable slot {}, but "
+                        + "only {} dependenc{} declared — its generic type is ignored and the "
+                        + "parameter is injected null. dependencies[i] binds to the i-th "
+                        + "injectable parameter.",
+                    method.getDeclaringClass().getSimpleName(), method.getName(), position, slot,
+                    deps.size(), deps.size() == 1 ? "y is" : "ies are");
+                continue;
             }
-            // Find matching dep by capability or parameterName
-            boolean matched = false;
-            for (MeshRouteRegistry.DependencySpec dep : deps) {
-                if (dep.getCapability().equals(matchKey) || matchKey.equals(dep.getParameterName())) {
-                    dep.setReturnType(returnType);
-                    matched = true;
-                    break;
-                }
-            }
-            if (!matched) {
-                log.warn("No matching dependency spec for McpMeshTool parameter '{}' in method {}",
-                    matchKey, method.getName());
-            }
+            deps.get(slot).setReturnType(returnType);
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteHandlerInterceptor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteHandlerInterceptor.java
@@ -15,7 +15,10 @@ import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 import tools.jackson.databind.ObjectMapper;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -45,7 +48,21 @@ public class MeshRouteHandlerInterceptor implements HandlerInterceptor {
     private static final ObjectMapper JSON = MeshObjectMappers.create();
 
     /**
-     * Request attribute key for resolved dependencies map.
+     * Request attribute key for the resolved dependencies.
+     *
+     * <p><b>The value is a {@code List<McpMeshTool>} positionally aligned with
+     * {@code RouteMetadata.getDependencies()}</b> — index {@code i} holds the
+     * proxy for declared dependency {@code i}, or {@code null} when that
+     * dependency is unavailable. The list is pre-sized to the declared count and
+     * assigned by index, never appended to: an unavailable dependency in the
+     * middle of the list must leave every later slot where it is (issue #1390,
+     * the whole point of #1401's positional contract).
+     *
+     * <p>Before 3.4 this held a capability-keyed {@code Map}. Code that wants
+     * capability-keyed access should call
+     * {@link MeshRouteUtils#getDependencies(HttpServletRequest)}, which rebuilds
+     * that view from this list plus {@link #MESH_ROUTE_METADATA_ATTR} — one
+     * source of truth, two views.
      */
     public static final String MESH_DEPENDENCIES_ATTR = "io.mcpmesh.route.dependencies";
 
@@ -118,8 +135,18 @@ public class MeshRouteHandlerInterceptor implements HandlerInterceptor {
         // Store metadata in request for later access
         request.setAttribute(MESH_ROUTE_METADATA_ATTR, metadata);
 
-        // Resolve dependencies
-        Map<String, McpMeshTool> resolvedDeps = new LinkedHashMap<>();
+        // Resolve dependencies.
+        //
+        // POSITIONAL (issue #1401): the list is PRE-SIZED to the declared count
+        // and null-padded, and every store below is an indexed set(). It is
+        // never built with add() — an unavailable dependency must leave its own
+        // slot null and every later slot exactly where it is. Appending only
+        // the available ones would shift each subsequent parameter onto the
+        // wrong proxy, which is the #1390 defect this contract exists to
+        // prevent.
+        List<MeshRouteRegistry.DependencySpec> declared = metadata.getDependencies();
+        List<McpMeshTool> resolvedDeps =
+            new ArrayList<>(Collections.nCopies(declared.size(), (McpMeshTool) null));
         boolean allResolved = true;
         // Issue #1249 perimeter: capability of the first UNAVAILABLE dependency
         // declared required=true. When non-null after resolution, the route
@@ -131,7 +158,8 @@ public class MeshRouteHandlerInterceptor implements HandlerInterceptor {
 
         io.mcpmesh.spring.MeshSettleState settleState =
             io.mcpmesh.spring.MeshSettleState.getInstance();
-        for (MeshRouteRegistry.DependencySpec dep : metadata.getDependencies()) {
+        for (int depIndex = 0; depIndex < declared.size(); depIndex++) {
+            MeshRouteRegistry.DependencySpec dep = declared.get(depIndex);
             try {
                 McpMeshTool tool = resolveDependency(dep);
                 // Settling-window grace (#1193): while the agent is still
@@ -152,10 +180,10 @@ public class MeshRouteHandlerInterceptor implements HandlerInterceptor {
                     tool = resolveDependency(dep);
                 }
                 if (tool != null && tool.isAvailable()) {
-                    resolvedDeps.put(dep.getCapability(), tool);
-                    // Also store by parameter name for @MeshInject
-                    resolvedDeps.put(dep.getParameterName(), tool);
-                    log.debug("Resolved dependency '{}' for route", dep.getCapability());
+                    // Indexed assignment — see the pre-sizing note above.
+                    resolvedDeps.set(depIndex, tool);
+                    log.debug("Resolved dependency[{}] '{}' for route",
+                        depIndex, dep.getCapability());
                 } else {
                     log.warn("Dependency '{}' not available for route {}",
                         dep.getCapability(), handlerMethodId);
@@ -177,8 +205,8 @@ public class MeshRouteHandlerInterceptor implements HandlerInterceptor {
             }
         }
 
-        // Store resolved dependencies in request
-        request.setAttribute(MESH_DEPENDENCIES_ATTR, resolvedDeps);
+        // Store resolved dependencies in request, positionally
+        request.setAttribute(MESH_DEPENDENCIES_ATTR, Collections.unmodifiableList(resolvedDeps));
 
         // Issue #1249 perimeter 503: a dependency declared required=true is
         // unavailable at call time — return 503 with the capability reason

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteUtils.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteUtils.java
@@ -4,6 +4,8 @@ import io.mcpmesh.types.McpMeshTool;
 import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -43,18 +45,79 @@ public final class MeshRouteUtils {
     }
 
     /**
-     * Get all resolved dependencies from the request.
+     * Get all resolved dependencies from the request, keyed by capability.
+     *
+     * <p><b>This accessor stays capability-keyed under the positional contract
+     * (issue #1401), on purpose.</b> Parameter injection is positional because
+     * a parameter's name is incidental — nothing ties it to a capability, so
+     * matching on it silently misbinds when the declaration list is reordered.
+     * Here the capability is typed <i>at the call site</i>
+     * ({@code getDependency(request, "pdf-tool")}), so there is no such drift
+     * hazard: the caller names the edge it wants and gets exactly that edge or
+     * null.
+     *
+     * <p>The map is rebuilt on each call from the positional list the
+     * interceptor stored plus the route metadata, rather than being maintained
+     * alongside it — one source of truth, two views. Unavailable dependencies
+     * are absent from the map (as before); their slots are null in the
+     * positional list.
      *
      * @param request HTTP servlet request
      * @return map of capability name to McpMeshTool, or empty map if no dependencies
      */
     @SuppressWarnings("unchecked")
     public static Map<String, McpMeshTool> getDependencies(HttpServletRequest request) {
-        Object deps = request.getAttribute(MeshRouteHandlerInterceptor.MESH_DEPENDENCIES_ATTR);
-        if (deps instanceof Map) {
-            return (Map<String, McpMeshTool>) deps;
+        Object attr = request.getAttribute(MeshRouteHandlerInterceptor.MESH_DEPENDENCIES_ATTR);
+        if (!(attr instanceof List)) {
+            return Collections.emptyMap();
         }
-        return Collections.emptyMap();
+        List<McpMeshTool> resolved = (List<McpMeshTool>) attr;
+        MeshRouteRegistry.RouteMetadata metadata = getRouteMetadata(request);
+        if (metadata == null) {
+            return Collections.emptyMap();
+        }
+        List<MeshRouteRegistry.DependencySpec> declared = metadata.getDependencies();
+        int n = Math.min(resolved.size(), declared.size());
+
+        Map<String, McpMeshTool> byName = new LinkedHashMap<>();
+        for (int i = 0; i < n; i++) {
+            if (resolved.get(i) != null) {
+                byName.put(declared.get(i).getCapability(), resolved.get(i));
+            }
+        }
+        // The @MeshDependency(name = ...) alias is a secondary key, added only
+        // where it does not shadow a capability — a capability lookup must
+        // never be answered by another dependency's alias.
+        for (int i = 0; i < n; i++) {
+            String alias = declared.get(i).getParameterName();
+            if (resolved.get(i) != null && alias != null && !alias.isEmpty()) {
+                byName.putIfAbsent(alias, resolved.get(i));
+            }
+        }
+        return Collections.unmodifiableMap(byName);
+    }
+
+    /**
+     * Get a resolved dependency by its DECLARATION INDEX — the same index
+     * parameter injection uses (issue #1401): index {@code i} is the {@code i}-th
+     * entry of {@code dependencies = {...}}.
+     *
+     * @param request HTTP servlet request
+     * @param index   zero-based index into the route's declared dependency list
+     * @return the McpMeshTool, or null when the index is out of range or that
+     *         dependency is unavailable
+     */
+    @SuppressWarnings("unchecked")
+    public static McpMeshTool getDependency(HttpServletRequest request, int index) {
+        Object attr = request.getAttribute(MeshRouteHandlerInterceptor.MESH_DEPENDENCIES_ATTR);
+        if (!(attr instanceof List)) {
+            return null;
+        }
+        List<McpMeshTool> resolved = (List<McpMeshTool>) attr;
+        if (index < 0 || index >= resolved.size()) {
+            return null;
+        }
+        return resolved.get(index);
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshInjectAssertionBootTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshInjectAssertionBootTest.java
@@ -1,0 +1,218 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+import io.mcpmesh.spring.web.MeshA2A;
+import io.mcpmesh.spring.web.MeshA2ABeanPostProcessor;
+import io.mcpmesh.spring.web.MeshA2ARegistry;
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshInject;
+import io.mcpmesh.spring.web.MeshRoute;
+import io.mcpmesh.spring.web.MeshRouteBeanPostProcessor;
+import io.mcpmesh.spring.web.MeshRouteRegistry;
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code @MeshInject} is a checked assertion at every injection site (issue
+ * #1401): its value must name the dependency positional pairing assigns, or the
+ * application does not boot.
+ *
+ * <p>These tests drive the real boot components — the two bean post-processors
+ * and the {@code MeshToolWrapper} constructor — rather than the analyzer, so
+ * what is pinned is that the check is actually wired in, with a diagnostic a
+ * user can act on. The correctly-ordered twin of each broken handler is
+ * asserted to boot clean, because a guard that can stop a boot must not fire on
+ * correct code.
+ *
+ * <p>{@code @MeshTool} is included because the annotation was <b>silently
+ * ignored</b> there before 3.4 — the wrapper never imported it — which meant it
+ * meant two different things depending on where it was written.
+ */
+@DisplayName("@MeshInject is a checked assertion at boot (issue #1401)")
+class MeshInjectAssertionBootTest {
+
+    // ─────────────────────────────────────────────────────────────────
+    // @MeshRoute
+    // ─────────────────────────────────────────────────────────────────
+
+    @RestController
+    @SuppressWarnings("unused")
+    public static class ReorderedRouteController {
+        @GetMapping("/bad")
+        @MeshRoute(dependencies = {
+            @MeshDependency(capability = "get_employee"),
+            @MeshDependency(capability = "employee_count")})
+        public String handler(
+                @MeshInject("employee_count") McpMeshTool statsTool,
+                @MeshInject("get_employee") McpMeshTool employeeTool) {
+            return "";
+        }
+    }
+
+    @RestController
+    @SuppressWarnings("unused")
+    public static class CorrectRouteController {
+        @GetMapping("/good")
+        @MeshRoute(dependencies = {
+            @MeshDependency(capability = "employee_count"),
+            @MeshDependency(capability = "get_employee")})
+        public String handler(
+                @MeshInject("employee_count") McpMeshTool statsTool,
+                @MeshInject("get_employee") McpMeshTool employeeTool) {
+            return "";
+        }
+    }
+
+    @Test
+    @DisplayName("@MeshRoute: a reordered handler fails the boot, naming both orderings and the fix")
+    void reorderedRouteFailsBoot() {
+        MeshRouteBeanPostProcessor processor =
+            new MeshRouteBeanPostProcessor(new MeshRouteRegistry());
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, () ->
+            processor.postProcessAfterInitialization(new ReorderedRouteController(), "bad"));
+
+        String m = e.getMessage();
+        assertTrue(m.contains("@MeshRoute"), m);
+        assertTrue(m.contains("ReorderedRouteController.handler"), m);
+        assertTrue(m.contains("@MeshInject value contradicts"), m);
+        assertTrue(m.contains("2 declared dependencies: [0] 'get_employee', [1] 'employee_count'"), m);
+        assertTrue(m.contains("@MeshInject(\"employee_count\") asserts:"), m);
+        assertTrue(m.contains("dependency[1] 'employee_count'"), m);
+        assertTrue(m.contains("dependency[0] 'get_employee'"), m);
+        assertTrue(m.contains(
+            "reorder dependencies = {...} to: [0] 'employee_count', [1] 'get_employee'"), m);
+    }
+
+    @Test
+    @DisplayName("@MeshRoute: the correctly-ordered twin boots clean")
+    void correctRouteBoots() {
+        new MeshRouteBeanPostProcessor(new MeshRouteRegistry())
+            .postProcessAfterInitialization(new CorrectRouteController(), "good");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // @MeshA2A
+    // ─────────────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unused")
+    public static class ReorderedA2ABean {
+        @MeshA2A(path = "/bad", skillId = "bad", skillName = "bad", dependencies = {
+            @MeshDependency(capability = "alpha"),
+            @MeshDependency(capability = "beta")})
+        public Object handler(
+                Map<String, Object> message,
+                @MeshInject("beta") McpMeshTool first,
+                @MeshInject("alpha") McpMeshTool second) {
+            return Map.of();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class CorrectA2ABean {
+        @MeshA2A(path = "/good", skillId = "good", skillName = "good", dependencies = {
+            @MeshDependency(capability = "beta"),
+            @MeshDependency(capability = "alpha")})
+        public Object handler(
+                Map<String, Object> message,
+                @MeshInject("beta") McpMeshTool first,
+                @MeshInject("alpha") McpMeshTool second) {
+            return Map.of();
+        }
+    }
+
+    @Test
+    @DisplayName("@MeshA2A: a reordered handler fails the boot")
+    void reorderedA2AFailsBoot() {
+        MeshA2ABeanPostProcessor processor = new MeshA2ABeanPostProcessor(new MeshA2ARegistry());
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, () ->
+            processor.postProcessAfterInitialization(new ReorderedA2ABean(), "bad"));
+
+        String m = e.getMessage();
+        assertTrue(m.contains("@MeshA2A"), m);
+        assertTrue(m.contains("@MeshInject value contradicts"), m);
+        assertTrue(m.contains("reorder dependencies = {...} to: [0] 'beta', [1] 'alpha'"), m);
+    }
+
+    @Test
+    @DisplayName("@MeshA2A: the correctly-ordered twin boots clean")
+    void correctA2ABoots() {
+        new MeshA2ABeanPostProcessor(new MeshA2ARegistry())
+            .postProcessAfterInitialization(new CorrectA2ABean(), "good");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // @MeshTool — where @MeshInject used to be silently ignored
+    // ─────────────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unused")
+    public static class ToolBean {
+        @MeshTool(capability = "reordered", dependencies = {
+            @Selector(capability = "alpha"),
+            @Selector(capability = "beta")})
+        public Object reordered(
+                @Param("id") String id,
+                @MeshInject("beta") McpMeshTool first,
+                @MeshInject("alpha") McpMeshTool second) {
+            return Map.of();
+        }
+
+        @MeshTool(capability = "correct", dependencies = {
+            @Selector(capability = "beta"),
+            @Selector(capability = "alpha")})
+        public Object correct(
+                @Param("id") String id,
+                @MeshInject("beta") McpMeshTool first,
+                @MeshInject("alpha") McpMeshTool second) {
+            return Map.of();
+        }
+    }
+
+    @Test
+    @DisplayName("@MeshTool: a contradicting @MeshInject now fails the boot instead of being ignored")
+    void reorderedToolFailsBoot() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+            () -> wrapper("reordered", List.of("alpha", "beta")));
+
+        String m = e.getMessage();
+        assertTrue(m.contains("@MeshTool"), m);
+        assertTrue(m.contains("@MeshInject value contradicts"), m);
+        assertTrue(m.contains("reorder dependencies = {...} to: [0] 'beta', [1] 'alpha'"), m);
+    }
+
+    @Test
+    @DisplayName("@MeshTool: the correctly-ordered twin constructs clean")
+    void correctToolBoots() throws Exception {
+        wrapper("correct", List.of("beta", "alpha"));
+    }
+
+    private static MeshToolWrapper wrapper(String methodName, List<String> capabilities)
+            throws Exception {
+        Method method = null;
+        for (Method m : ToolBean.class.getDeclaredMethods()) {
+            if (m.getName().equals(methodName)) {
+                method = m;
+            }
+        }
+        if (method == null) {
+            throw new AssertionError("No such tool: " + methodName);
+        }
+        return new MeshToolWrapper(
+            "ToolBean." + methodName, methodName, "test", new ToolBean(), method,
+            capabilities, JsonMapper.builder().build());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshRoutePositionalBindingTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshRoutePositionalBindingTest.java
@@ -1,0 +1,411 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshRoute;
+import io.mcpmesh.spring.web.MeshRouteBeanPostProcessor;
+import io.mcpmesh.spring.web.MeshRouteHandlerInterceptor;
+import io.mcpmesh.spring.web.MeshRouteRegistry;
+import io.mcpmesh.spring.web.MeshRouteUtils;
+import io.mcpmesh.types.McpMeshTool;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.method.HandlerMethod;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The {@code @MeshRoute} half of the positional-binding conversion (issue
+ * #1401), covering the three pieces the argument resolver's own tests cannot
+ * reach: what the interceptor <i>stores</i>, what {@link MeshRouteUtils} reads
+ * back out of it, and what {@code enrichDependencyReturnTypes} stamps onto each
+ * dependency spec.
+ *
+ * <p>Placed in {@code io.mcpmesh.spring} so the package-private
+ * {@code MeshSettleState} reset hook is visible (settled=true short-circuits the
+ * settling-window wait, so an unavailable dependency is judged immediately).
+ */
+@DisplayName("@MeshRoute positional binding: attribute shape, MeshRouteUtils, return types")
+class MeshRoutePositionalBindingTest {
+
+    private MeshRouteRegistry registry;
+    private MeshDependencyInjector injector;
+    private MeshRouteHandlerInterceptor interceptor;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        MeshSettleState.resetForTests(0.0);
+        registry = new MeshRouteRegistry();
+        injector = mock(MeshDependencyInjector.class);
+        ObjectProvider<MeshDependencyInjector> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(injector);
+        interceptor = new MeshRouteHandlerInterceptor(registry, provider);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // What the interceptor stores
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("The request attribute is a list aligned 1:1 with the declared dependencies")
+    void attributeIsPositional() throws Exception {
+        McpMeshTool a = live("a");
+        McpMeshTool b = live("b");
+        MockHttpServletRequest request = route("/all", "handler", "a", "b");
+
+        assertTrue(interceptor.preHandle(request, mock(HttpServletResponse.class),
+            handler("handler")));
+
+        assertEquals(Arrays.asList(a, b), resolved(request));
+    }
+
+    @Test
+    @DisplayName("NULL-PADDING: an unavailable MIDDLE dependency leaves later slots in place")
+    void unavailableMiddleDependencyIsNullPadded() throws Exception {
+        // The trap this conversion must not reintroduce (#1390): the pre-3.4
+        // interceptor inserted map entries only for AVAILABLE dependencies. Port
+        // that to a list with add() and every later slot shifts by one.
+        McpMeshTool a = live("a");
+        McpMeshTool c = live("c");
+        when(injector.getToolProxy("b")).thenReturn(null);
+        MockHttpServletRequest request = route("/gap", "handler3", "a", "b", "c");
+
+        assertTrue(interceptor.preHandle(request, mock(HttpServletResponse.class),
+            handler("handler3")));
+
+        List<McpMeshTool> deps = resolved(request);
+        assertEquals(3, deps.size(), "the list is pre-sized to the DECLARED count");
+        assertSame(a, deps.get(0));
+        assertNull(deps.get(1), "the unavailable dependency holds its own slot");
+        assertSame(c, deps.get(2), "'c' must stay at index 2 — never compacted to index 1");
+    }
+
+    @Test
+    @DisplayName("NULL-PADDING: a dependency that throws during resolution also holds its slot")
+    void throwingDependencyIsNullPadded() throws Exception {
+        McpMeshTool c = live("c");
+        when(injector.getToolProxy("b")).thenThrow(new IllegalStateException("boom"));
+        MockHttpServletRequest request = route("/throw", "handler3", "a", "b", "c");
+        when(injector.getToolProxy("a")).thenReturn(null);
+
+        assertTrue(interceptor.preHandle(request, mock(HttpServletResponse.class),
+            handler("handler3")));
+
+        List<McpMeshTool> deps = resolved(request);
+        assertNull(deps.get(0));
+        assertNull(deps.get(1));
+        assertSame(c, deps.get(2));
+    }
+
+    @Test
+    @DisplayName("A proxy that exists but reports unavailable is null, not the proxy")
+    void unavailableProxyIsNotStored() throws Exception {
+        McpMeshTool down = mock(McpMeshTool.class);
+        when(down.isAvailable()).thenReturn(false);
+        when(injector.getToolProxy("a")).thenReturn(down);
+        McpMeshTool b = live("b");
+        MockHttpServletRequest request = route("/down", "handler", "a", "b");
+
+        assertTrue(interceptor.preHandle(request, mock(HttpServletResponse.class),
+            handler("handler")));
+
+        assertEquals(Arrays.asList(null, b), resolved(request));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // MeshRouteUtils still works after the attribute type change
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("MeshRouteUtils rebuilds the capability-keyed view from the positional list")
+    void routeUtilsGetDependencies() throws Exception {
+        McpMeshTool a = live("a");
+        McpMeshTool b = live("b");
+        MockHttpServletRequest request = route("/utils", "handler", "a", "b");
+        interceptor.preHandle(request, mock(HttpServletResponse.class), handler("handler"));
+
+        Map<String, McpMeshTool> byCapability = MeshRouteUtils.getDependencies(request);
+
+        assertSame(a, byCapability.get("a"));
+        assertSame(b, byCapability.get("b"));
+        assertSame(a, MeshRouteUtils.getDependency(request, "a"));
+        assertSame(b, MeshRouteUtils.requireDependency(request, "b"));
+        assertTrue(MeshRouteUtils.hasDependency(request, "a"));
+    }
+
+    @Test
+    @DisplayName("MeshRouteUtils: an unavailable dependency is absent, and requireDependency throws")
+    void routeUtilsOnAnUnavailableDependency() throws Exception {
+        when(injector.getToolProxy("b")).thenReturn(null);
+        McpMeshTool a = live("a");
+        MockHttpServletRequest request = route("/utils2", "handler", "a", "b");
+        interceptor.preHandle(request, mock(HttpServletResponse.class), handler("handler"));
+
+        assertEquals(1, MeshRouteUtils.getDependencies(request).size());
+        assertNull(MeshRouteUtils.getDependency(request, "b"));
+        assertSame(a, MeshRouteUtils.getDependency(request, "a"),
+            "the surviving dependency is still reachable by ITS capability");
+        assertThrows(IllegalStateException.class,
+            () -> MeshRouteUtils.requireDependency(request, "b"));
+    }
+
+    @Test
+    @DisplayName("MeshRouteUtils: the @MeshDependency name alias is a secondary key")
+    void routeUtilsAliasKey() throws Exception {
+        McpMeshTool baseCap = live("base-cap");
+        MockHttpServletRequest request = route("/alias", "handler1", "base-cap");
+        interceptor.preHandle(request, mock(HttpServletResponse.class), handler("handler1"));
+
+        assertSame(baseCap, MeshRouteUtils.getDependency(request, "base-cap"));
+        assertSame(baseCap, MeshRouteUtils.getDependency(request, "baseCap"),
+            "DependencySpec defaults its name to the camelCased capability");
+    }
+
+    @Test
+    @DisplayName("MeshRouteUtils: the declaration-index accessor mirrors parameter injection")
+    void routeUtilsByIndex() throws Exception {
+        McpMeshTool a = live("a");
+        McpMeshTool c = live("c");
+        when(injector.getToolProxy("b")).thenReturn(null);
+        MockHttpServletRequest request = route("/index", "handler3", "a", "b", "c");
+        interceptor.preHandle(request, mock(HttpServletResponse.class), handler("handler3"));
+
+        assertSame(a, MeshRouteUtils.getDependency(request, 0));
+        assertNull(MeshRouteUtils.getDependency(request, 1));
+        assertSame(c, MeshRouteUtils.getDependency(request, 2));
+        assertNull(MeshRouteUtils.getDependency(request, 3), "out of range");
+        assertNull(MeshRouteUtils.getDependency(request, -1));
+    }
+
+    @Test
+    @DisplayName("MeshRouteUtils on a non-@MeshRoute request: empty map, no exception")
+    void routeUtilsWithoutTheAttribute() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        assertTrue(MeshRouteUtils.getDependencies(request).isEmpty());
+        assertNull(MeshRouteUtils.getDependency(request, "a"));
+        assertNull(MeshRouteUtils.getDependency(request, 0));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Return-type enrichment: the generic must follow the POSITION
+    // ─────────────────────────────────────────────────────────────────
+
+    /** Distinct payload types so a mis-assigned generic is visible. */
+    public record Alpha(String a) {}
+
+    /** Second payload type. */
+    public record Beta(int b) {}
+
+    @RestController
+    @SuppressWarnings("unused")
+    public static class TypedController {
+
+        /** Declaration order matches the parameters. */
+        @GetMapping("/typed")
+        @MeshRoute(dependencies = {
+            @MeshDependency(capability = "alpha"),
+            @MeshDependency(capability = "beta")})
+        public String typed(McpMeshTool<Alpha> first, McpMeshTool<Beta> second) {
+            return "";
+        }
+
+        /**
+         * The SAME parameters with the declaration list reordered. Positional
+         * binding gives parameter 0 the 'beta' edge, so 'beta' must carry
+         * {@code Alpha} as its response type — the generic follows the
+         * parameter, not the capability name.
+         */
+        @GetMapping("/reordered")
+        @MeshRoute(dependencies = {
+            @MeshDependency(capability = "beta"),
+            @MeshDependency(capability = "alpha")})
+        public String reordered(McpMeshTool<Alpha> first, McpMeshTool<Beta> second) {
+            return "";
+        }
+
+        /** A raw McpMeshTool in the middle must not shift the later generic. */
+        @GetMapping("/raw-middle")
+        @MeshRoute(dependencies = {
+            @MeshDependency(capability = "alpha"),
+            @MeshDependency(capability = "raw"),
+            @MeshDependency(capability = "beta")})
+        public String rawMiddle(
+                McpMeshTool<Alpha> first,
+                @SuppressWarnings("rawtypes") McpMeshTool second,
+                McpMeshTool<Beta> third) {
+            return "";
+        }
+    }
+
+    @Test
+    @DisplayName("Each McpMeshTool<T> generic lands on the dependency its PARAMETER binds to")
+    void returnTypesFollowPosition() {
+        Map<String, java.lang.reflect.Type> types = enrich("typed");
+
+        assertEquals(Alpha.class, types.get("alpha"));
+        assertEquals(Beta.class, types.get("beta"));
+    }
+
+    @Test
+    @DisplayName("REORDERED: the generic follows the position, so response deserialization matches")
+    void returnTypesFollowPositionAfterAReorder() {
+        // The by-name enrichment this replaced would have given 'alpha' the
+        // Alpha type even though parameter 1 — the McpMeshTool<Beta> — is what
+        // binds to it, deserializing every response into the wrong type.
+        Map<String, java.lang.reflect.Type> types = enrich("reordered");
+
+        assertEquals(Alpha.class, types.get("beta"),
+            "dependency[0] 'beta' binds to parameter 0, which is McpMeshTool<Alpha>");
+        assertEquals(Beta.class, types.get("alpha"),
+            "dependency[1] 'alpha' binds to parameter 1, which is McpMeshTool<Beta>");
+    }
+
+    @Test
+    @DisplayName("A raw McpMeshTool consumes its slot without stealing the next generic")
+    void rawParameterHoldsItsSlot() {
+        Map<String, java.lang.reflect.Type> types = enrich("rawMiddle");
+
+        assertEquals(Alpha.class, types.get("alpha"));
+        assertNull(types.get("raw"), "a raw McpMeshTool contributes no type");
+        assertEquals(Beta.class, types.get("beta"),
+            "the third parameter's generic must not slide onto 'raw'");
+    }
+
+    @Test
+    @DisplayName("The enriched type reaches the injector as the proxy's response type")
+    void enrichedTypeIsUsedToBuildTheProxy() throws Exception {
+        MeshRouteBeanPostProcessor processor = new MeshRouteBeanPostProcessor(registry);
+        processor.postProcessAfterInitialization(new TypedController(), "typedController");
+
+        McpMeshTool proxy = mock(McpMeshTool.class);
+        when(proxy.isAvailable()).thenReturn(true);
+        when(injector.getToolProxy(any(String.class), any(java.lang.reflect.Type.class)))
+            .thenReturn(proxy);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/reordered");
+        interceptor.preHandle(request, mock(HttpServletResponse.class),
+            new HandlerMethod(new TypedController(), methodOf(TypedController.class, "reordered")));
+
+        // dependency[0] is 'beta' and binds to the McpMeshTool<Alpha> parameter.
+        org.mockito.Mockito.verify(injector).getToolProxy(eq("beta"), eq(Alpha.class));
+        org.mockito.Mockito.verify(injector).getToolProxy(eq("alpha"), eq(Beta.class));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Harness
+    // ─────────────────────────────────────────────────────────────────
+
+    /** Sample controller whose method IDs back the registered route metadata. */
+    @SuppressWarnings("unused")
+    static class SampleController {
+        public String handler1() { return "ok"; }
+        public String handler() { return "ok"; }
+        public String handler3() { return "ok"; }
+    }
+
+    private McpMeshTool live(String capability) {
+        McpMeshTool tool = mock(McpMeshTool.class, capability);
+        when(tool.isAvailable()).thenReturn(true);
+        when(injector.getToolProxy(capability)).thenReturn(tool);
+        return tool;
+    }
+
+    /** Register a route and build the matching request. */
+    private MockHttpServletRequest route(String path, String methodName, String... capabilities) {
+        List<MeshRouteRegistry.DependencySpec> deps = new ArrayList<>();
+        for (String capability : capabilities) {
+            deps.add(MeshRouteRegistry.DependencySpec.fromAnnotation(
+                dependencyAnnotation(capability)));
+        }
+        registry.register("GET", path, new MeshRouteRegistry.RouteMetadata(
+            SampleController.class.getName() + "." + methodName, deps, "test", false));
+        return new MockHttpServletRequest("GET", path);
+    }
+
+    private HandlerMethod handler(String methodName) {
+        return new HandlerMethod(new SampleController(),
+            methodOf(SampleController.class, methodName));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<McpMeshTool> resolved(HttpServletRequest request) {
+        return (List<McpMeshTool>)
+            request.getAttribute(MeshRouteHandlerInterceptor.MESH_DEPENDENCIES_ATTR);
+    }
+
+    /** Run the bean post-processor and read back capability → enriched return type. */
+    private Map<String, java.lang.reflect.Type> enrich(String methodName) {
+        MeshRouteRegistry local = new MeshRouteRegistry();
+        new MeshRouteBeanPostProcessor(local)
+            .postProcessAfterInitialization(new TypedController(), "typedController");
+        MeshRouteRegistry.RouteMetadata metadata = local.getByHandlerMethodId(
+            TypedController.class.getName() + "." + methodName);
+        Map<String, java.lang.reflect.Type> types = new java.util.LinkedHashMap<>();
+        for (MeshRouteRegistry.DependencySpec dep : metadata.getDependencies()) {
+            types.put(dep.getCapability(), dep.getReturnType());
+        }
+        return types;
+    }
+
+    private static Method methodOf(Class<?> type, String name) {
+        for (Method m : type.getDeclaredMethods()) {
+            if (m.getName().equals(name)) {
+                return m;
+            }
+        }
+        throw new AssertionError("No such method: " + name);
+    }
+
+    /** A synthetic {@code @MeshDependency} so specs get their real defaults. */
+    private static MeshDependency dependencyAnnotation(String capability) {
+        return DepHolder.of(capability);
+    }
+
+    /** Holder supplying real {@code @MeshDependency} instances by reflection. */
+    @SuppressWarnings("unused")
+    private static final class DepHolder {
+        @MeshRoute(dependencies = {
+            @MeshDependency(capability = "a"),
+            @MeshDependency(capability = "b"),
+            @MeshDependency(capability = "c"),
+            @MeshDependency(capability = "base-cap")})
+        static void shapes() {}
+
+        static MeshDependency of(String capability) {
+            try {
+                MeshRoute route = DepHolder.class
+                    .getDeclaredMethod("shapes").getAnnotation(MeshRoute.class);
+                for (MeshDependency dep : route.dependencies()) {
+                    if (dep.capability().equals(capability)) {
+                        return dep;
+                    }
+                }
+            } catch (NoSuchMethodException e) {
+                throw new AssertionError(e);
+            }
+            throw new AssertionError("No @MeshDependency fixture for " + capability);
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherDependencyBindingCharacterizationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherDependencyBindingCharacterizationTest.java
@@ -23,28 +23,28 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Characterization tests for {@code MeshA2ADispatcher.resolveDependency}'s
- * {@link McpMeshTool} branch — the {@code @MeshA2A} injection path (issue
- * #1401).
+ * Characterization tests for {@code MeshA2ADispatcher}'s argument binding — the
+ * {@code @MeshA2A} injection path (issue #1401).
  *
- * <p><b>Why these exist.</b> Only the {@code MeshJobSubmitter} branch of the
- * dispatcher's argument binding had coverage;
- * {@link A2ATestFixtures} even carries a comment noting that "most tests don't
- * exercise {@code @MeshInject} parameter resolution". The conversion of
- * {@code @MeshA2A} from name-based to positional binding rewrites exactly this
- * code, so today's behaviour is pinned first — the rewrite of this file then
- * <b>is</b> the semantic change, made visible in a diff.
+ * <p><b>What changed.</b> This file previously pinned by-NAME binding: the
+ * dispatcher derived a capability string from {@code @MeshInject}'s value or the
+ * reflective parameter name and linearly scanned the surface's declared
+ * dependencies for a match, so the parameter's position was never consulted. It
+ * now pins the POSITIONAL contract: the Nth injectable parameter in signature
+ * order receives the Nth declared {@code @MeshDependency}, and no name is
+ * consulted at dispatch time. The diff against the previous revision of this
+ * file <b>is</b> the semantic change.
  *
- * <p><b>The contract being pinned:</b> the dispatcher derives a capability
- * <i>string</i> — {@code @MeshInject}'s value when non-empty, otherwise the raw
- * reflective parameter name — and linearly scans the surface's declared
- * dependencies for one whose capability or {@code DependencySpec} name equals
- * it. The parameter's position in the signature is never consulted.
+ * <p>What did <i>not</i> change, and is re-pinned here because the rewrite of
+ * {@code invokeHandler} could easily have broken it: A2A's slot rules are wider
+ * than the route's ({@code @MeshInject} claims any parameter type), and the four
+ * parameter roles have a precedence order that used to be implicit in an if/else
+ * chain and is now written out.
  *
  * <p>Tests drive the real {@code tasks/send} dispatch path rather than calling
  * the private resolver, so what is pinned is the behaviour a user observes.
  */
-@DisplayName("MeshA2ADispatcher: today's by-NAME dependency binding (issue #1401 characterization)")
+@DisplayName("MeshA2ADispatcher: POSITIONAL dependency binding (issue #1401)")
 class MeshA2ADispatcherDependencyBindingCharacterizationTest {
 
     private MeshA2ARegistry registry;
@@ -53,6 +53,7 @@ class MeshA2ADispatcherDependencyBindingCharacterizationTest {
 
     private McpMeshTool alphaProxy;
     private McpMeshTool betaProxy;
+    private McpMeshTool gammaProxy;
 
     @BeforeEach
     void setUp() {
@@ -61,6 +62,7 @@ class MeshA2ADispatcherDependencyBindingCharacterizationTest {
         mapper = A2ATestFixtures.objectMapper();
         alphaProxy = mock(McpMeshTool.class, "alpha-proxy");
         betaProxy = mock(McpMeshTool.class, "beta-proxy");
+        gammaProxy = mock(McpMeshTool.class, "gamma-proxy");
         CapturingBean.ARGS.remove();
     }
 
@@ -70,12 +72,12 @@ class MeshA2ADispatcherDependencyBindingCharacterizationTest {
     }
 
     // ─────────────────────────────────────────────────────────────────
-    // The pins
+    // The contract
     // ─────────────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("@MeshInject values agreeing with declaration order: each parameter gets its own proxy")
-    void agreeingInjectValuesResolveToTheirOwnCapability() {
+    @DisplayName("The Nth injectable parameter receives the Nth declared dependency")
+    void slotOrdinalSelectsTheDependency() {
         dispatch("agreeing", List.of(dep("alpha"), dep("beta")));
 
         assertSame(alphaProxy, CapturingBean.ARGS.get().get(0));
@@ -83,40 +85,42 @@ class MeshA2ADispatcherDependencyBindingCharacterizationTest {
     }
 
     @Test
-    @DisplayName("PIN: @MeshInject value WINS over parameter position — declaration order is ignored")
-    void nameBeatsPositionToday() {
-        // Declaration order is [alpha, beta]; positional binding would give the
-        // first injectable parameter the alpha proxy. Today the name decides.
+    @DisplayName("PIN: POSITION wins — a reversed @MeshInject value does not swap the proxies")
+    void positionBeatsName() {
+        // Declaration order is [alpha, beta]. The first injectable parameter is
+        // annotated @MeshInject("beta"), which under the pre-3.4 rule handed it
+        // the beta proxy. Position decides now — and this exact shape is refused
+        // at boot, so the value can never be a lie in practice.
         dispatch("disagreeing", List.of(dep("alpha"), dep("beta")));
 
-        assertSame(betaProxy, CapturingBean.ARGS.get().get(0),
-            "parameter annotated @MeshInject(\"beta\") must receive the beta proxy today");
-        assertSame(alphaProxy, CapturingBean.ARGS.get().get(1),
-            "parameter annotated @MeshInject(\"alpha\") must receive the alpha proxy today");
+        assertSame(alphaProxy, CapturingBean.ARGS.get().get(0),
+            "slot 0 takes dependency[0] regardless of what @MeshInject says");
+        assertSame(betaProxy, CapturingBean.ARGS.get().get(1),
+            "slot 1 takes dependency[1] regardless of what @MeshInject says");
     }
 
     @Test
-    @DisplayName("@MeshInject value matching no declared capability: null, dispatch still succeeds")
-    void undeclaredInjectValueResolvesToNull() {
-        dispatch("undeclared", List.of(dep("alpha"), dep("beta")));
-
-        assertNull(CapturingBean.ARGS.get().get(0),
-            "an unmatched capability is a debug-and-inject-null, not a failure");
-    }
-
-    @Test
-    @DisplayName("No @MeshInject: the PARAMETER NAME is the lookup key")
-    void parameterNameIsTheFallbackKey() {
-        dispatch("parameterNameFallback", List.of(dep("alpha")));
+    @DisplayName("PIN: a parameter NAME matching another capability does not redirect the binding")
+    void parameterNameIsNotConsulted() {
+        // The first injectable parameter is literally named "beta".
+        dispatch("misleadingNames", List.of(dep("alpha"), dep("beta")));
 
         assertSame(alphaProxy, CapturingBean.ARGS.get().get(0));
+        assertSame(betaProxy, CapturingBean.ARGS.get().get(1));
     }
 
     @Test
-    @DisplayName("No @MeshInject, kebab-case capability: the camelCased DependencySpec name matches")
-    void camelCasedDependencySpecNameMatches() {
-        // DependencySpec.fromAnnotation defaults the spec name to the camelCased
-        // capability, and the dispatcher scans that field too.
+    @DisplayName("PIN: @MeshInject is inert at dispatch time — even a value naming nothing binds")
+    void annotationIsInertAtDispatchTime() {
+        dispatch("undeclared", List.of(dep("alpha"), dep("beta")));
+
+        assertSame(alphaProxy, CapturingBean.ARGS.get().get(0),
+            "@MeshInject(\"nope\") on slot 0 still receives dependency[0]");
+    }
+
+    @Test
+    @DisplayName("A kebab-case capability needs no camelCase parameter name to bind")
+    void kebabCaseCapabilityBindsWithoutANameMatch() {
         when(injector().getToolProxy("base-cap")).thenReturn(alphaProxy);
         dispatch("camelCasedParameterName",
             List.of(new MeshRouteRegistry.DependencySpec(
@@ -126,7 +130,7 @@ class MeshA2ADispatcherDependencyBindingCharacterizationTest {
     }
 
     @Test
-    @DisplayName("Declared dependency with no parameter naming it: simply unbound, no error")
+    @DisplayName("Declared dependency with no parameter to reach it: simply unbound, no error")
     void surplusDeclaredDependencyIsIgnored() {
         dispatch("parameterNameFallback", List.of(dep("alpha"), dep("beta")));
 
@@ -136,14 +140,92 @@ class MeshA2ADispatcherDependencyBindingCharacterizationTest {
     }
 
     @Test
-    @DisplayName("@MeshInject on a NON-McpMeshTool parameter is also a dependency slot on the A2A path")
+    @DisplayName("More injectable parameters than dependencies: the surplus is null")
+    void surplusSlotIsNull() {
+        dispatch("three", List.of(dep("alpha"), dep("beta")));
+
+        assertSame(alphaProxy, CapturingBean.ARGS.get().get(0));
+        assertSame(betaProxy, CapturingBean.ARGS.get().get(1));
+        assertNull(CapturingBean.ARGS.get().get(2),
+            "no dependency is declared at index 2");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Slot preservation (issue #1390)
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("SLOT PRESERVATION: an unresolvable MIDDLE dependency does not shift the later ones")
+    void unresolvedMiddleDependencyHoldsItsOwnSlot() {
+        // 'beta_down' resolves to null through the injector — the provider is
+        // gone. Every other parameter must keep its own proxy.
+        dispatch("three", List.of(dep("alpha"), dep("beta_down"), dep("gamma")));
+
+        assertSame(alphaProxy, CapturingBean.ARGS.get().get(0), "slot 0 keeps its own proxy");
+        assertNull(CapturingBean.ARGS.get().get(1),
+            "the unresolvable dependency leaves ITS OWN slot null");
+        assertSame(gammaProxy, CapturingBean.ARGS.get().get(2),
+            "slot 2 must still receive gamma — it must not slide up into slot 1");
+    }
+
+    @Test
+    @DisplayName("SLOT PRESERVATION: only the middle dependency resolvable fills only the middle slot")
+    void resolvedMiddleDependencyDoesNotSlideDown() {
+        dispatch("three", List.of(dep("alpha_down"), dep("beta"), dep("gamma_down")));
+
+        assertNull(CapturingBean.ARGS.get().get(0));
+        assertSame(betaProxy, CapturingBean.ARGS.get().get(1),
+            "the single resolvable dependency lands in ITS slot, not slot 0");
+        assertNull(CapturingBean.ARGS.get().get(2));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // A2A's slot rules and role precedence — unchanged, re-pinned
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("@MeshInject on a NON-McpMeshTool parameter is still a dependency slot on the A2A path")
     void meshInjectOnNonProxyTypeIsStillASlot() {
         // Divergence from @MeshRoute: the dispatcher owns the whole argument
-        // array, so @MeshInject claims any parameter type. The injector returns
-        // an McpMeshTool, which is then assigned into an Object slot.
+        // array, so @MeshInject claims any parameter type. It consumes a
+        // positional slot like any other.
         dispatch("injectOnObjectParam", List.of(dep("alpha")));
 
         assertSame(alphaProxy, CapturingBean.ARGS.get().get(0));
+    }
+
+    @Test
+    @DisplayName("A dependency slot at index 0 does not steal the message: it moves to the Map")
+    void dependencySlotAndMessageCoexist() {
+        dispatch("injectBeforeMessage", List.of(dep("alpha")));
+
+        assertSame(alphaProxy, CapturingBean.ARGS.get().get(0),
+            "the dependency role outranks the message's index-0 fallback");
+        assertEquals("message", CapturingBean.ARGS.get().get(1),
+            "the message still finds the first UNCLAIMED Map parameter");
+    }
+
+    @Test
+    @DisplayName("An McpMeshTool at parameter 0 beats the message's index-0 fallback")
+    void dependencySlotBeatsTheIndexZeroMessageFallback() {
+        // The message's "parameter 0 if nothing else claimed it" fallback and a
+        // dependency slot both want index 0. Slots win — previously only
+        // because the dependency branch was tested first.
+        dispatch("proxyFirstNoMap", List.of(dep("alpha")));
+
+        assertSame(alphaProxy, CapturingBean.ARGS.get().get(0));
+        assertNull(CapturingBean.ARGS.get().get(1),
+            "the non-Map parameter 1 is not eligible for the index-0 fallback");
+    }
+
+    @Test
+    @DisplayName("A non-Map parameter 0 still takes the message when nothing else claimed it")
+    void indexZeroFallbackStillApplies() {
+        dispatch("pojoMessage", List.of(dep("alpha")));
+
+        assertEquals("message", CapturingBean.ARGS.get().get(0),
+            "parameter 0 takes the message even though it is not a Map");
+        assertSame(alphaProxy, CapturingBean.ARGS.get().get(1));
     }
 
     // ─────────────────────────────────────────────────────────────────
@@ -155,9 +237,11 @@ class MeshA2ADispatcherDependencyBindingCharacterizationTest {
     private MeshDependencyInjector injector() {
         if (injectorMock == null) {
             injectorMock = mock(MeshDependencyInjector.class);
+            // Anything ending in _down is an unresolvable capability.
             when(injectorMock.getToolProxy(anyString())).thenReturn(null);
             when(injectorMock.getToolProxy("alpha")).thenReturn(alphaProxy);
             when(injectorMock.getToolProxy("beta")).thenReturn(betaProxy);
+            when(injectorMock.getToolProxy("gamma")).thenReturn(gammaProxy);
         }
         return injectorMock;
     }
@@ -204,7 +288,7 @@ class MeshA2ADispatcherDependencyBindingCharacterizationTest {
     }
 
     /**
-     * Handler bean recording exactly what landed in each injectable slot, in
+     * Handler bean recording exactly what landed in each captured slot, in
      * signature order.
      */
     @SuppressWarnings("unused")
@@ -226,6 +310,13 @@ class MeshA2ADispatcherDependencyBindingCharacterizationTest {
             return capture(first, second);
         }
 
+        public Object misleadingNames(
+                Map<String, Object> message,
+                McpMeshTool beta,
+                McpMeshTool alpha) {
+            return capture(beta, alpha);
+        }
+
         public Object undeclared(
                 Map<String, Object> message,
                 @MeshInject("nope") McpMeshTool ghost) {
@@ -240,10 +331,32 @@ class MeshA2ADispatcherDependencyBindingCharacterizationTest {
             return capture(baseCap);
         }
 
+        public Object three(
+                Map<String, Object> message,
+                McpMeshTool a,
+                McpMeshTool b,
+                McpMeshTool c) {
+            return capture(a, b, c);
+        }
+
         public Object injectOnObjectParam(
                 Map<String, Object> message,
                 @MeshInject("alpha") Object anything) {
             return capture(anything);
+        }
+
+        public Object injectBeforeMessage(
+                @MeshInject("alpha") Object claimed,
+                Map<String, Object> message) {
+            return capture(claimed, message == null ? null : "message");
+        }
+
+        public Object proxyFirstNoMap(McpMeshTool a, String notAMessage) {
+            return capture(a, notAMessage);
+        }
+
+        public Object pojoMessage(Object message, McpMeshTool a) {
+            return capture(message == null ? null : "message", a);
         }
 
         private static Object capture(Object... args) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherOverloadedHandlerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshA2ADispatcherOverloadedHandlerTest.java
@@ -1,0 +1,319 @@
+package io.mcpmesh.spring.web;
+
+import io.mcpmesh.MeshJobSubmitter;
+import io.mcpmesh.core.AgentSpec;
+import io.mcpmesh.spring.MeshDependencyInjector;
+import io.mcpmesh.spring.MeshRuntime;
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.ResponseEntity;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Two {@code @MeshA2A} handlers with the SAME method name must each get their
+ * own argument plan (issue #1401).
+ *
+ * <p>{@code handlerMethodId} is {@code "ClassName.methodName"} — parameter types
+ * are not part of it, so overloads share one id. {@link MeshA2ARegistry} dedupes
+ * surfaces by {@code path}, not by handler id, so both overloads register as
+ * distinct surfaces. Keying the plan cache by that id therefore handed the
+ * second overload the FIRST one's plan: an out-of-bounds throw when the arities
+ * differ, and silent misbinding when they agree. The cache is keyed by the
+ * resolved {@link Method} instead.
+ */
+@DisplayName("MeshA2ADispatcher: overloaded @MeshA2A handlers get separate argument plans")
+class MeshA2ADispatcherOverloadedHandlerTest {
+
+    private MeshA2ARegistry registry;
+    private MeshA2ATaskStore taskStore;
+    private ObjectMapper mapper;
+    private MeshA2ADispatcher dispatcher;
+
+    private McpMeshTool alphaProxy;
+    private McpMeshTool betaProxy;
+    private MeshDependencyInjector injector;
+
+    @BeforeEach
+    void setUp() {
+        registry = new MeshA2ARegistry();
+        taskStore = new MeshA2ATaskStore();
+        mapper = A2ATestFixtures.objectMapper();
+        alphaProxy = mock(McpMeshTool.class, "alpha-proxy");
+        betaProxy = mock(McpMeshTool.class, "beta-proxy");
+        injector = mock(MeshDependencyInjector.class);
+        when(injector.getToolProxy(anyString())).thenReturn(null);
+        when(injector.getToolProxy("alpha")).thenReturn(alphaProxy);
+        when(injector.getToolProxy("beta")).thenReturn(betaProxy);
+        dispatcher = new MeshA2ADispatcher(registry, taskStore, mapper, provider(injector));
+        OverloadBean.CAPTURES.remove();
+        OverloadBean.SUBMITTERS.remove();
+    }
+
+    @AfterEach
+    void tearDown() {
+        OverloadBean.CAPTURES.remove();
+        OverloadBean.SUBMITTERS.remove();
+    }
+
+    @Test
+    @DisplayName("Overloads of differing arity: the wider one is not invoked with the narrower plan")
+    void differingArityDoesNotReuseTheNarrowPlan() {
+        register("/arity-two", "arity", "two", Map.class, McpMeshTool.class);
+        register("/arity-three", "arity", "three", Map.class, Object.class, McpMeshTool.class);
+
+        // Narrow overload first — it is what populates the cache.
+        assertEquals("completed", dispatch("/arity-two", "t1"));
+        assertSame(alphaProxy, captured("two").get(0));
+
+        assertEquals("completed", dispatch("/arity-three", "t2"),
+            "the 3-parameter overload must not be planned as if it had 2 parameters");
+        List<Object> three = captured("three");
+        assertNotNull(three, "the 3-parameter overload never ran");
+        assertNull(three.get(0), "the Object spacer binds nothing");
+        assertSame(betaProxy, three.get(1),
+            "the 3-parameter overload's own dependency reaches its own slot");
+    }
+
+    @Test
+    @DisplayName("Overloads of equal arity: a dependency at a different position is not misbound")
+    void equalArityDoesNotMisbindTheDependency() {
+        register("/shift-early", "shifted", "early", Map.class, McpMeshTool.class, Object.class);
+        register("/shift-late", "shifted", "late", Map.class, Object.class, McpMeshTool.class);
+
+        assertEquals("completed", dispatch("/shift-early", "t1"));
+        List<Object> early = captured("early");
+        assertSame(alphaProxy, early.get(0));
+        assertNull(early.get(1));
+
+        assertEquals("completed", dispatch("/shift-late", "t2"));
+        List<Object> late = captured("late");
+        assertNull(late.get(0),
+            "the Object parameter is UNBOUND here — it must not receive the proxy the other "
+                + "overload's plan puts at this position");
+        assertSame(betaProxy, late.get(1), "the McpMeshTool parameter receives the dependency");
+    }
+
+    @Test
+    @DisplayName("Overloads with the same role layout still resolve their OWN declared capability")
+    void sameRoleLayoutStillUsesItsOwnCapabilities() {
+        // Identical role layout ([MESSAGE, DEPENDENCY]) — only the declared
+        // dependency differs, which lives on the surface and is baked into the
+        // plan's binding. Nothing here can throw; a shared plan is silent.
+        register("/caps-alpha", "caps", "alphaSide", Map.class, McpMeshTool.class);
+        register("/caps-beta", "caps", "betaSide", Object.class, McpMeshTool.class);
+
+        assertEquals("completed", dispatch("/caps-alpha", "t1"));
+        assertSame(alphaProxy, captured("alphaSide").get(0));
+
+        assertEquals("completed", dispatch("/caps-beta", "t2"));
+        assertSame(betaProxy, captured("betaSide").get(0),
+            "the second overload declares 'beta' and must receive the beta proxy");
+    }
+
+    @Test
+    @DisplayName("Each overload gets a MeshJobSubmitter bound to ITS OWN capability")
+    void jobSubmitterIsNotSharedAcrossOverloads() {
+        // The submitter cache had the same collision as the plan cache, one
+        // field away. Capability comes from the surface (first @MeshDependency,
+        // else skillId kebab-to-snake), so a shared cache entry points the
+        // second overload's submitter at the first overload's capability —
+        // jobs get submitted under the wrong capability, silently.
+        registerSubmitterSurface("/job-first", "job-first", Map.class);
+        registerSubmitterSurface("/job-second", "job-second", Object.class);
+
+        MeshRuntime runtime = mock(MeshRuntime.class);
+        AgentSpec spec = new AgentSpec();
+        spec.setAgentId("overload-agent");
+        spec.setRegistryUrl("http://localhost:8000");
+        when(runtime.getAgentSpec()).thenReturn(spec);
+        dispatcher = new MeshA2ADispatcher(
+            registry, taskStore, mapper, provider(injector), singletonProvider(runtime));
+
+        assertEquals("completed", dispatch("/job-first", "t1"));
+        assertEquals("job_first", submitter("first").capability());
+
+        assertEquals("completed", dispatch("/job-second", "t2"));
+        assertEquals("job_second", submitter("second").capability(),
+            "the second overload's submitter must target its own skill's capability");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Harness
+    // ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Register one overload as its own surface. The declared dependency is
+     * {@code alpha} for the first surface of each pair and {@code beta} for the
+     * second, so a plan leak shows up as the wrong proxy.
+     */
+    private void register(String path, String methodName, String label, Class<?>... paramTypes) {
+        Method method;
+        try {
+            method = OverloadBean.class.getDeclaredMethod(methodName, paramTypes);
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError("No such overload: " + methodName, e);
+        }
+        String capability = registry.size() == 0 ? "alpha" : "beta";
+        registry.register(new MeshA2ARegistry.SurfaceMetadata(
+            path, "skill-" + label, "skill-" + label, "", List.of(),
+            List.of(new MeshRouteRegistry.DependencySpec(
+                capability, new String[0], "", capability)),
+            "",
+            // The colliding key, built exactly as MeshA2ABeanPostProcessor does.
+            OverloadBean.class.getName() + "." + methodName,
+            new OverloadBean(), method));
+    }
+
+    /**
+     * Register one {@code submitJob} overload as its own surface, with no
+     * declared dependency so the submitter capability comes from {@code skillId}
+     * (kebab-to-snake) and therefore differs between the two overloads.
+     */
+    private void registerSubmitterSurface(String path, String skillId, Class<?> messageParamType) {
+        Method method;
+        try {
+            method = OverloadBean.class.getDeclaredMethod(
+                "submitJob", messageParamType, MeshJobSubmitter.class);
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError("No such overload: submitJob", e);
+        }
+        registry.register(new MeshA2ARegistry.SurfaceMetadata(
+            path, skillId, skillId, "", List.of(), List.of(), "",
+            OverloadBean.class.getName() + ".submitJob",
+            new OverloadBean(), method));
+    }
+
+    /** @return the task state from the JSON-RPC envelope. */
+    private String dispatch(String path, String taskId) {
+        ResponseEntity<String> resp = dispatcher.dispatch(path,
+            A2ATestFixtures.jsonRpcBody(1, "tasks/send",
+                Map.of("id", taskId, "message", Map.of("text", "hi"))));
+        JsonNode env = mapper.readTree(resp.getBody());
+        JsonNode result = env.get("result");
+        assertNotNull(result, "no result in response: " + resp.getBody());
+        String state = result.get("status").get("state").asText();
+        if (!"completed".equals(state)) {
+            // Surface the handler failure text — an out-of-bounds plan lookup
+            // lands here as a state=failed task.
+            return state + ": " + result.get("status").toString();
+        }
+        return state;
+    }
+
+    private List<Object> captured(String label) {
+        Map<String, List<Object>> all = OverloadBean.CAPTURES.get();
+        return all == null ? null : all.get(label);
+    }
+
+    private MeshJobSubmitter submitter(String label) {
+        Map<String, MeshJobSubmitter> all = OverloadBean.SUBMITTERS.get();
+        MeshJobSubmitter s = all == null ? null : all.get(label);
+        assertNotNull(s, "no MeshJobSubmitter captured for '" + label + "'");
+        return s;
+    }
+
+    private static ObjectProvider<MeshRuntime> singletonProvider(MeshRuntime runtime) {
+        return new ObjectProvider<>() {
+            @Override public MeshRuntime getObject() { return runtime; }
+            @Override public MeshRuntime getObject(Object... args) { return runtime; }
+            @Override public MeshRuntime getIfAvailable() { return runtime; }
+            @Override public MeshRuntime getIfUnique() { return runtime; }
+        };
+    }
+
+    private static ObjectProvider<MeshDependencyInjector> provider(MeshDependencyInjector injector) {
+        return new ObjectProvider<>() {
+            @Override public MeshDependencyInjector getObject() { return injector; }
+            @Override public MeshDependencyInjector getObject(Object... args) { return injector; }
+            @Override public MeshDependencyInjector getIfAvailable() { return injector; }
+            @Override public MeshDependencyInjector getIfUnique() { return injector; }
+        };
+    }
+
+    /** Overloaded handlers recording what landed in each non-message parameter. */
+    @SuppressWarnings("unused")
+    public static class OverloadBean {
+
+        static final ThreadLocal<Map<String, List<Object>>> CAPTURES = new ThreadLocal<>();
+        static final ThreadLocal<Map<String, MeshJobSubmitter>> SUBMITTERS = new ThreadLocal<>();
+
+        public Object submitJob(Map<String, Object> message, MeshJobSubmitter submitter) {
+            return captureSubmitter("first", submitter);
+        }
+
+        public Object submitJob(Object message, MeshJobSubmitter submitter) {
+            return captureSubmitter("second", submitter);
+        }
+
+        public Object arity(Map<String, Object> message, McpMeshTool a) {
+            return capture("two", a);
+        }
+
+        public Object arity(Map<String, Object> message, Object spacer, McpMeshTool b) {
+            return capture("three", spacer, b);
+        }
+
+        public Object shifted(Map<String, Object> message, McpMeshTool a, Object spacer) {
+            return capture("early", a, spacer);
+        }
+
+        public Object shifted(Map<String, Object> message, Object spacer, McpMeshTool b) {
+            return capture("late", spacer, b);
+        }
+
+        public Object caps(Map<String, Object> message, McpMeshTool a) {
+            return capture("alphaSide", a);
+        }
+
+        public Object caps(Object message, McpMeshTool b) {
+            return capture("betaSide", b);
+        }
+
+        private static Object captureSubmitter(String label, MeshJobSubmitter submitter) {
+            Map<String, MeshJobSubmitter> all = SUBMITTERS.get();
+            if (all == null) {
+                all = new HashMap<>();
+                SUBMITTERS.set(all);
+            }
+            if (submitter == null) {
+                throw new IllegalStateException("submitter was null for " + label);
+            }
+            all.put(label, submitter);
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("ok", label);
+            return result;
+        }
+
+        private static Object capture(String label, Object... args) {
+            Map<String, List<Object>> all = CAPTURES.get();
+            if (all == null) {
+                all = new HashMap<>();
+                CAPTURES.set(all);
+            }
+            all.put(label, new ArrayList<>(java.util.Arrays.asList(args)));
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("ok", label);
+            return result;
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshInjectArgumentResolverCharacterizationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshInjectArgumentResolverCharacterizationTest.java
@@ -9,42 +9,38 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.ServletWebRequest;
 
 import java.lang.reflect.Method;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Characterization tests for {@link MeshInjectArgumentResolver} — the
  * {@code @MeshRoute} injection path (issue #1401).
  *
- * <p><b>Why these exist.</b> Before this PR there was no unit test anywhere for
- * this resolver; its only coverage was end-to-end integration fixtures. The
- * conversion of {@code @MeshRoute} from name-based to positional binding touches
- * exactly this code, so today's behaviour is pinned <i>first</i>. These tests
- * describe what the resolver does now, not what it should do — when the
- * conversion lands, the rewrite of this file <b>is</b> the semantic change, made
- * visible in a diff.
+ * <p><b>What changed.</b> This file previously pinned by-NAME binding: the
+ * resolver derived a capability string from {@code @MeshInject}'s value or the
+ * parameter name and looked it up in a capability-keyed map, so declaration
+ * order was irrelevant. It now pins the POSITIONAL contract: the Nth
+ * {@code McpMeshTool} parameter in signature order receives the Nth declared
+ * dependency, and no name — annotation value or parameter name — is consulted at
+ * request time. The diff against the previous revision of this file <b>is</b> the
+ * semantic change.
  *
- * <p><b>The contract being pinned:</b> the resolver derives a capability
- * <i>string</i> — {@code @MeshInject}'s value when non-empty, otherwise the
- * parameter name — and looks it up in the map the interceptor put on the
- * request. Declaration order of {@code dependencies = {...}} is never consulted,
- * so a parameter's position in the signature is irrelevant.
+ * <p>The three cases that used to prove name binding are kept and inverted:
+ * {@code disagreeing} (annotation values reversed), {@code parameterNameFallback}
+ * (no annotation), and {@code camelCasedParameterName}. Each now asserts the
+ * opposite of what it asserted before.
  *
- * <p><b>On the no-{@code -parameters} case.</b> The test harness reproduces it
- * by not installing a {@code ParameterNameDiscoverer} on the
- * {@link MethodParameter}, which is the same null that Spring's
- * {@code StandardReflectionParameterNameDiscoverer} returns for a class compiled
- * without {@code -parameters} (it refuses to fall back on the synthetic
- * {@code arg0} names). This module compiles <i>with</i> {@code -parameters}, so
- * the real bytecode shape cannot be produced in-tree.
+ * <p>{@code @MeshInject} still exists, but as an assertion checked at boot by
+ * {@link MeshLegacyBindingDetector} — nothing in this resolver reads it, which is
+ * what {@link #annotationIsInertAtRequestTime()} pins.
  */
-@DisplayName("MeshInjectArgumentResolver: today's by-NAME binding (issue #1401 characterization)")
+@DisplayName("MeshInjectArgumentResolver: POSITIONAL binding (issue #1401)")
 class MeshInjectArgumentResolverCharacterizationTest {
 
     private final MeshInjectArgumentResolver resolver = new MeshInjectArgumentResolver();
@@ -65,8 +61,8 @@ class MeshInjectArgumentResolverCharacterizationTest {
 
         /**
          * @MeshInject values are the REVERSE of declaration order
-         * [alpha, beta]. Under name binding this is correct code; under
-         * positional binding the two parameters swap.
+         * [alpha, beta]. This shape no longer reaches the resolver — it fails
+         * the boot — but the resolver must still bind by position if it does.
          */
         String disagreeing(
                 @MeshInject("beta") McpMeshTool first,
@@ -79,116 +75,176 @@ class MeshInjectArgumentResolverCharacterizationTest {
             return "";
         }
 
-        /** No annotation — the parameter NAME is the lookup key. */
+        /** No annotation — nothing about the name matters any more. */
         String parameterNameFallback(McpMeshTool alpha) {
             return "";
         }
 
-        /**
-         * No annotation, and the capability is kebab-case: the interceptor also
-         * keys the map by {@code DependencySpec.getParameterName()}, which
-         * defaults to the camelCased capability.
-         */
+        /** A parameter named after the SECOND declared capability, sitting first. */
+        String misleadingName(McpMeshTool beta, McpMeshTool alpha) {
+            return "";
+        }
+
+        /** No annotation, kebab-case capability — no camelCase key to match. */
         String camelCasedParameterName(McpMeshTool baseCap) {
             return "";
         }
 
-        /** @MeshInject present but with an empty value — falls back to the name. */
+        /** @MeshInject present but with an empty value — asserts nothing. */
         String emptyInjectValue(@MeshInject McpMeshTool alpha) {
+            return "";
+        }
+
+        /** Non-injectable parameters between the slots must not shift them. */
+        String interleaved(
+                String body,
+                McpMeshTool first,
+                int count,
+                McpMeshTool second) {
+            return "";
+        }
+
+        /** Three slots — the middle one is the unavailable dependency. */
+        String three(McpMeshTool a, McpMeshTool b, McpMeshTool c) {
+            return "";
+        }
+
+        /** More injectable parameters than declared dependencies. */
+        String moreSlotsThanDeps(McpMeshTool a, McpMeshTool b) {
             return "";
         }
     }
 
     // ─────────────────────────────────────────────────────────────────
-    // The pins
+    // The contract
     // ─────────────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("@MeshInject value agreeing with declaration order: each parameter gets its own proxy")
-    void agreeingInjectValuesResolveToTheirOwnCapability() {
+    @DisplayName("The Nth McpMeshTool parameter receives the Nth declared dependency")
+    void slotOrdinalSelectsTheDependency() {
         McpMeshTool alpha = stub("alpha");
         McpMeshTool beta = stub("beta");
-        ServletWebRequest request = requestWith(deps(alpha, beta));
+        ServletWebRequest request = requestWith(List.of("alpha", "beta"), alpha, beta);
 
         assertSame(alpha, resolve("agreeing", 0, request));
         assertSame(beta, resolve("agreeing", 1, request));
     }
 
     @Test
-    @DisplayName("PIN: @MeshInject value WINS over parameter position — declaration order is ignored")
-    void nameBeatsPositionToday() {
+    @DisplayName("PIN: POSITION wins — a reversed @MeshInject value does not swap the proxies")
+    void positionBeatsName() {
         McpMeshTool alpha = stub("alpha");
         McpMeshTool beta = stub("beta");
-        ServletWebRequest request = requestWith(deps(alpha, beta));
+        ServletWebRequest request = requestWith(List.of("alpha", "beta"), alpha, beta);
 
-        // Declaration order is [alpha, beta]; positional binding would give
-        // parameter 0 the alpha proxy. Today the @MeshInject value decides.
-        assertSame(beta, resolve("disagreeing", 0, request),
-            "parameter 0 is annotated @MeshInject(\"beta\") and must receive the beta proxy today");
-        assertSame(alpha, resolve("disagreeing", 1, request),
-            "parameter 1 is annotated @MeshInject(\"alpha\") and must receive the alpha proxy today");
+        // Declaration order is [alpha, beta]. Parameter 0 is annotated
+        // @MeshInject("beta"), which under the pre-3.4 rule handed it the beta
+        // proxy. Position decides now — and this exact shape is refused at boot
+        // (MeshLegacyBindingDetectorTest), so the value can never be a lie in
+        // practice.
+        assertSame(alpha, resolve("disagreeing", 0, request),
+            "slot 0 takes dependency[0] regardless of what @MeshInject says");
+        assertSame(beta, resolve("disagreeing", 1, request),
+            "slot 1 takes dependency[1] regardless of what @MeshInject says");
     }
 
     @Test
-    @DisplayName("@MeshInject value matching no declared capability: null, no exception")
-    void undeclaredInjectValueResolvesToNull() {
-        ServletWebRequest request = requestWith(deps(stub("alpha"), stub("beta")));
-
-        assertNull(resolve("undeclared", 0, request),
-            "an unmatched capability is a warn-and-inject-null, not a failure");
-    }
-
-    @Test
-    @DisplayName("No @MeshInject: the PARAMETER NAME is the lookup key")
-    void parameterNameIsTheFallbackKey() {
+    @DisplayName("PIN: a parameter NAME matching another capability does not redirect the binding")
+    void parameterNameIsNotConsulted() {
         McpMeshTool alpha = stub("alpha");
-        ServletWebRequest request = requestWith(deps(alpha));
+        McpMeshTool beta = stub("beta");
+        ServletWebRequest request = requestWith(List.of("alpha", "beta"), alpha, beta);
 
-        assertSame(alpha, resolve("parameterNameFallback", 0, request));
+        // Parameter 0 is literally named "beta". Under the pre-3.4 rule it
+        // received the beta proxy; it now receives dependency[0].
+        assertSame(alpha, resolve("misleadingName", 0, request));
+        assertSame(beta, resolve("misleadingName", 1, request));
     }
 
     @Test
-    @DisplayName("No @MeshInject, kebab-case capability: the camelCased DependencySpec name matches")
-    void camelCasedParameterNameKeyMatches() {
-        // The interceptor double-keys the map: capability AND
-        // DependencySpec.getParameterName(), which camelCases "base-cap".
+    @DisplayName("PIN: @MeshInject is inert at request time — the resolver never reads it")
+    void annotationIsInertAtRequestTime() {
+        McpMeshTool alpha = stub("alpha");
+        ServletWebRequest request = requestWith(List.of("alpha"), alpha);
+
+        // Three slot-0 parameters with three different annotation states, one
+        // declared dependency: all three bind identically.
+        assertSame(alpha, resolve("agreeing", 0, request), "@MeshInject(\"alpha\")");
+        assertSame(alpha, resolve("emptyInjectValue", 0, request), "@MeshInject with no value");
+        assertSame(alpha, resolve("parameterNameFallback", 0, request), "no annotation");
+        assertSame(alpha, resolve("undeclared", 0, request),
+            "even a @MeshInject value naming nothing declared binds by position");
+    }
+
+    @Test
+    @DisplayName("A kebab-case capability needs no camelCase parameter name to bind")
+    void kebabCaseCapabilityBindsWithoutANameMatch() {
         McpMeshTool baseCap = stub("base-cap");
-        Map<String, McpMeshTool> map = new LinkedHashMap<>();
-        map.put("base-cap", baseCap);
-        map.put("baseCap", baseCap);
-        ServletWebRequest request = requestWith(map);
+        ServletWebRequest request = requestWith(List.of("base-cap"), baseCap);
 
         assertSame(baseCap, resolve("camelCasedParameterName", 0, request));
     }
 
     @Test
-    @DisplayName("@MeshInject with an empty value falls back to the parameter name")
-    void emptyInjectValueFallsBackToParameterName() {
+    @DisplayName("Non-injectable parameters between slots do not shift the slot ordinals")
+    void onlyInjectableParametersCount() {
         McpMeshTool alpha = stub("alpha");
-        ServletWebRequest request = requestWith(deps(alpha));
+        McpMeshTool beta = stub("beta");
+        ServletWebRequest request = requestWith(List.of("alpha", "beta"), alpha, beta);
 
-        assertSame(alpha, resolve("emptyInjectValue", 0, request));
+        // Signature is (String, McpMeshTool, int, McpMeshTool): the slots are at
+        // positions 1 and 3, but they are ordinals 0 and 1.
+        assertSame(alpha, resolve("interleaved", 1, request));
+        assertSame(beta, resolve("interleaved", 3, request));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Slot preservation (issue #1390) — the trap positional binding must not
+    // reintroduce
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("SLOT PRESERVATION: an unavailable MIDDLE dependency does not shift the later ones")
+    void unavailableMiddleDependencyHoldsItsOwnSlot() {
+        McpMeshTool a = stub("a");
+        McpMeshTool c = stub("c");
+        // The interceptor null-pads: dependency[1] is unavailable, so index 1
+        // is null and index 2 still holds c.
+        ServletWebRequest request = requestWith(List.of("a", "b", "c"), a, null, c);
+
+        assertSame(a, resolve("three", 0, request), "slot 0 keeps its own proxy");
+        assertNull(resolve("three", 1, request),
+            "the unavailable dependency leaves ITS OWN slot null");
+        assertSame(c, resolve("three", 2, request),
+            "slot 2 must still receive 'c' — it must not slide up into slot 1");
     }
 
     @Test
-    @DisplayName("No @MeshInject and no parameter name (compiled without -parameters): null")
-    void noNameSignalResolvesToNull() {
-        ServletWebRequest request = requestWith(deps(stub("alpha")));
+    @DisplayName("SLOT PRESERVATION: only the middle dependency available fills only the middle slot")
+    void availableMiddleDependencyDoesNotSlideDown() {
+        McpMeshTool b = stub("b");
+        ServletWebRequest request = requestWith(List.of("a", "b", "c"), null, b, null);
 
-        // A class compiled without -parameters cannot be produced in-tree (this
-        // module compiles WITH it), so the shape is reproduced at the resolver's
-        // seam: MethodParameter.getParameterName() returns null. Verified against
-        // Spring 7.0.7 — for a class compiled without -parameters it returns null
-        // both with and without a ParameterNameDiscoverer installed, because
-        // StandardReflectionParameterNameDiscoverer refuses the synthetic argN
-        // names.
-        MethodParameter parameter = mock(MethodParameter.class);
-        when(parameter.getParameterAnnotation(MeshInject.class)).thenReturn(null);
-        when(parameter.getParameterName()).thenReturn(null);
-
-        assertNull(resolver.resolveArgument(parameter, null, request, null),
-            "a parameter with no @MeshInject value and no discoverable name binds to nothing today");
+        assertNull(resolve("three", 0, request));
+        assertSame(b, resolve("three", 1, request),
+            "the single available dependency lands in ITS slot, not slot 0");
+        assertNull(resolve("three", 2, request));
     }
+
+    @Test
+    @DisplayName("More injectable parameters than dependencies: the surplus is null, not shifted")
+    void surplusSlotIsNull() {
+        McpMeshTool alpha = stub("alpha");
+        ServletWebRequest request = requestWith(List.of("alpha"), alpha);
+
+        assertSame(alpha, resolve("moreSlotsThanDeps", 0, request));
+        assertNull(resolve("moreSlotsThanDeps", 1, request),
+            "no dependency is declared at index 1");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Edges
+    // ─────────────────────────────────────────────────────────────────
 
     @Test
     @DisplayName("No mesh dependencies on the request (not a @MeshRoute handler): null")
@@ -216,6 +272,8 @@ class MeshInjectArgumentResolverCharacterizationTest {
     /**
      * A {@link MethodParameter} with name discovery installed — mirroring what
      * Spring MVC's {@code InvocableHandlerMethod} does before calling a resolver.
+     * Names are now irrelevant to binding; the discoverer stays so the tests
+     * prove that under the same conditions the old rule ran in.
      */
     private static MethodParameter named(Method method, int index) {
         MethodParameter parameter = new MethodParameter(method, index);
@@ -232,19 +290,27 @@ class MeshInjectArgumentResolverCharacterizationTest {
         throw new AssertionError("No such handler: " + name);
     }
 
-    private static ServletWebRequest requestWith(Map<String, McpMeshTool> dependencies) {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setAttribute(MeshRouteHandlerInterceptor.MESH_DEPENDENCIES_ATTR, dependencies);
-        return new ServletWebRequest(request);
-    }
-
-    /** Build the interceptor's map keyed by capability (names equal capabilities here). */
-    private static Map<String, McpMeshTool> deps(McpMeshTool... tools) {
-        Map<String, McpMeshTool> map = new LinkedHashMap<>();
-        for (McpMeshTool tool : tools) {
-            map.put(tool.toString(), tool);
+    /**
+     * Build a request carrying exactly what {@code MeshRouteHandlerInterceptor}
+     * stores: the route metadata plus a positional, null-padded proxy list whose
+     * length equals the declared dependency count.
+     */
+    private static ServletWebRequest requestWith(
+            List<String> capabilities, McpMeshTool... resolved) {
+        if (capabilities.size() != resolved.length) {
+            throw new AssertionError("the interceptor null-pads to the declared count");
         }
-        return map;
+        List<MeshRouteRegistry.DependencySpec> declared = new ArrayList<>();
+        for (String capability : capabilities) {
+            declared.add(new MeshRouteRegistry.DependencySpec(
+                capability, new String[0], "", capability));
+        }
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(MeshRouteHandlerInterceptor.MESH_ROUTE_METADATA_ATTR,
+            new MeshRouteRegistry.RouteMetadata("Handlers.test", declared, "", false));
+        request.setAttribute(MeshRouteHandlerInterceptor.MESH_DEPENDENCIES_ATTR,
+            java.util.Collections.unmodifiableList(Arrays.asList(resolved)));
+        return new ServletWebRequest(request);
     }
 
     /** An identity-bearing {@link McpMeshTool} — the mock's name is its capability. */

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshLegacyBindingDetectorTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/web/MeshLegacyBindingDetectorTest.java
@@ -26,15 +26,31 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
- * Tests for {@link MeshLegacyBindingDetector} — the issue #1401 migration
- * instrument.
+ * Tests for {@link MeshLegacyBindingDetector} — the issue #1401 boot-time
+ * guard for the positional dependency contract.
  *
- * <p>The detector must fire on exactly the handler shapes whose meaning changes
- * when {@code @MeshRoute} / {@code @MeshA2A} move to positional binding, and on
- * nothing else. Both halves matter: a false positive in the instrument that is
- * meant to make the migration trustworthy is as damaging as a miss.
+ * <p><b>What changed.</b> The predecessor of this file pinned a warning-only
+ * migration instrument that compared today's name binding with tomorrow's
+ * positional binding. Positional binding has landed, so the class now enforces
+ * rather than forecasts:
+ *
+ * <ul>
+ *   <li>a {@code @MeshInject} value that contradicts the position is an
+ *       <b>ERROR that fails the boot</b>, where it used to be a WARN;</li>
+ *   <li>a parameter name that points elsewhere is a <b>WARN</b> — a migration
+ *       signal, not a rule, because names carry no meaning now;</li>
+ *   <li>the two shapes that used to be ERRORs because they bound to
+ *       <i>nothing</i> — a name matching no declared capability, and a class
+ *       compiled without {@code -parameters} — are <b>OK</b>. They were broken
+ *       only because names were the binding key. Removing the key fixed them.
+ *       That last one is the claim the whole migration rested on, so it is kept
+ *       and inverted rather than deleted.</li>
+ * </ul>
+ *
+ * <p>Both halves still matter: a false positive in a check that can stop a boot
+ * is as damaging as a miss.
  */
-@DisplayName("MeshLegacyBindingDetector: legacy-shape detection (issue #1401)")
+@DisplayName("MeshLegacyBindingDetector: the positional binding guard (issue #1401)")
 class MeshLegacyBindingDetectorTest {
 
     @SuppressWarnings("unused")
@@ -66,6 +82,10 @@ class MeshLegacyBindingDetectorTest {
             return "";
         }
 
+        String unrelatedParameterNames(McpMeshTool primary, McpMeshTool secondary) {
+            return "";
+        }
+
         String camelCased(McpMeshTool baseCap) {
             return "";
         }
@@ -82,23 +102,28 @@ class MeshLegacyBindingDetectorTest {
             return "";
         }
 
+        /** Surplus parameters, no assertions — perfectly legal, injected null. */
+        String moreSlotsThanDepsUnannotated(McpMeshTool a, McpMeshTool b) {
+            return "";
+        }
+
         String a2aInjectOnObject(Map<String, Object> message, @MeshInject("alpha") Object anything) {
             return "";
         }
     }
 
     // ─────────────────────────────────────────────────────────────────
-    // Shapes that do NOT change meaning — the detector must stay quiet
+    // Shapes the guard must stay quiet about
     // ─────────────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("@MeshInject values in declaration order: OK, nothing changes")
+    @DisplayName("@MeshInject values in declaration order: OK — the assertion holds")
     void agreeingInjectValuesAreOk() {
         MeshLegacyBindingDetector.Finding finding =
             analyzeRoute("agreeing", deps("alpha", "beta"));
 
         assertEquals(MeshLegacyBindingDetector.Severity.OK, finding.severity());
-        assertTrue(finding.message().contains("agree"), finding.message());
+        assertTrue(finding.message().contains("consistent"), finding.message());
     }
 
     @Test
@@ -109,10 +134,25 @@ class MeshLegacyBindingDetectorTest {
     }
 
     @Test
-    @DisplayName("Kebab-case capability matched by its camelCased spec name: OK")
-    void camelCasedSpecNameIsOk() {
+    @DisplayName("NOW OK: parameter names matching no declared capability")
+    void unrelatedParameterNamesAreOk() {
+        // Under name binding these two parameters bound to nothing and were
+        // injected null (an ERROR in the predecessor of this class). Under
+        // positional binding they are ordinary slots — the name was never
+        // meant to carry information.
         assertEquals(MeshLegacyBindingDetector.Severity.OK,
-            analyzeRoute("camelCased",
+            analyzeRoute("unrelatedParameterNames", deps("alpha", "beta")).severity());
+    }
+
+    @Test
+    @DisplayName("Kebab-case capability asserted by its camelCased spec name: OK")
+    void camelCasedSpecNameIsAValidAssertion() {
+        // @MeshDependency(name = ...) is an explicit second spelling of the same
+        // edge, so asserting it is legal — it can never point at a DIFFERENT
+        // dependency, which is the whole check.
+        assertEquals(MeshLegacyBindingDetector.Severity.OK,
+            MeshLegacyBindingDetector.analyze("@MeshRoute", methodOf("camelCased"),
+                MeshInjectableSlots.routeSlots(methodOf("camelCased")),
                 List.of(new MeshRouteRegistry.DependencySpec(
                     "base-cap", new String[0], "", "baseCap"))).severity());
     }
@@ -135,82 +175,137 @@ class MeshLegacyBindingDetectorTest {
             analyzeRoute("mapAccessOnly", List.of()).severity());
     }
 
+    @Test
+    @DisplayName("Unannotated surplus parameters are OK — they are simply injected null")
+    void surplusUnannotatedSlotsAreOk() {
+        assertEquals(MeshLegacyBindingDetector.Severity.OK,
+            analyzeRoute("moreSlotsThanDepsUnannotated", deps("alpha")).severity());
+    }
+
     // ─────────────────────────────────────────────────────────────────
-    // Shapes that DO change meaning
+    // The assertion: @MeshInject must agree with the position
     // ─────────────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("Reversed @MeshInject values: WARN printing both orderings and the reorder")
-    void reversedInjectValuesWarn() {
+    @DisplayName("Reversed @MeshInject values: ERROR printing both orderings and the reorder")
+    void reversedInjectValuesAreAnError() {
         MeshLegacyBindingDetector.Finding finding =
             analyzeRoute("disagreeing", deps("alpha", "beta"));
 
-        assertEquals(MeshLegacyBindingDetector.Severity.WARN, finding.severity());
+        assertEquals(MeshLegacyBindingDetector.Severity.ERROR, finding.severity());
         String m = finding.message();
-        assertTrue(m.contains("bindings WILL CHANGE"), m);
+        assertTrue(m.contains("@MeshInject value contradicts"), m);
+        assertTrue(m.contains("ASSERTS the one positional pairing assigns"), m);
         // Both orderings, for both slots.
-        assertTrue(m.contains("today (by name, @MeshInject(\"beta\")):"), m);
+        assertTrue(m.contains("@MeshInject(\"beta\") asserts:"), m);
         assertTrue(m.contains("dependency[1] 'beta'"), m);
-        assertTrue(m.contains("after alignment (by position):"), m);
+        assertTrue(m.contains("binds (by position):"), m);
         assertTrue(m.contains("dependency[0] 'alpha'"), m);
-        // The prescription, in the order that preserves today's bindings.
-        assertTrue(m.contains("Reorder dependencies = {...} to: [0] 'beta', [1] 'alpha'"), m);
-        assertTrue(m.contains("MCP_MESH_STRICT_DI=true"), m);
+        // The prescription, in the order the assertions describe.
+        assertTrue(m.contains("reorder dependencies = {...} to: [0] 'beta', [1] 'alpha'"), m);
+        assertTrue(m.contains("correct the @MeshInject value"), m);
     }
 
     @Test
-    @DisplayName("Reversed parameter NAMES (no @MeshInject) warn identically")
-    void reversedParameterNamesWarn() {
-        MeshLegacyBindingDetector.Finding finding =
-            analyzeRoute("parameterNamesSwapped", deps("alpha", "beta"));
-
-        assertEquals(MeshLegacyBindingDetector.Severity.WARN, finding.severity());
-        assertTrue(finding.message().contains("by name, parameter name 'beta'"),
-            finding.message());
-    }
-
-    @Test
-    @DisplayName("@MeshInject naming nothing declared: ERROR — already broken today")
+    @DisplayName("@MeshInject naming nothing declared: ERROR")
     void undeclaredInjectValueIsAnError() {
         MeshLegacyBindingDetector.Finding finding =
             analyzeRoute("undeclared", deps("alpha"));
 
         assertEquals(MeshLegacyBindingDetector.Severity.ERROR, finding.severity());
         String m = finding.message();
-        assertTrue(m.contains("resolves to NO declared dependency"), m);
-        assertTrue(m.contains("already broken today"), m);
-        assertTrue(m.contains("Fix the unbound parameter(s) first"), m);
+        assertTrue(m.contains("@MeshInject(\"nope\") asserts:"), m);
+        assertTrue(m.contains("NO MATCH among the declared dependencies"), m);
     }
 
     @Test
-    @DisplayName("Two parameters naming one dependency: WARN, and no reorder is prescribed")
-    void nonInjectiveNamingCannotBeFixedByReordering() {
+    @DisplayName("An assertion at a position with no declared dependency: ERROR, no reorder prescribed")
+    void assertionBeyondTheDeclaredListIsAnError() {
         MeshLegacyBindingDetector.Finding finding =
             analyzeRoute("moreSlotsThanDeps", deps("alpha"));
 
-        assertEquals(MeshLegacyBindingDetector.Severity.WARN, finding.severity());
+        assertEquals(MeshLegacyBindingDetector.Severity.ERROR, finding.severity());
         String m = finding.message();
-        assertFalse(m.contains("Reorder dependencies = {...} to:"),
+        assertFalse(m.contains("reorder dependencies = {...} to:"),
             "no reordering can give two parameters the same dependency: " + m);
         assertTrue(m.contains("no dependency declared at index 1"), m);
     }
 
+    @Test
+    @DisplayName("An assertion failure is fatal with OR without MCP_MESH_STRICT_DI")
+    void assertionFailureIsAlwaysFatal() {
+        assertThrows(IllegalStateException.class, () ->
+            MeshLegacyBindingDetector.report(
+                analyzeRoute("disagreeing", deps("alpha", "beta")), false));
+        assertThrows(IllegalStateException.class, () ->
+            MeshLegacyBindingDetector.report(
+                analyzeRoute("disagreeing", deps("alpha", "beta")), true));
+    }
+
     // ─────────────────────────────────────────────────────────────────
-    // The load-bearing blind spot: no @MeshInject, no -parameters
+    // The migration signal: parameter names that point elsewhere
     // ─────────────────────────────────────────────────────────────────
 
     @Test
-    @DisplayName("LOAD-BEARING: without -parameters there is no name signal, so no working code exists")
-    void withoutParameterNamesThereIsNoBinding() throws Exception {
+    @DisplayName("Reversed parameter NAMES (no @MeshInject): WARN, with the pre-3.4 framing")
+    void reversedParameterNamesWarn() {
+        MeshLegacyBindingDetector.Finding finding =
+            analyzeRoute("parameterNamesSwapped", deps("alpha", "beta"));
+
+        assertEquals(MeshLegacyBindingDetector.Severity.WARN, finding.severity());
+        String m = finding.message();
+        assertTrue(m.contains("parameter name 'beta' used to bind:"), m);
+        assertTrue(m.contains("mcp-mesh 3.3 or earlier"), m);
+        assertTrue(m.contains("add @MeshInject"), m);
+        assertTrue(m.contains("MCP_MESH_STRICT_DI=true"), m);
+    }
+
+    @Test
+    @DisplayName("A name crossover becomes a boot failure under MCP_MESH_STRICT_DI")
+    void strictModePromotesTheWarning() {
+        assertThrows(IllegalStateException.class, () ->
+            MeshLegacyBindingDetector.report(
+                analyzeRoute("parameterNamesSwapped", deps("alpha", "beta")), true));
+
+        // ...but an agreeing handler still boots under strict.
+        MeshLegacyBindingDetector.report(analyzeRoute("agreeing", deps("alpha", "beta")), true);
+    }
+
+    @Test
+    @DisplayName("Default posture: a name crossover logs a WARN and nothing else is reported")
+    void defaultPostureIsPermissiveForNames() {
+        List<ILoggingEvent> events = capture(() -> {
+            MeshLegacyBindingDetector.report(
+                analyzeRoute("parameterNamesSwapped", deps("alpha", "beta")), false);
+            MeshLegacyBindingDetector.report(
+                analyzeRoute("agreeing", deps("alpha", "beta")), false);
+            MeshLegacyBindingDetector.report(
+                analyzeRoute("unrelatedParameterNames", deps("alpha", "beta")), false);
+        });
+
+        assertEquals(List.of(Level.WARN),
+            events.stream().map(ILoggingEvent::getLevel).toList(),
+            "only the crossover is reported above DEBUG");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // The load-bearing blind spot, now closed: no @MeshInject, no -parameters
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("LOAD-BEARING, inverted: without -parameters a handler now binds correctly")
+    void withoutParameterNamesBindingNowWorks() throws Exception {
         Method handler = compiledWithoutParameterNames();
         assumeTrue(handler != null, "system Java compiler unavailable");
 
-        // The whole migration rests on this: a handler in this shape cannot be
-        // working today, so it cannot regress from working to misbinding.
-        // MeshInjectArgumentResolver logs an error and injects null (Spring's
-        // MethodParameter.getParameterName() returns null — the reflection name
-        // is the synthetic 'arg0', which the discoverer refuses); the A2A
-        // dispatcher matches 'arg0' against nothing.
+        // The migration rested on this shape containing no WORKING code: with no
+        // name to match, MeshInjectArgumentResolver logged an error and injected
+        // null (Spring's MethodParameter.getParameterName() returns null — the
+        // reflection name is the synthetic 'arg0', which the discoverer
+        // refuses), and the A2A dispatcher matched 'arg0' against nothing. So
+        // nobody could regress from working to misbinding. Positional binding
+        // does not need a name at all, so the same shape is now correct — and
+        // must be reported as OK, not as the ERROR it used to be.
         assertFalse(handler.getParameters()[0].isNamePresent(),
             "fixture precondition: compiled without -parameters");
         assertEquals("arg0", handler.getParameters()[0].getName());
@@ -219,44 +314,7 @@ class MeshLegacyBindingDetectorTest {
             "@MeshRoute", handler, MeshInjectableSlots.routeSlots(handler),
             deps("alpha", "beta"));
 
-        assertEquals(MeshLegacyBindingDetector.Severity.ERROR, finding.severity());
-        assertTrue(finding.message().contains("compiled without -parameters"),
-            finding.message());
-        assertTrue(finding.message().contains("already broken today"), finding.message());
-    }
-
-    // ─────────────────────────────────────────────────────────────────
-    // Reporting policy
-    // ─────────────────────────────────────────────────────────────────
-
-    @Test
-    @DisplayName("Default posture: a changed binding is a WARN, a broken one an ERROR — never fatal")
-    void defaultPostureIsPermissive() {
-        List<ILoggingEvent> events = capture(() -> {
-            MeshLegacyBindingDetector.report(
-                analyzeRoute("disagreeing", deps("alpha", "beta")), false);
-            MeshLegacyBindingDetector.report(
-                analyzeRoute("undeclared", deps("alpha")), false);
-            MeshLegacyBindingDetector.report(
-                analyzeRoute("agreeing", deps("alpha", "beta")), false);
-        });
-
-        assertEquals(List.of(Level.WARN, Level.ERROR),
-            events.stream().map(ILoggingEvent::getLevel).toList(),
-            "an agreeing handler must not be reported at all above DEBUG");
-    }
-
-    @Test
-    @DisplayName("MCP_MESH_STRICT_DI: a changed binding becomes a boot failure")
-    void strictModeFailsBoot() {
-        assertThrows(IllegalStateException.class, () ->
-            MeshLegacyBindingDetector.report(
-                analyzeRoute("disagreeing", deps("alpha", "beta")), true));
-        assertThrows(IllegalStateException.class, () ->
-            MeshLegacyBindingDetector.report(analyzeRoute("undeclared", deps("alpha")), true));
-
-        // ...but an agreeing handler still boots under strict.
-        MeshLegacyBindingDetector.report(analyzeRoute("agreeing", deps("alpha", "beta")), true);
+        assertEquals(MeshLegacyBindingDetector.Severity.OK, finding.severity(), finding.message());
     }
 
     private static List<ILoggingEvent> capture(Runnable body) {
@@ -289,10 +347,34 @@ class MeshLegacyBindingDetectorTest {
                 .map(MeshPositionalBinder.Slot::parameterPosition).toList(),
             "the dispatcher owns the whole argument array, so @MeshInject claims any type");
 
-        // And the detector follows each path's own rule.
+        // And the guard follows each path's own rule.
         assertEquals(MeshLegacyBindingDetector.Severity.OK,
             MeshLegacyBindingDetector.analyze("@MeshA2A", method,
                 MeshInjectableSlots.a2aSlots(method), deps("alpha")).severity());
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // @MeshTool: the assertion applies, the name signal does not
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("@MeshTool: a contradicting @MeshInject is an ERROR there too")
+    void toolAssertionIsChecked() {
+        MeshLegacyBindingDetector.Finding finding =
+            analyzeTool("disagreeing", "alpha", "beta");
+
+        assertEquals(MeshLegacyBindingDetector.Severity.ERROR, finding.severity());
+        assertTrue(finding.message().startsWith("@MeshTool "), finding.message());
+    }
+
+    @Test
+    @DisplayName("@MeshTool: crossing parameter NAMES are NOT reported — it was never name-based")
+    void toolNamesAreNotAMigrationSignal() {
+        // The name-crossover warning exists to catch handlers written when
+        // @MeshRoute / @MeshA2A bound by name. @MeshTool has always been
+        // positional, so a name coincidence there says nothing.
+        assertEquals(MeshLegacyBindingDetector.Severity.OK,
+            analyzeTool("parameterNamesSwapped", "alpha", "beta").severity());
     }
 
     // ─────────────────────────────────────────────────────────────────
@@ -304,6 +386,14 @@ class MeshLegacyBindingDetectorTest {
         Method method = methodOf(methodName);
         return MeshLegacyBindingDetector.analyze(
             "@MeshRoute", method, MeshInjectableSlots.routeSlots(method), deps);
+    }
+
+    private static MeshLegacyBindingDetector.Finding analyzeTool(
+            String methodName, String... capabilities) {
+        Method method = methodOf(methodName);
+        List<MeshPositionalBinder.Slot> slots = MeshInjectableSlots.routeSlots(method);
+        return MeshLegacyBindingDetector.analyzeTool(MeshPositionalBinder.bind(
+            method, slots, List.of(capabilities), capabilities.length));
     }
 
     private static Method methodOf(String name) {

--- a/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/src/main/java/com/example/streaming/Application.java
+++ b/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/src/main/java/com/example/streaming/Application.java
@@ -56,9 +56,9 @@ class GatewayController {
      * tool's {@code stream(args)} method, mirroring the TS gateway's
      * {@code trip_planning.stream(req.body)}.
      */
-    // Parameter name MUST match the capability name (snake_case → snake_case)
-    // so MeshInjectArgumentResolver resolves the dep by parameter name.
-    // This mirrors the rest-api-consumer example exactly.
+    // The single declared dependency binds to the single McpMeshTool parameter
+    // by POSITION; the parameter name is incidental. This mirrors the
+    // rest-api-consumer example exactly.
     @PostMapping("/plan")
     @MeshRoute(dependencies = @MeshDependency(capability = "trip_planning"))
     public SseEmitter plan(


### PR DESCRIPTION
## Summary

**PR B of the #1401 sequence — the breaking Java conversion.** `@MeshRoute` and `@MeshA2A` dependencies now bind **by position**, matching Python and Java's own `@MeshTool`. Parameter names are never consulted.

Four sites convert together. Three had to, or the fix would have created new silent failures.

## The four sites

1. **`MeshInjectArgumentResolver`** — the parameter's injectable-slot ordinal (from `MeshInjectableSlots.routeSlots`, cached per `Method`) indexes the positional list. No name read at request time.
2. **`MeshRouteHandlerInterceptor`** — `MESH_DEPENDENCIES_ATTR` is now `List<McpMeshTool>`.
3. **`MeshRouteBeanPostProcessor.enrichDependencyReturnTypes`** — the `McpMeshTool<T>` generic follows the slot ordinal.
4. **`MeshA2ADispatcher`** — `invokeHandler` consults a cached `ArgPlan` from `planArguments`.

## Why site 3 had to be in this PR — demonstrated, not argued

The return-type enrichment feeds `injector.getToolProxy(cap, returnType)`, driving response deserialization and the #547 schema payload. Converting the resolver while leaving it by-name would make a reordered handler deserialize into the **wrong type**.

The deliberate-break run shows exactly that flip:

```
before = {employee_count=DepartmentStats, get_employee=Employee}
after  = {get_employee=DepartmentStats, employee_count=Employee}
```

A new silent failure, created by the fix, now closed by it.

## The three traps

**(1) Null-padding — avoided by construction.** `MESH_DEPENDENCIES_ATTR` is pre-sized with `Collections.nCopies(declared.size(), null)` and written with `set(i, …)`; the loop is index-driven and there is **no `add()` anywhere in the file**. The old map simply omitted unavailable dependencies, which is harmless for a map and shifts every later slot in a list — precisely the defect #1390 pinned.

**(2) `MeshRouteUtils` kept working.** `getDependencies` is rebuilt from `MESH_ROUTE_METADATA_ATTR` plus the positional list on each call, so there is one source of truth. Capability keys first, `@MeshDependency(name=…)` aliases via `putIfAbsent` so an alias can never shadow a capability. Added `getDependency(request, int)` — the attribute is positional now and had no public positional accessor.

**(3) A2A precedence is explicit.** `planArguments` assigns roles in four ordered passes — dependency slots → `MeshJobSubmitter` → message → null — rather than relying on if/else ordering, where the tool branch previously won a collision only because it was tested first.

## `@MeshInject` is now a checked assertion

Its value must equal what position assigns, or boot fails — **unconditionally, not gated on `MCP_MESH_STRICT_DI`**. Correctly-ordered code behaves identically; a redundant annotation becomes a safety net. It is now also honoured on `@MeshTool` parameters, where it was silently ignored.

```
BOOT FAILED: com.example.api.ApiController
@MeshRoute ...getEmployee(int, McpMeshTool, McpMeshTool): a @MeshInject value
contradicts the dependency its parameter's POSITION binds to.
  2 declared dependencies: [0] 'get_employee', [1] 'employee_count'
    slot 0 = parameter 1 (McpMeshTool statsTool)
        @MeshInject("employee_count") asserts:  dependency[1] 'employee_count'
        binds (by position):                    dependency[0] 'get_employee'
  Fix — pick one:
    • reorder dependencies = {...} to: [0] 'employee_count', [1] 'get_employee'
```

## No in-tree app changes behaviour — verified independently of PR A

PR A's detector predicted this: 0 findings across 102 modules. Confirmed here by a different method — all 79 example/fixture modules compiled against the modified SDK (`ok=79 fail=0`), then a throwaway scanner carrying a **verbatim reimplementation of the three deleted name-matching paths** run against the real shipped components:

```
handlers=21 (route=14 a2a=7)  slots=14  SLOT DIFFERENCES=0  RETURN-TYPE DIFFERENCES=0
shipped guard verdicts: OK=21 WARN=0 ERROR=0
```

14/14 route and 7/7 a2a matches PR A's census exactly. Two independent methods, same answer.

## Validation

- **Null-padding**, asserted on the interceptor's stored list: an unavailable middle dependency leaves index 2 holding `c`. Also the throwing-resolution and `isAvailable()==false` variants, and A2A equivalents driven through real `tasks/send`.
- **`MeshRouteUtils`** — 5 tests across `getDependencies`, `getDependency(String)`, `requireDependency` (including the throw), `hasDependency`, the alias key, the index accessor and the no-attribute path.
- **Return-type enrichment** — `TypedController` declares identical `(McpMeshTool<Alpha>, McpMeshTool<Beta>)` parameters under two declaration orders; the reordered case asserts `beta→Alpha, alpha→Beta`, with a separate test proving `getToolProxy("beta", Alpha.class)` reaches the injector.
- **Suite**: 1080 → **1112** (+32). `MeshPositionalBinderTest` 12/12 and `MeshToolWrapperUnresolvedDepPositionTest` 5/5 pass **unedited**. `go build ./...` clean.

*Baseline note:* PR A reported starter 739 / total 1082; this environment measures 737 / 1080 at that same SHA. A 2-test environmental gap, not a regression — both sides of the comparison above were measured here, and every touched class is accounted for.

## Judgement calls for review

- **Parameter-name crossover stays WARN (strict-promotable), only `@MeshInject` is fatal.** The brief said "detector goes WARN → ERROR", but that paragraph was about `@MeshInject`. Making a *name* coincidence permanently fatal — under a contract that says names are never consulted — would be unfixable except by renaming a parameter. One-line change if you want it fatal in 3.4 as a forcing function.
- **`@MeshInject` accepts the `@MeshDependency(name=…)` alias** as well as the capability, at the paired index only, so it can never point at a different dependency. Without it, `capability="base-cap"` + `@MeshInject("baseCap")` would fail boot on a spelling the framework itself generates.
- **Class name `MeshLegacyBindingDetector` kept** though it now enforces rather than forecasts — so the PR A ↔ PR B diff reads as a content change rather than delete+add. Rename is cheap.

## Out of scope

TypeScript (PR C), docs/man/release notes (PR D), and the `jobBeforeProxy` discriminator from PR A — no guard added, still awaiting a decision.

Refs #1401


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mesh dependencies are now injected consistently by parameter position across routes, A2A handlers, and tools.
  - `@MeshInject` validates the expected dependency position during startup, with clear errors for contradictions.
  - Dependency handling preserves parameter slots, including unavailable dependencies.

- **Bug Fixes**
  - Prevented silent mismatches caused by dependency names or parameter names.

- **Documentation**
  - Updated guidance and examples to explain positional dependency binding and startup validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->