### PR TITLE
docs(di): state the positional dependency-injection contract on every surface

### DIFF
--- a/cmd/meshctl/templates/java/api/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/api/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -55,8 +55,10 @@ class ApiController {
      * Call the "hello" mesh capability.
      *
      * <p>The @MeshRoute annotation declares a dependency on the "hello" capability.
-     * At request time, the framework resolves the dependency and injects it as a
-     * McpMeshTool parameter (matched by @MeshInject name).
+     * At request time, the framework resolves the dependency and injects it
+     * BY POSITION: the Nth declared dependency fills the Nth McpMeshTool
+     * parameter. @MeshInject does not select a dependency -- it asserts the
+     * one position assigns, and boot fails if the two disagree.
      */
     @GetMapping("/api/hello")
     @MeshRoute(dependencies = @MeshDependency(capability = "hello"))

--- a/cmd/meshctl/templates/python/api/main.py.tmpl
+++ b/cmd/meshctl/templates/python/api/main.py.tmpl
@@ -33,8 +33,9 @@ async def hello_endpoint(request: Request, hello: McpMeshTool = None):
     Example API endpoint that calls the "hello" mesh capability.
 
     The @mesh.route decorator declares dependencies on mesh capabilities.
-    At request time, the framework resolves each dependency and injects
-    it as a McpMeshTool parameter (matched by parameter name).
+    At request time, the framework resolves each dependency and injects it
+    BY POSITION: the Nth declared dependency fills the Nth McpMeshTool
+    parameter. Parameter names are never consulted.
     """
     if not hello:
         raise HTTPException(status_code=503, detail="hello capability unavailable")

--- a/docs/a2a/producer.md
+++ b/docs/a2a/producer.md
@@ -21,13 +21,13 @@ Issue #972: the same code path also flips `a2a_producer=true` on the agent paylo
 
     `@MeshA2A(path = "/agents/<skill>", ...)` on a Spring Boot bean method (sibling to `@MeshRoute`). The framework auto-mounts both routes on the application's `DispatcherServlet` — the user owns the Spring Boot lifecycle (`SpringApplication.run(...)`).
 
-    Mesh dependencies are declared via `@MeshDependency` entries on the annotation and injected at `@MeshInject` parameter slots, identical to the `@MeshRoute` DDDI path.
+    Mesh dependencies are declared via `@MeshDependency` entries on the annotation and injected **by position** into the handler's `McpMeshTool` parameters, identical to the `@MeshRoute` DDDI path. (Changed in 3.4.0 — `@MeshA2A` used to bind by name; see [Migrating to positional DI](../migration/3.4-positional-di.md).)
 
 === "TypeScript"
 
     `mesh.a2a.mount(app, config, handler)` on a user-owned Express app (sibling to `mesh.route(...)`). The user owns the Express app AND the `app.listen()` lifecycle — same shape as `mesh.route(...)` HTTP handlers. The mesh api-runtime pipeline picks up the mounted A2A surface from the `A2AProducerRegistry` and registers the agent with the registry as `agent_type=a2a` on each heartbeat.
 
-    Mesh dependencies are declared via the `dependencies` array on the mount config and supplied to the handler under the `deps` argument keyed by capability name, identical to how `mesh.route(...)` injects resolved `McpMeshTool` proxies.
+    Mesh dependencies are declared via the `dependencies` array on the mount config and supplied to the handler as a **positional** `deps` array — `deps[i]` is the i-th declared dependency, `null` until it resolves — identical to how `mesh.route(...)` injects resolved `McpMeshTool` proxies. (Changed in 3.4.0 — the argument used to be an object keyed by capability; see [Migrating to positional DI](../migration/3.4-positional-di.md).)
 
 ## Sync handler
 

--- a/docs/concepts/dddi.md
+++ b/docs/concepts/dddi.md
@@ -64,7 +64,10 @@ DDDI uses **capability-based discovery** with tag matching, not hardcoded servic
       name: "greet",
       capability: "greeting",
       dependencies: ["calculator"],
-      execute: async (args, { calculator }) => {
+      execute: async (args, calculator: McpMeshTool | null = null) => {
+        if (!calculator) {
+          return "Calculator unavailable";
+        }
         const result = await calculator({ expression: "2+2" });
         return `The answer is ${result}`;
       },

--- a/docs/concepts/routes.md
+++ b/docs/concepts/routes.md
@@ -26,7 +26,7 @@ route handler  ──── injects proxy for capability "session_state.record_q
 resolved provider agent ──► result ──► HTTP response
 ```
 
-The per-runtime surface differs — Java pairs `@MeshRoute(dependencies = {…})` with a `@MeshInject` parameter typed `McpMeshTool<…>`; Python and TypeScript declare the dependency on the route and receive the proxy — but the shape is the same everywhere: one route, the specific capabilities it names, one resolved proxy per capability, called inline in the handler. The exact declaration syntax lives in the dependency-injection guides linked below.
+The per-runtime surface differs in syntax — Java declares `@MeshRoute(dependencies = {…})` and takes `McpMeshTool<…>` parameters, Python declares on the decorator and takes typed parameters, TypeScript declares on `mesh.route(...)` and destructures a `deps` array — but the shape is the same everywhere: one route, the specific capabilities it names, one resolved proxy per capability, called inline in the handler. **Binding is positional in all three**: the Nth declared capability lands in the Nth injectable slot, and names are never consulted. The exact declaration syntax lives in the dependency-injection guides linked below.
 
 Because the proxy is an ordinary resolved dependency, everything DDDI gives a consumer applies here too: the capability hot-swaps to a better or healthier provider between requests, calls thread call context and appear in the audit trail, and an unavailable optional capability injects a null/unavailable proxy that the handler can fall back around.
 
@@ -68,8 +68,9 @@ A route is a DDDI consumer with an HTTP trigger. Each capability it injects is o
 This page stays at the concept level; the exact route declaration, dependency wiring, and injection syntax live in the runtime guides:
 
 - [Dependency Injection (Python)](../python/dependency-injection.md#required-dependencies) — `@mesh.route`, required deps, the 503 perimeter
-- [Dependency Injection (Java)](../java/dependency-injection.md#views-and-meshroute) — `@MeshRoute` + `@MeshInject`, per-capability injection
+- [Dependency Injection (Java)](../java/dependency-injection.md#views-and-meshroute) — `@MeshRoute`, positional pairing, per-capability injection
 - [Dependency Injection (TypeScript)](../typescript/dependency-injection.md#required-dependencies) — `mesh.route()`, required deps, the 503 perimeter
+- [Migrating to positional DI (3.4)](../migration/3.4-positional-di.md) — the Java and TypeScript route binding change
 
 ## See Also
 

--- a/docs/concepts/schema-matching.md
+++ b/docs/concepts/schema-matching.md
@@ -114,7 +114,7 @@ agent.addTool({
     },
   ],
   parameters: z.object({}),
-  execute: async ({}, { lookup_employee }) => { /* ... */ },
+  execute: async ({}, lookupEmployee: McpMeshTool | null = null) => { /* ... */ },
 });
 ```
 

--- a/docs/concepts/service-views.md
+++ b/docs/concepts/service-views.md
@@ -185,7 +185,7 @@ A service view is a grouping convenience, not a default. The [Zero wire and regi
 
 ### When per-capability injection is the better fit
 
-- **A handler uses only 1–2 capabilities of the group** — declare exactly those with per-capability injection: a Python dependency on the specific `@mesh.tool` handler, a Java `@Selector` + `@MeshInject` → `McpMeshTool`, or a TypeScript dependency → `McpMeshTool`. Don't inject a 13-method view to reach two methods.
+- **A handler uses only 1–2 capabilities of the group** — declare exactly those with per-capability injection: a Python dependency on the specific `@mesh.tool` handler, a Java `@Selector` / `@MeshDependency` → `McpMeshTool`, or a TypeScript dependency → `McpMeshTool`. Don't inject a 13-method view to reach two methods.
 - **The consumer is a route handler** (`@mesh.route` / `mesh.route(...)` / `@MeshRoute`) — views are a tool-parameter surface and are **rejected** on routes anyway; a route declares the specific dotted capability it needs and injects that proxy.
 - **Precise `required`-gating matters** — a view's `required` methods gate the handler as a set; if those methods span multiple providers, the handler is gated on capabilities it never calls. Per-capability injection gates on exactly what the handler invokes.
 - **Dep-count legibility / registry footprint matters** — when you want `meshctl list` to show what a handler actually depends on, not the whole group behind one type.

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -91,8 +91,11 @@ Once a producer streams, two consumer code paths are available — and both work
 
     app.post("/api/chat", mesh.route(
       [{ capability: "chat" }],
-      async (req, res, { chat }) => {
-        if (!chat) return res.status(503).json({ error: "chat unavailable" });
+      async (req, res, [chat]) => {
+        if (!chat) {
+          res.status(503).json({ error: "chat unavailable" });
+          return;
+        }
         await mesh.sseStream(res, chat.stream({ prompt: req.body.prompt }));
       }
     ));

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -108,13 +108,19 @@ export MCP_MESH_TOOL_WORKERS=1
 export MCP_MESH_TOOL_ISOLATION=true
 ```
 
-### Strict DI Diagnostics (Python)
+### Strict DI Diagnostics (Python, Java)
 
 ```bash
 # Default: false. When truthy, ambiguous or skipped dependency-injection
-# configurations raise StrictDIError at decoration/startup instead of
-# warning. Injection semantics are unchanged — only the diagnostic
-# severity is promoted.
+# configurations fail at decoration/startup instead of warning. Injection
+# semantics are unchanged — only the diagnostic severity is promoted.
+#
+# - Python: raises StrictDIError at decoration/startup.
+# - Java: promotes the boot-time dependency/parameter arity mismatch and
+#   the @MeshRoute / @MeshA2A legacy-order warning to a startup failure.
+#   A contradicting @MeshInject value is fatal either way — it asserts the
+#   dependency position already assigns, so a false assertion is never
+#   survivable. Accepts 1 / true / yes.
 export MCP_MESH_STRICT_DI=true
 ```
 

--- a/docs/java/annotations.md
+++ b/docs/java/annotations.md
@@ -85,6 +85,8 @@ public GreetingResponse greet(
 
 **Note**: Dependencies are injected as `McpMeshTool<T>` parameters on the method. They may be `null` if unavailable.
 
+**Note**: `dependencies` entries pair with the method's `McpMeshTool<T>` (and `MeshJob`) parameters **by position**, in declaration order; parameter names are never consulted. `@MeshRoute` and `@MeshA2A` use the identical rule (changed in 3.4.0 — they used to bind by name). See [Dependency Injection](dependency-injection.md) for the full pairing rule, including where a `MeshJob` parameter fits and what `@MeshInject` asserts.
+
 ## @Param
 
 Documents tool parameters. Applied to method parameters.
@@ -266,7 +268,7 @@ public class ClaudeProviderApplication {
 
 ## @MeshRoute
 
-Enables mesh dependency injection in REST endpoint handlers.
+Enables mesh dependency injection in REST endpoint handlers. The Nth `@MeshDependency` binds to the Nth `McpMeshTool` parameter, in signature order; `@MeshInject` asserts that pairing rather than selecting it.
 
 ```java
 @MeshRoute(dependencies = @MeshDependency(capability = "avatar_chat"))

--- a/docs/java/dependency-injection.md
+++ b/docs/java/dependency-injection.md
@@ -46,6 +46,69 @@ public GreetingResponse smartGreet(
 
 **Important**: Dependencies are injected as `McpMeshTool<T>` parameters on the method. They may be `null` if unavailable.
 
+**How pairing works**: dependencies bind **by position**, at every injection site. The `dependencies` entries pair with the method's dependency-typed parameters — `McpMeshTool<T>` and, where present, `MeshJob` — in declaration order: the first entry fills the first such parameter, the second fills the second, and so on. `@Param`-annotated business parameters take no part in the pairing. Parameter names are never consulted, so they are yours to choose:
+
+```java
+@MeshTool(capability = "report",
+          dependencies = {@Selector(capability = "data_service"),
+                          @Selector(capability = "formatter")})
+public Report generateReport(
+        @Param(value = "query", description = "Report query") String query,
+        McpMeshTool<Data> data,        // ← data_service
+        McpMeshTool<String> format) {  // ← formatter
+    ...
+}
+```
+
+A `MeshJob` parameter (at most one per method) occupies a position in this same ordering and binds its paired dependency as the job's submitter. The same order-based rule applies in Python (`dependencies=[...]`) and TypeScript (`addTool({ dependencies: [...] })`).
+
+### One rule, every site
+
+`@MeshRoute` and `@MeshA2A` follow the identical rule: the Nth `@MeshDependency` binds to the Nth injectable parameter, in signature order. Parameter names are never consulted, and `@MeshDependency(name = ...)` no longer steers where a dependency lands — it survives only as an alias `@MeshInject` may assert against, and as a lookup key for `MeshRouteUtils`.
+
+```java
+@MeshRoute(dependencies = {
+    @MeshDependency(capability = "lookup_employee"),
+    @MeshDependency(capability = "employee_count")
+})
+@PostMapping("/report")
+public ResponseEntity<Report> report(
+        @RequestBody ReportRequest body,
+        McpMeshTool<Employee> employeeLookup,   // dependencies[0] — lookup_employee
+        McpMeshTool<Integer> headcount) { ... } // dependencies[1] — employee_count
+```
+
+!!! warning "Changed in 3.4.0"
+
+    `@MeshRoute` and `@MeshA2A` previously bound **by name** — by the `@MeshInject` value, or by the Java parameter name. They now bind by position, like `@MeshTool` and like every Python and TypeScript site. A handler whose declaration order disagrees with its old names is diagnosed at boot rather than silently rebound. See [Migrating to positional DI](../migration/3.4-positional-di.md).
+
+### `@MeshInject` is an assertion
+
+`@MeshInject` no longer *selects* a dependency — it *asserts* the one position already assigns. Its value must equal the capability (or the `@MeshDependency(name = ...)` alias) at that parameter's slot, or the application fails to start:
+
+```java
+@MeshRoute(dependencies = {
+    @MeshDependency(capability = "lookup_employee"),
+    @MeshDependency(capability = "employee_count")
+})
+@PostMapping("/report")
+public ResponseEntity<Report> report(
+        @RequestBody ReportRequest body,
+        @MeshInject("lookup_employee") McpMeshTool<Employee> employeeLookup,
+        @MeshInject("employee_count") McpMeshTool<Integer> headcount) { ... }
+```
+
+Keeping it is optional and changes **nothing about what binds** — but it is not inert at boot. A correct annotation pins the pairing: it silences the legacy-order warning described below, and turns a later reorder of one end without the other into a startup failure rather than a quiet rebind. A contradicting annotation is fatal **unconditionally**, not gated on `MCP_MESH_STRICT_DI`, because a false assertion is never a survivable shape. `@MeshInject` is honoured on `@MeshTool` parameters too, under the same assertion semantics.
+
+### Order validation
+
+Two boot-time checks back the positional contract:
+
+- **Arity.** A method that declares more dependencies than it has injectable parameters (the surplus is resolved and advertised but injected nowhere), or fewer (the surplus parameters are injected `null`), is reported. WARN by default; `MCP_MESH_STRICT_DI=true` promotes it to a startup failure.
+- **Order.** A handler whose parameter *names* match the declared capabilities in a different order — the fingerprint of code written against the pre-3.4 by-name rule — is reported with both orderings and the prescribed reorder. WARN by default, fatal under `MCP_MESH_STRICT_DI`. Adding a correct `@MeshInject` to each parameter silences it.
+
+`@MeshDependsOn` beans are the one deliberate exception: they bind by Spring bean name via `@Qualifier`, because that is a Spring wiring surface rather than a mesh parameter-pairing one.
+
 ### Dependencies with Filters
 
 Use the `@Selector` annotation with tags or version to filter providers:
@@ -68,7 +131,7 @@ public String generateReport(
 
 ## Component-level dependency declaration with `@MeshDependsOn`
 
-`@MeshInject` and `@MeshRoute(dependencies=...)` work at the controller-method scope. For everything else — `@Service` beans, `@Component`s, servlet `Filter`s, `@Scheduled` jobs — declare the capabilities your bean needs with the class-level `@MeshDependsOn` annotation. The auto-configuration then registers a singleton `McpMeshTool` bean named by each capability, so you can wire it the standard Spring way.
+`@MeshRoute(dependencies=...)` works at the controller-method scope. For everything else — `@Service` beans, `@Component`s, servlet `Filter`s, `@Scheduled` jobs — declare the capabilities your bean needs with the class-level `@MeshDependsOn` annotation. The auto-configuration then registers a singleton `McpMeshTool` bean named by each capability, so you can wire it the standard Spring way.
 
 ### Constructor injection (recommended)
 
@@ -113,11 +176,11 @@ public class HolidayChecker {
 | Scenario | Annotation |
 | -------- | ---------- |
 | `@MeshTool` method needing remote helpers | `@MeshTool(dependencies = @Selector(...))` + parameter injection |
-| `@RestController` handler method | `@MeshRoute(dependencies = {...})` + `@MeshInject` parameter |
+| `@RestController` handler method | `@MeshRoute(dependencies = {...})` + positional `McpMeshTool<T>` parameters |
 | `@Service` / `@Component` / `Filter` / `@Scheduled` / any other Spring bean | **`@MeshDependsOn` + `@Qualifier`** |
 | Several capabilities behind one typed facade | **`@MeshService` interface + `@Autowired`** |
 
-`@MeshDependsOn` and `@MeshInject`/`@MeshRoute` are complementary — same heartbeat-driven proxy lifecycle, same auto-rewiring on topology change, same `isAvailable()` semantics. Pick the surface that matches where you need the dependency. If the same capability shows up via multiple sources the framework deduplicates: a single proxy and a single registry entry per capability name.
+`@MeshDependsOn` and `@MeshRoute` are complementary — same heartbeat-driven proxy lifecycle, same auto-rewiring on topology change, same `isAvailable()` semantics. Pick the surface that matches where you need the dependency. If the same capability shows up via multiple sources the framework deduplicates: a single proxy and a single registry entry per capability name.
 
 ### Tags, version, and bean-name conflicts
 
@@ -252,7 +315,7 @@ The same interface can be used both ways at once — autowired as a bean **and**
 
 ### Views and `@MeshRoute`
 
-A `@MeshService` view interface is a **tool-parameter / bean-only** surface: used as a `@MeshRoute` handler parameter it is **rejected** at boot (a view facade cannot become a route perimeter). A route consumes a specific capability via `@MeshInject` instead — including a single dotted capability that a view would otherwise group. Declare the capability in the route's `dependencies = {}` and inject its proxy by name:
+A `@MeshService` view interface is a **tool-parameter / bean-only** surface: used as a `@MeshRoute` handler parameter it is **rejected** at boot (a view facade cannot become a route perimeter). A route consumes a specific capability as an ordinary positional dependency instead — including a single dotted capability that a view would otherwise group. Declare the capability in the route's `dependencies = {}` and take its proxy at the matching parameter position:
 
 ```java
 @MeshRoute(dependencies = {

--- a/docs/java/spring-boot-integration.md
+++ b/docs/java/spring-boot-integration.md
@@ -8,11 +8,11 @@
   <span>Looking for TypeScript? See <a href="../typescript/express-integration/">TypeScript Express Integration</a></span>
 </div>
 
-> Use mesh dependency injection in Spring Boot REST controllers with `@MeshRoute` and `@MeshInject`
+> Use mesh dependency injection in Spring Boot REST controllers with `@MeshRoute`
 
 ## Overview
 
-MCP Mesh provides `@MeshRoute` and `@MeshInject` annotations for Spring Boot REST controllers that need to consume mesh capabilities. This enables traditional REST APIs to leverage the mesh service layer without being full MCP agents themselves.
+MCP Mesh provides the `@MeshRoute` annotation for Spring Boot REST controllers that need to consume mesh capabilities. This enables traditional REST APIs to leverage the mesh service layer without being full MCP agents themselves.
 
 **Important**: This is for integrating MCP Mesh into your EXISTING Spring Boot app. To create a new MCP agent, use `meshctl scaffold --lang java` instead.
 
@@ -49,9 +49,9 @@ MCP Mesh provides `@MeshRoute` and `@MeshInject` annotations for Spring Boot RES
 
 Apply `@MeshRoute` to a `@RestController` method to declare mesh dependencies. Dependencies are injected as typed `McpMeshTool<T>` parameters.
 
-### Parameter Name Matching (Recommended)
+### Positional Pairing
 
-When the method parameter name matches the capability name, no extra annotation is needed:
+The Nth `@MeshDependency` binds to the Nth `McpMeshTool` parameter, in signature order. Parameter names are never consulted, and business parameters (`@RequestParam`, `@RequestBody`, ...) take no part in the pairing:
 
 ```java
 @GetMapping("/greet")
@@ -61,7 +61,7 @@ When the method parameter name matches the capability name, no extra annotation 
 )
 public ResponseEntity<Map<String, Object>> greet(
         @RequestParam(defaultValue = "World") String name,
-        McpMeshTool<Map<String, Object>> greeting) {  // "greeting" matches capability
+        McpMeshTool<Map<String, Object>> greeting) {  // dependencies[0]
 
     Map<String, Object> result = greeting.call(Map.of("name", name));
 
@@ -73,9 +73,7 @@ public ResponseEntity<Map<String, Object>> greet(
 }
 ```
 
-### @MeshInject for Name Mismatch
-
-Use `@MeshInject` when your parameter name differs from the capability name:
+With several dependencies, declaration order is the binding — name the parameters however reads best:
 
 ```java
 @PostMapping("/process")
@@ -88,10 +86,10 @@ Use `@MeshInject` when your parameter name differs from the capability name:
 )
 public ResponseEntity<Map<String, Object>> process(
         @RequestBody Map<String, Object> input,
-        McpMeshTool<Map<String, Object>> greeting,                      // Name matches
-        @MeshInject("agent_info") McpMeshTool<Map<String, Object>> infoTool) {  // Name differs
+        McpMeshTool<Map<String, Object>> greeter,    // dependencies[0] - greeting
+        McpMeshTool<Map<String, Object>> infoTool) { // dependencies[1] - agent_info
 
-    Map<String, Object> greetingResult = greeting.call(Map.of("name", input.get("name")));
+    Map<String, Object> greetingResult = greeter.call(Map.of("name", input.get("name")));
     Map<String, Object> info = infoTool.call();
 
     return ResponseEntity.ok(Map.of(
@@ -100,6 +98,21 @@ public ResponseEntity<Map<String, Object>> process(
     ));
 }
 ```
+
+### @MeshInject asserts the position
+
+`@MeshInject` does not select a dependency — it asserts the one position already assigns, and the application fails to start if the two disagree. It is optional; add it when you want the pairing pinned against a future reorder of either end:
+
+```java
+public ResponseEntity<Map<String, Object>> process(
+        @RequestBody Map<String, Object> input,
+        @MeshInject("greeting") McpMeshTool<Map<String, Object>> greeter,
+        @MeshInject("agent_info") McpMeshTool<Map<String, Object>> infoTool) { ... }
+```
+
+!!! warning "Changed in 3.4.0"
+
+    `@MeshRoute` used to bind **by name** — by the `@MeshInject` value, falling back to the Java parameter name. It now binds by position, like `@MeshTool` and like every Python and TypeScript site. See [Migrating to positional DI](../migration/3.4-positional-di.md) before upgrading a controller that declares more than one dependency.
 
 ## Optional Dependencies
 
@@ -163,7 +176,6 @@ package com.example.api;
 
 import io.mcpmesh.MeshAgent;
 import io.mcpmesh.spring.web.MeshDependency;
-import io.mcpmesh.spring.web.MeshInject;
 import io.mcpmesh.spring.web.MeshRoute;
 import io.mcpmesh.types.McpMeshTool;
 import org.springframework.boot.SpringApplication;

--- a/docs/migration/3.4-positional-di.md
+++ b/docs/migration/3.4-positional-di.md
@@ -1,0 +1,317 @@
+---
+title: "3.4 — Positional Dependency Injection"
+description: Migrating Java @MeshRoute/@MeshA2A and TypeScript mesh.route/mesh.a2a.mount to positional dependency binding
+---
+
+# 3.4 — Positional Dependency Injection
+
+!!! warning "Breaking change in two runtimes"
+
+    Java `@MeshRoute` / `@MeshA2A` and TypeScript `mesh.route` / `mesh.a2a.mount` changed how declared dependencies reach handler parameters. **Python is unchanged**, and so is *binding* at Java `@MeshTool` and TypeScript `addTool` — both were already positional. One caveat at `@MeshTool`: `@MeshInject` is now **honoured** on its parameters, where it was previously ignored, so a `@MeshTool` parameter whose `@MeshInject` value disagrees with its position now fails at boot.
+
+As of 3.4.0 mcp-mesh has **one** dependency-injection rule, at every injection site in every runtime:
+
+> The **Nth** declared dependency binds to the **Nth** injectable parameter, in signature order. Parameter names are never consulted.
+
+Before 3.4, four of the seven injection sites followed that rule and three did not. Java `@MeshRoute` and `@MeshA2A` matched by name — the `@MeshInject` value, falling back to the Java parameter name. TypeScript `mesh.route` and `mesh.a2a.mount` handed the handler an object keyed by capability. The two rules lived inside the same annotation family, with the same `McpMeshTool` parameter type at every slot, so the mental model carried from one to the other silently misbound and neither the compiler nor an IDE could catch it.
+
+| Runtime    | `tool`     | `route`                        | `a2a`                          |
+| ---------- | ---------- | ------------------------------ | ------------------------------ |
+| Python     | positional | positional                     | positional                     |
+| TypeScript | positional | **was capability-keyed**       | **was capability-keyed**       |
+| Java       | positional | **was by name**                | **was by name**                |
+
+## What breaks
+
+### Java
+
+- **A handler whose declaration order disagrees with its `@MeshInject` values fails at boot.** `@MeshInject` no longer *selects* a dependency — it *asserts* the one position already assigns. A false assertion is fatal **unconditionally**, not gated on `MCP_MESH_STRICT_DI`.
+- **A handler whose parameter *names* match the declared capabilities in a different order is diagnosed**, not silently rebound. WARN by default, a startup failure under `MCP_MESH_STRICT_DI=true`.
+- **Return-type enrichment follows position too.** The `McpMeshTool<T>` generic that drives response deserialization and the schema-match payload is taken from the parameter's slot ordinal, not its name. This had to move with the resolver: leaving it by-name would have made a reordered handler deserialize into the wrong type.
+- **`@MeshInject` is now honoured on `@MeshTool` parameters**, where it was previously ignored — under the same assertion semantics.
+
+### TypeScript
+
+- **`deps.capability` throws.** The dependency argument is an array; reading a *declared* capability off it by name raises a `TypeError` naming the index and printing the corrected signature.
+- **`mount<{ ... }>` and `route<{ ... }>` fail to compile.** `RouteDependencies` and `A2ADependencies` now alias a newly-exported `PositionalDependencies` (`Array<McpMeshTool | null>`), so an object type argument no longer satisfies the constraint (`TS2344`).
+- **Duplicate capabilities each own their index.** The old per-capability dedupe on the required perimeter was correct only because injection collapsed duplicates into one key. Each declaration now has its own slot, so each is checked independently.
+
+## What does not break
+
+**Correctly-ordered code is unaffected.** That is measured, not assumed — every handler in the repository was compared under both rules, on both sides of each conversion:
+
+| Runtime    | Handlers                | Bound slots | Binding differences |
+| ---------- | ----------------------- | ----------- | ------------------- |
+| Java       | 21 (14 route, 7 a2a)    | 14          | **0**               |
+| TypeScript | 35 (27 route, 8 a2a)    | 30          | **0**               |
+
+Also unchanged:
+
+- **Slot preservation.** An unresolved dependency holds its own index as `null` (TypeScript) or an unavailable proxy / `null` (Java) and never shifts a later dependency up.
+- **Everything about resolution.** Tags, version constraints, `expectedType` / `expectedSchema`, `required`, the 503 route perimeter, the settle window, auto-rewiring, and the wire format are all untouched. This is a binding change inside the consumer, not a protocol change.
+- **`@MeshDependsOn` beans.** They bind by Spring bean name via `@Qualifier` — a Spring wiring surface, not a mesh parameter-pairing one — and are deliberately out of scope.
+- **Python.** Every Python site was already positional.
+
+## Find your exposure before upgrading
+
+A handler declaring **two or more** dependencies can rebind whenever its declaration order disagrees with the names it was written against. But **do not use the dependency count as a filter** — a one-dependency handler is exempt only under conditions worth stating, and they differ by runtime:
+
+- **TypeScript — no exemption.** What changed is the *callback shape*, not the pairing. A sole-dependency handler still written `async (req, res, { cap }) => …`, or reading `deps["cap"]` inside a `mount`, throws through the new guard exactly as a five-dependency one does. Every keyed handler becomes `[cap]`, whatever it declares.
+- **Java — exempt only when its `@MeshInject` already names the declared capability, or carries none.** With one slot there is nothing for position to reorder, so an unannotated single-dependency handler cannot change meaning. A sole `@MeshInject` whose value does *not* name the declared capability did change, though: on 3.3 it selected nothing and the parameter was injected `null` with a warning; on 3.4 it is a false assertion and the boot fails. Same for `@MeshInject` on a `@MeshTool` parameter, where it used to be ignored outright.
+
+### Java — the detector ships in 3.3.x and warns
+
+Upgrade to the latest 3.3.x first. It carries the legacy-shape detector, which changes no binding and only logs. Start each Spring Boot application and read the startup log:
+
+```bash
+grep -n "declaration order\|parameter names disagree\|BY POSITION (issue #1401)" app.log
+```
+
+A handler written against the old rule looks like this. Note that it prints **both** orderings, so you can see exactly what would move:
+
+```text
+@MeshRoute com.example.api.ApiController.report(McpMeshTool, McpMeshTool): parameter
+names disagree with declaration order, so these parameters do NOT bind the way their
+names suggest.
+  @MeshRoute binds mesh dependencies BY POSITION (issue #1401): the Nth declared
+  dependency binds to the Nth injectable parameter, and parameter names are never
+  consulted. @MeshTool, and every Python and TypeScript site, work the same way.
+  @MeshInject no longer SELECTS a dependency — it ASSERTS the one positional pairing
+  assigns.
+  2 declared dependencies: [0] 'get_employee', [1] 'employee_count'
+    slot 0 = parameter 0 (McpMeshTool employee_count)
+        parameter name 'employee_count' used to bind:   dependency[1] 'employee_count'
+        binds (by position):                            dependency[0] 'get_employee'
+    slot 1 = parameter 1 (McpMeshTool get_employee)
+        parameter name 'get_employee' used to bind:     dependency[0] 'get_employee'
+        binds (by position):                            dependency[1] 'employee_count'
+  If this handler was written for mcp-mesh 3.3 or earlier (when @MeshRoute and @MeshA2A
+  bound by name), fix it — pick one:
+    • reorder dependencies = {...} to: [0] 'employee_count', [1] 'get_employee'
+      (move each whole @MeshDependency — keep its tags, version, required and schema
+      attributes with its capability)
+    • or reorder the parameters to match the declaration order
+    • or, if the current bindings are already what you want, add @MeshInject("<capability>")
+      to each parameter to assert it — that pins the pairing and silences this warning
+  Set MCP_MESH_STRICT_DI=true to fail startup on this instead of logging it.
+```
+
+The two **reorder** fixes it prescribes are **behaviour-preserving on 3.3 and correct on 3.4** — moving whole `@MeshDependency` entries, or moving the parameters, is name-neutral under the old rule — so you can land that sweep before you upgrade the SDK. Its third suggestion, *adding* an `@MeshInject` where the parameter carried none, preserves 3.3 behaviour only where the parameter name already selected that same dependency; where the name matched no declared capability, 3.3 injected `null` there and the new annotation starts injecting a real proxy. Set `MCP_MESH_STRICT_DI=true` in CI to make the sweep enforceable.
+
+The same pass also reports arity mismatches — a method declaring more dependencies than it has injectable parameters (the surplus is resolved and advertised but injected nowhere), or fewer (the surplus parameters receive `null`). Java had no such check before 3.3.x.
+
+!!! note "Compiled without `-parameters`?"
+
+    The blind spot is narrower than it sounds — it covers **unannotated** parameters only.
+
+    A parameter carrying `@MeshInject("cap")` needs no reflected name: the annotation supplies the key. Such handlers worked fine on 3.3 without `-parameters`, and they are **not** in the blind spot — the detector compares the annotation value against the parameter's *position*, so it reads them exactly as it would in a `-parameters` build and a value that disagrees with its slot still fails the boot. They still have to be validated against the 3.4 positional order.
+
+    Only an **unannotated**, name-bound parameter is invisible: with no name there is nothing to compare, and the detector cannot speak. That case contains no working code — without `-parameters` the pre-3.4 route path already logged an error and injected `null`, and the A2A path matched `arg0` against nothing — so nobody can regress from working to misbinding there.
+
+### TypeScript — no pre-upgrade signal, and none needed
+
+Misbinding is structurally impossible: string keys and numeric indices are disjoint, so a stale `deps.capability` on the new array can only be `undefined`, never another dependency's proxy. Rather than let that surface far from the cause as `Cannot read properties of undefined (reading 'call')`, the array is wrapped so an un-migrated access throws immediately (see below).
+
+To find candidates ahead of time, grep your handlers for the object-destructuring form:
+
+```bash
+grep -rn "req, res, {" src/
+grep -rn "mesh.a2a.mount" -A 3 src/
+```
+
+## How to fix each shape
+
+### Java — `@MeshInject` handler
+
+The annotation values were the binding. Move the `@MeshDependency` entries so declaration order matches the parameters (or move the parameters — either end works):
+
+```java
+// BEFORE (3.3) — bound by @MeshInject value; declaration order was irrelevant.
+@MeshRoute(dependencies = {
+    @MeshDependency(capability = "get_employee"),
+    @MeshDependency(capability = "employee_count")
+})
+@GetMapping("/report")
+public ResponseEntity<Report> report(
+        @RequestParam int id,
+        @MeshInject("employee_count") McpMeshTool<Integer> stats,
+        @MeshInject("get_employee") McpMeshTool<Employee> lookup) { ... }
+```
+
+```java
+// AFTER (3.4) — declaration order IS the binding.
+@MeshRoute(dependencies = {
+    @MeshDependency(capability = "employee_count"),
+    @MeshDependency(capability = "get_employee")
+})
+@GetMapping("/report")
+public ResponseEntity<Report> report(
+        @RequestParam int id,
+        @MeshInject("employee_count") McpMeshTool<Integer> stats,
+        @MeshInject("get_employee") McpMeshTool<Employee> lookup) { ... }
+```
+
+Keeping the annotations is optional and behaviour-neutral. A **correct** `@MeshInject` is a safety net: it pins the pairing, so a later reorder of one end without the other fails the boot instead of quietly rebinding. Dropping them entirely is equally valid **once you are on 3.4**.
+
+Do not fold that into a pre-upgrade sweep. On 3.3 `@MeshInject` still *selects* the dependency, so removing it there falls back to parameter-name matching — which can silently rebind a running application, or inject `null` if no capability matches the name. Dropping is safe on 3.3 only where the parameter names already produce the same binding the annotations do.
+
+If you leave them wrong, the boot fails with both orderings printed:
+
+```text
+@MeshRoute com.example.api.ApiController.report(int, McpMeshTool, McpMeshTool): a
+@MeshInject value contradicts the dependency its parameter's POSITION binds to.
+  2 declared dependencies: [0] 'get_employee', [1] 'employee_count'
+    slot 0 = parameter 1 (McpMeshTool stats)
+        @MeshInject("employee_count") asserts:          dependency[1] 'employee_count'
+        binds (by position):                            dependency[0] 'get_employee'
+    slot 1 = parameter 2 (McpMeshTool lookup)
+        @MeshInject("get_employee") asserts:            dependency[0] 'get_employee'
+        binds (by position):                            dependency[1] 'employee_count'
+  Fix — pick one:
+    • reorder dependencies = {...} to: [0] 'employee_count', [1] 'get_employee'
+      (move each whole @MeshDependency — keep its tags, version, required and schema
+      attributes with its capability)
+    • or reorder the parameters to match the declaration order
+    • or correct the @MeshInject value on each parameter to name the dependency at that
+      parameter's position (@MeshInject is an assertion — dropping it entirely is also
+      valid, and binding is unchanged either way)
+```
+
+When you reorder, **move the whole `@MeshDependency`** — `tags`, `version`, `required`, `expectedType` and `schemaMode` belong to the capability, not to the slot.
+
+`@MeshInject` still accepts the `@MeshDependency(name = ...)` alias as well as the capability, at the paired index only — so a `capability = "base-cap"` declared with the framework-generated `baseCap` alias can be asserted either way.
+
+### Java — unannotated handler
+
+Identical fix, with nothing to correct at the parameter end. The names carried the binding; now they carry nothing:
+
+```java
+// BEFORE (3.3) — parameter names were the match keys.
+@MeshRoute(dependencies = {
+    @MeshDependency(capability = "get_employee"),
+    @MeshDependency(capability = "employee_count")
+})
+public ResponseEntity<Report> report(
+        McpMeshTool<Integer> employee_count,
+        McpMeshTool<Employee> get_employee) { ... }
+```
+
+```java
+// AFTER (3.4) — reorder the declarations; rename the parameters to whatever reads best.
+@MeshRoute(dependencies = {
+    @MeshDependency(capability = "employee_count"),
+    @MeshDependency(capability = "get_employee")
+})
+public ResponseEntity<Report> report(
+        McpMeshTool<Integer> headcount,
+        McpMeshTool<Employee> lookup) { ... }
+```
+
+`@MeshA2A` handlers convert the same way. Their dependency slots are `McpMeshTool` parameters (and any `@MeshInject`-annotated parameter, since the dispatcher owns the whole argument array); the inbound message parameter and an injected `MeshJobSubmitter` are not dependency slots and take no index.
+
+### TypeScript — `mesh.route`
+
+```typescript
+// BEFORE (3.3)
+app.post(
+  "/lucky",
+  mesh.route(["add", "greet_lucky"], async (req, res, { add, greet_lucky }) => {
+    if (!add || !greet_lucky) {
+      res.status(503).json({ error: "unavailable" });
+      return;
+    }
+    res.json({ result: await greet_lucky({ n: await add({ a: 1, b: 2 }) }) });
+  }),
+);
+```
+
+```typescript
+// AFTER (3.4)
+app.post(
+  "/lucky",
+  mesh.route(["add", "greet_lucky"], async (req, res, [add, greetLucky]) => {
+    if (!add || !greetLucky) {
+      res.status(503).json({ error: "unavailable" });
+      return;
+    }
+    res.json({ result: await greetLucky({ n: await add({ a: 1, b: 2 }) }) });
+  }),
+);
+```
+
+The binding names in the array pattern are yours — `greetLucky` above renames `greet_lucky`. The keyed form could rename too, but only by spelling the alias out (`{ greet_lucky: greetLucky }`). What it could not bind plainly at all was a capability whose name is not a valid identifier: `greet-lucky`, with a hyphen, needed a quoted alias (`{ "greet-lucky": greetLucky }`) or a `deps["greet-lucky"]` bracket access.
+
+If you miss one, the guard names the index and prints the rewrite:
+
+```text
+mesh.route dependencies are positional as of 3.4.0.
+You accessed `deps.add`; "add" is declared dependency [0].
+Rewrite the handler as:  async (req, res, [add, greet_lucky]) => { ... }
+```
+
+The guard fires **only** on declared capabilities, checked before anything else. Everything else passes straight through to the array — `deps[0]`, destructuring, spread, `for...of`, `deps.length`, array methods, `Array.isArray`, `JSON.stringify`, `console.log`, `util.inspect`, and test-framework matchers all behave exactly as they would on a bare array. A capability literally named `map` or `length` still throws rather than silently returning the array method. An **undeclared** key returns `undefined`, as it did before — that is a typo, not a migration signal, and there is no rewrite to prescribe for it.
+
+### TypeScript — `mesh.a2a.mount`
+
+```typescript
+// BEFORE (3.3)
+mesh.a2a.mount(
+  app,
+  {
+    path: "/agents/date",
+    skillId: "get-date",
+    dependencies: ["date_service"],
+  },
+  async (deps, payload) => {
+    const dateService = deps["date_service"] as McpMeshTool | null;
+    if (!dateService) return { error: "date_service unresolved" };
+    return { date: await dateService({}) };
+  },
+);
+```
+
+```typescript
+// AFTER (3.4)
+mesh.a2a.mount(
+  app,
+  {
+    path: "/agents/date",
+    skillId: "get-date",
+    dependencies: ["date_service"],
+  },
+  async ([dateService], payload) => {
+    if (!dateService) return { error: "date_service unresolved" };
+    return { date: await dateService({}) };
+  },
+);
+```
+
+The cast in the "before" form is worth calling out: it defeated the compiler entirely, which is why the runtime guard exists rather than relying on type errors alone.
+
+A long-running handler still takes the `MeshJobSubmitter` as its third argument — `async ([dep], payload, jobSubmitter) => { ... }` — and that argument is not a dependency slot.
+
+### TypeScript — type arguments
+
+```typescript
+// BEFORE (3.3) — object shape
+mesh.a2a.mount<{ date_service: McpMeshTool }>(app, config, handler);
+
+// AFTER (3.4) — per-slot tuple, and more useful than the object form was
+mesh.a2a.mount<[McpMeshTool | null]>(app, config, handler);
+```
+
+`mesh.a2a.mount` cannot guarantee a resolved slot, so per-slot type arguments stay nullable. `mesh.route` is generic in the same way. Leaving the type argument off is fine — it defaults to `PositionalDependencies`.
+
+## After upgrading
+
+- **Java**: keep `MCP_MESH_STRICT_DI=true` in CI. The arity check and the legacy-order check both become startup failures under it, so a future reorder cannot land silently.
+- **TypeScript**: `tsc --noEmit` catches the type-argument shape at build time; the runtime guard catches the handler bodies on first request.
+- **Neither runtime needs a coordinated rollout.** Nothing on the wire changed, so a 3.4 consumer and a 3.3 provider (or the reverse) interoperate normally. This is a source-level migration inside each consumer.
+
+## See also
+
+- [Dependency Injection (Java)](../java/dependency-injection.md)
+- [Dependency Injection (TypeScript)](../typescript/dependency-injection.md)
+- [DDDI: Distributed Dynamic Dependency Injection](../concepts/dddi.md)
+- `meshctl man upgrading` — the same guidance offline
+- [Issue #1401](https://github.com/dhyansraj/mcp-mesh/issues/1401)

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,7 +8,7 @@
   <link rel="sitemap" type="application/xml" title="Sitemap" href="{{ config.site_url }}sitemap.xml" />
 
   <!-- Sky Chatbot Widget -->
-  <script>window.SKY_CONFIG = { apiUrl: "https://chat.mcp-mesh.ai", theme: "auto" };</script>
+  <script>window.SKY_CONFIG = { apiUrl: "https://chat.mcp-mesh.ai", theme: "auto", embeddedAuth: true };</script>
   <script defer src="https://chat.mcp-mesh.ai/widget.js"></script>
 
   {{ super() }}

--- a/docs/typescript/dependency-injection.md
+++ b/docs/typescript/dependency-injection.md
@@ -48,7 +48,51 @@ agent.addTool({
 });
 ```
 
-**How pairing works**: Dependencies are injected positionally as parameters after the first `args` parameter, in declaration order (`dependencies[0]`, `dependencies[1]`, ...), and arrive as `null` if unavailable. Parameter names are yours to choose; pick whatever reads best.
+**How pairing works**: Dependencies are injected **by position** as parameters after the first `args` parameter, in declaration order (`dependencies[0]`, `dependencies[1]`, ...), and arrive as `null` if unavailable. Parameter names are never consulted, so they are yours to choose; pick whatever reads best.
+
+### `mesh.route` and `mesh.a2a.mount`
+
+The same rule, in array form. `mesh.route` hands the handler a positional `deps` array as its third argument; `mesh.a2a.mount` hands it as the first. `deps[i]` is the proxy for the i-th declared dependency, or `null` when it is not currently resolved:
+
+```typescript
+app.post(
+  "/report",
+  mesh.route(
+    ["data_service", "formatter"],
+    async (req, res, [dataService, formatter]) => {
+      if (!dataService || !formatter) {
+        res.status(503).json({ error: "dependencies unavailable" });
+        return;
+      }
+      const data = await dataService({ query: req.body.query });
+      res.json({ report: await formatter({ data }) });
+    },
+  ),
+);
+
+mesh.a2a.mount(
+  app,
+  { path: "/agents/date", skillId: "get-date", dependencies: ["date_service"] },
+  async ([dateService], _payload) => {
+    if (!dateService) return { error: "date_service unresolved" };
+    return { date: await dateService({}) };
+  },
+);
+```
+
+Slots are never compacted: an unresolved dependency holds its own index as `null` and never shifts a later one up.
+
+!!! warning "Changed in 3.4.0"
+
+    Both surfaces used to hand the handler an object keyed by capability (`{ data_service, formatter }`). Reading a **declared** capability by name on the array now throws with the index and the corrected signature:
+
+    ```text
+    mesh.route dependencies are positional as of 3.4.0.
+    You accessed `deps.data_service`; "data_service" is declared dependency [0].
+    Rewrite the handler as:  async (req, res, [data_service, formatter]) => { ... }
+    ```
+
+    `RouteDependencies` and `A2ADependencies` now alias `PositionalDependencies` (`Array<McpMeshTool | null>`), so an object type argument — `mesh.a2a.mount<{ date_service: McpMeshTool }>(...)` — no longer compiles. Use per-slot tuples instead: `mount<[McpMeshTool | null]>(...)`. See [Migrating to positional DI](../migration/3.4-positional-di.md).
 
 ### Dependencies with Filters
 

--- a/docs/typescript/express-integration.md
+++ b/docs/typescript/express-integration.md
@@ -42,14 +42,15 @@ app.use(express.json());
 
 app.post("/chat", mesh.route(
   [{ capability: "avatar_chat" }],
-  async (req, res, { avatar_chat }) => {
-    if (!avatar_chat) {
-      return res.status(503).json({ error: "Service unavailable" });
+  async (req, res, [avatarChat]) => {
+    if (!avatarChat) {
+      res.status(503).json({ error: "Service unavailable" });
+      return;
     }
-    const result = await avatar_chat({
+    const result = (await avatarChat({
       message: req.body.message,
       user_email: "user@example.com",
-    });
+    })) as { message?: string };
     res.json({ response: result.message });
   }
 ));
@@ -59,16 +60,23 @@ app.listen(3000);
 
 ## Dependency Declaration
 
-### Simple (by capability name)
+### Positional pairing
+
+The handler's third argument is an array: `deps[i]` is the proxy for the i-th declared dependency, or `null` when it is not currently resolved. Destructure it positionally — the binding names are yours to choose.
 
 ```typescript
 app.post("/users", mesh.route(
   ["user_service", "notification_service"],
-  async (req, res, { user_service, notification_service }) => {
-    // Dependencies are keyed by capability name
+  async (req, res, [userService, notificationService]) => {
+    // userService         === deps[0] — "user_service"
+    // notificationService === deps[1] — "notification_service"
   }
 ));
 ```
+
+!!! warning "Changed in 3.4.0"
+
+    `mesh.route` used to hand the handler an object keyed by capability (`{ user_service }`). It is now an array, matching Python, Java, and `addTool`. Reading a **declared** capability by name throws a `TypeError` naming the index and printing the rewrite. See [Migrating to positional DI](../migration/3.4-positional-di.md).
 
 ### With Tag Filtering
 
@@ -78,7 +86,7 @@ app.post("/analyze", mesh.route(
     { capability: "llm", tags: ["+claude"] },
     { capability: "storage", tags: ["-deprecated"] },
   ],
-  async (req, res, { llm, storage }) => {
+  async (req, res, [llm, storage]) => {
     // Use filtered dependencies
   }
 ));
@@ -107,19 +115,20 @@ interface ChatResponse {
 // Chat endpoint that delegates to mesh avatar agent
 app.post("/api/chat", mesh.route(
   [{ capability: "avatar_chat" }],
-  async (req: Request<{}, ChatResponse, ChatRequest>, res: Response<ChatResponse>, { avatar_chat }) => {
-    if (!avatar_chat) {
-      return res.status(503).json({
+  async (req: Request<{}, ChatResponse, ChatRequest>, res: Response<ChatResponse>, [avatarChat]) => {
+    if (!avatarChat) {
+      res.status(503).json({
         response: "Avatar service unavailable",
         avatarId: ""
       });
+      return;
     }
 
-    const result = await avatar_chat({
+    const result = (await avatarChat({
       message: req.body.message,
       avatar_id: req.body.avatarId || "default",
       user_email: "user@example.com",
-    });
+    })) as { message?: string };
 
     res.json({
       response: result.message || "",
@@ -131,11 +140,15 @@ app.post("/api/chat", mesh.route(
 // History endpoint using mesh agent
 app.get("/api/history", mesh.route(
   [{ capability: "conversation_history_get" }],
-  async (req, res, { conversation_history_get }) => {
-    const result = await conversation_history_get({
+  async (req, res, [historyGet]) => {
+    if (!historyGet) {
+      res.status(503).json({ error: "history service unavailable" });
+      return;
+    }
+    const result = (await historyGet({
       avatar_id: req.query.avatarId || "default",
       limit: parseInt(req.query.limit as string) || 50,
-    });
+    })) as { messages?: unknown[] };
     res.json({ messages: result.messages || [] });
   }
 ));
@@ -161,7 +174,7 @@ The backend will:
 1. Auto-initialize mesh connection on first `mesh.route()` call
 2. Connect to the mesh registry
 3. Resolve dependencies declared in `mesh.route()`
-4. Inject proxies into route handlers as the `deps` object
+4. Inject proxies into route handlers as the positional `deps` array
 5. Re-resolve on topology changes (auto-rewiring)
 
 ## Advanced: Explicit Control
@@ -184,7 +197,11 @@ const meshApp = meshExpress(app, {
 // Define routes with mesh.route()
 app.post("/compute", mesh.route(
   [{ capability: "calculator" }],
-  async (req, res, { calculator }) => {
+  async (req, res, [calculator]) => {
+    if (!calculator) {
+      res.status(503).json({ error: "calculator unavailable" });
+      return;
+    }
     res.json({ result: await calculator(req.body) });
   }
 ));

--- a/docs/typescript/mesh-functions.md
+++ b/docs/typescript/mesh-functions.md
@@ -77,7 +77,7 @@ agent.addTool({
 });
 ```
 
-**Note**: Dependencies are injected positionally as `McpMeshTool | null` parameters after the first `args` parameter, in declaration order, and parameter names are yours to choose. See the [Dependency Injection](dependency-injection.md) guide for the full pairing rule.
+**Note**: Dependencies are injected **by position** as `McpMeshTool | null` parameters after the first `args` parameter, in declaration order; parameter names are never consulted, so they are yours to choose. See the [Dependency Injection](dependency-injection.md) guide for the full pairing rule.
 
 ### Dependency Injection Types
 
@@ -190,21 +190,24 @@ const app = express();
 app.use(express.json());
 
 app.post("/chat", mesh.route(
-  [{ capability: "avatar_chat" }],  // Dependencies
-  async (req, res, { avatar_chat }) => {
-    if (!avatar_chat) {
-      return res.status(503).json({ error: "Service unavailable" });
+  [{ capability: "avatar_chat" }],  // Dependencies, in binding order
+  async (req, res, [avatarChat]) => {
+    if (!avatarChat) {
+      res.status(503).json({ error: "Service unavailable" });
+      return;
     }
-    const result = await avatar_chat({
+    const result = (await avatarChat({
       message: req.body.message,
       user_email: "user@example.com",
-    });
+    })) as { message?: string };
     res.json({ response: result.message });
   }
 ));
 
 app.listen(3000);
 ```
+
+**Note**: the handler's third argument is a positional array — `deps[i]` is the i-th declared dependency, `null` when unresolved. (Changed in 3.4.0; it used to be an object keyed by capability. See [Migrating to positional DI](../migration/3.4-positional-di.md).)
 
 **Note**: `mesh.route()` is for Express backends that _consume_ mesh capabilities. Use `agent.addTool()` for MCP agents that _provide_ capabilities.
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -10,6 +10,22 @@ job safety for upgrading a mesh that is already serving traffic. For local
 development you can restart freely; this page is about upgrading a running
 deployment without dropping in-flight work.
 
+!!! warning "Source migration required for 3.4.0 (Java and TypeScript)"
+
+    3.4.0 aligns every dependency-injection site on positional binding. Java
+    `@MeshRoute` / `@MeshA2A` and TypeScript `mesh.route` / `mesh.a2a.mount`
+    changed how declared dependencies reach handler parameters. Python is
+    unchanged, and Java `@MeshTool` and TypeScript `addTool` were already
+    positional — but `@MeshInject` is now honoured on `@MeshTool` parameters,
+    where it was previously ignored, so a value that disagrees with its
+    parameter's position fails at boot. Nothing on the wire
+    changed, so no coordinated rollout is needed — but handlers need a source
+    edit. Do not filter by dependency count: every TypeScript handler still
+    taking a capability-keyed object converts whatever it declares, and a Java
+    handler with one dependency is exempt only when its `@MeshInject` already
+    names that capability, or carries none. See
+    [Migrating to positional DI](migration/3.4-positional-di.md).
+
 ## Recommended order
 
 Upgrade the **registry first, then the agents**.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -288,6 +288,9 @@ nav:
           - Call & Debug Tools: typescript/local-development/05-calling-tools.md
           - Troubleshooting: typescript/local-development/troubleshooting.md
 
+  - Migration:
+      - "3.4 — Positional Dependency Injection": migration/3.4-positional-di.md
+
   - Deployment:
       - deployment.md
       - Upgrading a Live Mesh: upgrading.md

--- a/src/core/cli/man/content/a2a.md
+++ b/src/core/cli/man/content/a2a.md
@@ -133,6 +133,16 @@ A single Python process may NOT host both `@mesh.tool` capabilities and a `mesh.
 
 The same producer surface ships in Java (`@MeshA2A`) and TypeScript (`mesh.a2a.mount(...)`), each with the identical sync / long-running / SSE behavior — see the respective SDK docs for the runtime-specific syntax.
 
+**Dependency injection is positional in every runtime.** The Nth declared dependency binds to the Nth injectable slot — the Nth `McpMeshTool` handler parameter in Python and Java, and the Nth element of the TypeScript `deps` array, which is **zero-based**: `deps[0]` is the first declared dependency. Names are never consulted:
+
+| Runtime    | Declaration              | Handler slot                                    |
+| ---------- | ------------------------ | ----------------------------------------------- |
+| Python     | `dependencies=[...]`     | `McpMeshTool` parameters, in signature order     |
+| Java       | `@MeshDependency` list   | `McpMeshTool<T>` parameters, in signature order  |
+| TypeScript | `dependencies: [...]`    | `deps[i]` on the handler's first argument        |
+
+> **Changed in 3.4.0.** Java `@MeshA2A` bound by parameter name (or `@MeshInject` value), and TypeScript `mesh.a2a.mount` handed the handler an object keyed by capability. Both now bind by position. Python is unchanged. See `meshctl man upgrading`.
+
 ## Consumer (Python / Java / TypeScript)
 
 The consumer marker per runtime:

--- a/src/core/cli/man/content/api_java.md
+++ b/src/core/cli/man/content/api_java.md
@@ -56,7 +56,7 @@ public ResponseEntity<Map<String, Object>> greet(
 }
 ```
 
-The `McpMeshTool` is injected by parameter name matching the capability. Call `.call()` with your arguments -- mesh handles routing to the actual agent.
+The `McpMeshTool` is injected **by position**: the Nth entry of `dependencies` binds to the Nth `McpMeshTool` parameter, in signature order. Parameter names are never consulted -- name them however reads best. Call `.call()` with your arguments; mesh handles routing to the actual agent.
 
 ## Consumer-Only Mode
 
@@ -86,20 +86,30 @@ That is all. The framework detects `@MeshRoute` usage and starts in consumer-onl
 
 ## Dependency Declaration
 
-### Simple (by capability name)
+### Positional pairing
+
+The Nth `@MeshDependency` binds to the Nth `McpMeshTool` parameter, in signature order. Business parameters (`@RequestParam`, `@RequestBody`, ...) take no part in the pairing:
 
 ```java
 @GetMapping("/data")
-@MeshRoute(dependencies = @MeshDependency(capability = "user_service"))
-public ResponseEntity<?> getData(McpMeshTool<Map<String, Object>> user_service) {
-    Map<String, Object> result = user_service.call(Map.of("id", 42));
+@MeshRoute(dependencies = {
+    @MeshDependency(capability = "user_service"),
+    @MeshDependency(capability = "notification_service")
+})
+public ResponseEntity<?> getData(
+        @RequestParam int id,
+        McpMeshTool<Map<String, Object>> users,     // dependencies[0] -- user_service
+        McpMeshTool<Map<String, Object>> notify) {  // dependencies[1] -- notification_service
+
+    Map<String, Object> result = users.call(Map.of("id", id));
+    notify.call(Map.of("event", "read"));
     return ResponseEntity.ok(result);
 }
 ```
 
-### With @MeshInject (explicit binding)
+### With @MeshInject (assertion)
 
-When the parameter name does not match the capability, use `@MeshInject`:
+`@MeshInject` does not select a dependency -- it asserts the one position already assigns, and the application fails to start if the two disagree. It is optional; add it when you want the pairing pinned against a future reorder:
 
 ```java
 @GetMapping("/employee")
@@ -112,6 +122,8 @@ public ResponseEntity<?> getEmployee(
     return ResponseEntity.ok(employee);
 }
 ```
+
+> **Changed in 3.4.0.** `@MeshRoute` used to bind by name -- by the `@MeshInject` value, or by the parameter name. See `meshctl man upgrading` before upgrading a controller that declares more than one dependency.
 
 ## Typed Deserialization
 

--- a/src/core/cli/man/content/api_typescript.md
+++ b/src/core/cli/man/content/api_typescript.md
@@ -36,18 +36,24 @@ app.post(
   "/chat",
   mesh.route(
     [{ capability: "avatar_chat" }],
-    async (req, res, { avatar_chat }) => {
-      const result = await avatar_chat({
+    async (req, res, [avatarChat]) => {
+      if (!avatarChat) {
+        res.status(503).json({ error: "avatar_chat unavailable" });
+        return;
+      }
+      const result = (await avatarChat({
         message: req.body.message,
         user_email: "user@example.com",
-      });
+      })) as { message?: string };
       res.json({ response: result.message });
     },
   ),
 );
 ```
 
-The third argument to your handler is a dependencies object -- mesh resolves and injects the proxies by **position**. The first dependency maps to the first key in the destructured object, and so on.
+The third argument to your handler is a dependencies **array**: `deps[i]` is the proxy for the i-th declared dependency, or `null` when it is not currently resolved. Destructure it positionally -- the binding names are yours to choose.
+
+> **Changed in 3.4.0.** `mesh.route` used to hand the handler a capability-keyed object (`{ avatar_chat }`). It is now an array, matching Python, Java, and `addTool`. Reading a declared capability by name throws with the index and the rewrite -- see `meshctl man upgrading`.
 
 ## Starting Fresh
 
@@ -62,8 +68,12 @@ app.use(express.json());
 
 app.post(
   "/greet",
-  mesh.route(["greeting"], async (req, res, { greeting }) => {
-    const result = await greeting({ name: req.body.name });
+  mesh.route(["greeting"], async (req, res, [greeting]) => {
+    if (!greeting) {
+      res.status(503).json({ error: "greeting unavailable" });
+      return;
+    }
+    const result = (await greeting({ name: req.body.name })) as { text?: string };
     res.json({ message: result.text || "" });
   }),
 );
@@ -73,15 +83,16 @@ app.listen(3000);
 
 ## Dependency Declaration
 
-### Simple (by capability name)
+### Positional pairing
 
 ```typescript
 app.post(
   "/users",
   mesh.route(
     ["user_service", "notification_service"],
-    async (req, res, { user_service, notification_service }) => {
-      // Dependencies are keyed by capability name
+    async (req, res, [userService, notificationService]) => {
+      // userService         === deps[0] -- "user_service"
+      // notificationService === deps[1] -- "notification_service"
     },
   ),
 );
@@ -97,7 +108,7 @@ app.post(
       { capability: "llm", tags: ["+claude"] },
       { capability: "storage", tags: ["-deprecated"] },
     ],
-    async (req, res, { llm, storage }) => {
+    async (req, res, [llm, storage]) => {
       // Use filtered dependencies
     },
   ),
@@ -122,7 +133,7 @@ npx tsx src/server.ts
 1. Auto-initializes mesh connection on first `mesh.route()` call
 2. Connects to the mesh registry
 3. Resolves dependencies declared in `mesh.route()`
-4. Injects proxies into your route handler as the `deps` object
+4. Injects proxies into your route handler as the positional `deps` array
 5. Re-resolves on topology changes (auto-rewiring)
 
 ## Advanced: Explicit Control
@@ -146,7 +157,11 @@ app.post(
   "/compute",
   mesh.route(
     [{ capability: "calculator" }],
-    async (req, res, { calculator }) => {
+    async (req, res, [calculator]) => {
+      if (!calculator) {
+        res.status(503).json({ error: "calculator unavailable" });
+        return;
+      }
       res.json({ result: await calculator(req.body) });
     },
   ),
@@ -163,11 +178,12 @@ If a dependency might not be available, check for null:
 ```typescript
 app.post(
   "/greet",
-  mesh.route([{ capability: "greeting" }], async (req, res, { greeting }) => {
+  mesh.route([{ capability: "greeting" }], async (req, res, [greeting]) => {
     if (!greeting) {
-      return res.status(503).json({ error: "Service unavailable" });
+      res.status(503).json({ error: "Service unavailable" });
+      return;
     }
-    const result = await greeting({ name: req.body.name });
+    const result = (await greeting({ name: req.body.name })) as { text?: string };
     res.json({ message: result.text });
   }),
 );
@@ -182,9 +198,9 @@ app.post(
   "/greet",
   mesh.route(
     [{ capability: "greeting", required: true }],
-    async (req, res, { greeting }) => {
+    async (req, res, [greeting]) => {
       // framework guarantees greeting is live
-      const result = await greeting({ name: req.body.name });
+      const result = (await greeting!({ name: req.body.name })) as { text?: string };
       res.json({ message: result.text });
     },
   ),

--- a/src/core/cli/man/content/capabilities_typescript.md
+++ b/src/core/cli/man/content/capabilities_typescript.md
@@ -153,9 +153,9 @@ agent.addTool({
   capability: "forecast",
   dependencies: [{ capability: "weather_data", tags: ["+premium"] }],
   parameters: z.object({}),
-  execute: async ({}, { weather_data }) => {
-    if (weather_data) {
-      return await weather_data({ city: "NYC" });
+  execute: async ({}, weatherData: McpMeshTool | null = null) => {
+    if (weatherData) {
+      return await weatherData({ city: "NYC" });
     }
     return "Weather service unavailable";
   },
@@ -172,8 +172,12 @@ agent.addTool({
   capability: "my_capability",
   dependencies: ["date_service", "weather_data"],
   parameters: z.object({ query: z.string() }),
-  execute: async ({ query }, { date_service, weather_data }) => {
-    // date_service and weather_data are McpMeshTool | null
+  execute: async (
+    { query },
+    dateService: McpMeshTool | null = null,   // dependencies[0]
+    weatherData: McpMeshTool | null = null,   // dependencies[1]
+  ) => {
+    // Both are McpMeshTool | null — bound by position, not by name
   },
 });
 ```
@@ -189,8 +193,12 @@ agent.addTool({
     { capability: "weather_data", tags: ["+accurate", "-deprecated"] },
   ],
   parameters: z.object({ query: z.string() }),
-  execute: async ({ query }, { date_service, weather_data }) => {
-    // Dependencies injected by capability name
+  execute: async (
+    { query },
+    dateService: McpMeshTool | null = null,   // dependencies[0]
+    weatherData: McpMeshTool | null = null,   // dependencies[1]
+  ) => {
+    // Dependencies are injected by position, in declaration order
   },
 });
 ```

--- a/src/core/cli/man/content/decorators_java.md
+++ b/src/core/cli/man/content/decorators_java.md
@@ -78,7 +78,7 @@ public GreetingResponse greet(
 
 **Note**: Dependencies are injected as `McpMeshTool<T>` parameters on the method. They may be `null` if unavailable.
 
-**Note**: `dependencies` entries pair with the method's `McpMeshTool<T>` (and `MeshJob`) parameters in declaration order, and parameter names are yours to choose. See `meshctl man dependency-injection --java` for the full pairing rule, including where a `MeshJob` parameter fits and how `@MeshRoute` differs.
+**Note**: `dependencies` entries pair with the method's `McpMeshTool<T>` (and `MeshJob`) parameters **by position**, in declaration order; parameter names are never consulted. `@MeshRoute` and `@MeshA2A` use the identical rule (changed in 3.4.0 — they used to bind by name). See `meshctl man dependency-injection --java` for the full pairing rule, including where a `MeshJob` parameter fits and what `@MeshInject` asserts.
 
 ### Schema-aware capabilities (issue #547)
 

--- a/src/core/cli/man/content/decorators_typescript.md
+++ b/src/core/cli/man/content/decorators_typescript.md
@@ -46,6 +46,7 @@ Registers a function as a mesh capability with dependency injection.
 
 ```typescript
 import { z } from "zod";
+import type { McpMeshTool } from "@mcpmesh/sdk";
 
 agent.addTool({
   name: "greet",
@@ -58,11 +59,11 @@ agent.addTool({
     name: z.string(),
   }),
   execute: async (
-    { name },                          // Input parameters
-    { date_service }                   // Injected dependencies (nullable)
+    { name },                                    // Input parameters
+    dateService: McpMeshTool | null = null       // dependencies[0] (nullable)
   ) => {
-    if (date_service) {
-      const today = await date_service({});
+    if (dateService) {
+      const today = await dateService({});
       return `Hello ${name}! Today is ${today}`;
     }
     return `Hello ${name}!`;  // Graceful degradation
@@ -70,7 +71,7 @@ agent.addTool({
 });
 ```
 
-**Note**: Dependencies are injected as the second parameter object, keyed by capability name. They may be `null` if unavailable.
+**Note**: Dependencies are injected **by position** as parameters after `args`, in declaration order — `dependencies[0]` is the second parameter, `dependencies[1]` the third, and so on. Parameter names are never consulted. A dependency arrives as `null` if unavailable.
 
 ### Dependency Injection Types
 
@@ -117,7 +118,7 @@ agent.addTool({
     },
   ],
   parameters: z.object({}),
-  execute: async ({}, { lookup_employee }) => { /* ... */ },
+  execute: async ({}, lookupEmployee: McpMeshTool | null = null) => { /* ... */ },
 });
 ```
 
@@ -239,21 +240,24 @@ const app = express();
 app.use(express.json());
 
 app.post("/chat", mesh.route(
-  [{ capability: "avatar_chat" }],  // Dependencies
-  async (req, res, { avatar_chat }) => {
-    if (!avatar_chat) {
-      return res.status(503).json({ error: "Service unavailable" });
+  [{ capability: "avatar_chat" }],  // Dependencies, in binding order
+  async (req, res, [avatarChat]) => {
+    if (!avatarChat) {
+      res.status(503).json({ error: "Service unavailable" });
+      return;
     }
-    const result = await avatar_chat({
+    const result = (await avatarChat({
       message: req.body.message,
       user_email: "user@example.com",
-    });
+    })) as { message?: string };
     res.json({ response: result.message });
   }
 ));
 
 app.listen(3000);
 ```
+
+**Note**: the handler's third argument is a positional array — `deps[i]` is the i-th declared dependency, `null` when unresolved. (Changed in 3.4.0; it used to be an object keyed by capability.)
 
 **Note**: `mesh.route()` is for Express backends that _consume_ mesh capabilities. Use `agent.addTool()` for MCP agents that _provide_ capabilities.
 
@@ -310,6 +314,7 @@ export MCP_MESH_REGISTRY_URL=http://registry:8000
 
 ```typescript
 import { FastMCP, mesh } from "@mcpmesh/sdk";
+import type { McpMeshTool } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 const server = new FastMCP({
@@ -346,10 +351,10 @@ agent.addTool({
     a: z.number(),
     b: z.number(),
   }),
-  execute: async ({ operation, a, b }, { audit_log }) => {
+  execute: async ({ operation, a, b }, auditLog: McpMeshTool | null = null) => {
     const result = operation === "add" ? a + b : a - b;
-    if (audit_log) {
-      await audit_log({ operation, a, b, result });
+    if (auditLog) {
+      await auditLog({ operation, a, b, result });
     }
     return String(result);
   },

--- a/src/core/cli/man/content/dependency-injection_java.md
+++ b/src/core/cli/man/content/dependency-injection_java.md
@@ -55,7 +55,7 @@ public GreetingResponse smartGreet(
 
 **Important**: Dependencies are injected as `McpMeshTool<T>` parameters on the method. They may be `null` if unavailable.
 
-**How pairing works**: On `@MeshTool`, the `dependencies` entries pair with the method's dependency-typed parameters — `McpMeshTool<T>` and, where present, `MeshJob` — in declaration order: the first `@Selector` fills the first such parameter, the second fills the second, and so on. `@Param`-annotated business parameters take no part in the pairing. Parameter names are yours to choose; pick whatever reads best. Declare more than one dependency as an array:
+**How pairing works**: dependencies bind **by position**, at every injection site. The `dependencies` entries pair with the method's dependency-typed parameters — `McpMeshTool<T>` and, where present, `MeshJob` — in declaration order: the first entry fills the first such parameter, the second fills the second, and so on. `@Param`-annotated business parameters take no part in the pairing. Parameter names are never consulted, so they are yours to choose; pick whatever reads best. Declare more than one dependency as an array:
 
 ```java
 @MeshTool(capability = "report",
@@ -71,23 +71,50 @@ public Report generateReport(
 
 A `MeshJob` parameter (at most one per method) occupies a position in this same ordering and binds its paired dependency as the job's submitter — see `meshctl man jobs --java`. The same order-based rule applies in Python (`dependencies=[...]`) and TypeScript (`addTool({ dependencies: [...] })`).
 
-`@MeshRoute` handlers bind **by name**, not by order. Each handler parameter contributes one match key — its `@MeshInject("...")` value when present, otherwise the Java parameter name — and binds to the `@MeshDependency` whose capability or injection name equals that key. The injection name is `name()` when you set it, and otherwise the capability with kebab hyphens folded to camelCase (`pdf-tool` becomes `pdfTool`); a capability containing no hyphen is left exactly as written. A snake_case capability therefore never matches a camelCase parameter on its own — name the binding explicitly, at whichever end reads better:
+### One rule, every site
+
+`@MeshRoute` and `@MeshA2A` follow the identical rule: the Nth `@MeshDependency` binds to the Nth injectable parameter, in signature order. Parameter names are never consulted, and `@MeshDependency(name = ...)` no longer steers where a dependency lands — it survives only as an alias `@MeshInject` may assert against, and as a lookup key for `MeshRouteUtils`.
 
 ```java
-// At the parameter: @MeshInject supplies the key directly.
-@MeshRoute(dependencies = @MeshDependency(capability = "lookup_employee"))
-@PostMapping("/a")
-public ResponseEntity<Report> a(
-        @MeshInject("lookup_employee") McpMeshTool<Employee> employeeLookup) { ... }
-
-// At the dependency: name() declares the parameter it should land on.
-@MeshRoute(dependencies = @MeshDependency(capability = "lookup_employee",
-                                          name = "employeeLookup"))
-@PostMapping("/b")
-public ResponseEntity<Report> b(McpMeshTool<Employee> employeeLookup) { ... }
+@MeshRoute(dependencies = {
+    @MeshDependency(capability = "lookup_employee"),
+    @MeshDependency(capability = "employee_count")
+})
+@PostMapping("/report")
+public ResponseEntity<Report> report(
+        @RequestBody ReportRequest body,
+        McpMeshTool<Employee> employeeLookup,   // dependencies[0] — lookup_employee
+        McpMeshTool<Integer> headcount) { ... } // dependencies[1] — employee_count
 ```
 
-Falling back to the bare Java parameter name also requires compiling with `-parameters`; `@MeshInject` does not. `@MeshDependsOn` beans bind by `@Qualifier`, by name as well.
+> **Changed in 3.4.0.** `@MeshRoute` and `@MeshA2A` previously bound **by name** — by the `@MeshInject` value, or by the Java parameter name. They now bind by position, like `@MeshTool` and like every Python and TypeScript site. A handler whose declaration order disagrees with its old names is diagnosed at boot rather than silently rebound. See `meshctl man upgrading`.
+
+### `@MeshInject` is an assertion
+
+`@MeshInject` no longer *selects* a dependency — it *asserts* the one position already assigns. Its value must equal the capability (or the `@MeshDependency(name = ...)` alias) at that parameter's slot, or the application fails to start:
+
+```java
+@MeshRoute(dependencies = {
+    @MeshDependency(capability = "lookup_employee"),
+    @MeshDependency(capability = "employee_count")
+})
+@PostMapping("/report")
+public ResponseEntity<Report> report(
+        @RequestBody ReportRequest body,
+        @MeshInject("lookup_employee") McpMeshTool<Employee> employeeLookup,
+        @MeshInject("employee_count") McpMeshTool<Integer> headcount) { ... }
+```
+
+Keeping it is optional and changes **nothing about what binds** — but it is not inert at boot. A correct annotation pins the pairing: it silences the legacy-order warning described below, and turns a later reorder of one end without the other into a startup failure rather than a quiet rebind. A contradicting annotation is fatal **unconditionally**, not gated on `MCP_MESH_STRICT_DI`, because a false assertion is never a survivable shape. `@MeshInject` is honoured on `@MeshTool` parameters too, under the same assertion semantics.
+
+### Order validation
+
+Two boot-time checks back the positional contract:
+
+- **Arity.** A method that declares more dependencies than it has injectable parameters (the surplus is resolved and advertised but injected nowhere), or fewer (the surplus parameters are injected `null`), is reported. WARN by default; `MCP_MESH_STRICT_DI=true` promotes it to a startup failure.
+- **Order.** A handler whose parameter *names* match the declared capabilities in a different order — the fingerprint of code written against the pre-3.4 by-name rule — is reported with both orderings and the prescribed reorder. WARN by default, fatal under `MCP_MESH_STRICT_DI`. Adding a correct `@MeshInject` to each parameter silences it.
+
+`@MeshDependsOn` beans are the one deliberate exception: they bind by Spring bean name via `@Qualifier`, because that is a Spring wiring surface rather than a mesh parameter-pairing one.
 
 ### Dependencies with Filters
 
@@ -150,7 +177,7 @@ See `meshctl man schema-matching` for `SUBSET` vs `STRICT` semantics, the cross-
 
 ## Component-level dependency declaration with `@MeshDependsOn`
 
-`@MeshInject` and `@MeshRoute(dependencies=...)` work at the controller-method scope. For everything else — `@Service` beans, `@Component`s, servlet `Filter`s, `@Scheduled` jobs — declare the capabilities your bean needs with the class-level `@MeshDependsOn` annotation. The auto-configuration then registers a singleton `McpMeshTool` bean named by each capability, so you can wire it the standard Spring way.
+`@MeshRoute(dependencies=...)` works at the controller-method scope. For everything else — `@Service` beans, `@Component`s, servlet `Filter`s, `@Scheduled` jobs — declare the capabilities your bean needs with the class-level `@MeshDependsOn` annotation. The auto-configuration then registers a singleton `McpMeshTool` bean named by each capability, so you can wire it the standard Spring way.
 
 ### Constructor injection (recommended)
 
@@ -195,11 +222,11 @@ public class HolidayChecker {
 | Scenario | Annotation |
 | -------- | ---------- |
 | `@MeshTool` method needing remote helpers | `@MeshTool(dependencies = @Selector(...))` + parameter injection |
-| `@RestController` handler method | `@MeshRoute(dependencies = {...})` + `@MeshInject` parameter |
+| `@RestController` handler method | `@MeshRoute(dependencies = {...})` + positional `McpMeshTool<T>` parameters |
 | `@Service` / `@Component` / `Filter` / `@Scheduled` / any other Spring bean | **`@MeshDependsOn` + `@Qualifier`** |
 | Several capabilities behind one typed facade | **`@MeshService` interface + `@Autowired`** |
 
-`@MeshDependsOn` and `@MeshInject`/`@MeshRoute` are complementary — same heartbeat-driven proxy lifecycle, same auto-rewiring on topology change, same `isAvailable()` semantics. Pick the surface that matches where you need the dependency. If the same capability shows up via multiple sources the framework deduplicates: a single proxy and a single registry entry per capability name.
+`@MeshDependsOn` and `@MeshRoute` are complementary — same heartbeat-driven proxy lifecycle, same auto-rewiring on topology change, same `isAvailable()` semantics. Pick the surface that matches where you need the dependency. If the same capability shows up via multiple sources the framework deduplicates: a single proxy and a single registry entry per capability name.
 
 ### Tags, version, and bean-name conflicts
 
@@ -334,7 +361,7 @@ The same interface can be used both ways at once — autowired as a bean **and**
 
 ### Views and `@MeshRoute`
 
-A `@MeshService` view interface is a **tool-parameter / bean-only** surface: used as a `@MeshRoute` handler parameter it is **rejected** at boot (a view facade cannot become a route perimeter). A route consumes a specific capability via `@MeshInject` instead — including a single dotted capability that a view would otherwise group. Declare the capability in the route's `dependencies = {}` and inject its proxy by name:
+A `@MeshService` view interface is a **tool-parameter / bean-only** surface: used as a `@MeshRoute` handler parameter it is **rejected** at boot (a view facade cannot become a route perimeter). A route consumes a specific capability as an ordinary positional dependency instead — including a single dotted capability that a view would otherwise group. Declare the capability in the route's `dependencies = {}` and take its proxy at the matching parameter position:
 
 ```java
 @MeshRoute(dependencies = {
@@ -363,7 +390,7 @@ The optional `@MeshService(minAvailable = N)` adds a consumer-local availability
 
 A service view is **consumer-local**, not a shared contract: two consumers may aggregate the same capabilities differently, and there is no group versioning or interface-level availability summary. Each method resolves independently.
 
-**Calling-job identity through the facade.** Invoking a view facade method — or a dotted capability wired via `@MeshInject` — threads the calling-job identity / `MeshCallContext` to the provider exactly like an ordinary tool call (the same `McpMeshToolProxy` → client path). A downstream claim fence or `callingJob()` therefore sees the same caller whether the call arrives via the facade, a dotted `@MeshInject`, or a hand-written `@MeshTool` dependency. See `meshctl man jobs --java` for calling-job identity details.
+**Calling-job identity through the facade.** Invoking a view facade method — or a dotted capability wired as a route dependency — threads the calling-job identity / `MeshCallContext` to the provider exactly like an ordinary tool call (the same `McpMeshToolProxy` → client path). A downstream claim fence or `callingJob()` therefore sees the same caller whether the call arrives via the facade, a dotted route dependency, or a hand-written `@MeshTool` dependency. See `meshctl man jobs --java` for calling-job identity details.
 
 ### Publishing the dotted capabilities a view binds
 

--- a/src/core/cli/man/content/dependency-injection_typescript.md
+++ b/src/core/cli/man/content/dependency-injection_typescript.md
@@ -57,7 +57,49 @@ agent.addTool({
 });
 ```
 
-**How pairing works**: Dependencies are injected positionally as parameters after the first `args` parameter, in declaration order (`dependencies[0]`, `dependencies[1]`, ...), and arrive as `null` if unavailable. Parameter names are yours to choose; pick whatever reads best.
+**How pairing works**: Dependencies are injected **by position** as parameters after the first `args` parameter, in declaration order (`dependencies[0]`, `dependencies[1]`, ...), and arrive as `null` if unavailable. Parameter names are never consulted, so they are yours to choose; pick whatever reads best.
+
+### `mesh.route` and `mesh.a2a.mount`
+
+The same rule, in array form. `mesh.route` hands the handler a positional `deps` array as its third argument; `mesh.a2a.mount` hands it as the first. `deps[i]` is the proxy for the i-th declared dependency, or `null` when it is not currently resolved:
+
+```typescript
+app.post(
+  "/report",
+  mesh.route(
+    ["data_service", "formatter"],
+    async (req, res, [dataService, formatter]) => {
+      if (!dataService || !formatter) {
+        res.status(503).json({ error: "dependencies unavailable" });
+        return;
+      }
+      const data = await dataService({ query: req.body.query });
+      res.json({ report: await formatter({ data }) });
+    },
+  ),
+);
+
+mesh.a2a.mount(
+  app,
+  { path: "/agents/date", skillId: "get-date", dependencies: ["date_service"] },
+  async ([dateService], _payload) => {
+    if (!dateService) return { error: "date_service unresolved" };
+    return { date: await dateService({}) };
+  },
+);
+```
+
+Slots are never compacted: an unresolved dependency holds its own index as `null` and never shifts a later one up.
+
+> **Changed in 3.4.0.** Both surfaces used to hand the handler an object keyed by capability (`{ data_service, formatter }`). Reading a **declared** capability by name on the array now throws with the index and the corrected signature:
+>
+> ```text
+> mesh.route dependencies are positional as of 3.4.0.
+> You accessed `deps.data_service`; "data_service" is declared dependency [0].
+> Rewrite the handler as:  async (req, res, [data_service, formatter]) => { ... }
+> ```
+>
+> `RouteDependencies` and `A2ADependencies` now alias `PositionalDependencies` (`Array<McpMeshTool | null>`), so an object type argument — `mesh.a2a.mount<{ date_service: McpMeshTool }>(...)` — no longer compiles. Use per-slot tuples instead: `mount<[McpMeshTool | null]>(...)`. See `meshctl man upgrading`.
 
 ### Dependencies with Filters
 

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -132,13 +132,19 @@ export MCP_MESH_TOOL_WORKERS=1
 export MCP_MESH_TOOL_ISOLATION=true
 ```
 
-### Strict DI Diagnostics (Python)
+### Strict DI Diagnostics (Python, Java)
 
 ```bash
 # Default: false. When truthy, ambiguous or skipped dependency-injection
-# configurations raise StrictDIError at decoration/startup instead of
-# warning. Injection semantics are unchanged — only the diagnostic
-# severity is promoted.
+# configurations fail at decoration/startup instead of warning. Injection
+# semantics are unchanged — only the diagnostic severity is promoted.
+#
+# - Python: raises StrictDIError at decoration/startup.
+# - Java: promotes the boot-time dependency/parameter arity mismatch and
+#   the @MeshRoute / @MeshA2A legacy-order warning to a startup failure.
+#   A contradicting @MeshInject value is fatal either way — it asserts the
+#   dependency position already assigns, so a false assertion is never
+#   survivable. Accepts 1 / true / yes.
 export MCP_MESH_STRICT_DI=true
 ```
 

--- a/src/core/cli/man/content/headers_java.md
+++ b/src/core/cli/man/content/headers_java.md
@@ -170,8 +170,8 @@ identity-provider subject to a local user row on first login, recording
 an audit event on every authenticated request, or hydrating a
 request-scoped principal from a remote profile service.
 
-`@MeshInject` only fires on `@MeshRoute` controller methods. To reach
-mesh capabilities from any other Spring-managed bean, declare the
+`@MeshRoute` parameter injection only fires on controller methods. To
+reach mesh capabilities from any other Spring-managed bean, declare the
 capability on the bean class with `@MeshDependsOn` and inject it via
 `@Qualifier`:
 
@@ -230,7 +230,7 @@ on call.
 
 Often that is the right answer — push provisioning, audit, and RBAC
 hydration into a controller body (or a downstream mesh tool) where
-`@MeshInject` works as designed. Use `@MeshDependsOn` when the
+`@MeshRoute` injection works as designed. Use `@MeshDependsOn` when the
 side-effect *genuinely* belongs in a non-controller surface: filters
 that run before MVC dispatch, security beans Spring constructs outside
 the request lifecycle, scheduled jobs without a request context.

--- a/src/core/cli/man/content/headers_typescript.md
+++ b/src/core/cli/man/content/headers_typescript.md
@@ -86,19 +86,23 @@ agent.addTool({
   capability: "relay_headers",
   dependencies: ["echo_headers"],
   parameters: z.object({}),
-  execute: async ({}, { echo_headers }: { echo_headers: McpMeshTool | null }) => {
+  execute: async ({}, echoHeaders: McpMeshTool | null = null) => {
+    if (!echoHeaders) {
+      return "Header echo unavailable";
+    }
+
     // Check what's already propagated
     const propagated = getCurrentPropagatedHeaders();
 
     if (!propagated["x-audit-id"]) {
       // Inject a new header on this specific call
-      const result = await echo_headers!({}, {
+      const result = await echoHeaders({}, {
         headers: { "x-audit-id": "audit-12345" },
       });
       return JSON.stringify(result);
     }
 
-    const result = await echo_headers!({});
+    const result = await echoHeaders({});
     return JSON.stringify(result);
   },
 });

--- a/src/core/cli/man/content/health_typescript.md
+++ b/src/core/cli/man/content/health_typescript.md
@@ -108,11 +108,11 @@ agent.addTool({
   capability: "my_capability",
   dependencies: ["date_service"],
   parameters: z.object({}),
-  execute: async ({}, { date_service }) => {
-    // If date_service agent restarts or is replaced,
-    // the proxy automatically points to new instance
-    if (date_service) {
-      return await date_service({});
+  execute: async ({}, dateService: McpMeshTool | null = null) => {
+    // If the date_service agent restarts or is replaced,
+    // the proxy automatically points to the new instance
+    if (dateService) {
+      return await dateService({});
     }
     return "Service unavailable";
   },
@@ -154,19 +154,23 @@ agent.addTool({
   capability: "resilient",
   dependencies: ["primary_service", "backup_service"],
   parameters: z.object({ data: z.string() }),
-  execute: async ({ data }, { primary_service, backup_service }) => {
+  execute: async (
+    { data },
+    primaryService: McpMeshTool | null = null,  // dependencies[0]
+    backupService: McpMeshTool | null = null,   // dependencies[1]
+  ) => {
     // Try primary first
-    if (primary_service) {
+    if (primaryService) {
       try {
-        return await primary_service({ data });
+        return await primaryService({ data });
       } catch (error) {
         console.log("Primary failed, trying backup");
       }
     }
 
     // Fall back to backup
-    if (backup_service) {
-      return await backup_service({ data });
+    if (backupService) {
+      return await backupService({ data });
     }
 
     // Both unavailable
@@ -220,24 +224,28 @@ agent.addTool({
     request: z.string(),
     priority: z.enum(["high", "normal", "low"]).default("normal"),
   }),
-  execute: async ({ request, priority }, { fast_processor, reliable_processor }) => {
+  execute: async (
+    { request, priority },
+    fastProcessor: McpMeshTool | null = null,      // dependencies[0]
+    reliableProcessor: McpMeshTool | null = null,  // dependencies[1]
+  ) => {
     // High priority: prefer fast if available
-    if (priority === "high" && fast_processor) {
+    if (priority === "high" && fastProcessor) {
       try {
-        return await fast_processor({ request });
+        return await fastProcessor({ request });
       } catch {
         console.log("Fast processor failed, falling back");
       }
     }
 
     // Normal/Low priority or fast failed: use reliable
-    if (reliable_processor) {
-      return await reliable_processor({ request });
+    if (reliableProcessor) {
+      return await reliableProcessor({ request });
     }
 
     // Last resort: try fast
-    if (fast_processor) {
-      return await fast_processor({ request });
+    if (fastProcessor) {
+      return await fastProcessor({ request });
     }
 
     return JSON.stringify({

--- a/src/core/cli/man/content/proxies_typescript.md
+++ b/src/core/cli/man/content/proxies_typescript.md
@@ -43,7 +43,7 @@ agent.addTool({
   capability: "my_capability",
   dependencies: ["helper"],
   parameters: z.object({}),
-  execute: async ({}, { helper }) => {
+  execute: async ({}, helper: McpMeshTool | null = null) => {
     if (helper) {
       const result = await helper({}); // Call default tool
       return result;
@@ -56,7 +56,7 @@ agent.addTool({
 ### Named Tool Call
 
 ```typescript
-execute: async ({}, { helper }) => {
+execute: async ({}, helper: McpMeshTool | null = null) => {
   if (helper) {
     const result = await helper.callTool("specific_tool", { arg: "value" });
     return result;
@@ -67,7 +67,7 @@ execute: async ({}, { helper }) => {
 ### With Arguments
 
 ```typescript
-execute: async ({}, { weather }) => {
+execute: async ({}, weather: McpMeshTool | null = null) => {
   if (weather) {
     const result = await weather({ city: "London", units: "metric" });
     return result;
@@ -100,9 +100,9 @@ agent.addTool({
     },
   },
   parameters: z.object({ data: z.string() }),
-  execute: async ({ data }, { slow_service }) => {
-    if (slow_service) {
-      return await slow_service({ data });
+  execute: async ({ data }, slowService: McpMeshTool | null = null) => {
+    if (slowService) {
+      return await slowService({ data });
     }
     return "Service unavailable";
   },
@@ -135,10 +135,10 @@ agent.addTool({
     stream_service: { streaming: true },
   },
   parameters: z.object({ query: z.string() }),
-  execute: async ({ query }, { stream_service }) => {
-    if (stream_service) {
+  execute: async ({ query }, streamService: McpMeshTool | null = null) => {
+    if (streamService) {
       const chunks: string[] = [];
-      for await (const chunk of stream_service.stream({ query })) {
+      for await (const chunk of streamService.stream({ query })) {
         chunks.push(chunk);
       }
       return chunks.join("");
@@ -164,12 +164,12 @@ agent.addTool({
     },
   },
   parameters: z.object({ action: z.string() }),
-  execute: async ({ action }, { stateful_service }) => {
-    if (stateful_service) {
+  execute: async ({ action }, statefulService: McpMeshTool | null = null) => {
+    if (statefulService) {
       // All calls routed to same instance
-      await stateful_service.callTool("initialize", {});
-      const result = await stateful_service.callTool("process", { action });
-      await stateful_service.callTool("cleanup", {});
+      await statefulService.callTool("initialize", {});
+      const result = await statefulService.callTool("process", { action });
+      await statefulService.callTool("cleanup", {});
       return result;
     }
     return "Service unavailable";
@@ -187,7 +187,7 @@ agent.addTool({
   capability: "resilient",
   dependencies: ["helper"],
   parameters: z.object({}),
-  execute: async ({}, { helper }) => {
+  execute: async ({}, helper: McpMeshTool | null = null) => {
     if (helper === null) {
       return "Service unavailable";
     }
@@ -249,12 +249,17 @@ agent.addTool({
   parameters: z.object({
     dataId: z.string(),
   }),
-  execute: async ({ dataId }, { data_source, validator, storage }) => {
+  execute: async (
+    { dataId },
+    dataSource: McpMeshTool | null = null,  // dependencies[0]
+    validator: McpMeshTool | null = null,   // dependencies[1]
+    storage: McpMeshTool | null = null,     // dependencies[2]
+  ) => {
     // Fetch data
-    if (!data_source) {
+    if (!dataSource) {
       return JSON.stringify({ error: "Data source unavailable" });
     }
-    const data = await data_source({ id: dataId });
+    const data = await dataSource({ id: dataId });
 
     // Validate (optional)
     if (validator) {

--- a/src/core/cli/man/content/schema-matching.md
+++ b/src/core/cli/man/content/schema-matching.md
@@ -112,7 +112,7 @@ agent.addTool({
     },
   ],
   parameters: z.object({}),
-  execute: async ({}, { lookup_employee }) => { /* ... */ },
+  execute: async ({}, lookupEmployee: McpMeshTool | null = null) => { /* ... */ },
 });
 ```
 

--- a/src/core/cli/man/content/service-views_java.md
+++ b/src/core/cli/man/content/service-views_java.md
@@ -4,7 +4,7 @@
 
 ## What a service view is
 
-A **service view** is a consumer-owned typed interface over a group of dot-namespaced capability dependencies (`media.caption`, `media.thumbnail`, `media.transcribe`, …). In Java you annotate an interface with `@MeshService`; each abstract method carries one `@Selector` that binds a single capability. Spring auto-discovers the interface and injects a facade bean you `@Autowired` and call directly — instead of declaring each capability as a separate `@MeshInject`'d `McpMeshTool<T>` and hand-wiring the proxies.
+A **service view** is a consumer-owned typed interface over a group of dot-namespaced capability dependencies (`media.caption`, `media.thumbnail`, `media.transcribe`, …). In Java you annotate an interface with `@MeshService`; each abstract method carries one `@Selector` that binds a single capability. Spring auto-discovers the interface and injects a facade bean you `@Autowired` and call directly — instead of declaring each capability as its own `@Selector` with a matching `McpMeshTool<T>` parameter and hand-wiring the proxies.
 
 Each method resolves **independently** through ordinary DDDI — different methods may bind different provider agents and rebind separately as the topology changes. The capability stays the atom; a view is a lens over capabilities, not a new registry entity. See `meshctl man dependency-injection --java` and the DDDI concept doc for the underlying model.
 
@@ -46,7 +46,7 @@ Reach for a service view when the grouping earns the edges:
 Prefer declaring the exact capabilities as ordinary dependencies when:
 
 - **A handler uses only 1–2 capabilities of the group** — declare exactly those via `@MeshTool(dependencies = @Selector(capability = "..."))` and inject each proxy as an `McpMeshTool<T>` parameter. Don't inject a 13-method view to reach 2 methods.
-- **The consumer is a `@MeshRoute` handler** — a `@MeshService` view is a tool-parameter / bean-only surface and is **rejected** at boot on a route perimeter. A route declares the specific dotted capability in its `dependencies = {}` and injects the proxy by name with `@MeshInject("media.caption") McpMeshTool<...>` (see the `@MeshRoute` pattern in `meshctl man dependency-injection --java`).
+- **The consumer is a `@MeshRoute` handler** — a `@MeshService` view is a tool-parameter / bean-only surface and is **rejected** at boot on a route perimeter. A route declares the specific dotted capability in its `dependencies = {}` and takes the proxy at the matching parameter position (see the `@MeshRoute` pattern in `meshctl man dependency-injection --java`).
 - **Precise `required`-gating matters** — a view's `required` methods gate the handler as a set; if those methods span multiple providers, the handler is gated on capabilities it never calls. Per-capability injection gates on exactly what the handler invokes.
 - **Dep-count legibility / registry footprint matters** — when you want `meshctl list` to show what a handler actually depends on, not the whole group behind one interface.
 
@@ -56,7 +56,7 @@ A fat view over ~13 capabilities injected into thin handlers that each call only
 
 Nothing is broken: every edge resolves fine, and an unused method costs **zero call overhead** — the extra edges are only heartbeat dependency-resolution metadata, not per-request work. But the consumer is inflated and heavier to reason about, carries more registry bookkeeping, and **over-gates** when the view's `required` methods span multiple providers: a handler can refuse (its pre-invoke `dependency_unavailable` guard trips) because a capability it never calls is down.
 
-The fix is not to abandon views — it is to size the view to the consumer: keep the view where a handler uses the group, and inject the 1–2 capabilities directly (`@Selector` + `@MeshInject` → `McpMeshTool`) where a handler uses only a slice.
+The fix is not to abandon views — it is to size the view to the consumer: keep the view where a handler uses the group, and inject the 1–2 capabilities directly (`@Selector` → `McpMeshTool` parameter, by position) where a handler uses only a slice.
 
 ## Principle and composition
 
@@ -65,7 +65,7 @@ A service view is a **grouping convenience, not a replacement for per-capability
 Pick the shape by what the consumer does:
 
 - **"I use the group"** → inject the `@MeshService` view.
-- **"I use a slice"** → inject exactly those capabilities per-capability (`@Selector` / `@MeshInject` → `McpMeshTool`).
+- **"I use a slice"** → inject exactly those capabilities per-capability (`@Selector` → `McpMeshTool` parameter, by position).
 
 The two compose freely: the same interface can even be autowired as a bean and passed as a `@MeshTool` parameter at once. Keep a view where it pays off and use per-capability injection in the handlers that touch only a couple of capabilities. Sizing each consumer to what it actually calls keeps dep counts legible and gating precise without giving up typed grouping where it helps.
 

--- a/src/core/cli/man/content/tags_typescript.md
+++ b/src/core/cli/man/content/tags_typescript.md
@@ -46,9 +46,9 @@ agent.addTool({
   capability: "my_capability",
   dependencies: [{ capability: "weather_data", tags: ["api"] }],
   parameters: z.object({}),
-  execute: async ({}, { weather_data }) => {
-    if (weather_data) {
-      return await weather_data({ city: "NYC" });
+  execute: async ({}, weatherData: McpMeshTool | null = null) => {
+    if (weatherData) {
+      return await weatherData({ city: "NYC" });
     }
     return "Weather service unavailable";
   },
@@ -73,9 +73,9 @@ agent.addTool({
     },
   ],
   parameters: z.object({}),
-  execute: async ({}, { weather_data }) => {
-    if (weather_data) {
-      return await weather_data({ city: "NYC" });
+  execute: async ({}, weatherData: McpMeshTool | null = null) => {
+    if (weatherData) {
+      return await weatherData({ city: "NYC" });
     }
     return "No suitable weather service found";
   },
@@ -204,15 +204,15 @@ agent.addTool({
     city: z.string(),
     days: z.number().default(5),
   }),
-  execute: async ({ city, days }, { weather_data }) => {
-    if (!weather_data) {
+  execute: async ({ city, days }, weatherData: McpMeshTool | null = null) => {
+    if (!weatherData) {
       return JSON.stringify({
         error: "No weather service available",
         suggestion: "Check mesh status with 'meshctl list'",
       });
     }
 
-    const forecast = await weather_data({ city, forecast_days: days });
+    const forecast = await weatherData({ city, forecast_days: days });
     return forecast;
   },
 });
@@ -245,7 +245,7 @@ agent.addTool({
     { capability: "math", tags: ["addition", ["python", "typescript"]] },
   ],
   parameters: z.object({ a: z.number(), b: z.number() }),
-  execute: async ({ a, b }, { math }) => {
+  execute: async ({ a, b }, math: McpMeshTool | null = null) => {
     if (!math) return "Service unavailable";
     return await math({ a, b });
   },

--- a/src/core/cli/man/content/upgrading.md
+++ b/src/core/cli/man/content/upgrading.md
@@ -1,6 +1,108 @@
 # Upgrading a Live Mesh
 
-> Order of operations, version-skew guarantees, schema migrations, and in-flight job safety for upgrading a running mesh
+> Order of operations, version-skew guarantees, schema migrations, in-flight job safety, and source migrations for upgrading a running mesh
+
+## 3.4.0 — Dependency injection is positional everywhere
+
+**Breaking, Java and TypeScript. Python is unchanged.** As of 3.4.0 the Nth declared dependency binds to the Nth injectable parameter, at every injection site in every runtime. Parameter names, capability keys and `@MeshInject` values are never used to *select* a dependency.
+
+Two sites changed:
+
+| Runtime    | Site                              | Before                          | After                     |
+| ---------- | --------------------------------- | ------------------------------- | ------------------------- |
+| Java       | `@MeshRoute`, `@MeshA2A`          | by `@MeshInject` value / by parameter name | by position    |
+| TypeScript | `mesh.route`, `mesh.a2a.mount`    | object keyed by capability      | positional array          |
+
+Java `@MeshTool`, TypeScript `addTool`, and every Python site were already positional, so their *binding* is untouched. One caveat at `@MeshTool`: `@MeshInject` is now honoured on its parameters, where it was previously ignored, so a value that disagrees with its parameter's position now fails at boot.
+
+### Find your exposure before you upgrade
+
+A handler declaring **two or more** dependencies can rebind when its declaration order disagrees with its old names. Do not use the dependency count as a filter, though — one dependency is exempt only in narrow cases, and they differ by runtime. In TypeScript there is no exemption at all: the *callback shape* changed, so a sole-dependency handler still written `async (req, res, { cap }) => ...` throws through the new guard exactly as a five-dependency one does. In Java a single dependency is exempt only when its `@MeshInject` already names the declared capability, or carries none — a sole `@MeshInject` naming something else selected nothing on 3.3 and was injected `null`, and on 3.4 it is a false assertion that fails the boot.
+
+The 3.3.x Java SDK already ships the detector that finds them, and it warns without changing behaviour. Upgrade to the latest 3.3.x first, start each Spring Boot app, and grep the startup log:
+
+```bash
+grep -n "declaration order\|parameter names disagree\|BY POSITION (issue #1401)" app.log
+```
+
+```text
+@MeshRoute com.example.api.ApiController.report(McpMeshTool, McpMeshTool): parameter
+names disagree with declaration order, so these parameters do NOT bind the way their
+names suggest.
+  2 declared dependencies: [0] 'get_employee', [1] 'employee_count'
+    slot 0 = parameter 0 (McpMeshTool employee_count)
+        parameter name 'employee_count' used to bind:   dependency[1] 'employee_count'
+        binds (by position):                            dependency[0] 'get_employee'
+  If this handler was written for mcp-mesh 3.3 or earlier (when @MeshRoute and @MeshA2A
+  bound by name), fix it — pick one:
+    • reorder dependencies = {...} to: [0] 'employee_count', [1] 'get_employee'
+```
+
+The two **reorder** fixes it prescribes are behaviour-preserving on 3.3 *and* correct on 3.4 — moving whole `@MeshDependency` entries, or moving the parameters, is name-neutral under the old rule — so you can land those before upgrading. Its third suggestion, *adding* an `@MeshInject` where the parameter carried none, preserves 3.3 behaviour only where the parameter name already selected that same dependency; where the name matched no declared capability, 3.3 injected `null` and the annotation starts injecting a real proxy. `MCP_MESH_STRICT_DI=true` turns the warnings into a startup failure if you want the sweep enforced in CI.
+
+TypeScript has no equivalent pre-upgrade signal, but it cannot misbind either: string keys and array indices are disjoint, so a stale `deps.capability` throws rather than silently returning another dependency's proxy.
+
+### Java — `@MeshInject` becomes an assertion
+
+`@MeshInject` no longer selects a dependency; it asserts the one position already assigns, and a contradiction fails the boot **unconditionally** (not gated on `MCP_MESH_STRICT_DI`). Reorder the declaration list to match the parameters, or drop the annotations — on 3.4 binding is identical either way. Drop them only *after* upgrading, though: on 3.3 `@MeshInject` still selects the dependency, so removing it there falls back to parameter-name matching and can rebind a running application.
+
+```java
+// Before (3.3) — bound by @MeshInject value; declaration order was irrelevant.
+@MeshRoute(dependencies = {
+    @MeshDependency(capability = "get_employee"),
+    @MeshDependency(capability = "employee_count")
+})
+public ResponseEntity<Report> report(
+        @MeshInject("employee_count") McpMeshTool<Integer> stats,
+        @MeshInject("get_employee") McpMeshTool<Employee> lookup) { ... }
+
+// After (3.4) — declaration order IS the binding. Reorder one end.
+@MeshRoute(dependencies = {
+    @MeshDependency(capability = "employee_count"),
+    @MeshDependency(capability = "get_employee")
+})
+public ResponseEntity<Report> report(
+        @MeshInject("employee_count") McpMeshTool<Integer> stats,
+        @MeshInject("get_employee") McpMeshTool<Employee> lookup) { ... }
+```
+
+An unannotated handler is the same fix with the annotations absent — the parameter names carry no meaning, so either reorder `dependencies = {...}` or reorder the parameters.
+
+### TypeScript — destructure the array
+
+```typescript
+// Before (3.3)
+mesh.route(["add", "greet_lucky"], async (req, res, { add, greet_lucky }) => { ... });
+
+// After (3.4)
+mesh.route(["add", "greet_lucky"], async (req, res, [add, greetLucky]) => { ... });
+```
+
+```typescript
+// Before (3.3)
+mesh.a2a.mount(app, config, async (deps, payload) => {
+  const dateService = deps["date_service"] as McpMeshTool | null;
+});
+
+// After (3.4)
+mesh.a2a.mount(app, config, async ([dateService], payload) => { ... });
+```
+
+Reading a **declared** capability by name on the new array throws with the index and the rewrite:
+
+```text
+mesh.route dependencies are positional as of 3.4.0.
+You accessed `deps.add`; "add" is declared dependency [0].
+Rewrite the handler as:  async (req, res, [add, greet_lucky]) => { ... }
+```
+
+`RouteDependencies` and `A2ADependencies` now alias `PositionalDependencies` (`Array<McpMeshTool | null>`), so an object type argument such as `mount<{ date_service: McpMeshTool }>(...)` stops compiling. Use a per-slot tuple: `mount<[McpMeshTool | null]>(...)`.
+
+### What does not change
+
+Correctly-ordered code is unaffected — the whole in-tree corpus was measured on both sides of the conversion: **Java 21 handlers, 0 binding differences; TypeScript 35 handlers, 0 binding differences.** Slot preservation is unchanged too: an unresolved dependency holds its own index as `null` and never shifts a later one up.
+
+Full guide with every before/after: <https://mcp-mesh.ai/migration/3.4-positional-di/>
 
 ## Recommended Order
 

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -152,8 +152,25 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 //
 // A docs change that moves these is expected to move them — update the
 // constant in the same commit and check the delta is the size you intended.
+// #1401 (docs): +28 inline code spans. These tests sample the DEFAULT variant
+// of each listed topic, so the many `_java` / `_typescript` edits in that
+// change are invisible here; the delta is entirely `a2a.md` (+7, the
+// cross-runtime positional-binding note plus the zero-based `deps[0]`
+// clarification) and `upgrading.md` (+21, the new "3.4.0 — Dependency
+// injection is positional everywhere" section, including the `@MeshTool`
+// `@MeshInject` caveat and the on-3.3 qualifications). Neither added a
+// markdown list line, so the two list goldens are unmoved.
+//
+// #1401 review follow-up: +4 more, all in `upgrading.md`. The "one dependency
+// cannot change meaning" exemption was wrong in both runtimes and was rewritten
+// to name the two real cases — a TypeScript handler still taking a
+// capability-keyed callback (`async (req, res, { cap }) => ...`) and a Java
+// sole `@MeshInject` that names a different capability (`null` on 3.3, a boot
+// failure on 3.4). Four code spans in one replaced paragraph; still no list
+// line, and the `text` fence labels added in the same change are skipped by
+// these tests, which treat any ``` line as a block delimiter.
 const (
-	wantInlineCodeSpans = 1605
+	wantInlineCodeSpans = 1637
 	wantListCodeSpans   = 488
 	wantMarkupListLines = 433
 )


### PR DESCRIPTION
## Summary

**PR D — the final PR of the #1401 sequence.** Documentation only, no code changes.

Dependency injection is now positional in every runtime and every decorator (#1434, #1435, #1436, #1438). This states that on every surface that described the old behaviour, and ships a migration guide covering both runtimes.

36 files. The deliverable is `docs/migration/3.4-positional-di.md` — what breaks, what does not, how to find your exposure on 3.3.x before upgrading, and before/after for all four shapes. Mirrored offline in `man upgrading`, with a Migration section added to `mkdocs.yml`.

## Golden delta, with the reason

`wantInlineCodeSpans` **1605 → 1626 (+21)**. `wantListCodeSpans` 488 and `wantMarkupListLines` 433 **unmoved**.

The tests iterate `ListGuides()` and call `GetGuide(name)`, which returns the **default** variant — the `_java` and `_typescript` files are never sampled. Of the +61 spans added across all variants, only `a2a.md` (+6) and `upgrading.md` (+15) are counted, and neither added a markdown list line. Arithmetic verified per-file before touching the constant.

## Two findings that changed the work

**1. `docs/` must not be wholesale-regenerated — the brief's instruction was wrong.**

Running `scripts/generate_docs_from_man.py` at HEAD produces a **23-file, +1145/−587** diff. The generator-managed pages carry substantial hand-authored content the man sources do not have: `!!! note` admonitions, the DDDI cross-link, an entire multimodal section, required-dependency prose. `git log -- docs/java/dependency-injection.md` shows six feature PRs editing it directly.

Regenerating would have silently deleted all of it. The managed trees were restored to HEAD and the man-derived changes applied to their `docs/` counterparts by hand.

Separately: `fastapi`, `spring-boot` and `express` have **no man source at all**, so `docs/*/{fastapi,spring-boot,express}-integration.md` are orphaned and now hand-maintained. Worth its own issue.

**2. 25 TypeScript `addTool` snippets taught an object destructure — and `addTool` has always been positional.**

Across `tags`/`health`/`proxies`/`capabilities`/`headers`/`decorators` `_typescript.md`, `schema-matching.md` and `docs/concepts/dddi.md`. These could never have run. Unrelated to this change; fixed while sweeping.

## Every stale surface found

The brief said to treat the inventory as untrusted, because PR C found `docs/a2a/producer.md` still teaching the keyed shape *after* the plan declared docs clean. That proved correct again — three surfaces below were not in any prior inventory.

| Surface | |
|---|---|
| `dependency-injection_java.md:74‑90` — the paragraph *stating* the by-name rule, plus 5 more sites | fixed |
| `api_java.md:59` "injected by parameter name", `:102` "when the parameter name does not match" | fixed |
| `service-views_java.md:49`, `decorators_java.md:81`, `headers_java.md:173,233` — `@MeshInject` described as "only fires on `@MeshRoute`", now false | fixed |
| `api_typescript.md` ×7 keyed handlers + "maps to the first key" prose; `decorators_typescript.md:73` + 3 snippets | fixed |
| **`docs/a2a/producer.md:30`** — prose still taught the keyed shape after #1438 fixed the snippet 100 lines below | fixed |
| **`docs/java/spring-boot-integration.md:54,76‑92`** — an entire "Parameter Name Matching (Recommended)" section | fixed |
| **`docs/typescript/express-integration.md`** ×5 keyed handlers | fixed |
| `docs/concepts/{routes,service-views,streaming}.md` | fixed |
| 25 `addTool` object destructures (see above) | fixed |
| 2 scaffold templates: `python/api/main.py.tmpl:37` "matched by parameter name" — wrong for Python too — and the Java `api` template | fixed |
| `docs/concepts/schema-matching.md:167`, `docs/reference/kwargs.md:257` | checked, correct as-is |
| `examples/**` | clean — converted in #1436/#1438 |

## Validation — every snippet was executed, not eyeballed

This sequence has repeatedly turned up doc examples that do not work, so none were taken on trust.

- **Java**: every snippet compiles against the starter (`javac exit=0`), and the **shipped `MeshLegacyBindingDetector`** was run over each one — 8 `OK`, and the migration guide's deliberate BEFORE example correctly `ERROR`s. All quoted error text was captured from the real components via a harness, not transcribed from PR descriptions.
- **TypeScript**: 13 route/express + 3 a2a snippets typechecked against the built `dist/` under `strict` — **0 errors**. The documented negative was confirmed to actually fail: `mount<{ date_service: McpMeshTool }>` → `TS2344`. Also fixed 9 pre-existing `result.message` accesses on `Promise<unknown>` in snippets touched.
- `go build ./...` clean; `go test ./src/core/cli/man/...` passes with the updated golden.
- `meshctl man` rendered from a **locally built** `./cmd/meshctl` (bypassing the npm `@mcpmesh/cli` on PATH, which serves a stale embedded page): new text confirmed in `upgrading`, `dependency-injection --java/--typescript`, `api --java/--typescript`, `a2a`, `environment`. All 9 topics render; `man --list` still 62.
- `mkdocs build --strict`: no broken-link or nav warnings.

## Pre-existing, not fixed here

**The documented `addTool` dependency idiom does not typecheck under `strict`.** `ToolConfig.execute`'s rest parameter is `...deps: (McpMeshTool | MeshJob | null)[]`, so the form taught at `dependency-injection_typescript.md:51`, in the SDK's own JSDoc (`types.ts:589-592`), and used by `examples/typescript/greeter` fails `TS2322` (`MeshJob` not assignable to `McpMeshTool | null | undefined`). Verified verbatim against HEAD.

The fix is making `ToolConfig` generic over its dependency tuple — exactly what #1438 did for `route<D>` — which is a code change and out of scope for a docs PR.

## Not included

`RELEASE_NOTES.md` — the previous nine touches are all `release:` commits, so the 3.4.0 note belongs in the release PR. The durable surfaces (migration guide, mkdocs nav, `man upgrading`) carry the content meanwhile.

The `jobBeforeProxy` guard (#1435) and whether parameter-name crossover should be fatal (#1436) are both described as still open; nothing presents them as settled.

Closes #1401


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Java and TypeScript dependencies bind by declaration order rather than parameter or capability names.
  * Added 3.4.0 migration guidance, including updated examples, types, diagnostics, and error handling.
  * Documented nullable unresolved dependencies and recommended 503 responses where applicable.
  * Expanded strict dependency-injection diagnostics for Java and Python, including startup failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->