### PR TITLE
feat(llm): native Responses streaming and image input for the OpenAI path

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -639,10 +639,70 @@ def _translate_response_format_to_text(response_format: Any) -> dict[str, Any]:
     return {"format": response_format}
 
 
-# ``ResponseInputImageParam.detail`` is ``Literal["low","high","auto"]`` and is
-# marked Required in the OpenAI SDK's own TypedDict — always emit one.
-_RESPONSES_IMAGE_DETAILS = frozenset({"low", "high", "auto"})
+# ``ResponseInputImageParam.detail`` is marked Required in the OpenAI SDK's own
+# TypedDict — always emit one.
 _RESPONSES_DEFAULT_IMAGE_DETAIL = "auto"
+# Long-stable trio, used only when SDK introspection is unavailable.
+_RESPONSES_IMAGE_DETAILS_FALLBACK = frozenset({"low", "high", "auto"})
+_RESPONSES_IMAGE_DETAILS_CACHE: frozenset[str] | None = None
+
+
+def _literal_strings(annotation: Any) -> frozenset[str]:
+    """Pull the string members out of a (possibly wrapped) ``Literal``.
+
+    Handles ``Required[Literal[...]]`` / ``Optional[Literal[...]]`` by
+    recursing into type args. Returns an empty set when there is no string
+    Literal to find.
+    """
+    import typing
+
+    args = typing.get_args(annotation)
+    if args and all(isinstance(a, str) for a in args):
+        return frozenset(args)
+    for arg in args:
+        found = _literal_strings(arg)
+        if found:
+            return found
+    return frozenset()
+
+
+def _valid_image_details() -> frozenset[str]:
+    """Accepted ``input_image.detail`` values for the INSTALLED openai SDK.
+
+    Read off ``ResponseInputImageParam``'s own ``Literal`` rather than
+    hard-coded. ``openai`` is an unpinned dependency and this enum GROWS:
+    2.14.0 had ``low``/``high``/``auto``; 2.52.0 added ``original``. A frozen
+    allowlist would silently downgrade a caller's valid ``detail="original"``
+    to ``auto`` — a wrong image fidelity, soft-failed with a misleading WARN.
+
+    Soft-fails to the long-stable trio if the SDK is absent or its layout
+    changes; this is a validator, it must never raise. Cached — the installed
+    SDK cannot change within a process.
+    """
+    global _RESPONSES_IMAGE_DETAILS_CACHE
+    if _RESPONSES_IMAGE_DETAILS_CACHE is not None:
+        return _RESPONSES_IMAGE_DETAILS_CACHE
+
+    details = _RESPONSES_IMAGE_DETAILS_FALLBACK
+    try:
+        import typing
+
+        from openai.types.responses import ResponseInputImageParam
+
+        hints = typing.get_type_hints(ResponseInputImageParam, include_extras=True)
+        found = _literal_strings(hints.get("detail"))
+        if found:
+            details = found
+    except Exception as exc:  # noqa: BLE001 — validator must not raise
+        logger.debug(
+            "Could not introspect ResponseInputImageParam.detail (%s); "
+            "falling back to %s",
+            exc,
+            sorted(_RESPONSES_IMAGE_DETAILS_FALLBACK),
+        )
+
+    _RESPONSES_IMAGE_DETAILS_CACHE = details
+    return details
 
 
 def _translate_image_part(part: dict[str, Any]) -> dict[str, Any]:
@@ -682,11 +742,13 @@ def _translate_image_part(part: dict[str, Any]) -> dict[str, Any]:
             f"got image_url={field!r}"
         )
 
-    if detail is not None and detail not in _RESPONSES_IMAGE_DETAILS:
+    valid_details = _valid_image_details()
+    if detail is not None and detail not in valid_details:
         logger.warning(
             "OpenAI Responses path: unsupported image detail %r "
-            "(expected one of low/high/auto); using %s",
+            "(this openai SDK accepts %s); using %s",
             detail,
+            "/".join(sorted(valid_details)),
             _RESPONSES_DEFAULT_IMAGE_DETAIL,
         )
         detail = None

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/openai_native.py
@@ -639,18 +639,84 @@ def _translate_response_format_to_text(response_format: Any) -> dict[str, Any]:
     return {"format": response_format}
 
 
+# ``ResponseInputImageParam.detail`` is ``Literal["low","high","auto"]`` and is
+# marked Required in the OpenAI SDK's own TypedDict — always emit one.
+_RESPONSES_IMAGE_DETAILS = frozenset({"low", "high", "auto"})
+_RESPONSES_DEFAULT_IMAGE_DETAIL = "auto"
+
+
+def _translate_image_part(part: dict[str, Any]) -> dict[str, Any]:
+    """chat ``{"type":"image_url", ...}`` → Responses ``{"type":"input_image"}``.
+
+    Shape taken from the installed OpenAI SDK's
+    ``openai.types.responses.ResponseInputImageParam``: a FLAT part carrying
+    ``image_url`` as a plain string ("a fully qualified URL or base64 encoded
+    image in a data URL" — so http(s) URLs and ``data:`` URIs both go in the
+    same field, no vendor-specific split like Anthropic's base64/url sources)
+    plus a required ``detail`` of ``low``/``high``/``auto``.
+
+    Accepts every image form the chat path accepts:
+      * ``{"image_url": {"url": ..., "detail": ...}}`` — mesh's own emitter
+        (``_mcp_mesh.media.resolver._format_for_openai`` produces a data URI
+        with ``detail="high"``).
+      * ``{"image_url": "<url>"}`` — bare-string form some clients send, which
+        the Anthropic/Gemini adapters also accept.
+      * A ``detail`` on the part itself rather than nested under ``image_url``.
+    """
+    field = part.get("image_url")
+    detail: Any = None
+    if isinstance(field, str):
+        url: Any = field
+    elif isinstance(field, dict):
+        url = field.get("url")
+        detail = field.get("detail")
+    else:
+        url = None
+    if detail is None:
+        detail = part.get("detail")
+
+    if not url or not isinstance(url, str):
+        raise ValueError(
+            "OpenAI Responses path: image content part has no usable url "
+            "(expected image_url={'url': ...} or image_url='<url>'); "
+            f"got image_url={field!r}"
+        )
+
+    if detail is not None and detail not in _RESPONSES_IMAGE_DETAILS:
+        logger.warning(
+            "OpenAI Responses path: unsupported image detail %r "
+            "(expected one of low/high/auto); using %s",
+            detail,
+            _RESPONSES_DEFAULT_IMAGE_DETAIL,
+        )
+        detail = None
+
+    return {
+        "type": "input_image",
+        "image_url": url,
+        "detail": detail or _RESPONSES_DEFAULT_IMAGE_DETAIL,
+    }
+
+
 def _translate_message_content(content: Any, role: str) -> Any:
     """Translate chat-style message ``content`` into the Responses input shape.
 
     Plain-string content passes through unchanged (the common case). A
-    content-part ARRAY is translated part-by-part: text parts
-    ``{"type":"text","text":...}`` become ``input_text`` (user/system) or
-    ``output_text`` (assistant), matching the part types Responses expects.
+    content-part ARRAY is translated part-by-part:
 
-    Any image or other non-text part raises a clear ``ValueError`` rather than
+      * text parts ``{"type":"text","text":...}`` → ``input_text`` (user/system)
+        or ``output_text`` (assistant), matching the part types Responses
+        expects.
+      * image parts ``{"type":"image_url", ...}`` → ``input_image``
+        (issue #1336) so reasoning + tools + vision works on this path. See
+        :func:`_translate_image_part` for the accepted input forms.
+      * parts already in Responses shape (``input_text`` / ``output_text`` /
+        ``input_image`` / ``input_file``) pass through untouched so the
+        translation is idempotent.
+
+    Any other part type still raises a clear ``ValueError`` rather than
     forwarding an untranslated chat-shape part that would yield a cryptic
-    OpenAI 400. Image translation is deliberately NOT attempted here (the
-    Responses image-part shape differs and is unverified for this path).
+    OpenAI 400.
     """
     if not isinstance(content, list):
         return content
@@ -660,10 +726,15 @@ def _translate_message_content(content: Any, role: str) -> Any:
         ptype = part.get("type") if isinstance(part, dict) else None
         if ptype == "text":
             translated.append({"type": text_type, "text": part.get("text")})
+        elif ptype == "image_url":
+            translated.append(_translate_image_part(part))
+        elif ptype in ("input_text", "output_text", "input_image", "input_file"):
+            # Already Responses-shaped — passthrough (idempotent).
+            translated.append(part)
         else:
             raise ValueError(
-                "OpenAI Responses path (reasoning model + tools) does not yet "
-                "support multimodal image content; use string/text content, "
+                "OpenAI Responses path (reasoning model + tools) does not "
+                "support this content part type; use text or image_url parts, "
                 "drop tools, or use a non-reasoning model "
                 f"(unsupported content part type={ptype!r})"
             )
