### PR TITLE
docs: publish release notes on the site and document probe endpoints

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'RELEASE_NOTES.md'  # included verbatim by docs/release-notes.md
       - '.github/workflows/docs.yml'
       - 'examples/tutorial/**'
       - 'scripts/generate_tutorial_artifacts.sh'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,18 +1,8 @@
 # MCP Mesh Release Notes
 
-[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.5.1...HEAD)
+[Unreleased changes](https://github.com/dhyansraj/mcp-mesh/compare/v3.5.1...HEAD)
 
 [Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.5.0...v3.5.1)
-
-[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.4.0...v3.5.0)
-
-[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.3.2...v3.4.0)
-
-[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.3.1...v3.3.2)
-
-[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.3.0...v3.3.1)
-
-[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.2.3...v3.3.0)
 
 ## v3.5.1 (2026-08-04)
 
@@ -29,6 +19,8 @@ A one-fix patch. The agent chart pointed liveness, readiness and startup at the 
 
 - **⚠️ Upgrade the agent chart and your Java or TypeScript images together.** The chart probes `/livez` for liveness and startup, and a 3.5.0 or older image of either runtime does not serve it — the probe 404s and Kubernetes restarts an agent that is perfectly healthy. This inverts the usual assumption that a chart tolerates older images, and nothing in the chart can detect the image version. Python agents are safe in either order; `/livez` has been served there since well before this release.
 - **Java and TypeScript `/ready` reports only whether the runtime is running.** Neither has a user health-check concept, so their readiness cannot yet reflect a dependency outage in either direction. Python's does.
+
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.4.0...v3.5.0)
 
 ## v3.5.0 (2026-08-04)
 
@@ -52,6 +44,8 @@ A small release with two breaking changes, both in deployment and packaging rath
 - **Python agents on any vendor other than Anthropic, OpenAI or Gemini need `mcp-mesh[litellm]`** in `requirements.txt`. The extra has been installable since 3.3.2 and layers over an existing install without upgrading the base. The big three need no change.
 - **⚠️ If a chart is already wedged in the dual-type volume state, delete the Deployment and let it be recreated before upgrading.** The rename is a clean remove-and-add only when the applying field manager owns the existing volume; otherwise the rename itself can stick.
 - **No wire-protocol, registry-schema, dependency-resolution or declaration-syntax changes.** The only runtime code change is the Python provider's vendor extraction, which now treats an absent `litellm` as the normal case instead of logging a startup warning.
+
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.3.2...v3.4.0)
 
 ## v3.4.0 (2026-08-01)
 
@@ -117,6 +111,8 @@ A minor release with breaking changes in two runtimes. Dependency injection is n
 - **Fresh installs resolve differently.** `openai` moves `>=1.60` → `>=2.14,<3`, and `anthropic`, `google-genai` and `litellm` gain `<1`, `<3` and `<2`. A `pip install` today resolves to exactly the same package set — the bounds exist to fail on a future major. Existing environments are unchanged until you reinstall.
 - **No wire-protocol, registry-schema or dependency-resolution changes.** The binding change is internal to the Java and TypeScript runtimes; #1433's registry change is telemetry housekeeping plus two new environment knobs.
 
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.3.1...v3.3.2)
+
 ## v3.3.2 (2026-07-28)
 
 A patch release, and an important one for Python `@mesh.route` users: **v3.3.1's declared FastAPI range resolves to versions where routes are silently broken.** On current FastAPI, SSE routes degrade to `application/jsonl` instead of `text/event-stream`, and handlers mounted with `include_router()` are never discovered at all, so they serve without mesh dependency injection. Neither failure is loud — startup succeeds, health checks pass, and the logs still claim success. Both are fixed here, alongside a published-manifest reconciliation and the first half of LiteLLM's move to an optional install. No wire, registry, resolution, or declaration-syntax changes.
@@ -160,6 +156,8 @@ A patch release, and an important one for Python `@mesh.route` users: **v3.3.1's
 - **The `[litellm]` extra requires no action.** `litellm` is still installed by default; the extra is additive today and only becomes load-bearing when the base dependency is removed at a future major.
 - **No wire, registry, resolution, or declaration-syntax changes.**
 
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.3.0...v3.3.1)
+
 ## v3.3.1 (2026-07-23)
 
 A release-infrastructure patch. No runtime, wire, registry, resolution, or declaration-syntax changes — behavior is identical to 3.3.0.
