### PR TITLE
docs(resolver): one canonical account of selection; mesh does not load balance

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -102,7 +102,7 @@ capability → tags → version → schema → tiebreaker
 - **version** — semver constraint (`>=2.0.0`, `^1.4`, etc.).
 - **schema** — opt-in canonical-shape check on the producer's `outputSchema`. See [Schema Matching](schema-matching.md).
 
-The tiebreaker (`HighestScoreFirst`) picks the winner from the surviving set. Every non-trivial decision is recorded in the registry event log so you can replay it with `meshctl audit` — see [Audit Trail](audit.md).
+The tiebreaker (`HighestScoreThenVersion`) picks **exactly one** winner from the surviving set — score, then highest version, then agent ID. It never round-robins; see [Tiebreaker](audit.md#tiebreaker) for the canonical description and for what that winner's endpoint means when the agent runs multiple replicas. Every non-trivial decision is recorded in the registry event log so you can replay it with `meshctl audit` — see [Audit Trail](audit.md).
 
 ## Service Discovery
 

--- a/docs/concepts/audit.md
+++ b/docs/concepts/audit.md
@@ -17,7 +17,7 @@ When a consumer asks the registry to resolve a dependency, candidates flow throu
 3. **`tags`** — apply required / preferred / excluded tag filters and compute scores. See [Tag Matching](tag-matching.md).
 4. **`version`** — apply semver constraint (`>=2.0.0`, `^1.4`, etc.).
 5. **`schema`** — apply the opt-in schema check. When the consumer didn't ask for schema matching, this stage is a pass-through and `spec.schema_mode` reads `"none"`. See [Schema Matching](schema-matching.md).
-6. **`tiebreaker`** — pick the winner from the surviving set. Currently `HighestScoreFirst` (highest tag-match score, first encountered if tied).
+6. **`tiebreaker`** — pick the winner from the surviving set: highest tag-match score first, then **highest version**, then agent ID for determinism (the newest satisfying version wins).
 
 Each stage records `kept` (survivors) and `evicted` (with a typed reason). The chosen producer is recorded on the `tiebreaker` stage and at the top level of the trace.
 
@@ -91,7 +91,7 @@ Each event's `data` field is an `AuditTrace`:
     },
     { "stage": "schema",     "kept": ["hr-v2:lookup"] },
     { "stage": "tiebreaker", "kept": ["hr-v2:lookup"],
-      "chosen": "hr-v2:lookup", "reason": "HighestScoreFirst" }
+      "chosen": "hr-v2:lookup", "reason": "HighestScoreThenVersion" }
   ],
   "chosen": {
     "agent_id":      "hr-v2",
@@ -139,9 +139,37 @@ Reasons are typed (not freeform strings) so audit consumers can pattern-match. T
 
 ## Tiebreaker
 
-After all filter stages, the surviving candidates are ordered by tag-match score (descending) and the first one wins. The audit records this as `reason: "HighestScoreFirst"` on the tiebreaker stage.
+This section is the canonical description of how the registry picks a winner. Other pages link here rather than restating it.
+
+After all filter stages, the surviving candidates are ordered by:
+
+1. **Tag-match score**, descending — see [Tag Matching](tag-matching.md).
+2. **Version**, highest first — among providers with the same score, the newest satisfying version wins.
+3. **Agent ID**, ascending — a deterministic last resort so a full tie is never arbitrary.
+
+The first candidate wins. The audit records this as `reason: "HighestScoreThenVersion"` on the tiebreaker stage.
+
+The sort is **stable**, so an unchanged topology resolves to the same provider every time. Re-resolution only moves the winner when the topology itself changes — a provider joins or leaves, a health state flips, or a version is deployed.
 
 Configurable tiebreakers (round-robin, latency-aware, etc.) are out of scope for v1 — the audit trail is forward-compatible: future tiebreakers will record their own name in the same `reason` field.
+
+### The registry does not load balance
+
+The registry selects **exactly one winner per dependency**, deterministically. It does not round-robin, and it does not spread calls across providers. Every call through an injected proxy goes to the winner's registered endpoint until the topology changes and the dependency is re-resolved.
+
+Whether calls then reach more than one process is a **deployment** question, decided by what that endpoint resolves to:
+
+| Deployment | Registered endpoint | What happens |
+| --- | --- | --- |
+| `mcp-mesh-agent` Helm chart | Kubernetes Service DNS (`<release>-mcp-mesh-agent.<namespace>`) | kube-proxy spreads calls across the Service's replica pods. The distribution is **Kubernetes'**, not the mesh's. |
+| Raw manifests, Docker, bare metal — no `MCP_MESH_HTTP_HOST` | Auto-detected host address (in Kubernetes, the pod IP) | Every call lands on that one process. Extra replicas register separately and add no throughput to an already-resolved edge. |
+
+The chart sets the Service DNS default via `MCP_MESH_HTTP_HOST` in its ConfigMap. Override it with `agent.advertisedHost` when the default is wrong — a fully qualified `<service>.<namespace>.svc.cluster.local` for cross-namespace consumers, or an external ingress hostname for cross-cluster ones.
+
+Two consequences worth planning around:
+
+- **Adding replicas only adds capacity if the endpoint is a Service.** If the agent advertises a pod IP, a second replica is idle as far as an existing consumer is concerned.
+- **Behind a Service, consecutive calls can land on different pods.** Anything the agent keeps in memory between calls is therefore unsafe — see [In-Process State](in-process-state.md).
 
 ## See Also
 

--- a/docs/concepts/dddi.md
+++ b/docs/concepts/dddi.md
@@ -99,8 +99,8 @@ Dependencies are injected as **proxy objects** that transparently handle:
 - Network communication (MCP protocol over HTTP)
 - Serialization and deserialization
 - Retry and failover
-- Load balancing across multiple providers
-- Health-aware routing (skip unhealthy instances)
+- Health-aware routing (unhealthy providers are filtered out at resolution)
+- Re-wiring when the registry picks a different winner
 
 The developer writes a function with typed parameters. The mesh fills them in.
 
@@ -119,9 +119,14 @@ Agent starts --> Registers capabilities with Registry
 Agent declares dependency "calculator"
     --> Registry finds all agents with capability "calculator"
     --> Tag matching scores candidates (+preferred, -excluded)
-    --> Best match selected (or load balanced)
+    --> Exactly one winner selected: score, then version, then agent ID
     --> Proxy object created and injected
 ```
+
+The registry picks a **single deterministic winner** — it does not round-robin
+or spread calls across providers. See [Tiebreaker](audit.md#tiebreaker) for the
+canonical description, including what the winner's endpoint means when that
+agent runs multiple replicas.
 
 ### Heartbeat Phase
 
@@ -210,10 +215,18 @@ async def analyze(query: str, llm: mesh.MeshLlmAgent = None) -> str:
 3. **Analyst calls calculator** -- Proxy handles MCP communication transparently
 4. **Calculator crashes** -- Analyst detects failure, continues with graceful degradation
 5. **Calculator restarts** -- Registry detects, analyst gets 203 heartbeat -- proxy re-injected
-6. **Second calculator starts** -- DDDI load-balances between both instances
+6. **Second calculator starts** -- it becomes a standby candidate, not a second lane. The tiebreaker still picks one winner (equal score and version, so lowest agent ID); the analyst's calls all go there, and the other takes over only if the winner goes unhealthy
 7. **Calculator v2 deployed** -- Version-aware routing sends traffic to v2
 
 All of this happens **without any configuration changes or restarts** to the analyst agent.
+
+!!! note "Redundancy, not throughput"
+
+    Step 6 buys **failover**, not capacity. DDDI selects; it never splits traffic
+    between providers. To actually spread load across replicas, put them behind one
+    Kubernetes Service and advertise the Service DNS name — which is what the
+    `mcp-mesh-agent` Helm chart does by default. See
+    [Tiebreaker](audit.md#tiebreaker).
 
 ## DDDI Design Principles
 

--- a/docs/concepts/in-process-state.md
+++ b/docs/concepts/in-process-state.md
@@ -235,19 +235,44 @@ override it from its own side.
 
 This is the central trade-off and it deserves a callout.
 
-State pins the agent to a single replica. If you deploy two replicas
-of this agent, tool calls from any given consumer will round-robin
-across them — and each replica has its own independent in-memory
-state. Reads against the wrong replica silently return stale or empty
-data; writes silently land in the wrong bucket.
+State pins the agent to a single replica, and each replica has its own
+independent copy of it. Deploy two and reads silently return stale or
+empty data while writes land in the wrong bucket.
+
+The mesh is not what spreads the calls. The registry selects **one
+winner** per dependency and holds it until the topology changes — it
+never round-robins (see [Tiebreaker](audit.md#tiebreaker)). How this
+breaks you depends on what that winner's endpoint resolves to, and
+both shapes are bad in different ways:
+
+**Deployed with the `mcp-mesh-agent` Helm chart** — the agent advertises
+Kubernetes Service DNS, so the winner is the Service and **kube-proxy**
+spreads consecutive calls across the replica pods. The corruption is
+immediate and obvious: a write and the read that follows it routinely
+land on different pods.
+
+**Deployed from raw manifests, Docker, or bare metal** without
+`MCP_MESH_HTTP_HOST` — the agent advertises an auto-detected address
+(in Kubernetes, its own pod IP). Each replica is a separate registry
+entry, the tiebreaker picks one, and every call pins to that single
+pod. **This is the nastier failure.** State appears to work perfectly
+— through testing, through staging, through weeks of production —
+until something moves the winner: the chosen pod restarts, fails a
+health check, or a rollout renames it. The new winner has an empty
+state, and the failure surfaces far from the deploy that caused it.
+The other replicas, meanwhile, were never carrying any load.
 
 Mitigations are all imperfect:
 
-- Run with `replicas: 1` and accept the loss of redundancy.
+- Run with `replicas: 1` and accept the loss of redundancy. This is
+  the only mitigation that is actually correct, and it is the one to
+  reach for first.
 - Use session-affinity routing (`session_required: True` in
   `dependency_kwargs`) to pin a consumer to a replica for the
   duration of a logical session. This shifts the problem rather
   than solving it: cross-session reads still hit the wrong replica.
+  It also only applies behind a Service — with a pod-IP endpoint
+  there is nothing to pin, because the calls were never spreading.
 - Externalize the state to a state agent — at which point you're
   back to the [MeshJob pattern](stateful-agents.md) and don't need
   this page.

--- a/docs/concepts/tag-matching.md
+++ b/docs/concepts/tag-matching.md
@@ -117,12 +117,15 @@ Scoring:
 
 ## Tie Breaking
 
-The resolver's tiebreaker is `HighestScoreThenVersion`: candidates are
-sorted by tag-match score (descending) first, then — among candidates with
-the same score — by highest semver version.
+The resolver's tiebreaker is `HighestScoreThenVersion`:
 
-1. **Score** - Highest tag-match score wins
-2. **Version** - Among equal scores, higher semver wins
+1. **Score** — highest tag-match score wins
+2. **Version** — among equal scores, higher semver wins
+3. **Agent ID** — among equal scores and versions, the lowest agent ID wins
+
+Exactly one candidate is selected, and the sort is stable, so an unchanged
+topology resolves the same way every time. See
+[Tiebreaker](audit.md#tiebreaker) for the canonical description.
 
 ## Combining with Versions
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -166,6 +166,17 @@ export MCP_MESH_HTTP_PORT=8080
 export MCP_MESH_HTTP_ENABLED=true
 ```
 
+!!! tip "This is what decides whether replicas share traffic"
+
+    The registry resolves each dependency to exactly one winner and hands back
+    that agent's registered host — it never round-robins. So whether a second
+    replica sees any traffic depends entirely on what `MCP_MESH_HTTP_HOST`
+    announced. Set it to a **Kubernetes Service name** and kube-proxy spreads
+    calls across the Service's pods; leave it unset and the agent auto-detects
+    its own address (its pod IP in Kubernetes), so every call pins to that one
+    process. The `mcp-mesh-agent` Helm chart sets Service DNS for you — override
+    it with `agent.advertisedHost`. See [Tiebreaker](concepts/audit.md#tiebreaker).
+
 ### Health and Monitoring
 
 ```bash

--- a/docs/java/capabilities-tags.md
+++ b/docs/java/capabilities-tags.md
@@ -154,7 +154,9 @@ When an agent requests a dependency, the registry resolves it by:
 1. **Name matching**: Find agents providing the requested capability
 2. **Tag filtering**: Apply tag constraints (if specified)
 3. **Version constraints**: Check semantic version compatibility
-4. **Load balancing**: Select from multiple matching providers
+4. **Tiebreaker**: Select exactly one winner from the survivors — highest tag score, then highest version, then agent ID
+
+The registry does not load balance: it picks a single deterministic winner and holds it until the topology changes. See [Tiebreaker](../concepts/audit.md#tiebreaker).
 
 ## Capability Naming Conventions
 

--- a/docs/python/capabilities-tags.md
+++ b/docs/python/capabilities-tags.md
@@ -117,7 +117,9 @@ When an agent requests a dependency, the registry resolves it by:
 1. **Name matching**: Find agents providing the requested capability
 2. **Tag filtering**: Apply tag constraints (if specified)
 3. **Version constraints**: Check semantic version compatibility
-4. **Load balancing**: Select from multiple matching providers
+4. **Tiebreaker**: Select exactly one winner from the survivors — highest tag score, then highest version, then agent ID
+
+The registry does not load balance: it picks a single deterministic winner and holds it until the topology changes. See [Tiebreaker](../concepts/audit.md#tiebreaker).
 
 ## Multiple Implementations
 

--- a/docs/typescript/capabilities-tags.md
+++ b/docs/typescript/capabilities-tags.md
@@ -121,7 +121,9 @@ When an agent requests a dependency, the registry resolves it by:
 1. **Name matching**: Find agents providing the requested capability
 2. **Tag filtering**: Apply tag constraints (if specified)
 3. **Version constraints**: Check semantic version compatibility
-4. **Load balancing**: Select from multiple matching providers
+4. **Tiebreaker**: Select exactly one winner from the survivors — highest tag score, then highest version, then agent ID
+
+The registry does not load balance: it picks a single deterministic winner and holds it until the topology changes. See [Tiebreaker](../concepts/audit.md#tiebreaker).
 
 ## Multiple Implementations
 

--- a/helm/mcp-mesh-agent/README.md
+++ b/helm/mcp-mesh-agent/README.md
@@ -79,6 +79,14 @@ helm uninstall my-agent -n mcp-mesh
 | `agent.command`             | Container command override                        | `[]`      |
 | `agent.advertisedHost`      | Hostname advertised to registry                   | `""`      |
 
+`agent.advertisedHost` sets `MCP_MESH_HTTP_HOST`, the address consumers actually
+dial. Empty means Service DNS (`<release>-mcp-mesh-agent.<namespace>`), which is
+what lets Kubernetes spread calls across replica pods — the registry itself picks
+one winner per dependency and never round-robins. Set it explicitly for
+cross-namespace (`<service>.<namespace>.svc.cluster.local`) or cross-cluster
+(external ingress hostname) consumers. Pointing it at a pod-specific address
+pins every call to that one pod.
+
 ### HTTP Configuration
 
 | Parameter                 | Description          | Default     |

--- a/helm/mcp-mesh-agent/templates/deployment.yaml
+++ b/helm/mcp-mesh-agent/templates/deployment.yaml
@@ -121,7 +121,11 @@ spec:
             # HTTP server binding - bind to all interfaces
             - name: HOST
               value: "0.0.0.0"
-            # 🎯 Kubernetes service discovery - auto-detect from labels
+            # NOT service discovery. No runtime reads SERVICE_NAME or NAMESPACE —
+            # the host the agent advertises to the registry comes from
+            # MCP_MESH_HTTP_HOST in the ConfigMap (agent.advertisedHost, defaulting
+            # to Service DNS). These two are downward-API metadata kept for
+            # operator convenience only; nothing in mesh consumes them.
             - name: SERVICE_NAME
               valueFrom:
                 fieldRef:
@@ -130,7 +134,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            # Fallback pod IP for backward compatibility
+            # Pod IP — read by the runtime for trace/context attribution only
+            # (not for endpoint advertisement; see MCP_MESH_HTTP_HOST above).
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/src/core/cli/man/content/audit.md
+++ b/src/core/cli/man/content/audit.md
@@ -136,9 +136,35 @@ Reasons are typed (not freeform strings) so audit consumers can pattern-match. T
 
 ## Tiebreaker
 
-After all filter stages, the surviving candidates are ordered by tag-match score (descending), then by version (highest first), then by agent ID for determinism — the first one wins. So among providers of the same capability and tags, the newest satisfying version is chosen. The audit records this as `reason: "HighestScoreThenVersion"` on the tiebreaker stage.
+This section is the canonical description of how the registry picks a winner. Other topics refer here rather than restating it.
+
+After all filter stages, the surviving candidates are ordered by:
+
+1. **Tag-match score**, descending — see `meshctl man tags`.
+2. **Version**, highest first — among providers with the same score, the newest satisfying version wins.
+3. **Agent ID**, ascending — a deterministic last resort so a full tie is never arbitrary.
+
+The first candidate wins. The audit records this as `reason: "HighestScoreThenVersion"` on the tiebreaker stage.
+
+The sort is **stable**, so an unchanged topology resolves to the same provider every time. Re-resolution only moves the winner when the topology itself changes — a provider joins or leaves, a health state flips, or a version is deployed.
 
 Configurable tiebreakers (round-robin, latency-aware, etc.) are out of scope for v1 — the audit trail is forward-compatible: future tiebreakers will record their own name in the same `reason` field.
+
+## The registry does not load balance
+
+The registry selects **exactly one winner per dependency**, deterministically. It does not round-robin, and it does not spread calls across providers. Every call through an injected proxy goes to the winner's registered endpoint until the topology changes and the dependency is re-resolved.
+
+Whether calls then reach more than one process is a **deployment** question, decided by what that endpoint resolves to:
+
+- **Deployed with the `mcp-mesh-agent` Helm chart** — the agent registers Kubernetes Service DNS (`<release>-mcp-mesh-agent.<namespace>`), so kube-proxy spreads calls across the Service's replica pods. The distribution is **Kubernetes'**, not the mesh's.
+- **Raw manifests, Docker, or bare metal with no `MCP_MESH_HTTP_HOST`** — the agent registers an auto-detected host address (in Kubernetes, its own pod IP), so every call lands on that one process. Extra replicas register separately and add no throughput to an already-resolved edge.
+
+The chart sets the Service DNS default via `MCP_MESH_HTTP_HOST` in its ConfigMap. Override it with `agent.advertisedHost` when the default is wrong — a fully qualified `<service>.<namespace>.svc.cluster.local` for cross-namespace consumers, or an external ingress hostname for cross-cluster ones.
+
+Two consequences worth planning around:
+
+- **Adding replicas only adds capacity if the endpoint is a Service.** If the agent advertises a pod IP, a second replica is idle as far as an existing consumer is concerned.
+- **Behind a Service, consecutive calls can land on different pods.** Anything the agent keeps in memory between calls is therefore unsafe: keep per-call state in the request, and externalize anything that must outlive it.
 
 ## See Also
 

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -169,10 +169,17 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // failure on 3.4). Four code spans in one replaced paragraph; still no list
 // line, and the `text` fence labels added in the same change are skipped by
 // these tests, which treat any ``` line as a block delimiter.
+// #1430: +7 / +4 / +7, all in `audit.md`. The tiebreaker prose became the
+// canonical description of resolver selection — a numbered score/version/agent-ID
+// list, plus a "registry does not load balance" section whose two deployment
+// shapes (Service DNS vs auto-detected pod IP) are bullets naming
+// `MCP_MESH_HTTP_HOST` and `agent.advertisedHost`. Bullets, not a table: the
+// renderer passes `|` lines through raw, so table-cell markup would print
+// literally.
 const (
-	wantInlineCodeSpans = 1637
-	wantListCodeSpans   = 488
-	wantMarkupListLines = 433
+	wantInlineCodeSpans = 1644
+	wantListCodeSpans   = 492
+	wantMarkupListLines = 440
 )
 
 // assertCorpusSize replaces the t.Logf these tests used to end on.


### PR DESCRIPTION
## Summary

Three concept docs made three different claims about how mesh distributes calls across replicas. One was right, two described behaviour the registry does not have, and — as it turned out — the "right" one was also wrong about the tiebreaker itself.

**Ground truth**: `resolver.go:480-495` sorts candidates by **tag score DESC → version DESC → agent ID ASC** with a stable sort and takes `afterSchema[0]`. A single deterministic winner. `llm_provider_resolver.go:104-118` does the same for LLM providers. The registry never round-robins.

What the winner's endpoint resolves to is **deployment-dependent**:

- **Helm-chart agents** register **Service DNS** (`configmap.yaml:29-36` sets `MCP_MESH_HTTP_HOST` to `<fullname>.<namespace>`), so kube-proxy spreads calls across replica pods. Confirmed live: `skybot-user -> http://user.skybot:8080`.
- **Raw-manifest agents** fall back to `ConfigKey::HttpHost => None // Special: auto-detect IP` — a pod IP, pinned to one process, no distribution at all. Confirmed live: `skybot-web-gateway -> http://10.42.3.197:8080`.

## What changed

`docs/concepts/audit.md#tiebreaker` and its man twin are now the **canonical** account — all three sort legs, the stability property, and a new "The registry does not load balance" section covering both deployment shapes and naming `agent.advertisedHost`. Everything else links there rather than restating, since three independent descriptions of one algorithm is why they diverged.

Corrected: `dddi.md:119` ("or load balanced"), `dddi.md:210` ("DDDI load-balances between both instances"), `in-process-state.md:239` ("round-robin").

## The doc designated as ground truth was itself wrong

`docs/concepts/audit.md` said the reason string is `HighestScoreFirst` in **three places** (`:20`, `:94`, `:142`) and described a score-only tiebreaker, "first encountered if tied". The code emits `HighestScoreThenVersion` (`audit_trace.go:52`) and sorts on three legs. Only the out-of-scope-for-v1 sentence was accurate. `architecture.md:105` carried the same wrong string.

And the **man copy was already current** — `man/content/audit.md:139` had it right while the mkdocs page was stale. The two surfaces had drifted, which is the same failure this issue is about, one level up.

## Three surfaces the issue did not list

`docs/{python,typescript,java}/capabilities-tags.md` each ended their resolution list with `4. **Load balancing**: Select from multiple matching providers` — the same false claim, three more copies.

## `in-process-state.md` — warning kept, mechanism fixed

Its conclusion is correct and stays: in-memory state pins an agent to one replica and multi-replica breaks it. Only the mechanism was wrong. It was also **understated** for raw-manifest deployments, where the winner is a single pod — so state appears to work until a re-resolution moves the winner, a nastier failure than the one described. That case is now stated.

## A renderer limitation caught by rendering, not by tests

The man renderer passes `|` lines through raw (`renderer.go:155-156`), so a markdown table's backticks and `**` print literally. The first draft used a table on both surfaces; rendered output showed literal markup and a 252-char row (widest existing: 233). The deployment-shape comparison is a table in the HTML docs and bullets in the man page.

Worth noting: **the corpus tests skip `|` lines**, so the table would have passed silently. Only rendering it caught this.

## Also fixed: a comment that pointed at the wrong mechanism

`helm/mcp-mesh-agent/templates/deployment.yaml` set two downward-API env vars under `# 🎯 Kubernetes service discovery - auto-detect from labels`. Neither `SERVICE_NAME` nor `NAMESPACE` is read by any runtime (`grep -rn` across `src/` returns nothing for both). The comment claimed a job the ConfigMap's `MCP_MESH_HTTP_HOST` actually performs, and it is what sent the original investigation looking in the wrong place.

**The env vars themselves are not removed here** — that changes the rendered manifest and needs its own upgrade note, since `NAMESPACE` is a generic enough name that a user's agent image may read it for its own purposes. `POD_IP` stays: read at `http_wrapper.py:147`, `agent_context_helper.py:68`, and `AgentContextProvider.java:59` (a third site the issue did not list), all for trace attribution.

## Validation

- `go build ./...`; `go test ./src/core/registry/... ./src/core/cli/...` all pass.
- **Goldens** 1637→**1644** (+7), 488→**492** (+4), 433→**440** (+7), all from `man/content/audit.md`. Each delta was predicted from the counting rules *before* running and matched the reported figure on both iterations. The comment records the reason and why bullets rather than a table.
- `mkdocs build --strict` — 14 warnings, **byte-identical to the same run on unmodified `dev`** (verified against a baseline worktree). All 14 are pre-existing `tutorial/downloads.md` links to unbuilt zip artifacts; `--strict` already aborts on `dev`. None mention a file touched here. The `#tiebreaker` anchor resolves and all 7 inbound links land on it — note the built HTML is minified (`id=tiebreaker`, unquoted), so a naive grep for `id="tiebreaker"` falsely reports it missing.
- Man rendered from a **locally built** `./cmd/meshctl`.
- **Chart render diff is comment-only** — `helm template` diff shows only comment lines, and parsing both outputs to YAML compares equal.

## Sweep — every hit and verdict

Left alone as correct: `MCP_MESH_TOOL_WORKERS` round-robin (`environment-variables.md:79`, `python/dependency-injection.md:351`, `stateful-agents.md:84`, `man/environment.md:104`) — worker loops within one process, a different claim. Load balancers *in front of the registry* (`concepts/registry.md:196,202`, `man/registry.md:186`, `man/upgrading.md:156`). LB health checks and dropped sockets (`jobs*.md`, `dependency-injection*.md`). `man/environment.md:81` `MCP_MESH_HTTP_ENDPOINT`. And `configmap.yaml:31` "enables K8s load balancing across replicas" — that one is the ground truth.

## Follow-ups

- The mkdocs and man copies of `audit.md` drifted once and are resynced here by hand. **No test asserts they stay consistent**, so nothing prevents a recurrence.
- Relevant to **#1424**: this settles the question that issue depends on — with chart-deployed agents the per-agent `edgeStats` aggregate across replica pods behind one Service; raw-manifest agents key per pod.

Closes #1430