@@ -846,12 +917,77 @@ def _build_responses_kwargs(
     return responses_kwargs
 
 
+# Semantic events that carry the finished ``Response`` — the only place the
+# Responses stream reports usage (there is no incremental usage, unlike
+# Anthropic's cumulative ``message_delta``).
+_RESPONSES_TERMINAL_EVENTS = frozenset({
+    "response.completed",
+    "response.incomplete",
+    "response.failed",
+})
+
+
 def _rget(obj: Any, key: str, default: Any = None) -> Any:
     """Attribute-or-key getter so adapters accept both SDK Pydantic objects
     and plain dicts (keeps the Responses adapter test-friendly)."""
     if isinstance(obj, dict):
         return obj.get(key, default)
     return getattr(obj, key, default)
+
+
+def _responses_usage(raw: Any) -> _Usage | None:
+    """``Response.usage`` (``input_tokens``/``output_tokens``) → :class:`_Usage`.
+
+    Shared by the buffered and streaming Responses paths so the two cannot
+    drift on the token mapping.
+    """
+    usage_obj = _rget(raw, "usage", None)
+    if usage_obj is None:
+        return None
+    return _Usage(
+        prompt_tokens=_rget(usage_obj, "input_tokens", 0) or 0,
+        completion_tokens=_rget(usage_obj, "output_tokens", 0) or 0,
+    )
+
+
+def _responses_finish_reason(raw: Any, *, has_tool_calls: bool) -> str:
+    """Derive a truthful chat-shape ``finish_reason`` from a Responses object.
+
+    Responses carries the signal on ``status`` / ``incomplete_details`` rather
+    than a ``finish_reason`` field: map truncation / content-filter / incomplete
+    outcomes instead of collapsing everything into stop/tool_calls. Shared by
+    the buffered and streaming Responses paths.
+    """
+    finish_reason = "tool_calls" if has_tool_calls else "stop"
+    status = _rget(raw, "status", None)
+    incomplete = _rget(raw, "incomplete_details", None)
+    if status == "incomplete":
+        reason = _rget(incomplete, "reason", None) if incomplete is not None else None
+        if reason == "max_output_tokens":
+            return "length"
+        if reason == "content_filter":
+            return "content_filter"
+        # An incomplete response with an unmapped (or empty) reason must not
+        # look like a clean stop — surface it for debugging.
+        logger.debug(
+            "Native OpenAI adapter (Responses): incomplete response with "
+            "unmapped reason (status=%r, incomplete_details=%r); keeping "
+            "finish_reason=%r",
+            status,
+            incomplete,
+            finish_reason,
+        )
+    elif status not in (None, "completed"):
+        # "failed" / any other terminal status — keep stop/tool_calls but log so
+        # an empty-output failure isn't a silent clean stop.
+        logger.debug(
+            "Native OpenAI adapter (Responses): non-completed status "
+            "(status=%r, incomplete_details=%r); keeping finish_reason=%r",
+            status,
+            incomplete,
+            finish_reason,
+        )
+    return finish_reason
 
 
 def _adapt_responses_response(raw: Any) -> _Response:
@@ -924,85 +1060,12 @@ def _adapt_responses_response(raw: Any) -> _Response:
         tool_calls=tool_calls or None,
     )
 
-    usage_obj = _rget(raw, "usage", None)
-    if usage_obj is not None:
-        usage = _Usage(
-            prompt_tokens=_rget(usage_obj, "input_tokens", 0) or 0,
-            completion_tokens=_rget(usage_obj, "output_tokens", 0) or 0,
-        )
-    else:
-        usage = None
-
-    # Preserve a truthful finish_reason (the chat path forwards the real one).
-    # Responses carries the signal on ``status`` / ``incomplete_details`` rather
-    # than a ``finish_reason`` field: map truncation / content-filter /
-    # incomplete outcomes instead of collapsing everything into stop/tool_calls.
-    finish_reason = "tool_calls" if tool_calls else "stop"
-    status = _rget(raw, "status", None)
-    incomplete = _rget(raw, "incomplete_details", None)
-    if status == "incomplete":
-        reason = _rget(incomplete, "reason", None) if incomplete is not None else None
-        if reason == "max_output_tokens":
-            finish_reason = "length"
-        elif reason == "content_filter":
-            finish_reason = "content_filter"
-        else:
-            # An incomplete response with an unmapped (or empty) reason must not
-            # look like a clean stop — surface it for debugging.
-            logger.debug(
-                "Native OpenAI adapter (Responses): incomplete response with "
-                "unmapped reason (status=%r, incomplete_details=%r); keeping "
-                "finish_reason=%r",
-                status,
-                incomplete,
-                finish_reason,
-            )
-    elif status not in (None, "completed"):
-        # "failed" / any other terminal status — keep stop/tool_calls but log so
-        # an empty-output failure isn't a silent clean stop.
-        logger.debug(
-            "Native OpenAI adapter (Responses): non-completed status "
-            "(status=%r, incomplete_details=%r); keeping finish_reason=%r",
-            status,
-            incomplete,
-            finish_reason,
-        )
-
     return _Response(
         message=message,
-        usage=usage,
+        usage=_responses_usage(raw),
         model=_rget(raw, "model", None),
-        finish_reason=finish_reason,
-    )
-
-
-def _responses_result_to_stream_chunk(resp: _Response) -> _StreamChunk:
-    """Collapse a buffered Responses ``_Response`` into a single terminal
-    ``_StreamChunk`` carrying content + tool-call deltas + usage + finish_reason.
-
-    Used by the buffered-fallback streaming path (see ``complete_stream``). The
-    provider-side consumer buffers all chunks and merges content / tool_calls /
-    usage across them, so one all-in-one chunk reassembles correctly.
-    """
-    choice = resp.choices[0]
-    msg = choice.message
-    tool_call_deltas: list[_StreamToolCallDelta] | None = None
-    if msg.tool_calls:
-        tool_call_deltas = [
-            _StreamToolCallDelta(
-                index=i,
-                id=tc.id,
-                type="function",
-                name=tc.function.name,
-                arguments=tc.function.arguments,
-            )
-            for i, tc in enumerate(msg.tool_calls)
-        ]
-    return _StreamChunk(
-        delta=_Delta(content=msg.content, tool_calls=tool_call_deltas),
-        usage=resp.usage,
-        model=resp.model,
-        finish_reason=choice.finish_reason,
+        # Preserve a truthful finish_reason (the chat path forwards the real one).
+        finish_reason=_responses_finish_reason(raw, has_tool_calls=bool(tool_calls)),
     )
 
 
@@ -1231,7 +1294,25 @@ async def complete_stream(
 ) -> AsyncIterator[Any]:
     """Stream an OpenAI completion as litellm-shape chunks.
 
-    OpenAI's SDK exposes streaming via ``await client.chat.completions.create(
+    Two backends, one chunk shape (consumers cannot tell them apart):
+
+    **Responses** (reasoning model + tools — issue #1334/#1336). ``await
+    client.responses.create(stream=True)`` returns an ``AsyncStream`` of
+    SEMANTIC events which are mapped as:
+
+      * ``response.created`` / ``response.in_progress`` → model id only.
+      * ``response.output_text.delta`` → chunk with ``delta.content``.
+      * ``response.output_item.added`` (``function_call``) → chunk with
+        ``delta.tool_calls`` carrying call_id + name (the argument-delta events
+        carry neither).
+      * ``response.function_call_arguments.delta`` → chunk with
+        ``delta.tool_calls`` carrying the argument fragment at the same index.
+      * ``response.output_item.done`` → backfill only (see inline note).
+      * ``response.completed`` / ``.incomplete`` / ``.failed`` → chunk with
+        usage + finish_reason.
+
+    **chat.completions** (everything else). OpenAI's SDK exposes streaming via
+    ``await client.chat.completions.create(
     stream=True)`` which returns an ``AsyncStream[ChatCompletionChunk]``.
     The adapter forces ``stream_options.include_usage=True`` so the final
     chunk carries the authoritative usage tally (matches LiteLLM's
@@ -1245,21 +1326,210 @@ async def complete_stream(
     """
     client = _build_client(model, api_key, base_url)
 
-    # Reasoning models WITH tools must use the Responses API (issue #1334).
-    # TODO(#1334): native Responses streaming. mesh does not yet stream the
-    # Responses API natively; run the call buffered and emit the terminal
-    # result as a single chunk. The provider-side consumer buffers all chunks
-    # and merges content / tool_calls / usage across them, so a single
-    # all-in-one chunk reassembles correctly (no interrupted-stream fallback
-    # is needed here — a buffered call has no partial-usage hole).
+    # Reasoning models WITH tools must use the Responses API (issue #1334) and
+    # stream it natively via semantic events (issue #1336).
     if _openai_wants_responses_api(model, request_params):
-        logger.info(
-            "Native OpenAI Responses path: buffering reasoning+tools stream "
-            "(native Responses streaming not yet implemented — #1334)"
-        )
         responses_kwargs = _build_responses_kwargs(request_params, model=model)
