### PR TITLE
fix(java): key mesh registries by Method, not by an id that cannot name an overload

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/JobsRuntimeManager.java
@@ -388,11 +388,14 @@ public final class JobsRuntimeManager implements SmartLifecycle {
             + "." + meta.method().getName();
         MeshToolWrapper wrapper = wrapperRegistry.getWrapper(funcId);
         if (wrapper == null) {
-            // Fall back via method name (defensive — covers any residual
-            // key divergence between registration and lookup).
-            log.debug("Wrapper lookup miss for funcId={}; falling back to method-name lookup '{}'",
-                funcId, meta.method().getName());
-            wrapper = wrapperRegistry.getWrapperByMethodName(meta.method().getName());
+            // Fall back via the METHOD (defensive — covers any residual key
+            // divergence between registration and lookup, e.g. an inherited
+            // @MeshTool whose declaring class is not the bean's target class).
+            // Issue #1437: this used the bare method NAME, which cannot
+            // distinguish two same-named @MeshTool methods in different classes.
+            log.debug("Wrapper lookup miss for funcId={}; falling back to method lookup '{}'",
+                funcId, meta.method());
+            wrapper = wrapperRegistry.getWrapperByMethod(meta.method());
         }
         return wrapper;
     }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmRegistry.java
@@ -43,8 +43,20 @@ public class MeshLlmRegistry {
     // Registry: functionId -> LlmConfig
     private final Map<String, LlmConfig> configsByFunctionId = new ConcurrentHashMap<>();
 
-    // Registry: method signature -> LlmConfig
-    private final Map<String, LlmConfig> configsByMethod = new ConcurrentHashMap<>();
+    /**
+     * Registry: handler {@link Method} -&gt; LlmConfig.
+     *
+     * <p>Keyed by {@code Method}, not by {@code "Class#methodName"} (issue
+     * #1437): that string omits parameter types, so two overloaded
+     * {@code @MeshLlm} methods in one class collided and the second registration
+     * silently replaced the first — handing one overload the other's provider
+     * selector, prompt and model. Every reader of this map already holds the
+     * {@code Method}, and {@link Method#equals} is value-based over
+     * {@code (declaringClass, name, returnType, parameterTypes)}, so the lookup
+     * key needs no derivation: it is strictly more precise than the string it
+     * replaces, with the same declaring-class component.
+     */
+    private final Map<Method, LlmConfig> configsByMethod = new ConcurrentHashMap<>();
 
     /**
      * Register an @MeshLlm annotated method.
@@ -55,7 +67,6 @@ public class MeshLlmRegistry {
      */
     public void register(Class<?> targetClass, Method method, MeshLlm annotation) {
         String functionId = targetClass.getName() + "." + method.getName();
-        String methodKey = getMethodKey(method);
 
         // v2: direct LLM mode is gone — every @MeshLlm consumer must point
         // providerSelector at a registered @MeshLlmProvider. An empty selector
@@ -89,7 +100,7 @@ public class MeshLlmRegistry {
         );
 
         configsByFunctionId.put(functionId, config);
-        configsByMethod.put(methodKey, config);
+        configsByMethod.put(method, config);
 
         log.info("Registered @MeshLlm: {} (mesh-delegated)", functionId);
     }
@@ -105,14 +116,14 @@ public class MeshLlmRegistry {
      * Get LLM config by method.
      */
     public LlmConfig getByMethod(Method method) {
-        return configsByMethod.get(getMethodKey(method));
+        return method == null ? null : configsByMethod.get(method);
     }
 
     /**
      * Check if a method has @MeshLlm configuration.
      */
     public boolean hasConfig(Method method) {
-        return configsByMethod.containsKey(getMethodKey(method));
+        return method != null && configsByMethod.containsKey(method);
     }
 
     /**
@@ -120,10 +131,6 @@ public class MeshLlmRegistry {
      */
     public Map<String, LlmConfig> getAllConfigs() {
         return Map.copyOf(configsByFunctionId);
-    }
-
-    private String getMethodKey(Method method) {
-        return method.getDeclaringClass().getName() + "#" + method.getName();
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -2014,9 +2014,21 @@ public class MeshToolWrapper implements McpToolHandler {
 
     /**
      * Get the method name (used as MCP tool name to match registry).
+     *
+     * <p>Not an identity — it carries no class (issue #1437). Use
+     * {@link #getMethod()} to identify this wrapper's handler.
      */
     public String getMethodName() {
         return method.getName();
+    }
+
+    /**
+     * The annotated {@code @MeshTool} method this wrapper invokes — the
+     * wrapper's exact identity, qualified by declaring class and parameter
+     * types (issue #1437).
+     */
+    public Method getMethod() {
+        return method;
     }
 
     public String getDescription() {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapperRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapperRegistry.java
@@ -5,10 +5,12 @@ import io.mcpmesh.types.MeshLlmAgent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -40,17 +42,37 @@ public class MeshToolWrapperRegistry {
     // funcId → wrapper (MeshToolWrapper only, for dependency updates)
     private final Map<String, MeshToolWrapper> wrappers = new ConcurrentHashMap<>();
 
-    // methodName → wrapper (for dependency resolution by function name from Rust core)
+    /**
+     * Handler {@link Method} → wrapper: the exact identity, qualified by
+     * declaring class AND parameter types (issue #1437). Used by callers that
+     * hold the method — they should never have to degrade to a name.
+     *
+     * <p>{@link Method#equals} is value-based, so a fresh copy from a later
+     * reflective lookup hits the entry registration wrote.
+     */
+    private final Map<Method, MeshToolWrapper> wrappersByMethod = new ConcurrentHashMap<>();
+
+    /**
+     * Bare {@code methodName} → wrapper. The weakest key in the package: no
+     * class qualifier at all, so two {@code @MeshTool} methods named
+     * {@code analyze} in different classes collide (issue #1437). It has to stay
+     * addressable by bare name — this is the wire-facing fallback for a core that
+     * names a slot by function name alone ({@link #resolveWrapper}) — so instead
+     * of a qualifier it gets a collision guard: a name claimed by more than one
+     * wrapper is recorded in {@link #ambiguousMethodNames} and refused at lookup,
+     * rather than resolving to whichever registered last and wiring one tool's
+     * dependency resolution into the other's slot.
+     */
     private final Map<String, MeshToolWrapper> wrappersByMethodName = new ConcurrentHashMap<>();
+
+    /** Bare method names claimed by more than one registered wrapper. */
+    private final Set<String> ambiguousMethodNames = ConcurrentHashMap.newKeySet();
 
     // funcId → handler (all handlers including LLM providers)
     private final Map<String, McpToolHandler> handlers = new ConcurrentHashMap<>();
 
     // capability → handler (for MCP SDK tool lookup by name)
     private final Map<String, McpToolHandler> handlersByCapability = new ConcurrentHashMap<>();
-
-    // methodName → handler (for MCP tool lookup by method name)
-    private final Map<String, McpToolHandler> handlersByMethodName = new ConcurrentHashMap<>();
 
     private final McpMeshToolProxyFactory proxyFactory;
 
@@ -91,12 +113,14 @@ public class MeshToolWrapperRegistry {
 
         // Store in wrapper maps (for dependency updates)
         wrappers.put(funcId, wrapper);
-        wrappersByMethodName.put(methodName, wrapper);
+        if (wrapper.getMethod() != null) {
+            wrappersByMethod.put(wrapper.getMethod(), wrapper);
+        }
+        indexBareMethodName(methodName, wrapper);
 
         // Store in handler maps (for MCP server)
         handlers.put(funcId, wrapper);
         handlersByCapability.put(capability, wrapper);
-        handlersByMethodName.put(methodName, wrapper);
 
         // Settling-window grace (#1193): declare this tool's dependency
         // slots with the process-wide settle state so the agent-level
@@ -129,10 +153,34 @@ public class MeshToolWrapperRegistry {
 
         handlers.put(funcId, handler);
         handlersByCapability.put(capability, handler);
-        handlersByMethodName.put(methodName, handler);
 
         log.info("Registered handler: {} (capability: {}, method: {})",
             funcId, capability, methodName);
+    }
+
+    /**
+     * Index a wrapper under its bare method name, refusing to overwrite a name
+     * another wrapper already claims (issue #1437).
+     *
+     * <p>The loser is not "the second one registered" — BOTH are dropped from
+     * the bare-name index and the name is marked ambiguous, because there is no
+     * defensible way to pick between them and answering with either one wires a
+     * dependency resolution into the wrong tool's slot. Both remain fully
+     * addressable by {@code funcId} and by {@link Method}, which is how they are
+     * addressed in practice.
+     */
+    private void indexBareMethodName(String methodName, MeshToolWrapper wrapper) {
+        if (methodName == null) {
+            return;
+        }
+        MeshToolWrapper previous = wrappersByMethodName.putIfAbsent(methodName, wrapper);
+        if (previous != null && previous != wrapper) {
+            ambiguousMethodNames.add(methodName);
+            log.warn("Method name '{}' is registered by more than one @MeshTool ({} and {}) — "
+                    + "it no longer resolves a wrapper by name alone. Both remain addressable "
+                    + "by their function ids.",
+                methodName, previous.getFuncId(), wrapper.getFuncId());
+        }
     }
 
     /**
@@ -146,12 +194,37 @@ public class MeshToolWrapperRegistry {
     }
 
     /**
-     * Get a wrapper by method name.
+     * Get a wrapper by its handler {@link Method} — exact, qualified by
+     * declaring class and parameter types.
+     *
+     * @param method The annotated {@code @MeshTool} method
+     * @return The wrapper, or null if that method registered no wrapper
+     */
+    public MeshToolWrapper getWrapperByMethod(Method method) {
+        return method == null ? null : wrappersByMethod.get(method);
+    }
+
+    /**
+     * Get a wrapper by bare method name.
+     *
+     * <p><b>Best-effort.</b> The name carries no class, so it cannot name one of
+     * several same-named {@code @MeshTool} methods; when more than one wrapper
+     * claims it this returns {@code null} rather than an arbitrary one of them
+     * (issue #1437). Prefer {@link #getWrapper(String)} with the function id, or
+     * {@link #getWrapperByMethod(Method)}.
      *
      * @param methodName The short method name (e.g., "analyze")
-     * @return The wrapper, or null if not found
+     * @return The wrapper, or null if not found or the name is ambiguous
      */
     public MeshToolWrapper getWrapperByMethodName(String methodName) {
+        if (methodName == null) {
+            return null;
+        }
+        if (ambiguousMethodNames.contains(methodName)) {
+            log.error("Method name '{}' names more than one @MeshTool wrapper — refusing to "
+                + "resolve it to an arbitrary one. Address the tool by its function id.", methodName);
+            return null;
+        }
         return wrappersByMethodName.get(methodName);
     }
 
@@ -229,7 +302,8 @@ public class MeshToolWrapperRegistry {
     private MeshToolWrapper resolveWrapper(String funcId) {
         MeshToolWrapper wrapper = wrappers.get(funcId);
         if (wrapper == null) {
-            wrapper = wrappersByMethodName.get(funcId);
+            // Bare-name fallback — collision-guarded (issue #1437).
+            wrapper = getWrapperByMethodName(funcId);
         }
         return wrapper;
     }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteBeanPostProcessor.java
@@ -78,10 +78,15 @@ public class MeshRouteBeanPostProcessor implements BeanPostProcessor {
             // handler still shaped for the pre-3.4 name-based binding.
             MeshLegacyBindingDetector.inspectRoute(method, deps);
 
-            // Register each HTTP method/path combination
-            String handlerMethodId = targetClass.getName() + "." + method.getName();
+            // Register each HTTP method/path combination.
+            //
+            // Issue #1437: the METHOD is the handler's identity. The registry
+            // derives the "ClassName.methodName" id from it for logs, but keys
+            // on the Method itself — that id omits parameter types, so two
+            // overloaded @MeshRoute handlers share it and the interceptor served
+            // one of them the other's (positional) dependency list.
             MeshRouteRegistry.RouteMetadata metadata = new MeshRouteRegistry.RouteMetadata(
-                handlerMethodId,
+                method,
                 deps,
                 meshRoute.description(),
                 meshRoute.failOnMissingDependency()

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteHandlerInterceptor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteHandlerInterceptor.java
@@ -102,16 +102,35 @@ public class MeshRouteHandlerInterceptor implements HandlerInterceptor {
     }
 
     @Override
+    @SuppressWarnings("deprecation")  // getByHandlerMethodId: compatibility fallback only
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
                              Object handler) throws Exception {
         if (!(handler instanceof HandlerMethod handlerMethod)) {
             return true;
         }
 
-        // Look up route metadata by handler method
+        // Look up route metadata by the handler METHOD (issue #1437).
+        //
+        // The method is the handler's identity; "ClassName.methodName" is not —
+        // it omits parameter types, so two overloaded @MeshRoute handlers share
+        // one id and this lookup served both of them whichever registered last.
+        // The injected dependency list is built from what comes back and is
+        // POSITIONAL (#1401), so the swap was invisible in the result's shape.
+        //
+        // The id is kept for log lines below, where the ambiguity is harmless
+        // and it reads better than Method.toString().
+        MeshRouteRegistry.RouteMetadata metadata =
+            registry.getByHandlerMethod(handlerMethod.getMethod());
         String handlerMethodId = handlerMethod.getBeanType().getName() + "." +
             handlerMethod.getMethod().getName();
-        MeshRouteRegistry.RouteMetadata metadata = registry.getByHandlerMethodId(handlerMethodId);
+        if (metadata == null) {
+            // Compatibility fallback for metadata registered without a Method
+            // identity, and for the exotic proxying arrangements where the
+            // method Spring MVC resolves is not the one the bean post-processor
+            // scanned. Refused by the registry when the id is ambiguous, so it
+            // can never resolve one overload to another's dependencies.
+            metadata = registry.getByHandlerMethodId(handlerMethodId);
+        }
 
         if (metadata == null || metadata.getDependencies().isEmpty()) {
             return true;

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -16,6 +17,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -34,9 +36,41 @@ public class MeshRouteRegistry {
     private final Map<String, RouteMetadata> routesByPath = new ConcurrentHashMap<>();
 
     /**
-     * Routes indexed by handler method ID (ClassName.methodName).
+     * Routes indexed by the handler {@link Method} — the identity
+     * {@link MeshRouteHandlerInterceptor} resolves each request against.
+     *
+     * <p>Keyed by {@code Method}, NOT by {@code handlerMethodId} (issue #1437).
+     * That id is {@code "ClassName.methodName"} with no parameter types, so two
+     * overloaded {@code @MeshRoute} handlers in one controller collide on it, and
+     * this map is keyed per HANDLER while {@link #routesByPath} is keyed per
+     * MAPPING — both overloads do register, on their own paths. The interceptor
+     * builds the injected dependency list from whatever this map returns, so on
+     * the string id a request to the first overload's path was served the second
+     * overload's dependencies — <b>positionally</b> since #1401, so nothing about
+     * the shape of the result signalled the swap. Matches
+     * {@link MeshA2ADispatcher}'s {@code argPlans} and
+     * {@link MeshInjectArgumentResolver}, both {@code Method}-keyed.
+     *
+     * <p>{@link Method#equals} is value-based over
+     * {@code (declaringClass, name, returnType, parameterTypes)}, so a fresh copy
+     * from a later {@code getDeclaredMethods()} call — which is what Spring MVC
+     * hands the interceptor — hits the entry the bean post-processor wrote.
      */
-    private final Map<String, RouteMetadata> routesByHandler = new ConcurrentHashMap<>();
+    private final Map<Method, RouteMetadata> routesByHandlerMethod = new ConcurrentHashMap<>();
+
+    /**
+     * Routes indexed by handler method ID ({@code "ClassName.methodName"}).
+     * Best-effort only: the id cannot distinguish overloads, so an id claimed by
+     * more than one handler is recorded in {@link #ambiguousHandlerIds} and
+     * refused at lookup rather than resolved to an arbitrary winner. First
+     * registration wins the slot; later ones only mark it ambiguous.
+     *
+     * @see #getByHandlerMethodId(String)
+     */
+    private final Map<String, RouteMetadata> routesByHandlerId = new ConcurrentHashMap<>();
+
+    /** Handler method IDs claimed by more than one distinct handler. */
+    private final Set<String> ambiguousHandlerIds = ConcurrentHashMap.newKeySet();
 
     /**
      * Register a @MeshRoute endpoint.
@@ -44,11 +78,17 @@ public class MeshRouteRegistry {
      * @param httpMethod HTTP method (GET, POST, etc.)
      * @param path       URL path pattern
      * @param metadata   Route metadata
+     * @throws IllegalStateException when a DIFFERENT handler is already
+     *                               registered for the same {@link Method} —
+     *                               a genuine duplicate registration, which
+     *                               fails the boot rather than silently winning
+     *                               (issue #1437, matching
+     *                               {@link MeshA2ARegistry#register})
      */
     public void register(String httpMethod, String path, RouteMetadata metadata) {
         String routeId = buildRouteId(httpMethod, path);
         routesByPath.put(routeId, metadata);
-        routesByHandler.put(metadata.getHandlerMethodId(), metadata);
+        indexHandler(metadata);
 
         // Settling-window grace (#1193): declare this route's dependency
         // capabilities with the process-wide settle state so the
@@ -79,13 +119,82 @@ public class MeshRouteRegistry {
     }
 
     /**
+     * Index one handler's metadata under both its exact {@link Method} identity
+     * and its (ambiguous) string id.
+     *
+     * <p>A {@code @MeshRoute} handler carrying several mappings — {@code @GetMapping}
+     * plus {@code @PostMapping}, or a multi-path {@code @RequestMapping} — is
+     * registered once PER MAPPING with the SAME metadata instance. That is not a
+     * duplicate: the guard fires only when a <b>different</b> metadata instance
+     * claims a {@link Method} that is already registered.
+     */
+    private void indexHandler(RouteMetadata metadata) {
+        Method handlerMethod = metadata.getHandlerMethod();
+        if (handlerMethod != null) {
+            RouteMetadata previous = routesByHandlerMethod.putIfAbsent(handlerMethod, metadata);
+            if (previous != null && previous != metadata) {
+                throw new IllegalStateException(
+                    "@MeshRoute handler collision: " + handlerMethod
+                        + " is already registered with a different route metadata"
+                        + " (dependencies " + previous.getDependencies() + " vs "
+                        + metadata.getDependencies() + "). Each handler method must be"
+                        + " registered exactly once.");
+            }
+        }
+
+        String handlerMethodId = metadata.getHandlerMethodId();
+        if (handlerMethodId == null) {
+            return;
+        }
+        RouteMetadata previousById = routesByHandlerId.putIfAbsent(handlerMethodId, metadata);
+        if (previousById != null && previousById != metadata) {
+            // Overloads. Legal — they map to different paths — but the string id
+            // can no longer name either of them, so refuse it at lookup instead
+            // of handing out whichever registered first.
+            ambiguousHandlerIds.add(handlerMethodId);
+            log.debug("Handler method id '{}' is claimed by more than one @MeshRoute handler "
+                    + "(overloads); it is no longer resolvable by id — lookups use the Method",
+                handlerMethodId);
+        }
+    }
+
+    /**
+     * Get route metadata by the handler {@link Method} — the exact identity,
+     * which distinguishes overloads.
+     *
+     * @param handlerMethod the resolved handler method (e.g.
+     *                      {@code HandlerMethod.getMethod()})
+     * @return route metadata or null if this method carries no {@code @MeshRoute}
+     */
+    public RouteMetadata getByHandlerMethod(Method handlerMethod) {
+        return handlerMethod == null ? null : routesByHandlerMethod.get(handlerMethod);
+    }
+
+    /**
      * Get route metadata by handler method ID.
      *
+     * @deprecated The id is {@code "ClassName.methodName"} with no parameter
+     *     types, so it cannot name one of several overloaded handlers (issue
+     *     #1437). Use {@link #getByHandlerMethod(Method)}, which is exact. This
+     *     accessor is retained for source/binary compatibility and now returns
+     *     {@code null} — logging an error — for an id claimed by more than one
+     *     handler, rather than resolving it to an arbitrary one of them.
+     *
      * @param handlerMethodId "ClassName.methodName" identifier
-     * @return route metadata or null if not found
+     * @return route metadata, or null if not found or the id is ambiguous
      */
+    @Deprecated
     public RouteMetadata getByHandlerMethodId(String handlerMethodId) {
-        return routesByHandler.get(handlerMethodId);
+        if (handlerMethodId == null) {
+            return null;
+        }
+        if (ambiguousHandlerIds.contains(handlerMethodId)) {
+            log.error("Handler method id '{}' names more than one @MeshRoute handler (overloads "
+                    + "differ only in parameter types) — refusing to resolve it to an arbitrary "
+                    + "one. Look the handler up by its Method instead.", handlerMethodId);
+            return null;
+        }
+        return routesByHandlerId.get(handlerMethodId);
     }
 
     /**
@@ -320,19 +429,67 @@ public class MeshRouteRegistry {
      * Metadata for a @MeshRoute annotated endpoint.
      */
     public static class RouteMetadata {
+        private final Method handlerMethod;
         private final String handlerMethodId;
         private final List<DependencySpec> dependencies;
         private final String description;
         private final boolean failOnMissingDependency;
 
+        /**
+         * Canonical constructor: the handler's {@link Method} IS its identity
+         * (issue #1437). The string id is derived from it and kept for logs,
+         * where its ambiguity across overloads is harmless and it is more
+         * readable than {@link Method#toString()}.
+         */
+        public RouteMetadata(Method handlerMethod, List<DependencySpec> dependencies,
+                            String description, boolean failOnMissingDependency) {
+            this(handlerMethod, buildHandlerMethodId(handlerMethod), dependencies,
+                description, failOnMissingDependency);
+        }
+
+        /**
+         * Identity-less variant, for callers that hold only the string id.
+         *
+         * <p>Metadata built this way is indexed by
+         * {@link MeshRouteRegistry#register} under the ambiguous string id ONLY —
+         * {@link MeshRouteHandlerInterceptor} resolves requests by {@link Method}
+         * first and falls back to the id, so such a route still serves, but only
+         * while no other handler shares its id. Prefer
+         * {@link #RouteMetadata(Method, List, String, boolean)}.
+         */
         public RouteMetadata(String handlerMethodId, List<DependencySpec> dependencies,
                             String description, boolean failOnMissingDependency) {
+            this(null, handlerMethodId, dependencies, description, failOnMissingDependency);
+        }
+
+        private RouteMetadata(Method handlerMethod, String handlerMethodId,
+                            List<DependencySpec> dependencies,
+                            String description, boolean failOnMissingDependency) {
+            this.handlerMethod = handlerMethod;
             this.handlerMethodId = handlerMethodId;
             this.dependencies = dependencies != null ? dependencies : Collections.emptyList();
             this.description = description;
             this.failOnMissingDependency = failOnMissingDependency;
         }
 
+        private static String buildHandlerMethodId(Method method) {
+            return method == null ? null
+                : method.getDeclaringClass().getName() + "." + method.getName();
+        }
+
+        /**
+         * The handler method itself — the identity this route is registered
+         * under. {@code null} only for metadata built from a bare string id.
+         */
+        public Method getHandlerMethod() {
+            return handlerMethod;
+        }
+
+        /**
+         * Human-readable {@code "ClassName.methodName"} id, for logs and
+         * diagnostics. <b>Not an identity</b>: it omits parameter types, so
+         * overloaded handlers share one id (issue #1437).
+         */
         public String getHandlerMethodId() {
             return handlerMethodId;
         }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmRegistryValidationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshLlmRegistryValidationTest.java
@@ -89,4 +89,37 @@ class MeshLlmRegistryValidationTest {
         assertTrue(ex.getMessage().contains("non-empty capability"),
             "error should mention non-empty capability, got: " + ex.getMessage());
     }
+
+    static class OverloadedConsumer {
+        @MeshLlm(providerSelector = @Selector(capability = "llm", tags = {"+claude"}),
+                 systemPrompt = "narrow")
+        public String ask(String question) {
+            return "ok";
+        }
+
+        @MeshLlm(providerSelector = @Selector(capability = "llm", tags = {"+gpt"}),
+                 systemPrompt = "wide")
+        public String ask(String question, int maxTokens) {
+            return "ok";
+        }
+    }
+
+    @Test
+    @DisplayName("overloaded @MeshLlm methods keep their own config (#1437)")
+    void overloadsDoNotShareOneConfig() throws Exception {
+        // configsByMethod keyed on "Class#methodName" — no parameter types — so
+        // the second registration silently replaced the first and one overload
+        // ran with the other's provider selector, prompt and model.
+        MeshLlmRegistry registry = new MeshLlmRegistry();
+        Method narrow = OverloadedConsumer.class.getMethod("ask", String.class);
+        Method wide = OverloadedConsumer.class.getMethod("ask", String.class, int.class);
+
+        registry.register(OverloadedConsumer.class, narrow, narrow.getAnnotation(MeshLlm.class));
+        registry.register(OverloadedConsumer.class, wide, wide.getAnnotation(MeshLlm.class));
+
+        assertEquals("narrow", registry.getByMethod(narrow).systemPrompt());
+        assertEquals("wide", registry.getByMethod(wide).systemPrompt());
+        assertTrue(registry.hasConfig(narrow));
+        assertTrue(registry.hasConfig(wide));
+    }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshRouteOverloadedHandlerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshRouteOverloadedHandlerTest.java
@@ -1,0 +1,352 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshInjectArgumentResolver;
+import io.mcpmesh.spring.web.MeshRoute;
+import io.mcpmesh.spring.web.MeshRouteBeanPostProcessor;
+import io.mcpmesh.spring.web.MeshRouteHandlerInterceptor;
+import io.mcpmesh.spring.web.MeshRouteRegistry;
+import io.mcpmesh.types.McpMeshTool;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.core.MethodParameter;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.method.HandlerMethod;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Two overloaded {@code @MeshRoute} handlers must each receive their OWN
+ * declared dependencies (issue #1437).
+ *
+ * <p>{@code MeshRouteRegistry} indexed handlers by
+ * {@code "ClassName.methodName"} — no parameter types — and wrote them with a
+ * bare {@code put}. Overloads collide on that id, and since the registry is
+ * keyed per HANDLER while routes are keyed per MAPPING, both overloads register
+ * on their own paths and the second silently replaced the first.
+ * {@code MeshRouteHandlerInterceptor.preHandle} rebuilt the same id and built
+ * the injected dependency list from whatever came back, so a request to
+ * {@code /a} was served {@code /b}'s proxies.
+ *
+ * <p>The list is <b>positional</b> since #1401, which is what makes the swap
+ * invisible: two overloads declaring the same two capabilities in opposite
+ * order produce a list of the same length holding the same objects, and only
+ * the parameter each one lands in changes. {@link #parametersReceiveTheirOwnDependencies()}
+ * pins it at the parameter, through the real argument resolver.
+ *
+ * <p>Placed in {@code io.mcpmesh.spring} so {@code MeshSettleState}'s
+ * package-private test reset is visible — settled=true short-circuits the
+ * settling-window wait.
+ */
+@DisplayName("@MeshRoute: overloaded handlers get their own dependency lists")
+class MeshRouteOverloadedHandlerTest {
+
+    private MeshRouteRegistry registry;
+    private MeshDependencyInjector injector;
+    private MeshRouteHandlerInterceptor interceptor;
+
+    private McpMeshTool alphaProxy;
+    private McpMeshTool betaProxy;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        MeshSettleState.resetForTests(0.0);
+        registry = new MeshRouteRegistry();
+        injector = mock(MeshDependencyInjector.class);
+        ObjectProvider<MeshDependencyInjector> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(injector);
+        interceptor = new MeshRouteHandlerInterceptor(registry, provider);
+
+        alphaProxy = mock(McpMeshTool.class, "alpha-proxy");
+        betaProxy = mock(McpMeshTool.class, "beta-proxy");
+        when(alphaProxy.isAvailable()).thenReturn(true);
+        when(betaProxy.isAvailable()).thenReturn(true);
+        when(injector.getToolProxy("alpha")).thenReturn(alphaProxy);
+        when(injector.getToolProxy("beta")).thenReturn(betaProxy);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // The collision
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Each overload resolves ITS OWN declared dependency order")
+    void eachOverloadResolvesItsOwnDependencies() throws Exception {
+        scan();
+
+        MockHttpServletRequest requestA = new MockHttpServletRequest("GET", "/a");
+        assertTrue(interceptor.preHandle(requestA, mock(HttpServletResponse.class), handlerA()));
+
+        // /a declares [alpha, beta]. On the colliding id it was served /b's
+        // metadata, which declares [beta, alpha] — same size, same two proxies,
+        // opposite order. Nothing about the shape of the list says so.
+        assertEquals(Arrays.asList(alphaProxy, betaProxy), resolved(requestA),
+            "the 2-parameter overload must get ITS OWN [alpha, beta], not the "
+                + "3-parameter overload's [beta, alpha]");
+
+        MockHttpServletRequest requestB = new MockHttpServletRequest("GET", "/b");
+        assertTrue(interceptor.preHandle(requestB, mock(HttpServletResponse.class), handlerB()));
+        assertEquals(Arrays.asList(betaProxy, alphaProxy), resolved(requestB));
+    }
+
+    @Test
+    @DisplayName("POSITIONAL: the swap is only visible at the parameter it binds")
+    void parametersReceiveTheirOwnDependencies() throws Exception {
+        scan();
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/a");
+        assertTrue(interceptor.preHandle(request, mock(HttpServletResponse.class), handlerA()));
+
+        // Drive the REAL argument resolver: injectable slot 0 of the 2-parameter
+        // overload is parameter 0, and dependencies[0] of ITS list is 'alpha'.
+        MeshInjectArgumentResolver resolver = new MeshInjectArgumentResolver();
+        Method handle = overload(McpMeshTool.class, McpMeshTool.class);
+
+        assertSame(alphaProxy, resolve(resolver, request, handle, 0),
+            "parameter 0 of the 2-parameter overload binds dependencies[0] = 'alpha'; "
+                + "on the shared id it received 'beta' — the other overload's slot 0");
+        assertSame(betaProxy, resolve(resolver, request, handle, 1));
+    }
+
+    @Test
+    @DisplayName("A registered overload does not make the other one unresolvable")
+    void bothOverloadsAreRegisteredAndAddressable() {
+        scan();
+
+        MeshRouteRegistry.RouteMetadata narrow =
+            registry.getByHandlerMethod(overload(McpMeshTool.class, McpMeshTool.class));
+        MeshRouteRegistry.RouteMetadata wide = registry.getByHandlerMethod(
+            overload(String.class, McpMeshTool.class, McpMeshTool.class));
+
+        assertNotNull(narrow);
+        assertNotNull(wide);
+        assertEquals(List.of("alpha", "beta"), capabilities(narrow));
+        assertEquals(List.of("beta", "alpha"), capabilities(wide));
+        assertSame(narrow, registry.getByRoute("GET", "/a"));
+        assertSame(wide, registry.getByRoute("GET", "/b"));
+    }
+
+    @Test
+    @DisplayName("The Method key is value-based — a fresh reflective copy still hits")
+    void freshMethodCopiesAreEqualKeys() {
+        // The assumption the whole re-key rests on, and the one
+        // MeshInjectArgumentResolver's Map<Method, int[]> already relies on:
+        // getDeclaredMethods() hands back a NEW Method object every call, and
+        // Method.equals/hashCode are value-based over (declaringClass, name,
+        // returnType, parameterTypes). Registration and lookup never share an
+        // instance — Spring MVC resolves its own.
+        Method one = overload(McpMeshTool.class, McpMeshTool.class);
+        Method two = overload(McpMeshTool.class, McpMeshTool.class);
+        assertNotSame(one, two, "getDeclaredMethod returns a fresh copy each call");
+        assertEquals(one, two);
+        assertEquals(one.hashCode(), two.hashCode());
+        assertNotEquals(one, overload(String.class, McpMeshTool.class, McpMeshTool.class),
+            "the overloads must NOT be equal — parameter types are part of the identity");
+
+        scan();
+        assertSame(registry.getByHandlerMethod(one), registry.getByHandlerMethod(two));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // The public string accessor
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("getByHandlerMethodId refuses an id that names more than one handler")
+    @SuppressWarnings("deprecation")
+    void ambiguousHandlerMethodIdIsRefused() {
+        scan();
+
+        assertNull(registry.getByHandlerMethodId(
+                OverloadedController.class.getName() + ".handle"),
+            "the id names both overloads — it must not resolve to an arbitrary one");
+    }
+
+    @Test
+    @DisplayName("getByHandlerMethodId still answers for a handler that is not overloaded")
+    @SuppressWarnings("deprecation")
+    void unambiguousHandlerMethodIdStillResolves() {
+        scan();
+
+        MeshRouteRegistry.RouteMetadata metadata = registry.getByHandlerMethodId(
+            OverloadedController.class.getName() + ".solo");
+        assertNotNull(metadata, "a non-overloaded handler is still addressable by id");
+        assertEquals(List.of("alpha"), capabilities(metadata));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // The boot guard
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("A genuine duplicate registration fails at boot")
+    void duplicateHandlerRegistrationFailsBoot() {
+        Method handle = overload(McpMeshTool.class, McpMeshTool.class);
+
+        registry.register("GET", "/first", new MeshRouteRegistry.RouteMetadata(
+            handle, List.of(dep("alpha")), "", false));
+
+        IllegalStateException boom = assertThrows(IllegalStateException.class, () ->
+            registry.register("GET", "/second", new MeshRouteRegistry.RouteMetadata(
+                handle, List.of(dep("beta")), "", false)));
+        assertTrue(boom.getMessage().contains("handler collision"), boom.getMessage());
+    }
+
+    @Test
+    @DisplayName("Overloads are NOT duplicates — the guard does not fire on them")
+    void overloadsDoNotTripTheBootGuard() {
+        // The whole point: two DIFFERENT methods sharing one id are legal and
+        // must boot. Only the same method registered twice with different
+        // metadata is a duplicate.
+        scan();
+
+        assertNotSame(
+            registry.getByHandlerMethod(overload(McpMeshTool.class, McpMeshTool.class)),
+            registry.getByHandlerMethod(
+                overload(String.class, McpMeshTool.class, McpMeshTool.class)),
+            "each overload keeps its own metadata");
+    }
+
+    @Test
+    @DisplayName("One handler on several mappings is NOT a duplicate")
+    void severalMappingsOnOneHandlerDoNotTripTheBootGuard() throws Exception {
+        // Registration is per MAPPING with one shared metadata instance —
+        // @GetMapping + @PostMapping on the same handler registers twice.
+        new MeshRouteBeanPostProcessor(registry)
+            .postProcessAfterInitialization(new MultiMappedController(), "multiMapped");
+
+        assertNotNull(registry.getByRoute("GET", "/multi"));
+        assertSame(registry.getByRoute("GET", "/multi"), registry.getByRoute("POST", "/multi"),
+            "both mappings share ONE metadata instance — that is not a duplicate handler");
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/multi");
+        assertTrue(interceptor.preHandle(request, mock(HttpServletResponse.class),
+            new HandlerMethod(new MultiMappedController(),
+                MultiMappedController.class.getDeclaredMethod("both", McpMeshTool.class))));
+        assertEquals(List.of(alphaProxy), resolved(request));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Harness
+    // ─────────────────────────────────────────────────────────────────
+
+    /** Run the real bean post-processor over the overloaded controller. */
+    private void scan() {
+        new MeshRouteBeanPostProcessor(registry)
+            .postProcessAfterInitialization(new OverloadedController(), "overloadedController");
+    }
+
+    private HandlerMethod handlerA() {
+        return new HandlerMethod(new OverloadedController(),
+            overload(McpMeshTool.class, McpMeshTool.class));
+    }
+
+    private HandlerMethod handlerB() {
+        return new HandlerMethod(new OverloadedController(),
+            overload(String.class, McpMeshTool.class, McpMeshTool.class));
+    }
+
+    private static Method overload(Class<?>... paramTypes) {
+        try {
+            // A FRESH reflective copy every call — Method.equals is value-based
+            // over (declaringClass, name, returnType, parameterTypes), which is
+            // what makes a Method-keyed registry lookup work at all.
+            return OverloadedController.class.getDeclaredMethod("handle", paramTypes);
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError("No such overload", e);
+        }
+    }
+
+    private static Object resolve(MeshInjectArgumentResolver resolver, HttpServletRequest request,
+                                  Method method, int parameterIndex) {
+        MethodParameter parameter = new MethodParameter(method, parameterIndex);
+        assertTrue(resolver.supportsParameter(parameter),
+            "parameter " + parameterIndex + " must be an injectable slot");
+        return resolver.resolveArgument(parameter, null,
+            new ServletWebRequest(request), null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<McpMeshTool> resolved(HttpServletRequest request) {
+        return (List<McpMeshTool>)
+            request.getAttribute(MeshRouteHandlerInterceptor.MESH_DEPENDENCIES_ATTR);
+    }
+
+    private static List<String> capabilities(MeshRouteRegistry.RouteMetadata metadata) {
+        return metadata.getDependencies().stream()
+            .map(MeshRouteRegistry.DependencySpec::getCapability)
+            .toList();
+    }
+
+    private static MeshRouteRegistry.DependencySpec dep(String capability) {
+        return new MeshRouteRegistry.DependencySpec(
+            capability, new String[0], "", capability);
+    }
+
+    /**
+     * Two {@code handle} overloads on different mappings, declaring the SAME two
+     * capabilities in OPPOSITE order — so a leaked dependency list is the same
+     * length and holds the same proxies, and only the binding differs.
+     */
+    @RestController
+    @SuppressWarnings("unused")
+    public static class OverloadedController {
+
+        @GetMapping("/a")
+        @MeshRoute(dependencies = {
+            @MeshDependency(capability = "alpha"),
+            @MeshDependency(capability = "beta")})
+        public String handle(McpMeshTool one, McpMeshTool two) {
+            return "a";
+        }
+
+        @GetMapping("/b")
+        @MeshRoute(dependencies = {
+            @MeshDependency(capability = "beta"),
+            @MeshDependency(capability = "alpha")})
+        public String handle(String query, McpMeshTool one, McpMeshTool two) {
+            return "b";
+        }
+
+        @GetMapping("/solo")
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String solo(McpMeshTool one) {
+            return "solo";
+        }
+    }
+
+    /** One handler, two mappings — registered twice with ONE metadata instance. */
+    @RestController
+    @SuppressWarnings("unused")
+    public static class MultiMappedController {
+
+        @GetMapping("/multi")
+        @PostMapping("/multi")
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String both(McpMeshTool one) {
+            return "multi";
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRegistryMethodNameCollisionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRegistryMethodNameCollisionTest.java
@@ -1,0 +1,195 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.Selector;
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Two {@code @MeshTool} methods with the same NAME in different classes must not
+ * share a registry slot (issue #1437).
+ *
+ * <p>{@code wrappersByMethodName} keyed on the bare method name with no class
+ * qualifier at all — the weakest key in the package. It is fallback-only, behind
+ * the funcId lookup in {@code resolveWrapper}, which is what kept it from being
+ * a routine failure; but when the fallback did fire it answered with whichever
+ * wrapper registered last, and a dependency resolution addressed to one tool was
+ * wired into the other tool's slot.
+ *
+ * <p>The name has to stay addressable — it is the wire-facing fallback for a
+ * core that names a slot by function name alone — so the fix is a collision
+ * guard, not a rename: a name claimed by two wrappers resolves to neither, and
+ * both stay addressable by function id and by {@link Method}.
+ */
+@DisplayName("MeshToolWrapperRegistry: same method name in different classes")
+class MeshToolWrapperRegistryMethodNameCollisionTest {
+
+    @Test
+    @DisplayName("A bare method name claimed by two classes resolves to neither")
+    void collidingMethodNameResolvesToNeither() throws Exception {
+        MeshToolWrapperRegistry registry = registry();
+        MeshToolWrapper first = wrapper(FirstAnalyzer.class, new FirstAnalyzer(), "first_analyze");
+        MeshToolWrapper second = wrapper(SecondAnalyzer.class, new SecondAnalyzer(), "second_analyze");
+        registry.registerWrapper(first);
+        registry.registerWrapper(second);
+
+        assertNull(registry.getWrapperByMethodName("analyze"),
+            "'analyze' names both wrappers — it must not resolve to the one that "
+                + "happened to register last");
+    }
+
+    @Test
+    @DisplayName("Both colliding wrappers stay addressable by funcId and by Method")
+    void bothWrappersStayAddressable() throws Exception {
+        MeshToolWrapperRegistry registry = registry();
+        MeshToolWrapper first = wrapper(FirstAnalyzer.class, new FirstAnalyzer(), "first_analyze");
+        MeshToolWrapper second = wrapper(SecondAnalyzer.class, new SecondAnalyzer(), "second_analyze");
+        registry.registerWrapper(first);
+        registry.registerWrapper(second);
+
+        assertSame(first, registry.getWrapper(FirstAnalyzer.class.getName() + ".analyze"));
+        assertSame(second, registry.getWrapper(SecondAnalyzer.class.getName() + ".analyze"));
+        // A FRESH reflective copy — Method.equals is value-based, which is what
+        // makes a Method-keyed index usable from a caller that re-looked it up.
+        assertSame(first, registry.getWrapperByMethod(analyzeOf(FirstAnalyzer.class)));
+        assertSame(second, registry.getWrapperByMethod(analyzeOf(SecondAnalyzer.class)));
+    }
+
+    @Test
+    @DisplayName("A dependency addressed by the colliding name is not wired into the wrong tool")
+    void collidingNameDoesNotMisrouteADependency() throws Exception {
+        MeshToolWrapperRegistry registry = registry();
+        FirstAnalyzer firstBean = new FirstAnalyzer();
+        SecondAnalyzer secondBean = new SecondAnalyzer();
+        registry.registerWrapper(wrapper(FirstAnalyzer.class, firstBean, "first_analyze"));
+        MeshToolWrapper second = wrapper(SecondAnalyzer.class, secondBean, "second_analyze");
+        registry.registerWrapper(second);
+
+        // The wire fallback: a composite key naming the tool by bare method name.
+        // 'second' registered last, so on the unguarded map it took this apply —
+        // silently wiring FIRST's dependency into SECOND's slot 0.
+        registry.updateDependency("analyze:dep_0", "http://provider", "lookup");
+
+        second.invoke(Map.of("q", "x"));
+        assertEquals(1, secondBean.received.size());
+        assertNull(secondBean.received.get(0),
+            "the second tool's slot must not receive a resolution addressed to an "
+                + "ambiguous name");
+    }
+
+    @Test
+    @DisplayName("An unambiguous method name still resolves — the fallback still works")
+    void unambiguousMethodNameStillResolves() throws Exception {
+        MeshToolWrapperRegistry registry = registry();
+        FirstAnalyzer bean = new FirstAnalyzer();
+        MeshToolWrapper only = wrapper(FirstAnalyzer.class, bean, "first_analyze");
+        registry.registerWrapper(only);
+
+        assertSame(only, registry.getWrapperByMethodName("analyze"));
+
+        registry.updateDependency("analyze:dep_0", "http://provider", "lookup");
+        only.invoke(Map.of("q", "x"));
+        assertEquals("lookup", capabilityOf(bean.received.get(0)),
+            "the bare-name fallback must still deliver when the name names one tool");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Harness
+    // ─────────────────────────────────────────────────────────────────
+
+    private static MeshToolWrapperRegistry registry() {
+        return new MeshToolWrapperRegistry(new StubProxyFactory());
+    }
+
+    private static MeshToolWrapper wrapper(Class<?> type, Object bean, String capability)
+            throws Exception {
+        Method method = analyzeOf(type);
+        return new MeshToolWrapper(
+            type.getName() + ".analyze",
+            capability,
+            "test",
+            bean,
+            method,
+            List.of("lookup"),
+            JsonMapper.builder().build());
+    }
+
+    private static Method analyzeOf(Class<?> type) throws NoSuchMethodException {
+        return type.getMethod("analyze", String.class, McpMeshTool.class);
+    }
+
+    private static String capabilityOf(Object dep) {
+        return dep == null ? null : ((McpMeshTool<?>) dep).getCapability();
+    }
+
+    /** Hands back a stub proxy labelled with the resolved function name. */
+    static class StubProxyFactory extends McpMeshToolProxyFactory {
+        StubProxyFactory() {
+            super(new McpHttpClient());
+        }
+
+        @Override
+        public McpMeshTool getOrCreateProxy(String endpoint, String functionName) {
+            return new StubProxy(functionName);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> McpMeshTool<T> getOrCreateProxy(String endpoint, String functionName,
+                                                   Type returnType) {
+            return (McpMeshTool<T>) new StubProxy(functionName);
+        }
+    }
+
+    static class StubProxy implements McpMeshTool<String> {
+        private final String capability;
+        StubProxy(String capability) { this.capability = capability; }
+        @Override public String call() { return capability; }
+        @Override public String call(Map<String, Object> params) { return capability; }
+        @Override public String call(Object... args) { return capability; }
+        @Override public CompletableFuture<String> callAsync() { return CompletableFuture.completedFuture(capability); }
+        @Override public CompletableFuture<String> callAsync(Map<String, Object> params) { return CompletableFuture.completedFuture(capability); }
+        @Override public CompletableFuture<String> callAsync(Object... keyValuePairs) { return CompletableFuture.completedFuture(capability); }
+        @Override public String getCapability() { return capability; }
+        @Override public String getEndpoint() { return "http://" + capability; }
+        @Override public String getFunctionName() { return capability; }
+        @Override public boolean isAvailable() { return true; }
+    }
+
+    /** Two DIFFERENT classes, both with a tool method named {@code analyze}. */
+    public static class FirstAnalyzer {
+        final List<McpMeshTool<?>> received = new ArrayList<>();
+
+        @MeshTool(capability = "first_analyze", dependencies = @Selector(capability = "lookup"))
+        public Object analyze(@Param("q") String q, McpMeshTool<String> lookup) {
+            received.clear();
+            received.add(lookup);
+            return Map.of("q", q);
+        }
+    }
+
+    public static class SecondAnalyzer {
+        final List<McpMeshTool<?>> received = new ArrayList<>();
+
+        @MeshTool(capability = "second_analyze", dependencies = @Selector(capability = "lookup"))
+        public Object analyze(@Param("q") String q, McpMeshTool<String> lookup) {
+            received.clear();
+            received.add(lookup);
+            return Map.of("q", q);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`MeshRouteRegistry.routesByHandler` was keyed by `"ClassName.methodName"` — no parameter types — and written with a bare `put`. Two overloaded `@MeshRoute` handlers in one controller therefore shared one entry, and `MeshRouteHandlerInterceptor.preHandle` built the **injected dependency list** from whichever registered last.

The last untouched instance of the defect class fixed twice in #1436.

## #1436 made this worse, and the corruption is nondeterministic

Route dependencies became positional in #1436, so a collision now hands one overload the other's proxies **by index** — same length, same types, nothing about the result signals the swap:

```
PROBE-A getByHandlerMethodId(Ctrl.handle) -> [beta, alpha]   <-- used for BOTH overloads
PROBE-A /a    DECLARES  [0]=alpha [1]=beta
PROBE-A /a    RECEIVES  [BETA-PROXY, ALPHA-PROXY]
PROBE-A /a    parameter 0 (slot 0) <- BETA-PROXY     EXPECT ALPHA-PROXY
```

Driven through the real `MeshInjectArgumentResolver`, not a mock.

**And which overload breaks is not stable.** An earlier probe on the *same unfixed binary* produced the opposite victim — `/b` corrupted instead of `/a` — because `getDeclaredMethods()` order is unspecified. The same artifact can corrupt a different route across JVM restarts.

After the fix, three consecutive runs are identical: `/a` gets ALPHA/BETA, `/b` gets BETA/ALPHA.

## What changed

**Route registry keyed by `Method`.** `preHandle` looks up with `handlerMethod.getMethod()`; the string id is retained for **logs only**, per #1436's precedent. `RouteMetadata` gained a canonical `(Method, deps, description, failOnMissing)` constructor that derives the id.

**Boot guard**, matching `MeshA2ARegistry`: `putIfAbsent` on the `Method` map, throwing when a *different* metadata instance claims a registered `Method`. Identity comparison is load-bearing — a handler with several mappings (`@GetMapping` + `@PostMapping`) registers once per mapping with one shared instance, and the guard must not fire on that. Both cases are asserted.

**Public API — deprecated, with a `Method` overload, and it now refuses ambiguity.** `getByHandlerMethodId(String)` is public API on a published artifact, so removing it breaks source and binary compatibility for anyone with a custom interceptor. Leaving it undeprecated invites new callers onto a key that cannot answer. Documenting it as "best-effort but ambiguous under overloads" was the alternative and was rejected — that is exactly what the issue's acceptance criterion forbids. It now returns `null` with an ERROR log for a contested id and answers normally otherwise. No in-tree callers outside the starter.

The interceptor keeps a string fallback for `RouteMetadata` built from a bare id (5 existing tests) and for exotic proxying. Because the registry refuses an ambiguous id, that fallback can never resolve one overload to another's dependencies.

## `MeshToolWrapperRegistry` — the obvious fix would have broken it

Qualifying the key with the declaring class kills the fallback: `resolveWrapper:229` is fed a **wire-supplied** funcId that may be a bare function name (`MeshEventProcessor:300,463`). So the bare-name index keeps its key and gains a **collision guard** — a name claimed by two wrappers resolves to *neither*, and both stay addressable by funcId and by `Method`.

Before, the cross-class case wrote to the wrong tool's slot:

```
PROBE-B getWrapperByMethodName("analyze") -> ...$SecondAnalyzer.analyze
PROBE-B after updateDependency("analyze:dep_0", ...):
PROBE-B   FirstAnalyzer.analyze  slot0 = null
PROBE-B   SecondAnalyzer.analyze slot0 = lookup     <-- wrong tool's slot written
```

Added `getWrapperByMethod(Method)`, used by `JobsRuntimeManager:395`, which held the `Method` and was degrading to its name. The sibling `handlersByMethodName` was **write-only dead code** — no getter, no internal read — and is deleted.

`MeshLlmRegistry.configsByMethod` keyed `Class#methodName`; both readers already take a `Method` and neither has a production caller, so it is keyed by `Method` directly.

## No behaviour change for the normal case

All 11 in-tree `@MeshRoute`-bearing modules compiled, then a scanner run through the **real** post-processor, interceptor and argument resolver against both trees:

```
CENSUS handlers=14 slots=12 classes=41
===== DIFF before vs after =====
NO DIFFERENCES
```

14 matches #1436's independent `route=14` census exactly.

`Method` value-semantics are pinned too (`freshMethodCopiesAreEqualKeys`): two separate `getDeclaredMethod` calls are `assertNotSame` but `assertEquals` with equal `hashCode` and hit the same entry, while the overloads are `assertNotEquals`.

## Suite

| | classes | tests | failures |
|---|---|---|---|
| baseline `67606213a` | 190 | 1119 | 0 |
| after | 192 | **1133** | 0 |

`MeshPositionalBinderTest`, `MeshToolWrapperUnresolvedDepPositionTest`, `MeshA2ADispatcherOverloadedHandlerTest` and `MeshRoutePositionalBindingTest` all pass **unedited**. `go build ./...` clean.

## Found while working, not fixed — worth their own issues

**1. Every `@MeshRoute` handler also registers a phantom route at the controller base path.** `MeshRouteBeanPostProcessor.getMappingInfo` falls through to `AnnotationUtils.findAnnotation(method, RequestMapping.class)`, which resolves the **meta-annotation** on `@GetMapping` with empty `value`/`path` — `findAnnotation` does not apply `@AliasFor` overrides, where `AnnotatedElementUtils.findMergedAnnotation` would. Three handlers produced four routes:

```
PROBE-C registered route count = 4
PROBE-C   GET:/ -> [beta, alpha]      <-- phantom, arbitrary winner
PROBE-C   GET:/a -> [alpha, beta]
```

Currently mild — `routesByPath` is not on the interceptor's path and its readers dedupe by capability — but `getRouteCount()` over-reports and `getByRoute(m, "/")` returns an arbitrary handler.

**2. The same defect shape exists one layer up, in wire identities.** `@MeshTool` funcId is `Class.methodName` and `MeshLlmRegistry.configsByFunctionId` likewise — both omit parameter types. These are **protocol** keys the Rust core echoes back, so re-keying is a wire change, not a refactor. Related and more immediate: `MeshMcpServerConfiguration:158` uses the bare `handler.getMethodName()` as the **MCP tool name**, so two same-named `@MeshTool` methods in different classes already collide at the MCP layer before reaching any registry.

**3. `routesByPath` is still a bare `put`** — duplicate path mappings silently overwrite. Spring MVC rejects ambiguous mappings itself, so it is guarded downstream; left alone since the issue's guard requirement was about handler identity.

Closes #1437


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented collisions between overloaded methods and same-named tools or routes.
  * Improved route and tool resolution accuracy by distinguishing exact handlers.
  * Ambiguous method-name lookups now fail safely instead of selecting an arbitrary handler.
  * Preserved compatibility for existing unambiguous lookups.

* **Tests**
  * Added coverage for overloaded methods, duplicate registrations, dependency wiring, and method-name collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->