### PR TITLE
test(meshjob): gate tc16 on real job status instead of a fixed 8s sleep

### DIFF
--- a/tests/integration/suites/uc21_meshjob/tc16_third_party_can_read_status/test.yaml
+++ b/tests/integration/suites/uc21_meshjob/tc16_third_party_can_read_status/test.yaml
@@ -22,7 +22,9 @@ tags:
   - issue-872
   - helpers
   - auth
-timeout: 120
+# 180 (was 120) so the completion status gate's failure-path diagnostics
+# can actually land instead of being cut off by the case timeout.
+timeout: 180
 
 pre_run:
   - routine: global.setup_for_python_agent
@@ -112,9 +114,48 @@ test:
     capture: submit_resp
     timeout: 15
 
-  - name: "Wait for completion"
-    handler: wait
-    seconds: 8
+  # Deterministic completion gate: poll job status until terminal
+  # (replaces a fixed 8s wait — the bystander reads below assert
+  # 'completed', and under `--parallel 8` contention the job outlived
+  # that fixed budget, so the bystanders observed status=working).
+  # Polls via the CONSUMER's __mesh_job_status helper so the bystander
+  # reads below remain the first third-party observations — polling
+  # through a bystander would pre-empt the very thing under test.
+  # Same shape as uc23/tc16's status gate.
+  - name: "Wait for job completion (status gate)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.. | objects | select(has("job_id")) | .job_id' | head -1)
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-consumer") | .id')
+      echo "AGENT=${AGENT} JOB=${JOB_ID}"
+      RESP=""
+      STATUS=""
+      for i in $(seq 1 45); do
+        RESP=$(meshctl call "${AGENT}:__mesh_job_status" "{\"job_id\":\"${JOB_ID}\"}" --raw 2>&1 || true)
+        STATUS=$(echo "$RESP" | jq -r '.. | objects | select(has("status")) | .status' 2>/dev/null | head -1)
+        if [ "$STATUS" = "completed" ]; then
+          echo "job completed after ~${i}s"
+          exit 0
+        fi
+        case "$STATUS" in
+          failed|cancelled)
+            echo "ERROR: job reached terminal status=$STATUS (expected completed)"
+            echo "=== last status response ==="
+            echo "$RESP"
+            exit 1
+            ;;
+        esac
+        sleep 1
+      done
+      echo "ERROR: job not completed within 45s (last status=$STATUS)"
+      echo "=== last status response ==="
+      echo "$RESP"
+      echo "=== long-task-provider log tail ==="
+      meshctl logs long-task-provider 2>&1 | tail -50 || true
+      exit 1
+    capture: wait_completion
+    timeout: 90
 
   - name: "Bystander X reads status"
     handler: shell

--- a/tests/integration/suites/uc22_meshjob_ts/tc16_third_party_can_read_status_ts/test.yaml
+++ b/tests/integration/suites/uc22_meshjob_ts/tc16_third_party_can_read_status_ts/test.yaml
@@ -104,9 +104,47 @@ test:
     capture: submit_resp
     timeout: 15
 
