### PR TITLE
ci: type-check the TypeScript SDK, which nothing was doing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,10 @@ jobs:
         working-directory: src/runtime/typescript
         run: npm install
 
+      - name: Type check TypeScript SDK (Express 4 + 5)
+        working-directory: src/runtime/typescript
+        run: npm run typecheck:all
+
       - name: Run TypeScript tests
         working-directory: src/runtime/typescript
         run: npm test


### PR DESCRIPTION
## Summary

Four lines. `src/runtime/typescript` has had a `typecheck` script all along; the `typescript-test` job installed dependencies and went straight to vitest. The `ui-test` job in the same workflow already runs `npx tsc --noEmit`, so the dashboard was type-checked in CI and the runtime SDK was not — a type error in `agent.ts` would reach `main` with every check green.

```yaml
- name: Type check TypeScript SDK (Express 4 + 5)
  working-directory: src/runtime/typescript
  run: npm run typecheck:all
```

The SDK's `tsconfig.json` is genuinely strict (`strict`, `noUnusedLocals`, `noUnusedParameters`, `noImplicitReturns`), so this is a real gate rather than a rubber stamp.

## Two details that make it correct

**`typecheck:all`, not `typecheck`.** The SDK declares `express: "^4.18.0 || ^5.0.0"` as a peer dep, and `package.json` already carries the express4/express5/all trio for exactly that matrix. Plain `typecheck` covers only the Express 4 half — an untested peer range can break silently. `tsconfig.express5.json` merely remaps `express` → `./node_modules/express-v5` and `@types/express` → `./node_modules/@types/express-v5` via `paths`, and both aliases are already in `devDependencies`, so the existing `npm install` covers it with no extra step. The `&&` chain short-circuits on an Express 4 failure.

**Step placement is load-bearing.** It sits *after* "Build @mcpmesh/core native module" and *before* the tests. `src/runtime/core/typescript/index.d.ts` is generated by `napi build` and is not tracked in git, and 61 files under `src/runtime/typescript/src/` import `@mcpmesh/core` — a typecheck ahead of that build would fail wholesale on unresolved types. Worth knowing if anyone reorders that job later.

## Verified clean, so this gates current behaviour

```
$ npm run typecheck:all
> tsc --noEmit                             # express4
> tsc --noEmit -p tsconfig.express5.json   # express5
EXIT=0
```

Both halves exit 0. No `|| true`, no `continue-on-error`, no suppression. This adds a gate over passing code rather than importing a backlog.

## Deliberately out of scope

No other CI job is touched. The diff is four added lines and nothing else — `lint-and-format`, `type-check` (Python mypy) and `pre-commit.yml` remain `if: false`, and `security-scan`'s condition is unchanged.

That is a decision, not an oversight: formatting and lint gates retrofitted onto an existing codebase are ongoing churn for little benefit.

Recording the mypy number so it is written down rather than re-measured later — Python mypy reports **205 errors across 48 files** (123 checked), and the `[tool.mypy]` config already has every strictness knob set to `false` (marked "Temporarily relaxed"), so that is the floor rather than a starting point. The distribution is shallow — the top 6 files are ~46%, the remaining ~111 errors smeared 1–9 each across 42 files — so there is no cheap subset to fix. Only ~27 are missing-stub noise; the rest are substantive `attr-defined`/`arg-type`/`assignment` complaints, mostly `Any | None` / `str | None` reaching non-optional parameters in the DI and heartbeat paths. Enabling it is a real project.

## Test plan

- [x] `npm run typecheck:all` clean locally, both Express 4 and Express 5
- [x] YAML parses; step order verified against the native-module build dependency
- [x] Workflow diff confirmed to be 4 added lines, no other job modified
- [ ] CI green — and the new step visibly runs

Closes #1450
