### PR TITLE
feat(typescript)!: bind mesh.route and mesh.a2a.mount dependencies by position

### DIFF
--- a/cmd/meshctl/templates/typescript/api/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/api/src/index.ts.tmpl
@@ -34,14 +34,16 @@ app.get("/health", (req: Request, res: Response) => {
  * GET /api/hello
  *
  * Example endpoint that calls the "hello" mesh capability.
- * The mesh.route() middleware resolves the dependency and injects
- * it into the handler via the deps object.
+ * The mesh.route() middleware resolves the dependency and injects it into
+ * the handler BY POSITION: deps[i] is the i-th declared dependency, so
+ * destructure the deps parameter as an array.
  */
 app.get(
   "/api/hello",
-  mesh.route([{ capability: "hello" }], async (req, res, { hello }) => {
+  mesh.route([{ capability: "hello" }], async (req, res, [hello]) => {
     if (!hello) {
-      return res.status(503).json({ error: "hello capability unavailable" });
+      res.status(503).json({ error: "hello capability unavailable" });
+      return;
     }
 
     try {
@@ -56,20 +58,21 @@ app.get(
 
 // ===== MULTI-DEPENDENCY EXAMPLE (uncomment and adapt) =====
 //
-// Declare multiple dependencies on a single route.
-// Each dependency is available on the deps object by capability name.
+// Declare multiple dependencies on a single route. Dependencies bind BY
+// POSITION — the Nth declared dependency is deps[N] — so destructure them
+// in the same order they are declared.
 //
 // app.get(
 //   "/api/combined",
 //   mesh.route(
 //     [{ capability: "time_service" }, { capability: "system_info" }],
-//     async (req, res, deps) => {
+//     async (req, res, [timeService, systemInfo]) => {
 //       const results: Record<string, unknown> = {};
-//       if (deps.time_service) {
-//         results.time = await deps.time_service({});
+//       if (timeService) {
+//         results.time = await timeService({});
 //       }
-//       if (deps.system_info) {
-//         results.system = await deps.system_info({});
+//       if (systemInfo) {
+//         results.system = await systemInfo({});
 //       }
 //       res.json(results);
 //     }
@@ -82,13 +85,14 @@ app.get(
 //
 // app.post(
 //   "/api/calculate",
-//   mesh.route([{ capability: "add" }], async (req, res, { add }) => {
+//   mesh.route([{ capability: "add" }], async (req, res, [add]) => {
 //     if (!add) {
-//       return res.status(503).json({ error: "Calculator unavailable" });
+//       res.status(503).json({ error: "Calculator unavailable" });
+//       return;
 //     }
 //     const { a, b } = req.body;
 //     const result = await add({ a, b });
-//     res.json({ operation: "add", a, b, result: parseFloat(result) });
+//     res.json({ operation: "add", a, b, result: parseFloat(String(result)) });
 //   })
 // );
 

--- a/docs/a2a/producer.md
+++ b/docs/a2a/producer.md
@@ -117,7 +117,7 @@ The simplest case — the upstream returns within seconds, so there is no parkin
 
     ```typescript
     import express from "express";
-    import { mesh, type McpMeshTool } from "@mcpmesh/sdk";
+    import { mesh } from "@mcpmesh/sdk";
 
     process.env.MCP_MESH_HTTP_PORT = process.env.MCP_MESH_HTTP_PORT ?? "9090";
     process.env.MCP_MESH_AGENT_NAME = process.env.MCP_MESH_AGENT_NAME ?? "date-a2a-agent";
@@ -135,12 +135,13 @@ The simplest case — the upstream returns within seconds, so there is no parkin
         tags: ["system", "date"],
         dependencies: ["date_service"],
       },
-      async (deps, _payload) => {
-        const dateService = deps.date_service as McpMeshTool | null;
+      async ([dateService], _payload) => {
+        // Dependencies bind BY POSITION (#1401): deps[0] is `date_service`.
+        // A slot holds `null` until the registry resolves it.
         if (dateService == null) {
           return { error: "date_service not yet resolved" };
         }
-        return { date: await dateService.call({}) };
+        return { date: await dateService({}) };
       },
     );
 

--- a/examples/typescript/express-api/index.ts
+++ b/examples/typescript/express-api/index.ts
@@ -61,19 +61,21 @@ app.get("/health", (req, res) => {
  */
 app.post(
   "/api/add",
-  mesh.route([{ capability: "add" }], async (req, res, { add }) => {
+  mesh.route([{ capability: "add" }], async (req, res, [add]) => {
     if (!add) {
-      return res.status(503).json({ error: "Calculator service unavailable" });
+      res.status(503).json({ error: "Calculator service unavailable" });
+      return;
     }
 
     const { a, b } = req.body;
     if (typeof a !== "number" || typeof b !== "number") {
-      return res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      return;
     }
 
     try {
       const result = await add({ a, b });
-      res.json({ operation: "add", a, b, result: parseFloat(result) });
+      res.json({ operation: "add", a, b, result: parseFloat(String(result)) });
     } catch (err) {
       res.status(500).json({ error: `Calculation failed: ${err}` });
     }
@@ -86,19 +88,21 @@ app.post(
  */
 app.post(
   "/api/subtract",
-  mesh.route([{ capability: "subtract" }], async (req, res, { subtract }) => {
+  mesh.route([{ capability: "subtract" }], async (req, res, [subtract]) => {
     if (!subtract) {
-      return res.status(503).json({ error: "Calculator service unavailable" });
+      res.status(503).json({ error: "Calculator service unavailable" });
+      return;
     }
 
     const { a, b } = req.body;
     if (typeof a !== "number" || typeof b !== "number") {
-      return res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      return;
     }
 
     try {
       const result = await subtract({ a, b });
-      res.json({ operation: "subtract", a, b, result: parseFloat(result) });
+      res.json({ operation: "subtract", a, b, result: parseFloat(String(result)) });
     } catch (err) {
       res.status(500).json({ error: `Calculation failed: ${err}` });
     }
@@ -111,19 +115,21 @@ app.post(
  */
 app.post(
   "/api/multiply",
-  mesh.route([{ capability: "multiply" }], async (req, res, { multiply }) => {
+  mesh.route([{ capability: "multiply" }], async (req, res, [multiply]) => {
     if (!multiply) {
-      return res.status(503).json({ error: "Calculator service unavailable" });
+      res.status(503).json({ error: "Calculator service unavailable" });
+      return;
     }
 
     const { a, b } = req.body;
     if (typeof a !== "number" || typeof b !== "number") {
-      return res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      return;
     }
 
     try {
       const result = await multiply({ a, b });
-      res.json({ operation: "multiply", a, b, result: parseFloat(result) });
+      res.json({ operation: "multiply", a, b, result: parseFloat(String(result)) });
     } catch (err) {
       res.status(500).json({ error: `Calculation failed: ${err}` });
     }
@@ -136,23 +142,26 @@ app.post(
  */
 app.post(
   "/api/divide",
-  mesh.route([{ capability: "divide" }], async (req, res, { divide }) => {
+  mesh.route([{ capability: "divide" }], async (req, res, [divide]) => {
     if (!divide) {
-      return res.status(503).json({ error: "Calculator service unavailable" });
+      res.status(503).json({ error: "Calculator service unavailable" });
+      return;
     }
 
     const { a, b } = req.body;
     if (typeof a !== "number" || typeof b !== "number") {
-      return res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      return;
     }
 
     if (b === 0) {
-      return res.status(400).json({ error: "Division by zero" });
+      res.status(400).json({ error: "Division by zero" });
+      return;
     }
 
     try {
       const result = await divide({ a, b });
-      res.json({ operation: "divide", a, b, result: parseFloat(result) });
+      res.json({ operation: "divide", a, b, result: parseFloat(String(result)) });
     } catch (err) {
       res.status(500).json({ error: `Calculation failed: ${err}` });
     }
@@ -169,14 +178,16 @@ app.post(
  */
 app.post(
   "/api/greet",
-  mesh.route([{ capability: "greet" }], async (req, res, { greet }) => {
+  mesh.route([{ capability: "greet" }], async (req, res, [greet]) => {
     if (!greet) {
-      return res.status(503).json({ error: "Greeter service unavailable" });
+      res.status(503).json({ error: "Greeter service unavailable" });
+      return;
     }
 
     const { name } = req.body;
     if (typeof name !== "string") {
-      return res.status(400).json({ error: "Parameter 'name' must be a string" });
+      res.status(400).json({ error: "Parameter 'name' must be a string" });
+      return;
     }
 
     try {
@@ -194,20 +205,22 @@ app.post(
  */
 app.post(
   "/api/greet/lucky",
-  mesh.route([{ capability: "greet-lucky" }], async (req, res, deps) => {
-    const greetLucky = deps["greet-lucky"];
+  mesh.route([{ capability: "greet-lucky" }], async (req, res, [greetLucky]) => {
     if (!greetLucky) {
-      return res.status(503).json({ error: "Greeter service unavailable" });
+      res.status(503).json({ error: "Greeter service unavailable" });
+      return;
     }
 
     const { name, birthYear, birthMonth } = req.body;
     if (typeof name !== "string") {
-      return res.status(400).json({ error: "Parameter 'name' must be a string" });
+      res.status(400).json({ error: "Parameter 'name' must be a string" });
+      return;
     }
     if (typeof birthYear !== "number" || typeof birthMonth !== "number") {
-      return res
+      res
         .status(400)
         .json({ error: "Parameters 'birthYear' and 'birthMonth' must be numbers" });
+      return;
     }
 
     try {
@@ -225,18 +238,20 @@ app.post(
  */
 app.post(
   "/api/greet/age",
-  mesh.route([{ capability: "greet-age" }], async (req, res, deps) => {
-    const greetAge = deps["greet-age"];
+  mesh.route([{ capability: "greet-age" }], async (req, res, [greetAge]) => {
     if (!greetAge) {
-      return res.status(503).json({ error: "Greeter service unavailable" });
+      res.status(503).json({ error: "Greeter service unavailable" });
+      return;
     }
 
     const { name, birthYear } = req.body;
     if (typeof name !== "string") {
-      return res.status(400).json({ error: "Parameter 'name' must be a string" });
+      res.status(400).json({ error: "Parameter 'name' must be a string" });
+      return;
     }
     if (typeof birthYear !== "number") {
-      return res.status(400).json({ error: "Parameter 'birthYear' must be a number" });
+      res.status(400).json({ error: "Parameter 'birthYear' must be a number" });
+      return;
     }
 
     try {
@@ -254,18 +269,20 @@ app.post(
  */
 app.post(
   "/api/greet/math",
-  mesh.route([{ capability: "greet-math" }], async (req, res, deps) => {
-    const greetMath = deps["greet-math"];
+  mesh.route([{ capability: "greet-math" }], async (req, res, [greetMath]) => {
     if (!greetMath) {
-      return res.status(503).json({ error: "Greeter service unavailable" });
+      res.status(503).json({ error: "Greeter service unavailable" });
+      return;
     }
 
     const { name, a, b } = req.body;
     if (typeof name !== "string") {
-      return res.status(400).json({ error: "Parameter 'name' must be a string" });
+      res.status(400).json({ error: "Parameter 'name' must be a string" });
+      return;
     }
     if (typeof a !== "number" || typeof b !== "number") {
-      return res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      return;
     }
 
     try {

--- a/examples/typescript/header-api/index.ts
+++ b/examples/typescript/header-api/index.ts
@@ -23,9 +23,10 @@ app.get("/health", (req, res) => {
  */
 app.get(
   "/api/echo-headers",
-  mesh.route([{ capability: "echo_headers" }], async (req, res, { echo_headers }) => {
+  mesh.route([{ capability: "echo_headers" }], async (req, res, [echo_headers]) => {
     if (!echo_headers) {
-      return res.status(503).json({ error: "echo_headers capability unavailable" });
+      res.status(503).json({ error: "echo_headers capability unavailable" });
+      return;
     }
 
     try {

--- a/examples/typescript/producer-date-agent/index.ts
+++ b/examples/typescript/producer-date-agent/index.ts
@@ -22,8 +22,9 @@
  *
  * The mesh dependency on `date_service` demonstrates DDDI inside an
  * A2A handler: at request time the framework resolves the `McpMeshTool`
- * proxy and supplies it under the `deps` argument keyed by capability
- * name — same wiring `mesh.route(...)` uses.
+ * proxy and supplies it in the `deps` argument BY POSITION — `deps[i]`
+ * is `dependencies[i]` (issue #1401) — same wiring `mesh.route(...)`
+ * uses.
  *
  * Stack
  * =====
@@ -72,7 +73,7 @@ const HTTP_PORT = resolveHttpPort();
 process.env.MCP_MESH_AGENT_NAME = process.env.MCP_MESH_AGENT_NAME ?? "date-a2a-agent";
 
 import express from "express";
-import { mesh, type McpMeshTool } from "@mcpmesh/sdk";
+import { mesh } from "@mcpmesh/sdk";
 
 const app = express();
 // `express.json()` is REQUIRED — the A2A dispatcher reads `req.body`
@@ -90,20 +91,20 @@ mesh.a2a.mount(
     tags: ["system", "date"],
     dependencies: ["date_service"],
   },
-  async (deps, _payload) => {
-    // The framework injects resolved McpMeshTool proxies keyed by
-    // capability name — same shape `mesh.route(...)` provides. Until
-    // the registry sees a matching provider the value is `null`; we
-    // emit a local fallback so the example stays runnable solo
-    // (matches Python/Java's defer-resolution behavior).
-    const dateService = deps.date_service as McpMeshTool | null;
+  async ([dateService], _payload) => {
+    // The framework injects resolved McpMeshTool proxies BY POSITION —
+    // deps[i] is the i-th entry of `dependencies` above, the same shape
+    // `mesh.route(...)` provides. Until the registry sees a matching
+    // provider the value is `null`; we emit a local fallback so the
+    // example stays runnable solo (matches Python/Java's
+    // defer-resolution behavior).
     if (dateService === null) {
       return {
         date: new Date().toISOString(),
         note: "date_service not yet resolved — returning local fallback",
       };
     }
-    const result = await dateService.call({});
+    const result = await dateService({});
     return { date: result };
   },
 );

--- a/src/runtime/typescript/src/__tests__/positional-deps-types.spec.ts
+++ b/src/runtime/typescript/src/__tests__/positional-deps-types.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Strict-mode COMPILE test for the positional dependency contract (#1401).
+ *
+ * The runtime Proxy in `positional-deps.ts` is a *migration* aid — it fires at
+ * request time. The stronger guarantee is that an un-migrated handler does not
+ * reach runtime at all: the shape change from `Record<string, McpMeshTool>` to
+ * `Array<McpMeshTool | null>` is a compile error at every site that named a
+ * capability, INCLUDING the `mount<{...}>` type argument.
+ *
+ * The project's `tsc --noEmit` (strict) type-checks this file, so each
+ * `@ts-expect-error` below is an assertion: if a listed pattern ever starts
+ * compiling again, the *unused* `@ts-expect-error` breaks the build.
+ *
+ * Nothing here is invoked — the bodies exist purely for the compiler. Vitest
+ * runs a trivial assertion so the file counts as a spec.
+ */
+import { describe, it, expect } from "vitest";
+import type { Request, Response } from "express";
+import type { Application } from "express";
+import { route } from "../route.js";
+import { mount } from "../a2a/producer/mount.js";
+import type {
+  A2ADependencies,
+  A2AHandler,
+} from "../a2a/producer/dispatcher.js";
+import type {
+  MeshRouteHandler,
+  RouteDependencies,
+} from "../route.js";
+import type { McpMeshTool, PositionalDependencies } from "../index.js";
+
+const app = {} as unknown as Application;
+const config = { path: "/agents/date", skillId: "get-date", dependencies: ["date_service"] };
+
+// ── The OLD capability-keyed type argument must NOT satisfy the constraint ───
+// This is the load-bearing compile break: a consumer's
+// `mount<{ date_service: McpMeshTool }>(...)` stops compiling outright rather
+// than surviving to runtime and reading `undefined`.
+// @ts-expect-error #1401: capability-keyed deps are gone; the type argument must be an array (or tuple) of McpMeshTool | null.
+type _OldKeyedHandlerArg = A2AHandler<{ date_service: McpMeshTool }>;
+// @ts-expect-error #1401: same constraint on the route handler type.
+type _OldKeyedRouteArg = MeshRouteHandler<{ calculator: McpMeshTool }>;
+
+// ── ...and the NEW forms must compile ────────────────────────────────────────
+function _newMountTypeArgsCompile(): void {
+  // Tuple — per-slot typing, the recommended form.
+  mount<[McpMeshTool | null]>(app, config, async ([dateService], _payload) => {
+    return dateService === null ? null : await dateService({});
+  });
+  // The default/alias name still works and still names the array type.
+  mount<A2ADependencies>(app, config, async (deps) => deps[0]);
+  // No type argument at all.
+  mount(app, config, async ([dateService]) => dateService);
+}
+
+// ── The alias types are all the same array type ──────────────────────────────
+const _routeDepsIsPositional: RouteDependencies = [] as PositionalDependencies;
+const _a2aDepsIsPositional: A2ADependencies = [] as PositionalDependencies;
+const _positionalIsRouteDeps: PositionalDependencies = [] as RouteDependencies;
+
+// ── mesh.route: naming a capability on deps must NOT compile ─────────────────
+const _oldRouteAccessIsRejected: MeshRouteHandler = async (_req, _res, deps) => {
+  // @ts-expect-error #1401: `deps` is an array; capabilities are not keys.
+  void deps.calculator;
+};
+
+const _oldRouteDestructureIsRejected: MeshRouteHandler = async (
+  _req,
+  _res,
+  // @ts-expect-error #1401: object destructuring no longer matches the deps type.
+  { calculator }
+) => {
+  void calculator;
+};
+
+// ── ...and the positional forms compile ──────────────────────────────────────
+const _newRouteDestructureCompiles: MeshRouteHandler = async (
+  _req,
+  _res,
+  [calculator]
+) => {
+  if (calculator) await calculator({});
+};
+
+const _tupleTypedRouteHandler: MeshRouteHandler<[McpMeshTool, McpMeshTool | null]> =
+  async (_req, _res, [always, maybe]) => {
+    await always({});
+    if (maybe) await maybe({});
+  };
+
+function _routeFactoryAcceptsPositionalHandler(): void {
+  // Unannotated: `add` / `subtract` are contextually typed McpMeshTool | null.
+  route(
+    [{ capability: "add" }, { capability: "subtract" }],
+    async (_req: Request, _res: Response, [add, subtract]) => {
+      if (add) await add({});
+      if (subtract) await subtract({});
+    }
+  );
+  // The 4-parameter (next) form is accepted by the same signature.
+  route([{ capability: "add" }], async (_req, _res, [add], next) => {
+    if (!add) return next();
+    await add({});
+  });
+  // Tuple type argument for per-slot narrowing at the factory.
+  route<[McpMeshTool, McpMeshTool | null]>(
+    [{ capability: "add" }, { capability: "subtract" }],
+    async (_req, _res, [add, subtract]) => {
+      await add({});
+      if (subtract) await subtract({});
+    }
+  );
+}
+
+// ── A2AHandler generic still constrains to the array shape ───────────────────
+const _a2aHandlerTuple: A2AHandler<[McpMeshTool | null]> = async ([dep]) => dep;
+
+describe("positional dependency contract compiles as documented (#1401)", () => {
+  it("type-checks the positional idioms and rejects the keyed ones", () => {
+    expect(typeof _newMountTypeArgsCompile).toBe("function");
+    expect(typeof _routeFactoryAcceptsPositionalHandler).toBe("function");
+    expect(typeof _oldRouteAccessIsRejected).toBe("function");
+    expect(typeof _oldRouteDestructureIsRejected).toBe("function");
+    expect(typeof _newRouteDestructureCompiles).toBe("function");
+    expect(typeof _tupleTypedRouteHandler).toBe("function");
+    expect(typeof _a2aHandlerTuple).toBe("function");
+    expect(_routeDepsIsPositional).toEqual([]);
+    expect(_a2aDepsIsPositional).toEqual([]);
+    expect(_positionalIsRouteDeps).toEqual([]);
+    // Reference the compile-only aliases so `noUnusedLocals` stays quiet;
+    // their assertions live in the @ts-expect-error directives above.
+    const _refs: [_OldKeyedHandlerArg?, _OldKeyedRouteArg?] = [];
+    expect(_refs).toEqual([]);
+  });
+});

--- a/src/runtime/typescript/src/__tests__/positional-deps.spec.ts
+++ b/src/runtime/typescript/src/__tests__/positional-deps.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * Issue #1401 — the positional-dependency migration guard.
+ *
+ * `mesh.route()` / `mesh.a2a.mount()` handlers receive an ARRAY as of 3.4.0,
+ * not a capability-keyed object. An un-migrated `deps.<capability>` read on an
+ * array would evaluate to `undefined` and fail later, deep in the handler, as
+ * `Cannot read properties of undefined (reading 'call')`. `wrapPositionalDeps`
+ * turns that into a prescriptive throw.
+ *
+ * Two properties, and the second matters as much as the first:
+ *
+ *   1. The trap FIRES on a declared capability, naming its index and printing
+ *      the corrected handler signature.
+ *   2. The trap is INERT for everything else. A `get` trap sits in front of
+ *      every property read a host makes, and hosts duck-type through invented
+ *      sentinel keys — `$$typeof`, `@@__IMMUTABLE_ITERABLE__@@`, `nodeType`,
+ *      `tagName`, `hasAttribute`, `toJSON`, `constructor` were all measured
+ *      coming out of ONE vitest `toHaveBeenCalledWith` assertion. Throwing on
+ *      unrecognised string keys would break `console.log`, `JSON.stringify`,
+ *      and users' own route tests. The pass-through half of the contract is
+ *      pinned below so a future "tighten the guard" refactor fails here.
+ */
+import { describe, it, expect, vi } from "vitest";
+import util from "node:util";
+import { wrapPositionalDeps } from "../positional-deps.js";
+import type { McpMeshTool } from "../types.js";
+
+const proxyA = (async () => "a") as unknown as McpMeshTool;
+
+function routeDeps(): Array<McpMeshTool | null> {
+  return wrapPositionalDeps([proxyA, null], ["add", "greet-lucky"], "mesh.route");
+}
+
+describe("wrapPositionalDeps — the guard fires (#1401)", () => {
+  it("throws on a declared capability read by name, naming the index", () => {
+    const deps = routeDeps() as unknown as Record<string, unknown>;
+    expect(() => deps.add).toThrowError(
+      /mesh\.route dependencies are positional as of 3\.4\.0\./
+    );
+    let message = "";
+    try {
+      void deps.add;
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("You accessed `deps.add`; \"add\" is declared dependency [0].");
+    expect(message).toContain(
+      "Rewrite the handler as:  async (req, res, [add, greet_lucky]) => { ... }"
+    );
+  });
+
+  it("renders a bracket accessor for a non-identifier capability", () => {
+    const deps = routeDeps() as unknown as Record<string, unknown>;
+    let message = "";
+    try {
+      void deps["greet-lucky"];
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    // The old shipped example used exactly this form:
+    //   const greetLucky = deps["greet-lucky"];
+    expect(message).toContain(
+      'You accessed `deps["greet-lucky"]`; "greet-lucky" is declared dependency [1].'
+    );
+  });
+
+  it("prescribes the a2a signature for the a2a surface", () => {
+    const deps = wrapPositionalDeps(
+      [null],
+      ["date_service"],
+      "mesh.a2a.mount"
+    ) as unknown as Record<string, unknown>;
+    let message = "";
+    try {
+      void deps.date_service;
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain("mesh.a2a.mount dependencies are positional");
+    expect(message).toContain(
+      "Rewrite the handler as:  async ([date_service], payload) => { ... }"
+    );
+  });
+
+  it("fires even when the capability collides with an Array.prototype member", () => {
+    // A capability literally named `map` must not silently hand back
+    // Array.prototype.map — the declared-capability check runs first.
+    const deps = wrapPositionalDeps([proxyA], ["map"], "mesh.route") as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(() => deps.map).toThrowError(/"map" is declared dependency \[0\]/);
+  });
+
+  it("still throws on a dependency whose slot is unresolved (null)", () => {
+    // The un-migrated read is wrong regardless of resolution state — a silent
+    // `undefined` here would look identical to the legitimate `null`.
+    const deps = routeDeps() as unknown as Record<string, unknown>;
+    expect(() => deps["greet-lucky"]).toThrow();
+  });
+});
+
+describe("wrapPositionalDeps — the guard is inert for everything else (#1401)", () => {
+  it("index reads return the slot", () => {
+    const deps = routeDeps();
+    expect(deps[0]).toBe(proxyA);
+    expect(deps[1]).toBeNull();
+    expect(deps[2]).toBeUndefined();
+  });
+
+  it("array destructuring works", () => {
+    const [add, lucky] = routeDeps();
+    expect(add).toBe(proxyA);
+    expect(lucky).toBeNull();
+  });
+
+  it("length works", () => {
+    expect(routeDeps().length).toBe(2);
+  });
+
+  it("Array.isArray sees through the Proxy to the target", () => {
+    expect(Array.isArray(routeDeps())).toBe(true);
+  });
+
+  it("spread works", () => {
+    expect([...routeDeps()]).toEqual([proxyA, null]);
+  });
+
+  it("for...of works", () => {
+    const seen: unknown[] = [];
+    for (const dep of routeDeps()) seen.push(dep);
+    expect(seen).toEqual([proxyA, null]);
+  });
+
+  it("console.log does not throw", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    expect(() => console.log(routeDeps())).not.toThrow();
+    spy.mockRestore();
+  });
+
+  it("util.inspect does not throw", () => {
+    expect(() => util.inspect(routeDeps())).not.toThrow();
+    expect(util.inspect(routeDeps())).toContain("[");
+  });
+
+  it("JSON.stringify does not throw (reads toJSON)", () => {
+    expect(() => JSON.stringify(routeDeps())).not.toThrow();
+    expect(JSON.parse(JSON.stringify(routeDeps()))).toEqual([null, null]);
+  });
+
+  it("String()/template interpolation does not throw (reads join, toString)", () => {
+    expect(() => `${routeDeps()}`).not.toThrow();
+  });
+
+  it("Array.prototype methods work", () => {
+    expect(routeDeps().filter((d) => d !== null)).toEqual([proxyA]);
+    expect(routeDeps().map((d) => d === null)).toEqual([false, true]);
+    expect(routeDeps().indexOf(proxyA)).toBe(0);
+    expect(routeDeps().slice(1)).toEqual([null]);
+  });
+
+  it("vitest matchers work on the wrapped array (the $$typeof regression)", () => {
+    // pretty-format probes $$typeof / @@__IMMUTABLE_*__@@ / nodeType /
+    // tagName / hasAttribute to duck-type the value. An unbounded throw here
+    // turned this assertion into a PrettyFormatPluginError.
+    const handler = vi.fn();
+    handler(routeDeps());
+    expect(handler).toHaveBeenCalledWith([proxyA, null]);
+    expect(routeDeps()).toEqual([proxyA, null]);
+  });
+
+  it("an UNDECLARED string key is plain-array undefined, not a throw", () => {
+    // This was `undefined` before positional injection too, so it is a typo,
+    // not a migration signal — and there would be no rewrite to prescribe.
+    const deps = routeDeps() as unknown as Record<string, unknown>;
+    expect(deps.notADependency).toBeUndefined();
+  });
+
+  it("skips the Proxy entirely when nothing is declared", () => {
+    const bare: Array<McpMeshTool | null> = [];
+    expect(wrapPositionalDeps(bare, [], "mesh.route")).toBe(bare);
+  });
+});

--- a/src/runtime/typescript/src/__tests__/route-required.spec.ts
+++ b/src/runtime/typescript/src/__tests__/route-required.spec.ts
@@ -118,11 +118,7 @@ describe("route perimeter 503 (#1249)", () => {
     await middleware(req, res, next);
 
     expect(res.status).not.toHaveBeenCalled();
-    expect(handler).toHaveBeenCalledWith(
-      req,
-      res,
-      expect.objectContaining({ calculator: mockCalc })
-    );
+    expect(handler).toHaveBeenCalledWith(req, res, [mockCalc]);
   });
 
   it("does NOT 503 for an unavailable OPTIONAL dep (soft-fail preserved)", async () => {
@@ -137,23 +133,25 @@ describe("route perimeter 503 (#1249)", () => {
 
     expect(res.status).not.toHaveBeenCalled();
     // Handler runs with a null proxy — the existing degraded behavior.
-    expect(handler).toHaveBeenCalledWith(
-      req,
-      res,
-      expect.objectContaining({ calculator: null })
-    );
+    expect(handler).toHaveBeenCalledWith(req, res, [null]);
   });
 
-  it("does NOT 503 when a duplicate capability is live in the winning slot", async () => {
-    // A capability declared twice collapses to one capability-keyed `deps`
-    // slot (last resolution wins). The perimeter must judge the same slot the
-    // handler sees — not a dead sibling index — so a live proxy means run.
+  it("503s when a REQUIRED duplicate-capability slot is dead, even if its sibling is live (#1401)", async () => {
+    // BEHAVIOUR CHANGE. Under capability-keyed injection a capability
+    // declared twice collapsed into ONE `deps[cap]` slot (last resolution
+    // won), so the perimeter had to dedupe per capability — 503-ing on a dead
+    // sibling index would have contradicted the live slot the handler read.
+    //
+    // Positionally each declaration owns its own index, so slot 0 really is
+    // null in the handler. Deduping now would wave through a required
+    // dependency the handler will read as `null` — exactly what the #1249
+    // perimeter exists to prevent. The check reverts to per-index.
     const registry = RouteRegistry.getInstance();
     const handler = vi.fn();
     const middleware = route(
       [
         { capability: "calculator", required: true }, // required, its index unresolved
-        { capability: "calculator" }, // optional, this index is live → wins deps[cap]
+        { capability: "calculator" }, // optional, this index is live
       ],
       handler
     ) as ReturnType<typeof route> & { _meshRouteId: string };
@@ -167,12 +165,44 @@ describe("route perimeter 503 (#1249)", () => {
 
     await middleware(req, res, next);
 
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "dependency_unavailable",
+      capability: "calculator",
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does NOT 503 when BOTH duplicate-capability slots are live, and each gets its own proxy (#1401)", async () => {
+    // The other half of the change: two slots declaring the same capability
+    // are two distinct slots, each holding its own resolved proxy — not one
+    // collapsed entry.
+    const registry = RouteRegistry.getInstance();
+    const handler = vi.fn();
+    const middleware = route(
+      [
+        { capability: "calculator", required: true },
+        { capability: "calculator" },
+      ],
+      handler
+    ) as ReturnType<typeof route> & { _meshRouteId: string };
+
+    const first = (async () => "first") as unknown as McpMeshTool;
+    const second = (async () => "second") as unknown as McpMeshTool;
+    registry.setDependency(middleware._meshRouteId, 0, first);
+    registry.setDependency(middleware._meshRouteId, 1, second);
+
+    const req = { method: "POST", path: "/compute", headers: {} } as unknown as Request;
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    await middleware(req, res, next);
+
     expect(res.status).not.toHaveBeenCalled();
-    expect(handler).toHaveBeenCalledWith(
-      req,
-      res,
-      expect.objectContaining({ calculator: mockCalc })
-    );
+    const injected = handler.mock.calls[0][2] as Array<McpMeshTool | null>;
+    expect(injected).toHaveLength(2);
+    expect(injected[0]).toBe(first);
+    expect(injected[1]).toBe(second);
   });
 
   it("503s on the first unavailable required dep among a mix", async () => {

--- a/src/runtime/typescript/src/__tests__/route.test.ts
+++ b/src/runtime/typescript/src/__tests__/route.test.ts
@@ -185,7 +185,7 @@ describe("RouteRegistry", () => {
       expect(dep).toBeNull();
     });
 
-    it("should get dependencies for route as object", () => {
+    it("should get dependencies for route as a positional array (#1401)", () => {
       const registry = RouteRegistry.getInstance();
       const routeId = registry.registerRoute("GET", "/test", [
         "calculator",
@@ -199,8 +199,53 @@ describe("RouteRegistry", () => {
       // Leave logger unset
 
       const deps = registry.getDependenciesForRoute(routeId);
-      expect(deps.calculator).toBe(mockCalc);
-      expect(deps.logger).toBeNull();
+      expect(Array.isArray(deps)).toBe(true);
+      // Declared count, not resolved count — the unresolved slot is padded,
+      // never omitted (an omission would shift every later dependency).
+      expect(deps).toHaveLength(2);
+      expect(deps[0]).toBe(mockCalc);
+      expect(deps[1]).toBeNull();
+    });
+
+    it("pads an UNRESOLVED LEADING dependency rather than shifting (#1401)", () => {
+      // The failure mode a push-based build would produce: with only the
+      // second dependency resolved, a compacted array would put `logger`'s
+      // proxy at index 0 — the handler's `[calculator, logger]` destructure
+      // would silently bind `calculator` to the logger proxy.
+      const registry = RouteRegistry.getInstance();
+      const routeId = registry.registerRoute("GET", "/test-shift", [
+        "calculator",
+        "logger",
+      ]);
+
+      const mockLogger = (() => Promise.resolve("log")) as unknown as McpMeshTool;
+      registry.setDependency(routeId, 1, mockLogger);
+
+      const deps = registry.getDependenciesForRoute(routeId);
+      expect(deps).toHaveLength(2);
+      expect(deps[0]).toBeNull();
+      expect(deps[1]).toBe(mockLogger);
+    });
+
+    it("gives a duplicate capability TWO independent slots (#1401)", () => {
+      // Under the old capability-keyed object these collapsed into ONE
+      // `deps.calculator` entry (last write won). Positionally each
+      // declaration owns its own index.
+      const registry = RouteRegistry.getInstance();
+      const routeId = registry.registerRoute("GET", "/test-dupe", [
+        "calculator",
+        "calculator",
+      ]);
+
+      const first = (() => Promise.resolve("a")) as unknown as McpMeshTool;
+      const second = (() => Promise.resolve("b")) as unknown as McpMeshTool;
+      registry.setDependency(routeId, 0, first);
+      registry.setDependency(routeId, 1, second);
+
+      const deps = registry.getDependenciesForRoute(routeId);
+      expect(deps).toHaveLength(2);
+      expect(deps[0]).toBe(first);
+      expect(deps[1]).toBe(second);
     });
 
     it("should clear all dependencies", () => {
@@ -254,13 +299,10 @@ describe("route()", () => {
     // Call middleware
     await middleware(mockReq, mockRes, mockNext);
 
-    // Handler should be called with req, res, and deps object
+    // Handler should be called with req, res, and the positional deps array
     expect(handler).toHaveBeenCalledTimes(1);
-    expect(handler).toHaveBeenCalledWith(
-      mockReq,
-      mockRes,
-      expect.objectContaining({ calculator: null }) // No deps resolved yet
-    );
+    expect(handler).toHaveBeenCalledWith(mockReq, mockRes, [null]); // #1401
+
   });
 
   it("should inject resolved dependencies", async () => {
@@ -282,12 +324,9 @@ describe("route()", () => {
     // Call middleware
     await middleware(mockReq, mockRes, mockNext);
 
-    // Handler should receive the resolved dependency
-    expect(handler).toHaveBeenCalledWith(
-      mockReq,
-      mockRes,
-      expect.objectContaining({ calculator: mockCalc })
-    );
+    // Handler should receive the resolved dependency at its declared index
+    expect(handler).toHaveBeenCalledWith(mockReq, mockRes, [mockCalc]); // #1401
+
   });
 
   it("should call next() on error", async () => {
@@ -391,15 +430,13 @@ describe("mesh.route integration", () => {
 
     await middleware(mockReq, mockRes, mockNext);
 
-    expect(handler).toHaveBeenCalledWith(
-      mockReq,
-      mockRes,
-      expect.objectContaining({
-        calculator: mockCalc,
-        logger: mockLogger,
-        formatter: null,
-      })
-    );
+    // #1401: positional — index order is DECLARATION order, and the
+    // unresolved trailing `formatter` holds its own slot as null.
+    expect(handler).toHaveBeenCalledWith(mockReq, mockRes, [
+      mockCalc,
+      mockLogger,
+      null,
+    ]);
   });
 
   it("should handle empty dependencies", async () => {
@@ -412,6 +449,6 @@ describe("mesh.route integration", () => {
 
     await middleware(mockReq, mockRes, mockNext);
 
-    expect(handler).toHaveBeenCalledWith(mockReq, mockRes, {});
+    expect(handler).toHaveBeenCalledWith(mockReq, mockRes, []);
   });
 });

--- a/src/runtime/typescript/src/__tests__/unresolved-dep-no-shift.spec.ts
+++ b/src/runtime/typescript/src/__tests__/unresolved-dep-no-shift.spec.ts
@@ -25,14 +25,33 @@
  * keyed by `depIndex` (never by "next free position"). These tests exercise
  * that end-to-end through the real `addTool` wrapper so a future refactor
  * that filters/compacts the slot array (e.g. `.filter(Boolean)`) fails here.
+ *
+ * ## Why this file now covers `route` and `a2a` too (issue #1401)
+ *
+ * Until 3.4.0 `mesh.route()` and `mesh.a2a.mount()` handed the handler a
+ * capability-KEYED object, for which slot preservation was vacuous: omitting
+ * an unresolved key from a map cannot move any other key. Under positional
+ * injection an omission shifts every later dependency into the wrong slot —
+ * the exact defect #1390 pinned — so `RouteRegistry.getDependenciesForRoute`
+ * must build the array with an index-preserving `map()` over the DECLARED
+ * dependencies and never by collecting the resolved ones. That is now load
+ * bearing for all three surfaces, so all three are pinned here.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { z } from "zod";
 import { MeshAgent, __resetUnwiredSlotWarnedForTests } from "../agent.js";
 import { PROXY_DISPATCH_META } from "../proxy.js";
 import { MeshJobSubmitter } from "../mesh-job-submitter.js";
-import { RouteRegistry } from "../route.js";
+import { route, RouteRegistry } from "../route.js";
 import { resetSettleStateForTests } from "../settle.js";
+import { A2ATaskStore } from "../a2a/producer/task-store.js";
+import {
+  buildDispatcherMiddleware,
+  type A2AHandler,
+} from "../a2a/producer/dispatcher.js";
+import type { A2ASurfaceMetadata } from "../a2a/producer/registry.js";
+import type { McpMeshTool } from "../types.js";
+import type { Request, Response, NextFunction } from "express";
 
 function makeFastMCPStub() {
   return {
@@ -358,5 +377,166 @@ describe("unresolved middle dependency does not shift", () => {
     expect((received[0] as MeshJobSubmitter).capability).toBe("run_workflow");
     expect(received[1]).toBeNull();
     expect(capabilityOf(received[2])).toBe("cap_c");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// mesh.route() — issue #1401
+// ────────────────────────────────────────────────────────────────────────
+
+/** Named stand-in proxies; identity is what the assertions compare. */
+function namedProxy(capability: string): McpMeshTool {
+  const fn = (async () => capability) as unknown as McpMeshTool;
+  Object.defineProperty(fn, "capability", { value: capability });
+  return fn;
+}
+
+function capName(dep: unknown): string | null {
+  if (dep === null || dep === undefined) return null;
+  return (dep as { capability?: string }).capability ?? null;
+}
+
+describe("mesh.route: unresolved middle dependency does not shift (#1401)", () => {
+  it("positions 0 and 2 keep their proxies, position 1 stays null", async () => {
+    const handler = vi.fn();
+    const middleware = route(
+      [{ capability: "cap_a" }, { capability: "cap_b" }, { capability: "cap_c" }],
+      handler
+    ) as ReturnType<typeof route> & { _meshRouteId: string };
+
+    const registry = RouteRegistry.getInstance();
+    // Resolve ONLY dep 0 and dep 2 — dep 1 never resolves.
+    registry.setDependency(middleware._meshRouteId, 0, namedProxy("cap_a"));
+    registry.setDependency(middleware._meshRouteId, 2, namedProxy("cap_c"));
+
+    const req = { method: "GET", path: "/x", headers: {} } as unknown as Request;
+    const res = {} as Response;
+    await middleware(req, res, vi.fn() as NextFunction);
+
+    const deps = handler.mock.calls[0][2] as Array<McpMeshTool | null>;
+    // Rule out compaction: a `.filter(Boolean)` build would produce length 2
+    // with cap_c sitting at index 1.
+    expect(deps).toHaveLength(3);
+    expect(capName(deps[0])).toBe("cap_a");
+    expect(deps[1]).toBeNull();
+    expect(capName(deps[2])).toBe("cap_c");
+    expect(deps[2]).not.toBeUndefined();
+  });
+
+  it("leading and trailing unresolved deps hold their own slots", async () => {
+    const handler = vi.fn();
+    const middleware = route(
+      [{ capability: "cap_a" }, { capability: "cap_b" }, { capability: "cap_c" }],
+      handler
+    ) as ReturnType<typeof route> & { _meshRouteId: string };
+
+    RouteRegistry.getInstance().setDependency(
+      middleware._meshRouteId,
+      1,
+      namedProxy("cap_b")
+    );
+
+    const req = { method: "GET", path: "/x", headers: {} } as unknown as Request;
+    await middleware(req, {} as Response, vi.fn() as NextFunction);
+
+    const deps = handler.mock.calls[0][2] as Array<McpMeshTool | null>;
+    expect(deps).toHaveLength(3);
+    expect(deps[0]).toBeNull();
+    expect(capName(deps[1])).toBe("cap_b");
+    expect(deps[2]).toBeNull();
+  });
+
+  it("a dependency going unavailable nulls only its own slot", async () => {
+    const handler = vi.fn();
+    const middleware = route(
+      [{ capability: "cap_a" }, { capability: "cap_b" }, { capability: "cap_c" }],
+      handler
+    ) as ReturnType<typeof route> & { _meshRouteId: string };
+
+    const registry = RouteRegistry.getInstance();
+    registry.setDependency(middleware._meshRouteId, 0, namedProxy("cap_a"));
+    registry.setDependency(middleware._meshRouteId, 1, namedProxy("cap_b"));
+    registry.setDependency(middleware._meshRouteId, 2, namedProxy("cap_c"));
+
+    const req = { method: "GET", path: "/x", headers: {} } as unknown as Request;
+    await middleware(req, {} as Response, vi.fn() as NextFunction);
+    expect(
+      (handler.mock.calls[0][2] as Array<McpMeshTool | null>).map(capName)
+    ).toEqual(["cap_a", "cap_b", "cap_c"]);
+
+    // The middle provider drops out mid-flight.
+    registry.removeDependency(middleware._meshRouteId, 1);
+    await middleware(req, {} as Response, vi.fn() as NextFunction);
+
+    const deps = handler.mock.calls[1][2] as Array<McpMeshTool | null>;
+    expect(capName(deps[0])).toBe("cap_a");
+    expect(deps[1]).toBeNull();
+    expect(capName(deps[2])).toBe("cap_c");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// mesh.a2a.mount() — issue #1401, driven through a real tasks/send
+// ────────────────────────────────────────────────────────────────────────
+
+describe("mesh.a2a.mount: unresolved middle dependency does not shift (#1401)", () => {
+  it("positions 0 and 2 keep their proxies, position 1 stays null", async () => {
+    const registry = RouteRegistry.getInstance();
+    const declared = [
+      { capability: "cap_a" },
+      { capability: "cap_b" },
+      { capability: "cap_c" },
+    ];
+    const routeId = registry.registerRoute("A2A", "/agents/t", declared);
+    registry.setDependency(routeId, 0, namedProxy("cap_a"));
+    registry.setDependency(routeId, 2, namedProxy("cap_c"));
+
+    const surface: A2ASurfaceMetadata = {
+      path: "/agents/t",
+      skillId: "t",
+      skillName: "T",
+      description: "",
+      tags: [],
+      dependencies: declared.map((d) => ({ ...d, tags: [] })),
+      auth: "",
+      routeId,
+    };
+
+    let received: Array<McpMeshTool | null> | null = null;
+    const handler: A2AHandler = async (deps) => {
+      received = deps as Array<McpMeshTool | null>;
+      return "ok";
+    };
+
+    const middleware = buildDispatcherMiddleware({
+      surface,
+      handler,
+      taskStore: new A2ATaskStore(),
+      routeRegistry: registry,
+    });
+
+    const req = {
+      body: {
+        jsonrpc: "2.0",
+        id: "1",
+        method: "tasks/send",
+        params: { id: "task-1", message: { role: "user" } },
+      },
+      headers: {},
+    } as unknown as Request;
+    const res = {
+      status() { return this; },
+      type() { return this; },
+      send() { return this; },
+    } as unknown as Response;
+
+    await middleware(req, res, vi.fn() as NextFunction);
+
+    expect(received).not.toBeNull();
+    const deps = received as unknown as Array<McpMeshTool | null>;
+    expect(deps).toHaveLength(3);
+    expect(capName(deps[0])).toBe("cap_a");
+    expect(deps[1]).toBeNull();
+    expect(capName(deps[2])).toBe("cap_c");
   });
 });

--- a/src/runtime/typescript/src/a2a/producer/dispatcher.ts
+++ b/src/runtime/typescript/src/a2a/producer/dispatcher.ts
@@ -38,8 +38,11 @@ import { randomUUID } from "node:crypto";
 
 import { JobProxy } from "@mcpmesh/core";
 
-import type { McpMeshTool } from "../../types.js";
 import { RouteRegistry } from "../../route.js";
+import {
+  resolvePositionalDeps,
+  type PositionalDependencies,
+} from "../../positional-deps.js";
 import { MeshJobSubmitter } from "../../mesh-job-submitter.js";
 import type { A2ASurfaceMetadata } from "./registry.js";
 import { A2ATaskStore, type TaskRecord } from "./task-store.js";
@@ -63,18 +66,28 @@ export const JSONRPC_METHOD_NOT_FOUND = -32601;
 export const JSONRPC_INVALID_PARAMS = -32602;
 
 /**
- * Dependencies object passed to A2A handlers — keyed by capability name,
- * same shape as `mesh.route()`'s `deps` parameter. Values are `null` when
- * the underlying dependency hasn't been resolved yet (registry has not
- * reported a `dependency_available` event for it).
+ * Dependencies passed to A2A handlers — **positional** as of 3.4.0 (issue
+ * #1401), the same shape as `mesh.route()`'s `deps` parameter. `deps[i]` is
+ * the i-th entry of the mount config's `dependencies[]`, or `null` when it
+ * hasn't been resolved yet (the registry has not reported a
+ * `dependency_available` event for it).
+ *
+ * Before 3.4.0 this was a capability-keyed object. A handler may narrow it
+ * to a tuple for per-slot typing — `mount<[McpMeshTool | null]>(...)`; the
+ * slot type stays nullable because the mount surface has no required-dependency
+ * perimeter to guarantee resolution. An object type argument
+ * (`mount<{ date_service: McpMeshTool }>`) no longer satisfies the
+ * constraint, so an un-migrated mount fails to COMPILE.
  */
-export type A2ADependencies = Record<string, McpMeshTool | null>;
+export type A2ADependencies = PositionalDependencies;
 
 /**
  * Handler signature for `mesh.a2a.mount(...)`. Receives:
  *
- * 1. Resolved dependencies (`deps`) — keyed by capability name, same shape
- *    as `mesh.route()`'s `deps` parameter. Destructure to access individual
+ * 1. Resolved dependencies (`deps`) — **by position**, same shape as
+ *    `mesh.route()`'s `deps` parameter: `deps[i]` is the i-th entry of the
+ *    mount config's `dependencies[]`. Destructure positionally
+ *    (`async ([dateService], payload) => ...`) to access individual
  *    `McpMeshTool` proxies.
  * 2. The raw A2A `tasks/send` `payload` (the `message` object the client
  *    sent).
@@ -132,6 +145,24 @@ export interface DispatcherDeps {
    * handler receives `null` on the third arg.
    */
   readonly jobSubmitterProvider?: () => MeshJobSubmitter | null;
+}
+
+/**
+ * Resolve this surface's dependencies into a positional array (issue #1401),
+ * behind the migration guard.
+ *
+ * Delegates to the shared {@link resolvePositionalDeps} — the same
+ * resolve/pad/wrap `mesh.route()` uses, so the two injection sites cannot
+ * drift. Called per dispatch: dependency resolution is live, so a proxy that
+ * arrives between two `tasks/send` calls must be visible to the second.
+ */
+function buildPositionalDeps(deps: DispatcherDeps): A2ADependencies {
+  return resolvePositionalDeps(
+    deps.routeRegistry,
+    deps.surface.routeId,
+    deps.surface.dependencies.map((dep) => dep.capability),
+    "mesh.a2a.mount"
+  ).deps;
 }
 
 /**
@@ -269,19 +300,9 @@ async function handleTasksSend(
 
   // Resolve dependencies the same way mesh.route() does — via the shared
   // RouteRegistry. The surface registered a synthetic route at mount time
-  // (see mount.ts); resolved McpMeshTool proxies surface here keyed by
-  // capability name.
-  const resolvedDeps = deps.routeRegistry.getDependenciesForRoute(
-    deps.surface.routeId
-  );
-  // Ensure every declared capability key is present (null when unresolved)
-  // — the user's destructure shouldn't crash on a partially-resolved
-  // dependency graph.
-  for (const dep of deps.surface.dependencies) {
-    if (resolvedDeps[dep.capability] === undefined) {
-      resolvedDeps[dep.capability] = null;
-    }
-  }
+  // (see mount.ts); resolved McpMeshTool proxies surface here BY POSITION,
+  // index-aligned with the mount config's `dependencies[]` (issue #1401).
+  const resolvedDeps = buildPositionalDeps(deps);
 
   const jobSubmitter = deps.jobSubmitterProvider
     ? deps.jobSubmitterProvider()
@@ -495,14 +516,7 @@ export async function buildSendSubscribeStream(
     ));
   }
 
-  const resolvedDeps = deps.routeRegistry.getDependenciesForRoute(
-    deps.surface.routeId
-  );
-  for (const dep of deps.surface.dependencies) {
-    if (resolvedDeps[dep.capability] === undefined) {
-      resolvedDeps[dep.capability] = null;
-    }
-  }
+  const resolvedDeps = buildPositionalDeps(deps);
 
   const jobSubmitter = deps.jobSubmitterProvider
     ? deps.jobSubmitterProvider()

--- a/src/runtime/typescript/src/a2a/producer/mount.ts
+++ b/src/runtime/typescript/src/a2a/producer/mount.ts
@@ -12,7 +12,8 @@
  *    non-empty).
  * 2. Register the dependencies as a synthetic route in `RouteRegistry` so
  *    DDDI events from the Rust core wire up resolved `McpMeshTool` proxies
- *    keyed by capability name — same plumbing `mesh.route()` uses.
+ *    keyed by dependency index, surfaced to the handler as a positional
+ *    array (#1401) — same plumbing `mesh.route()` uses.
  * 3. Store surface metadata in {@link A2AProducerRegistry} for heartbeat,
  *    card render, and auth gate lookups.
  * 4. Wire `app.post(path, [auth?,] dispatcher)` for JSON-RPC dispatch.
@@ -177,8 +178,9 @@ function buildCardRenderContext(surface: A2ASurfaceMetadata): CardRenderContext 
  * @param app     - Express application instance
  * @param config  - Mount configuration (path, skill id, dependencies, ...)
  * @param handler - User handler invoked on every `tasks/send` call. Receives
- *                  resolved `McpMeshTool` dependency proxies and the A2A
- *                  `tasks/send` `params` payload; returns a value (or
+ *                  resolved `McpMeshTool` dependency proxies **by position**
+ *                  (issue #1401 — `deps[i]` is `config.dependencies[i]`) and
+ *                  the A2A `tasks/send` `params` payload; returns a value (or
  *                  Promise of one) that the framework wraps into the A2A
  *                  `Task` envelope. Throw to surface as `state=failed`.
  *
@@ -192,11 +194,17 @@ function buildCardRenderContext(surface: A2ASurfaceMetadata): CardRenderContext 
  *   tags: ["system", "date"],
  *   dependencies: ["date_service"],
  *   auth: "bearer",
- * }, async (deps, payload) => {
- *   const result = await deps.date_service.call({});
+ * }, async ([dateService], payload) => {
+ *   // A slot holds `null` until the registry resolves it — narrow before use.
+ *   if (!dateService) return { error: "date_service unavailable" };
+ *   const result = await dateService({});
  *   return { date: result };
  * });
  * ```
+ *
+ * `mesh.a2a.mount` cannot guarantee a resolved slot, so per-slot type
+ * arguments stay nullable:
+ * `mesh.a2a.mount<[McpMeshTool | null]>(app, config, handler)`.
  */
 export function mount<D extends A2ADependencies = A2ADependencies>(
   app: Application,
@@ -245,8 +253,8 @@ export function mount<D extends A2ADependencies = A2ADependencies>(
   // mesh.route(). Each surface registers a synthetic route in
   // RouteRegistry with method/path placeholders; the Rust core's
   // dependency-resolution events then drive resolved McpMeshTool proxies
-  // into the registry, keyed by capability name, which the dispatcher
-  // pulls out via getDependenciesForRoute(routeId).
+  // into the registry, keyed by dependency INDEX, which the dispatcher
+  // pulls out as a positional array via getDependenciesForRoute(routeId).
   const routeRegistry = RouteRegistry.getInstance();
   const routeId = routeRegistry.registerRoute(
     "A2A",

--- a/src/runtime/typescript/src/a2a/producer/registry.ts
+++ b/src/runtime/typescript/src/a2a/producer/registry.ts
@@ -45,7 +45,10 @@ export interface A2ASurfaceMetadata {
   /**
    * The `routeId` returned by `RouteRegistry.registerRoute` for this surface's
    * dependencies — used by the dispatcher to look up resolved `McpMeshTool`
-   * proxies by position via `RouteRegistry.getDependenciesForRoute(routeId)`.
+   * proxies via `RouteRegistry.getDependenciesForRoute(routeId)`, which
+   * returns them **by position**, index-aligned with {@link dependencies}
+   * (issue #1401). Before 3.4.0 this comment claimed "by position" while the
+   * lookup was in fact capability-keyed; it is now accurate.
    */
   readonly routeId: string;
 }

--- a/src/runtime/typescript/src/api-runtime.ts
+++ b/src/runtime/typescript/src/api-runtime.ts
@@ -21,7 +21,7 @@
  * // mesh.route() triggers auto-init via nextTick
  * app.post("/compute", mesh.route(
  *   [{ capability: "calculator" }],
- *   async (req, res, { calculator }) => {
+ *   async (req, res, [calculator]) => {
  *     res.json({ result: await calculator({ a: 1, b: 2 }) });
  *   }
  * ));

--- a/src/runtime/typescript/src/express.ts
+++ b/src/runtime/typescript/src/express.ts
@@ -19,7 +19,7 @@
  * // mesh.route() auto-initializes the mesh connection
  * app.post("/compute", mesh.route(
  *   [{ capability: "calculator" }],
- *   async (req, res, { calculator }) => {
+ *   async (req, res, [calculator]) => {
  *     res.json({ result: await calculator({ a: req.body.a, b: req.body.b }) });
  *   }
  * ));

--- a/src/runtime/typescript/src/index.ts
+++ b/src/runtime/typescript/src/index.ts
@@ -39,7 +39,7 @@
  *
  * app.post("/compute", mesh.route(
  *   [{ capability: "calculator" }],
- *   async (req, res, { calculator }) => {
+ *   async (req, res, [calculator]) => {
  *     const result = await calculator({ a: req.body.a, b: req.body.b });
  *     res.json({ result });
  *   }
@@ -193,6 +193,10 @@ export {
   type MeshRouteConfig,
   type RouteMetadata,
 } from "./route.js";
+
+// Positional dependency injection (issue #1401). `RouteDependencies` and
+// `A2ADependencies` are both aliases of `PositionalDependencies`.
+export type { PositionalDependencies } from "./positional-deps.js";
 
 // Service views (RFC #1280) — consumer view factory + facade types.
 export {

--- a/src/runtime/typescript/src/positional-deps.ts
+++ b/src/runtime/typescript/src/positional-deps.ts
@@ -1,0 +1,189 @@
+/**
+ * Positional dependency arrays for `mesh.route()` and `mesh.a2a.mount()`.
+ *
+ * Issue #1401 — as of 3.4.0 every mcp-mesh injection site in every runtime
+ * pairs the Nth declared dependency with the Nth slot. TypeScript's `route`
+ * and `a2a.mount` handlers used to receive a **capability-keyed object**
+ * (`deps.calculator`); they now receive an **array** (`deps[0]`).
+ *
+ * ## Why a Proxy at all
+ *
+ * The shape change cannot misbind: string keys and numeric indices are
+ * disjoint, so an un-migrated `deps.calculator` on the new array evaluates to
+ * `undefined` — never to some *other* dependency's proxy. TypeScript is the
+ * safe side of this migration by construction. But `undefined` is a poor
+ * signal: it surfaces as `Cannot read properties of undefined (reading
+ * 'call')` deep inside the handler at request time, and a cast
+ * (`deps["cap"] as McpMeshTool | null`) — which both the shipped example and
+ * `docs/a2a/producer.md` used — defeats the compile error too.
+ *
+ * So {@link wrapPositionalDeps} hands user code an array behind a `get` trap
+ * that throws a prescriptive error naming the index and the rewrite.
+ *
+ * ## The trap is bounded to DECLARED CAPABILITIES, deliberately
+ *
+ * The obvious design — throw for *any* string key that is not a valid array
+ * index, behind a positive allowlist of array/protocol members — does not
+ * survive contact with real hosts. Every serious library duck-types unknown
+ * values through its own invented sentinel key, and each one hits the `get`
+ * trap. A single `expect(handler).toHaveBeenCalledWith(...)` in vitest probes,
+ * measured:
+ *
+ *     $$typeof  @@__IMMUTABLE_ITERABLE__@@  @@__IMMUTABLE_RECORD__@@
+ *     nodeType  tagName  hasAttribute  toJSON  constructor  length
+ *
+ * Seven library sentinels from one assertion in one framework — none of them
+ * enumerable in advance, and React/immutable/DOM are only the ones that
+ * happened to be in vitest's pretty-format. An allowlist cannot be closed over
+ * that set, and getting it wrong turns a user's *passing* route test into a
+ * `PrettyFormatPluginError` that hides the real assertion.
+ *
+ * The unbounded form also buys nothing. `deps.someUndeclaredThing` evaluated
+ * to `undefined` before this change and evaluates to `undefined` after it —
+ * that is not a migration signal, it is a typo, and there is no rewrite to
+ * prescribe. The migration hazard is exactly and only reading a **declared
+ * capability by name**, which is what "un-migrated handler" means. So:
+ *
+ *   - `prop` is a declared capability → throw, naming its index and printing
+ *     the corrected handler signature. Checked BEFORE anything else, so a
+ *     route declaring a capability literally named `map` or `length` still
+ *     gets the loud error rather than silently receiving the array method.
+ *   - anything else → plain array behaviour (`Reflect.get`).
+ *
+ * Consequences, all verified in `positional-deps.spec.ts`: `deps[0]`,
+ * destructuring, spread, `for...of`, `deps.length`, array methods,
+ * `console.log`, `util.inspect`, `JSON.stringify`, `Array.isArray` and
+ * `expect(...)` matchers all behave as they would on the bare array.
+ *
+ * This wrapper exists for the 3.4.x migration window. Once un-migrated
+ * handlers are no longer plausible it can be dropped and the raw array
+ * returned.
+ */
+
+import type { McpMeshTool } from "./types.js";
+
+/**
+ * Resolved dependencies handed to a handler, **by position**. `deps[i]` is
+ * the proxy for the i-th declared dependency, or `null` when it is not
+ * currently resolved. Slots are never compacted: an unavailable dependency
+ * holds its own index as `null` and never shifts a later dependency up.
+ */
+export type PositionalDependencies = Array<McpMeshTool | null>;
+
+/** `deps.foo` when `foo` is an identifier, `deps["foo-bar"]` otherwise. */
+function accessorForm(key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    ? `deps.${key}`
+    : `deps[${JSON.stringify(key)}]`;
+}
+
+/** A capability rendered as a binding name usable in an array destructure. */
+function bindingName(capability: string, index: number): string {
+  const safe = capability.replace(/[^A-Za-z0-9_$]/g, "_");
+  return /^[A-Za-z_$]/.test(safe) ? safe : `dep${index}`;
+}
+
+/** The corrected handler signature to print in the error. */
+function rewriteHint(surface: string, capabilities: readonly string[]): string {
+  const pattern = `[${capabilities.map(bindingName).join(", ")}]`;
+  return surface === "mesh.a2a.mount"
+    ? `async (${pattern}, payload) => { ... }`
+    : `async (req, res, ${pattern}) => { ... }`;
+}
+
+/**
+ * Wrap a positional dependency array in the migration guard described above.
+ *
+ * @param values       - Pre-sized, index-aligned dependency slots.
+ * @param capabilities - Declared capabilities in declaration order; index i
+ *                       describes `values[i]`.
+ * @param surface      - `"mesh.route"` or `"mesh.a2a.mount"`, for the message.
+ */
+export function wrapPositionalDeps<T extends PositionalDependencies>(
+  values: T,
+  capabilities: readonly string[],
+  surface: string
+): T {
+  // Nothing declared → nothing to mis-access. Skip the Proxy entirely so the
+  // common dependency-free surface pays no cost.
+  if (capabilities.length === 0) return values;
+
+  return new Proxy(values, {
+    get(target, prop, receiver) {
+      if (typeof prop === "string") {
+        const index = capabilities.indexOf(prop);
+        if (index >= 0) {
+          throw new TypeError(
+            `${surface} dependencies are positional as of 3.4.0.\n` +
+              `You accessed \`${accessorForm(prop)}\`; ` +
+              `${JSON.stringify(prop)} is declared dependency [${index}].\n` +
+              `Rewrite the handler as:  ${rewriteHint(surface, capabilities)}`
+          );
+        }
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as T;
+}
+
+/**
+ * The registry surface {@link resolvePositionalDeps} reads from. Declared
+ * structurally rather than importing `RouteRegistry`, so this module stays a
+ * leaf that `route.ts` (which owns `RouteRegistry`) can import without a cycle.
+ */
+export interface PositionalDepsSource {
+  getDependenciesForRoute(routeId: string): PositionalDependencies;
+}
+
+/** The two views {@link resolvePositionalDeps} returns. */
+export interface ResolvedPositionalDeps {
+  /**
+   * The padded slots WITHOUT the migration guard, for framework-side
+   * pre-flight checks that read by index — `mesh.route`'s required-dependency
+   * 503 among them. Reading those through the guarded view would let a
+   * capability named like an array index turn a framework read into a throw.
+   */
+  readonly values: PositionalDependencies;
+  /** The same slots behind the migration guard — this is what user code gets. */
+  readonly deps: PositionalDependencies;
+}
+
+/**
+ * Resolve one surface's declared dependencies into a positional array (issue
+ * #1401): read the registry, pad missing slots, apply the migration guard.
+ *
+ * Shared by `mesh.route()` and `mesh.a2a.mount()`'s dispatcher — #1401 exists
+ * because binding logic drifted across duplicated injection sites, so the
+ * resolve/pad/wrap sequence lives in exactly one place.
+ *
+ * The array is built by an index-preserving read over the DECLARED
+ * dependencies, never by collecting only the resolved ones.
+ * `getDependenciesForRoute` already pre-sizes to the declared count; the loop
+ * below re-pads defensively so a missing route entry (registry reset
+ * mid-flight) yields `null` at its own index rather than a short array whose
+ * later slots have shifted.
+ *
+ * Call this per request/dispatch — dependency resolution is live, so a proxy
+ * that arrives between two calls must be visible to the second.
+ *
+ * @param source       - Registry to read resolved proxies from.
+ * @param routeId      - The surface's (possibly pre-introspection) route id.
+ * @param capabilities - Declared capabilities in declaration order; index i
+ *                       describes slot i.
+ * @param surface      - `"mesh.route"` or `"mesh.a2a.mount"`, for the guard's
+ *                       error message.
+ */
+export function resolvePositionalDeps(
+  source: PositionalDepsSource,
+  routeId: string,
+  capabilities: readonly string[],
+  surface: string
+): ResolvedPositionalDeps {
+  const values = source.getDependenciesForRoute(routeId);
+  for (let i = 0; i < capabilities.length; i++) {
+    if (values[i] === undefined) {
+      values[i] = null;
+    }
+  }
+  return { values, deps: wrapPositionalDeps(values, capabilities, surface) };
+}

--- a/src/runtime/typescript/src/route.ts
+++ b/src/runtime/typescript/src/route.ts
@@ -17,9 +17,10 @@
  * app.use(express.json());
  *
  * // mesh.route() triggers auto-init - no meshExpress() or start() needed!
+ * // Dependencies bind BY POSITION: the Nth declared dependency is deps[N].
  * app.post("/compute", mesh.route(
  *   [{ capability: "calculator" }],
- *   async (req, res, { calculator }) => {
+ *   async (req, res, [calculator]) => {
  *     const result = await calculator({ a: req.body.a, b: req.body.b });
  *     res.json({ result });
  *   }
@@ -32,6 +33,7 @@
 import type { Request, Response, NextFunction, RequestHandler } from "express";
 import type { DependencySpec, McpMeshTool, DependencyKwargs, TagSpec } from "./types.js";
 import { normalizeDependency, runWithPropagatedHeaders, runWithTraceContext } from "./proxy.js";
+import { resolvePositionalDeps, type PositionalDependencies } from "./positional-deps.js";
 import { assertNoServiceViewDeps } from "./service-view.js";
 import { getApiRuntime, introspectExpressRoutes } from "./api-runtime.js";
 import { getSettleState, type PendingSettleDep } from "./settle.js";
@@ -51,31 +53,56 @@ import {
 let expressAutoDetected = false;
 
 /**
- * Dependencies object passed to route handlers.
- * Keys are capability names, values are proxy instances (or null if unavailable).
+ * Dependencies passed to route handlers — **positional** as of 3.4.0
+ * (issue #1401). `deps[i]` is the proxy for the i-th declared dependency, or
+ * `null` when it is not currently resolved. Slots are never compacted, so an
+ * unavailable dependency nulls its own index and never shifts a later one.
+ *
+ * Before 3.4.0 this was a capability-keyed object. Destructure positionally:
+ *
+ * ```typescript
+ * mesh.route([{ capability: "a" }, { capability: "b" }],
+ *   async (req, res, [a, b]) => { ... })
+ * ```
+ *
+ * A handler may narrow this to a tuple for per-slot typing, e.g.
+ * `MeshRouteHandler<[McpMeshTool, McpMeshTool | null]>`.
  */
-export type RouteDependencies = Record<string, McpMeshTool | null>;
+export type RouteDependencies = PositionalDependencies;
 
 /**
  * Route handler function with dependency injection.
  *
  * @param req - Express request object
  * @param res - Express response object
- * @param deps - Resolved dependencies as an object (keys are capability names)
+ * @param deps - Resolved dependencies **by position** — `deps[i]` is the i-th
+ *               declared dependency (see {@link RouteDependencies})
  */
-export type MeshRouteHandler = (
+export type MeshRouteHandler<D extends RouteDependencies = RouteDependencies> = (
   req: Request,
   res: Response,
-  deps: RouteDependencies
+  deps: D
 ) => void | Promise<void>;
 
 /**
  * Extended route handler with next function for middleware chaining.
+ *
+ * This is also the type {@link route} accepts — deliberately NOT a union with
+ * {@link MeshRouteHandler}. A 3-parameter handler is assignable here (fewer
+ * parameters always are), whereas a *union* of the two signatures defeats
+ * contextual typing for the `deps` array binding pattern: TypeScript cannot
+ * pick a contextual signature out of the union, falls back to the pattern's
+ * implied tuple (`[add]` → `[any]`), and then rejects the assignment because
+ * an array "may have fewer elements". The keyed object form masked this — its
+ * implied type `{ add: any }` happened to be satisfied by
+ * `Record<string, McpMeshTool | null>` — so it only surfaced under #1401.
  */
-export type MeshRouteHandlerWithNext = (
+export type MeshRouteHandlerWithNext<
+  D extends RouteDependencies = RouteDependencies,
+> = (
   req: Request,
   res: Response,
-  deps: RouteDependencies,
+  deps: D,
   next: NextFunction
 ) => void | Promise<void>;
 
@@ -241,23 +268,29 @@ export class RouteRegistry {
   }
 
   /**
-   * Get all resolved dependencies for a route as an object.
-   * Keys are capability names for easy destructuring in handlers.
+   * Get all resolved dependencies for a route as a **positional array**
+   * (issue #1401) — index i holds the i-th declared dependency's proxy, or
+   * `null` when it is unresolved.
+   *
    * Handles remapped route IDs (e.g., route_0_UNKNOWN:UNKNOWN -> GET:/time).
+   *
+   * Built with an index-preserving `map()` over the DECLARED dependencies —
+   * never by pushing resolved entries. A push-based build would omit
+   * unresolved slots and shift every later dependency into the wrong
+   * position; harmless for the old capability-keyed object, fatal for an
+   * array. Returns a plain array; the migration guard is applied at the
+   * user-code boundary (see `wrapPositionalDeps`).
    */
   getDependenciesForRoute(routeId: string): RouteDependencies {
     // Use getRoute to handle remapped IDs
     const route = this.getRoute(routeId);
-    if (!route) return {};
+    if (!route) return [];
 
     // Use the resolved route ID for dependency lookup
     const resolvedId = route.routeId;
-    const deps: RouteDependencies = {};
-    route.dependencies.forEach((dep, idx) => {
-      deps[dep.capability] = this.getDependency(resolvedId, idx);
-    });
-
-    return deps;
+    return route.dependencies.map((_dep, idx) =>
+      this.getDependency(resolvedId, idx)
+    );
   }
 
   /**
@@ -347,16 +380,18 @@ export function resetAutoDetection(): void {
  * Create an Express middleware that injects mesh dependencies.
  *
  * @param dependencies - Array of dependency specifications
- * @param handler - Route handler receiving (req, res, deps)
+ * @param handler - Route handler receiving (req, res, deps) where `deps` is
+ *                  **positional**: `deps[i]` is the i-th declared dependency
  * @returns Express middleware
  *
  * @example
  * ```typescript
  * app.post("/compute", mesh.route(
  *   [{ capability: "calculator" }],
- *   async (req, res, { calculator }) => {
+ *   async (req, res, [calculator]) => {
  *     if (!calculator) {
- *       return res.status(503).json({ error: "Calculator service unavailable" });
+ *       res.status(503).json({ error: "Calculator service unavailable" });
+ *       return;
  *     }
  *     const result = await calculator({ a: req.body.a, b: req.body.b });
  *     res.json({ result });
@@ -364,9 +399,9 @@ export function resetAutoDetection(): void {
  * ));
  * ```
  */
-export function route(
+export function route<D extends RouteDependencies = RouteDependencies>(
   dependencies: DependencySpec[],
-  handler: MeshRouteHandler | MeshRouteHandlerWithNext,
+  handler: MeshRouteHandlerWithNext<D>,
   options?: { dependencyKwargs?: DependencyKwargs[] }
 ): RequestHandler {
   const registry = RouteRegistry.getInstance();
@@ -399,13 +434,18 @@ export function route(
 
   // Issue #1249: does this route declare any required dep? Precomputed once so
   // the perimeter check below is a no-op for the common (all-optional) route.
-  // Every declared dep always has a slot in the `deps` object keyed by
-  // capability, so — unlike Python's positional injection — there is no
-  // "required perimeter INACTIVE (no injectable slot)" case to warn about.
+  // Every declared dep always has its own index in the positional `deps`
+  // array, so — unlike Python's positional injection, where a dep can be
+  // declared without a matching parameter — there is no "required perimeter
+  // INACTIVE (no injectable slot)" case to warn about.
   // TS `mesh.route` has no declared streaming/SSE variant either, and the 503
   // is emitted before the handler runs (nothing written to `res` yet), so
   // there is no stream to break and no creation-time bypass warning to emit.
   const hasRequiredDep = normalizedDeps.some((dep) => dep.required === true);
+
+  // Capability names in declaration order — the migration guard prints these
+  // when an un-migrated handler reads `deps.<capability>` (issue #1401).
+  const declaredCapabilities = normalizedDeps.map((dep) => dep.capability);
 
   // Return Express middleware
   const middleware: RequestHandler = async (
@@ -443,16 +483,19 @@ export function route(
         }
       }
 
-      // Get resolved dependencies as object (use ref to get current ID after introspection)
-      const deps = registry.getDependenciesForRoute(routeRef.id);
-
-      // Also try to resolve by capability name if route-specific resolution isn't available yet
-      // This handles the case where dependencies were resolved before the route was registered
-      for (const dep of normalizedDeps) {
-        if (deps[dep.capability] === undefined) {
-          deps[dep.capability] = null;
-        }
-      }
+      // Resolve, pad and guard the positional dependency array (issue #1401).
+      // Shared with the A2A producer dispatcher so the two injection sites
+      // cannot drift. `depValues` is the unguarded view the required-dependency
+      // perimeter below reads by index; `deps` is what user code receives —
+      // an un-migrated `deps.<capability>` access throws a prescriptive error
+      // instead of evaluating to `undefined`. Uses the ref to get the current
+      // route ID after introspection.
+      const { values: depValues, deps } = resolvePositionalDeps(
+        registry,
+        routeRef.id,
+        declaredCapabilities,
+        "mesh.route"
+      );
 
       // Issue #1249 perimeter: a route dep declared `required: true` whose
       // proxy is unavailable AT CALL TIME (after the settle wait above) makes
@@ -460,24 +503,24 @@ export function route(
       // capability, so monitoring alarms on 5xx and clients see a retryable
       // "unavailable" rather than a hand-written null check.
       //
-      // Evaluate required-ness PER UNIQUE CAPABILITY against the same
-      // capability-keyed `deps` object the handler receives — NOT per index.
-      // Injection is capability-keyed (a capability declared twice collapses to
-      // one `deps[cap]` slot, last resolution winning), so an index-based check
-      // could 503 on a dead sibling slot while `deps[cap]` is actually live.
-      // Deduping with "required wins" (a capability required in any slot is
-      // required) keeps the perimeter and the handler seeing identical state.
+      // Evaluate required-ness PER INDEX against the same positional array the
+      // handler receives (issue #1401). Injection used to be capability-keyed,
+      // which collapsed a capability declared twice into ONE `deps[cap]` slot —
+      // so the check had to dedupe per capability to avoid 503-ing on a dead
+      // sibling while the slot the handler read was live. Under positional
+      // injection each declaration owns its own index: two slots declaring the
+      // same capability are two distinct slots, either of which can be null in
+      // the handler. Deduping now would let a required slot the handler will
+      // read as `null` slip past the perimeter.
       if (hasRequiredDep) {
-        const checkedCaps = new Set<string>();
-        for (const dep of normalizedDeps) {
+        for (let i = 0; i < normalizedDeps.length; i++) {
+          const dep = normalizedDeps[i];
           if (dep.required !== true) continue;
-          if (checkedCaps.has(dep.capability)) continue;
-          checkedCaps.add(dep.capability);
           // `== null` catches both the resolved-null and never-set cases.
-          if (deps[dep.capability] == null) {
+          if (depValues[i] == null) {
             console.warn(
               `🚫 Route '${req.method} ${req.path}': required dependency ` +
-                `'${dep.capability}' unavailable — returning 503`
+                `[${i}] '${dep.capability}' unavailable — returning 503`
             );
             res.status(503).json({
               error: "dependency_unavailable",
@@ -566,7 +609,7 @@ export function route(
           argsCount: 0,
           kwargsCount: 0,
           dependencies: [],
-          injectedDependencies: Object.values(deps).filter((d) => d !== null).length,
+          injectedDependencies: depValues.filter((d) => d !== null).length,
           meshPositions: [],
         }).catch(() => {
           // Silently ignore publish errors
@@ -594,16 +637,16 @@ export function route(
  * app.post("/compute", mesh.routeWithConfig({
  *   dependencies: [{ capability: "calculator" }],
  *   dependencyKwargs: [{ timeout: 60 }],
- * }, async (req, res, { calculator }) => {
+ * }, async (req, res, [calculator]) => {
  *   // ...
  * }));
  * ```
  */
-export function routeWithConfig(
+export function routeWithConfig<D extends RouteDependencies = RouteDependencies>(
   config: MeshRouteConfig,
-  handler: MeshRouteHandler | MeshRouteHandlerWithNext
+  handler: MeshRouteHandlerWithNext<D>
 ): RequestHandler {
-  return route(config.dependencies, handler, {
+  return route<D>(config.dependencies, handler, {
     dependencyKwargs: config.dependencyKwargs,
   });
 }

--- a/src/runtime/typescript/src/sse-stream.ts
+++ b/src/runtime/typescript/src/sse-stream.ts
@@ -15,9 +15,10 @@
  * ```typescript
  * import { mesh } from "@mcpmesh/sdk";
  *
- * app.post("/plan", mesh.route(["trip_planner"], async (req, res, { trip_planner }) => {
- *   if (!trip_planner) return res.status(503).end();
- *   await mesh.sseStream(res, trip_planner.stream(req.body));
+ * // Dependencies bind by position: deps[0] is the first declared dependency.
+ * app.post("/plan", mesh.route(["trip_planner"], async (req, res, [tripPlanner]) => {
+ *   if (!tripPlanner) return res.status(503).end();
+ *   await mesh.sseStream(res, tripPlanner.stream(req.body));
  * }));
  * ```
  */

--- a/tests/integration/suites/uc06_observability/artifacts/express-api/index.ts
+++ b/tests/integration/suites/uc06_observability/artifacts/express-api/index.ts
@@ -61,19 +61,21 @@ app.get("/health", (req, res) => {
  */
 app.post(
   "/api/add",
-  mesh.route([{ capability: "add" }], async (req, res, { add }) => {
+  mesh.route([{ capability: "add" }], async (req, res, [add]) => {
     if (!add) {
-      return res.status(503).json({ error: "Calculator service unavailable" });
+      res.status(503).json({ error: "Calculator service unavailable" });
+      return;
     }
 
     const { a, b } = req.body;
     if (typeof a !== "number" || typeof b !== "number") {
-      return res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      return;
     }
 
     try {
       const result = await add({ a, b });
-      res.json({ operation: "add", a, b, result: parseFloat(result) });
+      res.json({ operation: "add", a, b, result: parseFloat(String(result)) });
     } catch (err) {
       res.status(500).json({ error: `Calculation failed: ${err}` });
     }
@@ -86,19 +88,21 @@ app.post(
  */
 app.post(
   "/api/subtract",
-  mesh.route([{ capability: "subtract" }], async (req, res, { subtract }) => {
+  mesh.route([{ capability: "subtract" }], async (req, res, [subtract]) => {
     if (!subtract) {
-      return res.status(503).json({ error: "Calculator service unavailable" });
+      res.status(503).json({ error: "Calculator service unavailable" });
+      return;
     }
 
     const { a, b } = req.body;
     if (typeof a !== "number" || typeof b !== "number") {
-      return res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      return;
     }
 
     try {
       const result = await subtract({ a, b });
-      res.json({ operation: "subtract", a, b, result: parseFloat(result) });
+      res.json({ operation: "subtract", a, b, result: parseFloat(String(result)) });
     } catch (err) {
       res.status(500).json({ error: `Calculation failed: ${err}` });
     }
@@ -111,19 +115,21 @@ app.post(
  */
 app.post(
   "/api/multiply",
-  mesh.route([{ capability: "multiply" }], async (req, res, { multiply }) => {
+  mesh.route([{ capability: "multiply" }], async (req, res, [multiply]) => {
     if (!multiply) {
-      return res.status(503).json({ error: "Calculator service unavailable" });
+      res.status(503).json({ error: "Calculator service unavailable" });
+      return;
     }
 
     const { a, b } = req.body;
     if (typeof a !== "number" || typeof b !== "number") {
-      return res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      return;
     }
 
     try {
       const result = await multiply({ a, b });
-      res.json({ operation: "multiply", a, b, result: parseFloat(result) });
+      res.json({ operation: "multiply", a, b, result: parseFloat(String(result)) });
     } catch (err) {
       res.status(500).json({ error: `Calculation failed: ${err}` });
     }
@@ -136,23 +142,26 @@ app.post(
  */
 app.post(
   "/api/divide",
-  mesh.route([{ capability: "divide" }], async (req, res, { divide }) => {
+  mesh.route([{ capability: "divide" }], async (req, res, [divide]) => {
     if (!divide) {
-      return res.status(503).json({ error: "Calculator service unavailable" });
+      res.status(503).json({ error: "Calculator service unavailable" });
+      return;
     }
 
     const { a, b } = req.body;
     if (typeof a !== "number" || typeof b !== "number") {
-      return res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      return;
     }
 
     if (b === 0) {
-      return res.status(400).json({ error: "Division by zero" });
+      res.status(400).json({ error: "Division by zero" });
+      return;
     }
 
     try {
       const result = await divide({ a, b });
-      res.json({ operation: "divide", a, b, result: parseFloat(result) });
+      res.json({ operation: "divide", a, b, result: parseFloat(String(result)) });
     } catch (err) {
       res.status(500).json({ error: `Calculation failed: ${err}` });
     }
@@ -169,14 +178,16 @@ app.post(
  */
 app.post(
   "/api/greet",
-  mesh.route([{ capability: "greet" }], async (req, res, { greet }) => {
+  mesh.route([{ capability: "greet" }], async (req, res, [greet]) => {
     if (!greet) {
-      return res.status(503).json({ error: "Greeter service unavailable" });
+      res.status(503).json({ error: "Greeter service unavailable" });
+      return;
     }
 
     const { name } = req.body;
     if (typeof name !== "string") {
-      return res.status(400).json({ error: "Parameter 'name' must be a string" });
+      res.status(400).json({ error: "Parameter 'name' must be a string" });
+      return;
     }
 
     try {
@@ -194,20 +205,22 @@ app.post(
  */
 app.post(
   "/api/greet/lucky",
-  mesh.route([{ capability: "greet-lucky" }], async (req, res, deps) => {
-    const greetLucky = deps["greet-lucky"];
+  mesh.route([{ capability: "greet-lucky" }], async (req, res, [greetLucky]) => {
     if (!greetLucky) {
-      return res.status(503).json({ error: "Greeter service unavailable" });
+      res.status(503).json({ error: "Greeter service unavailable" });
+      return;
     }
 
     const { name, birthYear, birthMonth } = req.body;
     if (typeof name !== "string") {
-      return res.status(400).json({ error: "Parameter 'name' must be a string" });
+      res.status(400).json({ error: "Parameter 'name' must be a string" });
+      return;
     }
     if (typeof birthYear !== "number" || typeof birthMonth !== "number") {
-      return res
+      res
         .status(400)
         .json({ error: "Parameters 'birthYear' and 'birthMonth' must be numbers" });
+      return;
     }
 
     try {
@@ -225,18 +238,20 @@ app.post(
  */
 app.post(
   "/api/greet/age",
-  mesh.route([{ capability: "greet-age" }], async (req, res, deps) => {
-    const greetAge = deps["greet-age"];
+  mesh.route([{ capability: "greet-age" }], async (req, res, [greetAge]) => {
     if (!greetAge) {
-      return res.status(503).json({ error: "Greeter service unavailable" });
+      res.status(503).json({ error: "Greeter service unavailable" });
+      return;
     }
 
     const { name, birthYear } = req.body;
     if (typeof name !== "string") {
-      return res.status(400).json({ error: "Parameter 'name' must be a string" });
+      res.status(400).json({ error: "Parameter 'name' must be a string" });
+      return;
     }
     if (typeof birthYear !== "number") {
-      return res.status(400).json({ error: "Parameter 'birthYear' must be a number" });
+      res.status(400).json({ error: "Parameter 'birthYear' must be a number" });
+      return;
     }
 
     try {
@@ -254,18 +269,20 @@ app.post(
  */
 app.post(
   "/api/greet/math",
-  mesh.route([{ capability: "greet-math" }], async (req, res, deps) => {
-    const greetMath = deps["greet-math"];
+  mesh.route([{ capability: "greet-math" }], async (req, res, [greetMath]) => {
     if (!greetMath) {
-      return res.status(503).json({ error: "Greeter service unavailable" });
+      res.status(503).json({ error: "Greeter service unavailable" });
+      return;
     }
 
     const { name, a, b } = req.body;
     if (typeof name !== "string") {
-      return res.status(400).json({ error: "Parameter 'name' must be a string" });
+      res.status(400).json({ error: "Parameter 'name' must be a string" });
+      return;
     }
     if (typeof a !== "number" || typeof b !== "number") {
-      return res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      res.status(400).json({ error: "Parameters 'a' and 'b' must be numbers" });
+      return;
     }
 
     try {

--- a/tests/integration/suites/uc18_streaming/artifacts/streaming/ts-stream-gateway/src/index.ts
+++ b/tests/integration/suites/uc18_streaming/artifacts/streaming/ts-stream-gateway/src/index.ts
@@ -26,7 +26,7 @@ app.post(
   "/plan",
   mesh.route(
     [{ capability: "trip_planning" }],
-    async (req: Request, res: Response, { trip_planning }) => {
+    async (req: Request, res: Response, [trip_planning]) => {
       if (!trip_planning) {
         res.status(503).json({ error: "trip_planning unavailable" });
         return;

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-agent-ts/src/index.ts
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-agent-ts/src/index.ts
@@ -20,7 +20,7 @@ const HTTP_PORT = parseInt(
 process.env.MCP_MESH_AGENT_NAME = process.env.MCP_MESH_AGENT_NAME ?? "date-a2a-agent";
 
 import express from "express";
-import { mesh, type McpMeshTool } from "@mcpmesh/sdk";
+import { mesh } from "@mcpmesh/sdk";
 
 const app = express();
 // express.json() is REQUIRED — the A2A dispatcher reads req.body to
@@ -38,8 +38,8 @@ mesh.a2a.mount(
     tags: ["system", "date"],
     dependencies: ["date_service"],
   },
-  async (deps, _payload) => {
-    const dateService = deps.date_service as McpMeshTool | null;
+  async ([dateService], _payload) => {
+    // Dependencies bind BY POSITION (#1401): deps[0] is `date_service`.
     if (dateService === null) {
       // Defer-resolution sentinel: keeps the fixture runnable solo and
       // mirrors the Python/Java producer fallback path.
@@ -48,7 +48,7 @@ mesh.a2a.mount(
         note: "date_service not yet resolved",
       };
     }
-    const result = await dateService.call({});
+    const result = await dateService({});
     return { date: result };
   },
 );


### PR DESCRIPTION
## Summary

**PR C of the #1401 sequence — the breaking TypeScript conversion.** `mesh.route` and `mesh.a2a.mount` dependencies now bind **by position**, matching Python and Java (#1436). `mesh.addTool` was already positional and is untouched.

The issue's table was wrong on one point: **`a2a.mount` was also capability-keyed**, so this converts three sites, not one.

## No in-tree app changes behaviour

A base↔head comparator (TS compiler API) built each handler's `local identifier → capability` table under each tree's own rule and diffed by identifier:

```
handlers=35 (route=27 a2a=8)  bound-slots=30  BINDING DIFFERENCES=0   UNMATCHED: none
```

Java's equivalent run was 21 handlers / 0 differences. Every in-tree handler declares exactly one dependency, so this is 30 single-slot rewrites plus one `deps["greet-lucky"] → [greetLucky]` rename class.

## The migration guard — and why it is bounded to declared capabilities

Silent misbinding is structurally impossible here: string keys and numeric indices are disjoint, so a stale `deps.cap` on an array yields `undefined`, never a wrong proxy. But `undefined` surfaces far from the cause as `Cannot read properties of undefined (reading 'call')`, and casts like `deps["cap"] as McpMeshTool | null` — present in our own examples — defeat the compiler entirely. So the array is Proxy-wrapped and throws with the index named:

```
mesh.route dependencies are positional as of 3.4.0.
You accessed `deps.add`; "add" is declared dependency [0].
Rewrite the handler as:  async (req, res, [add, greet_lucky]) => { ... }
```

**The originally-specified unbounded trap with a positive allowlist is not shippable, and this is the one deliberate deviation from the brief.** Its first host was vitest, which probes `$$typeof`, `@@__IMMUTABLE_ITERABLE__@@`, `@@__IMMUTABLE_RECORD__@@`, `nodeType`, `tagName`, `hasAttribute` and `toJSON` on a single `toHaveBeenCalledWith` — and the throw surfaced as `PrettyFormatPluginError`, **hiding the real assertion**. That key set is library-invented and not enumerable in advance, so no allowlist can close over it, and getting it wrong breaks users' currently-passing route tests.

Inverted instead: the trap fires on **declared capabilities**, checked before anything else. That catches 100% of the actual hazard — an un-migrated handler reading a declared capability by name, cast form included — while being immune to host probing. A capability named `map` or `length` still throws rather than silently returning the array method. Reading an *undeclared* key returned `undefined` before this change too: a typo, not a migration signal, with no rewrite to prescribe.

The rationale and the measured probe list are in the module docstring, and the pass-through half is pinned by 13 tests so a future "tighten this" refactor fails loudly.

Verified live against the built `dist/`: `deps[0]`, destructuring, `.length`, `Array.isArray`→true, spread, `for...of`, `JSON.stringify`, `console.log`/`util.inspect`, `.filter`, and undeclared-key→`undefined` all behave correctly.

## Two decisions

**`A2ADependencies` kept and repointed, not deprecated.** Repointing it at the array type achieves both goals at once: the name survives so barrels and imports are unchanged, *and* `mount<{ date_service: McpMeshTool }>` stops compiling, because an object type no longer satisfies the constraint (TS2344, pinned by `@ts-expect-error`). No `@deprecated` marker: the type was not *replaced*, it changed meaning, so there is no "use X instead" to point at — and it is still `A2AHandler`'s default type argument, so the marker would strike through the recommended usage. The generic is now more useful than before: `mount<[McpMeshTool, McpMeshTool | null]>` gives per-slot typing. `RouteDependencies` gets the same treatment; both alias a newly-exported `PositionalDependencies`.

**Duplicate capabilities — the required perimeter reverts to per-index.** The old per-capability dedupe was correct *because* injection collapsed duplicates into one `deps[cap]`. Positionally each declaration owns its index, so deduping would wave through a required dependency the handler reads as `null`. Two tests: required-dead-sibling now 503s, and both-live gives each slot its own distinct proxy.

## Two more things the conversion forced

**`route()`'s union handler parameter had to go, or every converted example fails to compile.** A union of the 3- and 4-param signatures defeats contextual typing for an array binding pattern — TS falls back to the implied tuple `[add] → [any]` and rejects the assignment. The keyed form masked this, because `{ add: any }` was satisfied by `Record<string, …>`. `route`/`routeWithConfig` are now generic and take `MeshRouteHandlerWithNext<D>`, to which a 3-param handler is assignable.

Verified against the **built SDK**: base `express-api` had 37 type errors, head has 8 — and those 8 are a pre-existing `express@^4` + `@types/express@^5` mismatch in that example's own `package.json`, unrelated and untouched. Properly-typed deps also surfaced two latent example bugs (`return res.json()` from a `void` handler, `parseFloat(unknown)`), both fixed.

**`meshctl scaffold api --lang typescript` was a missing site.** `cmd/meshctl/templates/typescript/api/src/index.ts.tmpl` emitted `async (req, res, { hello })` — a freshly scaffolded app would not have compiled. The plan had recorded scaffold as unaffected; it was wrong. Converted and verified end to end: built `meshctl`, scaffolded a gateway, `npm install`, `tsc -p tsconfig.json` → **exit 0**.

## Validation

`npm test` **1213 → 1240** (85 → 87 files). `tsc --noEmit` clean on both the express4 and express5 configs. `go build ./...` clean. Slot preservation extended to route and a2a — an unavailable middle dependency leaves later slots in place — with the a2a case driven through a real `tasks/send`.

## Out of scope

Java (#1436, merged), docs/man/release notes (PR D), and the `jobBeforeProxy` finding from PR A — still awaiting a decision, no guard added.

Refs #1401


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TypeScript route and A2A handlers now receive dependencies as positional arrays, aligned with their declared order.
  * Unavailable dependencies remain represented by `null`, preserving dependency positions.
  * Added a public type for positional dependencies.
* **Bug Fixes**
  * Improved handling of duplicate and unresolved dependencies.
  * Missing required dependencies now return clear 503 responses without continuing execution.
* **Documentation**
  * Updated TypeScript examples and guidance to demonstrate positional dependency access and migration behavior.
* **Tests**
  * Added comprehensive coverage for positional injection, unresolved slots, validation, and compatibility safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->