### PR TITLE
fix(deps): bound the vendor SDKs at their next major; correct a false openai floor

### DIFF
--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -82,10 +82,34 @@ dependencies = [
     # add a full transitive lockfile.
     "mcp==1.28.1",
     "fastmcp==3.4.3",
-    "litellm>=1.80.5,!=1.82.7,!=1.82.8",
-    "anthropic>=0.77",
-    "openai>=1.60",
-    "google-genai>=1.22",
+    # Bounded, never pinned exactly (#1454). The vendor SDKs ship breaking
+    # changes on a cadence of their own: openai crossed 1.x -> 2.x while our
+    # floor still read >=1.60, and a *minor* (2.14 -> 2.52) added a required
+    # response field that broke CI while local envs stayed green. An upper
+    # bound at the next major is the strongest constraint expressible here —
+    # an exact pin would export our testing constraint onto every user who
+    # depends on these SDKs directly, which is why mcp/fastmcp above can be
+    # pinned and these cannot. The bound catches the major jump only; the
+    # minor-level drift is what the transitive lockfile in #1454 is for.
+    #
+    # openai floor raised 1.60 -> 2.14: the native adapter imports
+    # ``openai.types.responses`` (verified absent in 1.60, added in 1.66) and
+    # 2.14 is the oldest release the suite has actually been run against.
+    #
+    # anthropic is 0.x, where a minor — not a major — is the breaking unit, so
+    # <1 is weaker than it looks. It is still the right bound: anthropic has
+    # shipped ~120 minors over three years at a near-weekly cadence, so a
+    # <0.<next-minor> cap would make mcp-mesh uninstallable alongside a
+    # current anthropic within days of every release. 1.0 is the boundary
+    # worth failing on; the lockfile covers everything below it.
+    #
+    # google-genai is capped <3, not <2: 2.0 shipped 2026-05 and a fresh
+    # install has resolved 2.x ever since, so <2 would roll us back onto a 1.x
+    # line nothing has tested in months.
+    "litellm>=1.80.5,!=1.82.7,!=1.82.8,<2",
+    "anthropic>=0.77,<1",
+    "openai>=2.14,<3",
+    "google-genai>=1.22,<3",
     "prometheus-client>=0.19.0,<1.0.0",
     "pyyaml>=6.0,<7.0",
     "jinja2>=3.1.0",
@@ -135,26 +159,26 @@ anthropic = [
     # Backward-compat alias: ``anthropic`` is now a base dependency (issue
     # #834). This entry is kept so existing ``pip install mcp-mesh[anthropic]``
     # commands continue to work without error.
-    "anthropic>=0.77"
+    "anthropic>=0.77,<1"
 ]
 anthropic-bedrock = [
     # AWS Bedrock backend for the native Anthropic adapter. Required when
     # using ``bedrock/anthropic.claude-*`` model strings. Opt-in because
     # boto3 is a heavy dependency.
-    "anthropic[bedrock]>=0.77"
+    "anthropic[bedrock]>=0.77,<1"
 ]
 openai = [
     # Backward-compat alias: ``openai`` is now a base dependency (issue
     # #834 PR 2). This entry is kept so existing ``pip install mcp-mesh[openai]``
     # commands continue to work without error.
-    "openai>=1.60"
+    "openai>=2.14,<3"
 ]
 gemini = [
     # Backward-compat alias: ``google-genai`` is now a base dependency
     # (issue #834 PR 3). This entry is kept so existing
     # ``pip install mcp-mesh[gemini]`` commands continue to work without
     # error.
-    "google-genai>=1.22"
+    "google-genai>=1.22,<3"
 ]
 litellm = [
     # LiteLLM long-tail provider path (issue #1383).
@@ -175,7 +199,7 @@ litellm = [
     # The pin MUST stay identical to the ``litellm`` entry in [project]
     # dependencies above. Enforced by
     # src/runtime/python/tests/unit/test_litellm_extra_pin_sync.py.
-    "litellm>=1.80.5,!=1.82.7,!=1.82.8"
+    "litellm>=1.80.5,!=1.82.7,!=1.82.8,<2"
 ]
 
 [project.urls]

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -79,10 +79,34 @@ dependencies = [
     # add a full transitive lockfile.
     "mcp==1.28.1",
     "fastmcp==3.4.3",
-    "litellm>=1.80.5,!=1.82.7,!=1.82.8",
-    "anthropic>=0.77",
-    "openai>=1.60",
-    "google-genai>=1.22",
+    # Bounded, never pinned exactly (#1454). The vendor SDKs ship breaking
+    # changes on a cadence of their own: openai crossed 1.x -> 2.x while our
+    # floor still read >=1.60, and a *minor* (2.14 -> 2.52) added a required
+    # response field that broke CI while local envs stayed green. An upper
+    # bound at the next major is the strongest constraint expressible here —
+    # an exact pin would export our testing constraint onto every user who
+    # depends on these SDKs directly, which is why mcp/fastmcp above can be
+    # pinned and these cannot. The bound catches the major jump only; the
+    # minor-level drift is what the transitive lockfile in #1454 is for.
+    #
+    # openai floor raised 1.60 -> 2.14: the native adapter imports
+    # ``openai.types.responses`` (verified absent in 1.60, added in 1.66) and
+    # 2.14 is the oldest release the suite has actually been run against.
+    #
+    # anthropic is 0.x, where a minor — not a major — is the breaking unit, so
+    # <1 is weaker than it looks. It is still the right bound: anthropic has
+    # shipped ~120 minors over three years at a near-weekly cadence, so a
+    # <0.<next-minor> cap would make mcp-mesh uninstallable alongside a
+    # current anthropic within days of every release. 1.0 is the boundary
+    # worth failing on; the lockfile covers everything below it.
+    #
+    # google-genai is capped <3, not <2: 2.0 shipped 2026-05 and a fresh
+    # install has resolved 2.x ever since, so <2 would roll us back onto a 1.x
+    # line nothing has tested in months.
+    "litellm>=1.80.5,!=1.82.7,!=1.82.8,<2",
+    "anthropic>=0.77,<1",
+    "openai>=2.14,<3",
+    "google-genai>=1.22,<3",
     "prometheus-client>=0.19.0",
     "pyyaml>=6.0",
     "jinja2>=3.1.0",
@@ -128,28 +152,28 @@ anthropic = [
     # #834 — native dispatch is default ON). This extra is preserved as a
     # no-op so ``pip install mcp-mesh[anthropic]`` still resolves cleanly
     # for users who pinned it from earlier docs.
-    "anthropic>=0.77"
+    "anthropic>=0.77,<1"
 ]
 anthropic-bedrock = [
     # AWS Bedrock backend for the native Anthropic adapter. Required when
     # using bedrock/anthropic.claude-* models with MCP_MESH_NATIVE_LLM=1.
     # Install via:
     #   pip install mcp-mesh[anthropic-bedrock]
-    "anthropic[bedrock]>=0.77"
+    "anthropic[bedrock]>=0.77,<1"
 ]
 openai = [
     # Backward-compat alias: ``openai`` is now a base dependency (issue
     # #834 PR 2 — native dispatch is default ON). This extra is preserved
     # as a no-op so ``pip install mcp-mesh[openai]`` still resolves cleanly
     # for users who pinned it from earlier docs.
-    "openai>=1.60"
+    "openai>=2.14,<3"
 ]
 gemini = [
     # Backward-compat alias: ``google-genai`` is now a base dependency
     # (issue #834 PR 3 — native dispatch is default ON). This extra is
     # preserved as a no-op so ``pip install mcp-mesh[gemini]`` still
     # resolves cleanly for users who pinned it from earlier docs.
-    "google-genai>=1.22"
+    "google-genai>=1.22,<3"
 ]
 litellm = [
     # LiteLLM long-tail provider path (issue #1383).
@@ -170,7 +194,7 @@ litellm = [
     # The pin MUST stay identical to the ``litellm`` entry in [project]
     # dependencies above. Enforced by
     # tests/unit/test_litellm_extra_pin_sync.py.
-    "litellm>=1.80.5,!=1.82.7,!=1.82.8"
+    "litellm>=1.80.5,!=1.82.7,!=1.82.8,<2"
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

The first half of #1454. All three vendor SDKs admitted **major-version jumps** from their floors — `openai>=1.60` spanned 1.60 through 2.52.0, two majors — with no upper bound at all.

```diff
-"litellm>=1.80.5,!=1.82.7,!=1.82.8",
-"anthropic>=0.77",
-"openai>=1.60",
-"google-genai>=1.22",
+"litellm>=1.80.5,!=1.82.7,!=1.82.8,<2",
+"anthropic>=0.77,<1",
+"openai>=2.14,<3",
+"google-genai>=1.22,<3",
```

Applied to **both** manifests — `packaging/pypi/pyproject.toml` is what the release workflow publishes, `src/runtime/python/pyproject.toml` is what editable and CI installs use — and mirrored into the back-compat extras so they cannot conflict.

**Bounds, not exact pins.** mcp-mesh is a published library: pinning `openai` or `anthropic` exactly would conflict for users who depend on those SDKs directly, and would cut against mesh's own contract that new model ids are pass-through and need no runtime change. `mcp`/`fastmcp` can be pinned because almost nobody depends on them directly. The exact set belongs in the lockfile #1454 tracks.

## `openai>=1.60` was a false floor, not a conservative one

`openai_native.py:690` does `from openai.types.responses import ResponseInputImageParam`. Verified against a venv built at the declared floor:

```
openai 1.60.0
ResponseInputImageParam: ModuleNotFoundError: No module named 'openai.types.responses'
client.responses attr: False
```

That module lands in 1.66. So the lowest version a user could legally install was one where the adapter cannot import — exactly the defect class #1409 fixed for FastAPI. Raised to 2.14, the oldest release the suite has actually been run against.

## Two bounds that are not the mechanical `<next-major>`

**`google-genai<3`, not `<2`.** `google-genai 2.0.0` shipped 2026-05-07 and a fresh install has resolved 2.x ever since, green in CI for nearly three months. Capping at `<2` would roll every install back onto a 1.x line nothing has tested since May — *creating* an untested band rather than closing one.

**`anthropic<1` is weaker than it looks**, since 0.x breaks at the minor, and it is kept deliberately. Anthropic has shipped ~120 minors over three years at near-weekly cadence (0.117.1 → 0.120.2 inside ten days in July). A minor-level cap would make mcp-mesh uninstallable alongside a current `anthropic` within days of each release — the same "export our testing constraint onto users" failure that rules out exact pins, spelled differently. 1.0 is the boundary worth failing on; everything below it is what the lockfile is for.

This is the honest limit of upper bounds: **they catch the major jump only.** They would not have caught the 2.14→2.52 minor that failed CI on #1453. That is #1454's remaining scope, not a gap here.

## Verification

- `pip install --dry-run` on the source manifest: 110 packages, `anthropic 0.120.2`, `openai 2.52.0`, `google-genai 2.16.0`, `litellm 1.94.1`. **Identical to pre-change** — the bounds are non-restrictive today and fail later, deliberately.
- All vendor extras together (`[litellm,anthropic,anthropic-bedrock,openai,gemini,vertex]`): 114 packages, no conflict.
- Published manifest's 31 requirement strings dry-run clean, including `mcp-mesh-core 3.3.2`.
- Python suite: **2516 passed, 7 skipped**. Includes `test_litellm_extra_pin_sync.py`, which proves the `,<2` landed in all four litellm declarations.
- `scripts/` suite: 85 passed.
- `bump_version.py` cannot over-match the new bounds — its pyproject patterns are anchored on `^version` and `"mcp-mesh-core>=OLD"`, both keyed to the mesh version. Checked against the #1379 over-match class.

## #1383 status, confirmed while here

Its items **1, 2, 4 and 5 already landed** — `4a604dcad` (#1386) and `2c07b64f7` (#1400). Demonstrated end-to-end in a throwaway venv with `litellm` uninstalled: `anthropic/claude-haiku-4-5`, `openai/gpt-4.1-mini` and `gemini/gemini-2.5-flash` all return **200**, `modules containing 'litellm' after import mesh: []`, and bare names resolve through the big-3 inference seam. The long tail fails with the friendly `ImportError` naming the extra and stamping the version, not a bare `ModuleNotFoundError`.

Only item 3's *base-slimming* half remains, deferred to a major — and the `[litellm]` extra already carries a `DELIBERATELY REDUNDANT TODAY` comment saying so.

One genuine-use site the issue's list would have flagged as a miss: `helpers.py:2732` keeps a bare `import litellm` **correctly** — it runs at decoration time inside a documented try/except that falls back to prefix extraction. Turning it into a hard error would break the very case this work enables.

## Noted, not fixed

- **The two manifests disagree on `fastapi`**: `packaging/pypi` already has `>=0.135.0,<1.0.0` while `src/runtime/python` is unbounded. Not touched — this PR's scope was the four vendor SDKs — but the published package and the CI install currently express different constraints.
- **The floors are unverified.** CI proves the ceiling (it resolves latest) but nothing exercises `anthropic==0.77` or `google-genai==1.22`. `openai>=1.60` being provably broken is what an unexercised floor looks like; extending #1409's floor-job pattern to the vendor SDKs would close it.
- `examples/docker-examples/agents/{claude,openai}-provider/requirements.txt` still pin litellm directly, though post-#1386 those big-3 providers need none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported integration versions to improve compatibility and stability across supported vendor services.
  * Aligned optional installation configurations with the same compatibility requirements.
  * No user-facing features or API changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->