-        raw = await client.responses.create(**responses_kwargs)
-        yield _responses_result_to_stream_chunk(_adapt_responses_response(raw))
+        responses_kwargs["stream"] = True
+        # NOTE: no ``stream_options`` here. Responses' StreamOptions has no
+        # ``include_usage`` (usage always rides on ``response.completed``), so
+        # forwarding the chat path's option would be rejected.
+
+        # item_id → {index, id_emitted, args_emitted}. Responses identifies a
+        # streamed function call by its OUTPUT-ITEM id, and the argument-delta
+        # events carry only that ``item_id`` — never the call_id or the name
+        # (those arrive once on ``response.output_item.added``). Map each item
+        # to a contiguous 0-based tool-call ordinal so the merged shape is
+        # indistinguishable from the chat path's (``output_index`` would leak
+        # reasoning items into the numbering).
+        tool_slots: dict[str, dict[str, Any]] = {}
+        next_tc_index = 0
+        saw_tool_call = False
+
+        # Same interrupted-stream contract as the chat path below: track the
+        # last usage counters seen on the wire and flip ``final_usage_emitted``
+        # only AFTER the authoritative yield returns, so a consumer that
+        # aborts mid-yield still gets the best-effort fallback from ``finally``.
+        last_input_tokens = 0
+        last_output_tokens = 0
+        last_model: str | None = _strip_prefix(model)
+        final_usage_emitted = False
+
+        try:
+            stream = await client.responses.create(**responses_kwargs)
+            async for event in stream:
+                etype = _rget(event, "type", None)
+
+                # Every lifecycle event (created / in_progress / queued /
+                # completed / incomplete / failed) embeds the ``Response``.
+                # Harvest the model id and any usage it carries BEFORE the
+                # per-type dispatch: OpenAI itself only fills usage on the
+                # terminal event, but an OpenAI-compatible server may report it
+                # earlier — and recording whatever we saw is what makes the
+                # interrupted-stream fallback below able to publish non-zero
+                # tokens (same reason anthropic_native records message_start /
+                # message_delta counters).
+                resp_obj = _rget(event, "response", None)
+                if resp_obj is not None:
+                    model_id = _rget(resp_obj, "model", None)
+                    if model_id:
+                        last_model = model_id
+                    event_usage = _responses_usage(resp_obj)
+                    if event_usage is not None:
+                        last_input_tokens = event_usage.prompt_tokens
+                        last_output_tokens = event_usage.completion_tokens
+
+                if etype == "response.output_text.delta":
+                    text = _rget(event, "delta", "") or ""
+                    if text:
+                        yield _StreamChunk(
+                            delta=_Delta(content=text), model=last_model
+                        )
+                    continue
+
+                if etype == "response.output_item.added":
+                    item = _rget(event, "item", None)
+                    if _rget(item, "type", None) != "function_call":
+                        # reasoning / message items carry no delta of their own.
+                        continue
+                    item_id = _rget(item, "id", None) or ""
+                    slot = tool_slots.get(item_id)
+                    if slot is None:
+                        slot = {
+                            "index": next_tc_index,
+                            "id_emitted": False,
+                            "args_emitted": False,
+                        }
+                        next_tc_index += 1
+                        tool_slots[item_id] = slot
+                    saw_tool_call = True
+                    slot["id_emitted"] = True
+                    yield _StreamChunk(
+                        delta=_Delta(
+                            tool_calls=[
+                                _StreamToolCallDelta(
+                                    index=slot["index"],
+                                    # chat ``tool_call.id`` ≡ Responses ``call_id``.
+                                    id=_rget(item, "call_id", None) or item_id,
+                                    type="function",
+                                    name=_rget(item, "name", None),
+                                )
+                            ]
+                        ),
+                        model=last_model,
+                    )
+                    continue
+
+                if etype == "response.function_call_arguments.delta":
+                    item_id = _rget(event, "item_id", None) or ""
+                    slot = tool_slots.get(item_id)
+                    if slot is None:
+                        # No ``output_item.added`` seen for this item (defensive
+                        # — an OpenAI-compatible proxy that skips it). Allocate
+                        # the ordinal anyway; ``output_item.done`` backfills the
+                        # id/name so the merger doesn't drop the call.
+                        slot = {
+                            "index": next_tc_index,
+                            "id_emitted": False,
+                            "args_emitted": False,
+                        }
+                        next_tc_index += 1
+                        tool_slots[item_id] = slot
+                    fragment = _rget(event, "delta", "") or ""
+                    if not fragment:
+                        continue
+                    slot["args_emitted"] = True
+                    yield _StreamChunk(
+                        delta=_Delta(
+                            tool_calls=[
+                                _StreamToolCallDelta(
+                                    index=slot["index"], arguments=fragment
+                                )
+                            ]
+                        ),
+                        model=last_model,
+                    )
+                    continue
+
+                if etype == "response.output_item.done":
+                    # Backfill-only safety net: emit ONLY the pieces the delta
+                    # events never delivered for this call. Re-emitting already
+                    # streamed arguments would double them (the merger
+                    # concatenates), so each piece is gated on its flag.
+                    item = _rget(event, "item", None)
+                    if _rget(item, "type", None) != "function_call":
+                        continue
+                    item_id = _rget(item, "id", None) or ""
+                    slot = tool_slots.get(item_id)
+                    if slot is None:
+                        slot = {
+                            "index": next_tc_index,
+                            "id_emitted": False,
+                            "args_emitted": False,
+                        }
+                        next_tc_index += 1
+                        tool_slots[item_id] = slot
+                    args = _rget(item, "arguments", None)
+                    need_id = not slot["id_emitted"]
+                    need_args = not slot["args_emitted"] and bool(args)
+                    if not (need_id or need_args):
+                        continue
+                    saw_tool_call = True
+                    slot["id_emitted"] = slot["id_emitted"] or need_id
+                    slot["args_emitted"] = slot["args_emitted"] or need_args
+                    yield _StreamChunk(
+                        delta=_Delta(
+                            tool_calls=[
+                                _StreamToolCallDelta(
+                                    index=slot["index"],
+                                    id=(
+                                        (_rget(item, "call_id", None) or item_id)
+                                        if need_id
+                                        else None
+                                    ),
+                                    type="function" if need_id else None,
+                                    name=_rget(item, "name", None) if need_id else None,
+                                    arguments=args if need_args else None,
+                                )
+                            ]
+                        ),
+                        model=last_model,
+                    )
+                    continue
+
+                if etype in _RESPONSES_TERMINAL_EVENTS:
+                    # ``response.completed`` / ``.incomplete`` / ``.failed`` all
+                    # carry the finished Response — where OpenAI reports the
+                    # authoritative usage (already harvested above).
+                    if resp_obj is None:
+                        continue
+                    usage = _responses_usage(resp_obj)
+                    yield _StreamChunk(
+                        delta=_Delta(),
+                        usage=usage,
+                        model=last_model,
+                        finish_reason=_responses_finish_reason(
+                            resp_obj, has_tool_calls=saw_tool_call
+                        ),
+                    )
+                    if usage is not None:
+                        final_usage_emitted = True
+                    continue
+        finally:
+            # Identical contract to the chat path's finally below — see there
+            # for the full rationale.
+            if not final_usage_emitted and (last_input_tokens or last_output_tokens):
+                try:
+                    yield _StreamChunk(
+                        delta=_Delta(),
+                        usage=_Usage(
+                            prompt_tokens=last_input_tokens,
+                            completion_tokens=last_output_tokens,
+                        ),
+                        model=last_model,
+                    )
+                except (GeneratorExit, StopAsyncIteration):
+                    pass
         return
 
     create_kwargs = _build_create_kwargs(request_params, model=model)

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
@@ -1912,31 +1912,34 @@ class TestBuildResponsesKwargs:
             "content": [{"type": "output_text", "text": "Sure thing."}],
         } in kwargs["input"]
 
