### PR TITLE
fix: stop heartbeating while the health check fails, so resolution moves on

### DIFF
--- a/src/runtime/core/python/mcp_mesh_core/__init__.py
+++ b/src/runtime/core/python/mcp_mesh_core/__init__.py
@@ -5,6 +5,7 @@ This module is implemented in Rust and provides:
 - AgentHandle: Handle to running agent runtime
 - MeshEvent: Events from topology changes
 - EventType: Type-safe event type enum
+- HealthStatus: Agent health status reported via AgentHandle.update_health()
 - start_agent: Start agent runtime
 - Config resolution functions (ENV > param > default)
 - Response parsing (JSON extraction, code fence stripping)
@@ -20,6 +21,7 @@ from .mcp_mesh_core import (
     AgentSpec,
     DependencySpec,
     EventType,
+    HealthStatus,
     JobController,
     JobProxy,
     LlmAgentSpec,
@@ -75,6 +77,7 @@ __all__ = [
     "AgentSpec",
     "DependencySpec",
     "EventType",
+    "HealthStatus",
     "JobController",
     "JobProxy",
     "LlmAgentSpec",

--- a/src/runtime/core/src/events.rs
+++ b/src/runtime/core/src/events.rs
@@ -27,7 +27,15 @@ pub enum EventType {
     DependencyChanged,
     /// LLM tools list was updated
     LlmToolsUpdated,
-    /// Health check is due (SDK should run health checks)
+    /// Health check is due (SDK should run health checks).
+    ///
+    /// INERT: defined but never emitted by the runtime, and every SDK logs it
+    /// as "not implemented yet". It is the inverse of the design that actually
+    /// shipped in issue #1472 — the SDK owns the health-check timer and pushes
+    /// its verdict in via `RuntimeCommand::UpdateHealth`, so the core never
+    /// needs to ask. Retained only because the variant is part of the
+    /// cross-runtime wire enum (Java's `MeshEvent.Type` maps it). Do not build
+    /// on it.
     HealthCheckDue,
     /// Agent health status changed
     HealthStatusChanged,

--- a/src/runtime/core/src/handle.rs
+++ b/src/runtime/core/src/handle.rs
@@ -204,6 +204,31 @@ impl AgentHandle {
         Ok(self.command_tx.try_send(RuntimeCommand::UpdatePort(port)).is_ok())
     }
 
+    /// Report the agent's health status to the runtime (issue #1472).
+    ///
+    /// Call this from the SDK's periodic health-check loop with the verdict of
+    /// the user-supplied `health_check`. While the status is `Unhealthy` the
+    /// runtime stops heartbeating, so the registry's staleness sweep withdraws
+    /// the agent from dependency resolution; pushing `Healthy` (or `Degraded`)
+    /// resumes heartbeats and the registry restores it — no process restart.
+    ///
+    /// Pushing the same status repeatedly is cheap and idempotent.
+    ///
+    /// Returns True if the update was queued successfully.
+    ///
+    /// # Example (Python)
+    /// ```python
+    /// from mcp_mesh_core import HealthStatus
+    /// handle.update_health(HealthStatus.Unhealthy)
+    /// ```
+    #[pyo3(name = "update_health")]
+    fn update_health_py(&self, status: HealthStatus) -> PyResult<bool> {
+        Ok(self
+            .command_tx
+            .try_send(RuntimeCommand::UpdateHealth(status))
+            .is_ok())
+    }
+
     fn __repr__(&self) -> String {
         let state = self.state.blocking_read();
         format!(
@@ -330,6 +355,27 @@ impl AgentHandle {
             .is_ok()
     }
 
+    /// Report the agent's health status to the runtime (issue #1472).
+    ///
+    /// While the status is `Unhealthy` the runtime suppresses registry traffic
+    /// so the staleness sweep withdraws the agent from resolution; pushing
+    /// `Healthy` / `Degraded` resumes it. Idempotent — SDKs push on every
+    /// health-check tick and the runtime only acts on transitions.
+    pub fn update_health(&self, status: HealthStatus) -> bool {
+        self.command_tx
+            .try_send(RuntimeCommand::UpdateHealth(status))
+            .is_ok()
+    }
+
+    /// Report the agent's health status — async version. Use this when calling
+    /// from an async context (e.g. napi-rs).
+    pub async fn update_health_async(&self, status: HealthStatus) -> bool {
+        self.command_tx
+            .send(RuntimeCommand::UpdateHealth(status))
+            .await
+            .is_ok()
+    }
+
     /// Update the A2A surfaces and agent_type registered with the registry
     /// (issue #938). Uses smart diffing — only triggers a heartbeat if the
     /// payload actually changed. Call this from the SDK after each
@@ -446,6 +492,35 @@ mod tests {
 
         handle.shutdown_async().await;
         assert!(handle.is_shutdown_requested_async().await);
+    }
+
+    /// Issue #1472: `update_health` must reach the runtime as an
+    /// `UpdateHealth` command carrying the reported status — this is the
+    /// whole channel between an SDK's health check and heartbeat suppression.
+    #[tokio::test]
+    async fn test_1472_update_health_enqueues_command() {
+        let (_event_tx, event_rx) = mpsc::channel(10);
+        let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
+        let (command_tx, mut command_rx) = mpsc::channel(10);
+        let state = Arc::new(RwLock::new(HandleState::default()));
+
+        let handle = AgentHandle::new(event_rx, state, shutdown_tx, command_tx);
+
+        assert!(handle.update_health(HealthStatus::Unhealthy));
+        match command_rx.try_recv() {
+            Ok(RuntimeCommand::UpdateHealth(status)) => {
+                assert_eq!(status, HealthStatus::Unhealthy);
+            }
+            other => panic!("expected UpdateHealth(Unhealthy), got {:?}", other),
+        }
+
+        assert!(handle.update_health_async(HealthStatus::Healthy).await);
+        match command_rx.try_recv() {
+            Ok(RuntimeCommand::UpdateHealth(status)) => {
+                assert_eq!(status, HealthStatus::Healthy);
+            }
+            other => panic!("expected UpdateHealth(Healthy), got {:?}", other),
+        }
     }
 
     /// Issue #1256: the event pull must be cancel-safe across its internal

--- a/src/runtime/core/src/heartbeat.rs
+++ b/src/runtime/core/src/heartbeat.rs
@@ -127,6 +127,17 @@ impl HeartbeatStateMachine {
         }
     }
 
+    /// Get the configured interval between heartbeats.
+    ///
+    /// Note this is the interval the machine was *built* with (derived from
+    /// `AgentSpec::heartbeat_interval`), not `RuntimeConfig::heartbeat.interval`
+    /// — the two diverge, so callers that need the effective cadence (e.g. the
+    /// health-suppression wait in `AgentRuntime::run`, issue #1472) must read it
+    /// from here.
+    pub fn heartbeat_interval(&self) -> Duration {
+        self.config.interval
+    }
+
     /// Get the heartbeat count.
     pub fn heartbeat_count(&self) -> u64 {
         self.heartbeat_count
@@ -463,6 +474,41 @@ mod tests {
             "expected jittered backoff to vary, got {:?}",
             values
         );
+    }
+
+    /// Issue #1472: the suppressed-wait cadence is read from the state
+    /// machine, not from `RuntimeConfig` — those two diverge (the machine is
+    /// built with the spec's per-agent interval). Guard the accessor so a
+    /// future refactor can't silently reintroduce the 5s default.
+    #[test]
+    fn test_heartbeat_interval_accessor_reports_configured_value() {
+        let config = HeartbeatConfig {
+            interval: Duration::from_secs(17),
+            ..Default::default()
+        };
+        let sm = HeartbeatStateMachine::new(config);
+        assert_eq!(sm.heartbeat_interval(), Duration::from_secs(17));
+    }
+
+    /// Issue #1472: `set_health_status` is what the `UpdateHealth` command
+    /// drives; the value must survive heartbeat outcomes so the run loop's
+    /// gate stays closed until the SDK says otherwise.
+    #[test]
+    fn test_health_status_round_trips() {
+        let mut sm = HeartbeatStateMachine::new(HeartbeatConfig::default());
+        assert_eq!(sm.health_status(), HealthStatus::Healthy);
+
+        sm.set_health_status(HealthStatus::Unhealthy);
+        assert_eq!(sm.health_status(), HealthStatus::Unhealthy);
+
+        // A successful heartbeat maps Unhealthy onto the Degraded *heartbeat*
+        // state but must not rewrite the SDK-reported health status.
+        sm.on_full_heartbeat_success();
+        assert_eq!(sm.health_status(), HealthStatus::Unhealthy);
+        assert_eq!(sm.state(), HeartbeatState::Degraded);
+
+        sm.set_health_status(HealthStatus::Healthy);
+        assert_eq!(sm.health_status(), HealthStatus::Healthy);
     }
 
     #[test]

--- a/src/runtime/core/src/runtime.rs
+++ b/src/runtime/core/src/runtime.rs
@@ -13,7 +13,7 @@ use tokio::sync::{mpsc, watch, RwLock};
 use tokio::time::sleep;
 use tracing::{info, trace, warn};
 
-use crate::events::{LlmProviderInfo, LlmToolInfo, MeshEvent};
+use crate::events::{HealthStatus, LlmProviderInfo, LlmToolInfo, MeshEvent};
 use crate::handle::HandleState;
 use crate::heartbeat::{HeartbeatAction, HeartbeatConfig, HeartbeatStateMachine};
 use crate::registry::{HeartbeatRequest, HeartbeatResponse, RegistryClient};
@@ -42,6 +42,21 @@ pub enum RuntimeCommand {
         agent_type: String,
         surfaces: Option<String>,
     },
+    /// Update the agent's self-reported health status (issue #1472).
+    ///
+    /// SDKs push the verdict of the user-supplied `health_check` here on
+    /// their own cadence (Python: every `health_check_ttl`, default 15s).
+    /// While the status is `Unhealthy` the runtime suppresses ALL registry
+    /// traffic — see [`AgentRuntime::heartbeat_suppressed`] — so the
+    /// registry's staleness sweep withdraws the agent from dependency
+    /// resolution. Pushing `Healthy` (or `Degraded`) resumes heartbeats and
+    /// the registry restores the agent on the next full heartbeat, with no
+    /// process restart.
+    ///
+    /// Carries the full [`HealthStatus`] rather than a `bool` so that giving
+    /// `Degraded` its own behaviour later is a change to the heartbeat loop,
+    /// not to this command API.
+    UpdateHealth(HealthStatus),
 }
 
 /// Internal provider tracking (non-PyO3 to avoid GIL issues in tokio thread).
@@ -235,7 +250,7 @@ impl AgentRuntime {
             }
 
             // Process any pending commands (non-blocking)
-            self.process_pending_commands();
+            self.process_pending_commands().await;
 
             if self.state_machine.is_shutting_down() {
                 // Gracefully unregister from registry before stopping
@@ -243,15 +258,39 @@ impl AgentRuntime {
                 break;
             }
 
+            // Issue #1472: the SDK reported the agent unhealthy — go silent
+            // so the registry's staleness sweep withdraws it from resolution.
+            let suppressed = self.heartbeat_suppressed();
+
             // Check if we need to force a full heartbeat (e.g., after tools update)
-            if self.force_full_heartbeat {
+            // The flag is deliberately NOT cleared while suppressed: the pending
+            // change (tools / port / surfaces) is remembered and pushed on the
+            // first heartbeat after recovery.
+            if self.force_full_heartbeat && !suppressed {
                 self.force_full_heartbeat = false;
                 self.send_full_heartbeat().await;
                 continue;
             }
 
             // Determine next action
-            let action = self.state_machine.next_action();
+            let mut action = self.state_machine.next_action();
+
+            // Issue #1472: while suppressed, swap any registry-bound action for
+            // a plain Wait. Waiting — rather than `continue`-ing — is
+            // load-bearing: the Wait arm's `select!` is what keeps the shutdown
+            // signal, the command channel (including the `UpdateHealth(Healthy)`
+            // that ENDS the suppression) and the independent dependency-reconcile
+            // tick alive. A bare `continue` would spin the loop hot and starve
+            // the reconcile timer, which only ticks inside that `select!`.
+            if suppressed {
+                if let HeartbeatAction::SendFull
+                | HeartbeatAction::SendFast
+                | HeartbeatAction::Retry { .. } = action
+                {
+                    trace!("Health status Unhealthy — suppressing {:?}", action);
+                    action = HeartbeatAction::Wait(self.state_machine.heartbeat_interval());
+                }
+            }
             trace!("Next action: {:?}", action);
 
             match action {
@@ -271,7 +310,7 @@ impl AgentRuntime {
                         }
                         cmd = self.command_rx.recv() => {
                             if let Some(cmd) = cmd {
-                                self.handle_command(cmd);
+                                self.handle_command(cmd).await;
                             }
                         }
                         // Independent wall-clock reconcile tick (issue #1314).
@@ -295,7 +334,7 @@ impl AgentRuntime {
                         }
                         cmd = self.command_rx.recv() => {
                             if let Some(cmd) = cmd {
-                                self.handle_command(cmd);
+                                self.handle_command(cmd).await;
                             }
                         }
                     }
@@ -308,6 +347,14 @@ impl AgentRuntime {
                     // Wait arm doesn't need this: it does no state-mutating
                     // work after its select.
                     if self.state_machine.is_shutting_down() {
+                        continue;
+                    }
+                    // Same shape for the health gate (issue #1472): an
+                    // `UpdateHealth(Unhealthy)` that landed on the command arm
+                    // during the backoff must not be undone by the heartbeat
+                    // this arm would otherwise send. Fall through to the loop
+                    // top, which re-evaluates the gate.
+                    if self.heartbeat_suppressed() {
                         continue;
                     }
                     // After backoff, try full registration
@@ -325,14 +372,14 @@ impl AgentRuntime {
     }
 
     /// Process any pending commands without blocking.
-    fn process_pending_commands(&mut self) {
+    async fn process_pending_commands(&mut self) {
         while let Ok(cmd) = self.command_rx.try_recv() {
-            self.handle_command(cmd);
+            self.handle_command(cmd).await;
         }
     }
 
     /// Handle a runtime command.
-    fn handle_command(&mut self, cmd: RuntimeCommand) {
+    async fn handle_command(&mut self, cmd: RuntimeCommand) {
         match cmd {
             RuntimeCommand::UpdateTools(new_tools) => {
                 self.handle_update_tools(new_tools);
@@ -347,6 +394,47 @@ impl AgentRuntime {
             RuntimeCommand::UpdateSurfaces { agent_type, surfaces } => {
                 self.handle_update_surfaces(agent_type, surfaces);
             }
+            RuntimeCommand::UpdateHealth(status) => {
+                self.handle_update_health(status).await;
+            }
+        }
+    }
+
+    /// Handle a health-status update pushed by the SDK (issue #1472).
+    ///
+    /// Records the status on the heartbeat state machine — which gates registry
+    /// traffic in [`Self::run`] and is reported on the next full heartbeat — and
+    /// mirrors it onto the shared handle state so `handle.get_status()` reflects
+    /// the SDK's verdict instead of a constant `Healthy`.
+    ///
+    /// No-ops when the status is unchanged, so a per-TTL push of the same
+    /// verdict costs one comparison and produces no log noise.
+    async fn handle_update_health(&mut self, status: HealthStatus) {
+        if self.state_machine.health_status() == status {
+            return;
+        }
+        // Logs the transition (see `HeartbeatStateMachine::set_health_status`).
+        self.state_machine.set_health_status(status);
+        self.shared_state.write().await.health_status = status;
+    }
+
+    /// Whether registry traffic is currently suppressed by the SDK-reported
+    /// health status (issue #1472).
+    ///
+    /// The match is exhaustive on purpose: only `Unhealthy` is load-bearing
+    /// today, and keeping every variant spelled out means giving `Degraded`
+    /// its own behaviour later is a change *here*, not to `RuntimeCommand`.
+    fn heartbeat_suppressed(&self) -> bool {
+        match self.state_machine.health_status() {
+            // Fully operational — beat normally.
+            HealthStatus::Healthy => false,
+            // Reduced functionality but still serving traffic; the registry
+            // should keep routing to it, so it beats exactly like Healthy.
+            HealthStatus::Degraded => false,
+            // Not operational — go silent. The registry marks the agent
+            // unhealthy once the heartbeat goes stale, and resolution stops
+            // selecting every capability this agent provides.
+            HealthStatus::Unhealthy => true,
         }
     }
 
@@ -1549,6 +1637,315 @@ mod tests {
             drain_available(&mut event_rx),
             1,
             "a just-emitted edge is not double-emitted by the same-cycle reconcile"
+        );
+    }
+
+    // ---- Issue #1472: SDK-reported health gates registry traffic ----
+
+    /// Build a spec pointing at `registry_url` with a 1s heartbeat cadence.
+    fn health_spec(registry_url: String) -> crate::spec::AgentSpec {
+        crate::spec::AgentSpec::new(
+            "health-agent".to_string(),
+            registry_url,
+            "1.0.0".to_string(),
+            "".to_string(),
+            8080,
+            "localhost".to_string(),
+            "default".to_string(),
+            None,
+            None,
+            None,
+            None,
+            1, // heartbeat_interval (secs)
+            None,
+        )
+    }
+
+    /// Only `Unhealthy` suppresses registry traffic. `Degraded` beats exactly
+    /// like `Healthy` today — the exhaustive match in `heartbeat_suppressed`
+    /// is what makes changing that a loop-local edit.
+    #[tokio::test]
+    async fn test_1472_only_unhealthy_suppresses() {
+        let (event_tx, _event_rx) = mpsc::channel(10);
+        let mut runtime = new_reconcile_runtime(event_tx).await;
+
+        assert!(
+            !runtime.heartbeat_suppressed(),
+            "a fresh runtime starts Healthy and must heartbeat"
+        );
+
+        runtime.handle_update_health(HealthStatus::Degraded).await;
+        assert!(
+            !runtime.heartbeat_suppressed(),
+            "Degraded must keep heartbeating (still serving traffic)"
+        );
+
+        runtime.handle_update_health(HealthStatus::Unhealthy).await;
+        assert!(runtime.heartbeat_suppressed(), "Unhealthy must go silent");
+
+        runtime.handle_update_health(HealthStatus::Healthy).await;
+        assert!(
+            !runtime.heartbeat_suppressed(),
+            "recovery must resume heartbeats"
+        );
+    }
+
+    /// `UpdateHealth` mirrors onto the shared handle state so
+    /// `handle.get_status()` reports the SDK's verdict instead of a constant
+    /// `Healthy` — the only observability left once the agent goes silent.
+    #[tokio::test]
+    async fn test_1472_health_mirrored_to_shared_state() {
+        let (event_tx, _event_rx) = mpsc::channel(10);
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let (_command_tx, command_rx) = mpsc::channel(10);
+        let shared_state = Arc::new(RwLock::new(HandleState::default()));
+
+        let mut runtime = AgentRuntime::new(
+            reconcile_spec(),
+            RuntimeConfig::default(),
+            event_tx,
+            shared_state.clone(),
+            shutdown_rx,
+            command_rx,
+        )
+        .await
+        .expect("runtime construction should succeed");
+
+        assert_eq!(shared_state.read().await.health_status, HealthStatus::Healthy);
+
+        runtime
+            .handle_command(RuntimeCommand::UpdateHealth(HealthStatus::Unhealthy))
+            .await;
+        assert_eq!(
+            shared_state.read().await.health_status,
+            HealthStatus::Unhealthy
+        );
+
+        runtime
+            .handle_command(RuntimeCommand::UpdateHealth(HealthStatus::Healthy))
+            .await;
+        assert_eq!(shared_state.read().await.health_status, HealthStatus::Healthy);
+    }
+
+    /// Issue #1472 core contract: an agent whose SDK reports `Unhealthy`
+    /// sends NO heartbeat at all — not the full POST, not the fast HEAD. The
+    /// command is queued before the runtime starts, so the very first
+    /// registration is suppressed and the assertion has no timing race.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_1472_unhealthy_stops_heartbeats() {
+        let mut server = mockito::Server::new_async().await;
+        let post = server
+            .mock("POST", "/heartbeat")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"status":"success","message":"ok","agent_id":"health-agent"}"#)
+            .expect(0)
+            .create_async()
+            .await;
+        let head = server
+            .mock("HEAD", mockito::Matcher::Any)
+            .with_status(200)
+            .expect(0)
+            .create_async()
+            .await;
+        // Shutdown still unregisters: withdrawing is always safe to report,
+        // and it is what keeps a stopped-while-unhealthy agent from lingering.
+        let _unregister = server
+            .mock("DELETE", "/agents/health-agent")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let (event_tx, _event_rx) = mpsc::channel(100);
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let (command_tx, command_rx) = mpsc::channel(10);
+        let shared_state = Arc::new(RwLock::new(HandleState::default()));
+
+        // Queued BEFORE run() — process_pending_commands drains it at the top
+        // of the very first iteration, so nothing is ever sent.
+        command_tx
+            .send(RuntimeCommand::UpdateHealth(HealthStatus::Unhealthy))
+            .await
+            .expect("queue health command");
+
+        let runtime = AgentRuntime::new(
+            health_spec(server.url()),
+            RuntimeConfig::default(),
+            event_tx,
+            shared_state,
+            shutdown_rx,
+            command_rx,
+        )
+        .await
+        .expect("runtime construction should succeed");
+
+        let join = tokio::spawn(runtime.run());
+
+        // Several heartbeat intervals' worth of silence.
+        sleep(Duration::from_millis(1200)).await;
+        shutdown_tx.send(()).await.expect("shutdown signal");
+        tokio::time::timeout(Duration::from_secs(5), join)
+            .await
+            .expect("runtime did not exit after shutdown")
+            .expect("runtime task panicked");
+
+        post.assert_async().await;
+        head.assert_async().await;
+    }
+
+    /// The other half of #1472: pushing `Healthy` again resumes heartbeats
+    /// in-process — no restart, no re-created runtime. This is the property
+    /// the whole design exists for.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_1472_recovery_resumes_heartbeats() {
+        use crate::events::EventType;
+
+        let mut server = mockito::Server::new_async().await;
+        let post = server
+            .mock("POST", "/heartbeat")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"status":"success","message":"ok","agent_id":"health-agent"}"#)
+            .expect_at_least(1)
+            .create_async()
+            .await;
+        let _head = server
+            .mock("HEAD", mockito::Matcher::Any)
+            .with_status(200)
+            .create_async()
+            .await;
+        let _unregister = server
+            .mock("DELETE", "/agents/health-agent")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let (event_tx, mut event_rx) = mpsc::channel(100);
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let (command_tx, command_rx) = mpsc::channel(10);
+        let shared_state = Arc::new(RwLock::new(HandleState::default()));
+
+        // Start suppressed so we know the eventual POST is the resumption.
+        command_tx
+            .send(RuntimeCommand::UpdateHealth(HealthStatus::Unhealthy))
+            .await
+            .expect("queue unhealthy");
+
+        let runtime = AgentRuntime::new(
+            health_spec(server.url()),
+            RuntimeConfig::default(),
+            event_tx,
+            shared_state,
+            shutdown_rx,
+            command_rx,
+        )
+        .await
+        .expect("runtime construction should succeed");
+
+        let join = tokio::spawn(runtime.run());
+
+        sleep(Duration::from_millis(600)).await;
+        assert!(
+            !post.matched_async().await,
+            "no heartbeat may be sent while suppressed"
+        );
+
+        // Health check passes again — the command arm inside the suppressed
+        // Wait wakes the loop immediately.
+        command_tx
+            .send(RuntimeCommand::UpdateHealth(HealthStatus::Healthy))
+            .await
+            .expect("queue healthy");
+
+        sleep(Duration::from_millis(600)).await;
+        shutdown_tx.send(()).await.expect("shutdown signal");
+        tokio::time::timeout(Duration::from_secs(5), join)
+            .await
+            .expect("runtime did not exit after shutdown")
+            .expect("runtime task panicked");
+
+        post.assert_async().await;
+
+        let mut saw_registered = false;
+        while let Ok(event) = event_rx.try_recv() {
+            if event.event_type == EventType::AgentRegistered {
+                saw_registered = true;
+            }
+        }
+        assert!(
+            saw_registered,
+            "resuming must register with the registry again, in-process"
+        );
+    }
+
+    /// Issue #1472 + #1314: suppression must NOT starve the independent
+    /// dependency-reconcile tick. The reconcile timer only fires inside the
+    /// `Wait` arm's `select!`, so the suppression is implemented as "wait"
+    /// rather than "continue" — if that ever regresses to a bare `continue`
+    /// (or a `sleep` outside the `select!`), this test goes silent.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_1472_reconcile_survives_suppression() {
+        let mut server = mockito::Server::new_async().await;
+        // Would succeed if called — it must not be, and that is precisely why
+        // only the reconcile can be the source of the events below.
+        let post = server
+            .mock("POST", "/heartbeat")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"status":"success","message":"ok","agent_id":"health-agent"}"#)
+            .expect(0)
+            .create_async()
+            .await;
+        let _unregister = server
+            .mock("DELETE", "/agents/health-agent")
+            .with_status(204)
+            .create_async()
+            .await;
+
+        let (event_tx, mut event_rx) = mpsc::channel(100);
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let (command_tx, command_rx) = mpsc::channel(10);
+        let shared_state = Arc::new(RwLock::new(HandleState::default()));
+
+        let mut runtime = AgentRuntime::new(
+            health_spec(server.url()),
+            RuntimeConfig::default(),
+            event_tx,
+            shared_state,
+            shutdown_rx,
+            command_rx,
+        )
+        .await
+        .expect("runtime construction should succeed");
+
+        // Seed a believed-delivered dependency edge, then shrink the reconcile
+        // cadence so the wall-clock tick is observable inside the test window.
+        runtime
+            .process_dependency_changes(&resolved_single("weather", "http://provider:9000"))
+            .await;
+        assert_eq!(drain_available(&mut event_rx), 1, "seed edge emits once");
+        runtime.reconcile_interval = Duration::from_millis(100);
+
+        command_tx
+            .send(RuntimeCommand::UpdateHealth(HealthStatus::Unhealthy))
+            .await
+            .expect("queue unhealthy");
+
+        let join = tokio::spawn(runtime.run());
+
+        // The suppressed Wait is a full heartbeat interval (1s) long; the
+        // reconcile ticks every 100ms inside it.
+        sleep(Duration::from_millis(700)).await;
+        shutdown_tx.send(()).await.expect("shutdown signal");
+        tokio::time::timeout(Duration::from_secs(5), join)
+            .await
+            .expect("runtime did not exit after shutdown")
+            .expect("runtime task panicked");
+
+        post.assert_async().await;
+        assert!(
+            drain_available(&mut event_rx) > 0,
+            "the dependency reconcile must keep ticking while heartbeats are suppressed"
         );
     }
 }

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
@@ -328,8 +328,15 @@ class FastAPIServerSetupStep(PipelineStep):
         health_check_ttl = agent_config.get("health_check_ttl", 15)
 
         # Create a background task to update health check results periodically
-        async def update_health_result():
-            """Update health check result in DecoratorRegistry."""
+        async def update_health_result(publish_to_core: bool = False):
+            """Update health check result in DecoratorRegistry.
+
+            Args:
+                publish_to_core: Also report the verdict to the Rust core so a
+                    failing check withdraws the agent from dependency
+                    resolution (issue #1472). False for the startup seed call —
+                    see the call sites below.
+            """
             if health_check_fn:
                 # Use health check cache if configured
                 from ...engine.decorator_registry import DecoratorRegistry
@@ -363,13 +370,33 @@ class FastAPIServerSetupStep(PipelineStep):
 
             DecoratorRegistry.store_health_check_result(result)
 
+            # Issue #1472: also tell the Rust core, which stops heartbeating
+            # while the status is unhealthy so the registry withdraws this
+            # agent from dependency resolution (and restores it, without a
+            # restart, when the check passes again). Best-effort and
+            # idempotent — the core only acts on transitions.
+            if publish_to_core:
+                from ...shared.health_check_manager import (
+                    publish_health_status_to_core,
+                )
+
+                publish_health_status_to_core(result["status"])
+
         # Run once immediately to populate initial result.
         # We're already in an async context (called from execute()), so just
         # await it. This seed call runs on the framework loop; if the user's
         # health_check_fn touches loop-affine resources created in lifespan
         # (asyncpg.Pool, redis.asyncio, ...) it may return unhealthy here.
         # The periodic refresh below runs on the user loop and recovers.
-        await update_health_result()
+        #
+        # Deliberately does NOT publish to the Rust core (issue #1472): this
+        # runs before the heartbeat task calls start_agent(), so there is no
+        # handle to publish to, AND the seed result is the unreliable one (see
+        # the loop-affinity caveat above). The agent registers first and
+        # becomes visible; the first real refresh, one TTL later, is what can
+        # withdraw it. `publish_to_core=False` states that intent rather than
+        # relying on the absent handle to make it a no-op.
+        await update_health_result(publish_to_core=False)
 
         # Issue #1072: spawn a periodic refresh loop on the user loop so
         # the stored /health result actually reflects the latest
@@ -415,6 +442,12 @@ class FastAPIServerSetupStep(PipelineStep):
                     ``__aenter__`` has returned, so the user's
                     ``health_check_fn`` never observes partially-
                     initialized lifespan state.
+
+                    Since issue #1472 this loop also drives dependency
+                    resolution: each refresh reports its verdict to the
+                    Rust core, which stops heartbeating while the agent
+                    is unhealthy. The TTL is therefore the detection
+                    latency for both directions — outage and recovery.
                     """
                     try:
                         await asyncio.wrap_future(ready_future)
@@ -435,7 +468,7 @@ class FastAPIServerSetupStep(PipelineStep):
                         try:
                             await asyncio.sleep(health_check_ttl)
                             clear_health_cache(agent_name)
-                            await update_health_result()
+                            await update_health_result(publish_to_core=True)
                         except asyncio.CancelledError:
                             raise
                         except Exception as e:

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/tests/test_health_publish_gating_1472.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/tests/test_health_publish_gating_1472.py
@@ -1,0 +1,107 @@
+"""The health refresh publishes to the Rust core; the startup seed does not.
+
+Issue #1472. ``_add_k8s_endpoints`` runs during pipeline setup — before the
+lifespan task calls ``start_agent()`` — and seeds the stored ``/health``
+result by invoking the user's ``health_check`` once on the framework loop.
+That seed result is known-unreliable (loop-affine resources created in the
+user's lifespan are not usable yet, see the comment at the call site), so it
+must never be able to withdraw the agent from dependency resolution.
+
+Only the periodic refresh, which runs on the user loop one TTL later, is
+allowed to report to the core.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+
+from _mcp_mesh.pipeline.mcp_startup.fastapiserver_setup import FastAPIServerSetupStep
+from _mcp_mesh.shared import health_check_manager
+
+
+@pytest.fixture(autouse=True)
+def clean_health_state():
+    """The TTL cache and stored result are module globals — reset both."""
+    health_check_manager.clear_health_cache()
+    health_check_manager.clear_health_check_result()
+    yield
+    health_check_manager.clear_health_cache()
+    health_check_manager.clear_health_check_result()
+
+
+@pytest.fixture
+def published(monkeypatch):
+    """Capture every status handed to the Rust core."""
+    calls: list[str] = []
+    monkeypatch.setattr(
+        health_check_manager,
+        "publish_health_status_to_core",
+        lambda status: calls.append(status) or True,
+    )
+    return calls
+
+
+@pytest.fixture
+def no_user_loop(monkeypatch):
+    """Skip the user-loop refresh scheduling — this test is about the seed.
+
+    Without this the step would start real worker threads and schedule a
+    long-lived coroutine; the seed call happens before any of that.
+    """
+    from _mcp_mesh.shared import tool_executor
+
+    monkeypatch.setattr(tool_executor, "_start_workers", lambda *a, **k: None)
+    monkeypatch.setattr(tool_executor, "get_worker_loops", lambda: [])
+
+
+async def _run_seed(step: FastAPIServerSetupStep, health_check_fn) -> None:
+    await step._add_k8s_endpoints(
+        FastAPI(),
+        {
+            "name": "seed-agent",
+            "health_check": health_check_fn,
+            "health_check_ttl": 15,
+        },
+        {},
+        {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_failing_seed_health_check_does_not_withdraw_the_agent(
+    published, no_user_loop
+):
+    """A health check that fails at startup must NOT suppress the heartbeat.
+
+    The agent should register and be visible; if the failure is real, the
+    first periodic refresh withdraws it one TTL later.
+    """
+    step = FastAPIServerSetupStep()
+
+    async def failing_health_check():
+        return False
+
+    await _run_seed(step, failing_health_check)
+
+    # The stored result reflects the failure (so /health and /ready 503)...
+    stored = health_check_manager.get_health_check_result()
+    assert stored["status"] == "unhealthy"
+    # ...but nothing was reported to the core.
+    assert published == []
+
+
+@pytest.mark.asyncio
+async def test_passing_seed_health_check_also_stays_local(published, no_user_loop):
+    """Same for the happy path — the seed never talks to the core at all,
+    so the rule is one branch, not two.
+    """
+    step = FastAPIServerSetupStep()
+
+    async def passing_health_check():
+        return True
+
+    await _run_seed(step, passing_health_check)
+
+    assert health_check_manager.get_health_check_result()["status"] == "healthy"
+    assert published == []

--- a/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
+++ b/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
@@ -203,6 +203,90 @@ def _parse_health_result(
     return status_type, checks, errors
 
 
+# =============================================================================
+# Health Status → Rust Core (issue #1472)
+# =============================================================================
+
+
+def publish_health_status_to_core(status: str) -> bool:
+    """Push the latest health-check verdict down to the Rust core.
+
+    A failing ``health_check`` used to affect nothing but the ``/health`` and
+    ``/ready`` responses: the heartbeat hardcoded HEALTHY, so the registry kept
+    routing to the agent. The core now suppresses heartbeats while the reported
+    status is ``unhealthy``; the registry's staleness sweep then marks the agent
+    unhealthy and resolution stops selecting it. Reporting ``healthy`` again
+    resumes heartbeats and the registry restores the agent — no restart.
+
+    Called on every refresh tick, so it is idempotent by design: the core only
+    acts on transitions.
+
+    Args:
+        status: The status string from the health-check result
+            (``healthy`` / ``degraded`` / ``unhealthy`` / ``unknown``).
+
+    Returns:
+        True if the status was handed to at least one live core handle.
+        False when there is no handle yet (startup — see below), when the Rust
+        core is unavailable, or when the push failed.
+
+    Startup ordering (deliberate): the seed health check runs during pipeline
+    setup, BEFORE the lifespan task calls ``start_agent()``, so no handle
+    exists and this is a no-op. That is the behaviour we want — the agent
+    registers and becomes visible first, then goes silent if the check is
+    genuinely failing on the next refresh. It also means the known-unreliable
+    seed result (it runs on the framework loop, where loop-affine resources
+    created in the user's lifespan are not yet usable) can never withdraw an
+    agent that is actually fine.
+    """
+    try:
+        import mcp_mesh_core
+    except ImportError:
+        # Pure-Python/test environments without the native core: nothing to
+        # tell. The /health and /ready endpoints still reflect the result.
+        logger.debug("Rust core unavailable — not publishing health status")
+        return False
+
+    from .simple_shutdown import get_active_rust_agent_handles
+
+    handles = get_active_rust_agent_handles()
+    if not handles:
+        logger.debug(
+            "No live Rust core handle yet — health status '%s' not published "
+            "(expected during startup, before the heartbeat task starts)",
+            status,
+        )
+        return False
+
+    # Anything we cannot parse maps to Degraded, NOT Unhealthy: an
+    # unrecognized status is a reporting defect, and withdrawing an agent
+    # from the mesh on one is a far worse failure than keeping it.
+    core_status = {
+        "healthy": mcp_mesh_core.HealthStatus.Healthy,
+        "degraded": mcp_mesh_core.HealthStatus.Degraded,
+        "unhealthy": mcp_mesh_core.HealthStatus.Unhealthy,
+    }.get(str(status).lower())
+    if core_status is None:
+        logger.warning(
+            "Unrecognized health status '%s' — reporting Degraded to the core "
+            "(the agent keeps heartbeating)",
+            status,
+        )
+        core_status = mcp_mesh_core.HealthStatus.Degraded
+
+    published = False
+    for handle in handles:
+        try:
+            if handle.update_health(core_status):
+                published = True
+        except Exception as e:
+            # Never let health reporting break the refresh loop.
+            logger.warning("Failed to publish health status to Rust core: %s", e)
+    if published:
+        logger.debug("Published health status '%s' to Rust core", status)
+    return published
+
+
 def clear_health_cache(agent_id: str | None = None) -> None:
     """Clear health cache for a specific agent or all agents."""
     if agent_id:

--- a/src/runtime/python/_mcp_mesh/shared/simple_shutdown.py
+++ b/src/runtime/python/_mcp_mesh/shared/simple_shutdown.py
@@ -76,6 +76,23 @@ def register_rust_agent_handle(handle: Any) -> None:
             logger.debug("Registered atexit hook to drain Rust agent handles")
 
 
+def get_active_rust_agent_handles() -> list:
+    """Snapshot of the live Rust ``AgentHandle`` objects in this process.
+
+    This list is the process-wide "handles that are currently running a Rust
+    core" registry — populated by every heartbeat flavour (MCP / API / A2A)
+    right after ``start_agent()``. It exists for the atexit drain above, but
+    it is also the only late-bound route from code that runs *after* startup
+    (e.g. the periodic health-check refresh, issue #1472) back to the handle,
+    which is created inside the lifespan task and never stored in the pipeline
+    context.
+
+    Returns a copy, so callers can iterate without holding the lock.
+    """
+    with _active_handles_lock:
+        return list(_active_handles)
+
+
 def unregister_rust_agent_handle(handle: Any) -> None:
     """Drop a handle from the registry (e.g. normal shutdown already drained it).
 

--- a/src/runtime/python/_mcp_mesh/shared/tests/test_health_status_publish_1472.py
+++ b/src/runtime/python/_mcp_mesh/shared/tests/test_health_status_publish_1472.py
@@ -1,0 +1,194 @@
+"""Unit tests for publishing the health-check verdict to the Rust core.
+
+Issue #1472 — a failing ``health_check`` used to affect only the ``/health``
+and ``/ready`` responses; the heartbeat hardcoded HEALTHY, so the registry
+kept routing to the agent. The verdict now travels to the Rust core, which
+stops heartbeating while the agent is unhealthy.
+
+These cover the Python half of that channel: the status mapping, the
+startup no-op, and the "never break the refresh loop" guarantees.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from _mcp_mesh.shared import health_check_manager, simple_shutdown
+
+
+class FakeHealthStatus:
+    """Stand-in for the Rust ``mcp_mesh_core.HealthStatus`` pyclass enum."""
+
+    Healthy = "core.Healthy"
+    Degraded = "core.Degraded"
+    Unhealthy = "core.Unhealthy"
+
+
+class FakeHandle:
+    """Records what the core was told, and how often."""
+
+    def __init__(self, accepted: bool = True, raises: bool = False):
+        self.calls: list = []
+        self._accepted = accepted
+        self._raises = raises
+
+    def update_health(self, status):
+        self.calls.append(status)
+        if self._raises:
+            raise RuntimeError("command channel closed")
+        return self._accepted
+
+
+@pytest.fixture
+def fake_core(monkeypatch):
+    """Install a fake ``mcp_mesh_core`` module for the duration of a test.
+
+    The publisher imports the core lazily inside the function, so patching
+    ``sys.modules`` is enough — no import-time coupling.
+    """
+    module = SimpleNamespace(HealthStatus=FakeHealthStatus)
+    monkeypatch.setitem(sys.modules, "mcp_mesh_core", module)
+    return module
+
+
+@pytest.fixture
+def no_handles(monkeypatch):
+    """Start every test from an empty process-wide handle registry."""
+    monkeypatch.setattr(simple_shutdown, "_active_handles", [])
+    yield
+
+
+@pytest.fixture
+def one_handle(no_handles, monkeypatch):
+    handle = FakeHandle()
+    monkeypatch.setattr(simple_shutdown, "_active_handles", [handle])
+    return handle
+
+
+class TestStatusMapping:
+    """Each health-check verdict maps onto the core's HealthStatus."""
+
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            ("healthy", FakeHealthStatus.Healthy),
+            ("degraded", FakeHealthStatus.Degraded),
+            ("unhealthy", FakeHealthStatus.Unhealthy),
+        ],
+    )
+    def test_known_statuses_map_directly(
+        self, fake_core, one_handle, status, expected
+    ):
+        assert health_check_manager.publish_health_status_to_core(status) is True
+        assert one_handle.calls == [expected]
+
+    def test_status_is_case_insensitive(self, fake_core, one_handle):
+        # ``HealthStatusType`` is a str-Enum whose ``.value`` is lowercase, but
+        # the stored dict is user-reachable — don't let casing withdraw an agent.
+        health_check_manager.publish_health_status_to_core("UNHEALTHY")
+        assert one_handle.calls == [FakeHealthStatus.Unhealthy]
+
+    def test_unknown_status_degrades_rather_than_withdraws(
+        self, fake_core, one_handle
+    ):
+        # "unknown" is what ``_parse_health_result`` produces for a dict with an
+        # unrecognized status string. Withdrawing an agent from the mesh because
+        # its status was unparseable is a worse failure than keeping it, so this
+        # must map to Degraded (which heartbeats normally), never Unhealthy.
+        health_check_manager.publish_health_status_to_core("unknown")
+        assert one_handle.calls == [FakeHealthStatus.Degraded]
+
+
+class TestStartupOrdering:
+    """Before the heartbeat task starts there is no handle — and that is the
+    intended behaviour, not an accident: the agent registers and becomes
+    visible first, then goes silent if the check is genuinely failing.
+    """
+
+    def test_no_handle_is_a_silent_noop(self, fake_core, no_handles):
+        assert health_check_manager.publish_health_status_to_core("unhealthy") is False
+
+    def test_missing_rust_core_is_a_noop(self, monkeypatch, no_handles):
+        # Pure-Python environments (unit tests, standalone mode) have no core.
+        monkeypatch.setitem(sys.modules, "mcp_mesh_core", None)
+        assert health_check_manager.publish_health_status_to_core("unhealthy") is False
+
+
+class TestFailureIsolation:
+    """Health reporting must never break the refresh loop that calls it."""
+
+    def test_handle_exception_is_swallowed(self, fake_core, no_handles, monkeypatch):
+        exploding = FakeHandle(raises=True)
+        monkeypatch.setattr(simple_shutdown, "_active_handles", [exploding])
+
+        assert health_check_manager.publish_health_status_to_core("unhealthy") is False
+        assert exploding.calls == [FakeHealthStatus.Unhealthy]
+
+    def test_rejected_command_reports_false(self, fake_core, no_handles, monkeypatch):
+        # ``update_health`` returns False when the command channel is full.
+        rejecting = FakeHandle(accepted=False)
+        monkeypatch.setattr(simple_shutdown, "_active_handles", [rejecting])
+
+        assert health_check_manager.publish_health_status_to_core("unhealthy") is False
+
+    def test_one_bad_handle_does_not_block_the_others(
+        self, fake_core, no_handles, monkeypatch
+    ):
+        exploding = FakeHandle(raises=True)
+        good = FakeHandle()
+        monkeypatch.setattr(simple_shutdown, "_active_handles", [exploding, good])
+
+        assert health_check_manager.publish_health_status_to_core("unhealthy") is True
+        assert good.calls == [FakeHealthStatus.Unhealthy]
+
+
+class TestRealCoreSurface:
+    """Guard the actual native surface the publisher depends on.
+
+    The fakes above deliberately don't exercise ``mcp_mesh_core`` itself, and
+    that blind spot is real: ``HealthStatus`` was registered on the pymodule
+    but missing from the package's ``__init__`` re-exports, so
+    ``mcp_mesh_core.HealthStatus`` raised AttributeError at runtime while
+    every mocked test stayed green.
+    """
+
+    def test_core_exposes_health_status_and_update_health(self):
+        core = pytest.importorskip(
+            "mcp_mesh_core", reason="native core not built in this environment"
+        )
+
+        # Reached as attributes on the package, which is how the publisher
+        # (and any SDK author) gets at them.
+        assert core.HealthStatus.Healthy is not None
+        assert core.HealthStatus.Degraded is not None
+        assert core.HealthStatus.Unhealthy is not None
+        assert hasattr(core.AgentHandle, "update_health")
+
+
+class TestHandleRegistryAccessor:
+    """``get_active_rust_agent_handles`` is the late-bound route from the
+    health refresh loop back to the handle created inside the lifespan task.
+    """
+
+    def test_returns_registered_handles(self, no_handles):
+        handle = FakeHandle()
+        simple_shutdown.register_rust_agent_handle(handle)
+        assert simple_shutdown.get_active_rust_agent_handles() == [handle]
+
+    def test_returns_a_copy(self, no_handles):
+        handle = FakeHandle()
+        simple_shutdown.register_rust_agent_handle(handle)
+
+        snapshot = simple_shutdown.get_active_rust_agent_handles()
+        snapshot.clear()
+
+        assert simple_shutdown.get_active_rust_agent_handles() == [handle]
+
+    def test_unregistered_handle_is_dropped(self, no_handles):
+        handle = FakeHandle()
+        simple_shutdown.register_rust_agent_handle(handle)
+        simple_shutdown.unregister_rust_agent_handle(handle)
+        assert simple_shutdown.get_active_rust_agent_handles() == []


### PR DESCRIPTION
## Summary

A failing `health_check` had **no effect on dependency resolution**. It fed only the `/health` and `/ready` endpoints; the heartbeat hardcoded `HEALTHY`, and the registry sets an agent unhealthy only when heartbeats go stale. So the registry learned an agent was bad exactly one way: **the beats stopped.**

Before #1467 that happened by accident — a vendor outage failed *liveness*, Kubernetes killed the pod, and the failover was a side effect of the crash. #1467 correctly stopped the restart loop, which also removed the only thing moving traffic. This restores it deliberately.

`RuntimeCommand::UpdateHealth(HealthStatus)` mirrors `UpdatePort`; `handle.update_health()` follows the same pyo3 shape; the loop suppresses its POST while `Unhealthy`. The match is exhaustive, so `Degraded` becomes a loop change later rather than an API change. Python calls it from the `update_health_result()` task that already runs every `health_check_ttl`.

**Scope is Rust + Python.** Java and TypeScript get their health-check API next; this makes the mechanism work for the runtime that already has one.

## End-to-end, three processes

| time | event |
|---|---|
| 22:55:35 | last heartbeat from `weather-a` |
| 22:55:40.5135 | health check reads `fail` → `unhealthy` |
| 22:55:40.5140 | core: `Health status changed: Healthy -> Unhealthy` — **0.4 ms later** |
| 22:55:40 → 22:56:40 | **0 heartbeats** from `weather-a`; `weather-b` beats every 5s throughout |
| ~22:56:00 | registry sweep marks it unhealthy, caps `0/1` |
| 22:56:02.8 | consumer: `Dependency 'weather' at ask:0 changed to …:9602` — **failover** |
| 22:56:40.5 | flag back to `ok` → `Unhealthy -> Healthy` → HEAD → 410 → re-register |
| 22:56:42.8 | consumer: `changed to …:9601` — restored |

**PID 16711 throughout**, `ELAPSED 02:36`, state `S`. One process across the whole outage and recovery — the crux of the issue. Probes on the failing agent: `/livez` 200, `/health` 503, `/ready` 503.

## The reconcile interaction was real

`reconcile_timer.tick()` lives **only** inside the `Wait` arm's `select!`. Suppressing with a bare `continue` — the obvious implementation — would have spun the loop hot on `SendFast` and never polled the reconcile timer. The action is rewritten to `Wait(interval)` instead, so the loop enters the same `select!` and keeps shutdown, the command channel (including the `UpdateHealth(Healthy)` that *ends* suppression) and the reconcile tick all live.

Measured **0.0% CPU** across a 60s suppression. `test_1472_reconcile_survives_suppression` asserts zero POSTs *and* continued `dependency_available` re-emissions.

Also: `force_full_heartbeat` is gated but **not cleared** while suppressed, so a pending tools/port change is pushed on recovery; and the Retry arm re-checks the gate after backoff, mirroring #1166's shutdown check.

## Four corrections to the issue's analysis

**The staleness window is 20s, not 60s.** `DefaultTimeoutThreshold: 60` is a fallback in `types_clean.go`/`ent_service.go`; the live default is `config.go:27` `envDefault:"20"`, sweep interval 10s. Registry startup logs `timeout: 20s, interval: 10s`; eviction measured ~25s. The "free hysteresis" margin is a third of what the issue claimed.

**A `health_check` that *raises* does not withdraw the agent.** `_execute_health_check` maps exceptions to `DEGRADED`. Returning `False` or `{"status": "unhealthy"}` withdraws. Left as-is — a buggy health check shouldn't nuke an agent — but it's an asymmetry worth documenting for anyone writing one.

**Recovery depends on #955.** The first HEAD after resuming gets `410 Gone`, mapped to `AgentUnknown` → full re-register. If that short-circuit is relaxed, recovery silently changes shape.

**`mcp_mesh_core.HealthStatus` was not importable** — registered on the pymodule but missing from the package `__init__` re-exports, so it raised `AttributeError` at runtime while **every mocked test stayed green**. Found only by exercising the real `.so`. `TestRealCoreSurface` (with an `importorskip` guard) stops it recurring.

## Two deliberate choices

`handle.get_status()` previously always returned `Healthy`; `UpdateHealth` now mirrors onto `HandleState`, because a silent agent still reporting healthy is a debugging trap.

An unparseable status maps to **`Degraded`, not `Unhealthy`** — withdrawing an agent because its status string couldn't be read is the worse failure.

## Test plan

- [x] Rust **484 passed** (was 476) — 5 in `runtime.rs`, 2 in `heartbeat.rs`, 1 in `handle.rs`
- [x] Python **2553 passed, 7 skipped** (was 2552) — +16 tests
- [x] `cargo check` clean for the `typescript,ffi,simd` feature set — the new variant breaks no other binding
- [x] End-to-end cycle above, PID unchanged
- [ ] CI green

Pre-existing flake, unrelated: 3 `tracing_publish` tests fail under parallel execution on shared process-global init; they pass serially.

## Follow-ups

- **TypeScript and Java need `update_health`.** The napi side already imports `HealthStatus` unused, so TS is small; Java needs an FFI entry point beside `mesh_update_port`.
- **The API and A2A pipelines have no health-check refresh loop at all** — only `mcp_startup` does. So `@mesh.route` and A2A agents get no health gating in either direction. Worth confirming that's intended before the Java/TS work assumes parity.
- `health_check_due` is left in place with an `INERT:` note rather than deleted — removing it would touch `MeshEvent.java`'s Jackson enum mapping, and Java is a later PR.

Closes #1472


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added health status reporting from agents to the runtime.
  - Health updates now control heartbeat publishing: unhealthy agents pause heartbeats and resume after recovery.
  - Exposed health status and heartbeat interval information through the SDK.
  - Health checks now support publishing results during ongoing operation while keeping startup checks local.

- **Bug Fixes**
  - Prevented startup health-check failures from unnecessarily withdrawing agents.
  - Improved health-state synchronization and handling when runtime components are unavailable.

- **Tests**
  - Added coverage for health propagation, heartbeat suppression and recovery, status mapping, and startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->