### PR TITLE
feat(python)!: remove litellm from the base install

### DIFF
--- a/cmd/meshctl/templates/python/llm-provider/requirements.txt.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/requirements.txt.tmpl
@@ -5,8 +5,9 @@
 
 # LiteLLM provider path (model: {{ .Model }}).
 # mcp-mesh bundles native SDK adapters for Anthropic, OpenAI and Gemini only;
-# every other vendor dispatches through LiteLLM. LiteLLM ships in the base
-# mcp-mesh install today, so this line currently changes nothing. It is
-# declared so this agent keeps working when LiteLLM becomes an opt-in extra.
+# every other vendor dispatches through LiteLLM, which is an opt-in extra and
+# is NOT part of the base install or the python-runtime base image. Without
+# this line the agent starts and registers normally, then fails on its first
+# LLM call.
 mcp-mesh[litellm]==3.4.0
 {{- end }}

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -21,9 +21,9 @@ MCP Mesh provides first-class support for LLM-powered agents through the `@mesh.
 The `mcp-mesh` package includes LLM support out of the box:
 
 - **Claude** (Anthropic), **GPT** (OpenAI) and **Gemini** (Google) dispatch through bundled native SDK adapters
-- **100+ other providers** (Bedrock, Cohere, Ollama, …) dispatch through LiteLLM
+- **100+ other providers** (Bedrock, Cohere, Ollama, …) dispatch through LiteLLM, installed via the `[litellm]` extra
 
-No additional packages needed. Just set your API keys:
+For the big-3, no additional packages are needed. Just set your API keys:
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
@@ -32,16 +32,21 @@ export OPENAI_API_KEY=sk-...
 
 !!! note "LiteLLM"
 
-    The big-3 vendors above need nothing beyond the base install. LiteLLM is
-    also part of the base install today, so long-tail providers work with no
-    extra step either — but it is moving to an opt-in extra in a future major
-    release. Declaring `mcp-mesh[litellm]` now is a no-op today and keeps a
-    long-tail agent working across that change; `meshctl scaffold` already
-    writes that pin into the generated `requirements.txt` when the selected
-    model is not Anthropic, OpenAI, Gemini or Vertex AI. `vertex_ai/*` is
-    native despite the long-tail-looking name: it runs the same Gemini models
-    through the same bundled SDK, only the auth differs (ADC / Workload
-    Identity instead of an AI Studio API key).
+    The big-3 vendors above need nothing beyond the base install. Every other
+    vendor dispatches through LiteLLM, which is an opt-in extra:
+
+    ```bash
+    pip install 'mcp-mesh[litellm]'
+    ```
+
+    For containerized agents, add `mcp-mesh[litellm]==<version>` to the
+    agent's `requirements.txt` so the image build picks it up — `meshctl
+    scaffold` writes that pin for you when the selected model is not
+    Anthropic, OpenAI, Gemini or Vertex AI. Without it the agent starts and
+    registers normally and fails on its first LLM call, with an error naming
+    the extra. `vertex_ai/*` is native despite the long-tail-looking name: it
+    runs the same Gemini models through the same bundled SDK, only the auth
+    differs (ADC / Workload Identity instead of an AI Studio API key).
 
 ## @mesh.llm Decorator
 

--- a/examples/docker-examples/agents/claude-provider/requirements.txt
+++ b/examples/docker-examples/agents/claude-provider/requirements.txt
@@ -4,8 +4,5 @@ mcp-mesh>=3.4.0
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0
 
-# LiteLLM for LLM provider
-litellm>=1.80.5,!=1.82.7,!=1.82.8
-
 # HTTP client for health checks
 httpx

--- a/examples/docker-examples/agents/openai-provider/requirements.txt
+++ b/examples/docker-examples/agents/openai-provider/requirements.txt
@@ -4,8 +4,5 @@ mcp-mesh>=3.4.0
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0
 
-# LiteLLM for LLM provider
-litellm>=1.80.5,!=1.82.7,!=1.82.8
-
 # HTTP client for health checks
 httpx

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -46,9 +46,9 @@ requires-python = ">=3.11"
 # openai SDK is included by default for native OpenAI dispatch (issue #834
 # PR 2). When MCP_MESH_NATIVE_LLM is unset (default ON), OpenAI provider
 # agents dispatch through the native openai SDK; without it they would
-# silently fall back to LiteLLM. (openai is also a transitive dep of
-# litellm today; promoting to a direct base dep prevents breakage if
-# litellm ever drops it as transitive.)
+# silently fall back to LiteLLM. (openai used to arrive transitively via
+# litellm; since litellm left the base install in 3.5.0 — issue #1383 —
+# this direct entry is the ONLY thing that installs it.)
 #
 # google-genai SDK is included by default for native Gemini dispatch
 # (issue #834 PR 3). Supports both AI Studio (gemini/*) and Vertex AI
@@ -106,7 +106,9 @@ dependencies = [
     # google-genai is capped <3, not <2: 2.0 shipped 2026-05 and a fresh
     # install has resolved 2.x ever since, so <2 would roll us back onto a 1.x
     # line nothing has tested in months.
-    "litellm>=1.80.5,!=1.82.7,!=1.82.8,<2",
+    #
+    # litellm is NOT here (issue #1383, removed in 3.5.0). It lives in the
+    # [litellm] optional extra; see the comment there.
     "anthropic>=0.77,<1",
     "openai>=2.14,<3",
     "google-genai>=1.22,<3",
@@ -121,8 +123,10 @@ dependencies = [
     # slow fallback) and ``mesh.helpers`` imports jsonschema unguarded at
     # module scope for synthetic-tool schema validation (#962), so
     # ``mesh.llm_provider`` fails to import without it. jsonschema happens
-    # to arrive via mcp/litellm today and orjson does not arrive at all;
-    # declaring both directly prevents breakage if those transitives shift.
+    # to arrive via mcp today and orjson does not arrive at all; declaring
+    # both directly prevents breakage if those transitives shift. (litellm
+    # used to be a second source of jsonschema; it left the base install in
+    # 3.5.0 — issue #1383 — which is exactly the shift this guards against.)
     "orjson>=3.10.0",
     "jsonschema>=4"
 ]
@@ -137,7 +141,13 @@ dev = [
     "mypy>=1.16.0",
     "pre-commit>=4.0.0",
     "isort>=6.0.0",
-    "bandit[toml]>=1.7.0"
+    "bandit[toml]>=1.7.0",
+    # The unit suite covers the LiteLLM long-tail path (tests/unit/
+    # test_provider_agentic_loop_*.py patch ``litellm.acompletion`` directly),
+    # so a dev/CI environment needs the package even though a user install no
+    # longer does (#1383). Self-referenced rather than restated so there is
+    # exactly one litellm pin per manifest.
+    "mcp-mesh[litellm]"
 ]
 docs = [
     "mkdocs>=1.5.0",
@@ -149,10 +159,13 @@ kubernetes = [
     "pykube-ng>=22.9.0"
 ]
 vertex = [
-    # google-auth is required for LiteLLM's vertex_ai/* model prefix to read
-    # Application Default Credentials. Optional because non-Vertex users (AI
-    # Studio, Claude, OpenAI) don't need it. Install via:
-    #   pip install mcp-mesh[vertex]
+    # Backward-compat alias: ``google-auth`` is now always installed because
+    # ``google-genai`` (a base dependency) requires ``google-auth[requests]
+    # >=2.48.1`` transitively. This extra is preserved as a no-op so
+    # ``pip install mcp-mesh[vertex]`` still resolves cleanly for users who
+    # pinned it from earlier docs (Vertex AI ADC reading for the vertex_ai/*
+    # model prefix, which dispatches through the native google-genai adapter
+    # and needs no litellm).
     "google-auth>=2.0.0"
 ]
 anthropic = [
@@ -183,22 +196,31 @@ gemini = [
 litellm = [
     # LiteLLM long-tail provider path (issue #1383).
     #
-    # DELIBERATELY REDUNDANT TODAY: ``litellm`` is still a BASE dependency
-    # above, so ``pip install mcp-mesh[litellm]`` resolves to exactly the same
-    # set as ``pip install mcp-mesh``. The extra exists now, ahead of the move,
-    # so that a pin written today (by a user, by ``meshctl scaffold``'s
-    # generated requirements.txt, or by the install guidance in
-    # ``mesh.helpers._require_litellm``) keeps working unchanged when the base
-    # entry is deleted at the next major — at that point THIS is the only
-    # declaration that installs litellm.
+    # THIS IS THE ONLY DECLARATION THAT INSTALLS LITELLM. The base entry was
+    # deleted in 3.5.0; ``pip install mcp-mesh`` no longer pulls litellm or its
+    # ~30 MB transitive tree. Anthropic / OpenAI / Gemini dispatch through the
+    # bundled native SDK adapters (base dependencies) and need nothing extra.
+    # Every other vendor — bedrock/*, vertex_ai/*, cohere/*, ollama/*, … —
+    # routes through GenericHandler → LiteLLM and requires:
+    #   pip install 'mcp-mesh[litellm]'
+    # Containerized agents add the same pin to requirements.txt; ``meshctl
+    # scaffold`` emits it automatically for non-big-3 models.
     #
-    # This is why the requirement is spelled out in full rather than left as an
-    # empty stub: an empty extra resolves cleanly today but would silently
-    # install nothing the day the base entry goes away.
+    # Missing-package failures are caught at the import site and re-raised with
+    # that guidance by ``mesh.helpers._require_litellm``.
     #
-    # The pin MUST stay identical to the ``litellm`` entry in [project]
-    # dependencies above. Enforced by
+    # The extra existed as a deliberate no-op from 3.3.2 through 3.4.x so a pin
+    # written against those releases keeps resolving unchanged here.
+    #
+    # The pin MUST stay identical to the ``litellm`` entry in the [litellm]
+    # extra of src/runtime/python/pyproject.toml (the manifest editable/source
+    # installs use). Enforced by
     # src/runtime/python/tests/unit/test_litellm_extra_pin_sync.py.
+    #
+    # Bounded, never pinned exactly, for the same reason as the vendor SDKs
+    # above: an exact pin would export our testing constraint onto every user
+    # who depends on litellm directly. 1.82.7/1.82.8 are excluded upstream
+    # breakages.
     "litellm>=1.80.5,!=1.82.7,!=1.82.8,<2"
 ]
 

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -12,9 +12,10 @@ The `mcp-mesh` package includes LLM support out of the box:
 
 - **Claude** (Anthropic), **GPT** (OpenAI) and **Gemini** (Google) dispatch
   through bundled native SDK adapters
-- **100+ other providers** (Bedrock, Cohere, Ollama, …) dispatch through LiteLLM
+- **100+ other providers** (Bedrock, Cohere, Ollama, …) dispatch through
+  LiteLLM, installed via the `[litellm]` extra
 
-No additional packages needed. Just set your API keys:
+For the big-3, no additional packages are needed. Just set your API keys:
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
@@ -22,15 +23,21 @@ export OPENAI_API_KEY=sk-...
 ```
 
 **Note on LiteLLM**: the big-3 vendors above need nothing beyond the base
-install. LiteLLM is also part of the base install today, so long-tail providers
-work with no extra step either — but it is moving to an opt-in extra in a future
-major release. Declaring `mcp-mesh[litellm]` now is a no-op today and keeps a
-long-tail agent working across that change; `meshctl scaffold` already writes
-that pin into the generated `requirements.txt` when the selected model is not
-Anthropic, OpenAI, Gemini or Vertex AI. `vertex_ai/*` is native despite the
-long-tail-looking name: it runs the same Gemini models through the same bundled
-SDK, only the auth differs (ADC / Workload Identity instead of an AI Studio API
-key).
+install. Every other vendor dispatches through LiteLLM, which is an opt-in
+extra:
+
+```bash
+pip install 'mcp-mesh[litellm]'
+```
+
+For containerized agents, add `mcp-mesh[litellm]==<version>` to the agent's
+`requirements.txt` so the image build picks it up — `meshctl scaffold` writes
+that pin for you when the selected model is not Anthropic, OpenAI, Gemini or
+Vertex AI. Without it the agent starts and registers normally and fails on its
+first LLM call, with an error naming the extra. `vertex_ai/*` is native despite
+the long-tail-looking name: it runs the same Gemini models through the same
+bundled SDK, only the auth differs (ADC / Workload Identity instead of an AI
+Studio API key).
 
 ## @mesh.llm Decorator
 

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -193,8 +193,15 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // explain `--set namespaceCreate=false` (now redundant, and dropped from every
 // recipe). The new section's version table contributes nothing: a `|` line is
 // skipped by all three tests.
+// #1383: +1 / +0 / +0. `llm.md`'s LiteLLM note is rewritten for the base
+// install losing `litellm`: the "moving to an opt-in extra" wording becomes a
+// statement of fact plus a `pip install 'mcp-mesh[litellm]'` block (fenced, so
+// it contributes nothing), and the long-tail bullet gains the `[litellm]`
+// extra. That bullet is the whole delta — the reworked paragraph swaps spans
+// one-for-one. The two list goldens are unmoved because the new span sits on
+// the bullet's wrapped continuation line, which is not itself a list line.
 const (
-	wantInlineCodeSpans = 1685
+	wantInlineCodeSpans = 1686
 	wantListCodeSpans   = 506
 	wantMarkupListLines = 442
 )

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -2726,7 +2726,7 @@ def llm_provider(
 
         app = current_module.app
 
-        # Extract vendor from model name using LiteLLM
+        # Extract vendor from model name using LiteLLM when it is available.
         vendor = "unknown"
         try:
             import litellm
@@ -2742,17 +2742,29 @@ def llm_provider(
             # AttributeError: get_llm_provider doesn't exist
             # ValueError: invalid model format
             # KeyError: model not in provider mapping
+            #
+            # Since #1383 litellm is an optional extra, so "not installed" is
+            # the DEFAULT state of a big-3 install, not a degradation — logging
+            # it at warning level would fire on every provider startup and be a
+            # pure false alarm. Any other failure means litellm IS present and
+            # still could not resolve the model, which is worth a warning.
+            litellm_absent = isinstance(e, ModuleNotFoundError) and e.name == "litellm"
             if "/" in model:
                 vendor = model.split("/")[0]
-                logger.warning(
-                    f"⚠️  Could not extract vendor using LiteLLM ({e}), "
-                    f"falling back to prefix extraction: '{vendor}'"
-                )
-            else:
-                logger.warning(
-                    f"⚠️  Could not extract vendor from model '{model}', "
-                    f"using 'unknown'"
-                )
+                if litellm_absent:
+                    logger.debug(
+                        f"litellm not installed; extracted vendor '{vendor}' "
+                        f"from the '{model}' prefix"
+                    )
+                else:
+                    logger.warning(
+                        f"⚠️  Could not extract vendor using LiteLLM ({e}), "
+                        f"falling back to prefix extraction: '{vendor}'"
+                    )
+            # A bare (unprefixed) name is not necessarily unresolvable — the
+            # big-3 inference below still gets a shot at it — so the "unknown"
+            # warning is deferred until after that block rather than emitted
+            # here and immediately contradicted.
 
         # Gap #1 (RFC #1100): route UNPREFIXED big-3 names to the native
         # handler. LiteLLM's get_llm_provider only resolves bare names that
@@ -2785,6 +2797,13 @@ def llm_provider(
                     f"name; normalized to '{provider_model}' for native "
                     f"dispatch (RFC #1100 Gap #1)"
                 )
+
+        if vendor == "unknown":
+            logger.warning(
+                f"⚠️  Could not extract vendor from model '{model}', using "
+                f"'unknown'. It will dispatch through the LiteLLM long-tail "
+                f"path, which needs: pip install 'mcp-mesh[litellm]'"
+            )
 
         def _prepare_provider_request(
             request: MeshLlmRequest,

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -46,9 +46,9 @@ requires-python = ">=3.11"
 # openai SDK is included by default for native OpenAI dispatch (issue #834
 # PR 2). When MCP_MESH_NATIVE_LLM is unset (default ON), OpenAI provider
 # agents dispatch through the native openai SDK; without it they would
-# silently fall back to LiteLLM. (openai is also a transitive dep of
-# litellm today; promoting to a direct base dep prevents breakage if
-# litellm ever drops it as transitive.)
+# silently fall back to LiteLLM. (openai used to arrive transitively via
+# litellm; since litellm left the base install in 3.5.0 — issue #1383 —
+# this direct entry is the ONLY thing that installs it.)
 #
 # google-genai SDK is included by default for native Gemini dispatch
 # (issue #834 PR 3). Supports both AI Studio (gemini/*) and Vertex AI
@@ -103,7 +103,9 @@ dependencies = [
     # google-genai is capped <3, not <2: 2.0 shipped 2026-05 and a fresh
     # install has resolved 2.x ever since, so <2 would roll us back onto a 1.x
     # line nothing has tested in months.
-    "litellm>=1.80.5,!=1.82.7,!=1.82.8,<2",
+    #
+    # litellm is NOT here (issue #1383, removed in 3.5.0). It lives in the
+    # [litellm] optional extra; see the comment there.
     "anthropic>=0.77,<1",
     "openai>=2.14,<3",
     "google-genai>=1.22,<3",
@@ -127,7 +129,13 @@ dev = [
     "mypy>=1.16.0",
     "pre-commit>=4.0.0",
     "isort>=6.0.0",
-    "bandit[toml]>=1.7.0"
+    "bandit[toml]>=1.7.0",
+    # The unit suite covers the LiteLLM long-tail path (tests/unit/
+    # test_provider_agentic_loop_*.py patch ``litellm.acompletion`` directly),
+    # so a dev/CI environment needs the package even though a user install no
+    # longer does (#1383). Self-referenced rather than restated so there is
+    # exactly one litellm pin per manifest.
+    "mcp-mesh[litellm]"
 ]
 docs = [
     "mkdocs>=1.5.0",
@@ -178,22 +186,30 @@ gemini = [
 litellm = [
     # LiteLLM long-tail provider path (issue #1383).
     #
-    # DELIBERATELY REDUNDANT TODAY: ``litellm`` is still a BASE dependency
-    # above, so ``pip install mcp-mesh[litellm]`` resolves to exactly the same
-    # set as ``pip install mcp-mesh``. The extra exists now, ahead of the move,
-    # so that a pin written today (by a user, by ``meshctl scaffold``'s
-    # generated requirements.txt, or by the install guidance in
-    # ``mesh.helpers._require_litellm``) keeps working unchanged when the base
-    # entry is deleted at the next major — at that point THIS is the only
-    # declaration that installs litellm.
+    # THIS IS THE ONLY DECLARATION THAT INSTALLS LITELLM. The base entry was
+    # deleted in 3.5.0; ``pip install mcp-mesh`` no longer pulls litellm or its
+    # ~30 MB transitive tree. Anthropic / OpenAI / Gemini dispatch through the
+    # bundled native SDK adapters (base dependencies) and need nothing extra.
+    # Every other vendor — bedrock/*, vertex_ai/*, cohere/*, ollama/*, … —
+    # routes through GenericHandler → LiteLLM and requires:
+    #   pip install 'mcp-mesh[litellm]'
+    # Containerized agents add the same pin to requirements.txt; ``meshctl
+    # scaffold`` emits it automatically for non-big-3 models.
     #
-    # This is why the requirement is spelled out in full rather than left as an
-    # empty stub: an empty extra resolves cleanly today but would silently
-    # install nothing the day the base entry goes away.
+    # Missing-package failures are caught at the import site and re-raised with
+    # that guidance by ``mesh.helpers._require_litellm``.
     #
-    # The pin MUST stay identical to the ``litellm`` entry in [project]
-    # dependencies above. Enforced by
-    # tests/unit/test_litellm_extra_pin_sync.py.
+    # The extra existed as a deliberate no-op from 3.3.2 through 3.4.x so a pin
+    # written against those releases keeps resolving unchanged here.
+    #
+    # The pin MUST stay identical to the ``litellm`` entry in the [litellm]
+    # extra of packaging/pypi/pyproject.toml (the manifest PyPI publishes).
+    # Enforced by tests/unit/test_litellm_extra_pin_sync.py.
+    #
+    # Bounded, never pinned exactly, for the same reason as the vendor SDKs
+    # above: an exact pin would export our testing constraint onto every user
+    # who depends on litellm directly. 1.82.7/1.82.8 are excluded upstream
+    # breakages.
     "litellm>=1.80.5,!=1.82.7,!=1.82.8,<2"
 ]
 

--- a/src/runtime/python/tests/unit/test_litellm_extra_pin_sync.py
+++ b/src/runtime/python/tests/unit/test_litellm_extra_pin_sync.py
@@ -1,17 +1,18 @@
-"""Guard the deliberately-duplicated ``litellm`` pin (issue #1383).
+"""Guard the ``[litellm]`` extra as the sole install path for LiteLLM (#1383).
 
-``litellm`` is declared twice in each Python manifest:
+As of 3.5.0 ``litellm`` is NOT a base dependency. It is declared exactly once
+per manifest, under ``[project.optional-dependencies] litellm``, and that entry
+is the only thing that installs it — ``pip install mcp-mesh`` is slim and
+big-3-native, ``pip install mcp-mesh[litellm]`` adds the long-tail provider
+path that ``meshctl scaffold`` and ``mesh.helpers._require_litellm`` tell users
+to pin.
 
-  * in ``[project] dependencies``  — it is still a BASE dependency today, so
-    nothing breaks for existing installs;
-  * in ``[project.optional-dependencies] litellm`` — the forward-compatible
-    opt-in extra that ``meshctl scaffold`` and
-    ``mesh.helpers._require_litellm`` tell users to pin.
+Two things can silently break that contract:
 
-The duplication is intentional (see the comments in both manifests), but a
-version bump or a new upstream exclusion applied to only one of the two would
-silently change what ``mcp-mesh[litellm]`` resolves to versus ``mcp-mesh``.
-These checks fail loudly on that drift.
+  * litellm creeping back into ``[project] dependencies`` — the extra would
+    still resolve, so nothing would fail, and every user would quietly get the
+    ~30 MB tree back;
+  * the two manifests drifting apart on the pin.
 
 Both manifests are checked because ``packaging/pypi/pyproject.toml`` is the one
 PyPI publishes and ``src/runtime/python/pyproject.toml`` is the one editable /
@@ -61,15 +62,25 @@ def _requirements_named(reqs: list[str], name: str) -> list[str]:
 
 
 @pytest.mark.parametrize("rel", sorted(_MANIFESTS))
-def test_litellm_extra_pin_matches_base_pin(rel: str) -> None:
-    """The ``[litellm]`` extra must restate the base pin verbatim."""
-    data = _load(rel)
-    project = data["project"]
+def test_litellm_is_not_a_base_dependency(rel: str) -> None:
+    """``pip install mcp-mesh`` must stay slim (#1383)."""
+    project = _load(rel)["project"]
 
     base = _requirements_named(project["dependencies"], "litellm")
-    assert len(base) == 1, f"{rel}: expected exactly one base litellm pin, got {base}"
+    assert base == [], (
+        f"{rel}: litellm is back in [project] dependencies as {base}. It was "
+        "removed in 3.5.0 (#1383): the big-3 vendors dispatch through the "
+        "bundled native SDK adapters and must not carry litellm's ~30 MB "
+        "transitive tree. It belongs in the [litellm] extra only."
+    )
 
+
+@pytest.mark.parametrize("rel", sorted(_MANIFESTS))
+def test_litellm_extra_declares_litellm_explicitly(rel: str) -> None:
+    """The extra is the only thing that installs litellm, so it must say so."""
+    project = _load(rel)["project"]
     extras = project["optional-dependencies"]
+
     assert "litellm" in extras, (
         f"{rel}: the [litellm] extra is missing. It is what "
         "'pip install mcp-mesh[litellm]' resolves against — the install "
@@ -79,37 +90,29 @@ def test_litellm_extra_pin_matches_base_pin(rel: str) -> None:
 
     extra = _requirements_named(extras["litellm"], "litellm")
     assert len(extra) == 1, (
-        f"{rel}: the [litellm] extra must declare litellm explicitly, got "
-        f"{extras['litellm']!r}. An empty/stub extra resolves cleanly today "
-        "(litellm is still a base dependency) but would silently install "
-        "nothing once the base entry is removed."
-    )
-
-    assert extra[0] == base[0], (
-        f"{rel}: the [litellm] extra pin drifted from the base pin.\n"
-        f"  base : {base[0]}\n"
-        f"  extra: {extra[0]}\n"
-        "Both must be updated together — otherwise 'mcp-mesh[litellm]' and "
-        "'mcp-mesh' resolve to different litellm versions."
+        f"{rel}: the [litellm] extra must declare litellm exactly once, got "
+        f"{extras['litellm']!r}. Nothing else installs litellm since 3.5.0, so "
+        "an empty/stub extra resolves cleanly and installs nothing."
     )
 
 
-def test_litellm_pin_is_the_same_across_manifests() -> None:
+def test_litellm_extra_pin_is_the_same_across_manifests() -> None:
     """The published manifest and the source manifest must agree on litellm.
 
     They deliberately differ on upper bounds for some other deps, but litellm
-    is one pin: a user installing from PyPI and a contributor installing the
-    source tree editable must get the same long-tail provider path.
+    is one pin: a user installing ``mcp-mesh[litellm]`` from PyPI and a
+    contributor installing the source tree editable must get the same
+    long-tail provider path.
     """
     pins = {}
     for rel in _MANIFESTS:
         project = _load(rel)["project"]
-        pins[rel] = (
-            _requirements_named(project["dependencies"], "litellm")[0],
-            _requirements_named(project["optional-dependencies"]["litellm"], "litellm")[
-                0
-            ],
-        )
+        pins[rel] = _requirements_named(
+            project["optional-dependencies"]["litellm"], "litellm"
+        )[0]
 
-    values = list(pins.values())
-    assert len(set(values)) == 1, f"litellm pins diverge across manifests: {pins}"
+    assert len(set(pins.values())) == 1, (
+        f"the [litellm] extra pin diverges across manifests: {pins}\n"
+        "Both must be updated together — otherwise 'mcp-mesh[litellm]' means "
+        "one thing from PyPI and another from a source checkout."
+    )


### PR DESCRIPTION
## Summary

Completes #1383. Items 1, 2, 4 and 5 landed in #1386/#1400; this is **item 3**: `pip install mcp-mesh` no longer pulls LiteLLM.

**110 → 101 dependencies, 311 MB → 189 MB of site-packages.** Long-tail vendors now need `mcp-mesh[litellm]` — an extra that has been valid since 3.3.2, so users have had two releases of runway to pin it ahead of the move.

The issue predicted ~92 packages. The real floor is **101**: that estimate credited litellm for several packages mesh declares directly. Nine removed (`litellm, tokenizers, tiktoken, regex, hf-xet, huggingface-hub, fsspec, filelock, fastuuid`), not eighteen.

## No undeclared dependency needed promoting — verified by construction

litellm's direct requires are `aiohttp, click, fastuuid, httpx, importlib-metadata, jinja2, jsonschema, openai, pydantic, python-dotenv, tiktoken, tokenizers`. Mesh already declares seven directly — the earlier `openai` and `jsonschema` promotions had done that work — and `python-dotenv`/`importlib-metadata` arrive via mcp/fastmcp. The litellm-exclusive residue appears in no `import` statement under `_mcp_mesh` or `mesh`.

Confirmed rather than reasoned: **all 150 modules** under both packages walked with `pkgutil.walk_packages` in a litellm-free venv — 150/150 imported, `litellm` never entering `sys.modules`.

## Two things that would have shipped broken

**49 tests would have turned CI red on merge.** They `patch("litellm.acompletion")`, which needs the real module importable, and CI installs `.[dev]`. Fixed by self-referencing `mcp-mesh[litellm]` from the `dev` extra rather than editing the workflow — keeps exactly one litellm pin per manifest, and `pip install -e '.[dev]'` was verified to resolve it.

**Every big-3 provider agent would have logged a startup WARNING.** `llm_provider` calls `litellm.get_llm_provider` at decoration time, and its `except` branch treated "litellm not installed" as a degradation — which is now the *default* state. Absence now logs at `debug`; present-but-unresolvable stays WARNING. The bare-name "using 'unknown' vendor" warning also moved below the big-3 inference block, where it previously contradicted itself one line later.

That second one is a behaviour change worth a look — it's the one part of this PR that isn't packaging.

## Live verification (litellm absent throughout)

| Model | Result |
|---|---|
| `anthropic/claude-sonnet-4-5` | 200, usage returned |
| `openai/gpt-4o-mini` | 200 |
| `gemini/gemini-2.5-flash` | 200 |
| `vertex_ai/gemini-2.5-flash` | 200 via native google-genai + ADC — confirms the long-tail-*looking* prefix stays native |
| streaming, all three | correct `_mesh_frame` chunk/end frames |
| `cohere/command-r`, `ollama/llama3` | friendly `ImportError` naming model, vendor and `pip install 'mcp-mesh[litellm]==…'` — not a bare `ModuleNotFoundError` |

## Layering verified for real

Installed the slimmed wheel (104 entries), then `pip install 'mcp-mesh[litellm]==3.4.0'` → `Requirement already satisfied: mcp-mesh`, installs only the 9 missing packages, returns to 113. **No base-version upgrade.** That is exactly what a scaffolded agent's `pip install -r requirements.txt` layer over `FROM mcpmesh/python-runtime` does.

`packaging/docker/python-runtime.Dockerfile` needs no change. No Dockerfile, compose file, chart or script anywhere assumes litellm is present.

## Docs and scaffold

`test_litellm_extra_pin_sync.py`'s base-vs-extra comparison became meaningless and now asserts what still matters: litellm is *not* a base dep, the extra declares it exactly once, and the extra agrees across both manifests.

Corrected several places that described the pre-move state as current — the `[litellm]` extra comment ("deleted at the next major"), `man/content/llm.md` and `docs/python/llm/index.md` ("a no-op today", "moving in a future major"), and the scaffolded `requirements.txt.tmpl` comment ("LiteLLM ships in the base install today, so this line currently changes nothing" — now false *and* dangerous). Also dropped a bare `litellm` pin from two big-3 example agents that never needed it.

## Test plan

- [x] Python unit suite (CI invocation): **2537 passed, 6 skipped**
- [x] `pytest scripts/` 106 passed · `go build ./...` · `go test ./src/core/cli/...` green
- [x] 150/150 module import walk in a slim venv
- [x] Live big-3 + long-tail, buffered and streaming
- [x] Extra-layering install verified, no base upgrade
- [ ] **src-tests + full integration** — running now; `tsuite-mesh:local` becomes litellm-free, so the whole suite runs against a slimmed image. Every integration model string is big-3 and nothing sets `MCP_MESH_NATIVE_LLM=0`, so no suite change is expected — but that is a prediction until the run lands.
- [ ] CI green

## For the 3.5.0 release notes

`RELEASE_NOTES.md` lines 95/96/117 describe the 3.4.0 state — "litellm is still installed by default", "additive today". Accurate when shipped; 3.5.0 needs an entry calling this out as the breaking change, and the upgrade action is one line in `requirements.txt`.

Closes #1383


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified LLM provider installation: Claude, GPT, and Gemini work with base install only; all other providers require the `[litellm]` extra.
  * Added guidance for containerized deployments and troubleshooting missing dependencies.

* **Refactor**
  * Made LiteLLM an optional dependency to reduce base package size.
  * Improved logging to provide clearer guidance when optional dependencies are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->