-    def test_image_part_array_raises_value_error(self):
-        """An image (or any non-text) content part raises a clear ValueError
-        rather than forwarding an untranslated shape that yields a cryptic
-        OpenAI 400."""
-        with pytest.raises(ValueError) as exc_info:
-            openai_native._build_responses_kwargs(
-                {
-                    "messages": [
-                        {
-                            "role": "user",
-                            "content": [
-                                {"type": "text", "text": "What is this?"},
-                                {
-                                    "type": "image_url",
-                                    "image_url": {"url": "https://x/y.png"},
-                                },
-                            ],
-                        }
-                    ]
-                },
-                model="openai/gpt-5.6-terra",
-            )
-        msg = str(exc_info.value)
-        assert "multimodal image content" in msg
-        assert "non-reasoning model" in msg
+    def test_unsupported_part_type_raises_value_error(self):
+        """A genuinely untranslatable content part still raises a clear
+        ValueError rather than forwarding a chat-shape part that yields a
+        cryptic OpenAI 400. (Images are translated — see
+        ``TestResponsesImageTranslation`` — but e.g. Anthropic-shape ``image``
+        blocks or audio parts are not.)"""
+        for part in (
+            {"type": "image", "source": {"type": "base64", "data": "AAA"}},
+            {"type": "input_audio", "input_audio": {"data": "AAA"}},
+        ):
+            with pytest.raises(ValueError) as exc_info:
+                openai_native._build_responses_kwargs(
+                    {
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "What is this?"},
+                                    part,
+                                ],
+                            }
+                        ]
+                    },
+                    model="openai/gpt-5.6-terra",
+                )
+            msg = str(exc_info.value)
+            assert "content part type" in msg
+            assert "non-reasoning model" in msg
 
     def test_tool_call_arguments_none_coerced_to_empty_string(self):
         """A stored ``arguments`` of explicit ``None`` must become ``""`` —
@@ -2260,21 +2263,15 @@ class TestResponsesDispatch:
         instance.responses.create.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_stream_reasoning_with_tools_buffers_via_responses(self):
-        """Streaming reasoning+tools falls back to a buffered Responses call and
-        emits a single terminal chunk carrying content + usage."""
-        cls_mock, instance = _patched_dual_openai(
-            chat_response=_make_openai_completion(text="chat"),
-            responses_response=_make_responses_response(
-                output=[
-                    {
-                        "type": "message",
-                        "content": [{"type": "output_text", "text": "buffered"}],
-                    }
-                ],
-                input_tokens=9,
-                output_tokens=3,
-            ),
+    async def test_stream_reasoning_with_tools_uses_responses_stream(self):
+        """Streaming reasoning+tools hits ``responses.create(stream=True)`` —
+        NOT chat.completions, and NOT a buffered non-streaming call (#1336)."""
+        cls_mock, instance = _patched_responses_stream(
+            [
+                _ev_created(),
+                _ev_text_delta("hi"),
+                _ev_completed(),
+            ]
         )
         with patch("openai.AsyncOpenAI", cls_mock):
             stream = openai_native.complete_stream(
@@ -2285,45 +2282,732 @@ class TestResponsesDispatch:
                 model="openai/gpt-5.6-terra",
                 api_key="sk-test",
             )
-            chunks = [c async for c in stream]
+            async for _ in stream:
+                pass
 
-        instance.responses.create.assert_called_once()
         instance.chat.completions.create.assert_not_called()
-        # Single terminal chunk with content + usage.
-        assert len(chunks) == 1
-        assert chunks[0].choices[0].delta.content == "buffered"
-        assert chunks[0].usage.prompt_tokens == 9
-        assert chunks[0].usage.completion_tokens == 3
+        instance.responses.create.assert_called_once()
+        kwargs = instance.responses.create.call_args.kwargs
+        assert kwargs["stream"] is True
+        # Responses' StreamOptions has no ``include_usage`` — forwarding the
+        # chat path's option would be rejected by the API.
+        assert "stream_options" not in kwargs
 
-    @pytest.mark.asyncio
-    async def test_stream_reasoning_with_tools_emits_tool_call_delta(self):
-        cls_mock, instance = _patched_dual_openai(
-            chat_response=_make_openai_completion(text="chat"),
-            responses_response=_make_responses_response(
-                output=[
+
+# ---------------------------------------------------------------------------
+# Multimodal input translation — chat image parts → Responses input_image
+# (issue #1336). Shape source: openai.types.responses.ResponseInputImageParam
+# in the installed SDK — a FLAT part with ``image_url`` as a plain string
+# ("a fully qualified URL or base64 encoded image in a data URL") and a
+# REQUIRED ``detail`` of low/high/auto.
+# ---------------------------------------------------------------------------
+
+
+def _translate_user_content(content):
+    """Run one user message's content through the Responses builder and return
+    the translated content of the resulting input item."""
+    kwargs = openai_native._build_responses_kwargs(
+        {"messages": [{"role": "user", "content": content}]},
+        model="openai/gpt-5.6-terra",
+    )
+    return kwargs["input"][0]["content"]
+
+
+class TestResponsesImageTranslation:
+    def test_image_part_no_longer_raises(self):
+        """Regression for the #1334 deferral: an image part used to raise a
+        deliberate ValueError on this path. It must now translate."""
+        parts = _translate_user_content(
+            [
+                {"type": "text", "text": "What is this?"},
+                {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+            ]
+        )
+        assert [p["type"] for p in parts] == ["input_text", "input_image"]
+
+    def test_mesh_resolver_shape_translated(self):
+        """The exact shape mesh's own emitter produces
+        (``_mcp_mesh.media.resolver._format_for_openai``): a base64 data URI
+        with ``detail="high"`` nested under ``image_url``."""
+        data_uri = "data:image/png;base64,iVBORw0KGgo="
+        parts = _translate_user_content(
+            [{"type": "image_url", "image_url": {"url": data_uri, "detail": "high"}}]
+        )
+        assert parts == [
+            {"type": "input_image", "image_url": data_uri, "detail": "high"}
+        ]
+
+    def test_https_url_form_translated(self):
+        parts = _translate_user_content(
+            [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}]
+        )
+        # URL and data-URI both ride in the same ``image_url`` string field.
+        assert parts[0]["image_url"] == "https://x/y.png"
+        assert parts[0]["type"] == "input_image"
+
+    def test_bare_string_image_url_form_translated(self):
+        """Some clients send ``image_url`` as a bare string; the Anthropic and
+        Gemini adapters accept it, so this path must too."""
+        parts = _translate_user_content(
+            [{"type": "image_url", "image_url": "https://x/y.png"}]
+        )
+        assert parts[0] == {
+            "type": "input_image",
+            "image_url": "https://x/y.png",
+            "detail": "auto",
+        }
+
+    def test_detail_defaults_to_auto_when_absent(self):
+        """``detail`` is Required in ResponseInputImageParam — always emit one."""
+        parts = _translate_user_content(
+            [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}]
+        )
+        assert parts[0]["detail"] == "auto"
+
+    @pytest.mark.parametrize("detail", ["low", "high", "auto"])
+    def test_valid_detail_forwarded(self, detail):
+        parts = _translate_user_content(
+            [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://x/y.png", "detail": detail},
+                }
+            ]
+        )
+        assert parts[0]["detail"] == detail
+
+    def test_detail_on_part_root_accepted(self):
+        parts = _translate_user_content(
+            [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://x/y.png"},
+                    "detail": "low",
+                }
+            ]
+        )
+        assert parts[0]["detail"] == "low"
+
+    def test_invalid_detail_warns_and_falls_back_to_auto(self, caplog):
+        """OpenAI only accepts low/high/auto — anything else would 400. Soft-fail
+        to the default with a WARN rather than forwarding the bad value."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger=openai_native.logger.name):
+            parts = _translate_user_content(
+                [
                     {
-                        "type": "function_call",
-                        "call_id": "call_s1",
-                        "name": "get_weather",
-                        "arguments": '{"city": "Paris"}',
+                        "type": "image_url",
+                        "image_url": {"url": "https://x/y.png", "detail": "ultra"},
                     }
                 ]
-            ),
+            )
+        assert parts[0]["detail"] == "auto"
+        assert any("ultra" in r.getMessage() for r in caplog.records)
+
+    def test_image_part_without_url_raises(self):
+        with pytest.raises(ValueError) as exc_info:
+            _translate_user_content([{"type": "image_url", "image_url": {}}])
+        assert "no usable url" in str(exc_info.value)
+
+    def test_already_responses_shaped_parts_pass_through(self):
+        """Translation is idempotent — re-running it over already-Responses
+        shapes must not raise or rewrite them."""
+        native = [
+            {"type": "input_text", "text": "hi"},
+            {"type": "input_image", "image_url": "https://x/y.png", "detail": "low"},
+        ]
+        assert _translate_user_content(native) == native
+
+    def test_mixed_text_and_image_ordering_preserved(self):
+        parts = _translate_user_content(
+            [
+                {"type": "text", "text": "before"},
+                {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+                {"type": "text", "text": "after"},
+            ]
         )
+        assert [p["type"] for p in parts] == [
+            "input_text",
+            "input_image",
+            "input_text",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Native Responses streaming (issue #1336)
+#
+# Events are built from the OpenAI SDK's OWN Pydantic models
+# (openai.types.responses.*) rather than hand-rolled namespaces, so the field
+# names/required-ness the adapter reads are exactly what the SDK emits.
+# ---------------------------------------------------------------------------
+
+
+def _sdk_response(
+    *,
+    status="completed",
+    usage=(11, 5),
+    model="gpt-5.6-terra",
+    incomplete_details=None,
+):
+    """Build a real ``openai.types.responses.Response``."""
+    from openai.types.responses import Response
+
+    payload = {
+        "id": "resp_1",
+        "created_at": 0,
+        "model": model,
+        "object": "response",
+        "output": [],
+        "parallel_tool_calls": True,
+        "tool_choice": "auto",
+        "tools": [],
+        "status": status,
+    }
+    if usage is not None:
+        payload["usage"] = {
+            "input_tokens": usage[0],
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens": usage[1],
+            "output_tokens_details": {"reasoning_tokens": 0},
+            "total_tokens": usage[0] + usage[1],
+        }
+    if incomplete_details is not None:
+        payload["incomplete_details"] = incomplete_details
+    return Response.model_validate(payload)
+
+
+def _ev_created(**kw):
+    from openai.types.responses import ResponseCreatedEvent
+
+    kw.setdefault("usage", None)
+    return ResponseCreatedEvent(
+        response=_sdk_response(status="in_progress", **kw),
+        sequence_number=0,
+        type="response.created",
+    )
+
+
+def _ev_text_delta(text, *, item_id="msg_1", output_index=1, seq=1):
+    from openai.types.responses import ResponseTextDeltaEvent
+
+    return ResponseTextDeltaEvent(
+        content_index=0,
+        delta=text,
+        item_id=item_id,
+        logprobs=[],
+        output_index=output_index,
+        sequence_number=seq,
+        type="response.output_text.delta",
+    )
+
+
+def _fc_item(*, item_id="fc_1", call_id="call_abc", name="get_weather", arguments=""):
+    from openai.types.responses import ResponseFunctionToolCall
+
+    return ResponseFunctionToolCall(
+        arguments=arguments,
+        call_id=call_id,
+        name=name,
+        type="function_call",
+        id=item_id,
+        status="in_progress",
+    )
+
+
+def _ev_item_added(item, *, output_index=1, seq=2):
+    from openai.types.responses import ResponseOutputItemAddedEvent
+
+    return ResponseOutputItemAddedEvent(
+        item=item,
+        output_index=output_index,
+        sequence_number=seq,
+        type="response.output_item.added",
+    )
+
+
+def _ev_item_done(item, *, output_index=1, seq=8):
+    from openai.types.responses import ResponseOutputItemDoneEvent
+
+    return ResponseOutputItemDoneEvent(
+        item=item,
+        output_index=output_index,
+        sequence_number=seq,
+        type="response.output_item.done",
+    )
+
+
+def _ev_args_delta(fragment, *, item_id="fc_1", output_index=1, seq=3):
+    from openai.types.responses import ResponseFunctionCallArgumentsDeltaEvent
+
+    return ResponseFunctionCallArgumentsDeltaEvent(
+        delta=fragment,
+        item_id=item_id,
+        output_index=output_index,
+        sequence_number=seq,
+        type="response.function_call_arguments.delta",
+    )
+
+
+def _ev_completed(*, usage=(11, 5), seq=9):
+    from openai.types.responses import ResponseCompletedEvent
+
+    return ResponseCompletedEvent(
+        response=_sdk_response(status="completed", usage=usage),
+        sequence_number=seq,
+        type="response.completed",
+    )
+
+
+def _ev_incomplete(*, reason="max_output_tokens", usage=(11, 5), seq=9):
+    from openai.types.responses import ResponseIncompleteEvent
+
+    return ResponseIncompleteEvent(
+        response=_sdk_response(
+            status="incomplete",
+            usage=usage,
+            incomplete_details={"reason": reason},
+        ),
+        sequence_number=seq,
+        type="response.incomplete",
+    )
+
+
+def _patched_responses_stream(events, *, stream_obj=None):
+    """(cls_mock, instance) whose ``responses.create`` returns an async stream
+    of the given semantic events."""
+    instance = MagicMock()
+    instance.chat = MagicMock()
+    instance.chat.completions = MagicMock()
+    instance.chat.completions.create = AsyncMock()
+    instance.responses = MagicMock()
+    instance.responses.create = AsyncMock(
+        return_value=stream_obj if stream_obj is not None else _FakeAsyncStream(events)
+    )
+    cls_mock = MagicMock(return_value=instance)
+    return cls_mock, instance
+
+
+_STREAM_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Look up weather.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+async def _run_responses_stream(events, *, stream_obj=None, tools=True):
+    """Drive ``complete_stream`` over the given events; return the chunks."""
+    cls_mock, instance = _patched_responses_stream(events, stream_obj=stream_obj)
+    params = {"messages": [{"role": "user", "content": "Hi."}]}
+    if tools:
+        params["tools"] = _STREAM_TOOLS
+    with patch("openai.AsyncOpenAI", cls_mock):
+        stream = openai_native.complete_stream(
+            params, model="openai/gpt-5.6-terra", api_key="sk-test"
+        )
+        return [c async for c in stream]
+
+
+def _contents(chunks):
+    out = []
+    for c in chunks:
+        if c.choices:
+            text = getattr(c.choices[0].delta, "content", None)
+            if text:
+                out.append(text)
+    return out
+
+
+class TestResponsesNativeStreaming:
+    @pytest.mark.asyncio
+    async def test_text_deltas_stream_incrementally_not_one_blob(self):
+        """The whole point of #1336: N text deltas produce N content chunks,
+        not one terminal blob."""
+        chunks = await _run_responses_stream(
+            [
+                _ev_created(),
+                _ev_text_delta("Hello "),
+                _ev_text_delta("from "),
+                _ev_text_delta("Responses"),
+                _ev_completed(),
+            ]
+        )
+        pieces = _contents(chunks)
+        assert len(pieces) == 3
+        assert "".join(pieces) == "Hello from Responses"
+
+    @pytest.mark.asyncio
+    async def test_empty_text_delta_yields_no_chunk(self):
+        chunks = await _run_responses_stream(
+            [_ev_created(), _ev_text_delta(""), _ev_completed()]
+        )
+        assert _contents(chunks) == []
+
+    @pytest.mark.asyncio
+    async def test_completed_event_carries_usage_and_model(self):
+        chunks = await _run_responses_stream(
+            [_ev_created(), _ev_text_delta("hi"), _ev_completed(usage=(31, 7))]
+        )
+        usage_chunks = [c for c in chunks if c.usage is not None]
+        assert len(usage_chunks) == 1
+        assert usage_chunks[0].usage.prompt_tokens == 31
+        assert usage_chunks[0].usage.completion_tokens == 7
+        assert usage_chunks[0].usage.total_tokens == 38
+        assert "gpt-5.6-terra" in [c.model for c in chunks if c.model]
+
+    @pytest.mark.asyncio
+    async def test_completed_terminal_chunk_is_last_and_carries_finish_reason(self):
+        chunks = await _run_responses_stream(
+            [_ev_created(), _ev_text_delta("hi"), _ev_completed()]
+        )
+        assert chunks[-1].usage is not None
+        assert chunks[-1].choices[0].finish_reason == "stop"
+
+    @pytest.mark.asyncio
+    async def test_incomplete_event_maps_finish_reason_length(self):
+        chunks = await _run_responses_stream(
+            [
+                _ev_created(),
+                _ev_text_delta("trunc"),
+                _ev_incomplete(reason="max_output_tokens"),
+            ]
+        )
+        assert chunks[-1].choices[0].finish_reason == "length"
+        assert chunks[-1].usage is not None
+
+    @pytest.mark.asyncio
+    async def test_tool_call_deltas_merge_via_agent_merger(self):
+        """The streamed tool-call shape must reassemble through the SAME merger
+        the chat path's chunks go through — consumers can't tell the paths
+        apart."""
+        from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+
+        item = _fc_item()
+        chunks = await _run_responses_stream(
+            [
+                _ev_created(),
+                _ev_item_added(item),
+                _ev_args_delta('{"city"'),
+                _ev_args_delta(': "Paris"}'),
+                _ev_item_done(
+                    item.model_copy(
+                        update={"arguments": '{"city": "Paris"}', "status": "completed"}
+                    )
+                ),
+                _ev_completed(),
+            ]
+        )
+        merged = MeshLlmAgent._merge_streamed_tool_calls(chunks)
+        assert len(merged) == 1
+        tc = merged[0]
+        assert tc["id"] == "call_abc"
+        assert tc["type"] == "function"
+        assert tc["function"]["name"] == "get_weather"
+        assert tc["function"]["arguments"] == '{"city": "Paris"}'
+        assert any(MeshLlmAgent._chunk_has_tool_call(c) for c in chunks)
+
+    @pytest.mark.asyncio
+    async def test_argument_deltas_arrive_as_separate_chunks(self):
+        """Argument fragments stream incrementally rather than as one blob."""
+        item = _fc_item()
+        chunks = await _run_responses_stream(
+            [
+                _ev_created(),
+                _ev_item_added(item),
+                _ev_args_delta('{"city"'),
+                _ev_args_delta(': "Paris"}'),
+                _ev_completed(),
+            ]
+        )
+        arg_chunks = [
+            c
+            for c in chunks
+            if c.choices
+            and c.choices[0].delta.tool_calls
+            and c.choices[0].delta.tool_calls[0].function.arguments
+        ]
+        assert len(arg_chunks) == 2
+
+    @pytest.mark.asyncio
+    async def test_output_item_done_does_not_double_arguments(self):
+        """``output_item.done`` repeats the FULL arguments string. Re-emitting
+        it would double the JSON through the concatenating merger."""
+        from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+
+        item = _fc_item()
+        chunks = await _run_responses_stream(
+            [
+                _ev_created(),
+                _ev_item_added(item),
+                _ev_args_delta('{"city": "Paris"}'),
+                _ev_item_done(
+                    item.model_copy(update={"arguments": '{"city": "Paris"}'})
+                ),
+                _ev_completed(),
+            ]
+        )
+        merged = MeshLlmAgent._merge_streamed_tool_calls(chunks)
+        assert merged[0]["function"]["arguments"] == '{"city": "Paris"}'
+
+    @pytest.mark.asyncio
+    async def test_output_item_done_backfills_when_added_missing(self):
+        """Defensive: an OpenAI-compatible server that skips
+        ``output_item.added`` would otherwise lose the call_id/name and the
+        merger would DROP the whole tool call (it discards id-less slots)."""
+        from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+
+        item = _fc_item()
+        chunks = await _run_responses_stream(
+            [
+                _ev_created(),
+                _ev_args_delta('{"city": "Paris"}'),
+                _ev_item_done(
+                    item.model_copy(update={"arguments": '{"city": "Paris"}'})
+                ),
+                _ev_completed(),
+            ]
+        )
+        merged = MeshLlmAgent._merge_streamed_tool_calls(chunks)
+        assert len(merged) == 1
+        assert merged[0]["id"] == "call_abc"
+        assert merged[0]["function"]["name"] == "get_weather"
+        assert merged[0]["function"]["arguments"] == '{"city": "Paris"}'
+
+    @pytest.mark.asyncio
+    async def test_parallel_tool_calls_get_contiguous_zero_based_indices(self):
+        """Responses numbers items by ``output_index`` (reasoning items occupy
+        slots too); the adapter must re-key to the chat path's contiguous
+        0-based tool-call ordinals."""
+        from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+
+        a = _fc_item(item_id="fc_a", call_id="call_a", name="get_weather")
+        b = _fc_item(item_id="fc_b", call_id="call_b", name="get_time")
+        chunks = await _run_responses_stream(
+            [
+                _ev_created(),
+                # output_index 1 and 2 — index 0 was a reasoning item.
+                _ev_item_added(a, output_index=1),
+                _ev_item_added(b, output_index=2),
+                _ev_args_delta('{"city": "Paris"}', item_id="fc_a"),
+                _ev_args_delta('{"tz": "CET"}', item_id="fc_b"),
+                _ev_completed(),
+            ]
+        )
+        indices = sorted(
+            {
+                tc.index
+                for c in chunks
+                if c.choices and c.choices[0].delta.tool_calls
+                for tc in c.choices[0].delta.tool_calls
+            }
+        )
+        assert indices == [0, 1]
+        merged = MeshLlmAgent._merge_streamed_tool_calls(chunks)
+        assert [m["id"] for m in merged] == ["call_a", "call_b"]
+        assert merged[0]["function"]["arguments"] == '{"city": "Paris"}'
+        assert merged[1]["function"]["arguments"] == '{"tz": "CET"}'
+
+    @pytest.mark.asyncio
+    async def test_finish_reason_is_tool_calls_when_tools_streamed(self):
+        chunks = await _run_responses_stream(
+            [
+                _ev_created(),
+                _ev_item_added(_fc_item()),
+                _ev_args_delta("{}"),
+                _ev_completed(),
+            ]
+        )
+        assert chunks[-1].choices[0].finish_reason == "tool_calls"
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_types_ignored(self):
+        """Responses emits many events mesh doesn't map (reasoning summaries,
+        content_part.added, web_search, ...). They must be skipped, not crash."""
+        from openai.types.responses import ResponseReasoningSummaryTextDeltaEvent
+
+        noise = ResponseReasoningSummaryTextDeltaEvent(
+            delta="thinking...",
+            item_id="rs_1",
+            output_index=0,
+            sequence_number=1,
+            summary_index=0,
+            type="response.reasoning_summary_text.delta",
+        )
+        chunks = await _run_responses_stream(
+            [_ev_created(), noise, _ev_text_delta("hi"), _ev_completed()]
+        )
+        assert _contents(chunks) == ["hi"]
+
+
+# ---------------------------------------------------------------------------
+# Responses streaming — interrupted-stream usage fallback (#1336)
+# Mirrors TestStreamInterruptionUsage on the chat path.
+# ---------------------------------------------------------------------------
+
+
+class _RaisingResponsesStream:
+    """Async stream that raises partway through — models a server cutoff."""
+
+    def __init__(self, events, exc=None):
+        self._events = events
+        self._exc = exc or RuntimeError("server cutoff")
+
+    def __aiter__(self):
+        async def _gen():
+            for e in self._events:
+                if e == "RAISE":
+                    raise self._exc
+                yield e
+
+        return _gen()
+
+
+class TestResponsesStreamInterruptionUsage:
+    @pytest.mark.asyncio
+    async def test_no_double_usage_when_terminal_chunk_delivered(self):
+        """The authoritative usage chunk reached the consumer, so the ``finally``
+        fallback must NOT also fire (matches the chat path's invariant)."""
+        chunks = await _run_responses_stream(
+            [_ev_created(), _ev_text_delta("hi"), _ev_completed(usage=(8, 2))]
+        )
+        usage_chunks = [c for c in chunks if c.usage is not None]
+        assert len(usage_chunks) == 1
+        assert usage_chunks[0].usage.prompt_tokens == 8
+        assert usage_chunks[0].usage.completion_tokens == 2
+
+    @pytest.mark.asyncio
+    async def test_no_usage_chunk_when_no_usage_ever_observed(self):
+        """Stream cut before any usage was seen: counters are 0 and the fallback
+        must NOT emit a misleading 0-token usage chunk."""
+        stream_obj = _RaisingResponsesStream(
+            [_ev_created(), _ev_text_delta("partial"), "RAISE"]
+        )
+        cls_mock, _ = _patched_responses_stream([], stream_obj=stream_obj)
+        raised = None
+        chunks = []
         with patch("openai.AsyncOpenAI", cls_mock):
             stream = openai_native.complete_stream(
                 {
                     "messages": [{"role": "user", "content": "Hi."}],
-                    "tools": self._TOOLS,
+                    "tools": _STREAM_TOOLS,
                 },
                 model="openai/gpt-5.6-terra",
                 api_key="sk-test",
             )
-            chunks = [c async for c in stream]
+            try:
+                async for c in stream:
+                    chunks.append(c)
+            except RuntimeError as exc:
+                raised = exc
 
-        instance.responses.create.assert_called_once()
-        tcs = chunks[0].choices[0].delta.tool_calls
-        assert tcs is not None and len(tcs) == 1
-        assert tcs[0].id == "call_s1"
-        assert tcs[0].function.name == "get_weather"
-        assert tcs[0].function.arguments == '{"city": "Paris"}'
+        assert raised is not None and "server cutoff" in str(raised)
+        assert [c for c in chunks if c.usage is not None] == []
+
+    @pytest.mark.asyncio
+    async def test_emits_best_effort_usage_when_stream_cut_after_usage_seen(self):
+        """Usage was observed on the wire but the authoritative terminal chunk
+        never reached the consumer — the ``finally`` block must publish a
+        best-effort usage chunk so telemetry doesn't record 0 tokens for a
+        partial generation."""
+        # A server that reports usage on an early lifecycle event and then
+        # drops the connection before ``response.completed``.
+        early = _ev_created(usage=(17, 4))
+        stream_obj = _RaisingResponsesStream(
+            [early, _ev_text_delta("partial"), "RAISE"]
+        )
+        cls_mock, _ = _patched_responses_stream([], stream_obj=stream_obj)
+        raised = None
+        chunks = []
+        with patch("openai.AsyncOpenAI", cls_mock):
+            stream = openai_native.complete_stream(
+                {
+                    "messages": [{"role": "user", "content": "Hi."}],
+                    "tools": _STREAM_TOOLS,
+                },
+                model="openai/gpt-5.6-terra",
+                api_key="sk-test",
+            )
+            try:
+                async for c in stream:
+                    chunks.append(c)
+            except RuntimeError as exc:
+                raised = exc
+
+        assert raised is not None
+        usage_chunks = [c for c in chunks if c.usage is not None]
+        assert len(usage_chunks) == 1, "expected the best-effort fallback chunk"
+        assert usage_chunks[0].usage.prompt_tokens == 17
+        assert usage_chunks[0].usage.completion_tokens == 4
+        assert usage_chunks[0].model == "gpt-5.6-terra"
+
+    @pytest.mark.asyncio
+    async def test_consumer_abort_teardown_matches_chat_path(self):
+        """Consumer abandons the stream and ``aclose()``s it while the
+        ``finally`` fallback still wants to yield.
+
+        Python raises ``RuntimeError: async generator ignored GeneratorExit``
+        here — the ``except (GeneratorExit, StopAsyncIteration)`` guard does NOT
+        intercept it, because the yield *succeeds* and it is the aclose
+        machinery that objects. This is PRE-EXISTING shared behaviour of the
+        chat path (and anthropic_native), not a Responses-path quirk, and
+        helpers.py's consumer wraps its aclose() in ``except Exception`` — so
+        the Responses path must behave identically rather than invent new
+        semantics. Asserted as an explicit parity check so a future fix moves
+        both paths together.
+        """
+
+        async def _abort_after_first(stream):
+            async for _ in stream:
+                break
+            try:
+                await stream.aclose()
+                return None
+            except Exception as exc:  # noqa: BLE001 — that's the comparison
+                return type(exc).__name__
+
+        # --- Responses path -------------------------------------------------
+        cls_mock, _ = _patched_responses_stream(
+            [
+                _ev_created(usage=(5, 3)),
+                _ev_text_delta("one"),
+                _ev_text_delta("two"),
+                _ev_completed(),
+            ]
+        )
+        with patch("openai.AsyncOpenAI", cls_mock):
+            responses_outcome = await _abort_after_first(
+                openai_native.complete_stream(
+                    {
+                        "messages": [{"role": "user", "content": "Hi."}],
+                        "tools": _STREAM_TOOLS,
+                    },
+                    model="openai/gpt-5.6-terra",
+                    api_key="sk-test",
+                )
+            )
+
+        # --- chat.completions path (same scenario: usage seen, then abort) ---
+        chat_chunks = [
+            _make_stream_chunk(
+                usage={"prompt_tokens": 5, "completion_tokens": 3},
+                model="gpt-4o-mini",
+            ),
+            _make_stream_chunk(content="one"),
+            _make_stream_chunk(content="two"),
+        ]
+        cls_mock2, _ = _patched_streaming_openai(chat_chunks)
+        with patch("openai.AsyncOpenAI", cls_mock2):
+            chat_outcome = await _abort_after_first(
+                openai_native.complete_stream(
+                    {"messages": [{"role": "user", "content": "Hi."}]},
+                    model="openai/gpt-4o-mini",
+                    api_key="sk-test",
+                )
+            )
+
+        assert responses_outcome == chat_outcome

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native.py
@@ -2376,6 +2376,37 @@ class TestResponsesImageTranslation:
         )
         assert parts[0]["detail"] == detail
 
