### PR TITLE
fix(helm)!: default namespaceCreate to false

### DIFF
--- a/docs/00-why-mcp-mesh/index.md
+++ b/docs/00-why-mcp-mesh/index.md
@@ -121,8 +121,7 @@ meshctl scaffold --compose --observability
 
 # Or deploy to Kubernetes (OCI registry)
 helm install my-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.4.0 -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false
+  --version 3.4.0 -n mcp-mesh --create-namespace
 ```
 
 ### 5. Built-in Observability

--- a/docs/04-kubernetes-basics.md
+++ b/docs/04-kubernetes-basics.md
@@ -19,18 +19,18 @@ The `mcp-mesh-core` chart deploys registry + PostgreSQL + Redis + Grafana + Temp
 # Deploy core (OCI registry - no "helm repo add" needed)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
-  -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false
+  -n mcp-mesh --create-namespace
 
 # Wait for registry
 kubectl wait --for=condition=available deployment/mcp-core-mcp-mesh-registry \
   -n mcp-mesh --timeout=120s
 ```
 
-`--create-namespace` creates the namespace; `--set namespaceCreate=false` stops
-the chart from also rendering one, which would collide with it. Both are
-required — see [Namespace handling](https://github.com/dhyansraj/mcp-mesh/blob/main/helm/mcp-mesh-core/README.md#namespace-handling)
-for why, and for what applies to a release that already exists.
+`--create-namespace` is what creates the namespace. The chart deliberately
+renders no `Namespace` of its own — one would collide with it — so nothing
+else is needed here. See [Namespace handling](https://github.com/dhyansraj/mcp-mesh/blob/main/helm/mcp-mesh-core/README.md#namespace-handling)
+for why, and for the upgrade order that applies to a release installed with
+chart 3.4.x or earlier.
 
 ### 2. Build Your Agent Image
 
@@ -143,7 +143,6 @@ resources:
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
   -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 ```
@@ -166,8 +165,7 @@ namespace — change `-n` and nothing else:
 # Deploy core to a custom namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
-  -n my-namespace --create-namespace \
-  --set namespaceCreate=false
+  -n my-namespace --create-namespace
 
 # Deploy agent to the same namespace
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
@@ -185,12 +183,12 @@ For **multi-tenant** clusters (separate core per team), deploy each core to its 
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
-  -n team-a --create-namespace --set namespaceCreate=false
+  -n team-a --create-namespace
 
 # Team B — same values, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
-  -n team-b --create-namespace --set namespaceCreate=false
+  -n team-b --create-namespace
 ```
 
 For **cross-namespace** access (agent in one namespace, core in another), use FQDNs:

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -19,7 +19,6 @@ The published `mcpmesh/ui` image serves at `/ops/dashboard` by default. Enable i
 ```bash
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false \
   --set ui.enabled=true
 ```
 

--- a/docs/dev-to-production.md
+++ b/docs/dev-to-production.md
@@ -85,8 +85,7 @@ The [TSuite](https://github.com/dhyansraj/mcp-mesh-test-suite) integration testi
 
     ```bash
     helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-      --version 3.4.0 -n mcp-mesh --create-namespace \
-      --set namespaceCreate=false
+      --version 3.4.0 -n mcp-mesh --create-namespace
 
     helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
       --version 3.4.0 -n mcp-mesh -f helm-values.yaml

--- a/docs/index.md
+++ b/docs/index.md
@@ -395,7 +395,7 @@ A `kubectl`-style command-line tool that follows you from first agent to product
 
     ```bash
     helm install mcp-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-      -n mcp-mesh --create-namespace --set namespaceCreate=false
+      -n mcp-mesh --create-namespace
     ```
 
     Kubernetes deployment with the umbrella chart.

--- a/docs/python/getting-started/prerequisites.md
+++ b/docs/python/getting-started/prerequisites.md
@@ -146,8 +146,7 @@ Available from OCI registry (no `helm repo add` needed):
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
-  -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false
+  -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \

--- a/docs/tutorial/day-09-kubernetes.md
+++ b/docs/tutorial/day-09-kubernetes.md
@@ -218,9 +218,9 @@ $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
     --wait --timeout 5m
 ```
 
-`values-core.yaml` sets `namespaceCreate: false`, which is what lets the chart
-install into the namespace `kubectl` created in Part 2. Without it the install
-fails with `invalid ownership metadata`.
+The chart renders no `Namespace` of its own, which is what lets it install into
+the namespace `kubectl` created in Part 2 — a chart-templated `Namespace` would
+collide with it and fail with `invalid ownership metadata`.
 
 Wait for the registry to become available:
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -10,6 +10,29 @@ job safety for upgrading a mesh that is already serving traffic. For local
 development you can restart freely; this page is about upgrading a running
 deployment without dropping in-flight work.
 
+!!! danger "Upgrade order for the Helm charts: 3.3.x → 3.4.x → 3.5.0"
+
+    **Do not upgrade the `mcp-mesh-core` chart from 3.3.x straight to 3.5.0.**
+    Chart 3.5.0 changes `namespaceCreate` to default `false`, which drops the
+    release's `Namespace` object from the rendered manifest — and Helm
+    *deletes* a resource that leaves the manifest, cascading to every agent,
+    Service, Secret and PVC in the namespace. What makes that removal safe is
+    `helm.sh/resource-policy: keep` on the live `Namespace`, and chart 3.4.0
+    is the first version that puts it there.
+
+    - **On chart 3.4.x already:** nothing to do — the annotation is on the
+      live namespace, so 3.5.0 removes the object without deleting anything.
+    - **On chart 3.3.x or older:** upgrade to the latest 3.4.x first, verify
+      with `kubectl get ns <ns> -o jsonpath='{.metadata.annotations}'`, then
+      upgrade to 3.5.0. To jump in one step instead, pin
+      `--set namespaceCreate=true` for that upgrade, verify the annotation,
+      and drop the pin on a second upgrade.
+
+    `--reuse-values` does **not** protect you: it replays the values you
+    supplied, and a release that simply took the old default has nothing to
+    replay. Details in
+    [Namespace handling](https://github.com/dhyansraj/mcp-mesh/blob/main/helm/mcp-mesh-core/README.md#existing-releases-upgrading-past-the-default-flip).
+
 !!! warning "Source migration required for 3.4.0 (Java and TypeScript)"
 
     3.4.0 aligns every dependency-injection site on positional binding. Java
@@ -197,35 +220,35 @@ helm get values <release>
   provisions a new, empty claim rather than recovering the reclaimed one. This
   is the deliberate opposite of Grafana's treatment above — Grafana's volume
   holds state you authored and nothing can replay.
-- **The core release owns its `Namespace`** (`namespaceCreate`, default
-  `true`). Older charts let `helm uninstall` delete that namespace and cascade
-  to every co-located agent, Secret, and PVC. Upgrading fixes this with no
-  action on your part: the `Namespace` picks up a
-  `"helm.sh/resource-policy": keep` annotation, so Helm skips it on uninstall
-  and the deletion cannot cascade to co-located agents, Secrets, and PVCs.
-  `helm uninstall` still removes the release's own resources — registry,
-  PostgreSQL, Redis, and any observability components.
-- **`helm.sh/resource-policy` is reserved in `commonAnnotations`.** The chart's
-  `keep` on the `Namespace` is what keeps that cascade from happening and a
-  `commonAnnotations` value would override it on last-wins, so the chart fails
+- **The core chart no longer renders a `Namespace`.** `namespaceCreate` now
+  defaults to `false`: `helm install --create-namespace`, `kubectl create
+  namespace`, or Argo CD's `CreateNamespace=true` creates the namespace, and
+  the release does not own it. The old default could not be installed at all
+  on Helm 3, or against any pre-created namespace on any client — Helm writes
+  the release secret into the `-n` namespace before applying the manifest, so
+  a chart-templated `Namespace` can only re-declare a namespace that already
+  exists, which Helm's ownership check rejects. **Read the upgrade-order
+  warning at the top of this page before upgrading an existing release**, and
+  see
+  [Namespace handling](https://github.com/dhyansraj/mcp-mesh/blob/main/helm/mcp-mesh-core/README.md#namespace-handling)
+  for the `--take-ownership` path if you want the release to own its namespace
+  deliberately.
+- **`helm.sh/resource-policy` is reserved in `commonAnnotations`.** When the
+  chart does render a `Namespace`, its `keep` is the only thing standing
+  between `helm uninstall` and everything in that namespace, and a
+  `commonAnnotations` value would override it on last-wins. So the chart fails
   the render when the key is set to anything but `keep` — remove it from
-  `commonAnnotations`, or set it to `keep`, before upgrading.
-- **Do not set `namespaceCreate=false` on an existing release as part of this
-  upgrade.** New installs should set it (the chart cannot create the namespace
-  it installs into — see
-  [Namespace handling](https://github.com/dhyansraj/mcp-mesh/blob/main/helm/mcp-mesh-core/README.md#namespace-handling)),
-  but on a release that already has it enabled the namespace is already in the
-  release manifest, so dropping it from the rendered output makes the very next
-  `helm upgrade` delete the namespace and everything in it — reporting
-  `STATUS: deployed` and exit 0 while doing so. When `global.namespace` matches
-  the namespace passed to `-n`, the change is also unrecoverable: Helm keeps
-  the release secret in the `-n` namespace, which is the one being deleted. A
-  retry while the namespace drains fails with `... is forbidden: ... because it
-  is being terminated`, and once it is gone `helm history` reports
-  `release: not found`.
-  The `keep` annotation above is what makes the flip safe, and Helm reads that
-  policy off the manifest of the revision being replaced — so if you want it,
-  do it as a *second*, separate upgrade, once this one has landed and
-  `kubectl get ns <ns> -o jsonpath='{.metadata.annotations}'` shows
-  `helm.sh/resource-policy: keep`. There is no need to rush it: with the
-  annotation in place, leaving `namespaceCreate` enabled is harmless.
+  `commonAnnotations`, or set it to `keep`, before upgrading. This check runs
+  whether or not `namespaceCreate` is on.
+- **What the namespace deletion actually looks like, if you skip the ordering
+  above.** The upgrade reports `STATUS: deployed` and exit 0 while deleting the
+  namespace and everything in it. When `global.namespace` matches the namespace
+  passed to `-n`, it is also unrecoverable: Helm keeps the release secret in
+  the `-n` namespace, which is the one being deleted. A retry while the
+  namespace drains fails with `... is forbidden: ... because it is being
+  terminated`, and once it is gone `helm history` reports `release: not found`.
+  Helm reads `helm.sh/resource-policy` off the **live** object, which is why
+  the annotation has to have landed on a previous upgrade — the chart cannot
+  check for it at render time, because `lookup` returns nothing under
+  `helm template`, the way Argo CD and every other GitOps renderer evaluates
+  it.

--- a/examples/k8s/tls/README.md
+++ b/examples/k8s/tls/README.md
@@ -51,7 +51,6 @@ kubectl get secret mcp-mesh-ca-secret -n mcp-mesh --show-labels
 
 # Install MCP Mesh core with TLS enabled
 helm install mcp-core helm/mcp-mesh-core -n mcp-mesh \
-  --set namespaceCreate=false \
   -f helm-values-tls.yaml
 
 # Install an agent with TLS
@@ -132,7 +131,6 @@ kubectl label secret mcp-mesh-ca-secret -n mcp-mesh \
 
 # Install with TLS values
 helm install mcp-core helm/mcp-mesh-core -n mcp-mesh \
-  --set namespaceCreate=false \
   -f helm-values-tls.yaml
 
 helm install my-agent helm/mcp-mesh-agent -n mcp-mesh \

--- a/examples/k8s/tls/helm-values-tls.yaml
+++ b/examples/k8s/tls/helm-values-tls.yaml
@@ -8,12 +8,12 @@
 # and mcp-mesh-agent charts. Each chart ignores keys it does not recognize,
 # so it is safe to pass the same file to both:
 #
-#   helm install mcp-core helm/mcp-mesh-core  -n mcp-mesh \
-#     --set namespaceCreate=false -f helm-values-tls.yaml
+#   helm install mcp-core helm/mcp-mesh-core  -n mcp-mesh -f helm-values-tls.yaml
 #   helm install my-agent helm/mcp-mesh-agent -n mcp-mesh -f helm-values-tls.yaml
 #
-# The core install needs --set namespaceCreate=false because the namespace was
-# created out of band above; see "Namespace handling" in the core chart README.
+# Neither install creates the namespace: it was created out of band above, and
+# the core chart renders no Namespace of its own — see "Namespace handling" in
+# the core chart README.
 #
 # Secret mapping (cert-manager Certificate -> K8s Secret -> Helm value):
 #

--- a/examples/tutorial/trip-planner/day-09/helm/values-core.yaml
+++ b/examples/tutorial/trip-planner/day-09/helm/values-core.yaml
@@ -6,9 +6,8 @@
 #   helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
 #     --version 3.4.0 -n trip-planner --create-namespace -f values-core.yaml
 
-# install.sh creates the namespace with kubectl, so the chart must not render
-# one of its own — see "Namespace handling" in the mcp-mesh-core chart README.
-namespaceCreate: false
+# install.sh creates the namespace with kubectl; the chart renders no Namespace
+# of its own — see "Namespace handling" in the mcp-mesh-core chart README.
 
 # All components enabled
 postgres:

--- a/examples/tutorial/trip-planner/day-10/helm/values-core.yaml
+++ b/examples/tutorial/trip-planner/day-10/helm/values-core.yaml
@@ -6,9 +6,8 @@
 #   helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
 #     --version 3.4.0 -n trip-planner --create-namespace -f values-core.yaml
 
-# install.sh creates the namespace with kubectl, so the chart must not render
-# one of its own — see "Namespace handling" in the mcp-mesh-core chart README.
-namespaceCreate: false
+# install.sh creates the namespace with kubectl; the chart renders no Namespace
+# of its own — see "Namespace handling" in the mcp-mesh-core chart README.
 
 # All components enabled
 postgres:

--- a/examples/tutorial/trip-planner/final_product/k8s/helm/values-core.yaml
+++ b/examples/tutorial/trip-planner/final_product/k8s/helm/values-core.yaml
@@ -5,9 +5,8 @@
 #   helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
 #     --version 3.4.0 -n trip-planner --create-namespace -f values-core.yaml
 
-# install.sh creates the namespace with kubectl, so the chart must not render
-# one of its own — see "Namespace handling" in the mcp-mesh-core chart README.
-namespaceCreate: false
+# install.sh creates the namespace with kubectl; the chart renders no Namespace
+# of its own — see "Namespace handling" in the mcp-mesh-core chart README.
 
 # All components enabled
 postgres:

--- a/helm/README.md
+++ b/helm/README.md
@@ -45,11 +45,12 @@ mkdir -p helm/mcp-mesh-grafana/files/dashboards
 cp observability/grafana/dashboards/*.json helm/mcp-mesh-grafana/files/dashboards/
 
 # 1. Install core infrastructure (registry + observability)
-#    --set namespaceCreate=false is required: see "Namespace handling" in
-#    mcp-mesh-core/README.md
+#    --create-namespace is what creates the namespace; the chart renders no
+#    Namespace object of its own. See "Namespace handling" in
+#    mcp-mesh-core/README.md — including the upgrade order for a release
+#    installed with chart 3.4.x or earlier.
 helm dependency update helm/mcp-mesh-core
-helm install mcp-core helm/mcp-mesh-core -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false
+helm install mcp-core helm/mcp-mesh-core -n mcp-mesh --create-namespace
 
 # 2. Install agents (repeat for each agent)
 helm install hello-world helm/mcp-mesh-agent -n mcp-mesh \
@@ -75,13 +76,11 @@ helm install mcp-ingress helm/mcp-mesh-ingress -n mcp-mesh
 ```bash
 # Core without observability
 helm install mcp-core helm/mcp-mesh-core -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 
 # Core without PostgreSQL (in-memory registry)
 helm install mcp-core helm/mcp-mesh-core -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false \
   --set postgres.enabled=false
 ```
 

--- a/helm/mcp-mesh-core/README.md
+++ b/helm/mcp-mesh-core/README.md
@@ -22,13 +22,11 @@ This umbrella chart deploys the core MCP Mesh infrastructure components:
 ```bash
 # Install core infrastructure
 helm install mcp-core ./mcp-mesh-core \
-  -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false
+  -n mcp-mesh --create-namespace
 
 # Or with custom values
 helm install mcp-core ./mcp-mesh-core \
   -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false \
   -f my-values.yaml
 ```
 
@@ -36,8 +34,8 @@ Deploy into any namespace by changing `-n`. Nothing else needs to change:
 every component lands in the release namespace, and short service names
 resolve within it.
 
-`--set namespaceCreate=false` is not optional decoration — without it the
-install fails on Helm 3 and on any pre-created namespace. See
+`--create-namespace` is what creates the namespace; the chart does not, and
+must not, render one for the namespace its own release installs into. See
 [Namespace handling](#namespace-handling) for why, for how to adopt a namespace
 that already exists, and for what applies to a release that already exists.
 
@@ -68,7 +66,7 @@ for the namespace a release installs into:
 | Mechanism                                                              | What it does                                                                                                                              |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `helm install --create-namespace` (Argo CD: `syncOptions: CreateNamespace=true`) | Creates the `-n` namespace as a plain object that no release owns, before the manifest is applied.                                        |
-| `namespaceCreate` (chart value, default `true`)                        | Renders a `Namespace` object **named `global.namespace`, not the release namespace** into the release manifest. Nothing else reads `global.namespace`. |
+| `namespaceCreate` (chart value, default `false`)                       | Renders a `Namespace` object **named `global.namespace`, not the release namespace** into the release manifest. Nothing else reads `global.namespace`. |
 
 Helm writes the release secret into the `-n` namespace *before* it applies the
 rendered manifest, so a chart-templated `Namespace` can never create the
@@ -77,31 +75,39 @@ already exists — and re-declaring an object the release does not own is exactl
 what Helm's ownership check rejects. Measured against a live cluster with the
 full chart:
 
-| Install shape                                                        | Helm 3.19.0                              | Helm 4.0.1                       |
+| Install shape (with `namespaceCreate` as marked)                     | Helm 3.19.0                              | Helm 4.0.1                       |
 | ---------------------------------------------------------------------- | ------------------------------------------ | ---------------------------------- |
-| `-n <new-ns>`, no `--create-namespace`                               | fails: `namespaces "<ns>" not found`     | fails the same way               |
-| `-n <ns> --create-namespace`                                         | fails: `namespaces "<ns>" already exists` | works — Helm 4 adopts the object |
-| `kubectl create namespace` first, then install                       | fails: `invalid ownership metadata`      | fails the same way               |
-| `-n <ns> --create-namespace --set namespaceCreate=false`             | **works**                                | **works**                        |
-| `kubectl create namespace` first, `--set namespaceCreate=false`      | **works**                                | **works**                        |
-| `kubectl create namespace` first, `--take-ownership`                 | works                                    | works                            |
+| `-n <new-ns>`, no `--create-namespace`, `namespaceCreate=true`       | fails: `namespaces "<ns>" not found`     | fails the same way               |
+| `-n <ns> --create-namespace`, `namespaceCreate=true`                 | fails: `namespaces "<ns>" already exists` | works — Helm 4 adopts the object |
+| `kubectl create namespace` first, `namespaceCreate=true`             | fails: `invalid ownership metadata`      | fails the same way               |
+| `-n <ns> --create-namespace` (**default**)                           | **works**                                | **works**                        |
+| `kubectl create namespace` first, then install (**default**)         | **works**                                | **works**                        |
+| `kubectl create namespace` first, `namespaceCreate=true --take-ownership` | works                               | works                            |
 
-Hence the recipe in "Installation": **new installs set `namespaceCreate=false`**
-and let `--create-namespace` (or `kubectl create namespace`, or Argo CD) create
-the namespace. With `namespaceCreate=false`, `global.namespace` is inert and can
-be left alone — there is no second name to keep in sync, and no stray namespace
-to create by getting it wrong.
+Hence the default and the recipe in "Installation": **the chart renders no
+`Namespace`**, and `--create-namespace` (or `kubectl create namespace`, or Argo
+CD) creates it. `global.namespace` is then inert and can be left alone — there
+is no second name to keep in sync, and no stray namespace to create by getting
+it wrong.
+
+`namespaceCreate` defaulted to `true` through chart 3.4.x, so an existing
+release very likely has a `Namespace` in its manifest even though nobody asked
+for one. Read
+[Existing releases](#existing-releases-upgrading-past-the-default-flip) before
+upgrading such a release — the flip is not automatically safe.
 
 ### Adopting a namespace that already exists
 
 If you want the release to own its `Namespace` anyway — GitOps setups that
 render the namespace from the chart, for instance — create the namespace first
-and install with `--take-ownership` (Helm 3.17+ and Helm 4):
+and install with `namespaceCreate` on plus `--take-ownership` (Helm 3.17+ and
+Helm 4):
 
 ```bash
 kubectl create namespace mcp-mesh
 helm install mcp-core ./mcp-mesh-core \
-  -n mcp-mesh --set global.namespace=mcp-mesh --take-ownership
+  -n mcp-mesh --set namespaceCreate=true --set global.namespace=mcp-mesh \
+  --take-ownership
 ```
 
 Helm stamps its ownership metadata plus `helm.sh/resource-policy: keep` onto the
@@ -110,43 +116,80 @@ existing namespace. `global.namespace` must match `-n`, or the release owns a
 when that happens. `--take-ownership` applies to every object in the manifest,
 not just the namespace, so use it deliberately.
 
-### Existing releases: do not flip `namespaceCreate` on its own
+### Existing releases: upgrading past the default flip
 
-The `Namespace` is already recorded in the release manifest. Dropping it from
-the rendered output makes the next `helm upgrade` **delete the namespace and
-everything in it** — agents, Secrets, PVCs the chart never created — while
-reporting `STATUS: deployed` and exit `0`. When `global.namespace` matches `-n`,
-that is also unrecoverable: the release secret lives in the namespace being
+**Upgrade `3.3.x` → `3.4.x` → `3.5.0`. Do not go from `3.3.x` straight to
+`3.5.0`.**
+
+`namespaceCreate` defaulted to `true` up to and including chart 3.4.x, so such
+a release has a `Namespace` recorded in its manifest. Chart 3.5.0 defaults it
+to `false`, which drops that object from the rendered output — and dropping a
+`Namespace` from the manifest makes `helm upgrade` **delete the namespace and
+everything in it**: agents, Secrets, PVCs the chart never created. It reports
+`STATUS: deployed` and exit `0` while doing so. When `global.namespace` matches
+`-n`, it is also unrecoverable: the release secret lives in the namespace being
 deleted. While the namespace drains, a retried `helm upgrade --install` fails
 with `secrets "sh.helm.release.v1.<release>.vN" is forbidden: ... because it is
 being terminated`; once it is gone, so is the release history, and
 `helm history` reports `release: not found`.
 
-From chart 3.4.0 the rendered `Namespace` carries `helm.sh/resource-policy:
-keep`, and Helm reads that policy from the manifest of the revision it is
-replacing. So the flip becomes safe only once the release's *current* revision
-was rendered by 3.4.0 or later — two separate upgrades:
+`--reuse-values` does not protect you. It replays the values *you* supplied, so
+a release that simply took the old default carries nothing to replay and picks
+up the new one.
+
+What makes the removal safe is `helm.sh/resource-policy: keep` on the
+`Namespace`. Helm reads that policy off the **live** object, and chart 3.4.0 is
+the first version that puts it there — a plain `helm upgrade` to 3.4.x applies
+it with no values change. So:
+
+- **Currently on 3.4.x** — nothing to do. The live namespace already carries
+  `keep`, and upgrading to 3.5.0 removes the object from the manifest without
+  deleting anything.
+- **Currently on 3.3.x or older** — upgrade to the latest 3.4.x first, confirm
+  the annotation landed, then upgrade to 3.5.0.
 
 ```bash
-# 1. Upgrade to >= 3.4.0, leaving namespaceCreate alone.
-helm upgrade mcp-core ./mcp-mesh-core -n mcp-mesh --reuse-values
+# 1. Land the keep annotation (latest 3.4.x, no values change).
+helm upgrade mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+  -n mcp-mesh --version '~3.4.0' --reuse-values
 
-# Confirm the live namespace picked up the policy before going further.
+# 2. Confirm it is on the LIVE namespace before going further.
 kubectl get ns mcp-mesh -o jsonpath='{.metadata.annotations}'
 #   {"helm.sh/resource-policy":"keep","meta.helm.sh/release-name":...}
 
-# 2. Only then, and only if you want it, drop the Namespace from the release.
-helm upgrade mcp-core ./mcp-mesh-core -n mcp-mesh --reuse-values \
-  --set namespaceCreate=false
+# 3. Now 3.5.0 can drop the Namespace from the manifest safely.
+helm upgrade mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+  -n mcp-mesh --reuse-values
 ```
 
-There is no hurry to do step 2. Once `keep` is on the namespace, leaving
-`namespaceCreate: true` is harmless — `helm uninstall` no longer deletes it (see
-"Uninstall").
+If you must go to 3.5.0 in one step, pin the old default for that upgrade and
+split it into the same two moves:
+
+```bash
+# keeps the Namespace in the manifest, which is what applies `keep` to it
+helm upgrade mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+  -n mcp-mesh --reuse-values --set namespaceCreate=true
+kubectl get ns mcp-mesh -o jsonpath='{.metadata.annotations}'
+helm upgrade mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+  -n mcp-mesh --reuse-values
+```
+
+There is no hurry to do the second step at all. Once `keep` is on the
+namespace, leaving `namespaceCreate=true` pinned is harmless —
+`helm uninstall` no longer deletes it (see "Uninstall").
+
+The chart cannot detect this situation and stop you. Telling the two cases
+apart needs to read the live namespace, and `lookup` returns nothing under
+`helm template` — which is how Argo CD and every other GitOps renderer
+evaluates the chart, and those are the pipelines that prune without a human
+watching.
 
 ### Recovering from a failed `--create-namespace` install
 
-On Helm 3, `-n <ns> --create-namespace` with `namespaceCreate: true` fails
+This applies to installs that turned `namespaceCreate` on, and to any install
+from chart 3.4.x or earlier, where it defaulted on.
+
+On Helm 3, `-n <ns> --create-namespace` with `namespaceCreate` enabled fails
 **non-atomically**. Helm creates the namespace, then the manifest's `Namespace`
 collides with it — but the rest of the manifest has already been applied.
 Deployments, the StatefulSet, PVCs, and Secrets are all live and running under a
@@ -157,15 +200,14 @@ Error: INSTALLATION FAILED: 1 error occurred:
 	* namespaces "<ns>" already exists
 ```
 
-Do **not** try to fix this with `helm upgrade --set namespaceCreate=false`. That
-reports `STATUS: deployed` and then deletes the namespace it just deployed into,
-cascading the release secret with it. Uninstall the wreckage and reinstall with
-the recipe from "Installation":
+Do **not** try to fix this by turning `namespaceCreate` back off with
+`helm upgrade`. That reports `STATUS: deployed` and then deletes the namespace
+it just deployed into, cascading the release secret with it. Uninstall the
+wreckage and reinstall with the recipe from "Installation":
 
 ```bash
 helm uninstall mcp-core -n mcp-mesh
-helm install mcp-core ./mcp-mesh-core \
-  -n mcp-mesh --set namespaceCreate=false
+helm install mcp-core ./mcp-mesh-core -n mcp-mesh
 ```
 
 The uninstall keeps the namespace (`resource-policy: keep`), so the reinstall
@@ -461,7 +503,7 @@ global:
 
 ```bash
 helm install mcp-core ./mcp-mesh-core \
-  -n mcp-mesh --create-namespace --set namespaceCreate=false \
+  -n mcp-mesh --create-namespace \
   -f values.yaml
 ```
 
@@ -568,9 +610,10 @@ single-writer local file.
 
 The core infrastructure follows this deployment pattern:
 
-1. **Namespace** - Creates `global.namespace` (default `mcp-mesh`) when
-   `namespaceCreate` is enabled — which new installs should not do, see
-   [Namespace handling](#namespace-handling)
+1. **Namespace** - Not created by the chart. `--create-namespace` (or
+   `kubectl create namespace`, or Argo CD) creates it; `namespaceCreate`
+   renders `global.namespace` as a release-owned object only if you turn it on,
+   see [Namespace handling](#namespace-handling)
 2. **PostgreSQL** - StatefulSet with persistent storage
 3. **Redis** - Deployment with emptyDir (cache-only)
 4. **Registry** - StatefulSet connected to PostgreSQL
@@ -735,7 +778,7 @@ deliberate:
 | `postgres-data-<release>-mcp-mesh-postgres-0` | yes (not release-owned) | Created by the StatefulSet's claim template, so Helm never had it to delete |
 | `<release>-mcp-mesh-postgres-credentials` | yes (`resource-policy: keep`) | Must keep matching the provisioned data directory |
 | `<release>-mcp-mesh-tempo-pvc` | **no** — and not rendered at all by default | A rolling trace buffer, not durable storage: `retention` (default `1h`) prunes it continuously, so what it holds is minutes old and already expiring. `mcp-mesh-tempo.tempo.persistence.enabled` defaults to `false`; opted back in, the claim is reclaimed on uninstall. See [Trace storage (Tempo)](#trace-storage-tempo) |
-| Namespace | yes (`resource-policy: keep`) | See [Namespace handling](#namespace-handling) |
+| Namespace | yes — and not rendered at all by default | Never release-owned unless `namespaceCreate` is on or `--take-ownership` was used, and then annotated `resource-policy: keep`. See [Namespace handling](#namespace-handling) |
 
 Reinstalling under the same release name adopts all of the kept objects, with
 their data. To reclaim the storage instead, delete the claims yourself — the
@@ -755,24 +798,25 @@ PostgreSQL's is a StatefulSet, so scale
 `statefulset/mcp-core-mcp-mesh-postgres` instead — its volume claim template
 recreates the PVC by itself on the next scale-up.)
 
-The namespace is left in place, whichever way it was created. A release
-installed with `namespaceCreate=false` never owned the namespace in the first
-place, so there is nothing for Helm to delete. A release that does own one —
-`namespaceCreate: true`, or `--take-ownership` — renders it with
-`"helm.sh/resource-policy": keep`, so from chart 3.4.0 onward Helm skips the
-object on uninstall and the delete cannot cascade to agents, Services, Secrets,
-and PVCs the chart never created. Releases installed with an older chart pick
-the annotation up automatically on `helm upgrade`; no other action is needed.
+The namespace is left in place, whichever way it was created. At the default
+the release never owned the namespace, so there is nothing for Helm to delete.
+A release that does own one — `namespaceCreate` turned on, or
+`--take-ownership` — renders it with `"helm.sh/resource-policy": keep`, so from
+chart 3.4.0 onward Helm skips the object on uninstall and the delete cannot
+cascade to agents, Services, Secrets, and PVCs the chart never created.
+Releases installed with an older chart pick the annotation up automatically on
+`helm upgrade`; no other action is needed.
 
-Do **not** try to get the same effect by setting `namespaceCreate=false` on an
-existing release — on its own that upgrade *deletes* the namespace. See
-[Existing releases](#existing-releases-do-not-flip-namespacecreate-on-its-own).
+Do **not** try to get the same effect by turning `namespaceCreate` off on an
+existing release that owns its namespace — on its own that upgrade *deletes*
+the namespace. See
+[Existing releases](#existing-releases-upgrading-past-the-default-flip).
 
 ## Values
 
 | Key                | Type   | Default      | Description                          |
 | ------------------ | ------ | ------------ | ------------------------------------ |
-| `global.namespace` | string | `"mcp-mesh"` | Name of the `Namespace` object rendered by `namespaceCreate`, and inert without it. Nothing else reads it — components always deploy to the release namespace (`-n`) |
+| `global.namespace` | string | `"mcp-mesh"` | Name of the `Namespace` object rendered by `namespaceCreate`, and inert without it — so inert by default. Nothing else reads it — components always deploy to the release namespace (`-n`) |
 | `global.imageRegistry` | string | `""` | Registry prefix applied to every image (repository paths preserved — see "Air-gapped / private registry installs"); per-component `image.registry` overrides win |
 | `global.imagePullSecrets` | list | `[]` | Pull secrets (`- name: ...`) added to every pod spec, merged with each chart's own `imagePullSecrets` and deduplicated by name |
 | `global.postgres.*` | object | bundled postgres | PostgreSQL endpoint/credentials inherited by all consumers (`host`, `port`, `name`, `username`, `password`, `sslmode`, `existingSecret`, `existingSecretUrlKey`, `existingSecretPasswordKey`, `tls.caSecret`, `tls.caKey`) |
@@ -785,7 +829,7 @@ existing release — on its own that upgrade *deletes* the namespace. See
 | `grafana.enabled`  | bool   | `true`       | Enable Grafana deployment            |
 | `tempo.enabled`    | bool   | `true`       | Enable Tempo deployment              |
 | `mcp-mesh-tempo.tempo.persistence.enabled` | bool | `false` | Give Tempo a `ReadWriteOnce` claim instead of an `emptyDir`. Off by default: the volume is a rolling buffer that `retention` prunes continuously. See [Trace storage (Tempo)](#trace-storage-tempo) |
-| `namespaceCreate`  | bool   | `true`       | Render `global.namespace` as a release-owned `Namespace`, annotated `"helm.sh/resource-policy": keep` so uninstall never deletes it. **Set `false` on new installs** — left `true`, the install fails on Helm 3 and on any pre-created namespace. Never flip it to `false` on an existing release in isolation. See [Namespace handling](#namespace-handling) |
+| `namespaceCreate`  | bool   | `false`      | Render `global.namespace` as a release-owned `Namespace`, annotated `"helm.sh/resource-policy": keep` so uninstall never deletes it. Off by default: turned on, the install fails on Helm 3 and against any pre-created namespace — the supported way to own the namespace is `--take-ownership`. Defaulted `true` through chart 3.4.x, so **upgrade 3.3.x → 3.4.x → 3.5.0** and never turn it off on an existing release in isolation. See [Namespace handling](#namespace-handling) |
 
 ## Service Discovery
 

--- a/helm/mcp-mesh-core/templates/namespace.yaml
+++ b/helm/mcp-mesh-core/templates/namespace.yaml
@@ -1,8 +1,11 @@
 {{- /* These are the SOLE invocations of both guards in the chart, and they
        must stay above the `if` so they run regardless of namespaceCreate.
-       Before deleting this file, or making it render nothing
-       unconditionally, move the includes to a template that always renders —
-       otherwise the guards silently stop firing. */ -}}
+       namespaceCreate defaults to false, so the `if` is closed on virtually
+       every install and this file's only output is the guards. Before
+       deleting it, or making it render nothing unconditionally, move the
+       includes to a template that always renders — otherwise the guards
+       silently stop firing. Covered by scripts/check_helm_render_matrix.py,
+       which pins namespaceCreate: false on a fail case for each. */ -}}
 {{- include "mcp-mesh-core.validateNoRemovedKeys" . -}}
 {{- include "mcp-mesh-core.validateNamespaceResourcePolicy" . -}}
 {{- if .Values.namespaceCreate }}

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -5,10 +5,10 @@
 global:
   # Name of the Namespace object rendered by namespaceCreate, and read by
   # nothing else: every component deploys to .Release.Namespace (the -n flag).
-  # With the recommended namespaceCreate: false this value is inert. It only
-  # matters when the release owns its Namespace (namespaceCreate: true or
-  # --take-ownership), and then it has to match -n — otherwise the release owns
-  # a stray namespace that nothing is deployed into.
+  # namespaceCreate is off by default, so this value is inert unless you turn
+  # it on. It only matters when the release owns its Namespace (namespaceCreate
+  # plus --take-ownership), and then it has to match -n — otherwise the release
+  # owns a stray namespace that nothing is deployed into.
   namespace: mcp-mesh
 
   # Private/air-gapped registry prefix applied to EVERY image in the stack:
@@ -356,24 +356,31 @@ mcp-mesh-ui:
 # Render global.namespace (above) as a release-owned Namespace object. Note
 # that is global.namespace, NOT the release namespace (-n).
 #
-# SET THIS TO false ON NEW INSTALLS. Helm writes the release secret into the -n
-# namespace before it applies the manifest, so a chart-templated Namespace can
-# never create the namespace its own release installs into — it can only
-# re-declare an existing one, which Helm's ownership check rejects. Left true,
-# the install fails on Helm 3 ("namespaces <ns> already exists") and, on any
-# client, against a pre-created namespace ("invalid ownership metadata"). Let
-# `helm install --create-namespace`, `kubectl create namespace`, or Argo CD's
-# CreateNamespace=true create the namespace instead; with namespaceCreate
-# false, global.namespace is inert.
+# OFF BY DEFAULT, and new installs should leave it off. Helm writes the release
+# secret into the -n namespace before it applies the manifest, so a
+# chart-templated Namespace can never create the namespace its own release
+# installs into — it can only re-declare an existing one, which Helm's
+# ownership check rejects. Turned on, the install fails on Helm 3 ("namespaces
+# <ns> already exists") and, on any client, against a pre-created namespace
+# ("invalid ownership metadata"). Let `helm install --create-namespace`,
+# `kubectl create namespace`, or Argo CD's CreateNamespace=true create the
+# namespace instead; off, global.namespace is inert.
 #
-# The default stays true because flipping it on an EXISTING release deletes the
-# namespace and everything in it: the Namespace is already in the release
-# manifest, and dropping it from the rendered output makes the next
-# `helm upgrade` garbage-collect it. The rendered Namespace carries
-# "helm.sh/resource-policy": keep, which makes `helm uninstall` skip it and
-# makes the flip safe — but only once the release's current revision came from
-# a chart that has the annotation. See "Namespace handling" in README.md.
-namespaceCreate: true
+# The one supported way to have the release own its Namespace is to create the
+# namespace first and install with --take-ownership (Helm 3.17+), which needs
+# this on and global.namespace equal to -n.
+#
+# UPGRADING FROM CHART < 3.4.0: turn this ON for that one upgrade
+# (`--set namespaceCreate=true`), or upgrade to a 3.4.x chart first. The
+# default used to be true, so the Namespace is in those releases' manifests;
+# dropping it from the rendered output makes `helm upgrade` delete the
+# namespace and everything in it, reporting STATUS: deployed while doing so.
+# What makes the flip safe is the "helm.sh/resource-policy": keep annotation
+# the rendered Namespace carries — Helm reads that policy off the LIVE object,
+# and 3.4.0 is the first chart that puts it there. A release whose current
+# revision came from 3.4.x already has it and needs nothing.
+# See "Namespace handling" in README.md.
+namespaceCreate: false
 
 # Common labels for all resources
 commonLabels:

--- a/helm/mcp-mesh-ingress/README.md
+++ b/helm/mcp-mesh-ingress/README.md
@@ -124,7 +124,7 @@ agents:
 ```bash
 # Deploy core infrastructure
 helm install mcp-core ./mcp-mesh-core \
-  -n mcp-mesh --create-namespace --set namespaceCreate=false
+  -n mcp-mesh --create-namespace
 
 # Deploy individual agents
 helm install hello-world ./mcp-mesh-agent --set agent.name=hello-world

--- a/scripts/check_helm_render_matrix.py
+++ b/scripts/check_helm_render_matrix.py
@@ -18,6 +18,15 @@ Each case declares the values that reach the guard and what must happen:
 The substring matters as much as the exit code. A guard rewritten to fire on
 the wrong condition still fails the render, just with someone else's message.
 
+A pass-path case may additionally pin which objects that render contains:
+
+  requires_kind="Namespace"  the render must contain an object of this kind
+  forbids_kind="Namespace"   it must not
+
+That is for values whose whole purpose is to add or remove a resource — an
+opt-in object silently becoming opt-out (or the reverse) is a behaviour change
+a non-empty render cannot detect.
+
 Usage: python3 scripts/check_helm_render_matrix.py  (run from anywhere)
 Exit code 0 = every case behaved as declared.
 """
@@ -52,6 +61,8 @@ class Case:
     values: dict
     expect_fail: str | None = None
     extra_args: tuple[str, ...] = field(default_factory=tuple)
+    requires_kind: str | None = None
+    forbids_kind: str | None = None
 
 
 CASES: list[Case] = [
@@ -66,6 +77,45 @@ CASES: list[Case] = [
         "mcp-mesh-core",
         "an explicit keep is a tolerated no-op",
         {"commonAnnotations": {"helm.sh/resource-policy": "keep"}},
+    ),
+    # Both guards live in namespace.yaml, above its `{{- if .Values.namespaceCreate }}`
+    # so they run whether or not the Namespace renders. namespaceCreate now
+    # defaults to false, which means that `if` is closed on virtually every
+    # install and the guards are the file's only output — pin the flag
+    # explicitly on one fail case each, so moving the includes below the `if`
+    # (or deleting the file once it renders nothing) is caught here rather
+    # than in the field.
+    Case(
+        "mcp-mesh-core",
+        "the resource-policy guard still fires with namespaceCreate off",
+        {
+            "namespaceCreate": False,
+            "commonAnnotations": {"helm.sh/resource-policy": "delete"},
+        },
+        expect_fail="blast radius",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "the removed-key guard still fires with namespaceCreate off",
+        {"namespaceCreate": False, "networkPolicies": {"enabled": True}},
+        expect_fail="networkPolicies.enabled was never consumed",
+    ),
+    # --- mcp-mesh-core: the Namespace object is opt-in --------------------
+    # A release that renders a Namespace it did not create cannot be installed
+    # (Helm's ownership check), and one that stops rendering a Namespace it did
+    # DELETES it, cascading to everything inside. Both directions are silent,
+    # so pin the default explicitly.
+    Case(
+        "mcp-mesh-core",
+        "no Namespace object at the shipped default",
+        {},
+        forbids_kind="Namespace",
+    ),
+    Case(
+        "mcp-mesh-core",
+        "...and one only when namespaceCreate is turned on",
+        {"namespaceCreate": True},
+        requires_kind="Namespace",
     ),
     # --- mcp-mesh-core: removed-key guards --------------------------------
     Case(
@@ -346,6 +396,14 @@ def run_case(case: Case, values_file: Path) -> str | None:
             return f"expected a clean render, helm template failed:\n{_indent(output)}"
         if not result.stdout.strip():
             return "expected a clean render, helm template produced no manifests"
+        kinds = _rendered_kinds(result.stdout)
+        if case.requires_kind and case.requires_kind not in kinds:
+            return f"the render contains no {case.requires_kind} object"
+        if case.forbids_kind and case.forbids_kind in kinds:
+            return (
+                f"the render contains a {case.forbids_kind} object, which "
+                "these values must not produce"
+            )
         return None
 
     if result.returncode == 0:
@@ -359,6 +417,14 @@ def run_case(case: Case, values_file: Path) -> str | None:
             f"guard (or a template error) fired:\n{_indent(output)}"
         )
     return None
+
+
+def _rendered_kinds(manifests: str) -> set[str]:
+    return {
+        doc["kind"]
+        for doc in yaml.safe_load_all(manifests)
+        if isinstance(doc, dict) and "kind" in doc
+    }
 
 
 def _indent(text: str) -> str:

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -156,8 +156,7 @@ For production Kubernetes deployment, use the official Helm charts from the MCP 
 # No "helm repo add" needed - uses OCI registry directly
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
-  -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false
+  -n mcp-mesh --create-namespace
 
 # Deploy agent using scaffold-generated helm-values.yaml
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
@@ -166,16 +165,28 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
   -f my-agent/helm-values.yaml
 ```
 
-`--create-namespace` creates the namespace, and `--set namespaceCreate=false`
-stops the core chart from rendering a second `Namespace` object that would
-collide with it. Both are required: Helm writes the release secret into the
-`-n` namespace before applying the manifest, so a chart-templated `Namespace`
-can never create the namespace its own release installs into. Left at the
-default, the install fails on Helm 3 (`namespaces "<ns>" already exists`) and,
-on any client, against a pre-created namespace (`invalid ownership metadata`).
+`--create-namespace` is what creates the namespace, and the core chart
+deliberately renders no `Namespace` object of its own — a second one would
+collide with it. Helm writes the release secret into the `-n` namespace before
+applying the manifest, so a chart-templated `Namespace` can never create the
+namespace its own release installs into: turn `namespaceCreate` on and the
+install fails on Helm 3 (`namespaces "<ns>" already exists`) and, on any
+client, against a pre-created namespace (`invalid ownership metadata`).
+
+**Upgrading an existing release: go `3.3.x` → `3.4.x` → `3.5.0`.**
+`namespaceCreate` defaulted to `true` through chart 3.4.x, so those releases
+carry a `Namespace` in their manifest, and 3.5.0 drops it. Removing a
+`Namespace` from a manifest *deletes* it — with every agent, Secret and PVC
+inside — unless the live object already carries
+`helm.sh/resource-policy: keep`, which chart 3.4.0 is the first to apply.
+`--reuse-values` does not protect you: a release that took the old default has
+nothing to replay and picks up the new one. To jump versions in one step, pin
+`--set namespaceCreate=true` for that upgrade, confirm the annotation with
+`kubectl get ns <ns> -o jsonpath='{.metadata.annotations}'`, then drop the pin
+on a second upgrade.
 
 Full detail, including how to adopt an existing namespace with
-`--take-ownership` and why an existing release must not flip the value:
+`--take-ownership`:
 https://github.com/dhyansraj/mcp-mesh/blob/main/helm/mcp-mesh-core/README.md#namespace-handling
 
 ### Custom Namespace
@@ -185,8 +196,7 @@ Deploy into any namespace — change `-n` and nothing else:
 ```bash
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
-  -n my-namespace --create-namespace \
-  --set namespaceCreate=false
+  -n my-namespace --create-namespace
 
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
   --version 3.4.0 \
@@ -209,7 +219,7 @@ its own namespace. Short service names resolve independently within each namespa
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
-  -n team-a --create-namespace --set namespaceCreate=false
+  -n team-a --create-namespace
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
   --version 3.4.0 -n team-a -f greeter/helm-values.yaml
@@ -217,7 +227,7 @@ helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 # Team B — same helm-values.yaml, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
-  -n team-b --create-namespace --set namespaceCreate=false
+  -n team-b --create-namespace
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
   --version 3.4.0 -n team-b -f greeter/helm-values.yaml
@@ -288,7 +298,6 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
   -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 
@@ -296,7 +305,6 @@ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
   -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false \
   --set postgres.enabled=false
 ```
 
@@ -421,7 +429,6 @@ The published `mcpmesh/ui` image serves at `/ops/dashboard` by default.
 ```bash
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false \
   --set ui.enabled=true
 ```
 
@@ -452,7 +459,6 @@ docker run -e MCP_MESH_UI_BASE_PATH=/my/custom/path mcpmesh/ui:3.4.0
 # Helm
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false \
   --set ui.enabled=true \
   --set mcp-mesh-ui.ui.basePath=/my/custom/path
 ```
@@ -466,7 +472,6 @@ For prerelease versions, override the image tag (floating major-minor tags only 
 ```bash
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false \
   --set ui.enabled=true \
   --set mcp-mesh-ui.image.tag=2.0.0-beta.3
 ```

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -203,11 +203,12 @@ For production Kubernetes deployment:
 
 ```bash
 # Install core infrastructure
-# --set namespaceCreate=false is required — run `meshctl man deployment`
+# --create-namespace creates the namespace; the chart renders none of its
+# own. Run `meshctl man deployment` for the namespace rules, including
+# the upgrade order for a release installed with chart 3.4.x or earlier.
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
-  -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false
+  -n mcp-mesh --create-namespace
 
 # Deploy Java agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -144,11 +144,12 @@ For production Kubernetes deployment:
 
 ```bash
 # Install core infrastructure
-# --set namespaceCreate=false is required — run `meshctl man deployment`
+# --create-namespace creates the namespace; the chart renders none of its
+# own. Run `meshctl man deployment` for the namespace rules, including
+# the upgrade order for a release installed with chart 3.4.x or earlier.
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
-  -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false
+  -n mcp-mesh --create-namespace
 
 # Deploy TypeScript agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -66,14 +66,12 @@ docker compose up -d
 # Install core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
-  -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false
+  -n mcp-mesh --create-namespace
 
 # Or disable observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
   -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false \
   --set tempo.enabled=false \
   --set grafana.enabled=false
 ```

--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -136,11 +136,12 @@ Available from OCI registry (no `helm repo add` needed):
 
 ```bash
 # Install core infrastructure
-# --set namespaceCreate=false is required — run `meshctl man deployment`
+# --create-namespace creates the namespace; the chart renders none of its
+# own. Run `meshctl man deployment` for the namespace rules, including
+# the upgrade order for a release installed with chart 3.4.x or earlier.
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
-  -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false
+  -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \

--- a/src/core/cli/man/content/registry.md
+++ b/src/core/cli/man/content/registry.md
@@ -204,7 +204,6 @@ The registry supports multiple replicas for high availability. All replicas shar
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
   --version 3.4.0 \
   -n mcp-mesh --create-namespace \
-  --set namespaceCreate=false \
   --set registry.replicas=3
 ```
 

--- a/src/core/cli/man/content/tutorial.md
+++ b/src/core/cli/man/content/tutorial.md
@@ -1704,9 +1704,9 @@ $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
     --wait --timeout 5m
 ```
 
-`values-core.yaml` sets `namespaceCreate: false`, which is what lets the chart
-install into the namespace `kubectl` created in Part 2. Without it the install
-fails with `invalid ownership metadata`.
+The chart renders no `Namespace` of its own, which is what lets it install into
+the namespace `kubectl` created in Part 2 — a chart-templated `Namespace` would
+collide with it and fail with `invalid ownership metadata`.
 
 ## Part 4: Deploy the agents
 

--- a/src/core/cli/man/content/upgrading.md
+++ b/src/core/cli/man/content/upgrading.md
@@ -2,6 +2,35 @@
 
 > Order of operations, version-skew guarantees, schema migrations, in-flight job safety, and source migrations for upgrading a running mesh
 
+## 3.5.0 — Helm chart upgrade order: 3.3.x → 3.4.x → 3.5.0
+
+**Do not upgrade the `mcp-mesh-core` chart from 3.3.x straight to 3.5.0.** Chart 3.5.0 changes `namespaceCreate` to default `false`, which drops the release's `Namespace` object from the rendered manifest — and Helm *deletes* a resource that leaves the manifest, cascading to every agent, Service, Secret and PVC in the namespace. What makes the removal safe is `helm.sh/resource-policy: keep` on the live `Namespace`, and chart 3.4.0 is the first version that applies it.
+
+| Current chart | What to do |
+| ------------- | ---------- |
+| 3.4.x | Nothing. The annotation is already on the live namespace; 3.5.0 removes the object without deleting anything. |
+| 3.3.x or older | Upgrade to the latest 3.4.x first, verify, then go to 3.5.0. |
+
+```bash
+# 1. Land the keep annotation (latest 3.4.x, no values change)
+helm upgrade mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+  -n mcp-mesh --version '~3.4.0' --reuse-values
+
+# 2. Verify it is on the LIVE namespace
+kubectl get ns mcp-mesh -o jsonpath='{.metadata.annotations}'
+#   {"helm.sh/resource-policy":"keep",...}
+
+# 3. Now 3.5.0 can drop the Namespace safely
+helm upgrade mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
+  -n mcp-mesh --reuse-values
+```
+
+To jump straight to 3.5.0 instead, pin `--set namespaceCreate=true` on that upgrade (which keeps the object, and applies the annotation), verify it landed, then drop the pin on a second upgrade.
+
+`--reuse-values` does **not** protect you: it replays the values *you* supplied, and a release that simply took the old default has nothing to replay. The chart cannot guard against this either — telling the safe case from the unsafe one means reading the live namespace, and `lookup` returns nothing under `helm template`, which is how Argo CD and every other GitOps renderer evaluates the chart.
+
+Skipping the order deletes the namespace while reporting `STATUS: deployed` and exit 0. Where `global.namespace` matches `-n` it is unrecoverable: the release secret lives in the namespace being deleted, a retry during the drain fails with `... is forbidden: ... because it is being terminated`, and afterwards `helm history` reports `release: not found`.
+
 ## 3.4.0 — Dependency injection is positional everywhere
 
 **Breaking, Java and TypeScript. Python is unchanged.** As of 3.4.0 the Nth declared dependency binds to the Nth injectable parameter, at every injection site in every runtime. Parameter names, capability keys and `@MeshInject` values are never used to *select* a dependency.
@@ -173,7 +202,7 @@ helm get values <release>
 
 - **`--reuse-values`** carries forward the environment configuration set at install time so an upgrade does not silently reset it. Confirm with `helm get values` that the values you expect are still present.
 - **Do not use `helm uninstall` as an upgrade mechanism.** To change the core, `helm upgrade` the existing release — uninstalling and reinstalling discards the release's history and values along with the running workloads, for no benefit.
-- **`helm uninstall` is still a legitimate, explicit teardown.** It removes the core workloads (registry, PostgreSQL, Redis, and any observability components), takes the registry offline with them, and leaves the `Namespace` in place — the core chart's `Namespace` carries `"helm.sh/resource-policy": keep`, so Helm skips it on uninstall and the deletion cannot cascade to co-located agents, Secrets, and PVCs. (Releases installed with an older chart pick the annotation up on `helm upgrade`, with no values change.) The registry's contents are derived state: agents re-register on their next heartbeat, so the registry repopulates itself and the cost is a transient topology gap, not data loss. Agents keep serving while it is down — resolved dependencies are never cleared on a registry disconnect. What pauses is topology detection: discovering new capabilities, re-resolving changed ones, and looking up an agent a client has not already resolved. What is *not* derived is application data — if your own workloads used the bundled PostgreSQL or Redis for their own storage, that data is yours to protect before you tear anything down.
-- **`helm.sh/resource-policy` is reserved in `commonAnnotations`.** The chart's `keep` on the `Namespace` is what keeps that cascade from happening and a `commonAnnotations` value would override it on last-wins, so the chart fails the render when the key is set to anything but `keep` — remove it from `commonAnnotations`, or set it to `keep`, before upgrading.
+- **`helm uninstall` is still a legitimate, explicit teardown.** It removes the core workloads (registry, PostgreSQL, Redis, and any observability components), takes the registry offline with them, and leaves the namespace in place — from chart 3.5.0 the release does not own it at all (`namespaceCreate` defaults to `false`), and a release that does own one, from an older chart or from `--take-ownership`, carries `"helm.sh/resource-policy": keep` on the object, so Helm skips it on uninstall and the deletion cannot cascade to co-located agents, Secrets, and PVCs. The registry's contents are derived state: agents re-register on their next heartbeat, so the registry repopulates itself and the cost is a transient topology gap, not data loss. Agents keep serving while it is down — resolved dependencies are never cleared on a registry disconnect. What pauses is topology detection: discovering new capabilities, re-resolving changed ones, and looking up an agent a client has not already resolved. What is *not* derived is application data — if your own workloads used the bundled PostgreSQL or Redis for their own storage, that data is yours to protect before you tear anything down.
+- **`helm.sh/resource-policy` is reserved in `commonAnnotations`.** When the chart does render a `Namespace`, its `keep` is the only thing standing between `helm uninstall` and everything in that namespace, and a `commonAnnotations` value would override it on last-wins. So the chart fails the render when the key is set to anything but `keep` — remove it from `commonAnnotations`, or set it to `keep`, before upgrading. This check runs whether or not `namespaceCreate` is on.
 - **`helm uninstall` no longer reclaims Grafana's data volume.** Grafana's PVC picks up `"helm.sh/resource-policy": keep` on upgrade — a metadata-only patch, no pod restart — because the dashboards, annotations, users, and API keys in `grafana.db` are not derived from anything the mesh can replay. A reinstall under the same release name adopts the claim, data intact; reclaim it deliberately with `kubectl delete pvc <release>-mcp-mesh-grafana-pvc -n <ns>`.
 - **Tempo's PVC is deleted by this upgrade, and that is intended.** `mcp-mesh-tempo.tempo.persistence.enabled` now defaults to `false`, so the claim leaves the rendered manifest and Helm reclaims it on the next `helm upgrade` — Tempo comes back on an `emptyDir`. What is lost is the volume plus up to `retention` (default `1h`) of buffered traces: it is a rolling buffer under active retention, not durable storage (3.1MB measured after 25 hours of uptime on a live install). Nothing else on the release is affected, and ingestion resumes normally. The `ReadWriteOnce` claim it required is a real rollout constraint on a single-replica Deployment, which is what deadlocked the chart on multi-node clusters — paid for minutes of traces. To keep the volume, pin the old value in the same upgrade: `--set mcp-mesh-tempo.tempo.persistence.enabled=true`. Setting it afterward provisions a new, empty claim rather than recovering the reclaimed one. Deliberately the opposite of Grafana's treatment above.

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -183,9 +183,19 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // the PVC deletion that flip causes on upgrade; the Grafana one (4 spans)
 // backfills the `resource-policy: keep` note that #1426 landed in `docs/` but
 // not here, since the Tempo bullet contrasts against it.
+// #1414: +29 / +2 / +0. `upgrading.md` +18 for the new "3.5.0 — Helm chart
+// upgrade order" section, which states the 3.3.x → 3.4.x → 3.5.0 sequence the
+// `namespaceCreate` default flip requires, plus a reworded `commonAnnotations`
+// bullet in "Helm Mechanics" (the +2 that also lands in the list golden — a
+// rewrite of an existing list line, so no new line and the third golden is
+// unmoved); `deployment.md` +11 for the same upgrade constraint restated where
+// the install recipe lives, plus the rewrite of the paragraph that used to
+// explain `--set namespaceCreate=false` (now redundant, and dropped from every
+// recipe). The new section's version table contributes nothing: a `|` line is
+// skipped by all three tests.
 const (
-	wantInlineCodeSpans = 1656
-	wantListCodeSpans   = 504
+	wantInlineCodeSpans = 1685
+	wantListCodeSpans   = 506
 	wantMarkupListLines = 442
 )
 


### PR DESCRIPTION
## Summary

`namespaceCreate` now defaults to `false`.

A chart-templated `Namespace` can never *create* the namespace its own release installs into — Helm writes the release secret there first — so the flag never did what its name suggests. The issue was filed as a Helm 3 problem; **it isn't.** Verified live against both clients:

| shape | Helm 3.19.0 | Helm 4.0.1 |
|---|---|---|
| `kubectl create ns` + install, matching `global.namespace` — **the primary quickstart** | FAIL ownership | **FAIL ownership** |
| `-n NS --create-namespace`, matching `global.namespace` | FAIL AlreadyExists | OK (adopts) |
| **`--create-namespace --set namespaceCreate=false`** | **OK** | **OK** |
| `global.namespace != -n` | OK, stray namespace | OK, stray namespace |

Only `namespaceCreate=false` works on both — which is what every documented recipe has passed explicitly since #1417. This makes the default match reality.

## Why it's safe now, and the one path that isn't

The flip removes the `Namespace` from the manifest, so it is only safe if `helm.sh/resource-policy: keep` is already on the **live** object. That shipped in #1413 → **3.4.0**, deployed for several days.

A doc inaccuracy was corrected while confirming this: the README claimed Helm reads the policy "from the manifest of the revision it is replacing." It doesn't — it re-`Get`s the object and reads live annotations. That distinction is exactly why 3.4.x-first is a *requirement*, not advice.

**Both directions verified live**, in throwaway namespaces:

- **No live `keep`** (simulating 3.3.2): upgrade returned `STATUS: deployed`, revision 2, **exit 0** — while the namespace went `Terminating`, taking the release secret with it.
- **Live `keep` present** (simulating 3.4.0): same upgrade, namespace `Active`, contents intact, release healthy.

So the unsafe path is **3.3.2 → 3.5.0 directly**: v3.3.2 released 2026-07-29, #1413 merged 2026-07-30, so 3.3.2's Namespace carries no annotation.

## Documented, not guarded — with the reasoning

A `lookup`-keyed render guard was considered and rejected. `lookup` behaviour was measured, not assumed:

| render mode | `lookup "v1" "Namespace" …` |
|---|---|
| `helm template` | **empty** |
| `helm install --dry-run` (client) | **empty** |
| `--dry-run=server` / real `helm upgrade` | populated |

Argo's repo-server renders with plain `helm template` and holds no destination-cluster credentials, so such a guard is **structurally unreachable for the cohort most at risk** — Argo prunes unattended, while a CLI operator at least sees output. It is technically viable for the CLI cohort (a chart-rendered Namespace carries `meta.helm.sh/release-name` + `managed-by: Helm`, which a `--create-namespace` one does not), but:

- its fail path **could never be regression-tested** — every `check_helm_render_matrix.py` case runs `helm template`, where `lookup` is always empty, so the guard would rot silently. That is the exact anti-pattern that script exists to prevent.
- it would disagree with its own preview: `--dry-run` renders clean, the real run fails.

So: documentation, in five places an upgrader actually hits — a `!!! danger` admonition atop `docs/upgrading.md`, a `## 3.5.0 — Helm chart upgrade order` section heading the man page, the chart README, `values.yaml`, and the install prose in `man/content/deployment.md`.

**Each one notes that `--reuse-values` does not protect you.** It replays only user-supplied values, so a release that took the old default silently picks up the new one. That is the actual trap, and it isn't obvious.

## Guard placement is now load-bearing

`namespace.yaml` puts `validateNoRemovedKeys` and `validateNamespaceResourcePolicy` **above** the `if`, so they run regardless of the flag. With the default now `false`, that applies to nearly every install — and coverage was **implicit only** (existing cases inherited the old default).

Added explicit `namespaceCreate: false` cases plus a `requires_kind`/`forbids_kind` capability, so "the Namespace renders only when enabled" — the whole point of this change — is actually asserted. Mutation-tested both ways:

- default flipped back to `true` → fails with *"the render contains a Namespace object, which these values must not produce"*
- guard includes moved below the `if` → **6 cases fail**

## The redundant `--set namespaceCreate=false` is dropped from recipes

It's now the default, and the repo's convention is that docs show only the current canonical form. Two facts made this clean: `bump_version.py` already rewrites the `--version` pins in those same recipes each release, and the docs site is unversioned (`mkdocs gh-deploy`, no `mike`), so it always describes `main`.

The cost is real and bounded: between merge and release, a reader pinning `--version 3.4.0` while omitting the flag gets a hard install failure. Same transient the repo already accepted for #1452's tempo flip. The version boundary is stated explicitly instead — the chart README's compat table marks `namespaceCreate` per row, and three doc surfaces name 3.4.x as the boundary. **Not** dropped where the flag still does something: `--take-ownership` adoption, and the pinned one-step upgrade escape hatch.

## Test plan

- [x] `helm template` default → 0 `kind: Namespace`; `--set namespaceCreate=true` → 1
- [x] Both validation guards fire with the new default — all four fail paths checked by hand
- [x] `check_helm_render_matrix.py` **38/38** (was 34/34), both mutations verified
- [x] `check_helm_pss.py` green · `check_helm_volume_keys.py` 9/9 · `helm lint` 9 charts, 0 failed
- [x] `go build ./...`, `go test ./src/core/...`, man-renderer tests green after golden update (1656→1685, 504→506, 442 unchanged — the version table is a `|` line, skipped by all three)
- [ ] CI green

## Two things for your call

- The `!!! danger` block and the man section name **3.5.0** explicitly. If the release lands under a different number, those strings need updating by hand — `bump_version.py` won't catch them, since they're prose rather than `--version` pins.
- Whether **Argo honours `helm.sh/resource-policy: keep` on prune** is version-dependent and was not tested — it would have meant creating an Application on the live cluster. The documented ordering is the safe instruction either way, but nailing it down is a separate experiment.

Closes #1414