@@ -171,6 +169,8 @@ A release-infrastructure patch. No runtime, wire, registry, resolution, or decla
 ### 📝 Docs
 
 - Refreshed the project cover image.
+
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.2.3...v3.3.0)
 
 ## v3.3.0 (2026-07-23)
 
@@ -2268,7 +2268,7 @@ All three bugs were regressions introduced in v0.9.7 by PR #585.
 
 **Advanced Dependency Resolution**
 
-- Added +/- operator support in tags: + means preferred, - means exclude
+- Added `+/-` operator support in tags: + means preferred, - means exclude
 
 ### 🐛 Bug Fixes & Stability
 

--- a/docs/concepts/health-discovery.md
+++ b/docs/concepts/health-discovery.md
@@ -72,6 +72,18 @@ class MyAgent:
     pass
 ```
 
+### Kubernetes Probes
+
+Every runtime serves three endpoints, and probes must not share one:
+
+| Endpoint  | Probe                             | Reports                                                                                             |
+| --------- | --------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `/livez`  | `livenessProbe`, `startupProbe`   | 200 for as long as the process is serving. Consults nothing else.                                     |
+| `/ready`  | `readinessProbe`                  | Whether traffic should be routed here. Reflects `health_check` on Python; Java and TypeScript have no user health check, so it reports only that the mesh runtime is running. |
+| `/health` | none                              | The diagnostic view: the `/ready` signal plus `checks` and `errors`.                                  |
+
+Pointing liveness or startup at `/health` or `/ready` turns an upstream outage into a pod restart, which cannot fix the outage. The Helm chart is already wired this way.
+
 ### Health States
 
 | State       | Description                 |

--- a/docs/concepts/health-discovery.md
+++ b/docs/concepts/health-discovery.md
@@ -80,9 +80,9 @@ Every runtime serves three endpoints, and probes must not share one:
 | --------- | --------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `/livez`  | `livenessProbe`, `startupProbe`   | 200 for as long as the process is serving. Consults nothing else.                                     |
 | `/ready`  | `readinessProbe`                  | Whether traffic should be routed here. Reflects `health_check` on Python; Java and TypeScript have no user health check, so it reports only that the mesh runtime is running. |
-| `/health` | none                              | The diagnostic view: the `/ready` signal plus `checks` and `errors`.                                  |
+| `/health` | none                              | Runtime-specific. Python returns the `/ready` signal plus `checks` and `errors`; Java reports the same runtime state without them; TypeScript returns a fixed `healthy` and reflects nothing. |
 
-Pointing liveness or startup at `/health` or `/ready` turns an upstream outage into a pod restart, which cannot fix the outage. The Helm chart is already wired this way.
+Never point liveness or startup at `/ready` or `/health`. On Python, where `/ready` reflects your `health_check`, that turns an upstream outage into a pod restart, which cannot fix the outage. On Java and TypeScript, where `/ready` reports only runtime state, it still restarts pods that are merely still booting. The Helm chart is already wired this way.
 
 ### Health States
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -418,6 +418,8 @@ A `kubectl`-style command-line tool that follows you from first agent to product
 - **Languages**: Python 3.11+, TypeScript/Node.js 18+, and Java 17+ (runtime), Go 1.23+ (registry)
 - **Status**: Production-ready, actively developed
 
+What changed in each version — breaking changes, upgrade notes and fixes — is in the [Release Notes](release-notes.md).
+
 ---
 
 ## :pray: Acknowledgments

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,12 @@
+---
+title: Release Notes
+description: Version history for MCP Mesh — every release, newest first.
+---
+
+<!--
+  Single source of truth: RELEASE_NOTES.md at the repository root.
+  It is included verbatim below. Never paste release content into this file —
+  a second copy would drift. Edit RELEASE_NOTES.md instead.
+-->
+
+--8<-- "RELEASE_NOTES.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,8 +124,9 @@ markdown_extensions:
   - pymdownx.smartsymbols
   - pymdownx.snippets:
       base_path: [docs, .]
-      auto_append:
-        - includes/abbreviations.md
+      # Fail the build on a missing snippet source instead of silently
+      # rendering an empty page (docs/release-notes.md includes RELEASE_NOTES.md).
+      check_paths: true
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid
@@ -312,6 +313,9 @@ nav:
       - Registration Trust: security/registration-trust.md
       - Agent-to-Agent mTLS: security/agent-to-agent-mtls.md
       - Authorization: security/authorization.md
+
+  # Included verbatim from RELEASE_NOTES.md at the repo root (single source of truth)
+  - Release Notes: release-notes.md
 
   - FAQ: faq.md
 

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -364,6 +364,14 @@ class MyAgent:
     pass
 ```
 
