### PR TITLE
fix(helm): make a volume's type part of its name, so a toggle is a key change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,8 +341,15 @@ jobs:
         with:
           python-version: "3.12"
 
+      # PyYAML because the chart guards parse rendered manifests, and pytest
+      # imports their test modules to collect them — without it the whole
+      # directory fails at collection rather than one file. Pinned to the
+      # version the helm-charts job installs so both jobs parse identically.
+      # This job deliberately has no helm: the chart guards' tests are mostly
+      # pure functions over parsed manifests and run here, while their few
+      # end-to-end cases skip and are covered for real in helm-charts.
       - name: Install pytest
-        run: pip install pytest
+        run: pip install pytest pyyaml==6.0.3
 
       - name: Run scripts/ tests
         run: python3 -m pytest scripts/ -v
@@ -464,6 +471,16 @@ jobs:
       # guard's fail path and the pass path next to it.
       - name: Render chart guards with non-default values
         run: python3 scripts/check_helm_render_matrix.py
+
+      # Both steps above assert things about a single render. #1461 was a
+      # defect *between* two renders: a volume that kept its name while
+      # changing type, which server-side apply can merge into an object the
+      # API server rejects. Nothing that renders one state at a time can see
+      # it. This one renders each persistence toggle in every state and
+      # compares them. (It still cannot see field-manager ownership — see the
+      # script header.)
+      - name: Check volume names carry volume types
+        run: python3 scripts/check_helm_volume_keys.py
 
       # Reviewer aid, not a gate — see the header of the script for why CI
       # cannot decide whether a chart delta is intended.