+    def test_every_detail_the_installed_sdk_accepts_is_forwarded(self):
+        """The allowlist must track the INSTALLED SDK, not a frozen trio.
+
+        ``openai`` is unpinned and this enum grows — 2.52.0 added ``original``
+        to low/high/auto. A hard-coded set silently downgrades a valid caller
+        value to ``auto``. Parametrising over the SDK's own Literal means this
+        test keeps its meaning on whatever version CI resolves.
+        """
+        import typing
+
+        from openai.types.responses import ResponseInputImageParam
+
+        hints = typing.get_type_hints(ResponseInputImageParam, include_extras=True)
+        sdk_details = openai_native._literal_strings(hints["detail"])
+        assert sdk_details, "could not read the SDK's detail Literal"
+        assert sdk_details <= openai_native._valid_image_details()
+
+        for detail in sorted(sdk_details):
+            parts = _translate_user_content(
+                [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://x/y.png", "detail": detail},
+                    }
+                ]
+            )
+            assert parts[0]["detail"] == detail, (
+                f"detail={detail!r} is valid for the installed openai SDK but "
+                "the adapter downgraded it"
+            )
+
     def test_detail_on_part_root_accepted(self):
         parts = _translate_user_content(
             [
@@ -2443,6 +2474,57 @@ class TestResponsesImageTranslation:
 # ---------------------------------------------------------------------------
 
 
+def _zero_filled(model_cls, known: dict | None = None) -> dict:
+    """``known`` plus a 0 for every OTHER required field on ``model_cls``.
+
+    Version-robustness for the token-counter models (see ``_sdk_usage``). Reads
+    the required-field set off the INSTALLED SDK rather than hard-coding it, so
+    a newly-added required counter is absorbed automatically.
+
+    Non-int required additions would fail ``model_validate`` — deliberately, and
+    in this one helper rather than across every streaming test.
+    """
+    out = dict(known or {})
+    for name, field in model_cls.model_fields.items():
+        if name not in out and field.is_required():
+            out[name] = 0
+    return out
+
+
+def _sdk_usage(input_tokens: int, output_tokens: int) -> dict:
+    """A ``ResponseUsage`` payload valid for whatever openai version is installed.
+
+    The adapter reads exactly two fields off usage — ``input_tokens`` and
+    ``output_tokens`` (see ``_responses_usage``). The nested ``*_tokens_details``
+    breakdowns are counters it never touches, so pinning their exact field set
+    into fixtures buys zero coverage while coupling the whole streaming suite to
+    one SDK version: ``openai`` is unpinned, and 2.52.0 added a required
+    ``InputTokensDetails.cache_write_tokens`` that broke 16 tests at once on CI
+    while passing locally on 2.14.0.
+
+    So: hard-code only what the adapter actually reads (still fully validated by
+    ``model_validate``, so the fields under test keep their real required-ness),
+    and derive the rest from the installed models. A future counter addition is
+    absorbed here, in ONE place.
+    """
+    from openai.types.responses.response_usage import (
+        InputTokensDetails,
+        OutputTokensDetails,
+        ResponseUsage,
+    )
+
+    return _zero_filled(
+        ResponseUsage,
+        {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+            "input_tokens_details": _zero_filled(InputTokensDetails),
+            "output_tokens_details": _zero_filled(OutputTokensDetails),
+        },
+    )
+
+
 def _sdk_response(
     *,
     status="completed",
@@ -2465,13 +2547,7 @@ def _sdk_response(
         "status": status,
     }
     if usage is not None:
-        payload["usage"] = {
-            "input_tokens": usage[0],
-            "input_tokens_details": {"cached_tokens": 0},
-            "output_tokens": usage[1],
-            "output_tokens_details": {"reasoning_tokens": 0},
-            "total_tokens": usage[0] + usage[1],
-        }
+        payload["usage"] = _sdk_usage(usage[0], usage[1])
     if incomplete_details is not None:
         payload["incomplete_details"] = incomplete_details
     return Response.model_validate(payload)

--- a/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native_contract.py
+++ b/src/runtime/python/_mcp_mesh/engine/native_clients/tests/test_openai_native_contract.py
@@ -21,6 +21,7 @@ Real network calls are mocked except in the live test class.
 
 from __future__ import annotations
 
+import json
 import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -459,3 +460,436 @@ class TestLiveRefusalIntegration:
                 (content or "")[:200]
             )
         )
+
+
+# ---------------------------------------------------------------------------
+# Live integration tests — Responses API native streaming + vision (#1336)
+#
+# These ARE the acceptance criteria of issue #1336, which are live smoke tests
+# by nature: the mocked unit tests in ``test_openai_native.py`` pin the event
+# mapping against the SDK's own types, but only a real call proves OpenAI
+# accepts what we send and streams what we expect. Same double gate as
+# ``TestLiveRefusalIntegration`` above.
+#
+# Skip-vs-fail policy, deliberately split:
+#   * MODEL BEHAVIOUR variance (declining to call the tool, describing the
+#     image oddly) → ``pytest.skip`` — out of our control.
+#   * MESH SHAPE violations (one terminal blob instead of deltas, missing
+#     usage, unmergeable tool call, image part rejected) → ``assert`` — that
+#     is precisely what #1336 changed and what a regression would break.
+# ---------------------------------------------------------------------------
+
+
+# Reasoning-model id used for the live Responses probes. Overridable because
+# gpt-5-family ids churn faster than this file does; any gpt-5 non-chat or
+# o-series id routes to the Responses API (see is_openai_reasoning_model).
+_LIVE_REASONING_MODEL_ENV = "MCP_MESH_LIVE_OPENAI_REASONING_MODEL"
+_LIVE_REASONING_MODEL = os.environ.get(
+    _LIVE_REASONING_MODEL_ENV, "openai/gpt-5.6-terra"
+)
+
+_LIVE_WEATHER_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+
+
+def _solid_red_png_data_uri(size: int = 512) -> str:
+    """A solid-red (#FF0000) PNG as a base64 data URI, generated in-process.
+
+    Deliberately NOT a committed binary fixture. The shape is exactly what
+    mesh's own emitter produces — ``_mcp_mesh.media.resolver._format_for_openai``
+    builds ``data:<mime>;base64,<data>`` — so the live probe exercises the real
+    upstream payload rather than a hand-written URL. Pure stdlib (zlib+struct);
+    no Pillow dependency.
+
+512px rather than a handful of pixels, for two measured reasons. (1) OpenAI's
+    vision pipeline rescales and re-encodes the input; on an 8x8 source the hue
+    shifted enough that gpt-5.6-terra described pure #FF0000 as "orange".
+    (2) gpt-5-family models bill images as 32x32 patches, so a small image
+    contributes only a handful of input tokens — too weak a signal for the
+    token-delta assertion below. 512px ≈ 256 patches, an unmistakable delta.
+    A solid colour compresses to ~1KB regardless of dimensions.
+    """
+    import base64
+    import struct
+    import zlib
+
+    width = height = size
+    # Raw scanlines: filter byte 0 + RGB triplets, all pure red.
+    raw = b"".join(b"\x00" + b"\xff\x00\x00" * width for _ in range(height))
+
+    def _chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + tag
+            + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    png = (
+        b"\x89PNG\r\n\x1a\n"
+        + _chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+        + _chunk(b"IDAT", zlib.compress(raw))
+        + _chunk(b"IEND", b"")
+    )
+    return "data:image/png;base64," + base64.b64encode(png).decode("ascii")
+
+
+def _chunk_text(chunk) -> str | None:
+    """Content delta off a mesh ``_StreamChunk`` (None when it carries none)."""
+    if not chunk.choices:
+        return None
+    return getattr(chunk.choices[0].delta, "content", None)
+
+
+def _chunk_tool_deltas(chunk) -> list:
+    if not chunk.choices:
+        return []
+    return getattr(chunk.choices[0].delta, "tool_calls", None) or []
+
+
+def _merge_tool_calls(chunks) -> list[dict]:
+    """Reassemble streamed tool calls with the REAL merger the agentic loop
+    uses — the point is that Responses-path chunks are indistinguishable from
+    chat-path chunks to it. Imported lazily to keep this module's import cheap
+    (mesh_llm_agent pulls in the wider engine)."""
+    from _mcp_mesh.engine.mesh_llm_agent import MeshLlmAgent
+
+    return MeshLlmAgent._merge_streamed_tool_calls(chunks)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not _LIVE_GATE_ENABLED,
+    reason=(
+        f"live integration not enabled; set {_LIVE_GATE_ENV}=1 to opt in "
+        "(mocked unit tests above are primary coverage)"
+    ),
+)
+@pytest.mark.skipif(
+    not _OPENAI_API_KEY_PRESENT,
+    reason="OPENAI_API_KEY not set; live OpenAI probe cannot run",
+)
+class TestLiveResponsesStreamingIntegration:
+    """#1336 acceptance 1 — native Responses streaming for reasoning + tools.
+
+    Two turns against the real API:
+      * turn 1 streams a function call (id/name arrive on
+        ``response.output_item.added``, JSON accrues via
+        ``response.function_call_arguments.delta``);
+      * turn 2 feeds the tool result back and streams the model's prose, which
+        is where incremental text deltas are observable.
+
+    The buffered fallback this issue removed emitted ONE chunk carrying content
+    + tool_calls + usage + finish_reason together. Both discriminators below
+    fail against that shape.
+    """
+
+    async def _collect(self, request_params):
+        chunks = []
+        stream = openai_native.complete_stream(
+            request_params, model=_LIVE_REASONING_MODEL
+        )
+        async for chunk in stream:
+            chunks.append(chunk)
+        return chunks
+
+    @pytest.mark.asyncio
+    async def test_reasoning_with_tools_streams_incrementally(self):
+        # Pin the routing decision so this can never silently degrade into a
+        # chat.completions test if the model id or predicate changes.
+        turn1_params = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "What is the weather in Paris? Use the get_weather "
+                        "tool, then describe the result in two sentences."
+                    ),
+                }
+            ],
+            "tools": _LIVE_WEATHER_TOOL,
+        }
+        assert openai_native._openai_wants_responses_api(
+            _LIVE_REASONING_MODEL, turn1_params
+        ), (
+            f"{_LIVE_REASONING_MODEL} does not route to the Responses API; "
+            f"set {_LIVE_REASONING_MODEL_ENV} to a gpt-5 non-chat / o-series id"
+        )
+
+        # --- turn 1: streamed tool call ------------------------------------
+        turn1 = await self._collect(turn1_params)
+        assert turn1, "Responses stream yielded no chunks at all"
+
+        merged = _merge_tool_calls(turn1)
+        if not merged:
+            # The model chose to answer without calling the tool — behaviour
+            # variance, not a mesh defect.
+            pytest.skip(
+                "model did not call the tool on this turn; streamed tool-call "
+                "reassembly not exercised (mocked tests cover the shape)"
+            )
+
+        tool_call = merged[0]
+        assert tool_call["id"], "merged tool call has no id (call_id lost)"
+        assert tool_call["type"] == "function"
+        assert tool_call["function"]["name"] == "get_weather"
+        # Arguments must reassemble into valid JSON — a doubled or truncated
+        # fragment stream fails here.
+        args = json.loads(tool_call["function"]["arguments"])
+        assert isinstance(args, dict)
+
+        # Terminal marker + usage on turn 1.
+        assert turn1[-1].usage is not None, "no terminal usage chunk on turn 1"
+        assert turn1[-1].usage.prompt_tokens > 0
+        assert turn1[-1].choices[0].finish_reason == "tool_calls"
+
+        # --- turn 2: streamed prose ----------------------------------------
+        turn2_params = {
+            "messages": turn1_params["messages"]
+            + [
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": tool_call["id"],
+                            "type": "function",
+                            "function": tool_call["function"],
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": tool_call["id"],
+                    "content": (
+                        '{"city": "Paris", "temp_c": 21, "condition": "sunny"}'
+                    ),
+                },
+            ],
+            "tools": _LIVE_WEATHER_TOOL,
+        }
+        turn2 = await self._collect(turn2_params)
+
+        text_chunks = [c for c in turn2 if _chunk_text(c)]
+        answer = "".join(_chunk_text(c) for c in text_chunks)
+        if not answer.strip():
+            pytest.skip(
+                "model emitted no prose on the follow-up turn (called the tool "
+                "again?); incremental-text assertion not exercised"
+            )
+
+        # DISCRIMINATOR 1 — real streaming produces many small deltas. The
+        # removed buffered fallback produced exactly one chunk holding the
+        # entire answer, so this fails against it.
+        assert len(text_chunks) >= 2, (
+            "expected multiple incremental content deltas, got "
+            f"{len(text_chunks)} — this is the buffered-blob shape #1336 "
+            f"removed (answer={answer[:120]!r})"
+        )
+
+        # DISCRIMINATOR 2 — shape-only, independent of token counts: native
+        # streaming NEVER carries content and usage on the same chunk, whereas
+        # the buffered fallback packed content + usage + finish_reason into one.
+        assert not any(
+            _chunk_text(c) and c.usage is not None for c in turn2
+        ), "a chunk carried both content and usage — buffered-blob shape"
+
+        # Terminal markers: usage last, non-zero, clean finish.
+        assert turn2[-1].usage is not None, "no terminal usage chunk on turn 2"
+        assert turn2[-1].usage.prompt_tokens > 0
+        assert turn2[-1].usage.completion_tokens > 0
+        assert _chunk_text(turn2[-1]) is None, "terminal chunk carried text"
+        assert turn2[-1].choices[0].finish_reason == "stop"
+        # Exactly one usage chunk — no double-emission from the finally block.
+        assert len([c for c in turn2 if c.usage is not None]) == 1
+
+    @pytest.mark.asyncio
+    async def test_streamed_tool_call_argument_deltas_are_fragmented(self):
+        """The call id/name and the JSON arguments must arrive as SEPARATE
+        deltas — that split only exists on the native event stream.
+
+        Structural only: asserts the id-bearing delta precedes any
+        argument-bearing delta, which is what the item_id → ordinal mapping in
+        the adapter guarantees.
+        """
+        params = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Use the get_weather tool for Tokyo.",
+                }
+            ],
+            "tools": _LIVE_WEATHER_TOOL,
+        }
+        chunks = await self._collect(params)
+        if not _merge_tool_calls(chunks):
+            pytest.skip("model did not call the tool on this turn")
+
+        id_positions, arg_positions = [], []
+        for i, chunk in enumerate(chunks):
+            for delta in _chunk_tool_deltas(chunk):
+                if delta.id:
+                    id_positions.append(i)
+                if delta.function.arguments:
+                    arg_positions.append(i)
+
+        assert id_positions, "no delta carried the tool-call id"
+        assert arg_positions, "no delta carried tool-call arguments"
+        assert min(id_positions) < min(arg_positions), (
+            "the id/name delta must precede argument fragments "
+            f"(id at {min(id_positions)}, args from {min(arg_positions)})"
+        )
+        # The id/name never rides on the same delta as an argument fragment on
+        # the native path (the buffered fallback packed them together).
+        assert not set(id_positions) & set(arg_positions), (
+            "id and arguments arrived on the same delta — buffered-blob shape"
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not _LIVE_GATE_ENABLED,
+    reason=(
+        f"live integration not enabled; set {_LIVE_GATE_ENV}=1 to opt in "
+        "(mocked unit tests above are primary coverage)"
+    ),
+)
+@pytest.mark.skipif(
+    not _OPENAI_API_KEY_PRESENT,
+    reason="OPENAI_API_KEY not set; live OpenAI probe cannot run",
+)
+class TestLiveResponsesVisionIntegration:
+    """#1336 acceptance 2 — vision + tools on the Responses (reasoning) path.
+
+    Before #1336 an image part raised a deliberate ``ValueError`` here. The
+    mocked tests prove the emitted part matches
+    ``openai.types.responses.ResponseInputImageParam``; only a live call proves
+    the SERVER accepts it (the SDK does not runtime-validate TypedDicts, so a
+    wrong shape passes client-side and surfaces as an HTTP 400).
+    """
+
+    _PROMPT = "What single colour fills this image? Answer with just the colour name."
+
+    def _params(self, *, with_image: bool):
+        content = [{"type": "text", "text": self._PROMPT}]
+        if with_image:
+            content.append(
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": _solid_red_png_data_uri(),
+                        "detail": "high",
+                    },
+                }
+            )
+        return {
+            "messages": [{"role": "user", "content": content}],
+            # Tools present so the request routes to Responses — vision WITHOUT
+            # tools would stay on chat.completions and prove nothing here.
+            "tools": _LIVE_WEATHER_TOOL,
+        }
+
+    @pytest.mark.asyncio
+    async def test_vision_with_tools_reasoning_request(self):
+        request_params = self._params(with_image=True)
+        assert openai_native._openai_wants_responses_api(
+            _LIVE_REASONING_MODEL, request_params
+        ), (
+            f"{_LIVE_REASONING_MODEL} does not route to the Responses API; "
+            f"set {_LIVE_REASONING_MODEL_ENV} to a gpt-5 non-chat / o-series id"
+        )
+
+        # A ValueError here means the image translation regressed; a
+        # BadRequestError means the input_image shape is wrong. Both must fail
+        # the test rather than skip.
+        response = await openai_native.complete(
+            request_params, model=_LIVE_REASONING_MODEL
+        )
+        assert response.usage is not None
+        assert response.usage.prompt_tokens > 0
+
+        # THE structural proof that the image was ingested, not merely accepted:
+        # the identical prompt without the image costs materially fewer input
+        # tokens (OpenAI bills image tiles as input tokens). This does NOT
+        # depend on the model's prose, so it cannot rot with model behaviour —
+        # unlike asserting a colour word, which is exactly the kind of
+        # exact-text assertion this repo's live tests avoid. Verified live:
+        # gpt-5.6-terra reads pure #FF0000 as "Orange", so the colour word is
+        # informational only (below), never load-bearing.
+        baseline = await openai_native.complete(
+            self._params(with_image=False), model=_LIVE_REASONING_MODEL
+        )
+        assert baseline.usage is not None
+        delta = response.usage.prompt_tokens - baseline.usage.prompt_tokens
+        assert delta > 50, (
+            "image contributed no meaningful input tokens "
+            f"(with-image={response.usage.prompt_tokens}, "
+            f"text-only={baseline.usage.prompt_tokens}, delta={delta}) — "
+            "the input_image part was accepted but not ingested"
+        )
+
+        content = response.choices[0].message.content
+        if not content:
+            pytest.skip(
+                "model returned no text for the vision turn (called a tool "
+                "instead?); colour naming not exercised"
+            )
+        if "red" not in content.lower():
+            # Model behaviour, not a mesh defect — the token delta above already
+            # proved the image reached it. Observed live on gpt-5.6-terra.
+            pytest.skip(
+                "model did not name the image red (colour perception on "
+                f"re-encoded input varies); content={content[:200]!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_vision_image_part_no_longer_raises_value_error(self):
+        """Direct regression guard for the #1334 deferral this issue removed.
+
+        Kept separate from the semantic check above so a server-side outage or
+        an unhelpful answer can never mask the fact that the translation itself
+        still runs.
+        """
+        request_params = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this image briefly."},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": _solid_red_png_data_uri()},
+                        },
+                    ],
+                }
+            ],
+            "tools": _LIVE_WEATHER_TOOL,
+        }
+        # The builder is where the old ValueError fired — exercise it directly,
+        # no network needed for this half.
+        kwargs = openai_native._build_responses_kwargs(
+            request_params, model=_LIVE_REASONING_MODEL
+        )
+        parts = kwargs["input"][0]["content"]
+        assert [p["type"] for p in parts] == ["input_text", "input_image"]
+        assert parts[1]["image_url"].startswith("data:image/png;base64,")
+        assert parts[1]["detail"] in ("low", "high", "auto")
+
+        # And the server accepts it.
+        response = await openai_native.complete(
+            request_params, model=_LIVE_REASONING_MODEL
+        )
+        assert response.usage is not None


