### PR TITLE
feat(java): @MeshHealthCheck so a provider can withdraw itself when its vendor is down

### DIFF
--- a/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -101,21 +101,26 @@ public class {{ .NamePascal }}Application {
                     .withCheck("anthropic_api_key_valid", false)
                     .withError("Anthropic API key is invalid");
             }
-            // Degraded, not unhealthy: an unexpected status may be transient,
-            // and this agent keeps serving while the mesh keeps routing to it.
+            // The vendor answered and it is not serving. Unhealthy: this is the
+            // outage the mesh has to route around, and DEGRADED would keep
+            // heartbeating and keep consumers pointed here.
             return health
-                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
                 .withCheck("anthropic_api_reachable", false)
                 .withError("Anthropic API returned status: " + status);
         } catch (InterruptedException e) {
+            // Degraded, deliberately: the probe was cut short, which says
+            // nothing about the vendor. Withdrawing on an indeterminate
+            // result would take the agent out on shutdown or thread interrupt.
             Thread.currentThread().interrupt();
             return health
                 .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
                 .withCheck("anthropic_api_reachable", false)
                 .withError("Anthropic API probe interrupted");
         } catch (Exception e) {
+            // The vendor is not answering at all (DNS, connect, timeout, TLS).
             return health
-                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
                 .withCheck("anthropic_api_reachable", false)
                 .withError("Anthropic API unreachable: " + e);
         }
@@ -162,21 +167,26 @@ public class {{ .NamePascal }}Application {
                     .withCheck("openai_api_key_valid", false)
                     .withError("OpenAI API key is invalid");
             }
-            // Degraded, not unhealthy: an unexpected status may be transient,
-            // and this agent keeps serving while the mesh keeps routing to it.
+            // The vendor answered and it is not serving. Unhealthy: this is the
+            // outage the mesh has to route around, and DEGRADED would keep
+            // heartbeating and keep consumers pointed here.
             return health
-                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
                 .withCheck("openai_api_reachable", false)
                 .withError("OpenAI API returned status: " + status);
         } catch (InterruptedException e) {
+            // Degraded, deliberately: the probe was cut short, which says
+            // nothing about the vendor. Withdrawing on an indeterminate
+            // result would take the agent out on shutdown or thread interrupt.
             Thread.currentThread().interrupt();
             return health
                 .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
                 .withCheck("openai_api_reachable", false)
                 .withError("OpenAI API probe interrupted");
         } catch (Exception e) {
+            // The vendor is not answering at all (DNS, connect, timeout, TLS).
             return health
-                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
                 .withCheck("openai_api_reachable", false)
                 .withError("OpenAI API unreachable: " + e);
         }
@@ -225,21 +235,26 @@ public class {{ .NamePascal }}Application {
                     .withCheck("google_api_key_valid", false)
                     .withError("Google API key is invalid");
             }
-            // Degraded, not unhealthy: an unexpected status may be transient,
-            // and this agent keeps serving while the mesh keeps routing to it.
+            // The vendor answered and it is not serving. Unhealthy: this is the
+            // outage the mesh has to route around, and DEGRADED would keep
+            // heartbeating and keep consumers pointed here.
             return health
-                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
                 .withCheck("gemini_api_reachable", false)
                 .withError("Gemini API returned status: " + status);
         } catch (InterruptedException e) {
+            // Degraded, deliberately: the probe was cut short, which says
+            // nothing about the vendor. Withdrawing on an indeterminate
+            // result would take the agent out on shutdown or thread interrupt.
             Thread.currentThread().interrupt();
             return health
                 .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
                 .withCheck("gemini_api_reachable", false)
                 .withError("Gemini API probe interrupted");
         } catch (Exception e) {
+            // The vendor is not answering at all (DNS, connect, timeout, TLS).
             return health
-                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
                 .withCheck("gemini_api_reachable", false)
                 .withError("Gemini API unreachable: " + e);
         }

--- a/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -1,11 +1,22 @@
 package {{ .JavaPackage }};
 
 import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthCheck;
 import io.mcpmesh.MeshLlmProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+{{- $model := default "anthropic/claude-sonnet-5" .Model }}
+{{- if or (contains $model "anthropic") (contains $model "openai") (contains $model "gemini") }}
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+{{- end }}
 
 /**
  * {{ .NamePascal }} - MCP Mesh LLM Provider
@@ -20,11 +31,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
     description = "{{ default "LLM provider" .Description }}",
     port = {{ .Port }}
 )
-{{- $model := default "anthropic/claude-sonnet-5" .Model }}
 @MeshLlmProvider(
     model = "{{ $model }}",
     capability = "llm",
-    tags = {{ "{" }}{{ if .Tags }}{{ range $i, $t := .Tags }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}{{ else if contains $model "anthropic" }}"llm", "claude", "anthropic", "provider"{{ else if contains $model "openai" }}"llm", "openai", "gpt", "provider"{{ else }}"llm", "provider"{{ end }}{{ "}" }},
+    tags = {{ "{" }}{{ if .Tags }}{{ range $i, $t := .Tags }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}{{ else if contains $model "anthropic" }}"llm", "claude", "anthropic", "provider"{{ else if contains $model "openai" }}"llm", "openai", "gpt", "provider"{{ else if contains $model "gemini" }}"llm", "gemini", "google", "provider"{{ else }}"llm", "provider"{{ end }}{{ "}" }},
     version = "1.0.0"
 )
 @SpringBootApplication
@@ -40,4 +50,218 @@ public class {{ .NamePascal }}Application {
 
     // No implementation needed - @MeshLlmProvider handles everything!
     // Resource links (images, PDFs) in tool results are automatically resolved.
+
+    // ===== HEALTH CHECK =====
+    //
+    // Runs every ttlSeconds. While it returns unhealthy the agent stops
+    // heartbeating, the registry withdraws it, and consumers fail over to
+    // another provider — automatically restored when the check passes again.
+{{ if contains $model "anthropic" }}
+    private static final HttpClient HTTP = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(5))
+        .build();
+
+    /**
+     * Health check for {{ .Name }}.
+     *
+     * Validates:
+     * 1. ANTHROPIC_API_KEY environment variable is set
+     * 2. The Anthropic API is reachable
+     *
+     * Uses /v1/models - metadata only, no tokens consumed.
+     */
+    @MeshHealthCheck(ttlSeconds = 30)
+    public MeshHealth healthCheck() {
+        String apiKey = System.getenv("ANTHROPIC_API_KEY");
+        if (apiKey == null || apiKey.isBlank()) {
+            return MeshHealth.unhealthy("ANTHROPIC_API_KEY not set")
+                .withCheck("anthropic_api_key_present", false);
+        }
+
+        MeshHealth health = MeshHealth.healthy().withCheck("anthropic_api_key_present", true);
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://api.anthropic.com/v1/models"))
+                .header("anthropic-version", "2023-06-01")
+                .header("x-api-key", apiKey)
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build();
+            int status = HTTP.send(request, HttpResponse.BodyHandlers.discarding()).statusCode();
+
+            if (status == 200) {
+                return health
+                    .withCheck("anthropic_api_reachable", true)
+                    .withCheck("anthropic_api_key_valid", true);
+            }
+            if (status == 401) {
+                return health
+                    .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
+                    .withCheck("anthropic_api_reachable", true)
+                    .withCheck("anthropic_api_key_valid", false)
+                    .withError("Anthropic API key is invalid");
+            }
+            // Degraded, not unhealthy: an unexpected status may be transient,
+            // and this agent keeps serving while the mesh keeps routing to it.
+            return health
+                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withCheck("anthropic_api_reachable", false)
+                .withError("Anthropic API returned status: " + status);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return health
+                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withCheck("anthropic_api_reachable", false)
+                .withError("Anthropic API probe interrupted");
+        } catch (Exception e) {
+            return health
+                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withCheck("anthropic_api_reachable", false)
+                .withError("Anthropic API unreachable: " + e);
+        }
+    }
+{{ else if contains $model "openai" }}
+    private static final HttpClient HTTP = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(5))
+        .build();
+
+    /**
+     * Health check for {{ .Name }}.
+     *
+     * Validates:
+     * 1. OPENAI_API_KEY environment variable is set
+     * 2. The OpenAI API is reachable
+     */
+    @MeshHealthCheck(ttlSeconds = 30)
+    public MeshHealth healthCheck() {
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        if (apiKey == null || apiKey.isBlank()) {
+            return MeshHealth.unhealthy("OPENAI_API_KEY not set")
+                .withCheck("openai_api_key_present", false);
+        }
+
+        MeshHealth health = MeshHealth.healthy().withCheck("openai_api_key_present", true);
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://api.openai.com/v1/models"))
+                .header("Authorization", "Bearer " + apiKey)
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build();
+            int status = HTTP.send(request, HttpResponse.BodyHandlers.discarding()).statusCode();
+
+            if (status == 200) {
+                return health
+                    .withCheck("openai_api_reachable", true)
+                    .withCheck("openai_api_key_valid", true);
+            }
+            if (status == 401) {
+                return health
+                    .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
+                    .withCheck("openai_api_reachable", true)
+                    .withCheck("openai_api_key_valid", false)
+                    .withError("OpenAI API key is invalid");
+            }
+            // Degraded, not unhealthy: an unexpected status may be transient,
+            // and this agent keeps serving while the mesh keeps routing to it.
+            return health
+                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withCheck("openai_api_reachable", false)
+                .withError("OpenAI API returned status: " + status);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return health
+                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withCheck("openai_api_reachable", false)
+                .withError("OpenAI API probe interrupted");
+        } catch (Exception e) {
+            return health
+                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withCheck("openai_api_reachable", false)
+                .withError("OpenAI API unreachable: " + e);
+        }
+    }
+{{ else if contains $model "gemini" }}
+    private static final HttpClient HTTP = HttpClient.newBuilder()
+        .connectTimeout(Duration.ofSeconds(5))
+        .build();
+
+    /**
+     * Health check for {{ .Name }}.
+     *
+     * Validates:
+     * 1. GOOGLE_API_KEY environment variable is set
+     * 2. The Google Gemini API is reachable
+     *
+     * Uses /v1beta/models - metadata only, no tokens consumed.
+     */
+    @MeshHealthCheck(ttlSeconds = 30)
+    public MeshHealth healthCheck() {
+        String apiKey = System.getenv("GOOGLE_API_KEY");
+        if (apiKey == null || apiKey.isBlank()) {
+            return MeshHealth.unhealthy("GOOGLE_API_KEY not set")
+                .withCheck("google_api_key_present", false);
+        }
+
+        MeshHealth health = MeshHealth.healthy().withCheck("google_api_key_present", true);
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(
+                    "https://generativelanguage.googleapis.com/v1beta/models?key=" + apiKey))
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build();
+            int status = HTTP.send(request, HttpResponse.BodyHandlers.discarding()).statusCode();
+
+            if (status == 200) {
+                return health
+                    .withCheck("gemini_api_reachable", true)
+                    .withCheck("google_api_key_valid", true);
+            }
+            if (status == 400 || status == 403) {
+                return health
+                    .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
+                    .withCheck("gemini_api_reachable", true)
+                    .withCheck("google_api_key_valid", false)
+                    .withError("Google API key is invalid");
+            }
+            // Degraded, not unhealthy: an unexpected status may be transient,
+            // and this agent keeps serving while the mesh keeps routing to it.
+            return health
+                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withCheck("gemini_api_reachable", false)
+                .withError("Gemini API returned status: " + status);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return health
+                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withCheck("gemini_api_reachable", false)
+                .withError("Gemini API probe interrupted");
+        } catch (Exception e) {
+            return health
+                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
+                .withCheck("gemini_api_reachable", false)
+                .withError("Gemini API unreachable: " + e);
+        }
+    }
+{{ else }}
+    /**
+     * Health check for {{ .Name }}.
+     *
+     * NOT IMPLEMENTED — this is a skeleton, and as written it CANNOT DETECT AN
+     * UPSTREAM OUTAGE. It always reports healthy, so if {{ $model }} goes down
+     * this agent keeps heartbeating and the mesh keeps routing traffic to a
+     * provider that cannot serve it.
+     *
+     * There is no generic reachability probe that works across every vendor, so
+     * you have to write this one. Replace the body with a cheap, metadata-only
+     * call to your provider — a models/list endpoint or equivalent, NOT a
+     * completion — and return MeshHealth.unhealthy(...) when it fails. That is
+     * what makes the mesh withdraw this agent and fail consumers over.
+     */
+    @MeshHealthCheck(ttlSeconds = 30)
+    public MeshHealth healthCheck() {
+        return MeshHealth.healthy().withCheck("provider_configured", true);
+    }
+{{ end }}
 }

--- a/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
@@ -195,6 +195,17 @@ async def health_check() -> dict:
     """
     Health check for {{ .Name }}.
 
+    NOT IMPLEMENTED - this is a skeleton, and as written it CANNOT DETECT AN
+    UPSTREAM OUTAGE. It always reports healthy, so if {{ .Model }} goes down
+    this agent keeps heartbeating and the mesh keeps routing traffic to a
+    provider that cannot serve it.
+
+    There is no generic reachability probe that works across every vendor, so
+    you have to write this one. Replace the body with a cheap, metadata-only
+    call to your provider - a models/list endpoint or equivalent, NOT a
+    completion - and return {"status": "unhealthy", ...} when it fails. That is
+    what makes the mesh withdraw this agent and fail consumers over.
+
     Returns:
         dict: Health status
     """

