### PR TITLE
fix: probe liveness and readiness separately, so an upstream outage cannot restart a pod

### DIFF
--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -309,10 +309,37 @@ agentCode:
   # Mount path
   mountPath: "/app/agent"
 
-# Health probe configurations (matches working examples)
+# Health probe configurations.
+#
+# Liveness and readiness MUST NOT share a URL (issue #1467). Every mesh
+# runtime serves three endpoints with three different meanings:
+#
+#   /livez   always 200 while the process is serving. Nothing else.
+#   /ready   should traffic be routed here? On Python this consults the
+#            user's health_check, so an upstream vendor outage makes the
+#            agent unready and the registry evicts it from resolution.
+#   /health  the diagnostic view for humans and `kubectl exec` curls.
+#            No probe points at it: it carries no consequence of its own.
+#
+# When liveness also pointed at /health, an upstream outage failed the
+# LIVENESS probe and Kubernetes restarted the pod. A restart cannot fix
+# someone else's API, and it erases the only state that knew this
+# provider was failing — the agent re-registers as healthy, consumers
+# route back to it, it fails again, forever. Readiness is the probe
+# whose remedy (stop sending traffic) matches that cause.
+#
+# The same reasoning applies to the startup probe: its failure action is
+# also a container restart, so gating startup on /health meant an agent
+# that booted DURING an outage never became "started" and was killed
+# after failureThreshold × periodSeconds — reproducing the same loop on
+# a slower cadence. It gates on /livez instead; readiness still governs
+# traffic, and an agent stuck mid-boot stays visible as 0/1 READY rather
+# than flapping through CrashLoopBackOff.
+#
+# Do not collapse these back onto one path.
 startupProbe:
   httpGet:
-    path: /health
+    path: /livez
     port: http
   initialDelaySeconds: 5
   periodSeconds: 10
@@ -321,7 +348,7 @@ startupProbe:
 
 livenessProbe:
   httpGet:
-    path: /health
+    path: /livez
     port: http
   initialDelaySeconds: 15
   periodSeconds: 10
@@ -330,7 +357,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /health
+    path: /ready
     port: http
   initialDelaySeconds: 10
   periodSeconds: 5

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -366,7 +366,14 @@ envFrom: []
   # - secretRef:
   #     name: special-secret
 
-# Liveness and readiness probes
+# Liveness and readiness probes.
+#
+# Unlike the agent chart (issue #1467), both may share /health here: the
+# registry's GET /health (src/core/registry/ent_handlers.go) returns a
+# static 200 with uptime and never consults the database, a dependency,
+# or a user-supplied check. It is already a pure liveness signal, so it
+# cannot turn an outage elsewhere into a registry restart. Should it ever
+# grow a dependency check, split the probes as the agent chart does.
 livenessProbe:
   httpGet:
     path: /health
@@ -378,7 +385,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /health # Matches working examples
+    path: /health
     port: http
   initialDelaySeconds: 10
   periodSeconds: 5

--- a/scripts/check_helm_render_matrix.py
+++ b/scripts/check_helm_render_matrix.py
@@ -27,6 +27,18 @@ That is for values whose whole purpose is to add or remove a resource — an
 opt-in object silently becoming opt-out (or the reverse) is a behaviour change
 a non-empty render cannot detect.
 