--- a/helm/mcp-mesh-grafana/templates/_helpers.tpl
+++ b/helm/mcp-mesh-grafana/templates/_helpers.tpl
@@ -182,3 +182,26 @@ imagePullSecrets:
 {{- end -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Name of the /var/lib/grafana volume — deliberately not a constant.
+
+Kubernetes merges spec.template.spec.volumes by name, so a stable name whose
+type flips between persistentVolumeClaim and emptyDir can end up carrying BOTH
+under server-side apply, when the two field sets have different owners; the API
+server then rejects the object with "may not specify more than 1 volume type"
+and the Deployment sticks unsyncable (#1461). Encoding the type in the key turns
+a grafana.persistence.enabled toggle into a remove-item + add-item on distinct
+keys, which is always representable, in either direction, under Helm, Argo,
+client-side and server-side apply alike.
+
+The persistent branch keeps the historical name so installations that never
+disabled persistence see no change at all.
+
+The matching volumeMounts entry MUST use this same helper — that list is keyed
+by name too, and a mount naming a volume that no longer exists is its own
+invalid-Deployment failure.
+*/}}
+{{- define "mcp-mesh-grafana.storageVolumeName" -}}
+{{- if .Values.grafana.persistence.enabled -}}storage{{- else -}}storage-ephemeral{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-grafana/templates/deployment.yaml
+++ b/helm/mcp-mesh-grafana/templates/deployment.yaml
@@ -109,8 +109,10 @@ spec:
         {{- end }}
         {{- /* /var/lib/grafana and /tmp must be writable (data, sqlite db,
                plugin install) — always volumes since the root filesystem is
-               read-only. */}}
-        - name: storage
+               read-only. The storage name is conditional on
+               persistence.enabled and must stay in lockstep with the volume
+               below — see the helper (#1461). */}}
+        - name: {{ include "mcp-mesh-grafana.storageVolumeName" . }}
           mountPath: /var/lib/grafana
         - name: tmp
           mountPath: /tmp
@@ -151,7 +153,8 @@ spec:
         configMap:
           name: {{ include "mcp-mesh-grafana.fullname" . }}-dashboard
       {{- end }}
-      - name: storage
+      {{- /* Name carries the volume type on purpose — see the helper (#1461). */}}
+      - name: {{ include "mcp-mesh-grafana.storageVolumeName" . }}
         {{- if .Values.grafana.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ include "mcp-mesh-grafana.fullname" . }}-pvc

--- a/helm/mcp-mesh-redis/templates/_helpers.tpl
+++ b/helm/mcp-mesh-redis/templates/_helpers.tpl
@@ -154,3 +154,26 @@ imagePullSecrets:
 {{- end -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Name of the /data volume — deliberately not a constant.
+
+Kubernetes merges spec.template.spec.volumes by name, so a stable name whose
+type flips between persistentVolumeClaim and emptyDir can end up carrying BOTH
+under server-side apply, when the two field sets have different owners; the API
+server then rejects the object with "may not specify more than 1 volume type"
+and the Deployment sticks unsyncable (#1461). Encoding the type in the key turns
+a persistence.enabled toggle into a remove-item + add-item on distinct keys,
+which is always representable, in either direction, under Helm, Argo,
+client-side and server-side apply alike.
+
+The persistent branch keeps the historical name so installations that never
+disabled persistence see no change at all.
+
+The matching volumeMounts entry MUST use this same helper — that list is keyed
+by name too, and a mount naming a volume that no longer exists is its own
+invalid-Deployment failure.
+*/}}
+{{- define "mcp-mesh-redis.dataVolumeName" -}}
+{{- if .Values.persistence.enabled -}}redis-data{{- else -}}redis-data-ephemeral{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-redis/templates/deployment.yaml
+++ b/helm/mcp-mesh-redis/templates/deployment.yaml
@@ -87,7 +87,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - name: redis-data
+            {{- /* Name is conditional on persistence.enabled and must stay in
+                   lockstep with the volume — see the helper (#1461). */}}
+            - name: {{ include "mcp-mesh-redis.dataVolumeName" . }}
               mountPath: /data
             {{- if .Values.customConfig }}
             - name: config
@@ -97,7 +99,8 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
       volumes:
-        - name: redis-data
+        {{- /* Name carries the volume type on purpose — see the helper (#1461). */}}
+        - name: {{ include "mcp-mesh-redis.dataVolumeName" . }}
           {{- /* This chart provisions no volume — there is no PVC template and
                  never was. persistence.enabled therefore mounts a claim you
                  created yourself and named in persistence.existingClaim; the

--- a/helm/mcp-mesh-registry/templates/_helpers.tpl
+++ b/helm/mcp-mesh-registry/templates/_helpers.tpl
@@ -453,3 +453,26 @@ Get persistence volume claim name
 {{- include "mcp-mesh-registry.fullname" . }}-data
 {{- end }}
 {{- end }}
+
+{{/*
+Name of the registry data volume — deliberately not a constant.
+
+Kubernetes merges spec.template.spec.volumes by name, so a stable name whose
+type flips between persistentVolumeClaim and emptyDir can end up carrying BOTH
+under server-side apply, when the two field sets have different owners; the API
+server then rejects the object with "may not specify more than 1 volume type"
+and the Deployment sticks unsyncable (#1461). Encoding the type in the key turns
+a persistence.enabled toggle into a remove-item + add-item on distinct keys,
+which is always representable, in either direction, under Helm, Argo,
+client-side and server-side apply alike.
+
+The persistent branch keeps the historical name so installations that never
+disabled persistence see no change at all.
+
+The matching volumeMounts entry MUST use this same helper — that list is keyed
+by name too, and a mount naming a volume that no longer exists is its own
+invalid-Deployment failure.
+*/}}
+{{- define "mcp-mesh-registry.dataVolumeName" -}}
+{{- if .Values.persistence.enabled -}}data{{- else -}}data-ephemeral{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-registry/templates/deployment.yaml
+++ b/helm/mcp-mesh-registry/templates/deployment.yaml
@@ -292,7 +292,9 @@ spec:
             - name: tmp
               mountPath: /tmp
             {{- if or .Values.persistence.enabled (eq .Values.registry.database.type "sqlite") }}
-            - name: data
+            {{- /* Name is conditional on persistence.enabled and must stay in
+                   lockstep with the volume — see the helper (#1461). */}}
+            - name: {{ include "mcp-mesh-registry.dataVolumeName" . }}
               mountPath: {{ .Values.persistence.mountPath }}
               {{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath }}
@@ -376,7 +378,8 @@ spec:
         - name: tmp
           emptyDir: {}
         {{- if or .Values.persistence.enabled (eq .Values.registry.database.type "sqlite") }}
-        - name: data
+        {{- /* Name carries the volume type on purpose — see the helper (#1461). */}}
+        - name: {{ include "mcp-mesh-registry.dataVolumeName" . }}
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (printf "%s-data" (include "mcp-mesh-registry.fullname" .)) }}

--- a/helm/mcp-mesh-tempo/templates/_helpers.tpl
+++ b/helm/mcp-mesh-tempo/templates/_helpers.tpl
@@ -96,3 +96,26 @@ imagePullSecrets:
 {{- end -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Name of the /var/tempo volume — deliberately not a constant.
+
+Kubernetes merges spec.template.spec.volumes by name, so a stable name whose
+type flips between persistentVolumeClaim and emptyDir can end up carrying BOTH
+under server-side apply, when the two field sets have different owners; the API
+server then rejects the object with "may not specify more than 1 volume type"
+and the Deployment sticks unsyncable (#1461). Encoding the type in the key turns
+a tempo.persistence.enabled toggle into a remove-item + add-item on distinct
+keys, which is always representable, in either direction, under Helm, Argo,
+client-side and server-side apply alike.
+
+The persistent branch keeps the historical name so installations that never
+disabled persistence see no change at all.
+
+The matching volumeMounts entry MUST use this same helper — that list is keyed
+by name too, and a mount naming a volume that no longer exists is its own
+invalid-Deployment failure.
+*/}}
+{{- define "mcp-mesh-tempo.storageVolumeName" -}}
+{{- if .Values.tempo.persistence.enabled -}}storage{{- else -}}storage-ephemeral{{- end -}}
+{{- end }}

--- a/helm/mcp-mesh-tempo/templates/deployment.yaml
+++ b/helm/mcp-mesh-tempo/templates/deployment.yaml
@@ -76,8 +76,10 @@ spec:
           subPath: tempo.yaml
           readOnly: true
         {{- /* /var/tempo (wal/blocks) and /tmp must be writable — always
-               volumes since the root filesystem is read-only. */}}
-        - name: storage
+               volumes since the root filesystem is read-only. The storage
+               name is conditional on persistence.enabled and must stay in
+               lockstep with the volume below — see the helper (#1461). */}}
+        - name: {{ include "mcp-mesh-tempo.storageVolumeName" . }}
           mountPath: /var/tempo
         - name: tmp
           mountPath: /tmp
@@ -103,7 +105,8 @@ spec:
       - name: config
         configMap:
           name: {{ include "mcp-mesh-tempo.fullname" . }}-config
-      - name: storage
+      {{- /* Name carries the volume type on purpose — see the helper (#1461). */}}
+      - name: {{ include "mcp-mesh-tempo.storageVolumeName" . }}
         {{- if .Values.tempo.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ include "mcp-mesh-tempo.fullname" . }}-pvc

--- a/scripts/check_helm_volume_keys.py
+++ b/scripts/check_helm_volume_keys.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Assert that a pod volume never changes TYPE while keeping the same NAME.
+
+Kubernetes merges `spec.template.spec.volumes` by `name`. A chart that renders
+
+    - name: storage
+      {{- if .Values.persistence.enabled }}
+      persistentVolumeClaim: {...}
+      {{- else }}
+      emptyDir: {}
+      {{- end }}
+
+is therefore describing two different objects under one merge key. Under
+server-side apply, if the `persistentVolumeClaim` field set is owned by a
+different field manager than the one now applying `emptyDir`, both survive the
+merge and the API server rejects the object outright:
+
+    spec.template.spec.volumes[1].persistentVolumeClaim: Forbidden:
+      may not specify more than 1 volume type
+
+The Deployment then sticks unsyncable until someone deletes it by hand. This
+happened on the 3.3.2 -> 3.4.0 upgrade when tempo's `persistence.enabled`
+default flipped, and it is bidirectional — re-enabling persistence hits the
+identical failure in reverse (#1461).
+
+The fix is to make the name carry the type, so that toggling persistence is a
+*key* change: remove-item plus add-item on distinct keys, which is always
+representable. This check pins that fix. It renders each chart in every state
+that moves a persistence toggle and asserts:
+
+  1. No volume name maps to two different types across any pair of states.
+     This is the real assertion — a direct statement of "a type change must be
+     a key change". Collapsing a conditional volume name back to a constant
+     turns it red.
+  2. Every volumeMount name resolves to a volume of that name, in every state.
+     Assertion 1 is satisfied by renaming, and renaming is exactly how the
+     matching mount gets left behind — that mistake produces a differently
+     invalid Deployment, so the two must be checked together.
+  3. No volume declares more than one type in a single render.
+
+StatefulSet volumeClaimTemplates participate as the pseudo-type
+`volumeClaimTemplate`: they are named storage a mount can resolve against, and
+converting one into a pod volume of the same name is the same defect class.
+
+WHAT THIS CANNOT SEE: field-manager ownership. Every assertion here is made
+against `helm template` output, so this proves the *charts* never ask for an
+unrepresentable merge. It does not exercise a real server-side apply against a
+live API server with real ownership history, which is the mechanism that
+turned the chart bug into an outage. A genuine SSA-upgrade test remains an open
+question — do not read a green run here as closing it.
+
+Usage: python3 scripts/check_helm_volume_keys.py  (run from anywhere)
+       python3 scripts/check_helm_volume_keys.py --helm-dir path/to/helm
+Exit code 0 = every chart keeps volume type and volume name in lockstep.
+"""
+
+import argparse
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from itertools import combinations
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import check_helm_pss  # noqa: E402
+from check_helm_pss import (  # noqa: E402
+    HELM_DIR,
+    POD_BEARING_KINDS,
+    build_dependencies,
+    pod_spec_of,
+)
+
+VOLUME_CLAIM_TEMPLATE = "volumeClaimTemplate"
+
+# Keys that appear on a volume entry without being a volume type.
+NON_TYPE_VOLUME_KEYS = {"name"}
+
+
+@dataclass(frozen=True)
+class State:
+    """One render of one chart: a label and the values that produce it."""
+
+    label: str
+    values: dict = field(default_factory=dict)
+
+
+# Every chart whose values carry a persistence toggle, rendered in each state
+# that toggle can put it in. scripts/test_check_helm_volume_keys.py asserts
+# this covers all of them, so a new chart with a persistence block cannot land
+# uncovered.
+#
+# Charts with no persistence toggle are still rendered (single default state)
+# so assertions 2 and 3 cover them; only assertion 1 needs two states to say
+# anything.
+STATES: dict[str, list[State]] = {
+    "mcp-mesh-tempo": [
+        State("persistence on", {"tempo": {"persistence": {"enabled": True}}}),
+        State("persistence off", {"tempo": {"persistence": {"enabled": False}}}),
+    ],
+    "mcp-mesh-grafana": [
+        State("persistence on", {"grafana": {"persistence": {"enabled": True}}}),
+        State("persistence off", {"grafana": {"persistence": {"enabled": False}}}),
+    ],
+    # The registry's data volume is gated on `persistence.enabled OR
+    # database.type == sqlite`, so toggling persistence alone leaves the state
+    # that actually swapped type (sqlite with persistence off, which renders an
+    # emptyDir under the same name the PVC uses) unrendered. Both dimensions.
+    "mcp-mesh-registry": [
+        State(
+            "postgres, persistence on",
+            {"persistence": {"enabled": True}, "registry": {"database": {"type": "postgres"}}},
+        ),
+        State(
+            "postgres, persistence off",
+            {"persistence": {"enabled": False}, "registry": {"database": {"type": "postgres"}}},
+        ),
+        State(
+            "sqlite, persistence on",
+            {"persistence": {"enabled": True}, "registry": {"database": {"type": "sqlite"}}},
+        ),
+        State(
+            "sqlite, persistence off",
+            {"persistence": {"enabled": False}, "registry": {"database": {"type": "sqlite"}}},
+        ),
+    ],
+    # This chart renders no PVC, so persistence.enabled requires an
+    # existingClaim — a template-time guard fails the render without one.
+    "mcp-mesh-redis": [
+        State(
+            "persistence on",
+            {"persistence": {"enabled": True, "existingClaim": "some-claim"}},
+        ),
+        State("persistence off", {"persistence": {"enabled": False}}),
+    ],
+    # Not affected today: the whole volume sits inside the conditional, so
+    # toggling persistence adds or removes a list item rather than swapping a
+    # type under a stable key. Covered anyway — adding an `else` branch here is
+    # precisely how it would become affected.
+    "mcp-mesh-agent": [
+        State("persistence on", {"persistence": {"enabled": True}}),
+        State("persistence off", {"persistence": {"enabled": False}}),
+    ],
+    # postgres-data is a StatefulSet volumeClaimTemplate rather than a pod
+    # volume, which is why this chart has never been at risk. Rendered so that
+    # converting it into a pod volume under the same name would be caught.
+    "mcp-mesh-postgres": [
+        State("persistence on", {"persistence": {"enabled": True}}),
+        State("persistence off", {"persistence": {"enabled": False}}),
+    ],
+    # The umbrella is what most installations actually apply, and it is where
+    # a subchart's toggle reaches a user. ui.enabled renders the optional pod.
+    "mcp-mesh-core": [
+        State("defaults", {"ui": {"enabled": True}}),
+        State(
+            "persistence on everywhere",
+            {
+                "ui": {"enabled": True},
+                "mcp-mesh-tempo": {"tempo": {"persistence": {"enabled": True}}},
+                "mcp-mesh-grafana": {"grafana": {"persistence": {"enabled": True}}},
+                "mcp-mesh-registry": {"persistence": {"enabled": True}},
+                "mcp-mesh-redis": {
+                    "persistence": {"enabled": True, "existingClaim": "some-claim"}
+                },
+            },
+        ),
+        State(
+            "persistence off everywhere",
+            {
+                "ui": {"enabled": True},
+                "mcp-mesh-tempo": {"tempo": {"persistence": {"enabled": False}}},
+                "mcp-mesh-grafana": {"grafana": {"persistence": {"enabled": False}}},
+                "mcp-mesh-registry": {"persistence": {"enabled": False}},
+                "mcp-mesh-redis": {"persistence": {"enabled": False}},
+            },
+        ),
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Analysis. Pure functions over already-parsed manifests: no helm, no yaml, so
+# scripts/test_check_helm_volume_keys.py can drive them from literal dicts.
+# ---------------------------------------------------------------------------
+
+
+def volume_types(vol: dict) -> list[str]:
+    """The type keys on one volume entry. Exactly one is legal."""
+    return sorted(set(vol) - NON_TYPE_VOLUME_KEYS)
+
+
+def volume_index(doc: dict, spec: dict) -> dict[str, str]:
+    """name -> type for everything a volumeMount in this workload can name.
+
+    A volume with zero or several types maps to a marker rather than being
+    dropped, so that assertion 1 still has something to compare and does not
+    silently go quiet on a malformed render.
+    """
+    index: dict[str, str] = {}
+    for vol in spec.get("volumes") or []:
+        types = volume_types(vol)
+        index[vol.get("name")] = types[0] if len(types) == 1 else f"<{len(types)} types>"
+    if doc.get("kind") == "StatefulSet":
+        for vct in doc.get("spec", {}).get("volumeClaimTemplates") or []:
+            index[vct.get("metadata", {}).get("name")] = VOLUME_CLAIM_TEMPLATE
+    return index
+
+
+def spec_problems(doc: dict, spec: dict) -> list[str]:
+    """Assertions 2 and 3, against a single rendered workload."""
+    problems = []
+    volumes = spec.get("volumes") or []
+
+    for vol in volumes:
+        types = volume_types(vol)
+        if len(types) > 1:
+            problems.append(
+                f"volume {vol.get('name')!r} declares {len(types)} types "
+                f"({', '.join(types)}); a volume may specify exactly one"
+            )
+        elif not types:
+            problems.append(f"volume {vol.get('name')!r} declares no type")
+
+    names = [v.get("name") for v in volumes]
+    for dupe in sorted({n for n in names if names.count(n) > 1}):
+        problems.append(f"volume name {dupe!r} is used more than once")
+
+    index = volume_index(doc, spec)
+    containers = (spec.get("containers") or []) + (spec.get("initContainers") or [])
+    for c in containers:
+        for mount in c.get("volumeMounts") or []:
+            if mount.get("name") not in index:
+                problems.append(
+                    f"{c.get('name')}: volumeMount {mount.get('name')!r} names no "
+                    f"volume in this pod (have: {sorted(index) or 'none'})"
+                )
+    return problems
+
+
+def type_collisions(per_state: dict[str, dict[str, dict[str, str]]]) -> list[str]:
+    """Assertion 1.
+
+    `per_state` is {state label: {workload name: {volume name: type}}}. A
+    volume name that appears in two states carrying different types is a merge
+    key describing two different objects — the #1461 defect.
+    """
+    problems = []
+    for left, right in combinations(sorted(per_state), 2):
+        workloads = set(per_state[left]) & set(per_state[right])
+        for workload in sorted(workloads):
+            a, b = per_state[left][workload], per_state[right][workload]
+            for name in sorted(set(a) & set(b)):
+                if a[name] != b[name]:
+                    problems.append(
+                        f"{workload}: volume {name!r} is {a[name]} with {left!r} but "
+                        f"{b[name]} with {right!r} — a volume that changes type must "
+                        f"change name, or server-side apply can merge both types "
+                        f"under this one key and the API server rejects the object"
+                    )
+    return problems
+
+
+def index_render(docs) -> tuple[dict[str, dict[str, str]], list[str]]:
+    """Walk parsed manifests once: build the per-workload volume index and
+    collect the single-render problems."""
+    index: dict[str, dict[str, str]] = {}
+    problems: list[str] = []
+    for doc in docs:
+        if not isinstance(doc, dict) or doc.get("kind") not in POD_BEARING_KINDS:
+            continue
+        spec, name = pod_spec_of(doc)
+        if spec is None:
+            continue
+        index[name] = volume_index(doc, spec)
+        problems.extend(f"{name}/{p}" for p in spec_problems(doc, spec))
+    return index, problems
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render(chart: str, state: State, helm_dir: Path) -> str:
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml") as values_file:
+        yaml.safe_dump(state.values, values_file)
+        values_file.flush()
+        result = subprocess.run(
+            [
+                "helm",
+                "template",
+                "volume-keys",
+                str(helm_dir / chart),
+                "--values",
+                values_file.name,
+            ],
+            capture_output=True,
+            text=True,
+        )
+    if result.returncode != 0:
+        print(f"FAIL {chart} [{state.label}]: helm template failed:\n{result.stderr}")
+        sys.exit(1)
+    return result.stdout
+
+
+def discover_charts(helm_dir: Path) -> list[str]:
+    return sorted(d.name for d in helm_dir.iterdir() if (d / "Chart.yaml").is_file())
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--helm-dir",
+        type=Path,
+        default=HELM_DIR,
+        help="chart directory to check (default: helm/ in this repo). Point it "
+        "at a worktree to confirm the check goes red on an older tree.",
+    )
+    args = parser.parse_args(argv)
+    helm_dir = args.helm_dir.resolve()
+    # build_dependencies packages subcharts relative to its own module global.
+    check_helm_pss.HELM_DIR = helm_dir
+
+    charts = discover_charts(helm_dir)
+    failures = 0
+    for chart in charts:
+        build_dependencies(chart)
+        states = STATES.get(chart) or [State("defaults")]
+        per_state: dict[str, dict[str, dict[str, str]]] = {}
+        problems: list[str] = []
+        for state in states:
+            docs = list(yaml.safe_load_all(render(chart, state, helm_dir)))
+            index, found = index_render(docs)
+            per_state[state.label] = index
+            problems.extend(f"[{state.label}] {p}" for p in found)
+        problems.extend(type_collisions(per_state))
+
+        if problems:
+            failures += 1
+            print(f"FAIL {chart} ({len(states)} state(s)):")
+            for p in problems:
+                print(f"  - {p}")
+        else:
+            print(f"OK   {chart} ({len(states)} state(s))")
+
+    print(
+        f"\n{len(charts) - failures}/{len(charts)} charts keep volume name "
+        "and type in lockstep"
+    )
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_helm_volume_keys.py
+++ b/scripts/test_check_helm_volume_keys.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Checks for scripts/check_helm_volume_keys.py (#1461).
+
+The analysis in that script is pure functions over parsed manifests, so almost
+everything here drives it from literal dicts rather than rendering charts. That
+is deliberate: a guard tested only by "the real tree is clean today" passes for
+the wrong reason the moment its logic is broken, which is how the defect it
+pins got in. Each failure mode is proven separately to go red.
+
+Only the end-to-end tests need `helm` on PATH and skip without it.
+"""
+
+import importlib.util
+import pathlib
+import shutil
+
+import yaml
+
+_spec = importlib.util.spec_from_file_location(
+    "check_helm_volume_keys",
+    pathlib.Path(__file__).with_name("check_helm_volume_keys.py"),
+)
+cvk = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cvk)
+
+PROJECT_ROOT = pathlib.Path(__file__).parent.parent
+HELM_DIR = PROJECT_ROOT / "helm"
+
+
+def _requires_helm() -> bool:
+    """True when the caller should bail out. Under pytest this raises Skipped
+    instead of returning, so the run reports it rather than passing quietly."""
+    if shutil.which("helm"):
+        return False
+    try:
+        import pytest
+
+        pytest.skip("helm is not installed")
+    except ImportError:
+        pass
+    return True
+
+
+def _deployment(volumes, mounts=(), name="dep", init_mounts=()):
+    return {
+        "kind": "Deployment",
+        "metadata": {"name": name},
+        "spec": {
+            "template": {
+                "spec": {
+                    "volumes": list(volumes),
+                    "containers": [
+                        {
+                            "name": "app",
+                            "volumeMounts": [{"name": m, "mountPath": "/x"} for m in mounts],
+                        }
+                    ],
+                    "initContainers": [
+                        {
+                            "name": "init",
+                            "volumeMounts": [
+                                {"name": m, "mountPath": "/x"} for m in init_mounts
+                            ],
+                        }
+                    ]
+                    if init_mounts
+                    else [],
+                }
+            }
+        },
+    }
+
+
+def _spec_of(doc):
+    return doc["spec"]["template"]["spec"]
+
+
+# --------------------------------------------------------------------------
+# Assertion 1: a type change must be a key change. The real one.
+# --------------------------------------------------------------------------
+
+
+def test_a_type_swap_under_a_stable_name_is_flagged():
+    """The #1461 defect exactly: one merge key, two different objects."""
+    found = cvk.type_collisions(
+        {
+            "persistence on": {"dep": {"storage": "persistentVolumeClaim"}},
+            "persistence off": {"dep": {"storage": "emptyDir"}},
+        }
+    )
+    assert len(found) == 1, found
+    assert "'storage'" in found[0]
+    assert "persistentVolumeClaim" in found[0] and "emptyDir" in found[0]
+
+
+def test_the_fix_shape_is_not_flagged():
+    """Type carried in the name: the two states share no key, so server-side
+    apply sees remove-item plus add-item and a dual-type volume is not
+    representable."""
+    assert (
+        cvk.type_collisions(
+            {
+                "persistence on": {"dep": {"storage": "persistentVolumeClaim"}},
+                "persistence off": {"dep": {"storage-ephemeral": "emptyDir"}},
+            }
+        )
+        == []
+    )
+
+
+def test_an_add_remove_volume_is_not_flagged():
+    """mcp-mesh-agent's shape — the whole volume inside the conditional. There
+    is no second type to collide with, so this must stay green or the check
+    would be demanding a rename nobody needs."""
+    assert (
+        cvk.type_collisions(
+            {
+                "persistence on": {"dep": {"data": "persistentVolumeClaim"}},
+                "persistence off": {"dep": {}},
+            }
+        )
+        == []
+    )
+
+
+def test_all_state_pairs_are_compared_not_just_neighbours():
+    """The registry has four states and the collision is between two of them
+    that are not adjacent in declaration order. Comparing consecutive states
+    only would call that tree clean."""
+    found = cvk.type_collisions(
+        {
+            "a": {"dep": {"data": "persistentVolumeClaim"}},
+            "b": {"dep": {}},
+            "c": {"dep": {"data": "emptyDir"}},
+        }
+    )
+    assert len(found) == 1, found
+    assert "'a'" in found[0] and "'c'" in found[0]
+
+
+def test_a_collision_in_a_different_workload_is_reported_per_workload():
+    found = cvk.type_collisions(
+        {
+            "on": {
+                "dep-a": {"storage": "persistentVolumeClaim"},
+                "dep-b": {"storage": "configMap"},
+            },
+            "off": {
+                "dep-a": {"storage": "emptyDir"},
+                "dep-b": {"storage": "configMap"},
+            },
+        }
+    )
+    assert len(found) == 1, found
+    assert found[0].startswith("dep-a:")
+
+
+def test_a_volume_becoming_a_claim_template_collides():
+    """Converting a StatefulSet volumeClaimTemplate into a pod volume of the
+    same name is the same defect wearing different clothes."""
+    found = cvk.type_collisions(
+        {
+            "on": {"sts": {"pgdata": cvk.VOLUME_CLAIM_TEMPLATE}},
+            "off": {"sts": {"pgdata": "emptyDir"}},
+        }
+    )
+    assert len(found) == 1, found
+
+
+# --------------------------------------------------------------------------
+# Assertion 2: mounts must resolve. The trap the #1461 fix itself can spring.
+# --------------------------------------------------------------------------
+
+
+def test_a_mount_naming_no_volume_is_flagged():
+    """Renaming the volume and forgetting the mount — the exact way a fix for
+    assertion 1 produces a differently invalid Deployment."""
+    doc = _deployment([{"name": "storage-ephemeral", "emptyDir": {}}], mounts=["storage"])
+    found = cvk.spec_problems(doc, _spec_of(doc))
+    assert len(found) == 1, found
+    assert "volumeMount 'storage' names no volume" in found[0]
+
+
+def test_a_mount_in_an_init_container_is_checked_too():
+    doc = _deployment(
+        [{"name": "data", "emptyDir": {}}], mounts=["data"], init_mounts=["gone"]
+    )
+    found = cvk.spec_problems(doc, _spec_of(doc))
+    assert len(found) == 1, found
+    assert "init:" in found[0] and "'gone'" in found[0]
+
+
+def test_a_mount_resolving_to_a_claim_template_is_accepted():
+    """A StatefulSet mount names its volumeClaimTemplate, not a pod volume.
+    Without this the check would report every StatefulSet as broken."""
+    doc = {
+        "kind": "StatefulSet",
+        "metadata": {"name": "sts"},
+        "spec": {
+            "volumeClaimTemplates": [{"metadata": {"name": "pgdata"}}],
+            "template": {
+                "spec": {
+                    "volumes": [],
+                    "containers": [
+                        {"name": "db", "volumeMounts": [{"name": "pgdata"}]}
+                    ],
+                }
+            },
+        },
+    }
+    assert cvk.spec_problems(doc, doc["spec"]["template"]["spec"]) == []
+
+
+def test_a_clean_spec_is_silent():
+    doc = _deployment(
+        [{"name": "data", "emptyDir": {}}, {"name": "cfg", "configMap": {"name": "c"}}],
+        mounts=["data", "cfg"],
+    )
+    assert cvk.spec_problems(doc, _spec_of(doc)) == []
+
+
+# --------------------------------------------------------------------------
+# Assertion 3: one type per volume
+# --------------------------------------------------------------------------
+
+
+def test_a_dual_type_volume_is_flagged():
+    """What the API server actually rejects, should a chart ever render it
+    directly rather than have SSA merge it into existence."""
+    doc = _deployment(
+        [{"name": "storage", "emptyDir": {}, "persistentVolumeClaim": {"claimName": "c"}}],
+        mounts=["storage"],
+    )
+    found = cvk.spec_problems(doc, _spec_of(doc))
+    assert len(found) == 1, found
+    assert "declares 2 types" in found[0]
+
+
+def test_a_typeless_volume_is_flagged():
+    doc = _deployment([{"name": "storage"}], mounts=["storage"])
+    found = cvk.spec_problems(doc, _spec_of(doc))
+    assert any("declares no type" in p for p in found), found
+
+
+def test_a_duplicated_volume_name_is_flagged():
+    doc = _deployment(
+        [{"name": "storage", "emptyDir": {}}, {"name": "storage", "emptyDir": {}}],
+        mounts=["storage"],
+    )
+    found = cvk.spec_problems(doc, _spec_of(doc))
+    assert any("used more than once" in p for p in found), found
+
+
+def test_a_malformed_volume_still_indexes_so_it_can_collide():
+    """A dual-type volume must not vanish from the index — dropping it would
+    make assertion 1 go quiet on the worst possible render."""
+    doc = _deployment([{"name": "storage", "emptyDir": {}, "configMap": {}}])
+    assert cvk.volume_index(doc, _spec_of(doc)) == {"storage": "<2 types>"}
+
+
+def test_non_workload_documents_are_ignored():
+    index, problems = cvk.index_render(
+        [
+            None,
+            {"kind": "Service", "metadata": {"name": "svc"}, "spec": {}},
+            _deployment([{"name": "data", "emptyDir": {}}], mounts=["data"]),
+        ]
+    )
+    assert list(index) == ["dep"]
+    assert problems == []
+
+
+# --------------------------------------------------------------------------
+# The declared matrix must actually cover the tree
+# --------------------------------------------------------------------------
+
+
+def _values(chart: str) -> dict:
+    return yaml.safe_load((HELM_DIR / chart / "values.yaml").read_text()) or {}
+
+
+def _has_persistence_toggle(values: dict) -> bool:
+    if isinstance(values, dict):
+        if isinstance(values.get("persistence"), dict) and "enabled" in values["persistence"]:
+            return True
+        return any(_has_persistence_toggle(v) for v in values.values())
+    return False
+
+
+def test_every_chart_with_a_persistence_toggle_is_rendered_in_both_states():
+    """A chart that grows a persistence toggle without a STATES entry gets
+    rendered once, and assertion 1 needs two states to say anything — so it
+    would join the tree already covered, silently uncovered."""
+    uncovered = []
+    for chart in cvk.discover_charts(HELM_DIR):
+        if not _has_persistence_toggle(_values(chart)):
+            continue
+        if len(cvk.STATES.get(chart, [])) < 2:
+            uncovered.append(chart)
+    assert not uncovered, (
+        "these charts toggle persistence but are not rendered in two states: "
+        f"{uncovered}"
+    )
+
+
+def test_the_registry_matrix_keeps_its_second_dimension():
+    """The registry's data volume is gated on `persistence.enabled OR
+    database.type == sqlite`. Toggling persistence alone never renders the
+    state that swapped type — sqlite with persistence off — so dropping the
+    database dimension turns this chart into a false green while the defect is
+    still there. Verified: pre-fix, the only collisions reported for the
+    registry involve the sqlite-off state."""
+    db_types = {
+        (s.values.get("registry") or {}).get("database", {}).get("type")
+        for s in cvk.STATES["mcp-mesh-registry"]
+    }
+    assert db_types == {"sqlite", "postgres"}, db_types
+    persistence = {s.values["persistence"]["enabled"] for s in cvk.STATES["mcp-mesh-registry"]}
+    assert persistence == {True, False}
+
+
+def test_the_matrix_names_only_charts_that_exist():
+    """A renamed chart would leave a STATES entry matching nothing, and the
+    chart itself would fall back to a single default render."""
+    charts = set(cvk.discover_charts(HELM_DIR))
+    assert set(cvk.STATES) <= charts, set(cvk.STATES) - charts
+
+
+def test_redis_persistence_state_names_a_claim():
+    """The chart refuses persistence.enabled without existingClaim, so a state
+    that omits it fails the render instead of being checked."""
+    on = next(s for s in cvk.STATES["mcp-mesh-redis"] if s.values["persistence"]["enabled"])
+    assert on.values["persistence"].get("existingClaim")
+
+
+# --------------------------------------------------------------------------
+# End to end, against the real charts
+# --------------------------------------------------------------------------
+
+
+def test_the_tree_is_clean():
+    if _requires_helm():
+        return
+    assert cvk.main([]) == 0
+
+
+def test_the_check_goes_red_on_a_chart_that_swaps_type(tmp_path):
+    """Proves the whole pipeline, not just the pure functions: a minimal chart
+    with the #1461 shape must fail, and the same chart with the name carrying
+    the type must pass. Without this, a wiring mistake between rendering and
+    analysis would leave every assertion above true and the script useless."""
+    if _requires_helm():
+        return
+
+    def chart(root: pathlib.Path, volume_name: str) -> None:
+        templates = root / "bad-chart" / "templates"
+        templates.mkdir(parents=True)
+        (root / "bad-chart" / "Chart.yaml").write_text(
+            "apiVersion: v2\nname: bad-chart\nversion: 0.0.0\n"
+        )
+        (root / "bad-chart" / "values.yaml").write_text("persistence:\n  enabled: false\n")
+        (templates / "deployment.yaml").write_text(
+            f"""\
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bad
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          volumeMounts:
+            - name: {volume_name}
+              mountPath: /data
+      volumes:
+        - name: {volume_name}
+          {{{{- if .Values.persistence.enabled }}}}
+          persistentVolumeClaim:
+            claimName: c
+          {{{{- else }}}}
+          emptyDir: {{}}
+          {{{{- end }}}}
+"""
+        )
+
+    stable = tmp_path / "stable"
+    chart(stable, "storage")
+    keyed = tmp_path / "keyed"
+    chart(keyed, '{{ if .Values.persistence.enabled }}storage{{ else }}storage-ephemeral{{ end }}')
+
+    states = [
+        cvk.State("on", {"persistence": {"enabled": True}}),
+        cvk.State("off", {"persistence": {"enabled": False}}),
+    ]
+    cvk.STATES["bad-chart"] = states
+    try:
+        assert cvk.main(["--helm-dir", str(stable)]) == 1
+        assert cvk.main(["--helm-dir", str(keyed)]) == 0
+    finally:
+        del cvk.STATES["bad-chart"]
+        cvk.check_helm_pss.HELM_DIR = HELM_DIR
+
+
+if __name__ == "__main__":
+    import tempfile
+
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        if fn.__code__.co_argcount:
+            with tempfile.TemporaryDirectory() as d:
+                fn(pathlib.Path(d))
+        else:
+            fn()
+        print(f"ok  {fn.__name__}")
+    print(f"\n{len(fns)} checks passed")


### PR DESCRIPTION
## Summary

Four charts rendered a volume whose **type** changed under a **stable name**. Volumes merge by `name`, so under server-side apply — what Argo uses, and what every dogfood app is deployed with — a `persistentVolumeClaim` owned by one field manager and an `emptyDir` applied by another both survive the merge:

```
spec.template.spec.volumes[1].persistentVolumeClaim: Forbidden:
  may not specify more than 1 volume type
spec.template.spec.containers[0].volumeMounts[1].name: Not found: "storage"
```

Hit in the field on 3.3.2 → 3.4.0, where #1452 flipped tempo persistence off. The Deployment and its PVC stick `OutOfSync` and the core release fails to sync. **Bidirectional** — re-enabling persistence wedges the same way in reverse, which is the recommended config for any cluster wanting trace history to outlive a restart.

The fix makes the type part of the name, so a toggle is a *key* change and a dual-type volume is not representable:

| Chart | persistence on | persistence off |
|---|---|---|
| `mcp-mesh-tempo` | `storage` | `storage-ephemeral` |
| `mcp-mesh-grafana` | `storage` | `storage-ephemeral` |
| `mcp-mesh-registry` | `data` | `data-ephemeral` |
| `mcp-mesh-redis` | `redis-data` | `redis-data-ephemeral` |

The persistent branch keeps its historical name, so installs that never disabled persistence render **byte-identically**. Each chart gets a named template rather than an inline conditional — the volume and its `volumeMount` sit in different parts of a 400-line file, and them drifting apart produces a *new* invalid Deployment. A helper makes that unrepresentable.

## The issue said three charts; it's four

`mcp-mesh-redis` has the identical defect. I missed it by grepping for `persistentVolumeClaim` rather than rendering every chart.

Verified clean by render, not by reading: **`mcp-mesh-agent`** (volume and mount both inside the conditional with no `else` — add/remove, not type-swap) and **`mcp-mesh-postgres`** (`volumeClaimTemplate` on a StatefulSet, never a pod volume). `mcp-mesh-ui`, `mcp-mesh-ingress`, `mcp-mesh-core` have no conditional volumes.

## Why this needed a new guard

Neither `check_helm_pss.py` nor `check_helm_render_matrix.py` can express a manifest-shape assertion — both assert about a **single** render, while this was a defect **between two renders**. That is why the class got in, and why the fix would otherwise ship unpinned: someone collapses the conditional name back and nothing notices.

`scripts/check_helm_volume_keys.py` asserts three properties across every chart × every persistence state:

1. no volume name appears in two states with a *different type* — the direct statement of "a type change must be a key change";
2. every `volumeMount` resolves to a volume of that name — catches the drift trap this fix can introduce;
3. no volume declares more than one type.

**Proven red, not assumed.** A `--helm-dir` flag exists specifically so this stays demonstrable: **4/9 charts against `HEAD`**, all four affected ones red plus the umbrella, agent and postgres green. **9/9 after.**

**Registry needs its sqlite dimension to bite at all.** Both its collisions involve `sqlite, persistence off`; with postgres alone, persistence-off renders no data volume, so there is nothing to collide and the check would have been a **false green** with the defect still present. A dedicated test pins that second dimension so it cannot be trimmed later.

Two design notes: StatefulSet `volumeClaimTemplates` participate as a pseudo-type, since they are named storage a mount resolves against (this is why postgres is *covered and passing* rather than excluded). And a malformed volume enters the index as `<N types>` rather than being dropped — dropping it would make assertion 1 go quiet on precisely the worst render.

The docstring states what it cannot see — field-manager ownership — and says explicitly not to read a green run as closing the SSA-upgrade question.

## Test plan

- [x] `pytest scripts/` — **106 passed** (was 85; +21 new)
- [x] New guard: 9/9 post-fix, **4/9 against HEAD**
- [x] Every assertion proven to fire *and* not to over-fire — the fix shape and the agent add/remove shape must not be flagged, or the check would demand a rename nobody needs
- [x] All state *pairs* compared, not adjacent ones — the registry collision is between non-adjacent states
- [x] End-to-end test builds a chart with the #1461 shape (expects exit 1), rebuilds with the fix (expects 0), so a wiring mistake can't leave every unit assertion true and the script useless
- [x] Persistence-enabled renders byte-identical to HEAD for all four charts; umbrella default render differs by exactly 4 lines — two matched mount/volume pairs
- [x] `check_helm_pss.py` 9/9, `check_helm_render_matrix.py` 34/34, `helm lint` 9 charts 0 failed
- [ ] CI green

## One CI change worth a look

`scripts-test` installs `pytest pyyaml==6.0.3` now, not just `pytest`. That job was stdlib-only, and pytest imports every test module at collection — so a PyYAML-dependent test would have failed the **entire** `scripts/` suite at collection, not just the new file. Verified with a stripped PATH: 19 passed, 2 skipped, the pure-logic tests running for real in a helm-less job with only the two end-to-end cases skipping (covered for real in `helm-charts`).

## For the release notes

The hop onto these charts renames the ephemeral volume, which is a clean remove+add **provided the applying manager owns the existing item**. Anyone currently wedged in the invalid dual-type state should apply the delete-and-recreate recovery **before** upgrading, or ownership is ambiguous and the rename itself can stick.

Closes #1461


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Helm deployments for Grafana, Redis, Registry, and Tempo when switching between persistent and ephemeral storage.
  - Ensured storage volume mounts remain correctly matched to their configured volumes across persistence modes.

- **Tests**
  - Added automated validation for Helm volume definitions, mounts, persistence configurations, duplicate names, and storage type conflicts.
  - Expanded CI checks to catch invalid volume configurations before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->