### PR TITLE
fix(java): treat same-identity re-registration as replacement, not collision

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapperRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapperRegistry.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -168,19 +169,33 @@ public class MeshToolWrapperRegistry {
      * dependency resolution into the wrong tool's slot. Both remain fully
      * addressable by {@code funcId} and by {@link Method}, which is how they are
      * addressed in practice.
+     *
+     * <p>The collision discriminator is the <b>funcId</b>, not the wrapper
+     * instance: {@link #registerWrapper} stores every other index ({@link #wrappers},
+     * {@link #wrappersByMethod}, {@link #handlers}, {@link #handlersByCapability})
+     * with a bare {@code put}, so re-registering the same funcId with a fresh
+     * wrapper instance cleanly replaces the old one everywhere. Treating that as a
+     * collision here — on instance identity — would permanently poison bare-name
+     * resolution for a tool that never actually collided with anything.
      */
     private void indexBareMethodName(String methodName, MeshToolWrapper wrapper) {
         if (methodName == null) {
             return;
         }
         MeshToolWrapper previous = wrappersByMethodName.putIfAbsent(methodName, wrapper);
-        if (previous != null && previous != wrapper) {
-            ambiguousMethodNames.add(methodName);
-            log.warn("Method name '{}' is registered by more than one @MeshTool ({} and {}) — "
-                    + "it no longer resolves a wrapper by name alone. Both remain addressable "
-                    + "by their function ids.",
-                methodName, previous.getFuncId(), wrapper.getFuncId());
+        if (previous == null) {
+            return;
         }
+        if (Objects.equals(previous.getFuncId(), wrapper.getFuncId())) {
+            // Re-registration of the same tool: replace, exactly like every other index.
+            wrappersByMethodName.put(methodName, wrapper);
+            return;
+        }
+        ambiguousMethodNames.add(methodName);
+        log.warn("Method name '{}' is registered by more than one @MeshTool ({} and {}) — "
+                + "it no longer resolves a wrapper by name alone. Both remain addressable "
+                + "by their function ids.",
+            methodName, previous.getFuncId(), wrapper.getFuncId());
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteHandlerInterceptor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteHandlerInterceptor.java
@@ -119,10 +119,15 @@ public class MeshRouteHandlerInterceptor implements HandlerInterceptor {
         //
         // The id is kept for log lines below, where the ambiguity is harmless
         // and it reads better than Method.toString().
+        //
+        // It is built by RouteMetadata's own helper so it matches what
+        // registration indexed. Deriving it from the BEAN TYPE instead diverged
+        // for a handler inherited from a base class (declaring class = base,
+        // bean type = concrete controller) and the fallback silently missed.
         MeshRouteRegistry.RouteMetadata metadata =
             registry.getByHandlerMethod(handlerMethod.getMethod());
-        String handlerMethodId = handlerMethod.getBeanType().getName() + "." +
-            handlerMethod.getMethod().getName();
+        String handlerMethodId = MeshRouteRegistry.RouteMetadata.buildHandlerMethodId(
+            handlerMethod.getMethod());
         if (metadata == null) {
             // Compatibility fallback for metadata registered without a Method
             // identity, and for the exotic proxying arrangements where the

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteRegistry.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -78,17 +79,23 @@ public class MeshRouteRegistry {
      * @param httpMethod HTTP method (GET, POST, etc.)
      * @param path       URL path pattern
      * @param metadata   Route metadata
-     * @throws IllegalStateException when a DIFFERENT handler is already
+     * @throws IllegalStateException when a CONFLICTING route is already
      *                               registered for the same {@link Method} —
-     *                               a genuine duplicate registration, which
-     *                               fails the boot rather than silently winning
-     *                               (issue #1437, matching
-     *                               {@link MeshA2ARegistry#register})
+     *                               i.e. different metadata declaring a
+     *                               different dependency list, which fails the
+     *                               boot rather than silently winning (issue
+     *                               #1437, matching
+     *                               {@link MeshA2ARegistry#register}).
+     *                               Re-registering the same handler with an
+     *                               equal dependency list is idempotent and does
+     *                               NOT throw. Indexing happens BEFORE the path
+     *                               map is written, so a rejected registration
+     *                               leaves the registry untouched.
      */
     public void register(String httpMethod, String path, RouteMetadata metadata) {
         String routeId = buildRouteId(httpMethod, path);
-        routesByPath.put(routeId, metadata);
         indexHandler(metadata);
+        routesByPath.put(routeId, metadata);
 
         // Settling-window grace (#1193): declare this route's dependency
         // capabilities with the process-wide settle state so the
@@ -127,18 +134,31 @@ public class MeshRouteRegistry {
      * registered once PER MAPPING with the SAME metadata instance. That is not a
      * duplicate: the guard fires only when a <b>different</b> metadata instance
      * claims a {@link Method} that is already registered.
+     *
+     * <p>Nor is a re-scan a duplicate: two bean definitions of the same
+     * controller class yield two distinct-but-equal {@link RouteMetadata} for the
+     * same {@link Method}. Instance identity would fail the boot on that, while
+     * {@link #register} itself replaces in {@link #routesByPath} without
+     * complaint. So the guard is narrowed to the thing that actually matters —
+     * the injected dependency list, which is what a lookup here feeds
+     * (positionally, since #1401): equal dependencies means the re-registration
+     * is a no-op and the incoming metadata simply replaces the old mapping;
+     * only a genuinely different dependency list throws.
      */
     private void indexHandler(RouteMetadata metadata) {
         Method handlerMethod = metadata.getHandlerMethod();
         if (handlerMethod != null) {
             RouteMetadata previous = routesByHandlerMethod.putIfAbsent(handlerMethod, metadata);
             if (previous != null && previous != metadata) {
-                throw new IllegalStateException(
-                    "@MeshRoute handler collision: " + handlerMethod
-                        + " is already registered with a different route metadata"
-                        + " (dependencies " + previous.getDependencies() + " vs "
-                        + metadata.getDependencies() + "). Each handler method must be"
-                        + " registered exactly once.");
+                if (!previous.getDependencies().equals(metadata.getDependencies())) {
+                    throw new IllegalStateException(
+                        "@MeshRoute handler collision: " + handlerMethod
+                            + " is already registered with a different route metadata"
+                            + " (dependencies " + previous.getDependencies() + " vs "
+                            + metadata.getDependencies() + "). Each handler method must be"
+                            + " registered exactly once.");
+                }
+                routesByHandlerMethod.put(handlerMethod, metadata);
             }
         }
 
@@ -472,7 +492,16 @@ public class MeshRouteRegistry {
             this.failOnMissingDependency = failOnMissingDependency;
         }
 
-        private static String buildHandlerMethodId(Method method) {
+        /**
+         * The single source of the {@code "ClassName.methodName"} id.
+         *
+         * <p>Package-visible so lookup sites — {@link MeshRouteHandlerInterceptor}'s
+         * compatibility fallback — build the id exactly the way registration did
+         * (issue #1437). Deriving it independently from the bean type instead of
+         * the DECLARING class diverges for a handler inherited from a base class,
+         * and the fallback then silently misses.
+         */
+        static String buildHandlerMethodId(Method method) {
             return method == null ? null
                 : method.getDeclaringClass().getName() + "." + method.getName();
         }
@@ -694,6 +723,39 @@ public class MeshRouteRegistry {
 
         public boolean hasVersion() {
             return version != null && !version.isEmpty();
+        }
+
+        /**
+         * Value equality over every declared field.
+         *
+         * <p>Load-bearing, not decoration: {@link MeshRouteRegistry#indexHandler}
+         * distinguishes an idempotent re-registration of a handler from a genuine
+         * conflicting one by comparing the two {@code List<DependencySpec>}. On the
+         * inherited identity {@code equals} that comparison could never be true for
+         * two separately-built specs, and the narrowed guard would be inert.
+         */
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof DependencySpec other)) {
+                return false;
+            }
+            return required == other.required
+                && Objects.equals(capability, other.capability)
+                && Arrays.equals(tags, other.tags)
+                && Objects.equals(version, other.version)
+                && Objects.equals(parameterName, other.parameterName)
+                && Objects.equals(expectedType, other.expectedType)
+                && schemaMode == other.schemaMode
+                && Objects.equals(returnType, other.returnType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(capability, Arrays.hashCode(tags), version, parameterName,
+                expectedType, schemaMode, required, returnType);
         }
 
         @Override

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshRouteRegistryReRegistrationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshRouteRegistryReRegistrationTest.java
@@ -1,0 +1,280 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshRoute;
+import io.mcpmesh.spring.web.MeshRouteBeanPostProcessor;
+import io.mcpmesh.spring.web.MeshRouteHandlerInterceptor;
+import io.mcpmesh.spring.web.MeshRouteRegistry;
+import io.mcpmesh.types.McpMeshTool;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.method.HandlerMethod;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@code MeshRouteRegistry} must distinguish a re-registration of a handler from
+ * a conflicting one, and must build its handler id the same way at registration
+ * and at lookup (issue #1437 follow-ups).
+ *
+ * <p>Three separate defects, all in the same family — a guard keyed on something
+ * narrower or wider than the thing it is actually protecting:
+ *
+ * <ul>
+ *   <li>{@code indexHandler} failed the boot whenever a DIFFERENT INSTANCE of
+ *       {@code RouteMetadata} claimed an already-registered {@code Method}, while
+ *       {@code register} itself replaced in {@code routesByPath} without
+ *       complaint. Two bean definitions of one controller class produce two
+ *       distinct-but-equal metadata objects for the same method — not a
+ *       duplicate. The guard now compares what a lookup here actually feeds: the
+ *       (positional, since #1401) dependency list.</li>
+ *   <li>{@code register} mutated {@code routesByPath} BEFORE running that guard,
+ *       so a rejected registration left the path map already written.</li>
+ *   <li>The interceptor's compatibility fallback built its lookup id from the
+ *       HandlerMethod's BEAN TYPE while registration built it from the method's
+ *       DECLARING class. Identical for a handler declared on the controller
+ *       itself; divergent for one inherited from a base class — and the fallback
+ *       then silently missed.</li>
+ * </ul>
+ *
+ * <p>Note on the inherited case: {@code MeshRouteBeanPostProcessor} scans
+ * {@code getDeclaredMethods()}, so an inherited handler is not auto-discovered
+ * on the subclass bean. The divergence is therefore reached through the
+ * string-id registration path — the public
+ * {@code RouteMetadata(String, List, String, boolean)} constructor — which is
+ * precisely the arrangement the interceptor's fallback exists to serve.
+ *
+ * <p>Placed in {@code io.mcpmesh.spring} so {@code MeshSettleState}'s
+ * package-private test reset is visible — settled=true short-circuits the
+ * settling-window wait, matching {@code MeshRouteOverloadedHandlerTest}.
+ */
+@DisplayName("MeshRouteRegistry: re-registration, ordering, and handler id alignment")
+class MeshRouteRegistryReRegistrationTest {
+
+    private MeshRouteRegistry registry;
+    private MeshDependencyInjector injector;
+    private MeshRouteHandlerInterceptor interceptor;
+
+    private McpMeshTool alphaProxy;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        MeshSettleState.resetForTests(0.0);
+        registry = new MeshRouteRegistry();
+        injector = mock(MeshDependencyInjector.class);
+        ObjectProvider<MeshDependencyInjector> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(injector);
+        interceptor = new MeshRouteHandlerInterceptor(registry, provider);
+
+        alphaProxy = mock(McpMeshTool.class, "alpha-proxy");
+        when(alphaProxy.isAvailable()).thenReturn(true);
+        when(injector.getToolProxy("alpha")).thenReturn(alphaProxy);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Re-registration vs. conflict
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("A second scan of the same controller is idempotent, not a duplicate")
+    void reScanningTheSameControllerDoesNotFailTheBoot() {
+        MeshRouteBeanPostProcessor scanner = new MeshRouteBeanPostProcessor(registry);
+        Method handle = handlerOf(ReScannedController.class);
+
+        scanner.postProcessAfterInitialization(new ReScannedController(), "primary");
+        MeshRouteRegistry.RouteMetadata first = registry.getByHandlerMethod(handle);
+        assertNotNull(first);
+
+        // A SECOND bean definition of the same controller class. The scanner
+        // builds a fresh RouteMetadata and a fresh List<DependencySpec> from the
+        // annotation every pass, so nothing is shared with the first pass.
+        assertDoesNotThrow(
+            () -> scanner.postProcessAfterInitialization(new ReScannedController(), "secondary"),
+            "two bean definitions of one controller are not a duplicate handler");
+
+        MeshRouteRegistry.RouteMetadata second = registry.getByHandlerMethod(handle);
+        assertNotSame(first, second, "the incoming metadata must win the Method index");
+        assertSame(second, registry.getByRoute("GET", "/rescan"),
+            "and routesByPath must hold that same incoming instance");
+    }
+
+    @Test
+    @DisplayName("The idempotency verdict rests on DependencySpec VALUE equality")
+    void reRegistrationIsJudgedByDependencyValueEquality() {
+        // This is what makes the narrowed guard a guard at all. DependencySpec
+        // had no equals/hashCode, so List.equals fell through to element
+        // IDENTITY — two separately-built specs could never compare equal and
+        // the narrowed condition would be inert, i.e. indistinguishable from the
+        // instance-identity check it replaced. Strip DependencySpec.equals and
+        // both this test and reScanningTheSameControllerDoesNotFailTheBoot fail.
+        MeshRouteBeanPostProcessor scanner = new MeshRouteBeanPostProcessor(registry);
+        Method handle = handlerOf(ReScannedController.class);
+
+        scanner.postProcessAfterInitialization(new ReScannedController(), "primary");
+        List<MeshRouteRegistry.DependencySpec> firstDeps =
+            registry.getByHandlerMethod(handle).getDependencies();
+        scanner.postProcessAfterInitialization(new ReScannedController(), "secondary");
+        List<MeshRouteRegistry.DependencySpec> secondDeps =
+            registry.getByHandlerMethod(handle).getDependencies();
+
+        assertNotSame(firstDeps, secondDeps);
+        assertNotSame(firstDeps.get(0), secondDeps.get(0),
+            "the two scans must produce SEPARATE spec objects — otherwise this "
+                + "proves nothing about value equality");
+        assertEquals(firstDeps, secondDeps,
+            "equal declarations must compare equal BY VALUE");
+        assertEquals(firstDeps.get(0).hashCode(), secondDeps.get(0).hashCode(),
+            "equals without a matching hashCode is a broken contract");
+    }
+
+    @Test
+    @DisplayName("A conflicting registration still fails the boot, naming both lists")
+    void conflictingRegistrationStillFailsBoot() {
+        Method handle = handlerOf(ReScannedController.class);
+        registry.register("GET", "/first", new MeshRouteRegistry.RouteMetadata(
+            handle, List.of(dep("alpha")), "", false));
+
+        IllegalStateException boom = assertThrows(IllegalStateException.class, () ->
+            registry.register("GET", "/second", new MeshRouteRegistry.RouteMetadata(
+                handle, List.of(dep("beta")), "", false)),
+            "narrowing the guard must not swallow a genuine conflict");
+
+        // The diagnostic is the whole value of failing here rather than later, at
+        // some request that silently got the other handler's proxies.
+        assertTrue(boom.getMessage().contains("handler collision"), boom.getMessage());
+        assertTrue(boom.getMessage().contains("[alpha]"),
+            "the message must name the ALREADY-registered dependency list: " + boom.getMessage());
+        assertTrue(boom.getMessage().contains("[beta]"),
+            "the message must name the INCOMING dependency list: " + boom.getMessage());
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Ordering
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("A rejected registration leaves routesByPath untouched")
+    void rejectedRegistrationDoesNotMutateTheRouteMap() {
+        Method handle = handlerOf(ReScannedController.class);
+        MeshRouteRegistry.RouteMetadata accepted = new MeshRouteRegistry.RouteMetadata(
+            handle, List.of(dep("alpha")), "", false);
+        registry.register("GET", "/first", accepted);
+
+        assertThrows(IllegalStateException.class, () ->
+            registry.register("GET", "/second", new MeshRouteRegistry.RouteMetadata(
+                handle, List.of(dep("beta")), "", false)));
+
+        // The throw is not the assertion — this is. register() used to write
+        // routesByPath BEFORE the guard ran, so a registration it then rejected
+        // still left the path resolvable, and every path-keyed consumer
+        // (getUniqueDependencySpecs, promoteCapabilityToRequired, the heartbeat
+        // spec) saw a route the registry had refused.
+        assertNull(registry.getByRoute("GET", "/second"),
+            "the rejected route must not be resolvable by path");
+        assertEquals(1, registry.getRouteCount(), "only the accepted route may be present");
+        assertSame(accepted, registry.getByRoute("GET", "/first"));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Handler id alignment
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("An inherited handler's id agrees between registration and lookup")
+    void inheritedHandlerIdMatchesAtLookup() throws Exception {
+        // Registration derives the id from the method's DECLARING class, so a
+        // handler inherited from a base class is registered under the BASE name.
+        String registeredId = BaseUploadController.class.getName() + ".handle";
+        MeshRouteRegistry.RouteMetadata metadata = new MeshRouteRegistry.RouteMetadata(
+            registeredId, List.of(dep("alpha")), "", false);
+        registry.register("GET", "/inherited", metadata);
+
+        Method inherited = ConcreteUploadController.class.getMethod("handle", McpMeshTool.class);
+        HandlerMethod handlerMethod = new HandlerMethod(new ConcreteUploadController(), inherited);
+        // The divergence itself: these two are NOT the same class.
+        assertEquals(BaseUploadController.class, inherited.getDeclaringClass());
+        assertEquals(ConcreteUploadController.class, handlerMethod.getBeanType());
+
+        // Metadata carries no Method identity, so preHandle must reach it through
+        // the compatibility fallback — which is where the two id constructions
+        // meet. Built from the bean type, the fallback looked up
+        // "ConcreteUploadController.handle" and missed.
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/inherited");
+        assertTrue(interceptor.preHandle(request, mock(HttpServletResponse.class), handlerMethod));
+        assertEquals(List.of(alphaProxy), resolved(request),
+            "the inherited handler must receive its declared dependency — on the "
+                + "bean-type id the fallback missed and the route was served with none");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Harness
+    // ─────────────────────────────────────────────────────────────────
+
+    private static Method handlerOf(Class<?> type) {
+        try {
+            return type.getDeclaredMethod("handle", McpMeshTool.class);
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError("No such handler", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<McpMeshTool> resolved(HttpServletRequest request) {
+        return (List<McpMeshTool>)
+            request.getAttribute(MeshRouteHandlerInterceptor.MESH_DEPENDENCIES_ATTR);
+    }
+
+    private static MeshRouteRegistry.DependencySpec dep(String capability) {
+        return new MeshRouteRegistry.DependencySpec(
+            capability, new String[0], "", capability);
+    }
+
+    /** Scanned twice, as two bean definitions of one controller class would be. */
+    @RestController
+    @SuppressWarnings("unused")
+    public static class ReScannedController {
+
+        @GetMapping("/rescan")
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String handle(McpMeshTool one) {
+            return "rescan";
+        }
+    }
+
+    /** Declares the handler; the concrete controller below only inherits it. */
+    @RestController
+    @SuppressWarnings("unused")
+    public abstract static class BaseUploadController {
+
+        @GetMapping("/inherited")
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String handle(McpMeshTool one) {
+            return "inherited";
+        }
+    }
+
+    /** Bean type = this class; declaring class of {@code handle} = the base. */
+    @RestController
+    public static class ConcreteUploadController extends BaseUploadController {
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRegistryMethodNameCollisionTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRegistryMethodNameCollisionTest.java
@@ -107,6 +107,36 @@ class MeshToolWrapperRegistryMethodNameCollisionTest {
             "the bare-name fallback must still deliver when the name names one tool");
     }
 
+    @Test
+    @DisplayName("Re-registering the same tool replaces it — it does not collide with itself")
+    void reRegisteringSameFuncIdReplacesRatherThanCollides() throws Exception {
+        MeshToolWrapperRegistry registry = registry();
+        FirstAnalyzer staleBean = new FirstAnalyzer();
+        FirstAnalyzer freshBean = new FirstAnalyzer();
+        // Two FRESH wrapper instances for the SAME funcId (same class, same method).
+        MeshToolWrapper stale = wrapper(FirstAnalyzer.class, staleBean, "first_analyze");
+        MeshToolWrapper fresh = wrapper(FirstAnalyzer.class, freshBean, "first_analyze");
+        registry.registerWrapper(stale);
+        registry.registerWrapper(fresh);
+
+        // Every other index in registerWrapper replaces on a bare put; the
+        // bare-name index must not be the one map that treats a re-registration
+        // as a collision and poisons the name forever.
+        assertSame(fresh, registry.getWrapperByMethodName("analyze"),
+            "a re-registration of the same funcId must replace the mapping, not "
+                + "make the name ambiguous");
+
+        registry.updateDependency("analyze:dep_0", "http://provider", "lookup");
+        fresh.invoke(Map.of("q", "x"));
+        assertEquals("lookup", capabilityOf(freshBean.received.get(0)),
+            "the resolution must land on the replacement bean");
+
+        stale.invoke(Map.of("q", "x"));
+        assertNull(staleBean.received.get(0),
+            "the replaced wrapper's slot must stay unwired — the apply went to the "
+                + "replacement, not to the instance it superseded");
+    }
+
     // ─────────────────────────────────────────────────────────────────
     // Harness
     // ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Follow-up to #1441. Those guards correctly stop an overload being served another overload's positional dependencies, but both discriminate on **instance identity**, which also catches a legitimate case: re-registering the same logical handler.

- **`indexBareMethodName` keys on `funcId`, not identity.** `registerWrapper`'s other four indices use a bare `put`, so a same-`funcId` re-register replaced cleanly in four places and permanently poisoned the fifth — a tool that never collided became unresolvable by bare method name.
- **`indexHandler` throws only when dependency lists actually differ.** Two bean definitions of one controller class produced equal-but-distinct `RouteMetadata` for a single `Method` and failed the boot.
- **`DependencySpec` gains value `equals`/`hashCode`.** Load-bearing, not decoration — see below.
- **`register()` indexes before publishing** to `routesByPath`, so a rejected registration leaves the registry unmutated.
- **`buildHandlerMethodId` is the single source of the handler id.** The interceptor built its fallback key from the bean type, which diverges from the declaring class and missed.

## Review notes

**The narrowed route guard is inert without `DependencySpec.equals`.** `List.equals` on `List<DependencySpec>` falls through to element identity, so "throw only when dependencies differ" behaves exactly like the unconditional throw. Demonstrated rather than argued: with the narrowed guard in place but `equals` stripped, the pre-fix failure reproduces byte-identically. The existing diagnostic was its own tell — it reported `(dependencies [alpha] vs [alpha])`, a collision error complaining that two identical lists conflict.

`required` and `returnType` are mutable post-construction, so `hashCode` is not stable over an instance's lifetime. `DependencySpec` is not used as a `Set` element or `Map` key anywhere in the starter's main sources today, but that is now a constraint.

**Scope of the handler-id fix is narrower than it first appears.** `MeshRouteBeanPostProcessor` scans `getDeclaredMethods()`, so an inherited `@MeshRoute` handler is never auto-discovered on the subclass at all. The divergence is reachable through the string-id constructor and programmatic registration — which is exactly what that fallback documents itself as serving. Whether the post-processor *should* scan inherited handlers is a separate open question.

**Two review suggestions were skipped.** Downgrading the ambiguous-name refusal from ERROR to DEBUG — that line fires when a dependency resolution is being dropped, which is the condition #1437 exists to surface; it is not on a per-request path. And replacing `@GetMapping`+`@PostMapping` with `@RequestMapping(method={GET,POST})` in the overload test — `getMappingInfo` reads those in separate branches, so the current form is what exercises the one-metadata-registered-twice path; `@RequestMapping` is already covered by a different branch.

## Test plan

- [x] Every fix pinned by a test verified to fail with **that fix alone** reverted, one at a time in an isolated copy
- [x] `equals`-stripped run confirms the narrowed guard would otherwise be inert
- [x] `MeshRouteOverloadedHandlerTest` stays 9/9 green under the narrowing, confirming it did not change what that suite pins
- [x] Full starter module suite: 793 tests, 0 failures
- [x] One draft test deleted for passing both before and after — it pinned nothing
- [ ] CI green

`conflictingRegistrationStillFailsBoot` also passes pre-fix and is kept deliberately: it is not a pin of the narrowing but the counterweight to it, failing if anyone later widens the guard and swallows a real conflict.

Closes #1444