--- a/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
@@ -64,13 +64,18 @@ async def health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # "degraded" would keep heartbeating and keep consumers
+                    # pointed here.
                     checks["anthropic_api_reachable"] = False
                     errors.append(f"Anthropic API returned status: {response.status_code}")
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,
@@ -121,13 +126,18 @@ async def health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # "degraded" would keep heartbeating and keep consumers
+                    # pointed here.
                     checks["openai_api_reachable"] = False
                     errors.append(f"OpenAI API returned status: {response.status_code}")
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,
@@ -177,13 +187,18 @@ async def health_check() -> dict:
                     errors.append("Google API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # "degraded" would keep heartbeating and keep consumers
+                    # pointed here.
                     checks["gemini_api_reachable"] = False
                     errors.append(f"Gemini API returned status: {response.status_code}")
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["gemini_api_reachable"] = False
             errors.append(f"Gemini API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/docs/concepts/health-discovery.md
+++ b/docs/concepts/health-discovery.md
@@ -72,6 +72,34 @@ class MyAgent:
     pass
 ```
 
+### Custom Health Function (Java)
+
+```java
+@MeshHealthCheck(ttlSeconds = 30)
+public MeshHealth healthCheck() {
+    if (!db.isConnected()) {
+        return MeshHealth.unhealthy("db disconnected")
+            .withCheck("db_connected", false);
+    }
+    if (memoryUsage() > 90) {
+        return MeshHealth.degraded("high memory");
+    }
+    return MeshHealth.healthy().withCheck("db_connected", true);
+}
+```
+
+One no-argument method per agent, on any Spring bean. Returning `boolean` works too: `true` is healthy, `false` unhealthy. `MCP_MESH_HEALTH_CHECK_TTL` overrides `ttlSeconds`.
+
+### What a Failing Check Does
+
+While the check reports `unhealthy` the agent stops heartbeating. The registry's staleness sweep then marks it unhealthy, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent - no restart, no redeploy. This is what lets a provider whose upstream vendor is down take itself out of rotation.
+
+Only an explicit unhealthy result does that. A check that raises is recorded as `degraded` and keeps heartbeating, on both Python and Java: a bug in the health check must not be able to remove a working agent from the mesh.
+
+`degraded` splits the two surfaces: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider.
+
+Route (`@mesh.route` / `@MeshRoute`) and A2A agents are deliberately exempt. A gateway is a fan-out point that many requests enter through - withdrawing a provider is correct, withdrawing the gateway takes the application down.
+
 ### Kubernetes Probes
 
 Every runtime serves three endpoints, and probes must not share one:
@@ -79,10 +107,10 @@ Every runtime serves three endpoints, and probes must not share one:
 | Endpoint  | Probe                             | Reports                                                                                             |
 | --------- | --------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `/livez`  | `livenessProbe`, `startupProbe`   | 200 for as long as the process is serving. Consults nothing else.                                     |
-| `/ready`  | `readinessProbe`                  | Whether traffic should be routed here. Reflects `health_check` on Python; Java and TypeScript have no user health check, so it reports only that the mesh runtime is running. |
-| `/health` | none                              | Runtime-specific. Python returns the `/ready` signal plus `checks` and `errors`; Java reports the same runtime state without them; TypeScript returns a fixed `healthy` and reflects nothing. |
+| `/ready`  | `readinessProbe`                  | Whether traffic should be routed here. Reflects your health check on Python (`health_check`) and Java (`@MeshHealthCheck`); TypeScript has no user health check, so it reports only that the mesh runtime is running. |
+| `/health` | none                              | Runtime-specific. Python and Java return the `/ready` signal plus `checks` and `errors`; TypeScript returns a fixed `healthy` and reflects nothing. |
 
-Never point liveness or startup at `/ready` or `/health`. On Python, where `/ready` reflects your `health_check`, that turns an upstream outage into a pod restart, which cannot fix the outage. On Java and TypeScript, where `/ready` reports only runtime state, it still restarts pods that are merely still booting. The Helm chart is already wired this way.
+Never point liveness or startup at `/ready` or `/health`. On Python and Java, where `/ready` reflects your health check, that turns an upstream outage into a pod restart, which cannot fix the outage. On TypeScript, where `/ready` reports only runtime state, it still restarts pods that are merely still booting. The Helm chart is already wired this way.
 
 ### Health States
 

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -274,10 +274,27 @@ Spring Boot agents automatically expose `/actuator/health`. The MCP Mesh starter
 The starter also serves the three mesh endpoints, and Kubernetes probes must not share one:
 
 - `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
-- `/ready` - `readinessProbe`. Whether traffic should be routed here. Java has no user health check, so this reports only that the mesh runtime is running.
-- `/health` - no probe. Reports the same runtime state as `/ready`, as a `status` field.
+- `/ready` - `readinessProbe`. Whether traffic should be routed here; reflects your `@MeshHealthCheck` on top of the mesh runtime state.
+- `/health` - no probe. The `/ready` signal plus the `checks` and `errors` your check returned.
 
 Both `/health` and `/ready` answer 503 until the mesh runtime is up, so pointing liveness or startup at either restarts pods that are merely still booting. The Helm chart is already wired this way.
+
+Annotate one no-argument method with `@MeshHealthCheck` to say what "ready" means for this agent:
+
+```java
+@MeshHealthCheck(ttlSeconds = 30)
+public MeshHealth healthCheck() {
+    if (!vendorReachable()) {
+        return MeshHealth.unhealthy("vendor API unreachable")
+            .withCheck("vendor_api_reachable", false);
+    }
+    return MeshHealth.healthy().withCheck("vendor_api_reachable", true);
+}
+```
+
+While the check returns unhealthy the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider - restored automatically when the check passes, with no restart. Returning `boolean` works too: `true` is healthy, `false` unhealthy. A check that throws is recorded as `degraded` and keeps heartbeating, so a bug in the check cannot take a working agent out of the mesh. `MCP_MESH_HEALTH_CHECK_TTL` overrides `ttlSeconds`.
+
+Route-only (`api`) and A2A agents are the exception: their check feeds the probes but never suppresses the heartbeat. A gateway is a fan-out point, and withdrawing it takes the application down.
 
 ### Graceful Shutdown
 

--- a/src/core/cli/man/content/health_java.md
+++ b/src/core/cli/man/content/health_java.md
@@ -31,6 +31,43 @@ MCP Mesh uses a dual-heartbeat system for fast failure detection and automatic t
 - Default threshold: 20 seconds (4 missed 5-second heartbeats)
 - Configurable via environment variables
 
+## Declaring Your Own Health Check
+
+Annotate one no-argument method with `@MeshHealthCheck` to tell the mesh what "able to serve" means for this agent:
+
+```java
+@Component
+public class VendorHealth {
+
+    @MeshHealthCheck(ttlSeconds = 30)
+    public MeshHealth healthCheck() {
+        if (!vendorReachable()) {
+            return MeshHealth.unhealthy("vendor API unreachable")
+                .withCheck("vendor_api_reachable", false);
+        }
+        return MeshHealth.healthy().withCheck("vendor_api_reachable", true);
+    }
+}
+```
+
+One check per agent, on any Spring bean. Return `MeshHealth` for full detail, or `boolean` for the terse form (`true` healthy, `false` unhealthy). `ttlSeconds` is how often it re-runs (default 15); `MCP_MESH_HEALTH_CHECK_TTL` overrides it.
+
+### What a Failing Check Does
+
+While the check reports unhealthy the agent **stops heartbeating**. The registry marks it unhealthy after the staleness window, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent - no restart. The TTL is the detection latency in both directions.
+
+The verdict also drives the probe endpoints: `/ready` answers 503 while unhealthy, and `/health` carries the `checks` and `errors` the method returned. `/livez` never consults it - a restart cannot fix a vendor outage.
+
+### Only an Explicit Unhealthy Withdraws the Agent
+
+A check that **throws** is recorded as `degraded`, not unhealthy, and keeps heartbeating. A bug in a health check must not be able to remove a working agent from the mesh. Return `false` or `MeshHealth.unhealthy(...)` to actually withdraw.
+
+`degraded` splits the two surfaces on purpose, the same way it does on Python: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider.
+
+### Route and A2A Agents
+
+On a route-only (`api`) or A2A agent the check feeds `/health` and `/ready` but **never** suppresses the heartbeat. A gateway is a fan-out point that many requests enter through: withdrawing a provider is correct, withdrawing the gateway takes the application down. This matches Python, whose API and A2A pipelines have no health-refresh loop at all.
+
 ## Checking Dependency Health
 
 Use `isAvailable()` on `McpMeshTool` to check if a dependency is reachable:

--- a/src/runtime/core/include/mcp_mesh_core.h
+++ b/src/runtime/core/include/mcp_mesh_core.h
@@ -167,7 +167,15 @@ char *mesh_next_event(const struct MeshAgentHandle *handle, int64_t timeout_ms);
 // * `handle` must be a valid handle from `mesh_start_agent`
 int32_t mesh_is_running(const struct MeshAgentHandle *handle);
 
-// Report agent health status.
+// Report agent health status — SHARED-STATE ONLY.
+//
+// Writes the status onto the handle's shared state so `mesh_*` readers see
+// it. It does NOT reach the runtime loop, so it does not gate heartbeats:
+// an agent reporting `unhealthy` through this entry point keeps beating and
+// keeps being selected by dependency resolution.
+//
+// Use [`mesh_update_health`] to make a health verdict actually withdraw the
+// agent from resolution (issue #1472).
 //
 // # Arguments
 // * `handle` - Agent handle
@@ -180,6 +188,34 @@ int32_t mesh_is_running(const struct MeshAgentHandle *handle);
 // * `handle` must be a valid handle from `mesh_start_agent`
 // * `status` must be a valid null-terminated C string
 int32_t mesh_report_health(const struct MeshAgentHandle *handle, const char *status);
+
+// Report the agent's health verdict to the runtime loop (issue #1472).
+//
+// The C-ABI counterpart of `AgentHandle::update_health` (pyo3:
+// `handle.update_health`). Call this from the SDK's periodic health-check
+// loop with the verdict of the user-supplied health check. While the status
+// is `unhealthy` the runtime stops heartbeating, so the registry's staleness
+// sweep withdraws the agent from dependency resolution; pushing `healthy`
+// (or `degraded`) resumes heartbeats and the registry restores it — with no
+// process restart.
+//
+// Distinct from [`mesh_report_health`], which only mutates shared state and
+// therefore cannot influence resolution.
+//
+// Pushing the same status repeatedly is cheap and idempotent — the runtime
+// only acts on transitions — so SDKs push on every health-check tick.
+//
+// # Arguments
+// * `handle` - Agent handle
+// * `status` - Health status: "healthy", "degraded", or "unhealthy"
+//
+// # Returns
+// 0 on success, -1 on error
+//
+// # Safety
+// * `handle` must be a valid handle from `mesh_start_agent`
+// * `status` must be a valid null-terminated C string
+int32_t mesh_update_health(const struct MeshAgentHandle *handle, const char *status);
 
 // Update the HTTP port after auto-detection.
 //

--- a/src/runtime/core/src/ffi.rs
+++ b/src/runtime/core/src/ffi.rs
@@ -479,7 +479,15 @@ pub unsafe extern "C" fn mesh_is_running(handle: *const MeshAgentHandle) -> i32 
 // Health Reporting
 // =============================================================================
 
-/// Report agent health status.
+/// Report agent health status — SHARED-STATE ONLY.
+///
+/// Writes the status onto the handle's shared state so `mesh_*` readers see
+/// it. It does NOT reach the runtime loop, so it does not gate heartbeats:
+/// an agent reporting `unhealthy` through this entry point keeps beating and
+/// keeps being selected by dependency resolution.
+///
+/// Use [`mesh_update_health`] to make a health verdict actually withdraw the
+/// agent from resolution (issue #1472).
 ///
 /// # Arguments
 /// * `handle` - Agent handle
@@ -537,6 +545,88 @@ pub unsafe extern "C" fn mesh_report_health(
     info!("FFI: Health status updated to: {}", status_str);
 
     0
+}
+
+/// Report the agent's health verdict to the runtime loop (issue #1472).
+///
+/// The C-ABI counterpart of `AgentHandle::update_health` (pyo3:
+/// `handle.update_health`). Call this from the SDK's periodic health-check
+/// loop with the verdict of the user-supplied health check. While the status
+/// is `unhealthy` the runtime stops heartbeating, so the registry's staleness
+/// sweep withdraws the agent from dependency resolution; pushing `healthy`
+/// (or `degraded`) resumes heartbeats and the registry restores it — with no
+/// process restart.
+///
+/// Distinct from [`mesh_report_health`], which only mutates shared state and
+/// therefore cannot influence resolution.
+///
+/// Pushing the same status repeatedly is cheap and idempotent — the runtime
+/// only acts on transitions — so SDKs push on every health-check tick.
+///
+/// # Arguments
+/// * `handle` - Agent handle
+/// * `status` - Health status: "healthy", "degraded", or "unhealthy"
+///
+/// # Returns
+/// 0 on success, -1 on error
+///
+/// # Safety
+/// * `handle` must be a valid handle from `mesh_start_agent`
+/// * `status` must be a valid null-terminated C string
+#[no_mangle]
+pub unsafe extern "C" fn mesh_update_health(
+    handle: *const MeshAgentHandle,
+    status: *const c_char,
+) -> i32 {
+    if handle.is_null() {
+        set_last_error("handle is null");
+        return -1;
+    }
+
+    if status.is_null() {
+        set_last_error("status is null");
+        return -1;
+    }
+
+    let status_str = match CStr::from_ptr(status).to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            set_last_error(format!("Invalid UTF-8 in status: {}", e));
+            return -1;
+        }
+    };
+
+    // Strict parse, deliberately. Callers normalize an unrecognized status to
+    // "degraded" BEFORE crossing the ABI (a reporting defect must never
+    // withdraw an agent); accepting junk here too would hide that they stopped.
+    let health_status = match status_str {
+        "healthy" => crate::events::HealthStatus::Healthy,
+        "degraded" => crate::events::HealthStatus::Degraded,
+        "unhealthy" => crate::events::HealthStatus::Unhealthy,
+        _ => {
+            set_last_error(format!(
+                "Invalid health status '{}', expected: healthy, degraded, or unhealthy",
+                status_str
+            ));
+            return -1;
+        }
+    };
+
+    let handle = handle_guard(handle);
+
+    match handle
+        .command_tx
+        .try_send(crate::runtime::RuntimeCommand::UpdateHealth(health_status))
+    {
+        Ok(_) => {
+            debug!("FFI: Health status pushed to runtime: {}", status_str);
+            0
+        }
+        Err(e) => {
+            set_last_error(format!("Failed to send health update: {}", e));
+            -1
+        }
+    }
 }
 
 /// Update the HTTP port after auto-detection.