+It may also pin the container probe paths:
+
+  probe_paths={"livenessProbe": "/livez", "readinessProbe": "/ready"}
+
+Issue #1467: liveness and readiness pointing at the SAME url is the bug —
+a dependency outage that should only make an agent unready instead restarts
+the pod, which cannot fix the dependency and launders the failing agent back
+into resolution. A values default is one careless edit away from collapsing
+back, and every render stays green when it does. Declaring the paths makes
+that edit fail here. Two probes sharing a path is additionally rejected
+outright, whatever the declared paths were.
+
 Usage: python3 scripts/check_helm_render_matrix.py  (run from anywhere)
 Exit code 0 = every case behaved as declared.
 """
@@ -63,6 +75,7 @@ class Case:
     extra_args: tuple[str, ...] = field(default_factory=tuple)
     requires_kind: str | None = None
     forbids_kind: str | None = None
+    probe_paths: dict[str, str] | None = None
 
 
 CASES: list[Case] = [
@@ -348,6 +361,20 @@ CASES: list[Case] = [
         "the v2.4.0 agent.environment defaults verbatim",
         {"agent": {"environment": dict(V240_AGENT_ENVIRONMENT)}},
     ),
+    # --- mcp-mesh-agent: liveness and readiness are different URLs --------
+    # Issue #1467. Liveness may only fail for something a restart can fix;
+    # /ready is what an unhealthy dependency is allowed to fail. The startup
+    # probe restarts the container too, so it gates on /livez as well.
+    Case(
+        "mcp-mesh-agent",
+        "probes at the shipped defaults point at distinct endpoints",
+        {},
+        probe_paths={
+            "startupProbe": "/livez",
+            "livenessProbe": "/livez",
+            "readinessProbe": "/ready",
+        },
+    ),
     # --- mcp-mesh-ingress (standalone chart) ------------------------------
     Case(
         "mcp-mesh-ingress",
@@ -404,6 +431,8 @@ def run_case(case: Case, values_file: Path) -> str | None:
                 f"the render contains a {case.forbids_kind} object, which "
                 "these values must not produce"
             )
+        if case.probe_paths:
+            return _check_probe_paths(result.stdout, case.probe_paths)
         return None
 
     if result.returncode == 0:
@@ -416,6 +445,45 @@ def run_case(case: Case, values_file: Path) -> str | None:
             f"render failed, but not with {case.expect_fail!r} — a different "
             f"guard (or a template error) fired:\n{_indent(output)}"
         )
+    return None
+
+
+def _check_probe_paths(manifests: str, expected: dict[str, str]) -> str | None:
+    """Assert every workload container's probes use the declared httpGet paths.
+
+    Also rejects two probes sharing one path regardless of what was declared —
+    the invariant behind issue #1467 is that liveness (restart) and readiness
+    (stop routing) can never be the same signal.
+    """
+    containers = [
+        container
+        for doc in yaml.safe_load_all(manifests)
+        if isinstance(doc, dict)
+        and doc.get("kind") in {"Deployment", "StatefulSet", "DaemonSet"}
+        for container in doc["spec"]["template"]["spec"].get("containers", [])
+    ]
+    if not containers:
+        return "the render contains no workload containers to probe"
+
+    for container in containers:
+        for probe, want in expected.items():
+            spec = container.get(probe)
+            if not spec:
+                return f"container {container['name']!r} has no {probe}"
+            got = spec.get("httpGet", {}).get("path")
+            if got != want:
+                return (
+                    f"container {container['name']!r} {probe} probes {got!r}, "
+                    f"expected {want!r}"
+                )
+        liveness = container.get("livenessProbe", {}).get("httpGet", {}).get("path")
+        readiness = container.get("readinessProbe", {}).get("httpGet", {}).get("path")
+        if liveness is not None and liveness == readiness:
+            return (
+                f"container {container['name']!r} probes liveness and readiness "
+                f"at the same path {liveness!r} — a dependency outage would "
+                "restart the pod instead of only taking it out of rotation"
+            )
     return None
 
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
@@ -6,14 +6,23 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.stereotype.Controller;
 
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
  * Health endpoint controller for MCP Mesh Java agents.
  *
- * <p>Provides {@code GET /health} and {@code HEAD /health} for Kubernetes probes,
- * load balancers, and Docker Compose healthchecks.
+ * <p>Provides {@code GET}/{@code HEAD} for {@code /health}, {@code /ready} and
+ * {@code /livez} for Kubernetes probes, load balancers, and Docker Compose
+ * healthchecks.
+ *
+ * <p>Liveness and readiness are deliberately DIFFERENT endpoints (issue #1467).
+ * When both probes share a URL, anything that makes an agent unready also makes
+ * Kubernetes restart it — a remedy that cannot fix a dependency outage and that
+ * erases the evidence the agent was failing. {@code /livez} therefore answers
+ * 200 unconditionally, while {@code /ready} reports whether the mesh runtime is
+ * up.
  */
 @Controller
 public class MeshHealthController {
@@ -39,5 +48,62 @@ public class MeshHealthController {
     public ResponseEntity<Void> healthHead() {
         boolean running = runtime != null && runtime.isRunning();
         return ResponseEntity.status(running ? 200 : 503).build();
+    }
+
+    /**
+     * Kubernetes readiness probe.
+     *
+     * <p>The Java runtime has no user-supplied health check (unlike Python), so
+     * the only honest readiness signal available is whether the mesh runtime is
+     * running — the same condition {@code /health} reports. It does NOT reflect
+     * the health of anything the agent depends on.
+     */
+    @GetMapping("/ready")
+    public ResponseEntity<Map<String, Object>> ready() {
+        boolean running = runtime != null && runtime.isRunning();
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("ready", running);
+        if (!running) {
+            body.put("reason", "mesh runtime is not running");
+        }
+        return ResponseEntity.status(running ? 200 : 503).body(body);
+    }
+
+    @RequestMapping(value = "/ready", method = RequestMethod.HEAD)
+    public ResponseEntity<Void> readyHead() {
+        boolean running = runtime != null && runtime.isRunning();
+        return ResponseEntity.status(running ? 200 : 503).build();
+    }
+
+    /**
+     * Kubernetes liveness probe — always 200 while the application is serving.
+     *
+     * <p>Deliberately does NOT consult {@link MeshRuntime#isRunning()}: the mesh
+     * runtime starts late in the Spring lifecycle, so a liveness probe gated on
+     * it would restart-loop an agent through a slow boot. Reaching this handler
+     * at all proves the servlet container is alive, which is the only failure a
+     * restart can actually repair.
+     */
+    @GetMapping("/livez")
+    public ResponseEntity<Map<String, Object>> livez() {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("alive", true);
+        // Best-effort agent name. `runtime` is a lazy proxy — resolving it can
+        // raise while the context is still coming up, and liveness must answer
+        // 200 regardless of whether the name is available.
+        try {
+            if (runtime != null && runtime.getAgentSpec() != null) {
+                body.put("agent", runtime.getAgentSpec().getName());
+            }
+        } catch (Exception ignored) {
+            // Name is decoration; liveness is not conditional on it.
+        }
+        body.put("timestamp", Instant.now().toString());
+        return ResponseEntity.ok(body);
+    }
+
+    @RequestMapping(value = "/livez", method = RequestMethod.HEAD)
+    public ResponseEntity<Void> livezHead() {
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthControllerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthControllerTest.java
@@ -1,0 +1,129 @@
+package io.mcpmesh.spring;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for the probe endpoints (issue #1467).
+ *
+ * <p>The invariant under test: liveness and readiness are DIFFERENT signals.
+ * {@code /ready} follows {@code runtime.isRunning()} so an agent whose runtime
+ * is down is taken out of rotation; {@code /livez} answers 200 regardless, so
+ * the same condition never causes a pod restart.
+ */
+class MeshHealthControllerTest {
+
+    private static MeshRuntime runtimeWith(boolean running) {
+        MeshRuntime runtime = mock(MeshRuntime.class);
+        when(runtime.isRunning()).thenReturn(running);
+        return runtime;
+    }
+
+    @Test
+    void livez_is200_whenRuntimeIsRunning() {
+        MeshHealthController controller = new MeshHealthController(runtimeWith(true));
+        ResponseEntity<Map<String, Object>> response = controller.livez();
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(Boolean.TRUE, response.getBody().get("alive"));
+        assertNotNull(response.getBody().get("timestamp"));
+    }
+
+    @Test
+    void livez_is200_evenWhenRuntimeIsNotRunning() {
+        // Unstubbed: isRunning() defaults to false AND the verify below proves
+        // liveness never asked.
+        MeshRuntime runtime = mock(MeshRuntime.class);
+        MeshHealthController controller = new MeshHealthController(runtime);
+
+        ResponseEntity<Map<String, Object>> response = controller.livez();
+
+        assertEquals(200, response.getStatusCode().value(),
+            "liveness must not restart an agent whose runtime is merely down/slow to boot");
+        assertEquals(Boolean.TRUE, response.getBody().get("alive"));
+        verify(runtime, never()).isRunning();
+    }
+
+    @Test
+    void livez_is200_evenWithNoRuntimeAtAll() {
+        MeshHealthController controller = new MeshHealthController(null);
+        ResponseEntity<Map<String, Object>> response = controller.livez();
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(Boolean.TRUE, response.getBody().get("alive"));
+    }
+
+    @Test
+    void livez_is200_whenTheLazyRuntimeProxyRaises() {
+        MeshRuntime runtime = mock(MeshRuntime.class);
+        when(runtime.getAgentSpec()).thenThrow(new IllegalStateException("bean not ready"));
+        MeshHealthController controller = new MeshHealthController(runtime);
+
+        ResponseEntity<Map<String, Object>> response = controller.livez();
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(Boolean.TRUE, response.getBody().get("alive"));
+        assertFalse(response.getBody().containsKey("agent"));
+    }
+
+    @Test
+    void livezHead_is200() {
+        MeshHealthController controller = new MeshHealthController(runtimeWith(false));
+        assertEquals(200, controller.livezHead().getStatusCode().value());
+    }
+
+    @Test
+    void ready_is200_whenRuntimeIsRunning() {
+        MeshHealthController controller = new MeshHealthController(runtimeWith(true));
+        ResponseEntity<Map<String, Object>> response = controller.ready();
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(Boolean.TRUE, response.getBody().get("ready"));
+    }
+
+    @Test
+    void ready_is503_whenRuntimeIsNotRunning() {
+        MeshHealthController controller = new MeshHealthController(runtimeWith(false));
+        ResponseEntity<Map<String, Object>> response = controller.ready();
+
+        assertEquals(503, response.getStatusCode().value());
+        assertEquals(Boolean.FALSE, response.getBody().get("ready"));
+        assertNotNull(response.getBody().get("reason"));
+    }
+
+    @Test
+    void ready_is503_withNoRuntimeAtAll() {
+        MeshHealthController controller = new MeshHealthController(null);
+        assertEquals(503, controller.ready().getStatusCode().value());
+    }
+
+    @Test
+    void readyHead_followsRuntimeState() {
+        assertEquals(200, new MeshHealthController(runtimeWith(true)).readyHead()
+            .getStatusCode().value());
+        assertEquals(503, new MeshHealthController(runtimeWith(false)).readyHead()
+            .getStatusCode().value());
+    }
+
+    @Test
+    void livenessAndReadinessDivergeWhenTheRuntimeIsDown() {
+        // The whole point of #1467: the same condition must be able to take an
+        // agent out of rotation without restarting it.
+        MeshHealthController controller = new MeshHealthController(runtimeWith(false));
+        assertEquals(503, controller.ready().getStatusCode().value());
+        assertEquals(200, controller.livez().getStatusCode().value());
+    }
+
+    @Test
+    void health_isUnchanged() {
+        assertEquals(200, new MeshHealthController(runtimeWith(true)).health()
+            .getStatusCode().value());
+        assertEquals(503, new MeshHealthController(runtimeWith(false)).health()
+            .getStatusCode().value());
+    }
+}

--- a/src/runtime/typescript/src/__tests__/a2a/agent-a2a-config.spec.ts
+++ b/src/runtime/typescript/src/__tests__/a2a/agent-a2a-config.spec.ts
@@ -33,7 +33,13 @@ beforeEach(() => {
     });
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Flush the auto-start tick a constructor may have scheduled in this
+  // test WHILE the stub above is still installed. Restoring first lets
+  // the real `_autoStart` run against the stub FastMCP, which aborts
+  // startup (no /livez route — issue #1467) and process.exit(1)s the
+  // worker.
+  await new Promise<void>((resolve) => process.nextTick(resolve));
   if (autoStartSpy) {
     autoStartSpy.mockRestore();
     autoStartSpy = null;

--- a/src/runtime/typescript/src/__tests__/agent-add-tool.spec.ts
+++ b/src/runtime/typescript/src/__tests__/agent-add-tool.spec.ts
@@ -49,7 +49,13 @@ beforeEach(() => {
     });
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Flush the auto-start tick a constructor may have scheduled in this
+  // test WHILE the stub above is still installed. Restoring first lets
+  // the real `_autoStart` run against the stub FastMCP, which aborts
+  // startup (no /livez route — issue #1467) and process.exit(1)s the
+  // worker.
+  await new Promise<void>((resolve) => process.nextTick(resolve));
   if (autoStartSpy) {
     autoStartSpy.mockRestore();
     autoStartSpy = null;

--- a/src/runtime/typescript/src/__tests__/agent-duplicate-tool-name.spec.ts
+++ b/src/runtime/typescript/src/__tests__/agent-duplicate-tool-name.spec.ts
@@ -38,7 +38,13 @@ beforeEach(() => {
     });
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Flush the auto-start tick a constructor may have scheduled in this
+  // test WHILE the stub above is still installed. Restoring first lets
+  // the real `_autoStart` run against the stub FastMCP, which aborts
+  // startup (no /livez route — issue #1467) and process.exit(1)s the
+  // worker.
+  await new Promise<void>((resolve) => process.nextTick(resolve));
   if (autoStartSpy) {
     autoStartSpy.mockRestore();
     autoStartSpy = null;

--- a/src/runtime/typescript/src/__tests__/direct-invoke-required.spec.ts
+++ b/src/runtime/typescript/src/__tests__/direct-invoke-required.spec.ts
@@ -81,7 +81,13 @@ beforeEach(() => {
   RouteRegistry.reset();
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Flush the auto-start tick a constructor may have scheduled in this
+  // test WHILE the stub above is still installed. Restoring first lets
+  // the real `_autoStart` run against the stub FastMCP, which aborts
+  // startup (no /livez route — issue #1467) and process.exit(1)s the
+  // worker.
+  await new Promise<void>((resolve) => process.nextTick(resolve));
   autoStartSpy?.mockRestore();
   autoStartSpy = null;
   warnSpy?.mockRestore();

--- a/src/runtime/typescript/src/__tests__/livez-route.spec.ts
+++ b/src/runtime/typescript/src/__tests__/livez-route.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Liveness endpoint tests (issue #1467).
+ *
+ * The agent chart points its liveness probe at `/livez` and its readiness
+ * probe at `/ready`. A TypeScript agent that does not answer `/livez`
+ * 404s the liveness probe and gets restarted by Kubernetes — a worse
+ * failure than the one the split was introduced to fix. These tests pin
+ * both TS HTTP surfaces:
+ *
+ *   - the FastMCP-hosted MeshAgent (route registered on FastMCP's Hono app)
+ *   - MeshExpress (route registered on the user's Express app)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { FastMCP } from "fastmcp";
+import type { Server } from "http";
+import express from "express";
+import { registerLivezRoute } from "../livez-route.js";
+import { MeshExpress } from "../express.js";
+
+describe("registerLivezRoute — FastMCP/Hono surface", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("registers GET and HEAD /livez on the Hono app", () => {
+    const onSpy = vi.fn();
+    const stubServer = {
+      getApp: () => ({ on: onSpy }),
+    } as unknown as FastMCP;
+
+    expect(registerLivezRoute(stubServer, "my-agent")).toBe(true);
+    expect(onSpy).toHaveBeenCalledWith(
+      ["GET", "HEAD"],
+      "/livez",
+      expect.any(Function),
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("the handler reports alive:true with the agent name", () => {
+    let handler: ((c: unknown) => unknown) | undefined;
+    const stubServer = {
+      getApp: () => ({
+        on: (_methods: string[], _path: string, h: (c: unknown) => unknown) => {
+          handler = h;
+        },
+      }),
+    } as unknown as FastMCP;
+
+    registerLivezRoute(stubServer, "my-agent");
+    expect(handler).toBeDefined();
+
+    const json = vi.fn((body: unknown) => body);
+    const body = handler!({ json }) as Record<string, unknown>;
+    expect(body.alive).toBe(true);
+    expect(body.agent).toBe("my-agent");
+    expect(typeof body.timestamp).toBe("string");
+  });
+
+  it("logs at console.error when getApp() throws", () => {
+    const stubServer = {
+      getApp: () => {
+        throw new Error("FastMCP server not started");
+      },
+    } as unknown as FastMCP;
+
+    expect(registerLivezRoute(stubServer, "my-agent")).toBe(false);
+    expect(errorSpy).toHaveBeenCalledOnce();
+    const msg = errorSpy.mock.calls[0][0] as string;
+    expect(msg).toContain("/livez route NOT registered");
+    expect(msg).toContain("FastMCP server not started");
+  });
+
+  it("logs at console.error when getApp() returns null", () => {
+    const stubServer = { getApp: () => null } as unknown as FastMCP;
+
+    expect(registerLivezRoute(stubServer, "my-agent")).toBe(false);
+    expect(errorSpy).toHaveBeenCalledOnce();
+    expect(errorSpy.mock.calls[0][0] as string).toContain("returned null");
+  });
+
+  it("logs at console.error when app.on() raises", () => {
+    const stubServer = {
+      getApp: () => ({
+        on: () => {
+          throw new Error("hono internal: route conflict");
+        },
+      }),
+    } as unknown as FastMCP;
+
+    expect(registerLivezRoute(stubServer, "my-agent")).toBe(false);
+    expect(errorSpy).toHaveBeenCalledOnce();
+    expect(errorSpy.mock.calls[0][0] as string).toContain(
+      "hono internal: route conflict",
+    );
+  });
+});
+
+describe("MeshExpress health endpoints", () => {
+  let server: Server;
+  let base: string;
+
+  beforeEach(async () => {
+    const app = express();
+    // Constructing MeshExpress wires the health endpoints; start() is NOT
+    // called (it would register with a registry and open a heartbeat).
+    new MeshExpress(app, { name: "livez-test-api", httpPort: 0 });
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+    base = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("GET /livez returns 200 with alive:true", async () => {
+    const res = await fetch(`${base}/livez`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.alive).toBe(true);
+    expect(body.agent).toBe("livez-test-api");
+    expect(typeof body.timestamp).toBe("string");
+  });
+
+  it("HEAD /livez returns 200", async () => {
+    const res = await fetch(`${base}/livez`, { method: "HEAD" });
+    expect(res.status).toBe(200);
+  });
+
+  it("/livez stays 200 while /ready is 503 (unstarted agent)", async () => {
+    // The #1467 invariant: the condition that takes the service out of
+    // rotation must NOT also restart it.
+    expect((await fetch(`${base}/ready`)).status).toBe(503);
+    expect((await fetch(`${base}/livez`)).status).toBe(200);
+  });
+
+  it("/health is unchanged", async () => {
+    const res = await fetch(`${base}/health`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe("healthy");
+  });
+});

--- a/src/runtime/typescript/src/__tests__/livez-route.spec.ts
+++ b/src/runtime/typescript/src/__tests__/livez-route.spec.ts
@@ -16,6 +16,7 @@ import type { Server } from "http";
 import express from "express";
 import { registerLivezRoute } from "../livez-route.js";
 import { MeshExpress } from "../express.js";
+import { MeshAgent } from "../agent.js";
 
 describe("registerLivezRoute — FastMCP/Hono surface", () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
@@ -97,6 +98,87 @@ describe("registerLivezRoute — FastMCP/Hono surface", () => {
     expect(errorSpy).toHaveBeenCalledOnce();
     expect(errorSpy.mock.calls[0][0] as string).toContain(
       "hono internal: route conflict",
+    );
+  });
+});
+
+describe("_autoStart aborts when /livez cannot be registered", () => {
+  // There is no degraded mode: an agent that serves without /livez is
+  // restarted by the kubelet every probe interval. `_autoStart` must
+  // therefore honour the boolean and fail fast (same class as
+  // #1387/#1389 in Python, made fail-fast in v3.3.2).
+  //
+  // The auto-scheduled `_autoStart` tick from the constructor is stubbed
+  // out (existing convention) — its rejection handler calls
+  // `process.exit(1)`, which would take the test runner down. The
+  // ORIGINAL method is captured and invoked explicitly instead.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const originalAutoStart = (MeshAgent.prototype as any)._autoStart;
+  const spies: ReturnType<typeof vi.spyOn>[] = [];
+
+  function stubPrototype(name: string, impl: () => unknown = () => undefined) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spies.push(vi.spyOn(MeshAgent.prototype as any, name).mockImplementation(impl));
+  }
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    stubPrototype("_autoStart", async () => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    spies.length = 0;
+  });
+
+  function newAgent(getApp: () => unknown): MeshAgent {
+    const server = {
+      addTool: vi.fn(),
+      start: vi.fn().mockResolvedValue(undefined),
+      getApp,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    return new MeshAgent(server, { name: "livez-abort-test", httpPort: 0 });
+  }
+
+  it("rejects with an actionable message when the route cannot be mounted", async () => {
+    const agent = newAgent(() => {
+      throw new Error("FastMCP server not started");
+    });
+
+    await expect(originalAutoStart.call(agent)).rejects.toThrow(
+      /\/livez liveness route failed to register/,
+    );
+  });
+
+  it("names the agent and the restart consequence in the abort message", async () => {
+    const agent = newAgent(() => null);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const err = await originalAutoStart.call(agent).catch((e: any) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("livez-abort-test");
+    expect(err.message).toContain("cannot start");
+    expect(err.message).toMatch(/restart/i);
+  });
+
+  it("continues past the /livez step when registration succeeds", async () => {
+    const on = vi.fn();
+    const agent = newAgent(() => ({ on, post: vi.fn() }));
+    // Everything after the /livez step reaches the registry, the napi
+    // handle and process-wide signal handlers — out of scope here.
+    stubPrototype("registerLlmTools");
+    stubPrototype("registerJobsHelperTools");
+    stubPrototype("startHeartbeat", async () => undefined);
+    stubPrototype("startClaimDispatchers");
+    stubPrototype("installSignalHandlers");
+
+    await expect(originalAutoStart.call(agent)).resolves.toBeUndefined();
+    expect(on).toHaveBeenCalledWith(
+      ["GET", "HEAD"],
+      "/livez",
+      expect.any(Function),
     );
   });
 });

--- a/src/runtime/typescript/src/__tests__/service-view.spec.ts
+++ b/src/runtime/typescript/src/__tests__/service-view.spec.ts
@@ -98,7 +98,13 @@ beforeEach(() => {
   RouteRegistry.reset();
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Flush the auto-start tick a constructor may have scheduled in this
+  // test WHILE the stub above is still installed. Restoring first lets
+  // the real `_autoStart` run against the stub FastMCP, which aborts
+  // startup (no /livez route — issue #1467) and process.exit(1)s the
+  // worker.
+  await new Promise<void>((resolve) => process.nextTick(resolve));
   autoStartSpy?.mockRestore();
   autoStartSpy = null;
   warnSpy?.mockRestore();

--- a/src/runtime/typescript/src/__tests__/unresolved-dep-no-shift.spec.ts
+++ b/src/runtime/typescript/src/__tests__/unresolved-dep-no-shift.spec.ts
@@ -101,7 +101,13 @@ beforeEach(() => {
   __resetUnwiredSlotWarnedForTests();
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Flush the auto-start tick a constructor may have scheduled in this
+  // test WHILE the stub above is still installed. Restoring first lets
+  // the real `_autoStart` run against the stub FastMCP, which aborts
+  // startup (no /livez route — issue #1467) and process.exit(1)s the
+  // worker.
+  await new Promise<void>((resolve) => process.nextTick(resolve));
   autoStartSpy?.mockRestore();
   autoStartSpy = null;
   warnSpy?.mockRestore();

--- a/src/runtime/typescript/src/__tests__/unwired-slot-warn.spec.ts
+++ b/src/runtime/typescript/src/__tests__/unwired-slot-warn.spec.ts
@@ -48,7 +48,13 @@ beforeEach(() => {
   __resetUnwiredSlotWarnedForTests();
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Flush the auto-start tick a constructor may have scheduled in this
+  // test WHILE the stub above is still installed. Restoring first lets
+  // the real `_autoStart` run against the stub FastMCP, which aborts
+  // startup (no /livez route — issue #1467) and process.exit(1)s the
+  // worker.
+  await new Promise<void>((resolve) => process.nextTick(resolve));
   if (autoStartSpy) {
     autoStartSpy.mockRestore();
     autoStartSpy = null;

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -1924,7 +1924,31 @@ export class MeshAgent {
     // own URL so a dependency outage can make the agent unready without
     // also making Kubernetes restart it. Unconditional (no registry
     // required): the kubelet probes the pod either way.
-    registerLivezRoute(this.server, this.config.name);
+    //
+    // Fail-fast, deliberately, against mesh's usual soft-fail posture:
+    // there is no degraded mode to fall back to. With the chart probing
+    // /livez, an unregistered route means the kubelet 404s liveness and
+    // Kubernetes restarts the pod every ~30s — continuing does not
+    // degrade gracefully, it produces a CrashLoopBackOff whose only
+    // stated cause is "liveness probe failed", with nothing pointing at
+    // the missing route. Throwing produces the same CrashLoopBackOff
+    // with an accurate, actionable message.
+    //
+    // Same class as #1387/#1389 in Python: route rebuilding depended on
+    // private FastAPI internals, one was renamed, the ImportError was
+    // swallowed and success reported. That was made fail-fast in v3.3.2
+    // as a documented behaviour change. registerLivezRoute reaches into
+    // FastMCP internals for its Hono app and is exactly as fragile — if
+    // fastmcp's shape changes this returns false, and every TypeScript
+    // agent restart-loops. Do not soften this back to a warning.
+    if (!registerLivezRoute(this.server, this.config.name)) {
+      throw new Error(
+        `agent ${this.agentId} cannot start: the /livez liveness route ` +
+          `failed to register (cause logged above). Kubernetes probes ` +
+          `/livez for liveness, so serving without it would restart this ` +
+          `agent on every probe interval.`,
+      );
+    }
 
     // 2. Register LLM tools from LlmToolRegistry
     this.registerLlmTools();

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -73,6 +73,7 @@ import {
   type HelperToolMeta,
 } from "./jobs-helper-tools.js";
 import { registerCancelRoute } from "./jobs-cancel-route.js";
+import { registerLivezRoute } from "./livez-route.js";
 import {
   clusterStrictEnabled,
   normalizeSchemaWithPolicy,
@@ -1917,6 +1918,13 @@ export class MeshAgent {
 
       console.log(`Agent listening on port ${this.config.httpPort}`);
     }
+
+    // 1.5 Issue #1467: mount GET|HEAD /livez as early as possible —
+    // FastMCP serves /health and /ready itself, but liveness needs its
+    // own URL so a dependency outage can make the agent unready without
+    // also making Kubernetes restart it. Unconditional (no registry
+    // required): the kubelet probes the pod either way.
+    registerLivezRoute(this.server, this.config.name);
 
     // 2. Register LLM tools from LlmToolRegistry
     this.registerLlmTools();

--- a/src/runtime/typescript/src/express.ts
+++ b/src/runtime/typescript/src/express.ts
@@ -208,6 +208,20 @@ export class MeshExpress {
         serviceId: this.serviceId,
       });
     });
+
+    // Liveness endpoint (issue #1467) — always 200 while the process is
+    // up. Deliberately consults NOTHING: liveness must not share a URL
+    // with readiness, or a dependency outage that should only make the
+    // service unready restarts the pod instead. Mirrors Python's
+    // `build_livez_response`.
+    this.app.get("/livez", (_req: Request, res: Response) => {
+      res.status(200).json({
+        alive: true,
+        agent: this.config.name,
+        serviceId: this.serviceId,
+        timestamp: new Date().toISOString(),
+      });
+    });
   }
 
   /**

--- a/src/runtime/typescript/src/livez-route.ts
+++ b/src/runtime/typescript/src/livez-route.ts
@@ -1,0 +1,74 @@
+/**
+ * Mount the Kubernetes liveness route (`GET|HEAD /livez`) on the agent's
+ * HTTP server (issue #1467).
+ *
+ * Mirrors Python's `/livez` in `mesh/decorators.py`, which is served by
+ * the framework loop and returns 200 for as long as the process is up.
+ *
+ * Liveness must be a DIFFERENT signal from readiness: a probe that
+ * consults anything the agent depends on (an upstream vendor, the
+ * registry, a user health check) turns a dependency outage into a pod
+ * restart, which cannot fix the dependency and erases the evidence that
+ * the agent was failing. `/livez` therefore answers 200 unconditionally
+ * — reaching the handler at all proves the event loop is alive, which is
+ * the only thing a restart can repair.
+ *
+ * FastMCP already serves `/health` and `/ready`; only `/livez` is
+ * missing, and it is registered on FastMCP's underlying Hono app (the
+ * same mechanism as the MeshJob cancel route — FastMCP consults the Hono
+ * router before its own built-in health handling, and there is no path
+ * overlap).
+ */
+import type { FastMCP } from "fastmcp";
+
+/**
+ * Register `GET|HEAD /livez` on the FastMCP server's Hono app. Returns
+ * `true` iff the route was registered. `server.getApp()` throws before
+ * the server has started, so this must be called after
+ * `server.start()`.
+ *
+ * A failure here is loud: with the chart's liveness probe pointing at
+ * `/livez`, a missing route 404s and Kubernetes restarts a perfectly
+ * healthy agent.
+ */
+export function registerLivezRoute(server: FastMCP, agentName: string): boolean {
+  let app: ReturnType<FastMCP["getApp"]> | null = null;
+  try {
+    app = server.getApp();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[mesh] /livez route NOT registered — FastMCP.getApp() ` +
+        `unavailable: ${reason}. A Kubernetes liveness probe pointed at ` +
+        `/livez will 404 and restart this agent.`,
+    );
+    return false;
+  }
+  if (!app) {
+    console.error(
+      `[mesh] /livez route NOT registered — FastMCP.getApp() returned ` +
+        `null. A Kubernetes liveness probe pointed at /livez will 404 ` +
+        `and restart this agent.`,
+    );
+    return false;
+  }
+
+  try {
+    app.on(["GET", "HEAD"], "/livez", (c) =>
+      c.json({
+        alive: true,
+        agent: agentName,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+    return true;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[mesh] /livez route NOT registered — app.on() raised: ${reason}. ` +
+        `A Kubernetes liveness probe pointed at /livez will 404 and ` +
+        `restart this agent.`,
+    );
+    return false;
+  }
+}

--- a/src/runtime/typescript/src/livez-route.ts
+++ b/src/runtime/typescript/src/livez-route.ts
@@ -27,9 +27,10 @@ import type { FastMCP } from "fastmcp";
  * the server has started, so this must be called after
  * `server.start()`.
  *
- * A failure here is loud: with the chart's liveness probe pointing at
- * `/livez`, a missing route 404s and Kubernetes restarts a perfectly
- * healthy agent.
+ * Each failure branch logs the CAUSE only. The consequence — that the
+ * agent cannot serve without this route, and startup is aborted — is
+ * stated once, by the caller that throws (see `agent.ts`), so the two
+ * messages complement rather than repeat each other.
  */
 export function registerLivezRoute(server: FastMCP, agentName: string): boolean {
   let app: ReturnType<FastMCP["getApp"]> | null = null;
@@ -39,16 +40,13 @@ export function registerLivezRoute(server: FastMCP, agentName: string): boolean 
     const reason = err instanceof Error ? err.message : String(err);
     console.error(
       `[mesh] /livez route NOT registered — FastMCP.getApp() ` +
-        `unavailable: ${reason}. A Kubernetes liveness probe pointed at ` +
-        `/livez will 404 and restart this agent.`,
+        `unavailable: ${reason}`,
     );
     return false;
   }
   if (!app) {
     console.error(
-      `[mesh] /livez route NOT registered — FastMCP.getApp() returned ` +
-        `null. A Kubernetes liveness probe pointed at /livez will 404 ` +
-        `and restart this agent.`,
+      `[mesh] /livez route NOT registered — FastMCP.getApp() returned null`,
     );
     return false;
   }
@@ -65,9 +63,7 @@ export function registerLivezRoute(server: FastMCP, agentName: string): boolean 
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     console.error(
-      `[mesh] /livez route NOT registered — app.on() raised: ${reason}. ` +
-        `A Kubernetes liveness probe pointed at /livez will 404 and ` +
-        `restart this agent.`,
+      `[mesh] /livez route NOT registered — app.on() raised: ${reason}`,
     );
     return false;
   }


### PR DESCRIPTION
## Summary

The agent chart pointed **all three probes at `/health`**, and on Python `/health` consults the user's `health_check`. So an LLM vendor outage failed **liveness** and Kubernetes killed the pod — which cannot fix the vendor, and destroys the only state that knew the provider was failing. It restarts, re-registers healthy, resolution switches back, and the consumer flaps for the entire outage.

**Not a resolver gap.** `ReasonUnhealthy` / `ReasonUnavailable` / `ReasonUnreachable` are already live eviction reasons, and the registry evicted correctly. The *restart* is what made the provider healthy again.

| runtime | before | after |
|---|---|---|
| Python | `/health`, `/ready`, `/livez` all correct | **unchanged** |
| TypeScript | `/health`, `/ready` | + `/livez` |
| Java | `/health` only | + `/livez`, `/ready` |
| chart | 3 probes → `/health` | startup → `/health`, liveness → `/livez`, readiness → `/ready` |

## The finding that would have caused a worse bug

**TypeScript has two health surfaces, not one.** MCP agents (`MeshAgent`) get `/health` and `/ready` from **fastmcp's own request handling**, not from `express.ts`. Patching `express.ts` alone would have left every `@mesh.tool` TypeScript agent 404ing `/livez` — producing exactly this restart loop in the runtime that never had it. `/livez` is now registered on FastMCP's Hono app too (fastmcp consults Hono first), mirroring `jobs-cancel-route.ts` conventions.

## `startupProbe` moved as well — the reasoning

A startup probe's failure action is **also a container restart**. Left on `/health`, a Python provider that boots *during* the outage never passes startup (`failureThreshold: 30 × periodSeconds: 10` = 300s) and gets killed, then restarts into the same outage — the same bug on a five-minute cadence, re-entered on every restart.

Counter-argument weighed: `/health`-based startup is the only probe that can restart a process which binds its port but wedges during init. Judged the worse trade — it can't distinguish a wedged boot from an external outage, and a wedged agent on `/livez` still shows `0/1 READY` (diagnosable, no traffic, no flapping), which fits mesh's soft-fail posture better than CrashLoopBackOff. One-line revert if you disagree.

## Two details in the Java implementation

`/livez` deliberately does **not** consult `isRunning()` — a runtime that hasn't started yet would otherwise restart-loop through a slow boot. The agent-name lookup is in a try/catch because `runtime` is a `@Lazy` proxy that can raise mid-boot, and liveness must still answer 200.

`/ready` is `isRunning()`, with a javadoc saying plainly that Java has no user health check and this does **not** reflect dependency health. Better an honest signal than an implied one.

## Registry chart — verified, not assumed

`GetHealth` (`ent_handlers.go:156`) returns a hardcoded `healthy` with uptime and touches no DB, dependency or user check. Pure liveness already, so both probes sharing it cannot loop on anything external. No change; a comment records why, so the next reader doesn't re-derive it.

## Proof all three runtimes answer `/livez` — before the chart default moved

Real agents, real curls, killed by PID:

| runtime | `GET /livez` | `HEAD /livez` | `/ready` | `/health` |
|---|---|---|---|---|
| Python (`hello_world.py`) | 200 | 200 | 200 | 200 |
| TypeScript (`greeter`, fastmcp path) | 200 | 200 | 200 | 200 |
| Java (`basic-tool-agent`) | 200 | 200 | 200 `{"ready":true}` | 200 |

All four surfaces answered with no registry reachable. MeshExpress is covered by a test binding a real socket.

## Test plan

- [x] TypeScript **1277 passed** (89 files), `typecheck` clean; 9 new tests
- [x] Java **1175 passed**, 0 failures; 11 new tests incl. HEAD variants
- [x] Python **1565 passed, 1 skipped** — unchanged, as expected
- [x] `check_helm_render_matrix.py` **39/39** (was 38) — now asserts the probe paths, since a chart default that silently reverts *is* this bug returning
- [x] `helm lint` 0 failed · `check_helm_pss.py` · `check_helm_volume_keys.py` green
- [x] Fail-without-fix proven for each: removing the express `/livez` → 3 failures; making Java's `/livez` consult `isRunning()` → 5 failures; flipping the chart's liveness path → matrix FAIL
- [ ] CI green

## ⚠️ Upgrade constraint — needs a release note

**Chart and runtime images must move together for Java and TypeScript agents.** The chart now probes `/livez`; a 3.5.0 Java or TS image doesn't serve it, so the probe 404s and Kubernetes restarts a healthy agent. Python agents are safe either way — `/livez` has existed there all along. Nothing in the chart can detect the image version, so this is documentation-only.

## Noted, not fixed

The new `probe_paths` matrix case asserts the agent chart's shipped defaults only; a user overriding paths in their own values file can still collapse them, and the values comment is the only defence there.

Java and TypeScript still have no user-health-check concept, so their `/ready` cannot surface a vendor outage in either direction. That is the separate feature #1467 calls out and this PR deliberately leaves alone.

Closes #1467


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated `/livez` liveness and `/ready` readiness endpoints across supported runtimes.
  - Liveness checks now return promptly and independently of dependency or runtime readiness.
  - Readiness checks report whether the mesh is available, including appropriate success or failure status codes.
  - Added support for both `GET` and `HEAD` requests on probe endpoints.
  - Preserved the existing `/health` endpoint.

- **Documentation**
  - Improved deployment guidance describing probe behavior, endpoint semantics, and restart handling.

- **Tests**
  - Added coverage for probe routing, responses, status codes, and Helm configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->