### PR TITLE
fix(llm): cover @mesh.llm injection with the settling-window grace

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/settle.py
+++ b/src/runtime/python/_mcp_mesh/engine/settle.py
@@ -44,11 +44,18 @@ Caller-supplied slots never wait: the documented mock contract lets callers
 pass a fake/proxy for any injectable parameter explicitly — the pending
 collection consults the call kwargs and skips those slots entirely.
 
-Scope (deliberate): the grace covers the dependency-injection wrappers only
-— ``@mesh.tool`` / ``@mesh.route`` call paths. Lifespan/startup-hook
-dependency usage, module-scope captured deps, and ``@mesh.llm``
-provider/filter assembly (registration-time, with its own update mechanism)
-are NOT covered.
+Scope (deliberate): the grace covers the injection wrappers only — the
+``@mesh.tool`` / ``@mesh.route`` dependency-injection call paths AND the
+``@mesh.llm`` provider-injection call path (issue #1456). The latter was
+originally excluded on the grounds that provider assembly has "its own
+update mechanism"; it does, but that mechanism had no wait, and providers
+resolve on the SAME heartbeat schedule as tool dependencies (the
+registration heartbeat always reports zero providers, because providers and
+consumers register in the same instant). So a call landing before the second
+heartbeat injected ``None`` and blew up in the user's function. The
+``@mesh.llm`` grace is keyed per CONSUMER FUNCTION — see
+``mesh.decorators._llm_settle_key``. Lifespan/startup-hook dependency usage
+and module-scope captured deps remain NOT covered.
 
 This is environmental, not a declaration mistake: ``MCP_MESH_STRICT_DI``
 never interacts with the settle window in any way.

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -2790,13 +2790,114 @@ def set_shutdown_context(context: dict[str, Any]):
     set_global_shutdown_context(context)
 
 
+def _llm_settle_key(function_id: str) -> str:
+    """Settle key for a ``@mesh.llm`` consumer's provider slot (issue #1456).
+
+    Keyed on the CONSUMER's ``function_id`` — never on the provider
+    capability — for the same reason ``@mesh.tool`` uses per-slot composite
+    ``"<func_id>:dep_<N>"`` keys rather than capability names:
+
+    * Resolution is delivered per consumer function. The registry returns
+      ``llm_providers`` keyed by function name; the injector maps that to a
+      ``function_id`` and calls THAT wrapper's ``_mesh_update_llm_agent``
+      (see ``mesh_llm_agent_injector._process_function_provider``). The unit
+      of resolution is the consumer, so the settle key must be too.
+    * The state a woken waiter re-reads is ``wrapper._mesh_llm_agent``,
+      which is per-wrapper. A settle key must be 1:1 with the state its
+      waiter observes, otherwise the wake is a lie.
+    * Two ``@mesh.llm`` consumers in one process routinely resolve at
+      different times even against the "same" capability: their provider
+      filters differ (tags/version, plus the auto-applied
+      ``±ai.mcpmesh.stream`` discrimination tag), one may resolve while the
+      other has no matching provider at all, and a consumer with a tool
+      ``filter`` has its wrapper update DEFERRED until the tools arrive in a
+      later phase. Capability-level keying would let consumer A's resolution
+      wake consumer B, which would re-read its own still-``None`` agent and
+      inject ``None`` anyway — the exact spurious wake the composite tool
+      keys exist to prevent.
+    * ``function_id`` carries a per-decoration uuid suffix, so dual-import
+      twins of the same module get distinct keys and cannot cross-wake.
+    """
+    return f"llm:{function_id}"
+
+
+def _pending_llm_settle(wrapper: Any, func_name: str) -> list:
+    """Settle-pending entry for this wrapper's LLM provider, or ``[]``.
+
+    Reuses the shared ``collect_pending_settle_deps`` gate so the settled
+    steady state costs exactly one latch check and never touches the wait
+    primitives — the single-slot shape is ``@mesh.llm``'s analogue of a
+    one-dependency tool wrapper. Returns ``[]`` for wrappers with no settle
+    key (hand-built test doubles, legacy wrappers), which keeps every
+    existing direct caller wait-free.
+    """
+    settle_key = getattr(wrapper, "_mesh_llm_settle_key", None)
+    if settle_key is None:
+        return []
+    from _mcp_mesh.engine.settle import collect_pending_settle_deps
+
+    config = getattr(wrapper, "_mesh_llm_config", None) or {}
+    provider = config.get("provider") or {}
+    capability = provider.get("capability") or "llm"
+    return collect_pending_settle_deps(
+        [settle_key],
+        [{"capability": f"{capability} (LLM provider for {func_name})"}],
+        [getattr(wrapper, "_mesh_llm_agent", None)],
+        lambda _key: None,
+    )
+
+
 def _get_llm_agent_for_injection(
+    wrapper: Any, param_name: str, kwargs: dict, func_name: str
+) -> Any:
+    """Sync injection entry point — settling-window grace then resolve.
+
+    Issue #1456: while the agent is still settling and this consumer's
+    provider has not resolved, block (bounded by the REMAINING settle
+    budget) instead of injecting ``None``. ``wait_for_settle_sync`` probes
+    for a running event loop and skips the blocking wait if one is found,
+    so this is safe on FastMCP's ``anyio.to_thread`` dispatch and degrades
+    to today's behavior anywhere else. On budget expiry the wait simply
+    returns and ``None`` is injected exactly as before — the window is a
+    ceiling, never a hang.
+    """
+    pending = _pending_llm_settle(wrapper, func_name)
+    if pending:
+        from _mcp_mesh.engine.settle import wait_for_settle_sync
+
+        wait_for_settle_sync(pending, logger)
+    return _resolve_llm_agent_for_injection(wrapper, param_name, kwargs, func_name)
+
+
+async def _await_llm_agent_for_injection(
+    wrapper: Any, param_name: str, kwargs: dict, func_name: str
+) -> Any:
+    """Async injection entry point — loop-native settling-window grace.
+
+    Async twin of :func:`_get_llm_agent_for_injection` (issue #1456). Awaits
+    a loop-native ``asyncio.Event`` mirror rather than blocking, so the
+    grace never consumes threadpool capacity and stays cancellable at
+    shutdown. Same budget ceiling, same ``None``-on-expiry contract.
+    """
+    pending = _pending_llm_settle(wrapper, func_name)
+    if pending:
+        from _mcp_mesh.engine.settle import wait_for_settle_async
+
+        await wait_for_settle_async(pending, logger)
+    return _resolve_llm_agent_for_injection(wrapper, param_name, kwargs, func_name)
+
+
+def _resolve_llm_agent_for_injection(
     wrapper: Any, param_name: str, kwargs: dict, func_name: str
 ) -> Any:
     """
     Get the appropriate LLM agent for injection based on template mode.
 
     Handles both template-based (per-call context) and non-template (cached) modes.
+
+    Read AFTER any settle wait so both the cached agent and the per-call
+    context factory (installed by the same heartbeat update) are re-read
+    post-resolution.
 
     Args:
         wrapper: The wrapper function with _mesh_llm_* attributes
@@ -3152,6 +3253,16 @@ def llm(
         # Step 4: Generate unique function ID
         function_id = f"{func.__name__}_{uuid.uuid4().hex[:8]}"
 
+        # Settling-window grace (#1456): declare this consumer's provider
+        # slot so a call landing before the provider resolves waits on the
+        # remaining budget instead of injecting None. Declared here (wiring
+        # time) exactly like the @mesh.tool dependency keys — the FIRST
+        # declaration in the process anchors the settle window.
+        from _mcp_mesh.engine.settle import get_settle_state
+
+        llm_settle_key = _llm_settle_key(function_id)
+        get_settle_state().register_declared(llm_settle_key)
+
         # Step 5: Register with DecoratorRegistry
         DecoratorRegistry.register_mesh_llm(
             func=func,
@@ -3211,17 +3322,46 @@ def llm(
             # Store the original call behavior to preserve DI injection
             original_call = existing_wrapper
 
-            # Create enhanced wrapper that does BOTH DI injection and LLM injection
-            @wraps(func)
-            def combined_injection_wrapper(*args, **kwargs):
-                """Wrapper that injects both MeshLlmAgent and DI parameters."""
-                # Inject LLM parameter if not provided or if it's None
-                if param_name not in kwargs or kwargs.get(param_name) is None:
-                    kwargs[param_name] = _get_llm_agent_for_injection(
-                        combined_injection_wrapper, param_name, kwargs, func.__name__
-                    )
-                # Then call the original wrapper (which handles DI injection)
-                return original_call(*args, **kwargs)
+            # Create enhanced wrapper that does BOTH DI injection and LLM
+            # injection.
+            #
+            # Two variants, mirroring the @mesh.a2a_consumer bridge: when the
+            # DI wrapper underneath is a coroutine function the combined
+            # wrapper is async too, so the settling-window grace (#1456) can
+            # use the loop-native await instead of blocking a threadpool
+            # thread for up to the whole window. Sync tools (FastMCP
+            # dispatches them via anyio.to_thread) keep the blocking wait,
+            # which is safe off the loop and self-skips on it.
+            if asyncio.iscoroutinefunction(original_call):
+
+                @wraps(func)
+                async def combined_injection_wrapper(*args, **kwargs):
+                    """Wrapper that injects both MeshLlmAgent and DI parameters."""
+                    if param_name not in kwargs or kwargs.get(param_name) is None:
+                        kwargs[param_name] = await _await_llm_agent_for_injection(
+                            combined_injection_wrapper,
+                            param_name,
+                            kwargs,
+                            func.__name__,
+                        )
+                    # Then call the original wrapper (which handles DI injection)
+                    return await original_call(*args, **kwargs)
+
+            else:
+
+                @wraps(func)
+                def combined_injection_wrapper(*args, **kwargs):
+                    """Wrapper that injects both MeshLlmAgent and DI parameters."""
+                    # Inject LLM parameter if not provided or if it's None
+                    if param_name not in kwargs or kwargs.get(param_name) is None:
+                        kwargs[param_name] = _get_llm_agent_for_injection(
+                            combined_injection_wrapper,
+                            param_name,
+                            kwargs,
+                            func.__name__,
+                        )
+                    # Then call the original wrapper (which handles DI injection)
+                    return original_call(*args, **kwargs)
 
             # Add LLM metadata attributes to combined wrapper
             combined_injection_wrapper._mesh_llm_agent = (
@@ -3231,6 +3371,9 @@ def llm(
             combined_injection_wrapper._mesh_llm_function_id = function_id
             combined_injection_wrapper._mesh_llm_config = resolved_config
             combined_injection_wrapper._mesh_llm_output_type = output_type
+            # Settling-window grace (#1456): the key this wrapper's waiters
+            # park on and update_llm_agent resolves.
+            combined_injection_wrapper._mesh_llm_settle_key = llm_settle_key
             combined_injection_wrapper.__wrapped__ = func
 
             # Override signature to hide LLM parameter from FastMCP schema.
@@ -3256,6 +3399,11 @@ def llm(
             # Create update method for heartbeat that updates the COMBINED wrapper
             def update_llm_agent(agent):
                 combined_injection_wrapper._mesh_llm_agent = agent
+                if agent is not None:
+                    # Settling-window grace (#1456): wake any settling call
+                    # parked on this consumer's provider slot AFTER the agent
+                    # is installed, so the woken call re-reads a real agent.
+                    get_settle_state().mark_resolved(llm_settle_key)
                 logger.info(
                     f"🔄 Updated MeshLlmAgent on combined wrapper for {func.__name__} (function_id={function_id})"
                 )
@@ -3297,19 +3445,42 @@ def llm(
                 f"📝 No existing wrapper found for '{func.__name__}' - creating new LLM wrapper"
             )
 
-            @wraps(func)
-            def llm_injection_wrapper(*args, **kwargs):
-                """Wrapper that injects MeshLlmAgent parameter."""
-                # Inject llm parameter if not provided or if it's None
-                if param_name not in kwargs or kwargs.get(param_name) is None:
-                    kwargs[param_name] = _get_llm_agent_for_injection(
-                        llm_injection_wrapper, param_name, kwargs, func.__name__
-                    )
-                return func(*args, **kwargs)
+            # Same sync/async split as the combined branch above (#1456):
+            # an async user function gets an async wrapper so the settle
+            # grace can await loop-natively. Async GENERATORS deliberately
+            # keep the sync wrapper — re-yielding through an async-generator
+            # shim would break the deterministic ``aclose()`` propagation the
+            # stream path relies on — and fall back to the blocking wait,
+            # which self-skips when invoked on a running loop.
+            if asyncio.iscoroutinefunction(func):
+
+                @wraps(func)
+                async def llm_injection_wrapper(*args, **kwargs):
+                    """Wrapper that injects MeshLlmAgent parameter."""
+                    if param_name not in kwargs or kwargs.get(param_name) is None:
+                        kwargs[param_name] = await _await_llm_agent_for_injection(
+                            llm_injection_wrapper, param_name, kwargs, func.__name__
+                        )
+                    return await func(*args, **kwargs)
+
+            else:
+
+                @wraps(func)
+                def llm_injection_wrapper(*args, **kwargs):
+                    """Wrapper that injects MeshLlmAgent parameter."""
+                    # Inject llm parameter if not provided or if it's None
+                    if param_name not in kwargs or kwargs.get(param_name) is None:
+                        kwargs[param_name] = _get_llm_agent_for_injection(
+                            llm_injection_wrapper, param_name, kwargs, func.__name__
+                        )
+                    return func(*args, **kwargs)
 
             # Create update method for heartbeat - updates the wrapper, not func
             def update_llm_agent(agent):
                 llm_injection_wrapper._mesh_llm_agent = agent
+                if agent is not None:
+                    # Settling-window grace (#1456) — see the combined branch.
+                    get_settle_state().mark_resolved(llm_settle_key)
                 logger.info(
                     f"🔄 Updated MeshLlmAgent for {func.__name__} (function_id={function_id})"
                 )
@@ -3320,6 +3491,7 @@ def llm(
             llm_injection_wrapper._mesh_llm_function_id = function_id
             llm_injection_wrapper._mesh_llm_config = resolved_config
             llm_injection_wrapper._mesh_llm_output_type = output_type
+            llm_injection_wrapper._mesh_llm_settle_key = llm_settle_key
             llm_injection_wrapper._mesh_update_llm_agent = update_llm_agent
 
             # Override signature to hide LLM parameter from FastMCP schema

--- a/src/runtime/python/tests/unit/test_llm_settle_1456.py
+++ b/src/runtime/python/tests/unit/test_llm_settle_1456.py
@@ -1,0 +1,306 @@
+"""Unit tests for the ``@mesh.llm`` settling-window grace (issue #1456).
+
+``@mesh.llm`` provider injection used to sit OUTSIDE the settling-window
+grace (#1193): ``combined_injection_wrapper._mesh_llm_agent`` starts as
+``None`` and is only filled by ``update_llm_agent`` when a heartbeat
+delivers ``llm_providers``. Because providers and consumers register in the
+same instant, the registration heartbeat always reports zero providers — so
+any call landing before the SECOND heartbeat injected ``None`` and the user
+function died on ``'NoneType' object is not callable``.
+
+These tests pin the fix:
+
+* a call that fires while the provider is unresolved WAITS and proceeds
+  early the moment ``_mesh_update_llm_agent`` lands (sync and async paths);
+* a provider that never resolves expires against the settle budget and
+  falls back to today's ``None`` injection — bounded, never a hang;
+* the settle key is per CONSUMER FUNCTION, so one consumer's provider
+  resolution cannot wake a different consumer's waiter;
+* the sync/async wrapper split that makes both wait primitives reachable.
+
+NOTE: do NOT add ``from __future__ import annotations`` — the @mesh.llm
+decorator's MeshLlmAgent detection compares ``param.annotation`` to the
+class directly, and PEP 563 would leave it a string.
+"""
+
+import asyncio
+import threading
+import time
+from unittest.mock import MagicMock
+
+import mesh
+import pytest
+
+from _mcp_mesh.engine import settle
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+from _mcp_mesh.engine.settle import get_settle_state
+from mesh.decorators import _llm_settle_key
+
+
+@pytest.fixture(autouse=True)
+def fresh_state(monkeypatch):
+    """Fresh settle state + uncached budget + clean decorator registry."""
+    monkeypatch.delenv("MCP_MESH_SETTLE_TIMEOUT", raising=False)
+    DecoratorRegistry.clear_all()
+    settle._reset_settle_state_for_tests()
+    yield
+    DecoratorRegistry.clear_all()
+    settle._reset_settle_state_for_tests()
+
+
+def _set_budget(monkeypatch, value: str) -> None:
+    """Set the settle budget and re-anchor the settle state on it.
+
+    Must run BEFORE decoration: ``@mesh.llm`` calls ``register_declared``
+    at decoration time, and that is what anchors the window.
+    """
+    monkeypatch.setenv("MCP_MESH_SETTLE_TIMEOUT", value)
+    settle._reset_settle_state_for_tests()
+
+
+def _make_sync_consumer(capability: str, seen: list):
+    """A sync ``@mesh.llm`` + ``@mesh.tool`` consumer (committee-agent shape)."""
+
+    @mesh.llm(provider={"capability": "llm"}, max_iterations=1)
+    @mesh.tool(capability=capability)
+    def consumer(prompt: str, llm: mesh.MeshLlmAgent = None) -> str:
+        seen.append(llm)
+        return "degraded" if llm is None else "resolved"
+
+    return consumer
+
+
+def _make_async_consumer(capability: str, seen: list):
+    """An async ``@mesh.llm`` + ``@mesh.tool`` consumer (planner shape)."""
+
+    @mesh.llm(provider={"capability": "llm"}, max_iterations=1)
+    @mesh.tool(capability=capability)
+    async def consumer(prompt: str, llm: mesh.MeshLlmAgent = None) -> str:
+        seen.append(llm)
+        return "degraded" if llm is None else "resolved"
+
+    return consumer
+
+
+class TestWrapperAsyncSplit:
+    """Both wait primitives must be reachable from real decorated tools."""
+
+    def test_sync_tool_gets_sync_wrapper(self):
+        wrapper = _make_sync_consumer("settle1456-split-sync", [])
+        assert not asyncio.iscoroutinefunction(wrapper)
+
+    def test_async_tool_gets_async_wrapper(self):
+        wrapper = _make_async_consumer("settle1456-split-async", [])
+        assert asyncio.iscoroutinefunction(wrapper), (
+            "an async @mesh.llm tool must get an async combined wrapper so the "
+            "settle grace can await loop-natively instead of blocking a "
+            "threadpool thread for the whole window"
+        )
+
+
+class TestDeclarationAndResolution:
+    def test_decoration_declares_the_provider_slot(self, monkeypatch):
+        _set_budget(monkeypatch, "10")
+        wrapper = _make_sync_consumer("settle1456-declare", [])
+        key = _llm_settle_key(wrapper._mesh_llm_function_id)
+
+        assert wrapper._mesh_llm_settle_key == key
+        assert key in get_settle_state()._declared
+
+    def test_update_llm_agent_marks_resolved(self, monkeypatch):
+        _set_budget(monkeypatch, "10")
+        wrapper = _make_sync_consumer("settle1456-resolve", [])
+        key = wrapper._mesh_llm_settle_key
+
+        assert key not in get_settle_state()._resolved
+        wrapper._mesh_update_llm_agent(MagicMock(name="agent"))
+        assert key in get_settle_state()._resolved
+
+    def test_settled_steady_state_never_waits(self, monkeypatch):
+        """Once resolved, calls take the fast path (no wait primitives)."""
+        _set_budget(monkeypatch, "10")
+        seen: list = []
+        wrapper = _make_sync_consumer("settle1456-steady", seen)
+        agent = MagicMock(name="agent")
+        wrapper._mesh_update_llm_agent(agent)
+
+        before = get_settle_state().wait_count
+        start = time.monotonic()
+        assert wrapper(prompt="hi") == "resolved"
+        assert wrapper(prompt="hi") == "resolved"
+        assert time.monotonic() - start < 1.0
+        assert get_settle_state().wait_count == before
+        assert seen == [agent, agent]
+
+
+class TestSyncInjectionPath:
+    """Plain ``def`` committee-agent shape — blocking wait on a worker thread."""
+
+    def test_waits_and_succeeds_when_provider_resolves_mid_call(
+        self, monkeypatch
+    ):
+        _set_budget(monkeypatch, "10")
+        seen: list = []
+        wrapper = _make_sync_consumer("settle1456-sync-wait", seen)
+        agent = MagicMock(name="agent")
+
+        timer = threading.Timer(
+            0.2, lambda: wrapper._mesh_update_llm_agent(agent)
+        )
+        timer.start()
+        start = time.monotonic()
+        result = wrapper(prompt="plan my trip")
+        elapsed = time.monotonic() - start
+        timer.join()
+
+        assert result == "resolved", (
+            "pre-fix the unresolved provider injected None and the user "
+            "function saw llm=None"
+        )
+        assert seen == [agent]
+        # Woken by the resolution event, not by the 10s budget ceiling.
+        assert elapsed < 5.0
+        assert get_settle_state().wait_count >= 1
+
+    def test_never_resolves_expires_at_budget_and_injects_none(
+        self, monkeypatch
+    ):
+        _set_budget(monkeypatch, "0.4")
+        seen: list = []
+        wrapper = _make_sync_consumer("settle1456-sync-expire", seen)
+
+        start = time.monotonic()
+        result = wrapper(prompt="plan my trip")
+        elapsed = time.monotonic() - start
+
+        # Today's behavior on expiry: None is injected, user code runs.
+        assert result == "degraded"
+        assert seen == [None]
+        # The wait actually happened...
+        assert elapsed >= 0.3
+        # ...and was bounded by the budget — never a hang.
+        assert elapsed < 5.0
+
+
+class TestAsyncInjectionPath:
+    """``async def`` planner shape — loop-native await, never blocks."""
+
+    @pytest.mark.asyncio
+    async def test_waits_and_succeeds_when_provider_resolves_mid_call(
+        self, monkeypatch
+    ):
+        _set_budget(monkeypatch, "10")
+        seen: list = []
+        wrapper = _make_async_consumer("settle1456-async-wait", seen)
+        agent = MagicMock(name="agent")
+
+        # Resolve from ANOTHER thread — the real heartbeat delivers
+        # resolutions off the serving loop, so this exercises the
+        # call_soon_threadsafe mirror rather than a same-loop shortcut.
+        timer = threading.Timer(
+            0.2, lambda: wrapper._mesh_update_llm_agent(agent)
+        )
+        timer.start()
+        start = time.monotonic()
+        result = await wrapper(prompt="plan my trip")
+        elapsed = time.monotonic() - start
+        timer.join()
+
+        assert result == "resolved"
+        assert seen == [agent]
+        assert elapsed < 5.0
+        assert get_settle_state().wait_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_async_wait_does_not_touch_the_executor(self, monkeypatch):
+        """The grace must not consume shared default-executor capacity."""
+        _set_budget(monkeypatch, "10")
+        seen: list = []
+        wrapper = _make_async_consumer("settle1456-async-noexec", seen)
+        agent = MagicMock(name="agent")
+
+        timer = threading.Timer(
+            0.2, lambda: wrapper._mesh_update_llm_agent(agent)
+        )
+        timer.start()
+        monkeypatch.setattr(
+            asyncio,
+            "to_thread",
+            MagicMock(
+                side_effect=AssertionError(
+                    "settle wait must not consume executor capacity"
+                )
+            ),
+        )
+        result = await wrapper(prompt="plan my trip")
+        timer.join()
+
+        assert result == "resolved"
+        assert seen == [agent]
+
+    @pytest.mark.asyncio
+    async def test_never_resolves_expires_at_budget_and_injects_none(
+        self, monkeypatch
+    ):
+        _set_budget(monkeypatch, "0.4")
+        seen: list = []
+        wrapper = _make_async_consumer("settle1456-async-expire", seen)
+
+        start = time.monotonic()
+        result = await wrapper(prompt="plan my trip")
+        elapsed = time.monotonic() - start
+
+        assert result == "degraded"
+        assert seen == [None]
+        assert elapsed >= 0.3
+        assert elapsed < 5.0
+
+
+class TestSettleKeyIsolation:
+    """One consumer's provider resolution must not wake another's waiter.
+
+    Same rationale as the per-slot ``<func_id>:dep_<N>`` composites on the
+    ``@mesh.tool`` path: a woken waiter re-reads its OWN
+    ``wrapper._mesh_llm_agent``, so a wake it didn't earn just burns the
+    grace and injects ``None`` anyway.
+    """
+
+    def test_keys_are_per_consumer_not_per_capability(self, monkeypatch):
+        _set_budget(monkeypatch, "10")
+        a = _make_sync_consumer("settle1456-keys-a", [])
+        b = _make_sync_consumer("settle1456-keys-b", [])
+
+        # Same provider capability declared by both consumers...
+        assert a._mesh_llm_config["provider"]["capability"] == "llm"
+        assert b._mesh_llm_config["provider"]["capability"] == "llm"
+        # ...but distinct settle keys.
+        assert a._mesh_llm_settle_key != b._mesh_llm_settle_key
+
+    def test_other_consumers_resolution_does_not_wake_this_waiter(
+        self, monkeypatch
+    ):
+        _set_budget(monkeypatch, "1.0")
+        seen_a: list = []
+        seen_b: list = []
+        a = _make_sync_consumer("settle1456-wake-a", seen_a)
+        b = _make_sync_consumer("settle1456-wake-b", seen_b)
+
+        # Consumer A resolves early; consumer B never does.
+        timer = threading.Timer(
+            0.1, lambda: a._mesh_update_llm_agent(MagicMock(name="agent-a"))
+        )
+        timer.start()
+        start = time.monotonic()
+        result = b(prompt="plan my trip")
+        elapsed = time.monotonic() - start
+        timer.join()
+
+        assert result == "degraded"
+        assert seen_b == [None]
+        # B must have sat out its own budget rather than being woken at
+        # ~0.1s by A's resolution.
+        assert elapsed >= 0.9, (
+            f"consumer B woke after {elapsed:.2f}s — A's provider resolution "
+            "leaked across the settle key"
+        )
+        assert elapsed < 5.0


### PR DESCRIPTION
## Summary

`uc20_tutorial/tc11_day10_bonus_streaming` started failing on assertion 15 (`SSE stream must end with '[DONE]'`). **The SSE machinery was correct** — it returned 200 with `text/event-stream` and emitted:

```
event: error
data: {"error": "Error calling tool 'plan_trip': ... 'NoneType' object is not callable"}
```

`[DONE]` is deliberately withheld on error (`route_integration.py:258-274`, pinned by `test_route_sse_wrapping.py:196-197`). Assertion 15 was faithfully reporting an upstream failure and is untouched.

The real defect: `@mesh.llm` injection sat outside the settling-window grace. `_mesh_llm_agent` starts `None` and is only set when a heartbeat delivers providers; the injection path returned that `None` with no wait. Because the registration heartbeat always reports zero providers — providers and consumers register in the same instant — resolution cannot happen before heartbeat 2, making the window one full interval wide.

```
20:11:49  Heartbeat ... 0 LLM providers
20:11:53  TypeError: 'NoneType' object is not callable   (x3)
20:11:54  Heartbeat ... 1 LLM providers → resolved
```

Missed by **one second** against a 5s interval. This is a *timing* regression, not a code one: agent registration got faster, moving the probe from just after heartbeat 2 to just before it. 6s wait → passed 6/6 historically; 4s wait → failed 3/3.

## The settle key: `llm:{function_id}`, per consumer

Not per provider capability. Resolution is delivered per consumer — the registry returns `llm_providers` keyed by function name, and the injector updates *that* wrapper. A settle key must be 1:1 with the state its waiter re-reads, and the waiter re-reads `wrapper._mesh_llm_agent`.

Same-capability consumers genuinely resolve at different times: provider filters differ (tags/version, plus the auto-applied `±ai.mcpmesh.stream` tag), one may match no provider at all, and a consumer with a tool `filter` has its update deferred to a later phase. With a shared key, consumer A's resolution wakes consumer B, which re-reads its own still-`None` agent and injects `None` anyway — burning the grace for nothing. That is the same spurious wake the per-slot `funcId:dep_N` tool keys exist to prevent.

**Proven, not asserted.** A second scratch build with the full fix but a capability-level key failed **exactly 2 of 12** tests — `test_keys_are_per_consumer_not_per_capability` and `test_other_consumers_resolution_does_not_wake_this_waiter`, and nothing else. Those two discriminate; the rest would not have caught it.

## A finding worth reading: the async path was unreachable

`combined_injection_wrapper` was a plain `def` **even for async tools**, so FastMCP saw a sync function and dispatched the whole call through `anyio.to_thread`. A blocking settle wait there would occupy one of anyio's 40 threadpool tokens for up to the full 20s window — exactly what `settle.py`'s async primitive exists to avoid. The fix would have "worked" while quietly doing the wrong thing under load.

Split on `asyncio.iscoroutinefunction`, mirroring the existing `@mesh.a2a_consumer` `bridge` pattern in the same file. Verified against the real tutorial shapes: `plan_trip` (`Stream[str]`) → async wrapper → `wait_for_settle_async`; committee tools (`def`) → sync wrapper → `wait_for_settle_sync`. `test_async_tool_gets_async_wrapper` pins it so it cannot regress back to one reachable path.

One deliberate exception, documented inline: async **generators** in the no-`@mesh.tool` fallback keep the sync wrapper, because an async-generator shim would break the deterministic `aclose()` propagation `_make_stream_wrapper` relies on for cancellation.

## Bounded when a provider never resolves

Both waits ceiling at `state.remaining()` = `max(0, timeout − elapsed)` — `threading.Event.wait(remaining)` and `asyncio.wait_for(..., remaining)`. `is_settled()` latches permanently at window expiry, and `collect_pending_settle_deps` short-circuits on it. So the cost is at most one window, once per process — never per call, never a hang — after which behaviour is exactly as today. Pinned sync and async (`elapsed >= 0.3` proves the wait happened; `elapsed < 5.0` proves it ended).

## Test plan

- [x] Unit: **2528 passed, 7 skipped** (baseline 2516; +12 new)
- [x] **10 of 12** new tests verified red against a scratch copy with `decorators.py`/`settle.py` restored from HEAD
- [x] Wrong-key control build isolates the 2 key-discriminating tests
- [x] `tsuite run --suite-path tests/src-tests` — 12 passed, 0 failed
- [x] `tc11_day10_bonus_streaming` — **passed 2/2**, both reporting *"All 12 agents registered after 4s"*: the exact quantization that failed 3/3. 313 and 277 data chunks, both ending `data: [DONE]`, full pipeline exercised
- [ ] CI green
- [ ] Full integration suite re-run before release (this touches the injection wrapper for every `@mesh.llm` consumer, so the narrow tc11 pass is not sufficient coverage)

**Two tests pass both ways and are kept:** `test_sync_tool_gets_sync_wrapper` (guards the split from over-reaching) and `test_settled_steady_state_never_waits` (no-regression on the wait-free fast path). Neither can fail by construction — pre-fix everything was sync and there was no wait at all.

`settle.py`'s docstring documented this exclusion as deliberate and has been rewritten, so it no longer contradicts the code. No doc surface restated it, so that was the only place needing correction.

## Follow-ups, not done

- **TypeScript and Java have the same gap.** `src/runtime/typescript/src/llm.ts` has a settle module next door (`settle.ts`) with zero integration; Java's `MeshLlm` likewise. The race is cross-runtime; this fix is Python-only by scope.
- On budget expiry users still get `'NoneType' object is not callable`. The grace narrows the window; it does not improve the diagnostic when the window genuinely expires. A typed error was explicitly scoped out of this change.
- `DependencyInjector.create_llm_injection_wrapper` → `create_injection_wrapper` has **no callers**, builds its own `update_llm_agent`, and is therefore outside the grace. Harmless while dead, but it is a second implementation that will drift.

Closes #1456


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `@mesh.llm` provider injection during the settling window.
  * Synchronous and asynchronous calls now wait appropriately for providers to become available.
  * Prevented unrelated consumers from being delayed by another consumer’s provider resolution.
  * Preserved graceful timeout behavior when a provider remains unavailable.

* **Tests**
  * Added coverage for synchronous and asynchronous injection, timeouts, fast-path resolution, and isolated consumer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->