### PR DESCRIPTION
## Summary

Completes the two capabilities #1334 deferred on the OpenAI **Responses** path (gpt-5/o-series reasoning models with tools).

**1. Native Responses streaming.** The reasoning+tools case ran the Responses call *buffered* and emitted a single terminal chunk. It now maps the semantic event stream onto `_StreamChunk`:

| Event | → `_StreamChunk` |
|---|---|
| `response.output_text.delta` | `delta.content` |
| `response.output_item.added` (`function_call`) | `delta.tool_calls` with `call_id` + `name` |
| `response.function_call_arguments.delta` | argument fragment at the same index |
| `response.completed` / `.incomplete` / `.failed` | usage + `finish_reason` |

**2. Multimodal input.** `{type:image_url}` now translates to Responses `input_image`; previously it raised a deliberate `ValueError`.

## Two shapes the SDK types forced

Both read from the installed `openai` 2.14.0 types, not from memory — and both are places the obvious guess is wrong:

- **`ResponseFunctionCallArgumentsDeltaEvent` carries only `delta` + `item_id`** — no `call_id`, no `name`. Those arrive once, on `response.output_item.added`. Without handling that event the merger drops **every** tool call, because it discards id-less slots. Item ids are re-keyed to contiguous 0-based ordinals so `output_index` (which reasoning items also occupy) can't leak into the merged shape.
- **`response.output_item.done` repeats the FULL arguments string.** Since `_merge_streamed_tool_calls` concatenates, it is used strictly as a gated backfill (`id_emitted`/`args_emitted`), never a re-emit.
- **`ResponseInputImageParam.image_url` is a flat `Optional[str]`** — https URLs and `data:` URIs share one field, with no Anthropic-style source split — and `detail` is `Required`, so one is always emitted (`auto` default; invalid values soft-fail to `auto` with a WARN).