+Every runtime serves three endpoints, and Kubernetes probes must not share one:
+
+- `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
+- `/ready` - `readinessProbe`. Whether traffic should be routed here; reflects your `health_check`.
+- `/health` - no probe. The diagnostic view: the `/ready` signal plus `checks` and `errors`.
+
+Pointing liveness or startup at `/health` or `/ready` turns an upstream outage into a pod restart, which cannot fix the outage. The Helm chart is already wired this way.
+
 ### Resource Limits
 
 ```yaml

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -275,9 +275,9 @@ The starter also serves the three mesh endpoints, and Kubernetes probes must not
 
 - `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
 - `/ready` - `readinessProbe`. Whether traffic should be routed here. Java has no user health check, so this reports only that the mesh runtime is running.
-- `/health` - no probe. The diagnostic view of the same signal.
+- `/health` - no probe. Reports the same runtime state as `/ready`, as a `status` field.
 
-Pointing liveness or startup at `/health` or `/ready` turns an upstream outage into a pod restart, which cannot fix the outage. The Helm chart is already wired this way.
+Both `/health` and `/ready` answer 503 until the mesh runtime is up, so pointing liveness or startup at either restarts pods that are merely still booting. The Helm chart is already wired this way.
 
 ### Graceful Shutdown
 

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -271,6 +271,14 @@ The Helm chart sets `MCP_MESH_HTTP_PORT=8080` which overrides `@MeshAgent(port =
 
 Spring Boot agents automatically expose `/actuator/health`. The MCP Mesh starter integrates with Spring Boot's health system.
 
+The starter also serves the three mesh endpoints, and Kubernetes probes must not share one:
+
+- `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
+- `/ready` - `readinessProbe`. Whether traffic should be routed here. Java has no user health check, so this reports only that the mesh runtime is running.
+- `/health` - no probe. The diagnostic view of the same signal.
+
+Pointing liveness or startup at `/health` or `/ready` turns an upstream outage into a pod restart, which cannot fix the outage. The Helm chart is already wired this way.
+
 ### Graceful Shutdown
 
 Spring Boot handles `SIGINT`/`SIGTERM` automatically. Agents deregister from the registry on shutdown.

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -228,9 +228,9 @@ There are three of them, and Kubernetes probes must not share one:
 
 - `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
 - `/ready` - `readinessProbe`. Whether traffic should be routed here. TypeScript has no user health check, so this reports only that the mesh runtime is running.
-- `/health` - no probe. The diagnostic view of the same signal.
+- `/health` - no probe. A fixed `{ status: "healthy" }` that reflects nothing.
 
-Pointing liveness or startup at `/health` or `/ready` turns an upstream outage into a pod restart, which cannot fix the outage. The Helm chart is already wired this way.
+`/ready` answers 503 until the mesh runtime is up, so pointing liveness or startup at it restarts pods that are merely still booting; `/health` never fails at all. The Helm chart is already wired this way.
 
 ### Graceful Shutdown
 

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -224,6 +224,14 @@ TypeScript agents automatically expose health endpoints:
 // Returns: { status: "healthy", agentId: "my-agent-abc123" }
 ```
 
+There are three of them, and Kubernetes probes must not share one:
+
+- `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
+- `/ready` - `readinessProbe`. Whether traffic should be routed here. TypeScript has no user health check, so this reports only that the mesh runtime is running.
+- `/health` - no probe. The diagnostic view of the same signal.
+
+Pointing liveness or startup at `/health` or `/ready` turns an upstream outage into a pod restart, which cannot fix the outage. The Helm chart is already wired this way.
+
 ### Graceful Shutdown
 
 TypeScript SDK handles SIGINT/SIGTERM automatically:

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -200,10 +200,21 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // extra. That bullet is the whole delta — the reworked paragraph swaps spans
 // one-for-one. The two list goldens are unmoved because the new span sits on
 // the bullet's wrapped continuation line, which is not itself a list line.
+// #1467/#1468 follow-up: +12 / +10 / +3, all in `deployment.md`. The probe
+// split landed in the chart with no doc surface saying which probe belongs on
+// which path, so anyone writing their own manifests would repeat what the chart
+// used to do — point everything at `/health` — and reproduce the restart loop.
+// Three bullets under "Health Checks" name the endpoints (`/livez` for liveness
+// and startup, `/ready` for readiness, `/health` for diagnostics only), which is
+// the whole list delta; the two remaining spans are the closing sentence that
+// names the two paths a liveness probe must not use. The `_java` and
+// `_typescript` variants gained the same bullets with a `/ready` clause for
+// runtimes that have no user health check, and are invisible here because these
+// tests sample only the default variant.
 const (
-	wantInlineCodeSpans = 1686
-	wantListCodeSpans   = 506
-	wantMarkupListLines = 442
+	wantInlineCodeSpans = 1698
+	wantListCodeSpans   = 516
+	wantMarkupListLines = 445
 )
 
 // assertCorpusSize replaces the t.Logf these tests used to end on.

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -208,9 +208,12 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // and startup, `/ready` for readiness, `/health` for diagnostics only), which is
 // the whole list delta; the two remaining spans are the closing sentence that
 // names the two paths a liveness probe must not use. The `_java` and
-// `_typescript` variants gained the same bullets with a `/ready` clause for
-// runtimes that have no user health check, and are invisible here because these
-// tests sample only the default variant.
+// `_typescript` variants carry the same three bullets, but their `/ready` and
+// `/health` lines and their closing reason are written to what those runtimes
+// actually return (no user health check; TypeScript's `/health` is a fixed
+// 200). None of that moves these constants: they sample only the default
+// variant, so edits confined to a `_java` / `_typescript` file are invisible
+// here and a review of those files cannot lean on this test.
 const (
 	wantInlineCodeSpans = 1698
 	wantListCodeSpans   = 516


### PR DESCRIPTION
Three related documentation gaps, all surfaced while releasing v3.5.1.

## 1. Release notes on the site — with no second copy

`docs/release-notes.md` is an 11-line stub whose only content is `--8<-- "RELEASE_NOTES.md"`. **Zero duplication** — the root file is read at build time.

`pymdownx.snippets` was chosen because it is *already* enabled, `base_path` already includes the repo root, and the tutorial already uses it 54 times to pull from `examples/`. No new plugin, no copy step, no symlink (a symlink would make `git-revision-date-localized` report the wrong date, and degrades to a text file on Windows checkouts — rendering as garbage rather than failing).

**Fail-loud, verified.** `check_paths: true` means a missing source kills the build by name:

```
ERROR - Error reading page 'release-notes.md': Snippet at path 'RELEASE_NOTES.md' could not be found
BUILD EXIT: 1
```

That flag immediately failed on a **pre-existing dead directive** — `auto_append: includes/abbreviations.md`, a file that has *never existed in this repo's history*, with no page defining a single abbreviation. Silently no-op'ing forever. Removed rather than stubbed. All 54 existing snippet references were then confirmed to resolve, so a renamed tutorial example will now break the build instead of rendering an empty code block.

**The docs workflow wouldn't have redeployed.** `docs.yml` triggered only on `docs/**` and `mkdocs.yml`, so a release commit touching only `RELEASE_NOTES.md` left the site stale. Added to the trigger paths.

Nav: after Security, before FAQ — Release Notes is something users actively look up, so it leads the meta tail rather than sitting behind it. Plus a one-sentence pointer on the home page after Project Status.

## 2. The changelog links had drifted

Rendering the file made this obvious in seconds. The convention — verified mechanically across **all 77 links**, not sampled — is that each sits immediately above the `## vX.Y.Z` heading it describes:

```markdown
[Full Changelog](.../compare/v3.2.0...v3.2.1)

## v3.2.1 (2026-07-17)
```

70 follow it. From **v3.3.0** onward each release appended its link to the *top of the file* instead, so seven stacked under the H1 — and the link physically above `## v3.5.1` described a release seven sections away. Two of those six were added by me while writing the 3.5.0 and 3.5.1 notes, by pattern-matching the top of the file rather than checking the older sections.

The six are moved to their headings. The unreleased pointer stays at the top and is relabelled **`[Unreleased changes]`** — two adjacent links both reading "Full Changelog" scan as a copy-paste slip. Link count is 77 before and after, so nothing was lost or doubled.

Also backticked a `+/-` at line 2271 that `pymdownx.smartsymbols` was rendering as `±`.

## 3. The v3.5.1 probe split was undocumented

#1467/#1468 changed which endpoint each probe should use and touched **neither** `docs/` nor the man corpus. `/livez` appeared only as an aside about loop topology. So anyone hand-writing manifests would point everything at `/health` — exactly the restart loop that change fixed — and `meshctl man` couldn't answer it offline.

Three bullets, after the existing "Always configure health checks" example:

```
- `/livez`  - livenessProbe and startupProbe. 200 while the process is serving; consults nothing else.
- `/ready`  - readinessProbe. Whether traffic should be routed here; reflects your health_check.
- `/health` - no probe. The diagnostic view: the /ready signal plus checks and errors.
```

Semantics were verified per runtime rather than assumed: on Python `/health` and `/ready` read the **same** stored value and both 503 together — `/health` merely carries `checks`/`errors` as well. Stated plainly rather than inventing a distinction.

**Bullets, not a table** — `renderer_test.go`'s #1430 provenance note records that the man renderer passes `|` rows through raw, so table markup would print literally.

**Added to `_java` and `_typescript` too.** A Java user never reads the Python page, and their `/ready` genuinely differs — neither runtime has a user health-check concept, so it reports only that the runtime is running. A cross-reference would have been wrong, not merely terse.

## Test plan

- [x] `mkdocs build` exit 0; fail-loud path verified by moving the source aside
- [x] All 54 pre-existing snippet references resolve under `check_paths`
- [x] Page renders 86 versions newest-first; every heading has its own link directly above it
- [x] `go test ./src/core/cli/man/...` green; goldens **+12 / +10 / +3**, reconciled exactly (10 spans across 3 bullets, 2 in the closing sentence, 3 new markup list lines)
- [x] `go build ./...` clean
- [ ] CI green

## Known and not fixed

**The TOC is long.** `toc.integrate` puts it in the left sidebar, and at `toc_depth: 3` that is **360 entries** — 86 versions plus 274 subsections, all expanded. It *is* a version list, but reaching v2.0.0 means scrolling past ~200 entries. Search rescues it in practice (362 indexed anchors — typing `3.2.0` jumps straight there). `toc_depth: 2` would give a clean 86-entry list but is global and strips `###` from every other page. A per-version split would need a generator, a nav plugin, 86 files churning per release, **and would break every existing anchor URL**.

**Four pre-existing changelog oddities**, each with two defensible repairs, so left for a decision: `## v3.2.3` has no link (v3.2.2 was never fully published); `## v1.1.0` is missing one; line 1494 duplicates v0.8.0's link above `## v0.7.21`; lines 2164/2174 are an interlocked off-by-one caused by v0.5.5 being tagged without a section. Everything at v0.5.1 and older predates the convention.

Closes #1470


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Release Notes page to the documentation site, including version-specific changes, upgrade notes, and fixes.
  - Reorganized release-note links for easier navigation between current and historical releases.
  - Added Kubernetes health-probe guidance covering separate liveness, readiness, and diagnostic endpoints across supported deployment types.
  - Documented the risks of using readiness or diagnostic endpoints for liveness and startup checks.
  - Updated project status information to link directly to release notes.

- **Chores**
  - Documentation publishing now updates when release notes change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->