### PR TITLE
fix: boot-fail on duplicate advertised MCP tool names; drop phantom base-path route

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshMcpServerConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshMcpServerConfiguration.java
@@ -68,6 +68,9 @@ public class MeshMcpServerConfiguration {
     private static final Map<String, Object> WRAP_RESULT_META =
         Map.of("fastmcp", Map.of("wrap_result", true));
 
+    /** funcId prefix {@code LlmProviderToolWrapper} builds ({@code llm_provider:<capability>}). */
+    private static final String LLM_PROVIDER_FUNC_ID_PREFIX = "llm_provider:";
+
     // MCP SDK 2.0.0 uses Jackson 3 (tools.jackson)
     private final tools.jackson.databind.json.JsonMapper mcpJsonMapper;
 
@@ -216,9 +219,20 @@ public class MeshMcpServerConfiguration {
                 continue;
             }
             String funcId = handler.getFuncId();
-            String previousFuncId = claimedBy.putIfAbsent(toolName, funcId);
-            if (previousFuncId == null || Objects.equals(previousFuncId, funcId)) {
-                // Unclaimed, or the same declaration re-registered — both fine.
+            // containsKey, NOT putIfAbsent: the map permits null values, and
+            // putIfAbsent REPLACES a null-valued mapping and returns null — so a
+            // name first claimed by a handler with a null funcId would read as
+            // unclaimed for every later claimant, and the collision this guard
+            // exists to catch would walk straight through. Nothing enforces a
+            // non-null funcId: McpToolHandler is a public interface and
+            // getFuncId() has no default.
+            if (!claimedBy.containsKey(toolName)) {
+                claimedBy.put(toolName, funcId);
+                continue;
+            }
+            String previousFuncId = claimedBy.get(toolName);
+            if (Objects.equals(previousFuncId, funcId)) {
+                // The same declaration re-registered — fine.
                 continue;
             }
             throw new IllegalStateException(String.format(
@@ -255,9 +269,6 @@ public class MeshMcpServerConfiguration {
         }
         return "Rename one of the methods, or move one of the tools to a separate agent.";
     }
-
-    /** funcId prefix {@code LlmProviderToolWrapper} builds ({@code llm_provider:<capability>}). */
-    private static final String LLM_PROVIDER_FUNC_ID_PREFIX = "llm_provider:";
 
     /**
      * Register a McpToolHandler as an MCP tool specification.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshMcpServerConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshMcpServerConfiguration.java
@@ -23,9 +23,11 @@ import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * MCP Server configuration for MCP Mesh agents.
@@ -123,6 +125,11 @@ public class MeshMcpServerConfiguration {
             .validateToolInputs(false)
             .build();
 
+        // Issue #1442: refuse to boot when two declarations would advertise the
+        // same MCP tool name. Runs BEFORE any addTool so the agent never comes up
+        // half-registered.
+        assertUniqueAdvertisedToolNames(wrapperRegistry.getAllHandlers());
+
         // Register all tools from wrapper registry (includes both @MeshTool and @MeshLlmProvider)
         for (McpToolHandler handler : wrapperRegistry.getAllHandlers()) {
             registerTool(server, handler);
@@ -149,6 +156,108 @@ public class MeshMcpServerConfiguration {
         log.info("Registered stateless MCP servlet at {}", MCP_ENDPOINT);
         return registration;
     }
+
+    /**
+     * Refuse to boot when two DIFFERENT tool declarations would be advertised
+     * under the same MCP tool name (issue #1442).
+     *
+     * <p>The advertised name is the wire name: a client's {@code tools/call}
+     * carries {@code params.name = <the registry's function_name>}, which is
+     * exactly {@link McpToolHandler#getMethodName()}. It is a bare method name
+     * with no class qualifier, so two {@code @MeshTool} methods named
+     * {@code analyze} in different classes claim the same slot — and the MCP SDK
+     * (2.0.0) resolves that by silently keeping one, leaving the other tool
+     * permanently unreachable even though the registry advertises it.
+     *
+     * <p>This is the MCP-layer analogue of the duplicate-capability guard in
+     * {@link MeshToolRegistry#registerTool}, and it borrows that guard's
+     * tolerance: the discriminator is the <b>funcId</b>
+     * ({@code FQCN.methodName}), not handler identity. Re-registering the SAME
+     * declaration — a prototype-scoped bean instantiated twice, a Spring context
+     * refresh, a repeated bean post-processing pass — produces a fresh handler
+     * instance for an unchanged funcId, which every other index in
+     * {@link MeshToolWrapperRegistry} already replaces without complaint. Only a
+     * second, genuinely different declaration throws.
+     *
+     * <p>The framework's own fixed names are each claimed exactly once per
+     * agent, so a normal agent never trips this:
+     * <ul>
+     *   <li>{@code llm_generate} — one {@code @MeshLlmProvider} class produces
+     *       one handler with funcId {@code llm_provider:<capability>}. TWO
+     *       provider classes on one agent DO throw, correctly: they would both
+     *       advertise {@code llm_generate} and one would be dead on the wire.</li>
+     *   <li>{@code __mesh_job_status} / {@code __mesh_job_result} /
+     *       {@code __mesh_job_cancel} — {@link JobsHelperToolsRegistrar}
+     *       registers one handler per op under the synthetic funcId
+     *       {@code __mesh_jobs_helper.<op>}, and the registry is keyed by funcId,
+     *       so a repeated registrar pass replaces rather than accumulates.</li>
+     * </ul>
+     *
+     * <p><b>Known limit — overloads in ONE class are not reached.</b> This scans
+     * {@link MeshToolWrapperRegistry#getAllHandlers()}, which is keyed by funcId,
+     * and a funcId is {@code FQCN.methodName} with no parameter types. Two
+     * overloaded {@code @MeshTool} methods in the same class therefore share a
+     * funcId and the second EVICTS the first from that map before this guard
+     * ever sees it — the collision is real but invisible here. Widening the
+     * funcId is not an option: it is the wire identity the Rust core echoes back
+     * on {@code funcId:dep_N} dependency-resolution events. The narrower
+     * same-class overload case is covered on the registry side by
+     * {@link MeshToolRegistry#registerTool}'s duplicate-capability guard
+     * whenever the overloads also share a capability.
+     *
+     * @param handlers every handler about to be registered with the MCP server
+     * @throws IllegalStateException naming both colliding declarations
+     */
+    static void assertUniqueAdvertisedToolNames(Collection<McpToolHandler> handlers) {
+        Map<String, String> claimedBy = new LinkedHashMap<>();
+        for (McpToolHandler handler : handlers) {
+            String toolName = handler.getMethodName();
+            if (toolName == null) {
+                continue;
+            }
+            String funcId = handler.getFuncId();
+            String previousFuncId = claimedBy.putIfAbsent(toolName, funcId);
+            if (previousFuncId == null || Objects.equals(previousFuncId, funcId)) {
+                // Unclaimed, or the same declaration re-registered — both fine.
+                continue;
+            }
+            throw new IllegalStateException(String.format(
+                "Duplicate MCP tool name '%s': advertised by both %s and %s. "
+                    + "The MCP tool name is the wire name a client calls "
+                    + "(tools/call params.name), so registering it twice leaves one of "
+                    + "these tools permanently unreachable. %s",
+                toolName, previousFuncId, funcId, remedyFor(previousFuncId, funcId)));
+        }
+    }
+
+    /**
+     * The actionable half of the duplicate-tool-name error. "Rename one of the
+     * methods" is wrong advice for an {@code @MeshLlmProvider} collision: there
+     * is no method to rename — {@code llm_generate} is a framework constant that
+     * every provider wrapper returns from {@code getMethodName()}, so the only
+     * fix is to stop hosting two providers on one agent.
+     */
+    private static String remedyFor(String previousFuncId, String funcId) {
+        boolean previousIsProvider = previousFuncId != null
+            && previousFuncId.startsWith(LLM_PROVIDER_FUNC_ID_PREFIX);
+        boolean incomingIsProvider = funcId != null
+            && funcId.startsWith(LLM_PROVIDER_FUNC_ID_PREFIX);
+        if (previousIsProvider && incomingIsProvider) {
+            return "Both are @MeshLlmProvider classes, and every provider advertises the "
+                + "framework's fixed 'llm_generate' tool name — there is no method name to "
+                + "change. One agent hosts at most one @MeshLlmProvider: keep one and move "
+                + "the other to its own agent.";
+        }
+        if (previousIsProvider || incomingIsProvider) {
+            return "One of them is a @MeshLlmProvider class, which always advertises the "
+                + "framework's fixed 'llm_generate' tool name. Rename the @MeshTool method, "
+                + "or move the provider to its own agent.";
+        }
+        return "Rename one of the methods, or move one of the tools to a separate agent.";
+    }
+
+    /** funcId prefix {@code LlmProviderToolWrapper} builds ({@code llm_provider:<capability>}). */
+    private static final String LLM_PROVIDER_FUNC_ID_PREFIX = "llm_provider:";
 
     /**
      * Register a McpToolHandler as an MCP tool specification.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/web/MeshRouteBeanPostProcessor.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -154,9 +155,18 @@ public class MeshRouteBeanPostProcessor implements BeanPostProcessor {
 
     /**
      * Get the base path from class-level @RequestMapping.
+     *
+     * <p>Issue #1443, one level up: {@link AnnotationUtils#findAnnotation} does
+     * not apply {@code @AliasFor}, so a controller annotated with a user-defined
+     * composed annotation (meta-annotated {@code @RequestMapping}, overriding
+     * {@code path}) surfaced the meta-annotation's empty defaults and the base
+     * path silently degraded to {@code ""} — misplacing EVERY route on that
+     * controller, not just adding a phantom.
+     * {@link AnnotatedElementUtils#findMergedAnnotation} resolves the override.
      */
     private String getClassBasePath(Class<?> clazz) {
-        RequestMapping mapping = AnnotationUtils.findAnnotation(clazz, RequestMapping.class);
+        RequestMapping mapping =
+            AnnotatedElementUtils.findMergedAnnotation(clazz, RequestMapping.class);
         if (mapping != null && mapping.value().length > 0) {
             return mapping.value()[0];
         }
@@ -168,65 +178,129 @@ public class MeshRouteBeanPostProcessor implements BeanPostProcessor {
 
     /**
      * Extract HTTP method and path from Spring mapping annotations.
+     *
+     * <p>Every mapping annotation the developer WROTE contributes, and nothing
+     * else does. The three sources are consulted independently:
+     *
+     * <ol>
+     *   <li>each of the five HTTP-verb shortcuts, separately — a method may
+     *       legally carry more than one ({@code @GetMapping} +
+     *       {@code @PostMapping} must yield TWO mappings), and a single
+     *       {@code findMergedAnnotation(method, RequestMapping.class)} returns
+     *       only ONE merged annotation, so collapsing them would silently drop
+     *       a mapping;</li>
+     *   <li>a {@code @RequestMapping} <b>directly present</b> on the method,
+     *       which contributes on top of any shortcut — that combination
+     *       compiles and the developer wrote both;</li>
+     *   <li>failing both, a merged {@code @RequestMapping} reached through a
+     *       user-defined composed annotation.</li>
+     * </ol>
+     *
+     * <p>Issue #1443: the {@code @RequestMapping} lookup used to be
+     * unconditional AND meta-annotation-aware. Each verb shortcut is itself
+     * meta-annotated {@code @RequestMapping}, so it matched for every handler —
+     * and {@code AnnotationUtils.findAnnotation} does not apply
+     * {@code @AliasFor}, so it surfaced the meta-annotation's own empty
+     * {@code value()}/{@code path()} and no {@code method()}, which the
+     * empty-path/default-GET fallbacks turned into a phantom
+     * {@code GET <controller base path>} per handler. Step 3 is now reached only
+     * when no annotation the developer wrote has already been read, and step 2
+     * reads the direct annotation directly, so a shortcut's meta-annotation is
+     * never mistaken for a mapping of its own.
+     *
+     * <p>{@link AnnotatedElementUtils#findMergedAnnotation} replaces
+     * {@link AnnotationUtils#findAnnotation} throughout so {@code @AliasFor} is
+     * applied: {@code value} ↔ {@code path} within each annotation, and
+     * meta-annotation attribute overrides for composed mapping annotations.
      */
     private List<MappingInfo> getMappingInfo(Method method) {
         List<MappingInfo> mappings = new ArrayList<>();
 
         // Check @GetMapping
-        GetMapping getMapping = AnnotationUtils.findAnnotation(method, GetMapping.class);
+        GetMapping getMapping = AnnotatedElementUtils.findMergedAnnotation(method, GetMapping.class);
         if (getMapping != null) {
             addMappings(mappings, "GET", getMapping.value(), getMapping.path());
         }
 
         // Check @PostMapping
-        PostMapping postMapping = AnnotationUtils.findAnnotation(method, PostMapping.class);
+        PostMapping postMapping = AnnotatedElementUtils.findMergedAnnotation(method, PostMapping.class);
         if (postMapping != null) {
             addMappings(mappings, "POST", postMapping.value(), postMapping.path());
         }
 
         // Check @PutMapping
-        PutMapping putMapping = AnnotationUtils.findAnnotation(method, PutMapping.class);
+        PutMapping putMapping = AnnotatedElementUtils.findMergedAnnotation(method, PutMapping.class);
         if (putMapping != null) {
             addMappings(mappings, "PUT", putMapping.value(), putMapping.path());
         }
 
         // Check @DeleteMapping
-        DeleteMapping deleteMapping = AnnotationUtils.findAnnotation(method, DeleteMapping.class);
+        DeleteMapping deleteMapping = AnnotatedElementUtils.findMergedAnnotation(method, DeleteMapping.class);
         if (deleteMapping != null) {
             addMappings(mappings, "DELETE", deleteMapping.value(), deleteMapping.path());
         }
 
         // Check @PatchMapping
-        PatchMapping patchMapping = AnnotationUtils.findAnnotation(method, PatchMapping.class);
+        PatchMapping patchMapping = AnnotatedElementUtils.findMergedAnnotation(method, PatchMapping.class);
         if (patchMapping != null) {
             addMappings(mappings, "PATCH", patchMapping.value(), patchMapping.path());
         }
 
-        // Check @RequestMapping (handles multiple HTTP methods)
-        RequestMapping requestMapping = AnnotationUtils.findAnnotation(method, RequestMapping.class);
-        if (requestMapping != null) {
-            String[] paths = requestMapping.value().length > 0 ?
-                requestMapping.value() : requestMapping.path();
-            if (paths.length == 0) {
-                paths = new String[]{""};
-            }
+        // A @RequestMapping the developer wrote DIRECTLY on the method. Legal
+        // alongside a verb shortcut, and then both were written, so both count.
+        // getAnnotation() is directly-present-only, so a shortcut's own
+        // meta-annotation can never reach here.
+        RequestMapping direct = method.getAnnotation(RequestMapping.class);
+        if (direct != null) {
+            addRequestMappings(mappings, direct);
+            return mappings;
+        }
 
-            // Get HTTP methods (default to GET if not specified)
-            var methods = requestMapping.method();
-            if (methods.length == 0) {
-                for (String path : paths) {
-                    mappings.add(new MappingInfo("GET", path));
-                }
-            } else {
-                for (var httpMethod : methods) {
-                    for (String path : paths) {
-                        mappings.add(new MappingInfo(httpMethod.name(), path));
-                    }
-                }
-            }
+        if (!mappings.isEmpty()) {
+            // A verb shortcut already described this handler. Anything a merged
+            // @RequestMapping lookup would find now is that same shortcut's
+            // meta-annotation (issue #1443).
+            return mappings;
+        }
+
+        // Nothing so far: the handler may carry a user-defined composed
+        // annotation that is meta-annotated @RequestMapping. Merging applies its
+        // @AliasFor overrides.
+        RequestMapping composed =
+            AnnotatedElementUtils.findMergedAnnotation(method, RequestMapping.class);
+        if (composed != null) {
+            addRequestMappings(mappings, composed);
         }
 
         return mappings;
+    }
+
+    /**
+     * Expand one {@code @RequestMapping} — which can carry several HTTP methods
+     * and several paths at once — into its mappings.
+     */
+    private void addRequestMappings(List<MappingInfo> mappings, RequestMapping requestMapping) {
+        String[] paths = requestMapping.value().length > 0 ?
+            requestMapping.value() : requestMapping.path();
+        if (paths.length == 0) {
+            // A genuine path-less @RequestMapping — the handler is mapped at
+            // the controller's base path, which is what Spring MVC does too.
+            paths = new String[]{""};
+        }
+
+        // Get HTTP methods (default to GET if not specified)
+        var methods = requestMapping.method();
+        if (methods.length == 0) {
+            for (String path : paths) {
+                mappings.add(new MappingInfo("GET", path));
+            }
+        } else {
+            for (var httpMethod : methods) {
+                for (String path : paths) {
+                    mappings.add(new MappingInfo(httpMethod.name(), path));
+                }
+            }
+        }
     }
 
     private void addMappings(List<MappingInfo> mappings, String httpMethod,

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshMcpServerDuplicateToolNameTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshMcpServerDuplicateToolNameTest.java
@@ -172,6 +172,49 @@ class MeshMcpServerDuplicateToolNameTest {
         assertTrue(!boom.getMessage().contains("@MeshLlmProvider"), boom.getMessage());
     }
 
+    @Test
+    @DisplayName("a null funcId claims the name — it must not read as unclaimed for the next handler")
+    void aNullFuncIdStillClaimsTheName() {
+        // McpToolHandler is a public interface and getFuncId() has no default,
+        // so nothing enforces non-null. The map permits null values, and
+        // putIfAbsent REPLACES a null-valued mapping and returns null — so on
+        // putIfAbsent the second handler read "unclaimed" and the collision
+        // walked through the one guard whose entire job is to not let it.
+        List<McpToolHandler> handlers = List.of(
+            new StubHandler(null, "first", "analyze"),
+            tool(BetaTools.class, "analyze"));
+
+        IllegalStateException boom = assertThrows(IllegalStateException.class,
+            () -> MeshMcpServerConfiguration.assertUniqueAdvertisedToolNames(handlers));
+        assertTrue(boom.getMessage().contains("'analyze'"), boom.getMessage());
+        assertTrue(boom.getMessage().contains(BetaTools.class.getName() + ".analyze"),
+            boom.getMessage());
+    }
+
+    @Test
+    @DisplayName("a null funcId on the SECOND handler is still a collision")
+    void aNullFuncIdOnTheIncomingHandlerIsACollision() {
+        List<McpToolHandler> handlers = List.of(
+            tool(AlphaTools.class, "analyze"),
+            new StubHandler(null, "second", "analyze"));
+
+        assertThrows(IllegalStateException.class,
+            () -> MeshMcpServerConfiguration.assertUniqueAdvertisedToolNames(handlers));
+    }
+
+    @Test
+    @DisplayName("two handlers that BOTH report a null funcId are treated as one declaration")
+    void twoNullFuncIdsAreNotDistinguishable() {
+        // Nothing distinguishes them, so this stays tolerant rather than
+        // failing a boot on a pair the guard cannot actually tell apart.
+        List<McpToolHandler> handlers = List.of(
+            new StubHandler(null, "a", "analyze"),
+            new StubHandler(null, "b", "analyze"));
+
+        assertDoesNotThrow(() ->
+            MeshMcpServerConfiguration.assertUniqueAdvertisedToolNames(handlers));
+    }
+
     // ─────────────────────────────────────────────────────────────────
     // Idempotent re-registration is NOT a collision (the #1445 lesson)
     // ─────────────────────────────────────────────────────────────────

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshMcpServerDuplicateToolNameTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshMcpServerDuplicateToolNameTest.java
@@ -1,0 +1,233 @@
+package io.mcpmesh.spring;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two declarations may not advertise the same MCP tool name — issue #1442.
+ *
+ * <p>{@code MeshMcpServerConfiguration.registerTool} names the MCP tool
+ * {@code handler.getMethodName()} — a BARE method name, no class qualifier —
+ * and the registration loop iterates {@code getAllHandlers()}, which is keyed
+ * by funcId ({@code FQCN.methodName}). Two {@code @MeshTool} methods named
+ * {@code analyze} in different classes therefore both reach
+ * {@code server.addTool}, and the MCP SDK 2.0.0 keeps one silently. Since the
+ * advertised name IS the wire name — {@code tools/call} carries
+ * {@code params.name = <registry function_name>} — the loser is unreachable
+ * while the registry keeps advertising it.
+ *
+ * <p>The guard is the MCP-layer analogue of
+ * {@link MeshToolRegistryDuplicateCapabilityTest}'s duplicate-capability boot
+ * error, and it borrows the same tolerance: the discriminator is the funcId,
+ * NOT handler identity, so re-registering the same declaration with a fresh
+ * handler instance (prototype bean, context refresh, repeated post-processing)
+ * is not a collision.
+ */
+@DisplayName("MCP registration — duplicate advertised tool name fails the boot (issue #1442)")
+class MeshMcpServerDuplicateToolNameTest {
+
+    /**
+     * Minimal {@link McpToolHandler}: the guard reads only the funcId and the
+     * advertised method name.
+     */
+    private record StubHandler(String funcId, String capability, String methodName)
+            implements McpToolHandler {
+
+        @Override
+        public String getFuncId() {
+            return funcId;
+        }
+
+        @Override
+        public String getCapability() {
+            return capability;
+        }
+
+        @Override
+        public String getMethodName() {
+            return methodName;
+        }
+
+        @Override
+        public String getDescription() {
+            return "stub";
+        }
+
+        @Override
+        public Map<String, Object> getInputSchema() {
+            return Map.of("type", "object");
+        }
+
+        @Override
+        public Object invoke(Map<String, Object> mcpArgs) {
+            return null;
+        }
+
+        @Override
+        public int getDependencyCount() {
+            return 0;
+        }
+
+        @Override
+        public int getLlmAgentCount() {
+            return 0;
+        }
+    }
+
+    private static StubHandler tool(Class<?> owner, String methodName) {
+        return new StubHandler(owner.getName() + "." + methodName, methodName, methodName);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // The collision
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("two @MeshTool methods named the same in different classes → boot error naming both")
+    void sameMethodNameInTwoClassesFailsBoot() {
+        List<McpToolHandler> handlers = List.of(
+            tool(AlphaTools.class, "analyze"),
+            tool(BetaTools.class, "analyze"));
+
+        IllegalStateException boom = assertThrows(IllegalStateException.class,
+            () -> MeshMcpServerConfiguration.assertUniqueAdvertisedToolNames(handlers));
+
+        assertTrue(boom.getMessage().contains("'analyze'"),
+            "the error must name the contested MCP tool name. Got: " + boom.getMessage());
+        assertTrue(boom.getMessage().contains(AlphaTools.class.getName() + ".analyze"),
+            "the error must name the first declaration by funcId. Got: " + boom.getMessage());
+        assertTrue(boom.getMessage().contains(BetaTools.class.getName() + ".analyze"),
+            "the error must name the second declaration by funcId. Got: " + boom.getMessage());
+    }
+
+    @Test
+    @DisplayName("the collision is caught through the real wrapper registry's handler collection")
+    void collisionIsCaughtThroughTheWrapperRegistry() {
+        MeshToolWrapperRegistry registry = new MeshToolWrapperRegistry(null);
+        registry.registerHandler(tool(AlphaTools.class, "search"));
+        registry.registerHandler(tool(BetaTools.class, "search"));
+
+        // Both survive getAllHandlers() — it is keyed by funcId, and the two
+        // funcIds differ. That is exactly why both reach server.addTool.
+        assertThrows(IllegalStateException.class,
+            () -> MeshMcpServerConfiguration.assertUniqueAdvertisedToolNames(
+                registry.getAllHandlers()));
+    }
+
+    @Test
+    @DisplayName("two @MeshLlmProvider classes get a remedy that fits — no method to rename")
+    void twoLlmProvidersGetAProviderSpecificRemedy() {
+        // Every provider wrapper returns the framework constant 'llm_generate'
+        // from getMethodName(), so "rename one of the methods" is advice the
+        // user cannot act on: the name is not theirs.
+        List<McpToolHandler> handlers = List.of(
+            new StubHandler("llm_provider:llm-claude", "llm-claude", "llm_generate"),
+            new StubHandler("llm_provider:llm-gpt", "llm-gpt", "llm_generate"));
+
+        IllegalStateException boom = assertThrows(IllegalStateException.class,
+            () -> MeshMcpServerConfiguration.assertUniqueAdvertisedToolNames(handlers));
+
+        assertTrue(boom.getMessage().contains("@MeshLlmProvider"),
+            "the remedy must name the annotation actually involved. Got: " + boom.getMessage());
+        assertTrue(boom.getMessage().contains("its own agent"),
+            "the only real fix is one provider per agent. Got: " + boom.getMessage());
+        assertTrue(!boom.getMessage().contains("Rename one of the methods"),
+            "there is no method to rename. Got: " + boom.getMessage());
+    }
+
+    @Test
+    @DisplayName("a @MeshTool colliding with the LLM provider names the provider explicitly")
+    void toolVersusProviderRemedyNamesTheProvider() {
+        List<McpToolHandler> handlers = List.of(
+            new StubHandler("llm_provider:llm", "llm", "llm_generate"),
+            new StubHandler(AlphaTools.class.getName() + ".llm_generate", "gen",
+                "llm_generate"));
+
+        IllegalStateException boom = assertThrows(IllegalStateException.class,
+            () -> MeshMcpServerConfiguration.assertUniqueAdvertisedToolNames(handlers));
+
+        assertTrue(boom.getMessage().contains("@MeshLlmProvider"), boom.getMessage());
+        assertTrue(boom.getMessage().contains("Rename the @MeshTool method"), boom.getMessage());
+    }
+
+    @Test
+    @DisplayName("an ordinary @MeshTool collision keeps the rename remedy")
+    void ordinaryCollisionKeepsTheRenameRemedy() {
+        List<McpToolHandler> handlers = List.of(
+            tool(AlphaTools.class, "analyze"),
+            tool(BetaTools.class, "analyze"));
+
+        IllegalStateException boom = assertThrows(IllegalStateException.class,
+            () -> MeshMcpServerConfiguration.assertUniqueAdvertisedToolNames(handlers));
+
+        assertTrue(boom.getMessage().contains("Rename one of the methods"), boom.getMessage());
+        assertTrue(!boom.getMessage().contains("@MeshLlmProvider"), boom.getMessage());
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Idempotent re-registration is NOT a collision (the #1445 lesson)
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("the SAME declaration re-registered is tolerated — a fresh instance is not a collision")
+    void sameDeclarationReRegisteredIsTolerated() {
+        // A prototype-scoped bean instantiated twice, or a Spring context
+        // refresh, hands the registry a NEW handler object for an UNCHANGED
+        // funcId. Discriminating on instance identity would boot-fail that.
+        StubHandler first = tool(AlphaTools.class, "analyze");
+        StubHandler second = tool(AlphaTools.class, "analyze");
+        assertTrue(first != second, "the two handlers must be distinct instances");
+
+        assertDoesNotThrow(() -> MeshMcpServerConfiguration.assertUniqueAdvertisedToolNames(
+            List.of(first, second)));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // A normal agent must not trip the guard
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("LLM provider + the three jobs helpers + regular @MeshTools boot clean")
+    void aNormalAgentDoesNotTripTheGuard() {
+        List<McpToolHandler> handlers = new ArrayList<>();
+        // One @MeshLlmProvider class → one handler, fixed name llm_generate.
+        handlers.add(new StubHandler("llm_provider:llm", "llm", "llm_generate"));
+        // JobsHelperToolsRegistrar, one handler per op under a synthetic funcId.
+        for (String op : List.of("__mesh_job_status", "__mesh_job_result", "__mesh_job_cancel")) {
+            handlers.add(new StubHandler("__mesh_jobs_helper." + op, op, op));
+        }
+        handlers.add(tool(AlphaTools.class, "greet"));
+        handlers.add(tool(AlphaTools.class, "analyze"));
+        handlers.add(tool(BetaTools.class, "summarize"));
+
+        assertDoesNotThrow(() -> MeshMcpServerConfiguration.assertUniqueAdvertisedToolNames(handlers));
+    }
+
+    @Test
+    @DisplayName("a repeated jobs-helper registration pass is idempotent, not a collision")
+    void repeatedJobsHelperRegistrationIsTolerated() {
+        // JobsHelperToolsRegistrar.register writes into a funcId-keyed map, so a
+        // second pass replaces rather than accumulates — but assert the guard
+        // itself tolerates the duplicate even if a collection ever carried both.
+        List<McpToolHandler> handlers = List.of(
+            new StubHandler("__mesh_jobs_helper.__mesh_job_status", "__mesh_job_status",
+                "__mesh_job_status"),
+            new StubHandler("__mesh_jobs_helper.__mesh_job_status", "__mesh_job_status",
+                "__mesh_job_status"));
+
+        assertDoesNotThrow(() ->
+            MeshMcpServerConfiguration.assertUniqueAdvertisedToolNames(handlers));
+    }
+
+    private static final class AlphaTools {}
+
+    private static final class BetaTools {}
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshRouteMappingScanTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshRouteMappingScanTest.java
@@ -1,0 +1,336 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.spring.web.MeshDependency;
+import io.mcpmesh.spring.web.MeshRoute;
+import io.mcpmesh.spring.web.MeshRouteBeanPostProcessor;
+import io.mcpmesh.spring.web.MeshRouteRegistry;
+import io.mcpmesh.types.McpMeshTool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * The mapping scan must register exactly the routes the developer wrote —
+ * issue #1443.
+ *
+ * <p>{@code getMappingInfo} checked the five HTTP-verb shortcuts and then
+ * <b>unconditionally</b> also looked up {@code @RequestMapping}. Every shortcut
+ * is meta-annotated {@code @RequestMapping}, so that last lookup matched for
+ * every handler — and {@code AnnotationUtils.findAnnotation} does not apply
+ * {@code @AliasFor}, so it surfaced the meta-annotation's own empty
+ * {@code value()}/{@code path()} and no {@code method()}. The empty-path and
+ * default-GET fallbacks then registered a phantom {@code GET <base path>} per
+ * handler: three handlers produced four routes, and the phantom's {@code ""}
+ * slot was overwritten once per handler, so {@code getByRoute("GET", "/")}
+ * answered with an arbitrary winner that could change between JVM restarts of
+ * the same artifact.
+ *
+ * <p>Placed in {@code io.mcpmesh.spring} alongside
+ * {@link MeshRouteOverloadedHandlerTest} so {@code MeshSettleState}'s
+ * package-private test reset is visible.
+ */
+@DisplayName("@MeshRoute: the mapping scan registers exactly the declared routes")
+class MeshRouteMappingScanTest {
+
+    private MeshRouteRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        MeshSettleState.resetForTests(0.0);
+        registry = new MeshRouteRegistry();
+    }
+
+    private void scan(Object controller) {
+        new MeshRouteBeanPostProcessor(registry)
+            .postProcessAfterInitialization(controller, controller.getClass().getSimpleName());
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // A1 — the phantom
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("@GetMapping(\"/x\") produces exactly ONE mapping")
+    void verbShortcutProducesExactlyOneMapping() {
+        scan(new SingleGetController());
+
+        assertEquals(1, registry.getRouteCount(),
+            "one @GetMapping handler is one route — the extra one is the phantom at the "
+                + "controller base path from the unconditional @RequestMapping fall-through");
+        assertNotNull(registry.getByRoute("GET", "/x"));
+        assertNull(registry.getByRoute("GET", "/"),
+            "nothing was mapped at the controller base path");
+    }
+
+    @Test
+    @DisplayName("N distinctly-mapped handlers under a base path register exactly N routes")
+    void basePathControllerRegistersOneRoutePerHandler() {
+        // The measurement in issue #1443: three handlers produced four routes,
+        // the fourth being GET /api with an arbitrary winner.
+        scan(new BasePathController());
+
+        assertEquals(3, registry.getRouteCount());
+        assertNotNull(registry.getByRoute("GET", "/api/a"));
+        assertNotNull(registry.getByRoute("GET", "/api/b"));
+        assertNotNull(registry.getByRoute("GET", "/api/solo"));
+        assertNull(registry.getByRoute("GET", "/api"),
+            "no handler is mapped at the controller base path");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // A2 — a DIRECT @RequestMapping still works, with @AliasFor applied
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("A direct @RequestMapping(path=..., method={GET, POST}) still yields BOTH")
+    void directRequestMappingYieldsEveryDeclaredMethod() {
+        scan(new DirectRequestMappingController());
+
+        assertEquals(2, registry.getRouteCount());
+        assertNotNull(registry.getByRoute("GET", "/y"));
+        assertNotNull(registry.getByRoute("POST", "/y"));
+        assertSame(registry.getByRoute("GET", "/y"), registry.getByRoute("POST", "/y"),
+            "one handler, one metadata instance on both mappings");
+        assertNull(registry.getByRoute("GET", "/"));
+    }
+
+    @Test
+    @DisplayName("A composed mapping annotation's @AliasFor override reaches the real path")
+    void composedMappingAnnotationAliasIsHonoured() {
+        // The @AliasFor case the old lookup could not see at all: a user-defined
+        // annotation meta-annotated @RequestMapping, overriding `path` via
+        // @AliasFor. AnnotationUtils.findAnnotation returns the meta-annotation
+        // with its OWN empty defaults, so the handler landed at the base path.
+        scan(new ComposedMappingController());
+
+        assertEquals(1, registry.getRouteCount());
+        assertNotNull(registry.getByRoute("GET", "/z"),
+            "@AliasFor(annotation = RequestMapping.class, attribute = \"path\") must resolve "
+                + "to /z, not degrade to the controller base path");
+        assertNull(registry.getByRoute("GET", "/"));
+    }
+
+    @Test
+    @DisplayName("@RequestMapping's own value/path @AliasFor is honoured (value= reaches the path)")
+    void directRequestMappingValueAliasIsHonoured() {
+        scan(new ValueAliasRequestMappingController());
+
+        assertEquals(1, registry.getRouteCount());
+        assertNotNull(registry.getByRoute("GET", "/zz"),
+            "value= is an @AliasFor path= — it must not degrade to the base path");
+    }
+
+    @Test
+    @DisplayName("A genuinely path-less @RequestMapping still maps at the controller base path")
+    void pathlessRequestMappingMapsAtBasePath() {
+        // The empty-path fallback is retained on purpose: now that it is only
+        // reachable from a DIRECT @RequestMapping, an empty path means the
+        // developer really did write @RequestMapping with no path, which Spring
+        // MVC maps at the class-level base path.
+        scan(new PathlessRequestMappingController());
+
+        assertEquals(1, registry.getRouteCount());
+        assertNotNull(registry.getByRoute("GET", "/root"));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // A3 — two verb shortcuts on ONE method must still yield two mappings
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("@GetMapping + @PostMapping on one method yields TWO mappings, not one and not three")
+    void twoVerbShortcutsOnOneMethodYieldTwoMappings() {
+        // Load-bearing: this is why the five shortcut branches cannot collapse
+        // into a single findMergedAnnotation(method, RequestMapping.class) —
+        // that returns ONE merged annotation and would drop a mapping. It is
+        // also the one-metadata-registered-twice path the registry's handler
+        // guard has to tolerate.
+        scan(new MultiVerbController());
+
+        assertEquals(2, registry.getRouteCount(),
+            "GET /multi and POST /multi — no phantom, and neither verb dropped");
+        assertSame(registry.getByRoute("GET", "/multi"), registry.getByRoute("POST", "/multi"));
+        assertNull(registry.getByRoute("GET", "/"));
+    }
+
+    @Test
+    @DisplayName("A verb shortcut AND a direct @RequestMapping on one method both count")
+    void shortcutAndDirectRequestMappingBothContribute() {
+        // Both annotations compile on one method, and the developer wrote both.
+        // Suppressing the direct @RequestMapping whenever a shortcut matched
+        // would drop POST /y — the same class of silent loss as collapsing the
+        // five shortcut branches.
+        scan(new ShortcutPlusDirectController());
+
+        assertEquals(2, registry.getRouteCount());
+        assertNotNull(registry.getByRoute("GET", "/x"), "the @GetMapping mapping");
+        assertNotNull(registry.getByRoute("POST", "/y"), "the direct @RequestMapping mapping");
+        assertNull(registry.getByRoute("GET", "/"),
+            "and still no phantom at the controller base path");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // The class-level base path has the same @AliasFor defect
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("A composed CLASS-level mapping annotation still yields the base path")
+    void composedClassLevelAnnotationYieldsTheBasePath() {
+        // One level up from the phantom: AnnotationUtils.findAnnotation on the
+        // CLASS does not apply @AliasFor either, so a composed controller
+        // annotation degraded the base path to "" and misplaced every route on
+        // that controller — /api/a became /a.
+        scan(new ComposedBasePathController());
+
+        assertEquals(1, registry.getRouteCount());
+        assertNotNull(registry.getByRoute("GET", "/api/a"),
+            "the class-level @AliasFor override must resolve to /api");
+        assertNull(registry.getByRoute("GET", "/a"),
+            "the route must not be misplaced at the root");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Fixtures
+    // ─────────────────────────────────────────────────────────────────
+
+    @RestController
+    @SuppressWarnings("unused")
+    public static class SingleGetController {
+        @GetMapping("/x")
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String x(McpMeshTool one) {
+            return "x";
+        }
+    }
+
+    @RestController
+    @RequestMapping("/api")
+    @SuppressWarnings("unused")
+    public static class BasePathController {
+        @GetMapping("/a")
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String a(McpMeshTool one) {
+            return "a";
+        }
+
+        @GetMapping("/b")
+        @MeshRoute(dependencies = @MeshDependency(capability = "beta"))
+        public String b(McpMeshTool one) {
+            return "b";
+        }
+
+        @GetMapping("/solo")
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String solo(McpMeshTool one) {
+            return "solo";
+        }
+    }
+
+    @RestController
+    @SuppressWarnings("unused")
+    public static class DirectRequestMappingController {
+        @RequestMapping(path = "/y", method = {RequestMethod.GET, RequestMethod.POST})
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String y(McpMeshTool one) {
+            return "y";
+        }
+    }
+
+    @RestController
+    @SuppressWarnings("unused")
+    public static class ValueAliasRequestMappingController {
+        @RequestMapping(value = "/zz", method = RequestMethod.GET)
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String zz(McpMeshTool one) {
+            return "zz";
+        }
+    }
+
+    /** A user-defined composed mapping annotation with an @AliasFor override. */
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @RequestMapping(method = RequestMethod.GET)
+    public @interface AuditedGet {
+        @AliasFor(annotation = RequestMapping.class, attribute = "path")
+        String[] value() default {};
+    }
+
+    @RestController
+    @SuppressWarnings("unused")
+    public static class ComposedMappingController {
+        @AuditedGet("/z")
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String z(McpMeshTool one) {
+            return "z";
+        }
+    }
+
+    @RestController
+    @RequestMapping("/root")
+    @SuppressWarnings("unused")
+    public static class PathlessRequestMappingController {
+        @RequestMapping
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String root(McpMeshTool one) {
+            return "root";
+        }
+    }
+
+    @RestController
+    @SuppressWarnings("unused")
+    public static class ShortcutPlusDirectController {
+        @GetMapping("/x")
+        @RequestMapping(path = "/y", method = RequestMethod.POST)
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String both(McpMeshTool one) {
+            return "both";
+        }
+    }
+
+    /** A user-defined composed CONTROLLER annotation with an @AliasFor override. */
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @RestController
+    @RequestMapping
+    public @interface ApiController {
+        @AliasFor(annotation = RequestMapping.class, attribute = "path")
+        String[] value() default {};
+    }
+
+    @ApiController("/api")
+    @SuppressWarnings("unused")
+    public static class ComposedBasePathController {
+        @GetMapping("/a")
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String a(McpMeshTool one) {
+            return "a";
+        }
+    }
+
+    @RestController
+    @SuppressWarnings("unused")
+    public static class MultiVerbController {
+        @GetMapping("/multi")
+        @PostMapping("/multi")
+        @MeshRoute(dependencies = @MeshDependency(capability = "alpha"))
+        public String both(McpMeshTool one) {
+            return "multi";
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshRouteOverloadedHandlerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshRouteOverloadedHandlerTest.java
@@ -140,6 +140,14 @@ class MeshRouteOverloadedHandlerTest {
         MeshRouteRegistry.RouteMetadata wide = registry.getByHandlerMethod(
             overload(String.class, McpMeshTool.class, McpMeshTool.class));
 
+        // Issue #1443: three distinctly-mapped handlers are three routes. This
+        // controller is the issue's PROBE-C measurement, which reported four —
+        // the fourth being a phantom GET / whose winner was whichever handler
+        // getDeclaredMethods() happened to hand over last.
+        assertEquals(3, registry.getRouteCount());
+        assertNull(registry.getByRoute("GET", "/"),
+            "no handler is mapped at the controller base path");
+
         assertNotNull(narrow);
         assertNotNull(wide);
         assertEquals(List.of("alpha", "beta"), capabilities(narrow));
@@ -237,6 +245,10 @@ class MeshRouteOverloadedHandlerTest {
         new MeshRouteBeanPostProcessor(registry)
             .postProcessAfterInitialization(new MultiMappedController(), "multiMapped");
 
+        // Exactly two — issue #1443: the scan also registered a phantom
+        // GET <base path> for every handler, so this controller yielded three.
+        assertEquals(2, registry.getRouteCount(),
+            "one handler on two mappings is two routes, not three");
         assertNotNull(registry.getByRoute("GET", "/multi"));
         assertSame(registry.getByRoute("GET", "/multi"), registry.getByRoute("POST", "/multi"),
             "both mappings share ONE metadata instance — that is not a duplicate handler");

--- a/src/runtime/python/_mcp_mesh/engine/decorator_registry.py
+++ b/src/runtime/python/_mcp_mesh/engine/decorator_registry.py
@@ -8,6 +8,7 @@ The DecoratorRegistry stores metadata from decorators like @mesh_agent without
 making any network calls or requiring any runtime infrastructure.
 """
 
+import inspect
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -15,6 +16,108 @@ from datetime import datetime
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
+
+
+#: Attribute a factory-built tool function carries to point at the USER
+#: declaration it stands in for. ``mesh.llm_provider`` sets it: every provider
+#: it builds is the SAME nested ``process_chat`` closure renamed to the user's
+#: function name (the issue #227 fix), so the closure's own source coordinates
+#: are identical for every provider in the process and cannot discriminate
+#: them. Any future decorator that synthesizes a tool from a shared template
+#: must stamp this too, or its tools become mutually indistinguishable to the
+#: issue #1442 guard.
+DECLARATION_ORIGIN_ATTR = "_mesh_declaration_origin"
+
+
+def _declaration_target(func: Callable) -> Callable:
+    """Resolve ``func`` to the function whose source IS the declaration."""
+    target = inspect.unwrap(func)
+    # A factory-built tool stands in for the user function it was built from.
+    # Checked AFTER unwrap because the marker is copied onto every
+    # ``functools.wraps`` layer above it.
+    origin = getattr(target, DECLARATION_ORIGIN_ATTR, None)
+    if origin is not None and callable(origin):
+        return inspect.unwrap(origin)
+    return target
+
+
+def _declaration_identity(func: Callable) -> tuple:
+    """A stable identity for the DECLARATION behind ``func`` (issue #1442).
+
+    Used to tell a genuine duplicate-tool-name collision (two different
+    functions claiming one advertised MCP tool name) apart from the SAME
+    declaration being registered again.
+
+    Prefers the compiled code object's source coordinates over anything
+    derived from the function object, because the re-registration cases are
+    exactly the ones that produce a *new* function object for an unchanged
+    declaration:
+
+    - ``importlib.reload`` and closure factories re-run the same ``def``;
+    - object identity of the decorated wrapper is never stable (that is the
+      trap PR #1445 had to undo elsewhere);
+    - the ``__main__.X`` / ``<module>.X`` dual-module footgun (issue #1031)
+      re-executes ONE source file as two modules. Same file, same line — so
+      this identity already treats it as one declaration. When the two loads
+      disagree on the path spelling as well, :func:`_is_dual_module_pair`
+      catches it.
+
+    Falls back to ``(__module__, __qualname__)`` for callables with no code
+    object (builtins, C extensions, callable instances).
+    """
+    target = _declaration_target(func)
+    code = getattr(target, "__code__", None)
+    if code is not None:
+        return (
+            "code",
+            code.co_filename,
+            code.co_firstlineno,
+            getattr(code, "co_qualname", None) or code.co_name,
+        )
+    return (
+        "name",
+        getattr(target, "__module__", None),
+        getattr(target, "__qualname__", getattr(target, "__name__", None)),
+    )
+
+
+def _is_dual_module_pair(previous: Callable, incoming: Callable) -> bool:
+    """Whether two declarations are the ``__main__.X`` / ``<module>.X`` pair.
+
+    ``python main.py`` plus a sibling's ``from main import X`` evaluates one
+    source file as two modules. Usually both loads report the same
+    ``co_filename`` so :func:`_declaration_identity` already calls them equal —
+    but the two loads can spell the path differently (relative for the entry
+    script, resolved for the import), and then the identities diverge for what
+    is really one declaration.
+
+    Mirrors the conservative rule in
+    :func:`_mcp_mesh.engine.dual_module_detection.detect_dual_module_registration`:
+    exactly one side must be ``__main__``, and both must name the same
+    function. Deliberately NOT a general "same qualname" tolerance — two
+    ordinary modules that both define ``analyze`` is the collision this guard
+    exists to catch. Tolerating the pair here hands the diagnosis to
+    ``pipeline.mcp_startup.dual_module_check``, whose message explains the
+    restructure-as-a-package fix.
+    """
+    prev = _declaration_target(previous)
+    inc = _declaration_target(incoming)
+    prev_module = getattr(prev, "__module__", None)
+    inc_module = getattr(inc, "__module__", None)
+    if (prev_module == "__main__") == (inc_module == "__main__"):
+        return False
+    return getattr(prev, "__qualname__", None) == getattr(inc, "__qualname__", None)
+
+
+def _describe_declaration(func: Callable) -> str:
+    """Human-readable ``module.qualname (file:line)`` for an error message."""
+    target = _declaration_target(func)
+    module = getattr(target, "__module__", "?")
+    qualname = getattr(target, "__qualname__", getattr(target, "__name__", "?"))
+    code = getattr(target, "__code__", None)
+    if code is None:
+        return f"{module}.{qualname}"
+    return f"{module}.{qualname} ({code.co_filename}:{code.co_firstlineno})"
 
 
 @dataclass
@@ -140,7 +243,21 @@ class DecoratorRegistry:
 
     @classmethod
     def register_mesh_tool(cls, func: Callable, metadata: dict[str, Any]) -> None:
-        """Register a @mesh_tool decorated function (future use)."""
+        """Register a @mesh_tool decorated function.
+
+        Raises:
+            ValueError: when a DIFFERENT declaration already claimed this
+                advertised MCP tool name (issue #1442). ``func.__name__`` is the
+                wire name — the heartbeat ships it as the tool's
+                ``function_name`` and a client's ``tools/call`` sends it back as
+                ``params.name`` — so a second claimant does not shadow the first
+                harmlessly: one of the two tools becomes permanently
+                unreachable. Re-registering the SAME declaration is an
+                idempotent refresh and does not raise.
+        """
+        tool_name = func.__name__
+        cls._assert_tool_name_unclaimed(tool_name, func)
+
         decorated_func = DecoratedFunction(
             decorator_type="mesh_tool",
             function=func,
@@ -148,7 +265,45 @@ class DecoratorRegistry:
             registered_at=datetime.now(),
         )
 
-        cls._mesh_tools[func.__name__] = decorated_func
+        cls._mesh_tools[tool_name] = decorated_func
+
+    @classmethod
+    def _assert_tool_name_unclaimed(cls, tool_name: str, func: Callable) -> None:
+        """Refuse a second, DIFFERENT declaration of one MCP tool name (#1442).
+
+        The claimed-name index is ``_mesh_tools`` itself — deliberately, rather
+        than a parallel dict. ``_mesh_tools`` is manipulated directly by several
+        test harnesses (snapshot / clear / restore) and by
+        :meth:`unregister_mesh_tool`; a side table would silently de-sync from
+        it and the guard would fire on names nothing holds any more, or miss
+        ones it should catch.
+
+        ``_mesh_tools`` holds the injection WRAPPER once
+        :meth:`update_mesh_tool_function` has run, so the stored function is
+        unwrapped back to its declaration before comparison — both wrapper
+        layers (``dependency_injector.create_injection_wrapper`` and
+        ``decorators._wrap_with_isolation``) use ``functools.wraps``.
+        """
+        previous = cls._mesh_tools.get(tool_name)
+        if previous is None:
+            return
+        if _declaration_identity(previous.function) == _declaration_identity(func):
+            return
+        if _is_dual_module_pair(previous.function, func):
+            logger.debug(
+                "Tool '%s' re-registered under a second module name — deferring to "
+                "the dual-module check (issue #1031)",
+                tool_name,
+            )
+            return
+        raise ValueError(
+            f"Duplicate MCP tool name '{tool_name}': already declared by "
+            f"{_describe_declaration(previous.function)}, declared again by "
+            f"{_describe_declaration(func)}. The tool name is the wire name a "
+            f"client calls (tools/call params.name), so registering it twice "
+            f"would leave one of these tools permanently unreachable. Rename one "
+            f"of the functions, or move one of the tools to a separate agent."
+        )
 
     @classmethod
     def update_mesh_tool_function(cls, func_name: str, new_func: Callable) -> None:

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/jobs_helper_tools.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/jobs_helper_tools.py
@@ -206,6 +206,26 @@ class JobsHelperToolsStep(PipelineStep):
             return result
 
         helpers = _make_helper_tools(registry_url)
+
+        # Issue #1442: a user tool may already have claimed a helper's name.
+        # This check has to run BEFORE _register_on_fastmcp — that call is what
+        # actually clobbers the user's tool on the wire, and it used to happen
+        # first, leaving the user's tool unreachable via MCP but still advertised
+        # in the heartbeat (the DecoratorRegistry guard raised afterwards, into
+        # an `except Exception` that downgraded it to a warning). Drop the
+        # colliding helper instead: the user's tool is the one a client is
+        # actually calling, and the helpers are framework conveniences.
+        claimed = self._names_claimed_by_user_tools(helpers)
+        for name in claimed:
+            self.logger.error(
+                "MeshJob helper tool '%s' is NOT registered: a tool of that name is "
+                "already declared by this agent. '__mesh_job_*' names are reserved by "
+                "the framework — rename your tool to restore job status/result/cancel "
+                "support on this agent.",
+                name,
+            )
+            helpers.pop(name, None)
+
         total_registered = 0
         for server_key, server_instance in servers.items():
             n = _register_on_fastmcp(server_instance, helpers)
@@ -230,6 +250,27 @@ class JobsHelperToolsStep(PipelineStep):
         )
         self.logger.info("📨 %s", result.message)
         return result
+
+    def _names_claimed_by_user_tools(self, helpers: dict[str, Any]) -> list[str]:
+        """Helper names a user-declared ``@mesh.tool`` already owns (#1442).
+
+        A helper re-registered from a previous pass in the same process is NOT
+        a claim — it is this step's own entry, recognised by the
+        ``framework_internal`` marker :meth:`_register_helpers_in_decorator_registry`
+        stamps on it.
+        """
+        try:
+            from ...engine.decorator_registry import DecoratorRegistry
+
+            registered = DecoratorRegistry.get_mesh_tools()
+        except Exception:  # pragma: no cover - registry import guarded below too
+            return []
+        return [
+            name
+            for name in helpers
+            if name in registered
+            and not registered[name].metadata.get("framework_internal")
+        ]
 
     def _register_helpers_in_decorator_registry(
         self, helpers: dict[str, Any]
@@ -288,6 +329,13 @@ class JobsHelperToolsStep(PipelineStep):
                     "jobs_helper_tools: registered %s in DecoratorRegistry",
                     tool_name,
                 )
+            except ValueError:
+                # Issue #1442: a duplicate-tool-name collision is a contract
+                # violation, not a best-effort registration hiccup. Downgrading
+                # it to a warning here is what let a clobbered user tool go
+                # unnoticed. `execute` drops claimed names before we get here,
+                # so reaching this is a real surprise and must surface.
+                raise
             except Exception as e:
                 self.logger.warning(
                     "jobs_helper_tools: failed to register %s in "

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -3498,8 +3498,15 @@ def llm_provider(
         # above is about. Stamp the origin so the guard can tell them apart.
         # Set BEFORE the decorators below so `functools.wraps` copies it onto every
         # wrapper layer.
-        process_chat._mesh_declaration_origin = func
-        process_chat_stream._mesh_declaration_origin = func
+        #
+        # The attribute NAME comes from the guard that reads it, not a literal:
+        # a rename on that side would otherwise silently stop this stamp from
+        # landing and take the whole @mesh.llm_provider surface back to being
+        # invisible to the guard, with nothing failing to say so.
+        from _mcp_mesh.engine.decorator_registry import DECLARATION_ORIGIN_ATTR
+
+        setattr(process_chat, DECLARATION_ORIGIN_ATTR, func)
+        setattr(process_chat_stream, DECLARATION_ORIGIN_ATTR, func)
 
         # CRITICAL: Apply @mesh.tool() FIRST (before FastMCP caches the function)
         # This ensures mesh DI wrapper is in place when FastMCP caches the function

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -3488,6 +3488,19 @@ def llm_provider(
         process_chat_stream.__name__ = f"{func.__name__}_stream"
         process_chat_stream.__qualname__ = f"{func.__qualname__}_stream"
 
+        # Issue #1442: the renames above make the TOOL NAME unique per provider,
+        # but every provider in the process is this same nested `process_chat`
+        # closure — same file, same line, same code object. The duplicate-tool-name
+        # guard identifies a declaration by its source coordinates, so without a
+        # pointer back to the user's function two providers that DO collide on the
+        # tool name (same function name in two modules) would compare equal and the
+        # second would silently replace the first — the very collision the #227 fix
+        # above is about. Stamp the origin so the guard can tell them apart.
+        # Set BEFORE the decorators below so `functools.wraps` copies it onto every
+        # wrapper layer.
+        process_chat._mesh_declaration_origin = func
+        process_chat_stream._mesh_declaration_origin = func
+
         # CRITICAL: Apply @mesh.tool() FIRST (before FastMCP caches the function)
         # This ensures mesh DI wrapper is in place when FastMCP caches the function
         # Decorators are applied bottom-up, so mesh wrapper must be innermost

--- a/src/runtime/python/tests/unit/test_1277_resume_cursor.py
+++ b/src/runtime/python/tests/unit/test_1277_resume_cursor.py
@@ -18,6 +18,18 @@ from unittest import mock
 
 import mesh
 import pytest
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    # Several cases here declare a tool function named ``handler``. Those are
+    # DIFFERENT declarations sharing one advertised MCP tool name, which is a
+    # boot error since issue #1442 — reset the process-wide registry between
+    # cases so each declares into a clean namespace.
+    DecoratorRegistry.clear_all()
+    yield
+    DecoratorRegistry.clear_all()
 
 
 # ===========================================================================

--- a/src/runtime/python/tests/unit/test_1442_duplicate_tool_name.py
+++ b/src/runtime/python/tests/unit/test_1442_duplicate_tool_name.py
@@ -321,6 +321,13 @@ def _fake_llm_provider_tool(user_func):
     Every provider in a process is the same `process_chat` def, renamed to the
     user's function name (the issue #227 fix). Its own source coordinates are
     therefore identical for every provider — hence the origin stamp.
+
+    The attribute name is spelled out as a LITERAL on purpose, where the runtime
+    (`helpers.py` writing it, `decorator_registry.py` reading it) shares a
+    constant. It is a contract between two modules, and a test that imported the
+    constant would follow a rename silently — leaving nothing to notice that
+    anything outside this repo stamping the old name has stopped working. Spelled
+    out, a rename turns these tests red and forces the decision to be conscious.
     """
 
     async def process_chat(request):

--- a/src/runtime/python/tests/unit/test_1442_duplicate_tool_name.py
+++ b/src/runtime/python/tests/unit/test_1442_duplicate_tool_name.py
@@ -1,0 +1,549 @@
+"""Issue #1442: two declarations may not advertise the same MCP tool name.
+
+``DecoratorRegistry.register_mesh_tool`` stored tools with a bare
+``cls._mesh_tools[func.__name__] = decorated_func``. The advertised tool name IS
+the wire name — the heartbeat ships ``func.__name__`` as the tool's
+``function_name`` and a client's ``tools/call`` sends it straight back as
+``params.name`` — so a second function of the same name in another module did
+not shadow the first harmlessly: it replaced it, and the loser never reached
+the heartbeat while still looking registered to whoever wrote it.
+
+The guard fails at registration (i.e. at import, when the decorator fires) and
+names both declaration sites. Its discriminator is the DECLARATION, not the
+function object, which is what keeps it off the legitimate re-registration
+paths — see ``test_dual_module_reregistration_is_not_a_collision``.
+"""
+
+import pytest
+
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    DecoratorRegistry.clear_all()
+    yield
+    DecoratorRegistry.clear_all()
+
+
+def _metadata(capability: str) -> dict:
+    return {
+        "capability": capability,
+        "tags": [],
+        "version": "1.0.0",
+        "dependencies": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Genuine collision
+# ---------------------------------------------------------------------------
+
+
+def test_two_different_functions_sharing_a_tool_name_raise():
+    """Two `analyze` functions from different modules → startup error."""
+
+    # Two genuinely separate declarations: distinct source files, distinct
+    # module names — exactly the "two classes both define `analyze`" shape from
+    # the issue, expressed in Python's module namespace.
+    src = "def analyze(text: str) -> str:\n    return text\n"
+    first = _load(src, "/agent/pkg_a/tools.py", "pkg_a.tools")["analyze"]
+    second = _load(src, "/agent/pkg_b/tools.py", "pkg_b.tools")["analyze"]
+
+    DecoratorRegistry.register_mesh_tool(first, _metadata("analyze-a"))
+
+    with pytest.raises(ValueError) as excinfo:
+        DecoratorRegistry.register_mesh_tool(second, _metadata("analyze-b"))
+
+    message = str(excinfo.value)
+    assert "'analyze'" in message, message
+    assert "pkg_a.tools.analyze" in message, message
+    assert "pkg_b.tools.analyze" in message, message
+
+
+def test_two_same_named_methods_on_different_classes_raise():
+    """The qualname case: `A.analyze` and `B.analyze` both advertise `analyze`."""
+
+    class A:
+        def analyze(self):
+            return "a"
+
+    class B:
+        def analyze(self):
+            return "b"
+
+    DecoratorRegistry.register_mesh_tool(A.analyze, _metadata("a-analyze"))
+
+    with pytest.raises(ValueError) as excinfo:
+        DecoratorRegistry.register_mesh_tool(B.analyze, _metadata("b-analyze"))
+
+    message = str(excinfo.value)
+    assert "A.analyze" in message, message
+    assert "B.analyze" in message, message
+
+
+def test_the_first_registration_survives_a_rejected_second():
+    """The winner must not be half-replaced by the raise."""
+
+    class A:
+        def analyze(self):
+            return "a"
+
+    class B:
+        def analyze(self):
+            return "b"
+
+    DecoratorRegistry.register_mesh_tool(A.analyze, _metadata("a-analyze"))
+    with pytest.raises(ValueError):
+        DecoratorRegistry.register_mesh_tool(B.analyze, _metadata("b-analyze"))
+
+    registered = DecoratorRegistry.get_mesh_tools()["analyze"]
+    assert registered.metadata["capability"] == "a-analyze"
+
+
+# ---------------------------------------------------------------------------
+# Idempotent re-registration is NOT a collision (the PR #1445 regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_same_function_reregistered_is_tolerated():
+    def greet(name: str) -> str:
+        return name
+
+    DecoratorRegistry.register_mesh_tool(greet, _metadata("greet"))
+    DecoratorRegistry.register_mesh_tool(greet, _metadata("greet"))
+
+    assert "greet" in DecoratorRegistry.get_mesh_tools()
+
+
+def _load(source: str, filename: str, module_name: str):
+    """Independently compile+exec `source`, as a real second import would."""
+    namespace: dict = {"__name__": module_name}
+    # A separate compile() per load: the same file read twice produces two
+    # distinct code objects that AGREE on (co_filename, co_firstlineno). Sharing
+    # one compiled object between both namespaces would make the test pass
+    # trivially, whatever the discriminator.
+    exec(compile(source, filename, "exec"), namespace)
+    return namespace
+
+
+def test_reexecuted_module_is_tolerated():
+    """`importlib.reload`-style re-execution produces a NEW function object.
+
+    Object identity would boot-fail this; the declaration identity (source
+    coordinates) does not.
+    """
+    src = "def greet(name):\n    return name\n"
+    first = _load(src, "/agent/greetings.py", "greetings")
+    second = _load(src, "/agent/greetings.py", "greetings")
+
+    assert first["greet"] is not second["greet"]
+    assert first["greet"].__code__ is not second["greet"].__code__
+
+    DecoratorRegistry.register_mesh_tool(first["greet"], _metadata("greet"))
+    DecoratorRegistry.register_mesh_tool(second["greet"], _metadata("greet"))
+
+    assert "greet" in DecoratorRegistry.get_mesh_tools()
+
+
+def test_dual_module_reregistration_is_not_a_collision():
+    """The `__main__.X` / `<module>.X` footgun (issue #1031) must NOT trip here.
+
+    ``python main.py`` plus a sibling's ``from main import X`` evaluates main.py
+    twice as two distinct module objects, so ``__module__`` differs (``__main__``
+    vs ``main``) for the SAME declaration. That case has its own dedicated
+    diagnostic in ``pipeline.mcp_startup.dual_module_check``, which explains the
+    restructure-as-a-package fix; a generic "duplicate tool name" error raised
+    here would pre-empt it with a much worse message.
+    """
+    src = "def greet(name):\n    return name\n"
+    main_ns = _load(src, "/agent/main.py", "__main__")
+    reimport_ns = _load(src, "/agent/main.py", "main")
+
+    assert main_ns["greet"].__module__ == "__main__"
+    assert reimport_ns["greet"].__module__ == "main"
+    assert main_ns["greet"].__code__ is not reimport_ns["greet"].__code__
+
+    DecoratorRegistry.register_mesh_tool(main_ns["greet"], _metadata("greet"))
+    DecoratorRegistry.register_mesh_tool(reimport_ns["greet"], _metadata("greet"))
+
+    assert "greet" in DecoratorRegistry.get_mesh_tools()
+
+
+def test_dual_module_tolerated_even_when_the_two_loads_spell_the_path_differently():
+    """The entry script and the re-import need not agree on `co_filename`.
+
+    ``python main.py`` can report the path as given on the command line while
+    the later ``import main`` reports the resolved one. Source coordinates then
+    disagree for what is still ONE declaration, so the guard falls back to the
+    same conservative rule ``dual_module_detection`` uses: exactly one side is
+    ``__main__``, and both name the same function.
+    """
+    src = "def greet(name):\n    return name\n"
+    main_ns = _load(src, "main.py", "__main__")
+    reimport_ns = _load(src, "/agent/main.py", "main")
+
+    assert main_ns["greet"].__code__.co_filename != (
+        reimport_ns["greet"].__code__.co_filename
+    )
+
+    DecoratorRegistry.register_mesh_tool(main_ns["greet"], _metadata("greet"))
+    DecoratorRegistry.register_mesh_tool(reimport_ns["greet"], _metadata("greet"))
+
+    assert "greet" in DecoratorRegistry.get_mesh_tools()
+
+
+def test_two_ordinary_modules_are_still_a_collision():
+    """The dual-module tolerance must not become a blanket same-name pass.
+
+    Neither side is ``__main__``, so this is the plain two-modules-define-
+    `analyze` case the guard exists to catch.
+    """
+    src = "def analyze(text):\n    return text\n"
+    a = _load(src, "/agent/pkg_a/tools.py", "pkg_a.tools")
+    b = _load(src, "/agent/pkg_b/tools.py", "pkg_b.tools")
+
+    DecoratorRegistry.register_mesh_tool(a["analyze"], _metadata("a"))
+    with pytest.raises(ValueError, match="Duplicate MCP tool name 'analyze'"):
+        DecoratorRegistry.register_mesh_tool(b["analyze"], _metadata("b"))
+
+
+def test_wrapper_reregistration_is_tolerated():
+    """A functools.wraps wrapper is the same declaration as what it wraps.
+
+    ``@mesh.tool`` registers the original function and then swaps in the
+    injection wrapper; a later pass registering the wrapper must not read as a
+    second declaration.
+    """
+    import functools
+
+    def greet(name: str) -> str:
+        return name
+
+    @functools.wraps(greet)
+    def wrapper(*args, **kwargs):
+        return greet(*args, **kwargs)
+
+    DecoratorRegistry.register_mesh_tool(greet, _metadata("greet"))
+    DecoratorRegistry.register_mesh_tool(wrapper, _metadata("greet"))
+
+    assert "greet" in DecoratorRegistry.get_mesh_tools()
+
+
+def test_unregistered_name_can_be_claimed_again():
+    """Decoration-failure cleanup must release the name, not poison it."""
+
+    class A:
+        def analyze(self):
+            return "a"
+
+    class B:
+        def analyze(self):
+            return "b"
+
+    DecoratorRegistry.register_mesh_tool(A.analyze, _metadata("a-analyze"))
+    DecoratorRegistry.unregister_mesh_tool("analyze")
+
+    DecoratorRegistry.register_mesh_tool(B.analyze, _metadata("b-analyze"))
+    assert DecoratorRegistry.get_mesh_tools()["analyze"].metadata["capability"] == (
+        "b-analyze"
+    )
+
+
+def test_clear_all_releases_claimed_names():
+    class A:
+        def analyze(self):
+            return "a"
+
+    class B:
+        def analyze(self):
+            return "b"
+
+    DecoratorRegistry.register_mesh_tool(A.analyze, _metadata("a-analyze"))
+    DecoratorRegistry.clear_all()
+
+    DecoratorRegistry.register_mesh_tool(B.analyze, _metadata("b-analyze"))
+    assert "analyze" in DecoratorRegistry.get_mesh_tools()
+
+
+def test_direct_mesh_tools_manipulation_cannot_desync_the_guard():
+    """`_mesh_tools` IS the claimed-name index — there is no side table.
+
+    Several test harnesses snapshot / clear / restore `_mesh_tools` directly.
+    A parallel dict would keep a name claimed that `_mesh_tools` no longer
+    holds, and the guard would refuse a name nothing owns.
+    """
+    src = "def analyze(text):\n    return text\n"
+    a = _load(src, "/agent/pkg_a/tools.py", "pkg_a.tools")["analyze"]
+    b = _load(src, "/agent/pkg_b/tools.py", "pkg_b.tools")["analyze"]
+
+    DecoratorRegistry.register_mesh_tool(a, _metadata("a"))
+    DecoratorRegistry._mesh_tools.clear()
+
+    DecoratorRegistry.register_mesh_tool(b, _metadata("b"))
+    assert DecoratorRegistry.get_mesh_tools()["analyze"].metadata["capability"] == "b"
+
+
+def test_collision_is_caught_after_the_wrapper_swap():
+    """The stored function becomes the injection WRAPPER — still discriminates.
+
+    `@mesh.tool` calls `update_mesh_tool_function` right after registration, so
+    by the time a second declaration arrives the registry no longer holds the
+    original function. Both wrapper layers use `functools.wraps`, so the guard
+    unwraps back to the declaration.
+    """
+    import functools
+
+    src = "def analyze(text):\n    return text\n"
+    a = _load(src, "/agent/pkg_a/tools.py", "pkg_a.tools")["analyze"]
+    b = _load(src, "/agent/pkg_b/tools.py", "pkg_b.tools")["analyze"]
+
+    DecoratorRegistry.register_mesh_tool(a, _metadata("a"))
+
+    @functools.wraps(a)
+    def injection_wrapper(*args, **kwargs):
+        return a(*args, **kwargs)
+
+    DecoratorRegistry.update_mesh_tool_function("analyze", injection_wrapper)
+
+    with pytest.raises(ValueError, match="Duplicate MCP tool name 'analyze'"):
+        DecoratorRegistry.register_mesh_tool(b, _metadata("b"))
+
+
+# ---------------------------------------------------------------------------
+# Factory-built tools: @mesh.llm_provider (issue #227 / #1442)
+# ---------------------------------------------------------------------------
+
+
+def _fake_llm_provider_tool(user_func):
+    """Reproduce `mesh.llm_provider`'s shape: ONE shared nested closure.
+
+    Every provider in a process is the same `process_chat` def, renamed to the
+    user's function name (the issue #227 fix). Its own source coordinates are
+    therefore identical for every provider — hence the origin stamp.
+    """
+
+    async def process_chat(request):
+        return await user_func(request)
+
+    process_chat.__name__ = user_func.__name__
+    process_chat.__qualname__ = user_func.__qualname__
+    process_chat._mesh_declaration_origin = user_func
+    return process_chat
+
+
+def test_two_llm_providers_sharing_a_function_name_collide():
+    """The collision `helpers.py`'s #227 comment is about.
+
+    Without the origin stamp both providers resolve to the SAME nested closure
+    (same file, same line), compare equal, and the second silently replaces the
+    first — the guard would be inert for the exact case it was built for.
+    """
+    src = "async def chat(request):\n    return request\n"
+    first_user = _load(src, "/agent/claude.py", "agent.claude")["chat"]
+    second_user = _load(src, "/agent/gpt.py", "agent.gpt")["chat"]
+
+    first = _fake_llm_provider_tool(first_user)
+    second = _fake_llm_provider_tool(second_user)
+    # The tool functions themselves are indistinguishable by source.
+    assert first.__code__ is second.__code__
+    assert first.__name__ == second.__name__ == "chat"
+
+    DecoratorRegistry.register_mesh_tool(first, _metadata("llm-claude"))
+    with pytest.raises(ValueError) as excinfo:
+        DecoratorRegistry.register_mesh_tool(second, _metadata("llm-gpt"))
+
+    message = str(excinfo.value)
+    assert "claude.py" in message, message
+    assert "gpt.py" in message, message
+
+
+def test_one_llm_provider_reregistered_is_still_tolerated():
+    src = "async def chat(request):\n    return request\n"
+    user = _load(src, "/agent/claude.py", "agent.claude")["chat"]
+
+    DecoratorRegistry.register_mesh_tool(
+        _fake_llm_provider_tool(user), _metadata("llm-claude")
+    )
+    DecoratorRegistry.register_mesh_tool(
+        _fake_llm_provider_tool(user), _metadata("llm-claude")
+    )
+
+    assert "chat" in DecoratorRegistry.get_mesh_tools()
+
+
+def test_real_llm_provider_decorator_rejects_two_providers_named_the_same():
+    """End-to-end through the real `mesh.llm_provider`, not a stand-in.
+
+    Links the stand-in above to the shipping decorator: `helpers.py` must stamp
+    the origin, or this pair is invisible to the guard.
+    """
+    import sys
+    import types
+
+    from fastmcp import FastMCP
+
+    import mesh
+
+    src = "def chat():\n    pass\n"
+    modules = []
+    try:
+        for module_name, filename in (
+            ("_t1442_provider_a", "/agent/a.py"),
+            ("_t1442_provider_b", "/agent/b.py"),
+        ):
+            module = types.ModuleType(module_name)
+            module.app = FastMCP(module_name)
+            sys.modules[module_name] = module
+            modules.append(module_name)
+
+        first = _load(src, "/agent/a.py", "_t1442_provider_a")["chat"]
+        second = _load(src, "/agent/b.py", "_t1442_provider_b")["chat"]
+
+        mesh.llm_provider(
+            model="anthropic/claude-3-5-haiku-20241022", capability="llm-a"
+        )(first)
+
+        with pytest.raises(ValueError) as excinfo:
+            mesh.llm_provider(model="openai/gpt-4o-mini", capability="llm-b")(second)
+        assert "Duplicate MCP tool name 'chat'" in str(excinfo.value)
+    finally:
+        for module_name in modules:
+            sys.modules.pop(module_name, None)
+
+
+def test_llm_provider_origin_survives_the_wrapper_layers():
+    """`functools.wraps` copies `__dict__`, so the stamp reaches every layer."""
+    import functools
+
+    src = "async def chat(request):\n    return request\n"
+    user = _load(src, "/agent/claude.py", "agent.claude")["chat"]
+    provider = _fake_llm_provider_tool(user)
+
+    @functools.wraps(provider)
+    async def injection_wrapper(*args, **kwargs):
+        return await provider(*args, **kwargs)
+
+    assert injection_wrapper._mesh_declaration_origin is user
+
+    other = _fake_llm_provider_tool(_load(src, "/agent/gpt.py", "agent.gpt")["chat"])
+    DecoratorRegistry.register_mesh_tool(injection_wrapper, _metadata("llm-claude"))
+    with pytest.raises(ValueError):
+        DecoratorRegistry.register_mesh_tool(other, _metadata("llm-gpt"))
+
+
+# ---------------------------------------------------------------------------
+# A normal agent must not trip the guard
+# ---------------------------------------------------------------------------
+
+
+def test_jobs_helper_registration_is_idempotent_across_passes():
+    """`_make_helper_tools` builds FRESH closures on every call.
+
+    The pipeline step can run more than once in a process (context restart,
+    repeated pipeline execution); the three helper names must not collide with
+    themselves.
+    """
+    from _mcp_mesh.pipeline.mcp_startup.jobs_helper_tools import _make_helper_tools
+
+    first = _make_helper_tools("http://registry:8000")
+    second = _make_helper_tools("http://registry:8000")
+    assert first["__mesh_job_status"] is not second["__mesh_job_status"]
+
+    for helpers in (first, second):
+        for name, fn in helpers.items():
+            DecoratorRegistry.register_mesh_tool(fn, _metadata(name))
+
+    tools = DecoratorRegistry.get_mesh_tools()
+    assert {"__mesh_job_status", "__mesh_job_result", "__mesh_job_cancel"} <= set(tools)
+
+
+@pytest.mark.asyncio
+async def test_jobs_helper_does_not_clobber_a_user_tool_of_the_same_name():
+    """A user tool named `__mesh_job_status` must survive on BOTH surfaces.
+
+    `_register_on_fastmcp` runs before the DecoratorRegistry registration, so
+    the helper used to overwrite the user's tool on the wire and only then hit
+    the guard — whose ValueError was swallowed by an `except Exception` →
+    warning. Net effect: the user's tool unreachable via MCP, still advertised
+    in the heartbeat.
+    """
+    from _mcp_mesh.pipeline.mcp_startup.jobs_helper_tools import JobsHelperToolsStep
+
+    src = "async def __mesh_job_status(job_id):\n    return {'mine': True}\n"
+    user_tool = _load(src, "/agent/main.py", "__main__")["__mesh_job_status"]
+    DecoratorRegistry.register_mesh_tool(user_tool, _metadata("__mesh_job_status"))
+
+    registered_on_fastmcp: list[str] = []
+
+    class _FakeFastMCP:
+        def tool(self, name: str, description: str = ""):
+            def _decorator(fn):
+                registered_on_fastmcp.append(name)
+                return fn
+
+            return _decorator
+
+    result = await JobsHelperToolsStep().execute(
+        {
+            "registry_url": "http://registry:8000",
+            "fastmcp_servers": {"default": _FakeFastMCP()},
+        }
+    )
+
+    assert result.status.name != "FAILED", result.message
+    assert "__mesh_job_status" not in registered_on_fastmcp, (
+        "the contested helper must not be registered on the FastMCP server — "
+        "that is what makes the user's tool unreachable"
+    )
+    assert {"__mesh_job_result", "__mesh_job_cancel"} <= set(
+        registered_on_fastmcp
+    ), "the other two helpers are uncontested and must still register"
+
+    # The user's tool still owns the name in the heartbeat catalog.
+    surviving = DecoratorRegistry.get_mesh_tools()["__mesh_job_status"]
+    assert surviving.metadata.get("framework_internal") is None
+
+
+@pytest.mark.asyncio
+async def test_jobs_helper_step_registers_all_three_when_uncontested():
+    from _mcp_mesh.pipeline.mcp_startup.jobs_helper_tools import JobsHelperToolsStep
+
+    registered_on_fastmcp: list[str] = []
+
+    class _FakeFastMCP:
+        def tool(self, name: str, description: str = ""):
+            def _decorator(fn):
+                registered_on_fastmcp.append(name)
+                return fn
+
+            return _decorator
+
+    await JobsHelperToolsStep().execute(
+        {
+            "registry_url": "http://registry:8000",
+            "fastmcp_servers": {"default": _FakeFastMCP()},
+        }
+    )
+
+    assert set(registered_on_fastmcp) == {
+        "__mesh_job_status",
+        "__mesh_job_result",
+        "__mesh_job_cancel",
+    }
+    assert {"__mesh_job_status", "__mesh_job_result", "__mesh_job_cancel"} <= set(
+        DecoratorRegistry.get_mesh_tools()
+    )
+
+
+def test_distinct_tool_names_coexist():
+    def greet(name: str) -> str:
+        return name
+
+    def farewell(name: str) -> str:
+        return name
+
+    DecoratorRegistry.register_mesh_tool(greet, _metadata("greet"))
+    DecoratorRegistry.register_mesh_tool(farewell, _metadata("farewell"))
+
+    assert set(DecoratorRegistry.get_mesh_tools()) == {"greet", "farewell"}

--- a/src/runtime/typescript/src/__tests__/agent-duplicate-tool-name.spec.ts
+++ b/src/runtime/typescript/src/__tests__/agent-duplicate-tool-name.spec.ts
@@ -480,6 +480,38 @@ describe("addLlmProvider — duplicate advertised tool name (#1442)", () => {
     expect(() => agent.addLlmProvider({ ...config })).not.toThrow();
   });
 
+  it("the error names addLlmProvider, not addTool", () => {
+    // The check is shared with `addTool`; the message must still point at the
+    // API the caller actually invoked.
+    const agent = newAgent();
+    agent.addLlmProvider({
+      model: "anthropic/claude-sonnet-4-5",
+      capability: "llm-claude",
+    });
+    expect(() =>
+      agent.addLlmProvider({
+        model: "openai/gpt-4o-mini",
+        capability: "llm-gpt",
+      }),
+    ).toThrow(/^addLlmProvider: duplicate MCP tool name/);
+  });
+
+  it("addTool's error still names addTool", () => {
+    const agent = newAgent();
+    agent.addTool({
+      name: "greet",
+      parameters: z.object({}),
+      execute: async () => "a",
+    });
+    expect(() =>
+      agent.addTool({
+        name: "greet",
+        parameters: z.object({}),
+        execute: async () => "b",
+      }),
+    ).toThrow(/^addTool: duplicate MCP tool name/);
+  });
+
   it("a provider collides with a same-named addTool declaration", () => {
     // Cross-surface: the wire name is one namespace regardless of which entry
     // point claimed it.
@@ -543,6 +575,54 @@ describe("jobs helper tools — do not clobber a user tool (#1442)", () => {
     expect((agent as any).tools.get("__mesh_job_status").capability).toBe(
       "my_status",
     );
+  });
+
+  it("a helper registered FIRST blocks a later conflicting addTool", () => {
+    // The reverse order. `registerJobsHelperTools` runs from `_autoStart`,
+    // which is process.nextTick-scheduled and awaits the port probe — so any
+    // `addTool` made after an `await` in user startup code lands after the
+    // helpers. Without recording the helper names, that `addTool` passed the
+    // guard and clobbered the helper on the FastMCP server (fastmcp's addTool
+    // filters out the previous entry); the catalog's `tools.has` check only
+    // protected the heartbeat view.
+    const stub = makeFastMCPStub();
+    const agent = new MeshAgent(stub, {
+      name: "test-agent-jobshelper-reverse",
+      httpPort: 0,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).config.registryUrl = "http://registry:8000";
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).registerJobsHelperTools();
+
+    expect(() =>
+      agent.addTool({
+        name: "__mesh_job_status",
+        capability: "my_status",
+        parameters: z.object({}),
+        execute: async () => "mine",
+      }),
+    ).toThrow(/duplicate MCP tool name '__mesh_job_status'/);
+  });
+
+  it("a second helper registration pass is idempotent, not a collision", () => {
+    // Same declaration, same names — re-running the pass must not throw.
+    const stub = makeFastMCPStub();
+    const agent = new MeshAgent(stub, {
+      name: "test-agent-jobshelper-twice",
+      httpPort: 0,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).config.registryUrl = "http://registry:8000";
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).registerJobsHelperTools();
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (agent as any).registerJobsHelperTools();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }).not.toThrow();
   });
 
   it("registers all three when uncontested", () => {

--- a/src/runtime/typescript/src/__tests__/agent-duplicate-tool-name.spec.ts
+++ b/src/runtime/typescript/src/__tests__/agent-duplicate-tool-name.spec.ts
@@ -1,0 +1,577 @@
+/**
+ * Issue #1442: two declarations may not advertise the same MCP tool name.
+ *
+ * `def.name` is the wire name — the heartbeat ships it as the tool's
+ * `function_name` and a client's `tools/call` sends it straight back as
+ * `params.name`. `addTool` validated the capability grammar but never checked
+ * the tool NAME, and both registration sinks are last-wins: `this.tools` is a
+ * plain `Map.set`, and fastmcp's own `addTool` filters out the previous entry.
+ * A second tool under an existing name therefore made the first one vanish from
+ * `tools/list` while the registry kept advertising it.
+ *
+ * The guard's discriminator is the DECLARATION (published capability + handler
+ * source), not the definition object's reference — the PR #1445 lesson: the
+ * re-registration paths are precisely the ones that hand over a fresh object
+ * for an unchanged declaration.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { z } from "zod";
+import { MeshAgent } from "../agent.js";
+
+function makeFastMCPStub() {
+  return {
+    addTool: vi.fn(),
+    start: vi.fn(),
+    getApp: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+let autoStartSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+beforeEach(() => {
+  autoStartSpy = vi
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .spyOn(MeshAgent.prototype as any, "_autoStart")
+    .mockImplementation(async () => {
+      /* no-op */
+    });
+});
+
+afterEach(() => {
+  if (autoStartSpy) {
+    autoStartSpy.mockRestore();
+    autoStartSpy = null;
+  }
+});
+
+describe("addTool — duplicate advertised tool name (issue #1442)", () => {
+  function newAgent(): MeshAgent {
+    return new MeshAgent(makeFastMCPStub(), {
+      name: "test-agent-dupname",
+      httpPort: 0,
+    });
+  }
+
+  it("rejects a second, different declaration under the same tool name", () => {
+    const agent = newAgent();
+    agent.addTool({
+      name: "analyze",
+      capability: "analyze-text",
+      parameters: z.object({}),
+      execute: async () => "text",
+    });
+
+    expect(() =>
+      agent.addTool({
+        name: "analyze",
+        capability: "analyze-image",
+        parameters: z.object({}),
+        execute: async () => "image",
+      }),
+    ).toThrow(/duplicate MCP tool name 'analyze'/);
+  });
+
+  it("names both colliding declarations in the error", () => {
+    const agent = newAgent();
+    agent.addTool({
+      name: "search",
+      capability: "search-docs",
+      parameters: z.object({}),
+      execute: async () => "docs",
+    });
+
+    let message = "";
+    try {
+      agent.addTool({
+        name: "search",
+        capability: "search-people",
+        parameters: z.object({}),
+        execute: async () => "people",
+      });
+    } catch (err) {
+      message = String(err);
+    }
+    expect(message).toContain("'search'");
+    expect(message).toContain("search-docs");
+    expect(message).toContain("search-people");
+  });
+
+  it("rejects a same-capability tool whose handler differs", () => {
+    // Same published capability, different implementation — still two tools
+    // fighting over one wire name.
+    const agent = newAgent();
+    agent.addTool({
+      name: "greet",
+      parameters: z.object({}),
+      execute: async () => "hello",
+    });
+
+    expect(() =>
+      agent.addTool({
+        name: "greet",
+        parameters: z.object({}),
+        execute: async () => "goodbye",
+      }),
+    ).toThrow(/duplicate MCP tool name 'greet'/);
+  });
+
+  it("does not register the rejected tool with fastmcp", () => {
+    const stub = makeFastMCPStub();
+    const agent = new MeshAgent(stub, {
+      name: "test-agent-dupname-nofastmcp",
+      httpPort: 0,
+    });
+    agent.addTool({
+      name: "analyze",
+      parameters: z.object({}),
+      execute: async () => "first",
+    });
+    expect(() =>
+      agent.addTool({
+        name: "analyze",
+        parameters: z.object({}),
+        execute: async () => "second",
+      }),
+    ).toThrow();
+
+    // Exactly one fastmcp registration — the guard runs before anything is
+    // handed to the server.
+    expect(stub.addTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows distinct tool names", () => {
+    const agent = newAgent();
+    expect(() => {
+      agent.addTool({
+        name: "greet",
+        parameters: z.object({}),
+        execute: async () => "hi",
+      });
+      agent.addTool({
+        name: "farewell",
+        parameters: z.object({}),
+        execute: async () => "bye",
+      });
+    }).not.toThrow();
+  });
+
+  // ── Idempotent re-registration is NOT a collision (the #1445 regression) ──
+
+  it("tolerates re-registering the exact same definition object", () => {
+    const agent = newAgent();
+    const def = {
+      name: "greet",
+      capability: "greet",
+      parameters: z.object({}),
+      execute: async () => "hi",
+    };
+    agent.addTool(def);
+    expect(() => agent.addTool(def)).not.toThrow();
+  });
+
+  it("tolerates an equivalent declaration built from a fresh object", () => {
+    // A module re-evaluated (test-runner module reset, dual CJS/ESM load)
+    // rebuilds the definition AND the handler closure. Reference identity
+    // would boot-fail that; the declaration identity does not.
+    const agent = newAgent();
+    const build = () => ({
+      name: "greet",
+      capability: "greet",
+      parameters: z.object({}),
+      execute: async () => "hi",
+    });
+    const first = build();
+    const second = build();
+    expect(first).not.toBe(second);
+    expect(first.execute).not.toBe(second.execute);
+
+    agent.addTool(first);
+    expect(() => agent.addTool(second)).not.toThrow();
+  });
+
+  it("tolerates a re-registration that only changes non-wire metadata", () => {
+    const agent = newAgent();
+    const execute = async () => "hi";
+    agent.addTool({
+      name: "greet",
+      capability: "greet",
+      description: "first pass",
+      parameters: z.object({}),
+      execute,
+    });
+    expect(() =>
+      agent.addTool({
+        name: "greet",
+        capability: "greet",
+        description: "second pass",
+        parameters: z.object({}),
+        execute,
+      }),
+    ).not.toThrow();
+  });
+
+  it("guards worker mode too", () => {
+    // Worker mode returns early from addTool (no fastmcp, no metadata), but
+    // the tool name still keys `_workerToolMap`, so the same collision applies.
+    const agent = newAgent();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any)._workerMode = true;
+    agent.addTool({
+      name: "analyze",
+      parameters: z.object({}),
+      execute: async () => "first",
+    });
+    expect(() =>
+      agent.addTool({
+        name: "analyze",
+        parameters: z.object({}),
+        execute: async () => "second",
+      }),
+    ).toThrow(/duplicate MCP tool name 'analyze'/);
+  });
+});
+
+// =============================================================================
+// The identity has to cover the WHOLE wire shape, not just the handler body.
+// Two declarations can share an `execute` source and still publish different
+// schemas / dependencies / tags / versions — and `Function.prototype.toString`
+// collapses to "[native code]" for bound and native functions, which would make
+// every one of those look like the same declaration.
+// =============================================================================
+
+describe("addTool — declaration identity covers the wire shape (#1442)", () => {
+  function newAgent(): MeshAgent {
+    return new MeshAgent(makeFastMCPStub(), {
+      name: "test-agent-identity",
+      httpPort: 0,
+    });
+  }
+
+  const sharedExecute = async () => "x";
+
+  function addWith(agent: MeshAgent, extra: Record<string, unknown>) {
+    agent.addTool({
+      name: "tool",
+      parameters: z.object({}),
+      execute: sharedExecute,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...(extra as any),
+    });
+  }
+
+  it("distinguishes declarations that differ only in input schema", () => {
+    const agent = newAgent();
+    agent.addTool({
+      name: "tool",
+      parameters: z.object({ a: z.string() }),
+      execute: sharedExecute,
+    });
+    expect(() =>
+      agent.addTool({
+        name: "tool",
+        parameters: z.object({ b: z.number() }),
+        execute: sharedExecute,
+      }),
+    ).toThrow(/duplicate MCP tool name 'tool'/);
+  });
+
+  it("distinguishes declarations that differ only in dependencies", () => {
+    const agent = newAgent();
+    addWith(agent, { dependencies: ["alpha"] });
+    expect(() => addWith(agent, { dependencies: ["beta"] })).toThrow(
+      /duplicate MCP tool name 'tool'/,
+    );
+  });
+
+  it("distinguishes declarations that differ only in tags", () => {
+    const agent = newAgent();
+    addWith(agent, { tags: ["one"] });
+    expect(() => addWith(agent, { tags: ["two"] })).toThrow(
+      /duplicate MCP tool name 'tool'/,
+    );
+  });
+
+  it("distinguishes declarations that differ only in version", () => {
+    const agent = newAgent();
+    addWith(agent, { version: "1.0.0" });
+    expect(() => addWith(agent, { version: "2.0.0" })).toThrow(
+      /duplicate MCP tool name 'tool'/,
+    );
+  });
+
+  it("distinguishes bound handlers, whose source text is '[native code]'", () => {
+    // Both handlers stringify to "function () { [native code] }" — the source
+    // text carries NO information here, so the wire fields are the only thing
+    // left to tell the two declarations apart.
+    const agent = newAgent();
+    const boundA = (async () => "a").bind(null);
+    const boundB = (async () => "b").bind(null);
+    expect(boundA.toString()).toBe(boundB.toString());
+
+    agent.addTool({
+      name: "tool",
+      capability: "cap",
+      parameters: z.object({ a: z.string() }),
+      execute: boundA,
+    });
+    expect(() =>
+      agent.addTool({
+        name: "tool",
+        capability: "cap",
+        parameters: z.object({ b: z.number() }),
+        execute: boundB,
+      }),
+    ).toThrow(/duplicate MCP tool name 'tool'/);
+  });
+
+  it("still tolerates a wire-identical redeclaration", () => {
+    const agent = newAgent();
+    const decl = () => ({
+      name: "tool",
+      capability: "cap",
+      version: "1.0.0",
+      tags: ["t"],
+      dependencies: ["alpha"],
+      parameters: z.object({ a: z.string() }),
+      execute: async () => "x",
+    });
+    agent.addTool(decl());
+    expect(() => agent.addTool(decl())).not.toThrow();
+  });
+});
+
+// =============================================================================
+// A failed registration must not leave the name claimed — otherwise fixing the
+// declaration and retrying is refused by the guard. Python gets this via
+// `unregister_mesh_tool`; this is the TS parity.
+// =============================================================================
+
+describe("addTool — a rejected declaration does not claim the name (#1442)", () => {
+  function newAgent(): MeshAgent {
+    return new MeshAgent(makeFastMCPStub(), {
+      name: "test-agent-claim-late",
+      httpPort: 0,
+    });
+  }
+
+  it("a tool rejected by a LATER validation leaves the name free", () => {
+    const agent = newAgent();
+    // `task: true` with a sync execute throws — after the duplicate-name check.
+    expect(() =>
+      agent.addTool({
+        name: "greet",
+        task: true,
+        parameters: z.object({}),
+        execute: function () {
+          return "x";
+        },
+      }),
+    ).toThrow(/requires an async execute function/);
+
+    // The corrected declaration must be accepted, not refused as a duplicate.
+    expect(() =>
+      agent.addTool({
+        name: "greet",
+        task: true,
+        parameters: z.object({}),
+        execute: async () => "x",
+      }),
+    ).not.toThrow();
+  });
+
+  it("a tool rejected by meshJobDepIndex validation leaves the name free", () => {
+    const agent = newAgent();
+    expect(() =>
+      agent.addTool({
+        name: "consume",
+        parameters: z.object({}),
+        dependencies: ["alpha"],
+        meshJobDepIndex: 5,
+        execute: async () => "x",
+      }),
+    ).toThrow(/out of range/);
+
+    // The natural fix for an out-of-range index is to declare the dependency
+    // it was pointing at — which changes the wire shape, so a claim left over
+    // from the rejected attempt would refuse this as a duplicate.
+    expect(() =>
+      agent.addTool({
+        name: "consume",
+        parameters: z.object({}),
+        dependencies: ["alpha", "beta", "gamma", "delta", "epsilon", "zeta"],
+        meshJobDepIndex: 5,
+        execute: async () => "x",
+      }),
+    ).not.toThrow();
+  });
+});
+
+// =============================================================================
+// addLlmProvider registers with FastMCP directly, never through addTool — so it
+// needs the same guard. `llmProvider` defaults the tool name to "process_chat",
+// so two providers with no explicit `name` both claim it.
+// =============================================================================
+
+describe("addLlmProvider — duplicate advertised tool name (#1442)", () => {
+  function newAgent(): MeshAgent {
+    return new MeshAgent(makeFastMCPStub(), {
+      name: "test-agent-llmprovider",
+      httpPort: 0,
+    });
+  }
+
+  it("rejects two providers that both default to 'process_chat'", () => {
+    const agent = newAgent();
+    agent.addLlmProvider({
+      model: "anthropic/claude-sonnet-4-5",
+      capability: "llm-claude",
+    });
+    expect(() =>
+      agent.addLlmProvider({
+        model: "openai/gpt-4o-mini",
+        capability: "llm-gpt",
+      }),
+    ).toThrow(/duplicate MCP tool name 'process_chat'/);
+  });
+
+  it("does not register the rejected provider with fastmcp", () => {
+    const stub = makeFastMCPStub();
+    const agent = new MeshAgent(stub, {
+      name: "test-agent-llmprovider-nofastmcp",
+      httpPort: 0,
+    });
+    agent.addLlmProvider({
+      model: "anthropic/claude-sonnet-4-5",
+      capability: "llm-claude",
+    });
+    expect(() =>
+      agent.addLlmProvider({
+        model: "openai/gpt-4o-mini",
+        capability: "llm-gpt",
+      }),
+    ).toThrow();
+    expect(stub.addTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows two providers under explicitly distinct names", () => {
+    const agent = newAgent();
+    expect(() => {
+      agent.addLlmProvider({
+        model: "anthropic/claude-sonnet-4-5",
+        capability: "llm-claude",
+        name: "claude_chat",
+      });
+      agent.addLlmProvider({
+        model: "openai/gpt-4o-mini",
+        capability: "llm-gpt",
+        name: "gpt_chat",
+      });
+    }).not.toThrow();
+  });
+
+  it("tolerates the same provider config registered twice", () => {
+    const agent = newAgent();
+    const config = {
+      model: "anthropic/claude-sonnet-4-5",
+      capability: "llm-claude",
+    };
+    agent.addLlmProvider({ ...config });
+    expect(() => agent.addLlmProvider({ ...config })).not.toThrow();
+  });
+
+  it("a provider collides with a same-named addTool declaration", () => {
+    // Cross-surface: the wire name is one namespace regardless of which entry
+    // point claimed it.
+    const agent = newAgent();
+    agent.addTool({
+      name: "process_chat",
+      capability: "my-chat",
+      parameters: z.object({}),
+      execute: async () => "x",
+    });
+    expect(() =>
+      agent.addLlmProvider({
+        model: "anthropic/claude-sonnet-4-5",
+        capability: "llm-claude",
+      }),
+    ).toThrow(/duplicate MCP tool name 'process_chat'/);
+  });
+});
+
+// =============================================================================
+// The three `__mesh_job_*` helper names are framework-reserved. When a user
+// tool owns one, the helper must not register over it on the FastMCP server.
+// =============================================================================
+
+describe("jobs helper tools — do not clobber a user tool (#1442)", () => {
+  it("skips only the contested helper, on the server as well as the catalog", () => {
+    const registered: string[] = [];
+    const stub = {
+      addTool: vi.fn((tool: { name: string }) => {
+        registered.push(tool.name);
+      }),
+      start: vi.fn(),
+      getApp: vi.fn(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const agent = new MeshAgent(stub, {
+      name: "test-agent-jobshelper",
+      httpPort: 0,
+    });
+    // `registryUrl` is resolved from the environment, not an AgentConfig field.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).config.registryUrl = "http://registry:8000";
+
+    agent.addTool({
+      name: "__mesh_job_status",
+      capability: "my_status",
+      parameters: z.object({}),
+      execute: async () => "mine",
+    });
+    registered.length = 0;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).registerJobsHelperTools();
+
+    expect(registered).not.toContain("__mesh_job_status");
+    expect(registered).toContain("__mesh_job_result");
+    expect(registered).toContain("__mesh_job_cancel");
+
+    // The user's tool still owns the name in the catalog.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((agent as any).tools.get("__mesh_job_status").capability).toBe(
+      "my_status",
+    );
+  });
+
+  it("registers all three when uncontested", () => {
+    const registered: string[] = [];
+    const stub = {
+      addTool: vi.fn((tool: { name: string }) => {
+        registered.push(tool.name);
+      }),
+      start: vi.fn(),
+      getApp: vi.fn(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const agent = new MeshAgent(stub, {
+      name: "test-agent-jobshelper-clean",
+      httpPort: 0,
+    });
+    // `registryUrl` is resolved from the environment, not an AgentConfig field.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).config.registryUrl = "http://registry:8000";
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (agent as any).registerJobsHelperTools();
+
+    expect(registered).toEqual(
+      expect.arrayContaining([
+        "__mesh_job_status",
+        "__mesh_job_result",
+        "__mesh_job_cancel",
+      ]),
+    );
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -67,7 +67,11 @@ import {
   stopDispatchers,
   type ClaimHandler,
 } from "./claim-dispatcher.js";
-import { registerJobHelperTools, type HelperToolMeta } from "./jobs-helper-tools.js";
+import {
+  registerJobHelperTools,
+  JOB_HELPER_TOOL_NAMES,
+  type HelperToolMeta,
+} from "./jobs-helper-tools.js";
 import { registerCancelRoute } from "./jobs-cancel-route.js";
 import {
   clusterStrictEnabled,
@@ -227,6 +231,35 @@ export function depSignature(
 }
 
 /**
+ * #1442: a stable identity for the DECLARATION behind a tool, used to tell a
+ * genuine duplicate-advertised-name collision (two different tools claiming one
+ * wire name) from the SAME declaration being registered again.
+ *
+ * Deliberately NOT the definition object's reference, nor `execute`'s
+ * reference: re-registration is exactly the case that hands over a fresh object
+ * for an unchanged declaration (a module re-evaluated under a test runner's
+ * module reset, a dual CJS/ESM load, a helper that re-runs the registration
+ * block). Discriminating on instance identity is the trap PR #1445 had to undo.
+ *
+ * It covers every field that reaches the wire — capability, version, tags,
+ * task, dependencies and the converted input schema — plus the handler's
+ * source text. Handler source alone is too weak in both directions: two
+ * declarations can share a body while publishing different schemas or
+ * dependencies, and `Function.prototype.toString` degrades to
+ * `"function () { [native code] }"` for bound and native functions, which would
+ * make all of those look alike. Two declarations agreeing on the whole wire
+ * shape AND the body are indistinguishable to every consumer of the tool name.
+ */
+function declarationIdentity(parts: unknown[]): string {
+  return stableStringify(parts);
+}
+
+/** Source text of a handler, or a stable marker when it has none. */
+function handlerSource(execute: unknown): string {
+  return typeof execute === "function" ? execute.toString() : String(execute);
+}
+
+/**
  * MeshAgent wraps a FastMCP server with MCP Mesh capabilities.
  *
  * It provides:
@@ -248,6 +281,13 @@ export class MeshAgent {
   private config: ResolvedAgentConfig;
   private agentId: string;
   private tools: Map<string, ToolMeta> = new Map();
+  /**
+   * Advertised MCP tool name -> identity of the declaration that claimed it
+   * (issue #1442). Kept alongside `tools` rather than derived from it because
+   * `tools` holds published METADATA, not enough to tell one declaration from
+   * another. See `toolDeclarationIdentity`.
+   */
+  private toolDeclarations: Map<string, string> = new Map();
   /**
    * Maps LLM provider tool names to their vendor (e.g., "process_chat" -> "anthropic").
    * TODO: Use for provider metrics, health checks, or exposing via getLlmProviderVendor() getter.
@@ -446,6 +486,26 @@ export class MeshAgent {
           `(cross-ref src/core/registry/validation.go).`,
       );
     }
+
+    // Issue #1442: `def.name` is the advertised MCP tool name — the wire name a
+    // client calls (`tools/call` sends `params.name = <registry function_name>`).
+    // Two different declarations claiming it did not shadow each other
+    // harmlessly: `this.tools` is a plain `Map.set` and fastmcp's own `addTool`
+    // filters out the previous entry, so the loser silently vanished from
+    // `tools/list` while the registry kept advertising it. Check here, before
+    // anything is registered; the name is CLAIMED only once registration has
+    // actually happened (the validations below still throw).
+    const identity = declarationIdentity([
+      "tool",
+      producedCapability,
+      def.version ?? "1.0.0",
+      def.tags ?? [],
+      def.task === true,
+      def.dependencies ?? [],
+      this.safeInputSchema(def.parameters),
+      handlerSource(execute),
+    ]);
+    this.assertToolNameAvailable(toolName, identity, producedCapability);
 
     // Phase 1 MeshJob substrate: validate `task: true` requires an
     // async function. Long-running tools need a Promise-based control
@@ -661,6 +721,7 @@ export class MeshAgent {
     // The worker entry will look up tools by name when handling dispatched
     // calls from the main thread.
     if (this._workerMode) {
+      this.toolDeclarations.set(toolName, identity);
       _workerToolMap.set(
         toolName,
         execute as unknown as (...args: unknown[]) => unknown
@@ -1175,6 +1236,10 @@ export class MeshAgent {
     const parametersWithPassthrough = typeof schema.passthrough === "function"
       ? schema.passthrough()
       : def.parameters;
+    // #1442: claim the name at the first irreversible registration — every
+    // validation above can still throw, and a name claimed with nothing behind
+    // it would refuse the corrected declaration on a retry.
+    this.toolDeclarations.set(toolName, identity);
     this.server.addTool({
       name: toolName,
       description: def.description,
@@ -1378,6 +1443,30 @@ export class MeshAgent {
     // Create the LLM provider tool definition
     const toolDef = llmProvider(config);
 
+    // Issue #1442: this path registers with FastMCP directly, never through
+    // `addTool`, so it used to bypass the duplicate-name guard entirely — and
+    // `llmProvider` defaults the tool name to `process_chat`, so two
+    // `addLlmProvider` calls without an explicit `name` both claimed it and one
+    // provider silently vanished from `tools/list`.
+    //
+    // The identity comes from the CONFIG, not from `toolDef.execute`: every
+    // provider is built by the same `llmProvider` factory, so all their handler
+    // closures share one source text and would compare equal (the same trap the
+    // Python `mesh.llm_provider` origin stamp exists for).
+    const identity = declarationIdentity([
+      "llmProvider",
+      config.model,
+      config.capability ?? "llm",
+      config.version ?? "1.0.0",
+      config.tags ?? [],
+    ]);
+    this.assertToolNameAvailable(
+      toolDef.name,
+      identity,
+      config.capability ?? "llm",
+    );
+    this.toolDeclarations.set(toolDef.name, identity);
+
     // Add to FastMCP server
     this.server.addTool({
       name: toolDef.name,
@@ -1406,6 +1495,50 @@ export class MeshAgent {
     }
 
     return this;
+  }
+
+  /**
+   * Issue #1442: refuse a second, DIFFERENT declaration of one advertised MCP
+   * tool name. Shared by every registration surface — `addTool` and
+   * `addLlmProvider` — because the name is claimed on the wire regardless of
+   * which one put it there.
+   *
+   * Re-registering the SAME declaration is tolerated (see
+   * {@link declarationIdentity}); that is the PR #1445 lesson.
+   */
+  private assertToolNameAvailable(
+    toolName: string,
+    identity: string,
+    producedCapability: string,
+  ): void {
+    const previousIdentity = this.toolDeclarations.get(toolName);
+    if (previousIdentity === undefined || previousIdentity === identity) {
+      return;
+    }
+    throw new Error(
+      `addTool: duplicate MCP tool name '${toolName}' — it is already ` +
+        `registered by a different tool declaration ` +
+        `(capability '${this.tools.get(toolName)?.capability ?? "?"}', now ` +
+        `'${producedCapability}'). The tool name is the wire name a client ` +
+        `calls (tools/call params.name), so registering it twice would leave ` +
+        `one of these tools permanently unreachable. Rename one of them ` +
+        `(addTool/addLlmProvider accept an explicit 'name'), or move one to a ` +
+        `separate agent.`,
+    );
+  }
+
+  /**
+   * Convert a Zod schema for the #1442 declaration identity, tolerating a
+   * conversion failure — an unconvertible schema must not turn the guard into
+   * a new way for `addTool` to throw.
+   */
+  private safeInputSchema(parameters: unknown): unknown {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return this.convertZodToJsonSchema(parameters as any);
+    } catch {
+      return "<unconvertible>";
+    }
   }
 
   /**
@@ -1833,9 +1966,30 @@ export class MeshAgent {
     if (!this.config.registryUrl) {
       return;
     }
+    // Issue #1442: a user tool may already own one of the reserved helper
+    // names. Skipping it only in the catalog loop below was not enough —
+    // `registerJobHelperTools` registers on the FastMCP server too, and
+    // fastmcp's `addTool` filters out the previous entry, so the user's tool
+    // went unreachable on the wire while the heartbeat kept advertising it.
+    const claimed = new Set(
+      JOB_HELPER_TOOL_NAMES.filter((name) => this.toolDeclarations.has(name)),
+    );
+    for (const name of claimed) {
+      console.error(
+        `[mesh-jobs] helper tool '${name}' is NOT registered: a tool of that ` +
+          `name is already declared on this agent. '__mesh_job_*' names are ` +
+          `reserved by the framework — rename your tool to restore job ` +
+          `status/result/cancel support on this agent.`,
+      );
+    }
+
     let helpers: Map<string, HelperToolMeta>;
     try {
-      helpers = registerJobHelperTools(this.server, this.config.registryUrl);
+      helpers = registerJobHelperTools(
+        this.server,
+        this.config.registryUrl,
+        claimed,
+      );
     } catch (err) {
       console.warn("[mesh-jobs] failed to register job helper tools:", err);
       return;

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -505,7 +505,7 @@ export class MeshAgent {
       this.safeInputSchema(def.parameters),
       handlerSource(execute),
     ]);
-    this.assertToolNameAvailable(toolName, identity, producedCapability);
+    this.assertToolNameAvailable(toolName, identity, producedCapability, "addTool");
 
     // Phase 1 MeshJob substrate: validate `task: true` requires an
     // async function. Long-running tools need a Promise-based control
@@ -1464,6 +1464,7 @@ export class MeshAgent {
       toolDef.name,
       identity,
       config.capability ?? "llm",
+      "addLlmProvider",
     );
     this.toolDeclarations.set(toolDef.name, identity);
 
@@ -1505,18 +1506,22 @@ export class MeshAgent {
    *
    * Re-registering the SAME declaration is tolerated (see
    * {@link declarationIdentity}); that is the PR #1445 lesson.
+   *
+   * @param api the API the caller actually used, so the message points at the
+   *            method they invoked rather than always at `addTool`.
    */
   private assertToolNameAvailable(
     toolName: string,
     identity: string,
     producedCapability: string,
+    api: "addTool" | "addLlmProvider",
   ): void {
     const previousIdentity = this.toolDeclarations.get(toolName);
     if (previousIdentity === undefined || previousIdentity === identity) {
       return;
     }
     throw new Error(
-      `addTool: duplicate MCP tool name '${toolName}' — it is already ` +
+      `${api}: duplicate MCP tool name '${toolName}' — it is already ` +
         `registered by a different tool declaration ` +
         `(capability '${this.tools.get(toolName)?.capability ?? "?"}', now ` +
         `'${producedCapability}'). The tool name is the wire name a client ` +
@@ -1995,6 +2000,18 @@ export class MeshAgent {
       return;
     }
     for (const [name, meta] of helpers.entries()) {
+      // Issue #1442, the reverse order: this runs from `_autoStart`, which is
+      // `process.nextTick`-scheduled and awaits the port probe, so an `addTool`
+      // made after any `await` in user startup code lands AFTER the helpers.
+      // Recording each registered helper keeps `toolDeclarations` a complete
+      // picture of the wire namespace, so that later `addTool` is refused
+      // instead of silently clobbering the helper on the FastMCP server. (The
+      // `tools.has` guard below protects only the mesh catalog, not the wire.)
+      this.toolDeclarations.set(
+        name,
+        declarationIdentity(["jobsHelper", name, meta.version]),
+      );
+
       // Don't overwrite a user-defined tool with the same name.
       if (this.tools.has(name)) continue;
       this.tools.set(name, {

--- a/src/runtime/typescript/src/jobs-helper-tools.ts
+++ b/src/runtime/typescript/src/jobs-helper-tools.ts
@@ -26,6 +26,14 @@ const TOOL_NAME_STATUS = "__mesh_job_status";
 const TOOL_NAME_RESULT = "__mesh_job_result";
 const TOOL_NAME_CANCEL = "__mesh_job_cancel";
 
+/** The framework-reserved helper tool names, for callers that need to
+ *  reconcile them against user-declared tools (issue #1442). */
+export const JOB_HELPER_TOOL_NAMES: readonly string[] = [
+  TOOL_NAME_STATUS,
+  TOOL_NAME_RESULT,
+  TOOL_NAME_CANCEL,
+];
+
 const DESCRIPTIONS: Record<string, string> = {
   [TOOL_NAME_STATUS]:
     "[Framework] Return the latest mesh-registry state for a job_id. " +
@@ -67,6 +75,13 @@ export interface HelperToolMeta {
 export function registerJobHelperTools(
   server: FastMCP,
   registryUrl: string,
+  /**
+   * Helper names a user-declared tool already owns (issue #1442). Registering
+   * over them would make the user's tool unreachable on the wire — fastmcp's
+   * `addTool` filters out the previous entry — while the heartbeat kept
+   * advertising it. Skipped entirely instead: not on the server, not in `meta`.
+   */
+  skipNames: ReadonlySet<string> = new Set(),
 ): Map<string, HelperToolMeta> {
   const meta = new Map<string, HelperToolMeta>();
   if (!registryUrl) {
@@ -100,79 +115,85 @@ export function registerJobHelperTools(
   });
 
   // Status: GET /jobs/{id} via JobProxy.status()
-  try {
-    server.addTool({
-      name: TOOL_NAME_STATUS,
-      description: DESCRIPTIONS[TOOL_NAME_STATUS],
-      parameters: inputParams,
-      execute: async (args: { jobId: string }) => {
-        const proxy = new JobProxy(args.jobId, registryUrl);
-        const snapshot = await proxy.status();
-        return JSON.stringify(snapshot);
-      },
-    });
-    meta.set(TOOL_NAME_STATUS, {
-      capability: TOOL_NAME_STATUS,
-      version: "1.0.0",
-      tags: ["mesh-jobs", "framework"],
-      description: DESCRIPTIONS[TOOL_NAME_STATUS],
-      inputSchema: inputSchemaJson,
-      task: false,
-    });
-  } catch (err) {
-    console.warn(`[mesh-jobs] could not register ${TOOL_NAME_STATUS}:`, err);
+  if (!skipNames.has(TOOL_NAME_STATUS)) {
+    try {
+      server.addTool({
+        name: TOOL_NAME_STATUS,
+        description: DESCRIPTIONS[TOOL_NAME_STATUS],
+        parameters: inputParams,
+        execute: async (args: { jobId: string }) => {
+          const proxy = new JobProxy(args.jobId, registryUrl);
+          const snapshot = await proxy.status();
+          return JSON.stringify(snapshot);
+        },
+      });
+      meta.set(TOOL_NAME_STATUS, {
+        capability: TOOL_NAME_STATUS,
+        version: "1.0.0",
+        tags: ["mesh-jobs", "framework"],
+        description: DESCRIPTIONS[TOOL_NAME_STATUS],
+        inputSchema: inputSchemaJson,
+        task: false,
+      });
+    } catch (err) {
+      console.warn(`[mesh-jobs] could not register ${TOOL_NAME_STATUS}:`, err);
+    }
   }
 
   // Result: same wire as status; helper unwraps just the terminal bits.
-  try {
-    server.addTool({
-      name: TOOL_NAME_RESULT,
-      description: DESCRIPTIONS[TOOL_NAME_RESULT],
-      parameters: inputParams,
-      execute: async (args: { jobId: string }) => {
-        const proxy = new JobProxy(args.jobId, registryUrl);
-        const snapshot = (await proxy.status()) as Record<string, unknown>;
-        return JSON.stringify({
-          status: snapshot.status,
-          result: snapshot.result,
-          error: snapshot.error,
-        });
-      },
-    });
-    meta.set(TOOL_NAME_RESULT, {
-      capability: TOOL_NAME_RESULT,
-      version: "1.0.0",
-      tags: ["mesh-jobs", "framework"],
-      description: DESCRIPTIONS[TOOL_NAME_RESULT],
-      inputSchema: inputSchemaJson,
-      task: false,
-    });
-  } catch (err) {
-    console.warn(`[mesh-jobs] could not register ${TOOL_NAME_RESULT}:`, err);
+  if (!skipNames.has(TOOL_NAME_RESULT)) {
+    try {
+      server.addTool({
+        name: TOOL_NAME_RESULT,
+        description: DESCRIPTIONS[TOOL_NAME_RESULT],
+        parameters: inputParams,
+        execute: async (args: { jobId: string }) => {
+          const proxy = new JobProxy(args.jobId, registryUrl);
+          const snapshot = (await proxy.status()) as Record<string, unknown>;
+          return JSON.stringify({
+            status: snapshot.status,
+            result: snapshot.result,
+            error: snapshot.error,
+          });
+        },
+      });
+      meta.set(TOOL_NAME_RESULT, {
+        capability: TOOL_NAME_RESULT,
+        version: "1.0.0",
+        tags: ["mesh-jobs", "framework"],
+        description: DESCRIPTIONS[TOOL_NAME_RESULT],
+        inputSchema: inputSchemaJson,
+        task: false,
+      });
+    } catch (err) {
+      console.warn(`[mesh-jobs] could not register ${TOOL_NAME_RESULT}:`, err);
+    }
   }
 
   // Cancel: POST /jobs/{id}/cancel via JobProxy.cancel()
-  try {
-    server.addTool({
-      name: TOOL_NAME_CANCEL,
-      description: DESCRIPTIONS[TOOL_NAME_CANCEL],
-      parameters: cancelParams,
-      execute: async (args: { jobId: string; reason?: string }) => {
-        const proxy = new JobProxy(args.jobId, registryUrl);
-        await proxy.cancel(args.reason ?? null);
-        return JSON.stringify({ ok: true, jobId: args.jobId });
-      },
-    });
-    meta.set(TOOL_NAME_CANCEL, {
-      capability: TOOL_NAME_CANCEL,
-      version: "1.0.0",
-      tags: ["mesh-jobs", "framework"],
-      description: DESCRIPTIONS[TOOL_NAME_CANCEL],
-      inputSchema: cancelSchemaJson,
-      task: false,
-    });
-  } catch (err) {
-    console.warn(`[mesh-jobs] could not register ${TOOL_NAME_CANCEL}:`, err);
+  if (!skipNames.has(TOOL_NAME_CANCEL)) {
+    try {
+      server.addTool({
+        name: TOOL_NAME_CANCEL,
+        description: DESCRIPTIONS[TOOL_NAME_CANCEL],
+        parameters: cancelParams,
+        execute: async (args: { jobId: string; reason?: string }) => {
+          const proxy = new JobProxy(args.jobId, registryUrl);
+          await proxy.cancel(args.reason ?? null);
+          return JSON.stringify({ ok: true, jobId: args.jobId });
+        },
+      });
+      meta.set(TOOL_NAME_CANCEL, {
+        capability: TOOL_NAME_CANCEL,
+        version: "1.0.0",
+        tags: ["mesh-jobs", "framework"],
+        description: DESCRIPTIONS[TOOL_NAME_CANCEL],
+        inputSchema: cancelSchemaJson,
+        task: false,
+      });
+    } catch (err) {
+      console.warn(`[mesh-jobs] could not register ${TOOL_NAME_CANCEL}:`, err);
+    }
   }
 
   return meta;


### PR DESCRIPTION
## Summary

Two issues from the #1441 review round, bundled because both are about a name derived from a method or annotation.

### #1442 — duplicate advertised MCP tool name

Two tool declarations advertising the same MCP tool name made one silently disappear, in **all three runtimes**:

| Runtime | Behaviour today |
|---|---|
| Java | SDK 2.0.0 replaces silently (`"Replace existing Tool with name '{}'"`) |
| Python | `decorator_registry.py:151` bare dict assign — the loser never reaches the heartbeat |
| TypeScript | fastmcp's `addTool` filters out the previous entry, no log |

All three now **fail at startup** on a genuine collision, matching the precedent `MeshToolRegistry` already set for duplicate *capability* ("Capability names must be unique within an agent").

**Nothing is renamed.** The advertised MCP name *is* the wire name — `tools/call` sends `params.name = function_name` in every runtime (`resolver.go:266` → `McpHttpClient.java:525`, `proxy.ts:383`, `unified_mcp_proxy.py:1203`); capability rides along only for logging and cache keys. Renaming would have broken every mesh DI call into the provider, so this is a guard only.

### #1443 — phantom route at the controller base path

Every `@MeshRoute` handler also registered a route at the controller base path: `getMappingInfo` consulted `@RequestMapping` unconditionally, and `AnnotationUtils.findAnnotation` finds a verb shortcut's meta-`@RequestMapping` **without applying `@AliasFor`** — so it returned empty paths and defaulted to `{""}` + GET. Lookups moved to `AnnotatedElementUtils.findMergedAnnotation`, and the merged lookup is now a last resort. `getClassBasePath` had the identical defect one level up and is migrated too.

## Review notes

**The guards discriminate on declaration origin, not on "have I seen this name."** Per the #1445 lesson, each tolerates the *same* declaration registered again (module re-import, repeated bean post-processing) and throws only for two *different* declarations. The discriminators are deliberate and were each validated against a wrong alternative:

- **Python** stamps `_mesh_declaration_origin` in `helpers.py` pointing at the user's function. Without it, every `@mesh.llm_provider` tool shares one code-object identity — `helpers.py` renames a nested `process_chat` for all of them — and the guard would have been **inert across the entire provider surface**, unable to protect the bug (#227) it was built for.
- **TypeScript** derives provider identity from the config, not `execute` — every provider is built by one factory, so their closures share source text and would have compared equal. The same trap.
- **Java** keys on funcId, matching `MeshToolWrapperRegistry.indexBareMethodName`.

**A dual-module filename disagreement broke the guard.** `python main.py` reports `co_filename` as `main.py` while a re-import reports `/agent/main.py`. Identities diverged and the guard raised *over* `dual_module_check`'s much better diagnostic. Fixed with `_is_dual_module_pair`, mirroring `detect_dual_module_registration`'s conservative rule (exactly one side `__main__`, same qualname) — deliberately not a blanket same-qualname pass, pinned by `test_two_ordinary_modules_are_still_a_collision`.

## Behavior changes — agents that boot today and now will not

- **Two `@MeshLlmProvider` classes on one Java agent.** Both advertise `llm_generate` with different funcIds. They already collide today — one is dead on the wire — so failing loudly is the correction, not a regression. `MeshLlmProviderProcessor` builds one wrapper per provider, so multi-provider agents look supported by construction; the error message special-cases the `llm_provider:` prefix rather than saying "rename one of the methods", which is impossible for a framework constant.
- **A user tool named `__mesh_job_status`/`_result`/`_cancel`** now wins; the framework helper is skipped on both surfaces instead of clobbering it on fastmcp while the heartbeat kept advertising the user's.

## Known limit (unchanged by this PR)

Two `@MeshTool` **overloads in one class** are still not caught: they share a funcId (`FQCN.methodName`, no parameter types), so the second evicts the first from the funcId-keyed map before the guard iterates. Widening funcId is off the table — it is the identity the core echoes on `funcId:dep_N`. The javadoc states this limit rather than implying full coverage. This is the tool-side twin of what #1441 fixed for routes and is worth deciding on separately.

`jobs-helper-tools.ts` shows ~155 changed lines but only **21 are insertions** — the rest is reindentation from wrapping each registration in a skip guard.

## Test plan

- [x] Java 1153 passed, 0 failures (full reactor)
- [x] Python 1551 passed, 1 skipped
- [x] TypeScript 1264 passed, 88 files; `typecheck` clean
- [x] Every new test verified red with its own fix reverted, one at a time, in a scratch copy
- [x] Two wrong-fix experiments run for #1443 — deleting the `@RequestMapping` branch, and collapsing the five shortcuts into one merged lookup — each confirmed to break a different test
- [x] Python discriminator validated against two wrong alternatives (`id(func)`, and `__module__`+`__qualname__`); both go red on real paths
- [x] Three tests that could not fail were rewritten or justified, not kept as-is
- [ ] CI green

A zero-context review agent reviewed the first draft and found 1 blocker + 10 warnings; all ten were verified real and fixed. The blocker was TS `addLlmProvider` bypassing the guard entirely, which would have shipped an "all three runtimes" claim with one path still silent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented different tools from registering with the same advertised MCP name, with clearer conflict details and remediation guidance.
  * Preserved safe re-registration of the same tool across reloads, wrappers, and supported runtime modes.
  * Prevented framework job helpers from overwriting user-defined tools; conflicting helpers are skipped.
  * Improved Spring route discovery for composed annotations, aliases, multiple HTTP verbs, and pathless mappings.
* **Tests**
  * Added comprehensive coverage for duplicate tools, helper collisions, and Spring route scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->