Interrupted-stream handling mirrors the chat path exactly: counters recorded before the yield, `final_usage_emitted` flipped only after it returns, same `finally`, same guard. `stream_options` is deliberately **not** forwarded — Responses' `StreamOptions` has no `include_usage`; usage always rides on `response.completed`.

## Live-verified, and the live run corrected two mistakes

4 gated integration tests pass against **three** reasoning models — `gpt-5.6-terra`, `gpt-5-nano`, and `o4-mini` (o-series included, so the routing isn't gpt-5-specific). Double-gated on `MCP_MESH_LIVE_INTEGRATION=1` **and** `OPENAI_API_KEY`, matching `TestLiveRefusalIntegration`. Verified three ways that neither gate alone spends:

```
no key + no gate       → 13 passed, 5 skipped
gate ON, no key        → 4 skipped, no errors
key present, gate OFF  → 4 skipped        ← no accidental spend
```

Two things a mocked-only pass would have shipped broken:

1. **A colour-word vision assertion that fails on terra.** `gpt-5.6-terra` describes a pure `#FF0000` image as *"Orange"*; `gpt-5-nano` says *"Red"*. The PNG was decoded bytewise to rule out a generation bug — filter bytes all 0, unique pixels `{(255,0,0)}` — so it is genuine model colour perception. Asserting a colour word is exactly the exact-model-text assertion this repo forbids. Replaced with a **structural** discriminator: identical prompt with and without the image, asserting the input-token delta. Colour word is now informational, `skip` on mismatch.
2. **The token threshold was also wrong** — first live run gave `delta=5`. gpt-5-family bills images as **32×32 patches**, so an 8×8 image is ~4 patches. Fixed by generating at 512px: measured `with-image=445, text-only=58, delta=387`. Both facts are documented in the helper docstring.

## The buffered-blob discriminator actually discriminates

Two independent checks, so a short answer can't produce a false pass:
- `len(text_chunks) >= 2`;
- **token-count-independent**: no chunk may carry content *and* usage together. The removed fallback packed content + tool_calls + usage + finish_reason into one chunk, so it fails this regardless of answer length.

Skip-vs-fail is split deliberately and documented: **model behaviour** (won't call the tool, odd colour word) → `skip`; **mesh shape** (blob instead of deltas, missing usage, unmergeable call, image rejected) → `assert`. Both classes assert `_openai_wants_responses_api(...)` up front so they cannot silently degrade into chat-path tests.

## Known defect, deliberately NOT fixed here

`aclose()` on a streaming generator raises `RuntimeError: async generator ignored GeneratorExit`. The `finally` block's fallback `yield` **succeeds**, and the aclose machinery objects afterwards — so the existing `except (GeneratorExit, StopAsyncIteration)` never fires.

**Pre-existing and not introduced here**, confirmed by probing the untouched *chat* path directly, which raises identically. It spans `openai_native`, `anthropic_native` and `gemini_native`. Production impact is contained: `helpers.py` wraps `aclose()` in `except Exception` and debug-logs, so the only casualty is a fallback usage chunk that had nowhere to go.

Pinned by `test_consumer_abort_teardown_matches_chat_path`, which asserts both paths produce the *same* outcome — so a future fix has to move them together rather than diverging. Worth its own issue.

## Test plan

- [x] `python -m pytest tests/unit/ _mcp_mesh/` — **2515 passed, 7 skipped** (was 2515/3; +4 live skips)
- [x] `python -m pytest` — 1551 passed, 1 skipped (unchanged)
- [x] 29 of 31 new unit tests verified red against a scratch copy with `openai_native.py` restored from HEAD
- [x] Live: 4 passed × 3 models
- [x] Gating verified in all three key/gate combinations
- [x] `ruff check` — zero new findings
- [ ] CI green

**Two unit tests cannot fail and are named rather than quietly kept:** `test_unsupported_part_type_raises_value_error` is a preservation test (the old code raised for all non-text parts, so it was already green; it goes red if the raise is removed), and `test_empty_text_delta_yields_no_chunk` is an edge-case guard, not a regression detector.

## Deviation worth noting

Usage counters are harvested from **any** lifecycle event carrying `response.usage`, not only the terminal one. OpenAI fills usage only at the end, so on the real API this changes nothing — it exists so the fallback branch is reachable for OpenAI-compatible servers that report early, and it matches what `anthropic_native` already does. Without it that branch would be decorative and untestable.

Closes #1336