-  - name: "Wait for completion"
-    handler: wait
-    seconds: 8
+  # Deterministic completion gate: poll job status until terminal
+  # (replaces a fixed 8s wait — the bystander reads below assert
+  # 'completed', and under `--parallel 8` contention the job can outlive
+  # that fixed budget, leaving the bystanders on status=working).
+  # Polls via the CONSUMER's __mesh_job_status helper so the bystander
+  # reads below remain the first third-party observations — polling
+  # through a bystander would pre-empt the very thing under test.
+  - name: "Wait for job completion (status gate)"
+    handler: shell
+    workdir: /workspace
+    command: |
+      JOB_ID=$(echo '${captured.submit_resp}' | jq -r '.content[0].text | fromjson | .job_id')
+      AGENT=$(curl -s http://localhost:8000/agents | jq -r '.agents[] | select(.name=="long-task-consumer-ts") | .id')
+      echo "AGENT=${AGENT} JOB=${JOB_ID}"
+      RESP=""
+      STATUS=""
+      for i in $(seq 1 45); do
+        RESP=$(meshctl call "${AGENT}:__mesh_job_status" "{\"jobId\":\"${JOB_ID}\"}" --raw 2>&1 || true)
+        STATUS=$(echo "$RESP" | jq -r '.content[0].text | fromjson | .status' 2>/dev/null || true)
+        if [ "$STATUS" = "completed" ]; then
+          echo "job completed after ~${i}s"
+          exit 0
+        fi
+        case "$STATUS" in
+          failed|cancelled)
+            echo "ERROR: job reached terminal status=$STATUS (expected completed)"
+            echo "=== last status response ==="
+            echo "$RESP"
+            exit 1
+            ;;
+        esac
+        sleep 1
+      done
+      echo "ERROR: job not completed within 45s (last status=$STATUS)"
+      echo "=== last status response ==="
+      echo "$RESP"
+      echo "=== long-task-provider-ts log tail ==="
+      meshctl logs long-task-provider-ts 2>&1 | tail -50 || true
+      exit 1
+    capture: wait_completion
+    timeout: 90
 
   - name: "Bystander X reads status"
     handler: shell


### PR DESCRIPTION
## Summary

Both tc16 variants slept a flat 8 seconds waiting for a long-running job, then asserted it was `completed`. Under `--parallel 8` the job outlives that budget and the bystanders read `status=working`:

```
assertion 4 (bystander-x should read the actual completed status (no auth gating))
  failed: does not contain "\"completed\""
```

Failed in **2 of 3** full parallel runs; passes scoped — which is what made it look flaky rather than under-specified.

**The Java twin already had this exact gate** (`uc23/tc16` ~line 141), which is precisely why it never failed. Python and TypeScript were the outliers, so this brings all three into line rather than introducing a new pattern.

## Two things beyond "wait longer"

**It polls via the consumer, not a bystander.** The bystanders reading job status without auth *is* the assertion under test — polling through one would pre-empt the very thing being proven. The comment says so, so a future editor doesn't "simplify" it.

**It distinguishes a broken job from a slow one.** Previously, a job that genuinely `failed` produced the *identical* message as one that was merely slow — `does not contain "completed"` — with the case timeout cutting off any diagnostics before they landed. The gate now exits immediately on `failed`/`cancelled` with the response body, dumps the last status and the provider log tail on timeout, and the case timeout moves 120 → 180 so that output can actually surface.

That second point is why this isn't just a flake fix: the old failure mode was uninformative by construction.

## Verification

Full suite at `--parallel 8`: **559 passed, 0 failed, 9 skipped**.

```
[PASS] uc21_meshjob/tc16_third_party_can_read_status        (38.9s)
[PASS] uc22_meshjob_ts/tc16_third_party_can_read_status_ts  (50.4s)
[PASS] uc23_meshjob_java/tc16_third_party_can_read_status_java (120.0s)
[PASS] uc20_tutorial/tc11_day10_bonus_streaming             (303.4s)
```

Assertions 4 and 5 are unchanged — they are the point of the test.

## Follow-up, not in this PR

**46 steps across the meshjob suites use `handler: wait`**, several standing in for real readiness conditions. tsuite 0.7.0 ships a `probe` handler (`interval`, `timeout`, `until`, `success_threshold`, `on_failure`) that the suite uses nowhere today. Worth migrating as one reviewed change — `on_failure` alone would have short-circuited two separate investigations today by attaching `meshctl logs <agent> | tail -50` to the failure output.

**Boundary for that work:** probe belongs on *infrastructure* readiness — agent serving HTTP, registry answering, job reaching terminal state — and **never** on dependency or provider resolution. The settling window (#1193) exists so integration tests don't wait on DI, and a probe waiting for the mesh to converge would have hidden #1456 entirely. That test failing is what surfaced a real runtime race.

Closes #1458


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved mesh job status test reliability by polling for completion instead of relying on a fixed wait.
  * Added clearer handling for failed, cancelled, and timed-out jobs.
  * Enhanced timeout diagnostics with captured status details and provider logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->