### PR TITLE
fix(java): reject two @MeshTool overloads in one class instead of evicting one

### DIFF
--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshMcpServerConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshMcpServerConfiguration.java
@@ -196,17 +196,18 @@ public class MeshMcpServerConfiguration {
      *       so a repeated registrar pass replaces rather than accumulates.</li>
      * </ul>
      *
-     * <p><b>Known limit — overloads in ONE class are not reached.</b> This scans
+     * <p><b>Overloads in ONE class never reach this guard — they are rejected
+     * earlier</b> (issue #1448). This scans
      * {@link MeshToolWrapperRegistry#getAllHandlers()}, which is keyed by funcId,
-     * and a funcId is {@code FQCN.methodName} with no parameter types. Two
-     * overloaded {@code @MeshTool} methods in the same class therefore share a
-     * funcId and the second EVICTS the first from that map before this guard
-     * ever sees it — the collision is real but invisible here. Widening the
-     * funcId is not an option: it is the wire identity the Rust core echoes back
-     * on {@code funcId:dep_N} dependency-resolution events. The narrower
-     * same-class overload case is covered on the registry side by
-     * {@link MeshToolRegistry#registerTool}'s duplicate-capability guard
-     * whenever the overloads also share a capability.
+     * and a funcId is {@code FQCN.methodName} with no parameter types, so two
+     * overloaded {@code @MeshTool} methods in the same class share one and the
+     * second would evict the first from that map before this guard ever sees it.
+     * {@link MeshToolWrapperRegistry#registerWrapper} now refuses that at the
+     * store site. Widening the funcId would not have helped: both overloads
+     * still collapse onto ONE wire name — the bare method name, which keys the
+     * MCP tool table, the registry's {@code dependencies_resolved} map and
+     * {@code wrappersByMethodName} — and {@code @MeshTool} has no name attribute
+     * to separate them.
      *
      * @param handlers every handler about to be registered with the MCP server
      * @throws IllegalStateException naming both colliding declarations

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapperRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapperRegistry.java
@@ -112,6 +112,11 @@ public class MeshToolWrapperRegistry {
         String capability = wrapper.getCapability();
         String methodName = wrapper.getMethodName();
 
+        // Two DIFFERENT declarations must never share a funcId (issue #1448).
+        // Checked HERE, immediately before the put that would evict the first
+        // one — this is the only point that sees both declarations.
+        assertNotAnOverload(funcId, wrapper);
+
         // Store in wrapper maps (for dependency updates)
         wrappers.put(funcId, wrapper);
         if (wrapper.getMethod() != null) {
@@ -157,6 +162,63 @@ public class MeshToolWrapperRegistry {
 
         log.info("Registered handler: {} (capability: {}, method: {})",
             funcId, capability, methodName);
+    }
+
+    /**
+     * Refuse to boot when two overloaded {@code @MeshTool} methods in ONE class
+     * would share a funcId (issue #1448).
+     *
+     * <p>A funcId is {@code FQCN.methodName} with no parameter types
+     * ({@code MeshToolBeanPostProcessor}), so {@code analyze(String)} and
+     * {@code analyze(int)} on one class compute the same one and the second
+     * registration silently EVICTS the first from every funcId-keyed map here.
+     * Nothing downstream notices: the duplicate-capability guard in
+     * {@link MeshToolRegistry#registerTool} is keyed by capability, so distinct
+     * capabilities walk through it, and the heartbeat still advertises BOTH
+     * tools — the evicted one with no MCP tool behind it. Worse, both advertise
+     * the same {@code function_name}, so the registry merges their dependency
+     * lists under that one key and an in-range {@code dep_index} can wire one
+     * overload's dependency into the other's slot.
+     *
+     * <p>Widening the funcId to include parameter types would not fix it: the
+     * bare method name is the wire name, and it keys three single-valued
+     * namespaces — the MCP SDK tool table, the registry's
+     * {@code dependencies_resolved} map, and {@link #wrappersByMethodName}.
+     * {@code @MeshTool} has no name attribute, so two overloads cannot be given
+     * distinct wire names and the declaration itself has to be rejected.
+     *
+     * <p>The discriminator is the handler {@link Method}, NOT wrapper identity,
+     * mirroring the tolerance {@link #indexBareMethodName} expresses on funcId:
+     * {@link Method#equals} is value-based and includes parameter types, so a
+     * prototype-scoped bean instantiated twice, a context refresh, or a repeated
+     * post-processing pass produces a fresh wrapper for an EQUAL Method and
+     * replaces cleanly, exactly as before (issue #1445). Only a genuinely
+     * different Method — a real overload — throws.
+     *
+     * <p>A {@code null} Method carries no identity to compare, so it falls back
+     * to the replacing behaviour rather than guessing.
+     */
+    private void assertNotAnOverload(String funcId, MeshToolWrapper incoming) {
+        MeshToolWrapper previous = wrappers.get(funcId);
+        if (previous == null) {
+            return;
+        }
+        Method previousMethod = previous.getMethod();
+        Method incomingMethod = incoming.getMethod();
+        if (previousMethod == null || incomingMethod == null
+                || previousMethod.equals(incomingMethod)) {
+            // Re-registration of the same declaration: replace, as before.
+            return;
+        }
+        throw new IllegalStateException(String.format(
+            "Overloaded @MeshTool methods share the function id '%s': %s and %s. "
+                + "A @MeshTool is advertised on the wire by its bare method name, which "
+                + "keys the MCP tool table, the registry's dependency resolutions and this "
+                + "registry's by-name index — two overloads collapse onto that one name, "
+                + "so one of them is unreachable and a dependency resolved for one can be "
+                + "injected into the other. @MeshTool has no name attribute to tell them "
+                + "apart: rename one of the methods, or move one to a separate class or agent.",
+            funcId, previousMethod, incomingMethod));
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapperRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapperRegistry.java
@@ -115,7 +115,9 @@ public class MeshToolWrapperRegistry {
         // Two DIFFERENT declarations must never share a funcId (issue #1448).
         // Checked HERE, immediately before the put that would evict the first
         // one — this is the only point that sees both declarations.
-        assertNotAnOverload(funcId, wrapper);
+        MeshToolWrapper previous = wrappers.get(funcId);
+        assertNotAnOverload(funcId, previous, wrapper);
+        releaseReplacedCapability(previous, capability);
 
         // Store in wrapper maps (for dependency updates)
         wrappers.put(funcId, wrapper);
@@ -198,8 +200,7 @@ public class MeshToolWrapperRegistry {
      * <p>A {@code null} Method carries no identity to compare, so it falls back
      * to the replacing behaviour rather than guessing.
      */
-    private void assertNotAnOverload(String funcId, MeshToolWrapper incoming) {
-        MeshToolWrapper previous = wrappers.get(funcId);
+    private void assertNotAnOverload(String funcId, MeshToolWrapper previous, MeshToolWrapper incoming) {
         if (previous == null) {
             return;
         }
@@ -219,6 +220,45 @@ public class MeshToolWrapperRegistry {
                 + "injected into the other. @MeshTool has no name attribute to tell them "
                 + "apart: rename one of the methods, or move one to a separate class or agent.",
             funcId, previousMethod, incomingMethod));
+    }
+
+    /**
+     * Drop the capability key a replaced wrapper owned, when the replacement
+     * declares a DIFFERENT one.
+     *
+     * <p>{@link #handlersByCapability} is the one index {@link #registerWrapper}
+     * writes that is NOT keyed by funcId, so a bare {@code put} cannot displace
+     * the replaced wrapper's own entry: the old capability keeps pointing at the
+     * wrapper that was just superseded, and {@link #getHandlerByCapability},
+     * {@link #hasCapability} and {@link #getHandlersByCapability} go on serving
+     * and reporting it.
+     *
+     * <p><b>Not reachable in production today.</b> {@link #registerWrapper} has
+     * one production caller ({@code MeshToolBeanPostProcessor}), which always
+     * builds the wrapper from a scanned {@link Method};
+     * {@link #assertNotAnOverload} rejects a different Method on an existing
+     * funcId, and an EQUAL Method carries the same {@code @MeshTool} annotation,
+     * so the capability cannot change across a replacement. The path stays open
+     * only for a null-Method wrapper, which production never constructs. It is
+     * closed anyway because the asymmetry itself is the hazard — every other
+     * index honours replacement and this one did not, which is the shape that
+     * produced #1437, #1445 and #1448.
+     *
+     * <p>The removal is conditional on the entry still pointing at the wrapper
+     * being replaced (two-arg {@link java.util.concurrent.ConcurrentHashMap#remove(Object, Object)};
+     * {@code MeshToolWrapper} does not override {@code equals}, so the match is
+     * identity). An unconditional {@code remove(previousCapability)} would evict
+     * a legitimate, unrelated wrapper that owns that capability now.
+     */
+    private void releaseReplacedCapability(MeshToolWrapper previous, String capability) {
+        if (previous == null) {
+            return;
+        }
+        String previousCapability = previous.getCapability();
+        if (previousCapability == null || Objects.equals(previousCapability, capability)) {
+            return;
+        }
+        handlersByCapability.remove(previousCapability, previous);
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRegistryOverloadTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRegistryOverloadTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -135,6 +137,76 @@ class MeshToolWrapperRegistryOverloadTest {
     }
 
     // ─────────────────────────────────────────────────────────────────
+    // Replacement must not strand the capability index
+    // ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("A replacement that changes capability releases the old capability key")
+    void changedCapabilityReleasesTheOldKey() throws Exception {
+        MeshToolWrapperRegistry registry = registry();
+        // A null-Method wrapper is the ONLY shape that reaches this: the
+        // overload guard rejects a different Method on an existing funcId, and
+        // an equal Method carries the same @MeshTool annotation, so production
+        // cannot change a capability across a replacement.
+        MeshToolWrapper stale = nullMethodWrapper(
+            FUNC_ID, new OverloadedAnalyzer(), stringOverload(), "analyze_string");
+        MeshToolWrapper fresh = nullMethodWrapper(
+            FUNC_ID, new OverloadedAnalyzer(), stringOverload(), "analyze_int");
+        registry.registerWrapper(stale);
+        registry.registerWrapper(fresh);
+
+        assertNull(registry.getHandlerByCapability("analyze_string"),
+            "the replaced wrapper must not still answer under the capability it "
+                + "no longer declares");
+        assertFalse(registry.hasCapability("analyze_string"),
+            "and it must not still be REPORTED as an owned capability");
+        assertSame(fresh, registry.getHandlerByCapability("analyze_int"),
+            "the replacement's own capability must resolve to it");
+    }
+
+    @Test
+    @DisplayName("Releasing the old key must not clobber an unrelated owner of that capability")
+    void changedCapabilityDoesNotClobberAnUnrelatedOwner() throws Exception {
+        MeshToolWrapperRegistry registry = registry();
+        String otherFuncId = OverloadedAnalyzer.class.getName() + ".other";
+        MeshToolWrapper stale = nullMethodWrapper(
+            FUNC_ID, new OverloadedAnalyzer(), stringOverload(), "analyze_string");
+        // An UNRELATED wrapper (different funcId) takes ownership of the very
+        // capability 'stale' used to hold...
+        MeshToolWrapper unrelated = nullMethodWrapper(
+            otherFuncId, new OverloadedAnalyzer(), stringOverload(), "analyze_string");
+        MeshToolWrapper fresh = nullMethodWrapper(
+            FUNC_ID, new OverloadedAnalyzer(), stringOverload(), "analyze_int");
+        registry.registerWrapper(stale);
+        registry.registerWrapper(unrelated);
+
+        // ...and replacing 'stale' must not evict it. An unconditional
+        // remove(previousCapability) would — the release has to be conditional
+        // on the entry still pointing at the wrapper being replaced.
+        registry.registerWrapper(fresh);
+
+        assertSame(unrelated, registry.getHandlerByCapability("analyze_string"),
+            "the capability's current owner is a different wrapper — replacing an "
+                + "unrelated funcId must leave it alone");
+        assertSame(fresh, registry.getHandlerByCapability("analyze_int"));
+    }
+
+    @Test
+    @DisplayName("A replacement keeping the same capability still replaces under it")
+    void sameCapabilityReplacementStillReplaces() throws Exception {
+        MeshToolWrapperRegistry registry = registry();
+        MeshToolWrapper stale = wrapper(new OverloadedAnalyzer(), stringOverload(), "analyze_string");
+        MeshToolWrapper fresh = wrapper(new OverloadedAnalyzer(), stringOverload(), "analyze_string");
+        registry.registerWrapper(stale);
+        registry.registerWrapper(fresh);
+
+        assertTrue(registry.hasCapability("analyze_string"));
+        assertSame(fresh, registry.getHandlerByCapability("analyze_string"),
+            "the ordinary same-capability replacement must be untouched by the "
+                + "old-key release");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
     // Harness
     // ─────────────────────────────────────────────────────────────────
 
@@ -149,7 +221,12 @@ class MeshToolWrapperRegistryOverloadTest {
 
     /** A handler that reports no {@link Method} — e.g. a non-{@code @MeshTool} handler. */
     private static MeshToolWrapper nullMethodWrapper(Object bean, Method method, String capability) {
-        return new MeshToolWrapper(FUNC_ID, capability, "test", bean, method,
+        return nullMethodWrapper(FUNC_ID, bean, method, capability);
+    }
+
+    private static MeshToolWrapper nullMethodWrapper(
+            String funcId, Object bean, Method method, String capability) {
+        return new MeshToolWrapper(funcId, capability, "test", bean, method,
                 List.of(), JsonMapper.builder().build()) {
             @Override
             public Method getMethod() {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRegistryOverloadTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRegistryOverloadTest.java
@@ -1,0 +1,182 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two overloaded {@code @MeshTool} methods in ONE class must fail the boot
+ * (issue #1448).
+ *
+ * <p>A funcId is {@code FQCN.methodName} with no parameter types, so both
+ * overloads compute the same one and the second used to EVICT the first from
+ * every funcId-keyed map — with no error and no warning. The duplicate-capability
+ * guard in {@code MeshToolRegistry#registerTool} does not fire (it is keyed by
+ * capability, and overloads may declare different ones) and the MCP-name guard in
+ * {@code MeshMcpServerConfiguration} cannot fire either, because it scans the
+ * funcId-keyed handler map the eviction already collapsed. The heartbeat then
+ * advertised BOTH capabilities under one {@code function_name}, one of them with
+ * no MCP tool behind it, and the merged dependency list could deliver one
+ * overload's resolution into the other's slot.
+ *
+ * <p>The discriminator is the handler {@link Method}, not wrapper identity —
+ * re-registering the SAME declaration (prototype scope, context refresh,
+ * repeated post-processing) must still replace cleanly (issue #1445).
+ */
+@DisplayName("MeshToolWrapperRegistry: overloaded @MeshTool methods in one class")
+class MeshToolWrapperRegistryOverloadTest {
+
+    private static final String FUNC_ID = OverloadedAnalyzer.class.getName() + ".analyze";
+
+    @Test
+    @DisplayName("Two overloads sharing a funcId are refused, naming both signatures")
+    void overloadsAreRefusedNamingBothSignatures() throws Exception {
+        MeshToolWrapperRegistry registry = registry();
+        OverloadedAnalyzer bean = new OverloadedAnalyzer();
+        registry.registerWrapper(wrapper(bean, stringOverload(), "analyze_string"));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> registry.registerWrapper(wrapper(bean, intOverload(), "analyze_int")),
+            "a second, genuinely different declaration on the same funcId must not "
+                + "silently evict the first");
+
+        assertTrue(ex.getMessage().contains(stringOverload().toString()),
+            "error must name the first colliding method in full. Got: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains(intOverload().toString()),
+            "error must name the second colliding method in full. Got: " + ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("The error is actionable: rename or split, not a nonexistent name attribute")
+    void errorNamesTheRemedy() throws Exception {
+        MeshToolWrapperRegistry registry = registry();
+        OverloadedAnalyzer bean = new OverloadedAnalyzer();
+        registry.registerWrapper(wrapper(bean, stringOverload(), "analyze_string"));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+            () -> registry.registerWrapper(wrapper(bean, intOverload(), "analyze_int")));
+
+        assertTrue(ex.getMessage().contains("rename"),
+            "@MeshTool has no name attribute — the only remedies are renaming a method "
+                + "or splitting the class. Got: " + ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("Re-registering the SAME method replaces cleanly — no false positive (#1445)")
+    void sameMethodFreshWrapperReplaces() throws Exception {
+        MeshToolWrapperRegistry registry = registry();
+        // Two FRESH wrapper instances over the same declaration, from two
+        // INDEPENDENT reflective lookups: Method.equals is value-based, so the
+        // guard must read these as one declaration registered twice.
+        MeshToolWrapper stale = wrapper(new OverloadedAnalyzer(), stringOverload(), "analyze_string");
+        MeshToolWrapper fresh = wrapper(new OverloadedAnalyzer(), stringOverload(), "analyze_string");
+        registry.registerWrapper(stale);
+
+        assertDoesNotThrow(() -> registry.registerWrapper(fresh),
+            "a prototype-scoped bean, a context refresh or a repeated post-processing "
+                + "pass re-registers the same declaration — that must still replace");
+        assertSame(fresh, registry.getWrapper(FUNC_ID), "the replacement must win");
+        assertSame(fresh, registry.getWrapperByMethodName("analyze"),
+            "and the bare-name index must not have been poisoned");
+    }
+
+    @Test
+    @DisplayName("A handler with a null Method carries no identity to compare — it does not throw")
+    void nullMethodDoesNotThrow() throws Exception {
+        MeshToolWrapperRegistry incomingIsNull = registry();
+        incomingIsNull.registerWrapper(wrapper(new OverloadedAnalyzer(), stringOverload(), "analyze_string"));
+        assertDoesNotThrow(() -> incomingIsNull.registerWrapper(
+            nullMethodWrapper(new OverloadedAnalyzer(), intOverload(), "analyze_int")));
+
+        MeshToolWrapperRegistry previousIsNull = registry();
+        previousIsNull.registerWrapper(
+            nullMethodWrapper(new OverloadedAnalyzer(), stringOverload(), "analyze_string"));
+        assertDoesNotThrow(() -> previousIsNull.registerWrapper(
+            wrapper(new OverloadedAnalyzer(), intOverload(), "analyze_int")));
+    }
+
+    @Test
+    @DisplayName("No capability is left advertised with no MCP tool behind it")
+    void noDeclarationIsDroppedSilently() throws Exception {
+        MeshToolWrapperRegistry registry = registry();
+        OverloadedAnalyzer bean = new OverloadedAnalyzer();
+        MeshToolWrapper first = wrapper(bean, stringOverload(), "analyze_string");
+        registry.registerWrapper(first);
+
+        assertThrows(IllegalStateException.class,
+            () -> registry.registerWrapper(wrapper(bean, intOverload(), "analyze_int")));
+
+        // The pre-fix end state: the funcId-keyed maps (wrappers, handlers) kept
+        // only the LAST overload while handlersByCapability kept BOTH — so
+        // 'analyze_string' was advertised to the registry with no MCP tool behind
+        // it. Every advertised capability must resolve to a handler the MCP
+        // server actually serves.
+        Collection<McpToolHandler> served = registry.getAllHandlers();
+        for (Map.Entry<String, McpToolHandler> entry : registry.getHandlersByCapability().entrySet()) {
+            assertTrue(served.contains(entry.getValue()),
+                "capability '" + entry.getKey() + "' is advertised but its handler is not "
+                    + "served by the MCP server — a declaration was dropped silently");
+        }
+        assertSame(first, registry.getWrapper(FUNC_ID),
+            "the first declaration must survive the rejected one intact");
+        assertSame(first, registry.getHandler(FUNC_ID));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Harness
+    // ─────────────────────────────────────────────────────────────────
+
+    private static MeshToolWrapperRegistry registry() {
+        return new MeshToolWrapperRegistry(new McpMeshToolProxyFactory());
+    }
+
+    private static MeshToolWrapper wrapper(Object bean, Method method, String capability) {
+        return new MeshToolWrapper(FUNC_ID, capability, "test", bean, method,
+            List.of(), JsonMapper.builder().build());
+    }
+
+    /** A handler that reports no {@link Method} — e.g. a non-{@code @MeshTool} handler. */
+    private static MeshToolWrapper nullMethodWrapper(Object bean, Method method, String capability) {
+        return new MeshToolWrapper(FUNC_ID, capability, "test", bean, method,
+                List.of(), JsonMapper.builder().build()) {
+            @Override
+            public Method getMethod() {
+                return null;
+            }
+        };
+    }
+
+    private static Method stringOverload() throws NoSuchMethodException {
+        return OverloadedAnalyzer.class.getMethod("analyze", String.class);
+    }
+
+    private static Method intOverload() throws NoSuchMethodException {
+        return OverloadedAnalyzer.class.getMethod("analyze", int.class);
+    }
+
+    /** ONE class, two {@code @MeshTool} overloads — different capabilities. */
+    public static class OverloadedAnalyzer {
+
+        @MeshTool(capability = "analyze_string", description = "analyze a query")
+        public String analyze(@Param("q") String q) {
+            return "string:" + q;
+        }
+
+        @MeshTool(capability = "analyze_int", description = "analyze a number")
+        public String analyze(@Param("n") int n) {
+            return "int:" + n;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Completes #1442. That closed the cross-class case; two `@MeshTool` overloads in **one** class stayed silent — and the failure is worse than a dropped tool.

funcId is `FQCN + "." + methodName` with no parameter types (`MeshToolBeanPostProcessor.java:322`), so both overloads compute `Foo.analyze` and the second evicts the first from `wrappers` and `handlers`. `MeshToolRegistry`'s duplicate guard doesn't fire (it's keyed by capability), and `indexBareMethodName`'s funcId-equality tolerance reads the pair as an idempotent re-registration. Net result, with no error or warning: **two capabilities advertised to the registry, one MCP tool behind them.** Reproduced with a probe rather than argued:

```
handlers(served)=1  capabilities=[analyze_string, analyze_int]
  capability analyze_string served=false     <-- advertised, nothing behind it
  capability analyze_int    served=true
```

**Dependencies can be misrouted, not just dropped.** Both advertise `function_name = "analyze"`, so the registry concatenates *both* tools' dependency lists under that single key (`ent_service.go:886`) and `dep_index` becomes a position in the merged list. Out-of-range indices are dropped by the bounds check; in-range ones are not. The surviving overload can be handed the other one's dependency in slot 0.

## Why not widen funcId

Three single-valued namespaces key on the bare method name — the MCP SDK tool table, the registry's `dependencies_resolved` map, and Java's own `wrappersByMethodName`. `@MeshTool` has no `name`/`toolName` attribute (unlike TypeScript's `addTool`), so there is no way to give two overloads distinct wire names.

Widening funcId would make both wrappers *locally* addressable while both still collapse onto one wire name: capability `a` would stay advertised, and a consumer resolving it would be routed into `analyze(int)`. Strictly worse than eviction. It would also break `MeshEventProcessor.java:385-388`, which derives the short name as `funcId.substring(funcId.lastIndexOf('.') + 1)` — for `Foo.analyze(java.lang.String)` that yields `"String)"`.

## Correcting a wrong claim from #1446

`MeshMcpServerConfiguration`'s javadoc claimed widening funcId was impossible because it "is the wire identity the Rust core echoes back on `funcId:dep_N`". **That is false and is removed.** No funcId crosses the FFI boundary. The core sends the bare method name:

`MeshToolRegistry.java:252` (`setFunctionName(meta.method().getName())` — the only `setFunctionName` call in the runtime) → `resolver.go:39` → `ent_service.go:886` → `runtime.rs:709` → `MeshEventProcessor.java:194`.

funcId is process-local. Each link was re-verified against the source for this PR rather than carried over. The real reason not to widen is the wire-name collision above.

Corroborating detail: `resolveWrapper` tries `wrappers.get(funcId)` and then falls back to the bare-name index — that fallback exists *because* the core sends bare names, so on the Java dependency path the funcId lookup always misses and the fallback is the production path.

## The guard

Sits in `MeshToolWrapperRegistry.registerWrapper` immediately before `wrappers.put(funcId, wrapper)` — the exact eviction site, and the only point that sees both declarations. Discriminates on `Method`, not instance identity (`Method.equals` is value-based and includes parameter types):

- same funcId + **equal** `Method` → prototype scope, context refresh, repeated post-processing → replace as today (#1445 lesson preserved)
- same funcId + **different** `Method` → throw, naming both full signatures
- null `Method` on either side → fall through; non-`@MeshTool` handlers have none

This also brings Java in line with Python and TypeScript, which #1446 guarded at declaration time. Java's only check was at MCP-server-build time — after the eviction had already happened.

## Test plan

- [x] Full Java reactor: **1164 tests, 0 failures** (15 + 117 + 821 + 211)
- [x] 3 of 5 new tests verified red with the guard removed in a scratch copy
- [x] Pre-fix end state reproduced with a probe, not assumed
- [x] All 258 `@MeshTool` annotations in the repo scanned for existing same-name-same-class pairs — **zero found**, nothing existing trips the guard
- [x] `MeshToolInheritanceScanTest` still 11/11: `MethodIntrospector.selectMethods` collapses override pairs to one logical method, so inheritance yields one `registerWrapper` call, not two
- [ ] CI green

**Two tests deliberately pass both with and without the fix.** `sameMethodFreshWrapperReplaces` and `nullMethodDoesNotThrow` assert the guard does *not* fire, so they cannot be red-without-fix by construction. They fence a wrong fix — instance-identity discrimination, or an unguarded null deref — rather than pinning this one. Dropping them would delete the #1445 protection.

## Known, not changed

The guard is check-then-act on a `ConcurrentHashMap` rather than atomic. Registration is Spring bean post-processing, which is serial at boot, and `indexBareMethodName` directly below has the same shape; consistency with the neighbour was preferred over wrapping the put in `compute()`.

Closes #1448


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented conflicting overloaded MCP tools from sharing the same function ID.
  * Added clear error messages identifying duplicate tool registrations.
  * Preserved registry consistency when duplicate registrations are rejected.
  * Allowed safe re-registration of the same method and entries without method metadata.

* **Documentation**
  * Clarified duplicate tool-name handling across registries and MCP tool listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->