@@ -2669,6 +2759,100 @@ mod tests {
         drop(event_tx);
         let got_null = parked.join().expect("parked mesh_next_event must not crash");
         assert!(got_null, "parked caller must observe channel close as NULL");
+    }
+
+    // ---- mesh_update_health (issue #1474: the Java entry point) -------------
+
+    /// Build a handle whose command channel the test owns, so the
+    /// `RuntimeCommand` the FFI enqueues can be read back.
+    fn health_test_handle(
+    ) -> (*mut MeshAgentHandle, mpsc::Receiver<crate::runtime::RuntimeCommand>) {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let (_event_tx, event_rx) = mpsc::channel::<MeshEvent>(4);
+        let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
+        let (command_tx, command_rx) = mpsc::channel(8);
+        let handle = Arc::new(MeshAgentHandle {
+            event_rx: Mutex::new(event_rx),
+            shutdown_tx,
+            command_tx,
+            runtime,
+            is_running: AtomicBool::new(true),
+            agent_id: None,
+            shared_state: Arc::new(tokio::sync::RwLock::new(HandleState::default())),
+        });
+        (Arc::into_raw(handle) as *mut MeshAgentHandle, command_rx)
+    }
+
+    #[test]
+    fn test_update_health_enqueues_command() {
+        let (ptr, mut command_rx) = health_test_handle();
+
+        for (input, expected) in [
+            ("unhealthy", crate::events::HealthStatus::Unhealthy),
+            ("healthy", crate::events::HealthStatus::Healthy),
+            ("degraded", crate::events::HealthStatus::Degraded),
+        ] {
+            let status = CString::new(input).unwrap();
+            let rc = unsafe { mesh_update_health(ptr, status.as_ptr()) };
+            assert_eq!(rc, 0, "mesh_update_health({input}) must succeed");
+            match command_rx.try_recv() {
+                Ok(crate::runtime::RuntimeCommand::UpdateHealth(got)) => {
+                    assert_eq!(got, expected, "wrong status for {input}");
+                }
+                other => panic!("expected UpdateHealth({expected:?}), got {other:?}"),
+            }
+        }
+
+        unsafe { mesh_free_handle(ptr) };
+    }
+
+    /// The whole point of the new entry point: `mesh_report_health` writes
+    /// shared state and never reaches the runtime loop, so it cannot gate the
+    /// heartbeat. Anyone "fixing" a health check by calling it would ship an
+    /// agent that reports unhealthy and keeps serving traffic.
+    #[test]
+    fn test_report_health_does_not_enqueue_command() {
+        let (ptr, mut command_rx) = health_test_handle();
+
+        let status = CString::new("unhealthy").unwrap();
+        assert_eq!(unsafe { mesh_report_health(ptr, status.as_ptr()) }, 0);
+        assert!(
+            command_rx.try_recv().is_err(),
+            "mesh_report_health must not reach the runtime loop"
+        );
+
+        unsafe { mesh_free_handle(ptr) };
+    }
+
+    #[test]
+    fn test_update_health_null_handle() {
+        unsafe {
+            let status = CString::new("unhealthy").unwrap();
+            assert_eq!(mesh_update_health(ptr::null_mut(), status.as_ptr()), -1);
+            let err = mesh_last_error();
+            assert!(!err.is_null());
+            mesh_free_string(err);
+        }
+    }
+
+    #[test]
+    fn test_update_health_rejects_unknown_status() {
+        let (ptr, mut command_rx) = health_test_handle();
+
+        // Callers normalize before the ABI; junk arriving here means they
+        // stopped, and the loud failure is the point.
+        let status = CString::new("mostly fine").unwrap();
+        assert_eq!(unsafe { mesh_update_health(ptr, status.as_ptr()) }, -1);
+        assert!(command_rx.try_recv().is_err(), "no command on a rejected status");
+        unsafe {
+            let err = mesh_last_error();
+            assert!(!err.is_null());
+            mesh_free_string(err);
+        }
+
+        assert_eq!(unsafe { mesh_update_health(ptr, ptr::null()) }, -1);
+
+        unsafe { mesh_free_handle(ptr) };
     }
 
     #[test]

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
@@ -89,13 +89,38 @@ public interface MeshCore {
     // ==========================================================================
 
     /**
-     * Report agent health status.
+     * Report agent health status — SHARED-STATE ONLY.
+     *
+     * <p>Does NOT reach the runtime loop, so it does not gate heartbeats: an
+     * agent reporting {@code unhealthy} here keeps beating and keeps being
+     * selected by dependency resolution. Use {@link #mesh_update_health} to
+     * make a verdict actually withdraw the agent.
      *
      * @param handle Agent handle
      * @param status Health status: "healthy", "degraded", or "unhealthy"
      * @return 0 on success, -1 on error
      */
     int mesh_report_health(Pointer handle, String status);
+
+    /**
+     * Report the agent's health verdict to the runtime loop (issue #1472).
+     *
+     * <p>While the status is {@code unhealthy} the runtime stops heartbeating,
+     * so the registry's staleness sweep withdraws the agent from dependency
+     * resolution; pushing {@code healthy} (or {@code degraded}) resumes
+     * heartbeats and the registry restores it — with no process restart.
+     *
+     * <p>Idempotent: the runtime only acts on transitions, so SDKs push on
+     * every health-check tick.
+     *
+     * <p>Rejects any status outside the three known values — callers normalize
+     * before crossing the ABI (see {@link MeshHandle#updateHealth}).
+     *
+     * @param handle Agent handle
+     * @param status Health status: "healthy", "degraded", or "unhealthy"
+     * @return 0 on success, -1 on error
+     */
+    int mesh_update_health(Pointer handle, String status);
 
     /**
      * Update the HTTP port after auto-detection.

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshHandle.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshHandle.java
@@ -243,6 +243,69 @@ public class MeshHandle implements Closeable {
     }
 
     /**
+     * The three statuses {@link #updateHealth(String)} may put on the wire.
+     * Anything else is normalized to {@code degraded} before the FFI call.
+     */
+    private static final java.util.Set<String> KNOWN_HEALTH_STATUSES =
+        java.util.Set.of("healthy", "degraded", "unhealthy");
+
+    /**
+     * Report the agent's health verdict to the mesh runtime (issue #1472/#1474).
+     *
+     * <p>While the reported status is {@code unhealthy} the runtime stops
+     * heartbeating, so the registry's staleness sweep withdraws this agent from
+     * dependency resolution and consumers fail over. Reporting {@code healthy}
+     * (or {@code degraded}) resumes heartbeats and the registry restores the
+     * agent — no process restart.
+     *
+     * <p>Distinct from {@link #reportHealth(String)}, which only mutates shared
+     * state and therefore cannot influence resolution.
+     *
+     * <p>Idempotent by design: the SDK's health-check timer calls this on every
+     * tick and the runtime only acts on transitions.
+     *
+     * <p>An unrecognized status is reported as {@code degraded} with a warning,
+     * NOT {@code unhealthy} — withdrawing an agent because its status string
+     * could not be read is the worse failure. Mirrors Python's
+     * {@code publish_health_status_to_core}.
+     *
+     * @param status "healthy", "degraded", or "unhealthy"
+     * @return true if the update was queued successfully
+     */
+    public boolean updateHealth(String status) {
+        String normalized = status == null ? null : status.trim().toLowerCase(java.util.Locale.ROOT);
+        if (normalized == null || !KNOWN_HEALTH_STATUSES.contains(normalized)) {
+            log.warn("Unrecognized health status '{}' — reporting degraded to the core "
+                + "(the agent keeps heartbeating)", status);
+            normalized = "degraded";
+        }
+
+        // Lock-free fast path: post-close calls fail immediately instead of
+        // queuing behind close()'s write lock. The check under the read lock
+        // below is the authoritative one for the close/accessor race.
+        if (closed.get()) {
+            throw new MeshException("Handle is closed");
+        }
+        lock.readLock().lock();
+        try {
+            if (closed.get()) {
+                throw new MeshException("Handle is closed");
+            }
+
+            int result = core.mesh_update_health(handle, normalized);
+            if (result != 0) {
+                String error = getLastError(core);
+                log.warn("Failed to publish health status '{}': {}", normalized, error);
+                return false;
+            }
+            log.debug("Published health status '{}' to the mesh runtime", normalized);
+            return true;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
      * Request graceful shutdown of the agent.
      *
      * <p>This is non-blocking. Use {@link #nextEvent(long)} to wait for the

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshHandle.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshHandle.java
@@ -270,7 +270,10 @@ public class MeshHandle implements Closeable {
      * {@code publish_health_status_to_core}.
      *
      * @param status "healthy", "degraded", or "unhealthy"
-     * @return true if the update was queued successfully
+     * @return true if the update was queued successfully; false if the native
+     *         call rejected it (never throws on a failed publish — health
+     *         reporting runs on a timer and must not take the loop down)
+     * @throws MeshException if the handle has been closed
      */
     public boolean updateHealth(String status) {
         String normalized = status == null ? null : status.trim().toLowerCase(java.util.Locale.ROOT);

--- a/src/runtime/java/mcp-mesh-core/src/test/java/io/mcpmesh/core/MeshHandleTest.java
+++ b/src/runtime/java/mcp-mesh-core/src/test/java/io/mcpmesh/core/MeshHandleTest.java
@@ -38,7 +38,7 @@ class MeshHandleTest {
     /** Native FFI entry points that dereference the agent handle. */
     private static final Set<String> HANDLE_TAKING = Set.of(
         "mesh_is_running", "mesh_next_event", "mesh_report_health",
-        "mesh_update_port", "mesh_shutdown", "mesh_free_handle");
+        "mesh_update_port", "mesh_update_health", "mesh_shutdown", "mesh_free_handle");
 
     /**
      * Fake MeshCore that mimics the Rust FFI contract relevant to #1179:
@@ -65,6 +65,11 @@ class MeshHandleTest {
         /** When true, mesh_free_handle blocks until {@link #freeRelease} —
          *  simulates the real free taking seconds (Rust shutdown + span drain). */
         volatile boolean blockFree = false;
+        /** Health statuses observed at the FFI boundary, in call order (#1474). */
+        final List<String> healthStatuses =
+            java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+        /** When non-zero, mesh_update_health fails with this return code. */
+        volatile int updateHealthReturn = 0;
         final CountDownLatch freeStarted = new CountDownLatch(1);
         final CountDownLatch freeRelease = new CountDownLatch(1);
 
@@ -86,6 +91,9 @@ class MeshHandleTest {
                 case "mesh_report_health":
                 case "mesh_update_port":
                     return 0;
+                case "mesh_update_health":
+                    healthStatuses.add((String) args[1]);
+                    return updateHealthReturn;
                 case "mesh_shutdown":
                     shutdownSignalled.set(true);
                     if (shutdownWakesNextEvent) {
@@ -362,6 +370,64 @@ class MeshHandleTest {
         fake.wake.countDown();
         parked.join(TimeUnit.SECONDS.toMillis(5));
         assertFalse(parked.isAlive());
+    }
+
+    // ---- updateHealth (issue #1474) ----------------------------------------
+
+    @Test
+    @Timeout(30)
+    void updateHealthPassesTheThreeKnownStatusesThrough() {
+        FakeCore fake = new FakeCore();
+        MeshHandle handle = newHandle(fake);
+
+        assertTrue(handle.updateHealth("unhealthy"));
+        assertTrue(handle.updateHealth("healthy"));
+        assertTrue(handle.updateHealth("degraded"));
+        // Case and surrounding whitespace are the author's, not the contract's.
+        assertTrue(handle.updateHealth("  UNHEALTHY "));
+
+        assertEquals(List.of("unhealthy", "healthy", "degraded", "unhealthy"),
+            fake.healthStatuses);
+    }
+
+    @Test
+    @Timeout(30)
+    void updateHealthReportsAnUnknownStatusAsDegradedNotUnhealthy() {
+        // Withdrawing an agent from the mesh because its status string could
+        // not be read is a worse failure than keeping it — mirrors Python's
+        // publish_health_status_to_core.
+        FakeCore fake = new FakeCore();
+        MeshHandle handle = newHandle(fake);
+
+        assertTrue(handle.updateHealth("mostly fine"));
+        assertTrue(handle.updateHealth(null));
+        assertTrue(handle.updateHealth(""));
+
+        assertEquals(List.of("degraded", "degraded", "degraded"), fake.healthStatuses);
+    }
+
+    @Test
+    @Timeout(30)
+    void updateHealthReturnsFalseWhenTheNativeCallFails() {
+        FakeCore fake = new FakeCore();
+        fake.updateHealthReturn = -1;
+        MeshHandle handle = newHandle(fake);
+
+        // A failed publish must not throw — health reporting runs on a timer
+        // and must never take the refresh loop down with it.
+        assertFalse(handle.updateHealth("unhealthy"));
+    }
+
+    @Test
+    @Timeout(30)
+    void updateHealthIsRejectedAfterCloseWithoutTouchingNative() {
+        FakeCore fake = new FakeCore();
+        MeshHandle handle = newHandle(fake);
+        handle.close();
+
+        assertThrows(MeshException.class, () -> handle.updateHealth("unhealthy"));
+        assertTrue(fake.healthStatuses.isEmpty());
+        assertFalse(fake.calledAfterFree.get());
     }
 
     @Test

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealth.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealth.java
@@ -46,9 +46,12 @@ public record MeshHealth(
         checks = checks == null || checks.isEmpty()
             ? Map.of()
             : Collections.unmodifiableMap(new LinkedHashMap<>(checks));
+        // Null-tolerant, not List.copyOf: a null error string must not throw
+        // out of the canonical constructor either — every other path
+        // (withError, a direct `new MeshHealth(...)`) funnels through here.
         errors = errors == null || errors.isEmpty()
             ? List.of()
-            : List.copyOf(errors);
+            : List.copyOf(errors.stream().filter(Objects::nonNull).toList());
     }
 
     /** Healthy, with no detail. */
@@ -59,20 +62,21 @@ public record MeshHealth(
     /**
      * Impaired but still serving — keeps heartbeating and stays in resolution.
      *
-     * @param errors reasons, rendered into {@code /health}
+     * @param errors reasons, rendered into {@code /health}; nulls are dropped
      */
     public static MeshHealth degraded(String... errors) {
-        return new MeshHealth(MeshHealthStatus.DEGRADED, null, List.of(errors));
+        return new MeshHealth(MeshHealthStatus.DEGRADED, null, cleanErrors(errors));
     }
 
     /**
      * Cannot serve — suppresses the heartbeat, so the registry withdraws this
      * agent and consumers fail over to another provider.
      *
-     * @param errors reasons, rendered into {@code /health} and {@code /ready}
+     * @param errors reasons, rendered into {@code /health} and {@code /ready};
+     *               nulls are dropped
      */
     public static MeshHealth unhealthy(String... errors) {
-        return new MeshHealth(MeshHealthStatus.UNHEALTHY, null, List.of(errors));
+        return new MeshHealth(MeshHealthStatus.UNHEALTHY, null, cleanErrors(errors));
     }
 
     /**
@@ -80,9 +84,32 @@ public record MeshHealth(
      * {@link MeshHealthStatus#DEGRADED} rather than unhealthy.
      *
      * @param status wire value: {@code healthy} / {@code degraded} / {@code unhealthy}
+     * @param errors reasons; nulls are dropped
      */
     public static MeshHealth of(String status, String... errors) {
-        return new MeshHealth(MeshHealthStatus.fromWire(status), null, List.of(errors));
+        return new MeshHealth(MeshHealthStatus.fromWire(status), null, cleanErrors(errors));
+    }
+
+    /**
+     * Drop nulls (and a null array) instead of letting {@link List#of} throw.
+     *
+     * <p>{@code unhealthy(null)} used to raise a {@link NullPointerException}
+     * out of the health check, which the runtime then recorded as DEGRADED —
+     * so an agent that explicitly declared itself unable to serve kept
+     * heartbeating. The requested STATUS is what routing depends on; a missing
+     * error string is a cosmetic defect and must not change it.
+     */
+    private static List<String> cleanErrors(String... errors) {
+        if (errors == null || errors.length == 0) {
+            return List.of();
+        }
+        List<String> cleaned = new ArrayList<>(errors.length);
+        for (String error : errors) {
+            if (error != null) {
+                cleaned.add(error);
+            }
+        }
+        return cleaned;
     }
 
     /** A copy with one more entry in {@link #checks()}. */

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealth.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealth.java
@@ -1,0 +1,121 @@
+package io.mcpmesh;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The result of a {@link MeshHealthCheck} (issue #1474).
+ *
+ * <p>Carries the same three things Python's {@code health_check} dict does,
+ * because they feed the same two consumers: a {@code status} that decides
+ * whether the agent stays in dependency resolution, and {@code checks} +
+ * {@code errors} that {@code /health} reports so an operator can see <i>which</i>
+ * probe failed and why.
+ *
+ * <p>A record rather than a {@code Map<String, Object>}: the status is the field
+ * the mesh acts on, and a map makes it a string that can be misspelled into
+ * silence. Here a wrong status does not compile. The detail stays a map because
+ * it genuinely is open-ended — one provider's {@code anthropic_api_reachable} is
+ * another's {@code pool_connections_free} — and it is rendered straight into the
+ * {@code /health} JSON body.
+ *
+ * <p>Instances are immutable; the {@code with*} methods return copies, so a
+ * check reads as a chain:
+ *
+ * <pre>{@code
+ * return MeshHealth.unhealthy("ANTHROPIC_API_KEY not set")
+ *     .withCheck("anthropic_api_key_present", false);
+ * }</pre>
+ *
+ * @param status the verdict — the only field that affects mesh routing
+ * @param checks per-probe detail, rendered into {@code /health}; never null
+ * @param errors human-readable failure reasons, rendered into {@code /health}
+ *               and {@code /ready}; never null
+ */
+public record MeshHealth(
+    MeshHealthStatus status,
+    Map<String, Object> checks,
+    List<String> errors) {
+
+    public MeshHealth {
+        Objects.requireNonNull(status, "status");
+        checks = checks == null || checks.isEmpty()
+            ? Map.of()
+            : Collections.unmodifiableMap(new LinkedHashMap<>(checks));
+        errors = errors == null || errors.isEmpty()
+            ? List.of()
+            : List.copyOf(errors);
+    }
+
+    /** Healthy, with no detail. */
+    public static MeshHealth healthy() {
+        return new MeshHealth(MeshHealthStatus.HEALTHY, null, null);
+    }
+
+    /**
+     * Impaired but still serving — keeps heartbeating and stays in resolution.
+     *
+     * @param errors reasons, rendered into {@code /health}
+     */
+    public static MeshHealth degraded(String... errors) {
+        return new MeshHealth(MeshHealthStatus.DEGRADED, null, List.of(errors));
+    }
+
+    /**
+     * Cannot serve — suppresses the heartbeat, so the registry withdraws this
+     * agent and consumers fail over to another provider.
+     *
+     * @param errors reasons, rendered into {@code /health} and {@code /ready}
+     */
+    public static MeshHealth unhealthy(String... errors) {
+        return new MeshHealth(MeshHealthStatus.UNHEALTHY, null, List.of(errors));
+    }
+
+    /**
+     * Build from a wire status string, mapping anything unrecognized to
+     * {@link MeshHealthStatus#DEGRADED} rather than unhealthy.
+     *
+     * @param status wire value: {@code healthy} / {@code degraded} / {@code unhealthy}
+     */
+    public static MeshHealth of(String status, String... errors) {
+        return new MeshHealth(MeshHealthStatus.fromWire(status), null, List.of(errors));
+    }
+
+    /** A copy with one more entry in {@link #checks()}. */
+    public MeshHealth withCheck(String name, Object value) {
+        Map<String, Object> merged = new LinkedHashMap<>(checks);
+        merged.put(name, value);
+        return new MeshHealth(status, merged, errors);
+    }
+
+    /** A copy with {@code additional} merged into {@link #checks()}. */
+    public MeshHealth withChecks(Map<String, Object> additional) {
+        if (additional == null || additional.isEmpty()) {
+            return this;
+        }
+        Map<String, Object> merged = new LinkedHashMap<>(checks);
+        merged.putAll(additional);
+        return new MeshHealth(status, merged, errors);
+    }
+
+    /** A copy with one more entry in {@link #errors()}. */
+    public MeshHealth withError(String error) {
+        List<String> merged = new ArrayList<>(errors);
+        merged.add(error);
+        return new MeshHealth(status, checks, merged);
+    }
+
+    /** A copy carrying a different verdict. */
+    public MeshHealth withStatus(MeshHealthStatus newStatus) {
+        return new MeshHealth(newStatus, checks, errors);
+    }
+
+    /** Whether this verdict keeps the agent in dependency resolution. */
+    public boolean isServing() {
+        return status != MeshHealthStatus.UNHEALTHY;
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealthCheck.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealthCheck.java
@@ -1,0 +1,83 @@
+package io.mcpmesh;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as this agent's health check (issue #1474).
+ *
+ * <p>The starter runs the annotated method on a timer and does two things with
+ * the verdict:
+ *
+ * <ol>
+ *   <li>serves it from {@code /health} (with per-check detail) and {@code /ready};</li>
+ *   <li>reports it to the mesh runtime. While the verdict is
+ *       {@link MeshHealthStatus#UNHEALTHY} the runtime <b>stops heartbeating</b>,
+ *       the registry's staleness sweep withdraws the agent, and dependency
+ *       resolution moves consumers to another provider. When the check passes
+ *       again the heartbeat resumes and the registry restores the agent —
+ *       with no process restart.</li>
+ * </ol>
+ *
+ * <p>This is what lets a provider whose upstream vendor is down take itself out
+ * of rotation instead of accepting calls it cannot serve.
+ *
+ * <h2>Shape</h2>
+ *
+ * <p>Annotate exactly one no-argument method on a Spring bean. The return type
+ * must be either {@link MeshHealth} (full detail) or {@code boolean} (terse:
+ * {@code true} = healthy, {@code false} = unhealthy). Anything else fails the
+ * boot with an actionable message rather than being silently ignored.
+ *
+ * <pre>{@code
+ * @Component
+ * public class VendorHealth {
+ *
+ *     @MeshHealthCheck(ttlSeconds = 30)
+ *     public MeshHealth check() {
+ *         if (!vendorReachable()) {
+ *             return MeshHealth.unhealthy("anthropic API unreachable")
+ *                 .withCheck("anthropic_api_reachable", false);
+ *         }
+ *         return MeshHealth.healthy().withCheck("anthropic_api_reachable", true);
+ *     }
+ * }
+ * }</pre>
+ *
+ * <h2>Only an explicit unhealthy verdict withdraws the agent</h2>
+ *
+ * <p>A check that <b>throws</b> is recorded as {@link MeshHealthStatus#DEGRADED},
+ * not unhealthy, so it keeps heartbeating. A buggy health check must not be able
+ * to remove a working agent from the mesh. Return {@code false} or
+ * {@link MeshHealth#unhealthy} to actually withdraw.
+ *
+ * <h2>Route and A2A agents</h2>
+ *
+ * <p>On an {@code api} (route-only) or {@code a2a} agent the verdict feeds the
+ * probe endpoints but <b>never</b> suppresses the heartbeat. A gateway is a
+ * fan-out point that many requests enter through: withdrawing a provider is
+ * correct, withdrawing the gateway takes the application down. This mirrors
+ * Python, whose API and A2A pipelines have no health-refresh loop at all.
+ *
+ * @see MeshHealth
+ * @see MeshHealthStatus
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MeshHealthCheck {
+
+    /**
+     * How often the check is re-run, in seconds.
+     *
+     * <p>Mirrors Python's {@code health_check_ttl}, and the same default (15).
+     * This is the detection latency in <b>both</b> directions: an outage takes
+     * up to one TTL to be noticed, and a recovery takes up to one TTL to be
+     * published.
+     *
+     * <p>Override with the {@code MCP_MESH_HEALTH_CHECK_TTL} environment
+     * variable.
+     */
+    int ttlSeconds() default 15;
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealthCheck.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealthCheck.java
@@ -31,11 +31,16 @@ import java.lang.annotation.Target;
  * {@code true} = healthy, {@code false} = unhealthy). Anything else fails the
  * boot with an actionable message rather than being silently ignored.
  *
- * <pre>{@code
- * @Component
+ * <p>Escaped as {@code &#64;} rather than wrapped in {@code {@code ...}}: an
+ * annotation is the first token on those lines, and Javadoc reads a leading
+ * {@code @} as a block tag even inside a code block — which would silently
+ * truncate this description at the first sample line.
+ *
+ * <pre>
+ * &#64;Component
  * public class VendorHealth {
  *
- *     @MeshHealthCheck(ttlSeconds = 30)
+ *     &#64;MeshHealthCheck(ttlSeconds = 30)
  *     public MeshHealth check() {
  *         if (!vendorReachable()) {
  *             return MeshHealth.unhealthy("anthropic API unreachable")
@@ -44,7 +49,7 @@ import java.lang.annotation.Target;
  *         return MeshHealth.healthy().withCheck("anthropic_api_reachable", true);
  *     }
  * }
- * }</pre>
+ * </pre>
  *
  * <h2>Only an explicit unhealthy verdict withdraws the agent</h2>
  *

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealthStatus.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealthStatus.java
@@ -1,0 +1,66 @@
+package io.mcpmesh;
+
+/**
+ * The three health verdicts a {@link MeshHealthCheck} can produce (issue #1474).
+ *
+ * <p>The wire values match Python's {@code HealthStatusType} and the Rust core's
+ * {@code HealthStatus} exactly, so a Java agent, a Python agent and the registry
+ * all mean the same thing by each word.
+ */
+public enum MeshHealthStatus {
+
+    /** Fully operational. The agent heartbeats and stays in resolution. */
+    HEALTHY("healthy"),
+
+    /**
+     * Working, but impaired. Still heartbeats and stays in resolution — the
+     * mesh does not withdraw an agent that says it can still serve.
+     *
+     * <p>Also where the runtime puts a verdict it could not trust: a check that
+     * threw, and a status string it could not parse.
+     */
+    DEGRADED("degraded"),
+
+    /**
+     * Cannot serve requests. The <b>only</b> verdict that suppresses the
+     * heartbeat and withdraws the agent from dependency resolution.
+     */
+    UNHEALTHY("unhealthy");
+
+    private final String wireValue;
+
+    MeshHealthStatus(String wireValue) {
+        this.wireValue = wireValue;
+    }
+
+    /** The lowercase cross-runtime wire form ({@code "healthy"}, ...). */
+    public String wireValue() {
+        return wireValue;
+    }
+
+    @Override
+    public String toString() {
+        return wireValue;
+    }
+
+    /**
+     * Parse a wire value, mapping anything unrecognized to {@link #DEGRADED}.
+     *
+     * <p>Deliberately NOT {@link #UNHEALTHY}: withdrawing an agent from the mesh
+     * because its status string could not be read is a far worse failure than
+     * keeping it. Mirrors Python's {@code publish_health_status_to_core}.
+     *
+     * @param value wire value; may be null
+     * @return the matching status, or {@link #DEGRADED}
+     */
+    public static MeshHealthStatus fromWire(String value) {
+        if (value != null) {
+            for (MeshHealthStatus status : values()) {
+                if (status.wireValue.equalsIgnoreCase(value.trim())) {
+                    return status;
+                }
+            }
+        }
+        return DEGRADED;
+    }
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshHealthTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshHealthTest.java
@@ -1,0 +1,123 @@
+package io.mcpmesh;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** {@link MeshHealth} construction rules (issue #1474). */
+class MeshHealthTest {
+
+    @Test
+    void factoriesCarryTheRequestedStatus() {
+        assertEquals(MeshHealthStatus.HEALTHY, MeshHealth.healthy().status());
+        assertEquals(MeshHealthStatus.DEGRADED, MeshHealth.degraded("slow").status());
+        assertEquals(MeshHealthStatus.UNHEALTHY, MeshHealth.unhealthy("down").status());
+        assertEquals(List.of("down"), MeshHealth.unhealthy("down").errors());
+    }
+
+    @Test
+    void aNullErrorMessageDoesNotStopTheAgentBeingWithdrawn() {
+        // List.of(errors) raised a NullPointerException OUT of the health
+        // check, which the runtime then recorded as DEGRADED — so an agent that
+        // explicitly declared itself unable to serve kept heartbeating. The
+        // STATUS is what routing depends on; a missing error string is
+        // cosmetic and must not change it.
+        MeshHealth health = MeshHealth.unhealthy((String) null);
+
+        assertEquals(MeshHealthStatus.UNHEALTHY, health.status());
+        assertTrue(health.errors().isEmpty());
+    }
+
+    @Test
+    void nullsAreDroppedFromEveryFactory() {
+        assertEquals(List.of("real"), MeshHealth.unhealthy(null, "real", null).errors());
+        assertEquals(MeshHealthStatus.UNHEALTHY,
+            MeshHealth.unhealthy(null, "real", null).status());
+
+        assertEquals(List.of("real"), MeshHealth.degraded(null, "real").errors());
+        assertEquals(MeshHealthStatus.DEGRADED, MeshHealth.degraded((String) null).status());
+
+        assertEquals(List.of("real"), MeshHealth.of("unhealthy", null, "real").errors());
+        assertEquals(MeshHealthStatus.UNHEALTHY, MeshHealth.of("unhealthy", (String) null).status());
+    }
+
+    @Test
+    void aNullVarargsArrayIsTreatedAsNoErrors() {
+        assertEquals(MeshHealthStatus.UNHEALTHY, MeshHealth.unhealthy((String[]) null).status());
+        assertTrue(MeshHealth.unhealthy((String[]) null).errors().isEmpty());
+        assertEquals(MeshHealthStatus.DEGRADED, MeshHealth.degraded((String[]) null).status());
+    }
+
+    @Test
+    void theCanonicalConstructorAlsoToleratesNullErrors() {
+        // Every other path (withError, a direct `new MeshHealth(...)` from the
+        // runtime) funnels through the compact constructor.
+        List<String> withNulls = new ArrayList<>(Arrays.asList("a", null, "b"));
+        MeshHealth health = new MeshHealth(MeshHealthStatus.UNHEALTHY, null, withNulls);
+
+        assertEquals(List.of("a", "b"), health.errors());
+        assertEquals(MeshHealthStatus.UNHEALTHY, health.status());
+        assertDoesNotThrow(() -> MeshHealth.healthy().withError(null));
+    }
+
+    @Test
+    void nullChecksAndErrorsBecomeEmptyNotNull() {
+        MeshHealth health = new MeshHealth(MeshHealthStatus.HEALTHY, null, null);
+
+        assertNotNull(health.checks());
+        assertNotNull(health.errors());
+        assertTrue(health.checks().isEmpty());
+        assertTrue(health.errors().isEmpty());
+    }
+
+    @Test
+    void statusIsStillRequired() {
+        // The one thing that must never be guessed.
+        assertThrows(NullPointerException.class,
+            () -> new MeshHealth(null, Map.of(), List.of()));
+    }
+
+    @Test
+    void withersReturnCopiesAndDoNotMutate() {
+        MeshHealth base = MeshHealth.healthy();
+        MeshHealth extended = base.withCheck("a", true).withError("boom");
+
+        assertTrue(base.checks().isEmpty());
+        assertTrue(base.errors().isEmpty());
+        assertEquals(Map.of("a", true), extended.checks());
+        assertEquals(List.of("boom"), extended.errors());
+        assertEquals(MeshHealthStatus.HEALTHY, extended.status());
+    }
+
+    @Test
+    void checksAreDefensivelyCopiedAndImmutable() {
+        Map<String, Object> source = new LinkedHashMap<>();
+        source.put("a", true);
+        MeshHealth health = new MeshHealth(MeshHealthStatus.HEALTHY, source, null);
+
+        source.put("b", false);
+        assertEquals(Map.of("a", true), health.checks(), "must not alias the caller's map");
+        assertThrows(UnsupportedOperationException.class, () -> health.checks().put("c", 1));
+    }
+
+    @Test
+    void unknownWireStatusIsDegradedNotUnhealthy() {
+        assertEquals(MeshHealthStatus.DEGRADED, MeshHealth.of("mostly fine").status());
+        assertEquals(MeshHealthStatus.DEGRADED, MeshHealthStatus.fromWire(null));
+        assertEquals(MeshHealthStatus.UNHEALTHY, MeshHealthStatus.fromWire(" UNHEALTHY "));
+        assertEquals("unhealthy", MeshHealthStatus.UNHEALTHY.wireValue());
+    }
+
+    @Test
+    void isServingTracksTheHeartbeatRule() {
+        assertTrue(MeshHealth.healthy().isServing());
+        assertTrue(MeshHealth.degraded("slow").isServing());
+        assertFalse(MeshHealth.unhealthy("down").isServing());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -703,8 +703,50 @@ public class MeshAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public MeshHealthController meshHealthController(
-            @org.springframework.context.annotation.Lazy MeshRuntime runtime) {
-        return new MeshHealthController(runtime);
+            @org.springframework.context.annotation.Lazy MeshRuntime runtime,
+            MeshHealthCheckRegistry healthCheckRegistry) {
+        return new MeshHealthController(runtime, healthCheckRegistry);
+    }
+
+    /**
+     * Issue #1474: holds the agent's {@code @MeshHealthCheck} and its latest
+     * verdict. A plain holder with no collaborators, so it is safe to inject
+     * eagerly into {@link MeshHealthController} — unlike {@link MeshRuntime},
+     * which that controller must take {@code @Lazy}.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public static MeshHealthCheckRegistry meshHealthCheckRegistry() {
+        return new MeshHealthCheckRegistry();
+    }
+
+    /**
+     * Issue #1474: scans beans for {@code @MeshHealthCheck}. Static factory so
+     * the processor is instantiated before user beans — the same pattern as
+     * {@link #meshToolBeanPostProcessor}.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public static MeshHealthCheckBeanPostProcessor meshHealthCheckBeanPostProcessor(
+            MeshHealthCheckRegistry registry) {
+        return new MeshHealthCheckBeanPostProcessor(registry);
+    }
+
+    /**
+     * Issue #1474: re-runs the health check every {@code ttlSeconds} and
+     * reports the verdict to the mesh runtime, where {@code unhealthy}
+     * suppresses the heartbeat so the registry withdraws this agent from
+     * dependency resolution.
+     *
+     * <p>Registered unconditionally; it starts no thread at all when no
+     * {@code @MeshHealthCheck} was declared, so an agent without one behaves
+     * exactly as it did before.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public MeshHealthCheckScheduler meshHealthCheckScheduler(
+            MeshRuntime runtime, MeshHealthCheckRegistry registry) {
+        return new MeshHealthCheckScheduler(runtime, registry);
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckBeanPostProcessor.java
@@ -1,0 +1,98 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthCheck;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.MethodIntrospector;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+/**
+ * Discovers the {@link MeshHealthCheck} method (issue #1474).
+ *
+ * <p>Same shape as {@link MeshToolBeanPostProcessor} and
+ * {@link io.mcpmesh.spring.web.MeshRouteBeanPostProcessor}: scan every bean,
+ * unwrap CGLIB proxies, select methods with {@link MethodIntrospector} so an
+ * inherited or bridged declaration is visited once, and register into a
+ * registry the rest of the starter reads.
+ *
+ * <p>Spring Actuator's {@code HealthIndicator} was considered and rejected: it
+ * is not a dependency of the starter, and it AGGREGATES every registered
+ * indicator (datasource, disk, mail, ...), so mesh routing would start gating
+ * on conditions the author never intended to affect it. Mesh gates on what the
+ * developer says gates traffic.
+ *
+ * <h2>Boot-time validation</h2>
+ *
+ * <p>The signature is checked here rather than coerced at runtime. A health
+ * check whose shape is wrong is a check that does not work, and finding that
+ * out from a {@code degraded} verdict on a running provider is the failure mode
+ * this whole feature exists to avoid.
+ */
+public class MeshHealthCheckBeanPostProcessor implements BeanPostProcessor, Ordered {
+
+    private static final Logger log =
+        LoggerFactory.getLogger(MeshHealthCheckBeanPostProcessor.class);
+
+    private final MeshHealthCheckRegistry registry;
+
+    public MeshHealthCheckBeanPostProcessor(MeshHealthCheckRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        Class<?> targetClass = AopUtils.getTargetClass(bean);
+
+        Map<Method, MeshHealthCheck> annotated = MethodIntrospector.selectMethods(targetClass,
+            (MethodIntrospector.MetadataLookup<MeshHealthCheck>) method ->
+                AnnotationUtils.findAnnotation(method, MeshHealthCheck.class));
+
+        annotated.forEach((method, annotation) -> {
+            validate(targetClass, method, annotation);
+            registry.register(bean, method, annotation.ttlSeconds());
+        });
+
+        return bean;
+    }
+
+    private static void validate(Class<?> targetClass, Method method, MeshHealthCheck annotation) {
+        String where = "@MeshHealthCheck on '" + targetClass.getName() + "#" + method.getName() + "'";
+
+        if (method.getParameterCount() != 0) {
+            throw new IllegalStateException(where + " must take no parameters — it is called on a "
+                + "timer with nothing to pass it. Read what it needs from the enclosing bean.");
+        }
+
+        Class<?> returnType = method.getReturnType();
+        boolean supported = MeshHealth.class.equals(returnType)
+            || boolean.class.equals(returnType)
+            || Boolean.class.equals(returnType);
+        if (!supported) {
+            throw new IllegalStateException(where + " returns " + returnType.getName()
+                + ", which the runtime cannot read as a health verdict. Return "
+                + MeshHealth.class.getName() + " (status + checks + errors) or boolean "
+                + "(true = healthy, false = unhealthy).");
+        }
+
+        if (annotation.ttlSeconds() < 1) {
+            throw new IllegalStateException(where + " has ttlSeconds=" + annotation.ttlSeconds()
+                + "; it must be at least 1 second.");
+        }
+
+        log.debug("Found {} returning {} (ttl={}s)", where, returnType.getSimpleName(),
+            annotation.ttlSeconds());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckBeanPostProcessor.java
@@ -4,6 +4,7 @@ import io.mcpmesh.MeshHealth;
 import io.mcpmesh.MeshHealthCheck;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
@@ -54,15 +55,44 @@ public class MeshHealthCheckBeanPostProcessor implements BeanPostProcessor, Orde
 
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        Class<?> targetClass = AopUtils.getTargetClass(bean);
+        // Reflect on, and invoke against, the SAME object (issue #1474 review).
+        //
+        // A Spring JDK dynamic proxy is TargetClassAware, so getTargetClass
+        // returns the target class — but the proxy does not EXTEND it (it
+        // implements the interface and extends java.lang.reflect.Proxy). A
+        // Method resolved on the target class then cannot be invoked with the
+        // proxy as receiver: Method.invoke throws "object is not an instance of
+        // declaring class", which the registry records as DEGRADED on every
+        // tick — a health check that silently never works. Spring produces JDK
+        // proxies for any interface-implementing bean when proxyTargetClass is
+        // false (@Transactional, @Async, @Validated, ...).
+        //
+        // Unwrapping to the singleton target fixes it and is also the right
+        // receiver: a health check should run against the real object, not
+        // through an advice chain that may open a transaction around it.
+        // CGLIB proxies have no such mismatch (the proxy IS a subclass), but
+        // unwrapping them is equally correct and keeps one code path.
+        Object receiver = AopProxyUtils.getSingletonTarget(bean);
+        if (receiver == null) {
+            // No singleton target (a prototype-targeted or otherwise opaque
+            // proxy). Reflect on the proxy's own runtime type instead, so the
+            // Method we register is one the proxy can actually receive.
+            receiver = bean;
+        }
+        Class<?> targetClass = AopUtils.getTargetClass(receiver);
+        if (!targetClass.isInstance(receiver)) {
+            targetClass = receiver.getClass();
+        }
 
         Map<Method, MeshHealthCheck> annotated = MethodIntrospector.selectMethods(targetClass,
             (MethodIntrospector.MetadataLookup<MeshHealthCheck>) method ->
                 AnnotationUtils.findAnnotation(method, MeshHealthCheck.class));
 
+        Object registrationTarget = receiver;
+        Class<?> registrationClass = targetClass;
         annotated.forEach((method, annotation) -> {
-            validate(targetClass, method, annotation);
-            registry.register(bean, method, annotation.ttlSeconds());
+            validate(registrationClass, method, annotation);
+            registry.register(registrationTarget, method, annotation.ttlSeconds());
         });
 
         return bean;

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckRegistry.java
@@ -84,9 +84,19 @@ public class MeshHealthCheckRegistry {
 
     /** Effective refresh period: the annotation value, or {@link #TTL_ENV_VAR}. */
     public int ttlSeconds() {
+        return ttlSeconds(System.getenv(TTL_ENV_VAR));
+    }
+
+    /**
+     * The env-free core of {@link #ttlSeconds()}, so the resolution rules can be
+     * driven directly instead of depending on the ambient environment (which the
+     * JDK gives no supported way to set from a test).
+     *
+     * @param override raw {@link #TTL_ENV_VAR} value, or null for "not set"
+     */
+    int ttlSeconds(String override) {
         Registration reg = registration;
         int ttl = reg != null ? reg.ttlSeconds() : DEFAULT_TTL_SECONDS;
-        String override = System.getenv(TTL_ENV_VAR);
         if (override != null && !override.isBlank()) {
             try {
                 int parsed = Integer.parseInt(override.trim());

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckRegistry.java
@@ -1,0 +1,173 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthCheck;
+import io.mcpmesh.MeshHealthStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Holds the agent's single {@link MeshHealthCheck} and the latest verdict it
+ * produced (issue #1474).
+ *
+ * <p>Two readers share this one result so they can never disagree:
+ * {@link MeshHealthController} renders it on {@code /health} and {@code /ready},
+ * and {@link MeshHealthCheckScheduler} publishes it to the mesh runtime, where
+ * an unhealthy verdict suppresses the heartbeat.
+ *
+ * <p>Mirrors the storage half of Python's {@code health_check_manager} — with
+ * the cache dropped. Python caches the result under {@code health_check_ttl} and
+ * then explicitly invalidates that cache before every refresh, so the cache only
+ * ever serves the endpoints between ticks. The scheduler here already runs on
+ * exactly that period and stores what it computed, so the endpoints read the
+ * same value with no expiry logic at all.
+ */
+public class MeshHealthCheckRegistry {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshHealthCheckRegistry.class);
+
+    /** Python's {@code health_check_ttl} default. */
+    public static final int DEFAULT_TTL_SECONDS = 15;
+
+    /** Overrides {@link MeshHealthCheck#ttlSeconds()} when set. */
+    public static final String TTL_ENV_VAR = "MCP_MESH_HEALTH_CHECK_TTL";
+
+    private volatile Registration registration;
+    private volatile Result latest;
+
+    /** One discovered health check. */
+    public record Registration(Object bean, Method method, int ttlSeconds) {
+        public String describe() {
+            return method.getDeclaringClass().getName() + "#" + method.getName();
+        }
+    }
+
+    /** The most recent verdict plus when it was computed. */
+    public record Result(MeshHealth health, Instant timestamp) {}
+
+    /**
+     * Record the agent's health check.
+     *
+     * @throws IllegalStateException when a second one is declared — Python
+     *     allows exactly one {@code health_check} per agent, and silently
+     *     picking one of two here would make routing depend on bean order.
+     */
+    public void register(Object bean, Method method, int ttlSeconds) {
+        Registration existing = this.registration;
+        if (existing != null) {
+            throw new IllegalStateException(
+                "Two @MeshHealthCheck methods found (" + existing.describe() + " and "
+                    + method.getDeclaringClass().getName() + "#" + method.getName()
+                    + "). An agent has exactly one health check — it is a single verdict "
+                    + "about whether this agent should keep receiving traffic. Combine the "
+                    + "probes into one method returning MeshHealth.");
+        }
+        method.setAccessible(true);
+        this.registration = new Registration(bean, method, ttlSeconds);
+        log.info("Registered @MeshHealthCheck {} (ttl={}s)",
+            this.registration.describe(), ttlSeconds);
+    }
+
+    public boolean hasHealthCheck() {
+        return registration != null;
+    }
+
+    public Registration registration() {
+        return registration;
+    }
+
+    /** Effective refresh period: the annotation value, or {@link #TTL_ENV_VAR}. */
+    public int ttlSeconds() {
+        Registration reg = registration;
+        int ttl = reg != null ? reg.ttlSeconds() : DEFAULT_TTL_SECONDS;
+        String override = System.getenv(TTL_ENV_VAR);
+        if (override != null && !override.isBlank()) {
+            try {
+                int parsed = Integer.parseInt(override.trim());
+                if (parsed >= 1) {
+                    return parsed;
+                }
+                log.warn("{}={} is below the 1s minimum — using {}s", TTL_ENV_VAR, override, ttl);
+            } catch (NumberFormatException e) {
+                log.warn("{}={} is not an integer — using {}s", TTL_ENV_VAR, override, ttl);
+            }
+        }
+        return ttl >= 1 ? ttl : DEFAULT_TTL_SECONDS;
+    }
+
+    /** The latest verdict, or null before the first run. */
+    public Result latest() {
+        return latest;
+    }
+
+    public void store(MeshHealth health) {
+        this.latest = new Result(health, Instant.now());
+    }
+
+    /**
+     * Run the registered check and convert whatever it returned into a
+     * {@link MeshHealth}.
+     *
+     * <p>Never throws. A check that <b>throws</b> becomes {@link
+     * MeshHealthStatus#DEGRADED}, not unhealthy, so the agent keeps
+     * heartbeating — a buggy health check must not be able to withdraw a
+     * working agent from the mesh. Same rule and same {@code checks} /
+     * {@code errors} keys as Python's {@code _execute_health_check}.
+     *
+     * @return the verdict, or null when no check is registered
+     */
+    public MeshHealth execute() {
+        Registration reg = registration;
+        if (reg == null) {
+            return null;
+        }
+        try {
+            Object raw = reg.method().invoke(reg.bean());
+            return coerce(raw);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            log.warn("@MeshHealthCheck {} threw — reporting degraded (the agent keeps "
+                + "heartbeating): {}", reg.describe(), cause.toString());
+            return new MeshHealth(
+                MeshHealthStatus.DEGRADED,
+                Map.of("health_check_execution", false),
+                List.of("Health check failed: " + cause));
+        } catch (Exception e) {
+            log.warn("@MeshHealthCheck {} could not be invoked — reporting degraded: {}",
+                reg.describe(), e.toString());
+            return new MeshHealth(
+                MeshHealthStatus.DEGRADED,
+                Map.of("health_check_execution", false),
+                List.of("Health check failed: " + e));
+        }
+    }
+
+    /**
+     * Convert a health-check return value. The accepted shapes are enforced at
+     * boot by {@link MeshHealthCheckBeanPostProcessor}, so the fallback here is
+     * defence in depth, not a supported path — and it degrades rather than
+     * withdrawing.
+     */
+    static MeshHealth coerce(Object raw) {
+        if (raw instanceof MeshHealth health) {
+            return health;
+        }
+        if (raw instanceof Boolean ok) {
+            // Python parity: True → healthy, False → unhealthy.
+            return ok
+                ? MeshHealth.healthy().withCheck("health_check", true)
+                : MeshHealth.unhealthy("Health check returned false")
+                    .withCheck("health_check", false);
+        }
+        return new MeshHealth(
+            MeshHealthStatus.DEGRADED,
+            Map.of("health_check_return_type", false),
+            List.of("Invalid return type: " + (raw == null ? "null" : raw.getClass().getName())));
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckScheduler.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckScheduler.java
@@ -1,0 +1,197 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
+
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Re-runs the {@link io.mcpmesh.MeshHealthCheck} on a timer and acts on the
+ * verdict (issue #1474).
+ *
+ * <p>Each tick stores the result for {@link MeshHealthController} and reports it
+ * to the mesh runtime, where {@code unhealthy} suppresses the heartbeat so the
+ * registry withdraws this agent from dependency resolution. The TTL is
+ * therefore the detection latency in <b>both</b> directions — outage and
+ * recovery. Mirrors Python's {@code update_health_result} refresh task.
+ *
+ * <h2>Why a ScheduledExecutorService and not {@code @Scheduled}</h2>
+ *
+ * <p>{@code @Scheduled} needs {@code @EnableScheduling}, which a starter cannot
+ * turn on without changing the HOST application: it registers a
+ * {@code TaskScheduler} and activates every {@code @Scheduled} method in the
+ * user's code, so adding the mesh dependency would start running their jobs.
+ * Worse, Spring's default scheduler is a single-threaded pool shared with those
+ * jobs — one slow user task would delay the mesh health refresh, and a health
+ * refresh that stalls is an agent that cannot be withdrawn. And the period is
+ * per-annotation ({@code ttlSeconds}), which {@code fixedDelay} cannot express
+ * without a SpEL indirection through a property.
+ *
+ * <p>One daemon thread we own, with a lifecycle bound to
+ * {@link SmartLifecycle}, is the same pattern {@link MeshEventProcessor}
+ * already uses for the event loop.
+ */
+public class MeshHealthCheckScheduler implements SmartLifecycle {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshHealthCheckScheduler.class);
+
+    /** After {@link MeshRuntime} (MAX-100) and {@link MeshEventProcessor} (MAX-50). */
+    private static final int LIFECYCLE_PHASE = Integer.MAX_VALUE - 40;
+
+    /**
+     * Agent types whose health verdict must never suppress the heartbeat.
+     *
+     * <p>A route ({@code api}) or A2A agent is a fan-out point that many
+     * requests enter through: withdrawing a provider is correct, withdrawing
+     * the gateway takes the application down. Python encodes the same asymmetry
+     * by giving its API and A2A pipelines no health-refresh loop at all.
+     */
+    private static final Set<String> NEVER_WITHDRAWN = Set.of("api", "a2a");
+
+    private final MeshRuntime runtime;
+    private final MeshHealthCheckRegistry registry;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    private volatile ScheduledExecutorService executor;
+    private volatile boolean publishToRuntime = true;
+
+    public MeshHealthCheckScheduler(MeshRuntime runtime, MeshHealthCheckRegistry registry) {
+        this.runtime = runtime;
+        this.registry = registry;
+    }
+
+    @Override
+    public int getPhase() {
+        return LIFECYCLE_PHASE;
+    }
+
+    @Override
+    public void start() {
+        if (!registry.hasHealthCheck()) {
+            // Nothing declared — no timer, no thread. This is also what keeps
+            // an agent without a health check behaving exactly as before.
+            return;
+        }
+        if (!running.compareAndSet(false, true)) {
+            return;
+        }
+
+        this.publishToRuntime = !NEVER_WITHDRAWN.contains(agentType());
+        int ttl = registry.ttlSeconds();
+
+        if (publishToRuntime) {
+            log.info("Health check {} runs every {}s; an unhealthy verdict stops the heartbeat "
+                + "and withdraws this agent from dependency resolution",
+                registry.registration().describe(), ttl);
+        } else {
+            log.info("Health check {} runs every {}s and feeds /health and /ready only — the "
+                + "heartbeat is never suppressed on an '{}' agent (a gateway is a fan-out "
+                + "point; withdrawing it takes the application down)",
+                registry.registration().describe(), ttl, agentType());
+        }
+
+        // Seed the endpoints immediately, but do NOT publish (Python parity).
+        // A check that fails during boot — a pool not warm yet, a lazily-built
+        // client — must not withdraw an agent that has only just registered.
+        // The first published verdict is one TTL later, once the agent is up.
+        refresh(false);
+
+        executor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "mesh-health-check");
+            t.setDaemon(true);
+            return t;
+        });
+        // Fixed DELAY, not rate: a check that takes longer than its TTL (a
+        // vendor probe timing out is exactly that) must not queue up back-to-back
+        // runs against an already-struggling upstream.
+        executor.scheduleWithFixedDelay(
+            () -> refresh(true), ttl, ttl, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void stop() {
+        if (!running.compareAndSet(true, false)) {
+            return;
+        }
+        ScheduledExecutorService ex = executor;
+        executor = null;
+        if (ex == null) {
+            return;
+        }
+        log.debug("Stopping health-check scheduler");
+        ex.shutdownNow();
+        try {
+            if (!ex.awaitTermination(5, TimeUnit.SECONDS)) {
+                log.warn("Health-check thread did not stop within 5s");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    /**
+     * Run the check, store the verdict, and (optionally) report it to the
+     * runtime.
+     *
+     * <p>Never throws: this runs on a scheduled executor, where an escaping
+     * exception silently cancels all future runs — the agent would stop
+     * refreshing its health forever, with nothing in the logs after the first
+     * failure.
+     */
+    void refresh(boolean publish) {
+        MeshHealth health;
+        try {
+            health = registry.execute();
+        } catch (Throwable t) {
+            // registry.execute() already converts a throwing check to DEGRADED;
+            // reaching here means the conversion itself failed.
+            log.warn("Health check refresh failed unexpectedly", t);
+            return;
+        }
+        if (health == null) {
+            return;
+        }
+
+        registry.store(health);
+
+        if (health.status() == MeshHealthStatus.UNHEALTHY) {
+            log.warn("Health check reports UNHEALTHY: {}", health.errors());
+        } else {
+            log.debug("Health check reports {}", health.status());
+        }
+
+        if (!publish || !publishToRuntime) {
+            return;
+        }
+        try {
+            runtime.updateHealth(health.status().wireValue());
+        } catch (Exception e) {
+            log.warn("Failed to report health status '{}' to the mesh runtime: {}",
+                health.status(), e.toString());
+        }
+    }
+
+    private String agentType() {
+        try {
+            if (runtime != null && runtime.getAgentSpec() != null) {
+                String type = runtime.getAgentSpec().getAgentType();
+                return type == null ? "" : type;
+            }
+        } catch (Exception e) {
+            log.debug("Could not read agent type: {}", e.toString());
+        }
+        return "";
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckScheduler.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckScheduler.java
@@ -97,17 +97,25 @@ public class MeshHealthCheckScheduler implements SmartLifecycle {
                 registry.registration().describe(), ttl, agentType());
         }
 
-        // Seed the endpoints immediately, but do NOT publish (Python parity).
-        // A check that fails during boot — a pool not warm yet, a lazily-built
-        // client — must not withdraw an agent that has only just registered.
-        // The first published verdict is one TTL later, once the agent is up.
-        refresh(false);
-
         executor = Executors.newSingleThreadScheduledExecutor(r -> {
             Thread t = new Thread(r, "mesh-health-check");
             t.setDaemon(true);
             return t;
         });
+
+        // Seed the endpoints, but do NOT publish (Python parity). A check that
+        // fails during boot — a pool not warm yet, a lazily-built client — must
+        // not withdraw an agent that has only just registered. The first
+        // PUBLISHED verdict is one TTL later, once the agent is up.
+        //
+        // Submitted to the executor rather than run inline: a scaffolded
+        // provider's check is an HTTP call to a vendor, and running it on the
+        // Spring lifecycle thread would stall application startup for as long
+        // as that vendor takes to answer — a hung vendor would hang the boot.
+        // It shares the single-threaded executor with the periodic task, so the
+        // seed still strictly precedes the first scheduled refresh.
+        executor.execute(() -> refresh(false));
+
         // Fixed DELAY, not rate: a check that takes longer than its TTL (a
         // vendor probe timing out is exactly that) must not queue up back-to-back
         // runs against an already-struggling upstream.
@@ -145,10 +153,14 @@ public class MeshHealthCheckScheduler implements SmartLifecycle {
      * Run the check, store the verdict, and (optionally) report it to the
      * runtime.
      *
-     * <p>Never throws: this runs on a scheduled executor, where an escaping
-     * exception silently cancels all future runs — the agent would stop
-     * refreshing its health forever, with nothing in the logs after the first
-     * failure.
+     * <p>Never throws — {@code Throwable}, not {@code Exception}. This runs on
+     * a {@link java.util.concurrent.ScheduledExecutorService}, which silently
+     * cancels all future runs when a task throws. A single {@code Error} (an
+     * {@code UnsatisfiedLinkError} from the native handle, an
+     * {@code OutOfMemoryError} in a user check) would therefore stop health
+     * refreshes permanently, with nothing in the logs after the first failure
+     * and no recovery short of a restart — the worst possible failure for a
+     * mechanism whose entire job is to notice failures.
      */
     void refresh(boolean publish) {
         MeshHealth health;
@@ -177,9 +189,11 @@ public class MeshHealthCheckScheduler implements SmartLifecycle {
         }
         try {
             runtime.updateHealth(health.status().wireValue());
-        } catch (Exception e) {
+        } catch (Throwable t) {
+            // Throwable, not Exception: see the method comment — an Error
+            // escaping here would cancel every future refresh silently.
             log.warn("Failed to report health status '{}' to the mesh runtime: {}",
-                health.status(), e.toString());
+                health.status(), t.toString());
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
@@ -1,5 +1,7 @@
 package io.mcpmesh.spring;
 
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,68 +23,141 @@ import java.util.Map;
  * When both probes share a URL, anything that makes an agent unready also makes
  * Kubernetes restart it — a remedy that cannot fix a dependency outage and that
  * erases the evidence the agent was failing. {@code /livez} therefore answers
- * 200 unconditionally, while {@code /ready} reports whether the mesh runtime is
- * up.
+ * 200 unconditionally, while {@code /ready} reports whether the agent should be
+ * receiving traffic.
+ *
+ * <p>Since issue #1474 {@code /ready} also reflects the user's
+ * {@link io.mcpmesh.MeshHealthCheck}, and {@code /health} carries its
+ * {@code checks} and {@code errors} so an operator can see WHICH probe failed.
+ * The runtime state remains the floor: an agent whose mesh runtime is not up is
+ * not ready regardless of what the user's check says.
  */
 @Controller
 public class MeshHealthController {
 
     private final MeshRuntime runtime;
+    private final MeshHealthCheckRegistry healthChecks;
 
     public MeshHealthController(MeshRuntime runtime) {
+        this(runtime, null);
+    }
+
+    public MeshHealthController(MeshRuntime runtime, MeshHealthCheckRegistry healthChecks) {
         this.runtime = runtime;
+        this.healthChecks = healthChecks;
+    }
+
+    /**
+     * The effective verdict: the user's health check, floored by the mesh
+     * runtime state.
+     *
+     * <p>The floor is not redundant with the user's check. A check that probes
+     * a vendor API says nothing about whether this agent is registered and
+     * reachable; a runtime that is down means no traffic should arrive here
+     * whatever the vendor's status is. Taking the worse of the two is the only
+     * answer that is true in both directions.
+     */
+    private MeshHealthStatus effectiveStatus() {
+        boolean running = runtime != null && runtime.isRunning();
+        if (!running) {
+            return MeshHealthStatus.UNHEALTHY;
+        }
+        MeshHealth latest = latestHealth();
+        return latest == null ? MeshHealthStatus.HEALTHY : latest.status();
+    }
+
+    private MeshHealth latestHealth() {
+        if (healthChecks == null) {
+            return null;
+        }
+        MeshHealthCheckRegistry.Result result = healthChecks.latest();
+        return result == null ? null : result.health();
+    }
+
+    /**
+     * Whether the probes answer 200. Only {@link MeshHealthStatus#HEALTHY}
+     * does — exactly Python's {@code build_health_response} /
+     * {@code build_ready_response}, which are {@code 200 if status ==
+     * "healthy" else 503}.
+     *
+     * <p>So {@code degraded} answers 503 here while the agent keeps
+     * heartbeating and stays in dependency resolution. That asymmetry is
+     * Python's and is deliberate on both sides: readiness is a load-balancer
+     * decision about NEW external traffic, while the heartbeat is a statement
+     * about whether this agent is still a valid provider for the mesh. An
+     * impaired agent can honestly answer "stop adding load" without also
+     * withdrawing itself from a mesh that may have no other provider.
+     */
+    private static boolean serving(MeshHealthStatus status) {
+        return status == MeshHealthStatus.HEALTHY;
     }
 
     @GetMapping("/health")
     public ResponseEntity<Map<String, Object>> health() {
-        boolean running = runtime != null && runtime.isRunning();
+        MeshHealthStatus status = effectiveStatus();
         Map<String, Object> body = new LinkedHashMap<>();
-        body.put("status", running ? "healthy" : "unhealthy");
+        body.put("status", status.wireValue());
         if (runtime != null && runtime.getAgentSpec() != null) {
             body.put("agent", runtime.getAgentSpec().getName());
         }
-        return ResponseEntity.status(running ? 200 : 503).body(body);
+        MeshHealthCheckRegistry.Result result =
+            healthChecks == null ? null : healthChecks.latest();
+        if (result != null) {
+            body.put("checks", result.health().checks());
+            body.put("errors", result.health().errors());
+            body.put("timestamp", result.timestamp().toString());
+        }
+        return ResponseEntity.status(serving(status) ? 200 : 503).body(body);
     }
 
     @RequestMapping(value = "/health", method = RequestMethod.HEAD)
     public ResponseEntity<Void> healthHead() {
-        boolean running = runtime != null && runtime.isRunning();
-        return ResponseEntity.status(running ? 200 : 503).build();
+        return ResponseEntity.status(serving(effectiveStatus()) ? 200 : 503).build();
     }
 
     /**
      * Kubernetes readiness probe.
      *
-     * <p>The Java runtime has no user-supplied health check (unlike Python), so
-     * the only honest readiness signal available is whether the mesh runtime is
-     * running — the same condition {@code /health} reports. It does NOT reflect
-     * the health of anything the agent depends on.
+     * <p>Reports whether traffic should be routed here: the mesh runtime is up
+     * AND the user's {@link io.mcpmesh.MeshHealthCheck} (if any) is not
+     * reporting unhealthy. It does NOT restart anything — see the class comment
+     * on why this is a separate endpoint from {@code /livez}.
      */
     @GetMapping("/ready")
     public ResponseEntity<Map<String, Object>> ready() {
         boolean running = runtime != null && runtime.isRunning();
+        MeshHealthStatus status = effectiveStatus();
+        boolean ready = serving(status);
+
         Map<String, Object> body = new LinkedHashMap<>();
-        body.put("ready", running);
-        if (!running) {
-            body.put("reason", "mesh runtime is not running");
+        body.put("ready", ready);
+        body.put("status", status.wireValue());
+        if (!ready) {
+            body.put("reason", running
+                ? "service is " + status.wireValue()
+                : "mesh runtime is not running");
+            MeshHealth latest = latestHealth();
+            if (latest != null && !latest.errors().isEmpty()) {
+                body.put("errors", latest.errors());
+            }
         }
-        return ResponseEntity.status(running ? 200 : 503).body(body);
+        return ResponseEntity.status(ready ? 200 : 503).body(body);
     }
 
     @RequestMapping(value = "/ready", method = RequestMethod.HEAD)
     public ResponseEntity<Void> readyHead() {
-        boolean running = runtime != null && runtime.isRunning();
-        return ResponseEntity.status(running ? 200 : 503).build();
+        return ResponseEntity.status(serving(effectiveStatus()) ? 200 : 503).build();
     }
 
     /**
      * Kubernetes liveness probe — always 200 while the application is serving.
      *
-     * <p>Deliberately does NOT consult {@link MeshRuntime#isRunning()}: the mesh
-     * runtime starts late in the Spring lifecycle, so a liveness probe gated on
-     * it would restart-loop an agent through a slow boot. Reaching this handler
-     * at all proves the servlet container is alive, which is the only failure a
-     * restart can actually repair.
+     * <p>Deliberately does NOT consult {@link MeshRuntime#isRunning()} or the
+     * user's health check: the mesh runtime starts late in the Spring
+     * lifecycle, so a liveness probe gated on it would restart-loop an agent
+     * through a slow boot, and a restart cannot fix a vendor outage — it only
+     * erases the evidence. Reaching this handler at all proves the servlet
+     * container is alive, which is the only failure a restart can repair.
      */
     @GetMapping("/livez")
     public ResponseEntity<Map<String, Object>> livez() {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
@@ -57,20 +57,28 @@ public class MeshHealthController {
      * whatever the vendor's status is. Taking the worse of the two is the only
      * answer that is true in both directions.
      */
-    private MeshHealthStatus effectiveStatus() {
+    private MeshHealthStatus effectiveStatus(MeshHealth latest) {
         boolean running = runtime != null && runtime.isRunning();
         if (!running) {
             return MeshHealthStatus.UNHEALTHY;
         }
-        MeshHealth latest = latestHealth();
         return latest == null ? MeshHealthStatus.HEALTHY : latest.status();
     }
 
-    private MeshHealth latestHealth() {
-        if (healthChecks == null) {
-            return null;
-        }
-        MeshHealthCheckRegistry.Result result = healthChecks.latest();
+    /**
+     * Snapshot the latest verdict ONCE per request.
+     *
+     * <p>{@code latest} is written by the health-check thread between calls, so
+     * reading it more than once while building a response can mix two different
+     * results — a body whose {@code status} came from one verdict and whose
+     * {@code checks} / {@code errors} came from the next. Every handler takes
+     * one snapshot and derives the whole response from it.
+     */
+    private MeshHealthCheckRegistry.Result latestResult() {
+        return healthChecks == null ? null : healthChecks.latest();
+    }
+
+    private static MeshHealth healthOf(MeshHealthCheckRegistry.Result result) {
         return result == null ? null : result.health();
     }
 
@@ -94,14 +102,14 @@ public class MeshHealthController {
 
     @GetMapping("/health")
     public ResponseEntity<Map<String, Object>> health() {
-        MeshHealthStatus status = effectiveStatus();
+        MeshHealthCheckRegistry.Result result = latestResult();
+        MeshHealthStatus status = effectiveStatus(healthOf(result));
+
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("status", status.wireValue());
         if (runtime != null && runtime.getAgentSpec() != null) {
             body.put("agent", runtime.getAgentSpec().getName());
         }
-        MeshHealthCheckRegistry.Result result =
-            healthChecks == null ? null : healthChecks.latest();
         if (result != null) {
             body.put("checks", result.health().checks());
             body.put("errors", result.health().errors());
@@ -112,7 +120,8 @@ public class MeshHealthController {
 
     @RequestMapping(value = "/health", method = RequestMethod.HEAD)
     public ResponseEntity<Void> healthHead() {
-        return ResponseEntity.status(serving(effectiveStatus()) ? 200 : 503).build();
+        return ResponseEntity.status(
+            serving(effectiveStatus(healthOf(latestResult()))) ? 200 : 503).build();
     }
 
     /**
@@ -126,7 +135,8 @@ public class MeshHealthController {
     @GetMapping("/ready")
     public ResponseEntity<Map<String, Object>> ready() {
         boolean running = runtime != null && runtime.isRunning();
-        MeshHealthStatus status = effectiveStatus();
+        MeshHealth latest = healthOf(latestResult());
+        MeshHealthStatus status = effectiveStatus(latest);
         boolean ready = serving(status);
 
         Map<String, Object> body = new LinkedHashMap<>();
@@ -136,7 +146,6 @@ public class MeshHealthController {
             body.put("reason", running
                 ? "service is " + status.wireValue()
                 : "mesh runtime is not running");
-            MeshHealth latest = latestHealth();
             if (latest != null && !latest.errors().isEmpty()) {
                 body.put("errors", latest.errors());
             }
@@ -146,7 +155,8 @@ public class MeshHealthController {
 
     @RequestMapping(value = "/ready", method = RequestMethod.HEAD)
     public ResponseEntity<Void> readyHead() {
-        return ResponseEntity.status(serving(effectiveStatus()) ? 200 : 503).build();
+        return ResponseEntity.status(
+            serving(effectiveStatus(healthOf(latestResult()))) ? 200 : 503).build();
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshRuntime.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshRuntime.java
@@ -154,6 +154,33 @@ public class MeshRuntime implements SmartLifecycle {
     }
 
     /**
+     * Report the agent's health verdict to the mesh runtime (issue #1474).
+     *
+     * <p>While the reported status is {@code unhealthy} the runtime stops
+     * heartbeating, so the registry's staleness sweep withdraws this agent from
+     * dependency resolution and consumers fail over. Reporting {@code healthy}
+     * again resumes heartbeats and the registry restores the agent — no restart.
+     *
+     * <p>Unlike {@link #reportHealth(String)} (shared state only) this reaches
+     * the runtime loop and therefore actually affects routing.
+     *
+     * <p>A no-op before the runtime has started or after it has stopped: there
+     * is nothing to report to. Called on every health-check tick, so it is
+     * idempotent by design.
+     *
+     * @param status "healthy", "degraded", or "unhealthy"
+     * @return true if the verdict was handed to a live handle
+     */
+    public boolean updateHealth(String status) {
+        MeshHandle h = handle;
+        if (h != null && running.get() && h.isRunning()) {
+            return h.updateHealth(status);
+        }
+        log.debug("Runtime not running — health status '{}' not published", status);
+        return false;
+    }
+
+    /**
      * Update the HTTP port after auto-detection.
      *
      * <p>Call this when the actual port is known (e.g., from WebServerInitializedEvent)

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckBeanPostProcessorTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckBeanPostProcessorTest.java
@@ -1,0 +1,171 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthCheck;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Discovery and boot-time validation of {@code @MeshHealthCheck} (issue #1474).
+ *
+ * <p>The shape is rejected at BOOT, not coerced at runtime: a health check with
+ * the wrong signature is a health check that does not work, and learning that
+ * from a permanently-degraded verdict on a live provider is exactly the failure
+ * this feature exists to prevent.
+ */
+class MeshHealthCheckBeanPostProcessorTest {
+
+    static class Valid {
+        @MeshHealthCheck(ttlSeconds = 30)
+        public MeshHealth check() {
+            return MeshHealth.healthy();
+        }
+    }
+
+    static class ValidBoolean {
+        @MeshHealthCheck
+        public boolean check() {
+            return true;
+        }
+    }
+
+    static class TakesParameters {
+        @MeshHealthCheck
+        public MeshHealth check(String why) {
+            return MeshHealth.healthy();
+        }
+    }
+
+    static class WrongReturnType {
+        @MeshHealthCheck
+        public String check() {
+            return "healthy";
+        }
+    }
+
+    static class VoidReturn {
+        @MeshHealthCheck
+        public void check() {
+        }
+    }
+
+    static class ZeroTtl {
+        @MeshHealthCheck(ttlSeconds = 0)
+        public MeshHealth check() {
+            return MeshHealth.healthy();
+        }
+    }
+
+    static class TwoChecks {
+        @MeshHealthCheck
+        public MeshHealth first() {
+            return MeshHealth.healthy();
+        }
+
+        @MeshHealthCheck
+        public boolean second() {
+            return true;
+        }
+    }
+
+    abstract static class Base {
+        @MeshHealthCheck
+        public MeshHealth check() {
+            return MeshHealth.healthy();
+        }
+    }
+
+    static class Derived extends Base {
+        @Override
+        public MeshHealth check() {
+            return MeshHealth.degraded("overridden");
+        }
+    }
+
+    static class NoAnnotation {
+        public MeshHealth check() {
+            return MeshHealth.healthy();
+        }
+    }
+
+    private static MeshHealthCheckRegistry process(Object bean) {
+        MeshHealthCheckRegistry registry = new MeshHealthCheckRegistry();
+        new MeshHealthCheckBeanPostProcessor(registry)
+            .postProcessAfterInitialization(bean, "bean");
+        return registry;
+    }
+
+    @Test
+    void discoversTheAnnotatedMethodAndItsTtl() {
+        MeshHealthCheckRegistry registry = process(new Valid());
+
+        assertTrue(registry.hasHealthCheck());
+        assertEquals("check", registry.registration().method().getName());
+        assertEquals(30, registry.ttlSeconds());
+    }
+
+    @Test
+    void acceptsABooleanCheck() {
+        assertTrue(process(new ValidBoolean()).hasHealthCheck());
+    }
+
+    @Test
+    void ignoresBeansWithoutTheAnnotation() {
+        assertFalse(process(new NoAnnotation()).hasHealthCheck());
+    }
+
+    @Test
+    void rejectsAMethodWithParameters() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+            () -> process(new TakesParameters()));
+        assertTrue(e.getMessage().contains("must take no parameters"), e.getMessage());
+    }
+
+    @Test
+    void rejectsAnUnreadableReturnType() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+            () -> process(new WrongReturnType()));
+        assertTrue(e.getMessage().contains("cannot read as a health verdict"), e.getMessage());
+
+        // void is the one worth naming: it compiles, reads like a check, and
+        // could never report anything.
+        assertThrows(IllegalStateException.class, () -> process(new VoidReturn()));
+    }
+
+    @Test
+    void rejectsANonPositiveTtl() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+            () -> process(new ZeroTtl()));
+        assertTrue(e.getMessage().contains("at least 1 second"), e.getMessage());
+    }
+
+    @Test
+    void rejectsTwoChecksOnOneBean() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+            () -> process(new TwoChecks()));
+        assertTrue(e.getMessage().contains("Two @MeshHealthCheck methods"), e.getMessage());
+    }
+
+    @Test
+    void rejectsTwoChecksAcrossBeans() {
+        MeshHealthCheckRegistry registry = new MeshHealthCheckRegistry();
+        MeshHealthCheckBeanPostProcessor processor = new MeshHealthCheckBeanPostProcessor(registry);
+        processor.postProcessAfterInitialization(new Valid(), "a");
+
+        assertThrows(IllegalStateException.class,
+            () -> processor.postProcessAfterInitialization(new ValidBoolean(), "b"));
+    }
+
+    @Test
+    void anInheritedCheckRegistersOnceAndInvokesTheOverride() {
+        // A bare ReflectionUtils walk visits an overridden method once per
+        // declaring class plus bridges — which here would trip the
+        // "two health checks" guard on a single legitimate check.
+        MeshHealthCheckRegistry registry = process(new Derived());
+
+        assertTrue(registry.hasHealthCheck());
+        assertEquals(io.mcpmesh.MeshHealthStatus.DEGRADED, registry.execute().status(),
+            "must dispatch to the most-derived declaration");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckBeanPostProcessorTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckBeanPostProcessorTest.java
@@ -89,6 +89,19 @@ class MeshHealthCheckBeanPostProcessorTest {
         }
     }
 
+    /** A JDK-proxyable health check: the annotation lives on the interface. */
+    public interface ProxyableCheck {
+        @MeshHealthCheck
+        MeshHealth check();
+    }
+
+    public static class ProxyableCheckImpl implements ProxyableCheck {
+        @Override
+        public MeshHealth check() {
+            return MeshHealth.degraded("from the real target");
+        }
+    }
+
     private static MeshHealthCheckRegistry process(Object bean) {
         MeshHealthCheckRegistry registry = new MeshHealthCheckRegistry();
         new MeshHealthCheckBeanPostProcessor(registry)
@@ -155,6 +168,54 @@ class MeshHealthCheckBeanPostProcessorTest {
 
         assertThrows(IllegalStateException.class,
             () -> processor.postProcessAfterInitialization(new ValidBoolean(), "b"));
+    }
+
+    @Test
+    void aSpringJdkDynamicProxyBeanIsStillInvocable() {
+        // A Spring JDK proxy is TargetClassAware, so AopUtils.getTargetClass
+        // returns ProxyableCheckImpl — but the proxy itself does NOT extend it
+        // (it implements the interface and extends java.lang.reflect.Proxy).
+        // Registering the PROXY alongside a Method resolved on the TARGET CLASS
+        // makes Method.invoke throw "object is not an instance of declaring
+        // class", which the registry reports as DEGRADED forever: an agent
+        // whose health check silently never works. Spring produces JDK proxies
+        // for any interface-implementing bean under proxyTargetClass=false
+        // (@Transactional, @Async, @Validated, ...).
+        org.springframework.aop.framework.ProxyFactory factory =
+            new org.springframework.aop.framework.ProxyFactory(new ProxyableCheckImpl());
+        factory.setInterfaces(ProxyableCheck.class);
+        factory.setProxyTargetClass(false);
+        Object proxy = factory.getProxy();
+
+        assertTrue(java.lang.reflect.Proxy.isProxyClass(proxy.getClass()),
+            "fixture must produce a JDK proxy, not CGLIB");
+        assertEquals(ProxyableCheckImpl.class,
+            org.springframework.aop.support.AopUtils.getTargetClass(proxy),
+            "fixture must be TargetClassAware — that is what creates the mismatch");
+
+        MeshHealthCheckRegistry registry = new MeshHealthCheckRegistry();
+        new MeshHealthCheckBeanPostProcessor(registry)
+            .postProcessAfterInitialization(proxy, "proxied");
+
+        assertTrue(registry.hasHealthCheck());
+        MeshHealth health = registry.execute();
+        assertEquals(io.mcpmesh.MeshHealthStatus.DEGRADED, health.status());
+        assertEquals(java.util.List.of("from the real target"), health.errors(),
+            "the check must actually run, not fail into a DEGRADED placeholder");
+    }
+
+    @Test
+    void aCglibProxyBeanIsStillInvocable() {
+        org.springframework.aop.framework.ProxyFactory factory =
+            new org.springframework.aop.framework.ProxyFactory(new ProxyableCheckImpl());
+        factory.setProxyTargetClass(true);
+        Object proxy = factory.getProxy();
+
+        MeshHealthCheckRegistry registry = new MeshHealthCheckRegistry();
+        new MeshHealthCheckBeanPostProcessor(registry)
+            .postProcessAfterInitialization(proxy, "proxied");
+
+        assertEquals(java.util.List.of("from the real target"), registry.execute().errors());
     }
 
     @Test

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckRegistryTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckRegistryTest.java
@@ -140,11 +140,37 @@ class MeshHealthCheckRegistryTest {
 
     @Test
     void ttlComesFromTheAnnotation() {
-        assertEquals(30, registryFor(new Checks(), "withTtl").ttlSeconds());
-        assertEquals(15, registryFor(new Checks(), "detailed").ttlSeconds(),
+        // Drive the env-free overload: the public ttlSeconds() reads
+        // MCP_MESH_HEALTH_CHECK_TTL, and an ambient value in the developer's or
+        // CI's environment would silently flip these assertions.
+        assertEquals(30, registryFor(new Checks(), "withTtl").ttlSeconds(null));
+        assertEquals(15, registryFor(new Checks(), "detailed").ttlSeconds(null),
             "default must match Python's health_check_ttl");
         assertEquals(MeshHealthCheckRegistry.DEFAULT_TTL_SECONDS,
-            new MeshHealthCheckRegistry().ttlSeconds());
+            new MeshHealthCheckRegistry().ttlSeconds(null));
+    }
+
+    @Test
+    void theEnvVarOverridesTheAnnotation() {
+        MeshHealthCheckRegistry registry = registryFor(new Checks(), "withTtl");
+
+        assertEquals(5, registry.ttlSeconds("5"));
+        assertEquals(5, registry.ttlSeconds("  5  "), "surrounding whitespace is the operator's");
+    }
+
+    @Test
+    void anUnusableEnvVarFallsBackToTheAnnotation() {
+        MeshHealthCheckRegistry registry = registryFor(new Checks(), "withTtl");
+
+        // Sub-1s would busy-probe the vendor; not an integer is a typo. Both
+        // fall back rather than failing the boot — a bad override must not stop
+        // an agent from starting, and 30s is a safe answer.
+        assertEquals(30, registry.ttlSeconds("0"));
+        assertEquals(30, registry.ttlSeconds("-1"));
+        assertEquals(30, registry.ttlSeconds("thirty"));
+        assertEquals(30, registry.ttlSeconds("15s"));
+        assertEquals(30, registry.ttlSeconds(""), "blank is 'not set'");
+        assertEquals(30, registry.ttlSeconds("   "));
     }
 
     @Test

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckRegistryTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckRegistryTest.java
@@ -1,0 +1,161 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthCheck;
+import io.mcpmesh.MeshHealthStatus;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verdict conversion and storage for {@code @MeshHealthCheck} (issue #1474).
+ *
+ * <p>The load-bearing assertion here is the asymmetry #1472 established and
+ * this change had to mirror: only an EXPLICIT unhealthy result withdraws an
+ * agent. A check that throws, or whose verdict cannot be read, is DEGRADED —
+ * it keeps heartbeating.
+ */
+class MeshHealthCheckRegistryTest {
+
+    static class Checks {
+        boolean fail = false;
+
+        @MeshHealthCheck
+        public MeshHealth detailed() {
+            return fail
+                ? MeshHealth.unhealthy("vendor down").withCheck("vendor_reachable", false)
+                : MeshHealth.healthy().withCheck("vendor_reachable", true);
+        }
+
+        @MeshHealthCheck
+        public boolean terse() {
+            return !fail;
+        }
+
+        @MeshHealthCheck
+        public MeshHealth explodes() {
+            throw new IllegalStateException("connection pool is null");
+        }
+
+        @MeshHealthCheck(ttlSeconds = 30)
+        public MeshHealth withTtl() {
+            return MeshHealth.healthy();
+        }
+    }
+
+    private static MeshHealthCheckRegistry registryFor(Checks bean, String methodName) {
+        try {
+            Method method = Checks.class.getMethod(methodName);
+            MeshHealthCheckRegistry registry = new MeshHealthCheckRegistry();
+            MeshHealthCheck annotation = method.getAnnotation(MeshHealthCheck.class);
+            registry.register(bean, method, annotation.ttlSeconds());
+            return registry;
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    @Test
+    void meshHealthResultPassesThroughWithItsDetail() {
+        Checks bean = new Checks();
+        MeshHealthCheckRegistry registry = registryFor(bean, "detailed");
+
+        MeshHealth healthy = registry.execute();
+        assertEquals(MeshHealthStatus.HEALTHY, healthy.status());
+        assertEquals(Boolean.TRUE, healthy.checks().get("vendor_reachable"));
+        assertTrue(healthy.errors().isEmpty());
+
+        bean.fail = true;
+        MeshHealth unhealthy = registry.execute();
+        assertEquals(MeshHealthStatus.UNHEALTHY, unhealthy.status());
+        assertEquals(Boolean.FALSE, unhealthy.checks().get("vendor_reachable"));
+        assertEquals(java.util.List.of("vendor down"), unhealthy.errors());
+    }
+
+    @Test
+    void booleanReturnMapsTrueToHealthyAndFalseToUnhealthy() {
+        // Python parity: bool True → HEALTHY, False → UNHEALTHY.
+        Checks bean = new Checks();
+        MeshHealthCheckRegistry registry = registryFor(bean, "terse");
+
+        assertEquals(MeshHealthStatus.HEALTHY, registry.execute().status());
+
+        bean.fail = true;
+        MeshHealth unhealthy = registry.execute();
+        assertEquals(MeshHealthStatus.UNHEALTHY, unhealthy.status());
+        assertEquals(Boolean.FALSE, unhealthy.checks().get("health_check"));
+        assertFalse(unhealthy.errors().isEmpty());
+    }
+
+    @Test
+    void aCheckThatThrowsIsDegradedNotUnhealthy() {
+        // The crux: a buggy health check must not nuke a working agent. DEGRADED
+        // keeps heartbeating; UNHEALTHY would withdraw it from resolution.
+        MeshHealthCheckRegistry registry = registryFor(new Checks(), "explodes");
+
+        MeshHealth health = registry.execute();
+        assertEquals(MeshHealthStatus.DEGRADED, health.status(),
+            "an exception must not withdraw the agent");
+        assertEquals(Boolean.FALSE, health.checks().get("health_check_execution"));
+        assertEquals(1, health.errors().size());
+        assertTrue(health.errors().get(0).contains("connection pool is null"));
+    }
+
+    @Test
+    void anUnreadableReturnValueIsDegradedNotUnhealthy() {
+        // Unreachable through the annotation (the post-processor rejects the
+        // shape at boot) — asserted so the defensive branch cannot drift into
+        // withdrawing an agent over a reporting defect.
+        MeshHealth health = MeshHealthCheckRegistry.coerce("healthy-ish");
+        assertEquals(MeshHealthStatus.DEGRADED, health.status());
+        assertEquals(Boolean.FALSE, health.checks().get("health_check_return_type"));
+
+        assertEquals(MeshHealthStatus.DEGRADED, MeshHealthCheckRegistry.coerce(null).status());
+    }
+
+    @Test
+    void executeReturnsNullWithNoRegisteredCheck() {
+        assertNull(new MeshHealthCheckRegistry().execute());
+        assertFalse(new MeshHealthCheckRegistry().hasHealthCheck());
+        assertNull(new MeshHealthCheckRegistry().latest());
+    }
+
+    @Test
+    void aSecondHealthCheckFailsFastRatherThanPickingOne() {
+        Checks bean = new Checks();
+        MeshHealthCheckRegistry registry = registryFor(bean, "detailed");
+
+        Method second;
+        try {
+            second = Checks.class.getMethod("terse");
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+            () -> registry.register(bean, second, 15));
+        assertTrue(e.getMessage().contains("Two @MeshHealthCheck methods"));
+    }
+
+    @Test
+    void ttlComesFromTheAnnotation() {
+        assertEquals(30, registryFor(new Checks(), "withTtl").ttlSeconds());
+        assertEquals(15, registryFor(new Checks(), "detailed").ttlSeconds(),
+            "default must match Python's health_check_ttl");
+        assertEquals(MeshHealthCheckRegistry.DEFAULT_TTL_SECONDS,
+            new MeshHealthCheckRegistry().ttlSeconds());
+    }
+
+    @Test
+    void storeAndLatestRoundTripWithATimestamp() {
+        MeshHealthCheckRegistry registry = registryFor(new Checks(), "detailed");
+        assertNull(registry.latest());
+
+        MeshHealth health = MeshHealth.degraded("slow");
+        registry.store(health);
+
+        assertSame(health, registry.latest().health());
+        assertNotNull(registry.latest().timestamp());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckSchedulerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckSchedulerTest.java
@@ -140,8 +140,9 @@ class MeshHealthCheckSchedulerTest {
 
         scheduler.start();
         try {
+            waitUntil(() -> registry.latest() != null);
             assertEquals(MeshHealthStatus.UNHEALTHY, registry.latest().health().status(),
-                "the seed must reach /health and /ready immediately");
+                "the seed must reach /health and /ready");
             assertTrue(published.isEmpty(), "the seed must not publish to the runtime");
 
             // ttlSeconds=1 — the first scheduled tick publishes.
@@ -220,6 +221,72 @@ class MeshHealthCheckSchedulerTest {
         } finally {
             scheduler.stop();
         }
+    }
+
+    @Test
+    @Timeout(30)
+    void startDoesNotBlockOnASlowHealthCheck() throws Exception {
+        // A scaffolded provider's check is an HTTP call to a vendor. Running the
+        // startup seed on the Spring lifecycle thread would stall application
+        // boot for as long as the vendor takes to answer — a hung vendor would
+        // hang the boot outright.
+        java.util.concurrent.CountDownLatch entered = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.CountDownLatch release = new java.util.concurrent.CountDownLatch(1);
+
+        class SlowChecks {
+            @MeshHealthCheck(ttlSeconds = 1)
+            public MeshHealth check() {
+                entered.countDown();
+                try {
+                    release.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return MeshHealth.healthy();
+            }
+        }
+        SlowChecks bean = new SlowChecks();
+        MeshHealthCheckRegistry registry = new MeshHealthCheckRegistry();
+        registry.register(bean, SlowChecks.class.getMethod("check"), 1);
+
+        MeshHealthCheckScheduler scheduler = new MeshHealthCheckScheduler(
+            runtimeOf("mcp_agent", Collections.synchronizedList(new ArrayList<>())), registry);
+
+        long start = System.nanoTime();
+        scheduler.start();
+        long startMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+        try {
+            assertTrue(entered.await(10, TimeUnit.SECONDS), "the seed must still run");
+            assertTrue(startMs < 2000,
+                "start() blocked on the health check for " + startMs + "ms");
+        } finally {
+            release.countDown();
+            scheduler.stop();
+        }
+    }
+
+    @Test
+    void anErrorFromPublishingDoesNotKillTheRefreshLoop() {
+        // A ScheduledExecutorService silently cancels ALL future runs when a
+        // task throws. catch(Exception) would let an Error through — and the
+        // agent would stop refreshing its health permanently, with nothing in
+        // the logs after the first failure and no recovery short of a restart.
+        MeshRuntime runtime = mock(MeshRuntime.class);
+        when(runtime.isRunning()).thenReturn(true);
+        AgentSpec spec = new AgentSpec();
+        spec.setAgentType("mcp_agent");
+        when(runtime.getAgentSpec()).thenReturn(spec);
+        when(runtime.updateHealth(anyString()))
+            .thenThrow(new UnsatisfiedLinkError("mesh_update_health"));
+
+        MeshHealthCheckRegistry registry = registryFor(new Checks());
+        MeshHealthCheckScheduler scheduler = new MeshHealthCheckScheduler(runtime, registry);
+
+        assertDoesNotThrow(() -> scheduler.refresh(true));
+        assertNotNull(registry.latest(), "the verdict is still stored for /health");
+        // And the next tick still runs.
+        assertDoesNotThrow(() -> scheduler.refresh(true));
     }
 
     @Test

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckSchedulerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckSchedulerTest.java
@@ -1,0 +1,251 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthCheck;
+import io.mcpmesh.MeshHealthStatus;
+import io.mcpmesh.core.AgentSpec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * What the health-check timer does with each verdict (issue #1474).
+ *
+ * <p>Three invariants carried over from #1472, all asserted here:
+ * <ul>
+ *   <li>only an explicit UNHEALTHY reaches the runtime as {@code "unhealthy"} —
+ *       a throwing check publishes {@code "degraded"} and keeps beating;</li>
+ *   <li>the startup seed does NOT publish, so a check that fails during boot
+ *       cannot withdraw an agent that has only just registered;</li>
+ *   <li>a route ({@code api}) or A2A agent is never withdrawn by its own check.</li>
+ * </ul>
+ */
+class MeshHealthCheckSchedulerTest {
+
+    static class Checks {
+        volatile MeshHealth next = MeshHealth.healthy();
+        volatile boolean explode = false;
+
+        @MeshHealthCheck(ttlSeconds = 1)
+        public MeshHealth check() {
+            if (explode) {
+                throw new IllegalStateException("boom");
+            }
+            return next;
+        }
+    }
+
+    private static MeshHealthCheckRegistry registryFor(Checks bean) {
+        try {
+            Method method = Checks.class.getMethod("check");
+            MeshHealthCheckRegistry registry = new MeshHealthCheckRegistry();
+            registry.register(bean, method, method.getAnnotation(MeshHealthCheck.class).ttlSeconds());
+            return registry;
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /** A running runtime of the given agent type, recording every published status. */
+    private static MeshRuntime runtimeOf(String agentType, List<String> published) {
+        MeshRuntime runtime = mock(MeshRuntime.class);
+        when(runtime.isRunning()).thenReturn(true);
+        AgentSpec spec = new AgentSpec();
+        spec.setName("provider");
+        spec.setAgentType(agentType);
+        when(runtime.getAgentSpec()).thenReturn(spec);
+        when(runtime.updateHealth(anyString())).thenAnswer(inv -> {
+            published.add(inv.getArgument(0));
+            return true;
+        });
+        return runtime;
+    }
+
+    @Test
+    void aHealthyVerdictIsStoredAndPublished() {
+        List<String> published = Collections.synchronizedList(new ArrayList<>());
+        Checks bean = new Checks();
+        MeshHealthCheckRegistry registry = registryFor(bean);
+        MeshHealthCheckScheduler scheduler =
+            new MeshHealthCheckScheduler(runtimeOf("mcp_agent", published), registry);
+
+        scheduler.refresh(true);
+
+        assertEquals(MeshHealthStatus.HEALTHY, registry.latest().health().status());
+        assertEquals(List.of("healthy"), published);
+    }
+
+    @Test
+    void anUnhealthyVerdictIsPublishedAsUnhealthy() {
+        // This is the whole mechanism: "unhealthy" is what stops the heartbeat.
+        List<String> published = Collections.synchronizedList(new ArrayList<>());
+        Checks bean = new Checks();
+        bean.next = MeshHealth.unhealthy("vendor 503");
+        MeshHealthCheckRegistry registry = registryFor(bean);
+
+        new MeshHealthCheckScheduler(runtimeOf("mcp_agent", published), registry).refresh(true);
+
+        assertEquals(List.of("unhealthy"), published);
+        assertEquals(List.of("vendor 503"), registry.latest().health().errors());
+    }
+
+    @Test
+    void aThrowingCheckPublishesDegradedSoTheAgentKeepsBeating() {
+        List<String> published = Collections.synchronizedList(new ArrayList<>());
+        Checks bean = new Checks();
+        bean.explode = true;
+        MeshHealthCheckRegistry registry = registryFor(bean);
+
+        new MeshHealthCheckScheduler(runtimeOf("mcp_agent", published), registry).refresh(true);
+
+        assertEquals(List.of("degraded"), published,
+            "a buggy health check must not withdraw a working agent");
+        assertEquals(MeshHealthStatus.DEGRADED, registry.latest().health().status());
+    }
+
+    @Test
+    void aDegradedVerdictIsPublishedAsDegraded() {
+        List<String> published = Collections.synchronizedList(new ArrayList<>());
+        Checks bean = new Checks();
+        bean.next = MeshHealth.degraded("high latency");
+        MeshHealthCheckRegistry registry = registryFor(bean);
+
+        new MeshHealthCheckScheduler(runtimeOf("mcp_agent", published), registry).refresh(true);
+
+        assertEquals(List.of("degraded"), published);
+    }
+
+    @Test
+    @Timeout(30)
+    void theStartupSeedFeedsTheEndpointsButDoesNotWithdrawTheAgent() throws Exception {
+        // Python parity: the agent registers and becomes visible first; only the
+        // first refresh, one TTL later, can withdraw it. A vendor client built
+        // lazily on the first call would otherwise fail its own boot probe and
+        // take the agent out before it ever served anything.
+        List<String> published = Collections.synchronizedList(new ArrayList<>());
+        Checks bean = new Checks();
+        bean.next = MeshHealth.unhealthy("not warm yet");
+        MeshHealthCheckRegistry registry = registryFor(bean);
+        MeshHealthCheckScheduler scheduler =
+            new MeshHealthCheckScheduler(runtimeOf("mcp_agent", published), registry);
+
+        scheduler.start();
+        try {
+            assertEquals(MeshHealthStatus.UNHEALTHY, registry.latest().health().status(),
+                "the seed must reach /health and /ready immediately");
+            assertTrue(published.isEmpty(), "the seed must not publish to the runtime");
+
+            // ttlSeconds=1 — the first scheduled tick publishes.
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+            while (published.isEmpty() && System.nanoTime() < deadline) {
+                Thread.sleep(50);
+            }
+            assertEquals(List.of("unhealthy"), published,
+                "the first scheduled refresh must publish the verdict");
+        } finally {
+            scheduler.stop();
+        }
+        assertFalse(scheduler.isRunning());
+    }
+
+    @Test
+    @Timeout(30)
+    void recoveryIsPublishedWithoutARestart() throws Exception {
+        List<String> published = Collections.synchronizedList(new ArrayList<>());
+        Checks bean = new Checks();
+        bean.next = MeshHealth.unhealthy("vendor down");
+        MeshHealthCheckRegistry registry = registryFor(bean);
+        MeshHealthCheckScheduler scheduler =
+            new MeshHealthCheckScheduler(runtimeOf("mcp_agent", published), registry);
+
+        scheduler.start();
+        try {
+            waitUntil(() -> published.contains("unhealthy"));
+            bean.next = MeshHealth.healthy();
+            waitUntil(() -> published.contains("healthy"));
+        } finally {
+            scheduler.stop();
+        }
+
+        assertTrue(published.indexOf("unhealthy") < published.indexOf("healthy"));
+    }
+
+    @Test
+    void aRouteAgentIsNeverWithdrawnByItsOwnCheck() throws Exception {
+        // A gateway is a fan-out point: withdrawing a provider is correct,
+        // withdrawing the gateway takes the application down.
+        for (String agentType : List.of("api", "a2a")) {
+            List<String> published = Collections.synchronizedList(new ArrayList<>());
+            Checks bean = new Checks();
+            bean.next = MeshHealth.unhealthy("upstream down");
+            MeshHealthCheckRegistry registry = registryFor(bean);
+            MeshHealthCheckScheduler scheduler =
+                new MeshHealthCheckScheduler(runtimeOf(agentType, published), registry);
+
+            scheduler.start();
+            try {
+                scheduler.refresh(true);
+                assertTrue(published.isEmpty(),
+                    "'" + agentType + "' agent must never suppress its heartbeat");
+                assertEquals(MeshHealthStatus.UNHEALTHY, registry.latest().health().status(),
+                    "'" + agentType + "' agent must still reflect the verdict on its probes");
+            } finally {
+                scheduler.stop();
+            }
+        }
+    }
+
+    @Test
+    void noHealthCheckMeansNoTimerAndNoPublishing() {
+        List<String> published = Collections.synchronizedList(new ArrayList<>());
+        MeshHealthCheckRegistry empty = new MeshHealthCheckRegistry();
+        MeshHealthCheckScheduler scheduler =
+            new MeshHealthCheckScheduler(runtimeOf("mcp_agent", published), empty);
+
+        scheduler.start();
+        try {
+            assertFalse(scheduler.isRunning(), "no check declared — nothing to schedule");
+            scheduler.refresh(true);
+            assertTrue(published.isEmpty());
+            assertNull(empty.latest());
+        } finally {
+            scheduler.stop();
+        }
+    }
+
+    @Test
+    void aFailingPublishDoesNotKillTheRefreshLoop() {
+        // An escaping exception on a ScheduledExecutorService silently cancels
+        // every future run — the agent would stop refreshing forever, with
+        // nothing in the logs after the first failure.
+        MeshRuntime runtime = mock(MeshRuntime.class);
+        when(runtime.isRunning()).thenReturn(true);
+        AgentSpec spec = new AgentSpec();
+        spec.setAgentType("mcp_agent");
+        when(runtime.getAgentSpec()).thenReturn(spec);
+        when(runtime.updateHealth(anyString())).thenThrow(new RuntimeException("handle closed"));
+
+        MeshHealthCheckRegistry registry = registryFor(new Checks());
+        MeshHealthCheckScheduler scheduler = new MeshHealthCheckScheduler(runtime, registry);
+
+        assertDoesNotThrow(() -> scheduler.refresh(true));
+        assertNotNull(registry.latest(), "the verdict is still stored for /health");
+    }
+
+    private static void waitUntil(java.util.function.BooleanSupplier condition) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(20);
+        while (!condition.getAsBoolean()) {
+            assertTrue(System.nanoTime() < deadline, "condition not met within 20s");
+            Thread.sleep(50);
+        }
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthControllerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthControllerTest.java
@@ -126,4 +126,102 @@ class MeshHealthControllerTest {
         assertEquals(503, new MeshHealthController(runtimeWith(false)).health()
             .getStatusCode().value());
     }
+
+    // ---- @MeshHealthCheck reflection (issue #1474) --------------------------
+
+    private static MeshHealthCheckRegistry withVerdict(io.mcpmesh.MeshHealth health) {
+        MeshHealthCheckRegistry registry = new MeshHealthCheckRegistry();
+        registry.store(health);
+        return registry;
+    }
+
+    @Test
+    void ready_is503_whenTheUserHealthCheckIsUnhealthy() {
+        MeshHealthController controller = new MeshHealthController(runtimeWith(true),
+            withVerdict(io.mcpmesh.MeshHealth.unhealthy("anthropic API unreachable")));
+
+        ResponseEntity<Map<String, Object>> response = controller.ready();
+
+        assertEquals(503, response.getStatusCode().value());
+        assertEquals(Boolean.FALSE, response.getBody().get("ready"));
+        assertEquals("unhealthy", response.getBody().get("status"));
+        assertEquals("service is unhealthy", response.getBody().get("reason"));
+        assertEquals(java.util.List.of("anthropic API unreachable"),
+            response.getBody().get("errors"));
+        assertEquals(503, controller.readyHead().getStatusCode().value());
+    }
+
+    @Test
+    void ready_is503_whenTheUserHealthCheckIsDegraded() {
+        // Python parity: build_ready_response / build_health_response are
+        // `200 if status == "healthy" else 503`. Degraded therefore leaves the
+        // load balancer while STILL heartbeating and staying in dependency
+        // resolution — readiness is about new external traffic, the heartbeat
+        // is about whether this is still a valid mesh provider.
+        MeshHealthController controller = new MeshHealthController(runtimeWith(true),
+            withVerdict(io.mcpmesh.MeshHealth.degraded("elevated latency")));
+
+        ResponseEntity<Map<String, Object>> response = controller.ready();
+
+        assertEquals(503, response.getStatusCode().value());
+        assertEquals(Boolean.FALSE, response.getBody().get("ready"));
+        assertEquals("degraded", response.getBody().get("status"));
+        assertEquals("service is degraded", response.getBody().get("reason"));
+        assertEquals(503, controller.health().getStatusCode().value());
+    }
+
+    @Test
+    void ready_is503_whenTheRuntimeIsDownEvenIfTheCheckSaysHealthy() {
+        // The runtime state is the FLOOR: a vendor probe says nothing about
+        // whether this agent is registered and reachable.
+        MeshHealthController controller = new MeshHealthController(runtimeWith(false),
+            withVerdict(io.mcpmesh.MeshHealth.healthy()));
+
+        ResponseEntity<Map<String, Object>> response = controller.ready();
+
+        assertEquals(503, response.getStatusCode().value());
+        assertEquals("mesh runtime is not running", response.getBody().get("reason"));
+    }
+
+    @Test
+    void health_carriesChecksAndErrors() {
+        MeshHealthController controller = new MeshHealthController(runtimeWith(true),
+            withVerdict(io.mcpmesh.MeshHealth.unhealthy("ANTHROPIC_API_KEY not set")
+                .withCheck("anthropic_api_key_present", false)));
+
+        ResponseEntity<Map<String, Object>> response = controller.health();
+
+        assertEquals(503, response.getStatusCode().value());
+        assertEquals("unhealthy", response.getBody().get("status"));
+        assertEquals(Map.of("anthropic_api_key_present", false),
+            response.getBody().get("checks"));
+        assertEquals(java.util.List.of("ANTHROPIC_API_KEY not set"),
+            response.getBody().get("errors"));
+        assertNotNull(response.getBody().get("timestamp"));
+        assertEquals(503, controller.healthHead().getStatusCode().value());
+    }
+
+    @Test
+    void probes_areUnaffectedBeforeTheFirstCheckRuns() {
+        // Registry present but nothing stored yet (boot). The agent must not be
+        // 503 just because its first health-check tick has not landed.
+        MeshHealthController controller =
+            new MeshHealthController(runtimeWith(true), new MeshHealthCheckRegistry());
+
+        assertEquals(200, controller.ready().getStatusCode().value());
+        assertEquals(200, controller.health().getStatusCode().value());
+        assertFalse(controller.health().getBody().containsKey("checks"));
+    }
+
+    @Test
+    void livez_is200_evenWhenTheUserHealthCheckIsUnhealthy() {
+        // The #1467 invariant, extended: a vendor outage must never restart the
+        // pod — a restart cannot fix the vendor and erases the evidence.
+        MeshHealthController controller = new MeshHealthController(runtimeWith(true),
+            withVerdict(io.mcpmesh.MeshHealth.unhealthy("vendor down")));
+
+        assertEquals(200, controller.livez().getStatusCode().value());
+        assertEquals(200, controller.livezHead().getStatusCode().value());
+        assertEquals(503, controller.ready().getStatusCode().value());
+    }
 }


### PR DESCRIPTION
## Summary

Java had no way to express "my upstream is down", so a Java LLM provider whose vendor failed kept heartbeating and kept being selected. #1467 gave it the probe plumbing; #1472 gave Python the withdrawal mechanism. This gives Java something to plug in.

`@MeshHealthCheck` on a method, discovered by a bean post-processor following the `MeshTool`/`MeshRoute` conventions, with `ttlSeconds` (default 15, `MCP_MESH_HEALTH_CHECK_TTL` overrides).

## Two design calls worth reviewing

**Return type: a record, not a `Map`.** `MeshHealth(MeshHealthStatus status, Map<String,Object> checks, List<String> errors)`. Status is the field the mesh acts on, and a map makes it **misspellable into silence** — `{"status": "unhelathy"}` would never withdraw an agent, while an enum doesn't compile. Detail stays a map because it genuinely is open-ended. A bare `boolean` is accepted as Python-parity sugar; anything else **fails the boot**, because learning your health check has the wrong shape from a permanently-degraded live provider is exactly the failure this feature exists to prevent.

**Scheduler: `ScheduledExecutorService`, not `@Scheduled`.** This one matters. `@Scheduled` requires `@EnableScheduling`, which a *starter* cannot turn on without changing the host application — it registers a `TaskScheduler` and **activates every `@Scheduled` method in the user's own code**. Adding the mesh dependency would start running their jobs. Worse, Spring's default scheduler is a single-threaded pool shared with those jobs, so one slow user task delays the health refresh — and a stalled refresh is an agent that cannot be withdrawn. One daemon thread on `SmartLifecycle`, matching what `MeshEventProcessor` already does. `scheduleWithFixedDelay`, not `AtRate`, so a probe that times out doesn't queue back-to-back runs against a struggling upstream.

## The FFI didn't exist

`RuntimeCommand::UpdateHealth` landed in #1472, but only the **pyo3** binding — `mesh_update_health` had no C entry point. Added it plus the regenerated header, `MeshCore` / `MeshHandle.updateHealth` / `MeshRuntime`, modelled on `updatePort` including its lock-free fast path and read-lock closed-check.

Also documented that the pre-existing **`mesh_report_health` is shared-state only and cannot gate the heartbeat**, with a Rust test asserting it enqueues no command — so nobody "fixes" a health check by calling the plausible-looking function next to it.

## Mirrored from Python deliberately

- A check that **throws** → `DEGRADED`, keeps heartbeating. A buggy health check must not withdraw an agent. Verified live: beats continued every 5s and traffic kept routing.
- **Unknown status** → `DEGRADED`. The Rust side stays strict and returns -1, so if a caller ever stops normalising it fails loudly rather than silently.
- **Only an explicit unhealthy result suppresses.** The startup seed populates the endpoints but does not publish, so a check failing during boot can't withdraw an agent that just registered.

`api`/`a2a` agents run the check and reflect it on their probes but **never publish to the runtime**, with a boot log saying so. A route agent is a fan-out point: withdrawing a provider is right, withdrawing the gateway takes the app down.

## End-to-end (registry timeout 20s, sweep 10s)

| time | event |
|---|---|
| 00:13:36 | last heartbeat from `hc-provider-a`; flag flipped to `fail` |
| 00:13:36 → 00:14:11 | **35s, zero heartbeats**; `hc-provider-b` beat every 5s throughout |
| 00:14:02 | **consumer failover** → `"servedBy": "provider-b"` |
| 00:14:08 | flag back to `ok` |
| 00:14:11 | HEAD → **410 Gone** → re-register (#955 path) |
| 00:14:12 | consumer back on `provider-a` |

**PID 7408 throughout, `ELAPSED 11:18`** — one process across outage, recovery *and* the separate degraded test. Probes during the outage: `/livez` 200, `/health` 503, `/ready` 503, body carrying `vendor_api_reachable: false` and the error string.

## Test plan

- [x] Java **1211 passed, 0 failures** (+38)
- [x] Rust **488 passed** serially (the 2 `tracing_publish` parallel flakes are the ones documented in #1473)
- [x] Python **1566, 0 failures, 1 skipped**
- [x] `go build ./...`, `go test ./src/core/cli/man/...` and `./src/core/cli/scaffold/...` ok
- [x] All four scaffold branches render **and compile** (`mvn compile`) against the built starter
- [ ] CI green

## Three things that contradict the brief

**1. The man goldens did not move.** I said they would. `renderer_test.go:141` states the corpus tests sample only the *default* variant, so edits confined to `deployment_java.md` / `health_java.md` are invisible — which is the same gap recorded in #1471's provenance comment. Restating it here: **a review of `_java` doc files cannot lean on that test.**

**2. `degraded` answers 503 on `/ready` and `/health`, not 200.** 200 shipped first (reasoning: a degraded agent keeps heartbeating, so it should stay in the LB) and was caught during E2E — Python's builders are literally `200 if healthy else 503`. Java now matches. But note what that means: **a degraded agent keeps heartbeating and stays selectable by resolution, while Kubernetes pulls it from the Service.** Coherent if you read readiness as "new external traffic" and the heartbeat as "still a valid mesh provider" — but it is an inconsistency inherited from Python, not invented here, and worth revisiting across both runtimes.

**3. `--vendor litellm-fallback` gets the OpenAI probe, not the skeleton**, because it maps to `openai/gpt-4o` and both templates branch on the model string. Python behaves identically, so this is parity rather than a regression — but the long-tail skeleton is only reachable via an explicit `--model`.

Minor: added the missing `gemini` tag branch to the Java template (Python had it, Java didn't), and a short `@MeshHealthCheck` section to `health_java.md` — `meshctl man health --java` would otherwise never mention the annotation exists.

Closes #1474


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Java health checks with healthy, degraded, and unhealthy results.
  * Added provider-specific validation for Anthropic, OpenAI, and Gemini templates.
  * Health checks now update readiness, provider availability, and heartbeat behavior.
  * Added structured status, check details, errors, and refresh intervals.
  * Added support for boolean and detailed health-check results in Spring Boot applications.

* **Documentation**
  * Expanded guidance for Java health checks, Kubernetes probes, readiness, liveness, and deployment.
  * Clarified failure, recovery, route, and A2A agent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->