### PR TITLE
feat(typescript): health check that withdraws a provider while its vendor is down

### DIFF
--- a/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
@@ -7,13 +7,296 @@
  * This agent provides LLM access to other agents via the mesh network.
  */
 
-import { FastMCP, mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh, type MeshHealthResult } from "@mcpmesh/sdk";
 
 // FastMCP server instance
 const server = new FastMCP({
   name: "{{ toPascalCase .Name }}",
   version: "1.0.0",
 });
+
+// ===== HEALTH CHECK =====
+//
+// Runs every healthCheckTtl seconds. While it returns "unhealthy" the agent
+// stops heartbeating, the registry withdraws it, and consumers fail over to
+// another provider — automatically restored when the check passes again.
+{{ if or (contains .Model "anthropic") (contains .Model "openai") (contains .Model "gemini") }}
+const HEALTH_PROBE_TIMEOUT_MS = 5_000;
+
+/**
+ * True when the probe was CANCELLED rather than failing.
+ *
+ * A cancelled probe reached no conclusion about the vendor, so it is
+ * reported "degraded" and the agent keeps heartbeating. A probe that
+ * TIMED OUT is a different thing — `AbortSignal.timeout` rejects with a
+ * "TimeoutError", which falls through to the unhealthy branch along with
+ * DNS, connect and TLS failures.
+ */
+function isProbeCancelled(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { name?: unknown }).name === "AbortError"
+  );
+}
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message || err.name : String(err);
+}
+{{ end }}
+{{- if contains .Model "anthropic" }}
+/**
+ * Health check for {{ .Name }}.
+ *
+ * Validates:
+ * 1. ANTHROPIC_API_KEY environment variable is set
+ * 2. The Anthropic API is reachable
+ *
+ * Uses /v1/models - metadata only, no tokens consumed.
+ */
+async function healthCheck(): Promise<MeshHealthResult> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return {
+      status: "unhealthy",
+      checks: { anthropic_api_key_present: false },
+      errors: ["ANTHROPIC_API_KEY not set"],
+    };
+  }
+
+  const checks: Record<string, boolean> = { anthropic_api_key_present: true };
+  try {
+    const response = await fetch("https://api.anthropic.com/v1/models", {
+      headers: {
+        "anthropic-version": "2023-06-01",
+        "x-api-key": apiKey,
+      },
+      signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+    });
+
+    if (response.status === 200) {
+      checks.anthropic_api_reachable = true;
+      checks.anthropic_api_key_valid = true;
+      return { status: "healthy", checks, errors: [] };
+    }
+    if (response.status === 401) {
+      checks.anthropic_api_reachable = true;
+      checks.anthropic_api_key_valid = false;
+      return {
+        status: "unhealthy",
+        checks,
+        errors: ["Anthropic API key is invalid"],
+      };
+    }
+    // The vendor answered and it is not serving. Unhealthy: this is the
+    // outage the mesh has to route around, and "degraded" would keep
+    // heartbeating and keep consumers pointed here.
+    checks.anthropic_api_reachable = false;
+    return {
+      status: "unhealthy",
+      checks,
+      errors: [`Anthropic API returned status: ${response.status}`],
+    };
+  } catch (err) {
+    checks.anthropic_api_reachable = false;
+    if (isProbeCancelled(err)) {
+      // Degraded, deliberately: the probe was cut short, which says
+      // nothing about the vendor. Withdrawing on an indeterminate result
+      // would take the agent out of the mesh on shutdown.
+      return {
+        status: "degraded",
+        checks,
+        errors: ["Anthropic API probe was cancelled"],
+      };
+    }
+    // The vendor is not answering at all (DNS, connect, timeout, TLS).
+    return {
+      status: "unhealthy",
+      checks,
+      errors: [`Anthropic API unreachable: ${describeError(err)}`],
+    };
+  }
+}
+{{- else if contains .Model "openai" }}
+/**
+ * Health check for {{ .Name }}.
+ *
+ * Validates:
+ * 1. OPENAI_API_KEY environment variable is set
+ * 2. The OpenAI API is reachable
+ *
+ * Uses /v1/models - metadata only, no tokens consumed.
+ */
+async function healthCheck(): Promise<MeshHealthResult> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return {
+      status: "unhealthy",
+      checks: { openai_api_key_present: false },
+      errors: ["OPENAI_API_KEY not set"],
+    };
+  }
+
+  const checks: Record<string, boolean> = { openai_api_key_present: true };
+  try {
+    const response = await fetch("https://api.openai.com/v1/models", {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+    });
+
+    if (response.status === 200) {
+      checks.openai_api_reachable = true;
+      checks.openai_api_key_valid = true;
+      return { status: "healthy", checks, errors: [] };
+    }
+    if (response.status === 401) {
+      checks.openai_api_reachable = true;
+      checks.openai_api_key_valid = false;
+      return {
+        status: "unhealthy",
+        checks,
+        errors: ["OpenAI API key is invalid"],
+      };
+    }
+    // The vendor answered and it is not serving. Unhealthy: this is the
+    // outage the mesh has to route around, and "degraded" would keep
+    // heartbeating and keep consumers pointed here.
+    checks.openai_api_reachable = false;
+    return {
+      status: "unhealthy",
+      checks,
+      errors: [`OpenAI API returned status: ${response.status}`],
+    };
+  } catch (err) {
+    checks.openai_api_reachable = false;
+    if (isProbeCancelled(err)) {
+      // Degraded, deliberately: the probe was cut short, which says
+      // nothing about the vendor. Withdrawing on an indeterminate result
+      // would take the agent out of the mesh on shutdown.
+      return {
+        status: "degraded",
+        checks,
+        errors: ["OpenAI API probe was cancelled"],
+      };
+    }
+    // The vendor is not answering at all (DNS, connect, timeout, TLS).
+    return {
+      status: "unhealthy",
+      checks,
+      errors: [`OpenAI API unreachable: ${describeError(err)}`],
+    };
+  }
+}
+{{- else if contains .Model "gemini" }}
+/**
+ * Health check for {{ .Name }}.
+ *
+ * Validates:
+ * 1. GOOGLE_API_KEY environment variable is set
+ * 2. The Google Gemini API is reachable
+ *
+ * Uses /v1beta/models - metadata only, no tokens consumed.
+ */
+async function healthCheck(): Promise<MeshHealthResult> {
+  const apiKey = process.env.GOOGLE_API_KEY;
+  if (!apiKey) {
+    return {
+      status: "unhealthy",
+      checks: { google_api_key_present: false },
+      errors: ["GOOGLE_API_KEY not set"],
+    };
+  }
+
+  const checks: Record<string, boolean> = { google_api_key_present: true };
+  try {
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`,
+      { signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS) },
+    );
+
+    if (response.status === 200) {
+      checks.gemini_api_reachable = true;
+      checks.google_api_key_valid = true;
+      return { status: "healthy", checks, errors: [] };
+    }
+    if (response.status === 400 || response.status === 403) {
+      checks.gemini_api_reachable = true;
+      checks.google_api_key_valid = false;
+      return {
+        status: "unhealthy",
+        checks,
+        errors: ["Google API key is invalid"],
+      };
+    }
+    // The vendor answered and it is not serving. Unhealthy: this is the
+    // outage the mesh has to route around, and "degraded" would keep
+    // heartbeating and keep consumers pointed here.
+    checks.gemini_api_reachable = false;
+    return {
+      status: "unhealthy",
+      checks,
+      errors: [`Gemini API returned status: ${response.status}`],
+    };
+  } catch (err) {
+    checks.gemini_api_reachable = false;
+    if (isProbeCancelled(err)) {
+      // Degraded, deliberately: the probe was cut short, which says
+      // nothing about the vendor. Withdrawing on an indeterminate result
+      // would take the agent out of the mesh on shutdown.
+      return {
+        status: "degraded",
+        checks,
+        errors: ["Gemini API probe was cancelled"],
+      };
+    }
+    // The vendor is not answering at all (DNS, connect, timeout, TLS).
+    return {
+      status: "unhealthy",
+      checks,
+      errors: [`Gemini API unreachable: ${describeError(err)}`],
+    };
+  }
+}
+{{- else }}
+/**
+ * Health check for {{ .Name }}.
+ *
+ * NOT IMPLEMENTED — this is a skeleton, and as written it CANNOT DETECT AN
+ * UPSTREAM OUTAGE. It always reports healthy, so if {{ .Model }} goes down
+ * this agent keeps heartbeating and the mesh keeps routing traffic to a
+ * provider that cannot serve it.
+ *
+ * There is no generic reachability probe that works across every vendor, so
+ * you have to write this one. Replace the body with a cheap, metadata-only
+ * call to your provider — a models/list endpoint or equivalent, NOT a
+ * completion — and return { status: "unhealthy", ... } when it fails. That is
+ * what makes the mesh withdraw this agent and fail consumers over.
+ *
+ * A sketch of the shape:
+ *
+ *   const apiKey = process.env.MY_VENDOR_API_KEY;
+ *   if (!apiKey) {
+ *     return { status: "unhealthy", errors: ["MY_VENDOR_API_KEY not set"] };
+ *   }
+ *   try {
+ *     const response = await fetch("https://api.my-vendor.com/v1/models", {
+ *       headers: { Authorization: `Bearer ${apiKey}` },
+ *       signal: AbortSignal.timeout(5_000),
+ *     });
+ *     return response.ok
+ *       ? { status: "healthy", checks: { vendor_reachable: true } }
+ *       : { status: "unhealthy", errors: [`vendor returned ${response.status}`] };
+ *   } catch (err) {
+ *     // A cancelled probe is "degraded" — it concluded nothing. Everything
+ *     // else (DNS, connect, timeout, TLS) is a real outage: "unhealthy".
+ *     return { status: "unhealthy", errors: [`vendor unreachable: ${err}`] };
+ *   }
+ */
+async function healthCheck(): Promise<MeshHealthResult> {
+  return { status: "healthy", checks: { provider_configured: true }, errors: [] };
+}
+{{- end }}
+
 /**
  * LLM Provider agent that exposes {{ .Model }} via mesh.
  *
@@ -27,6 +310,9 @@ const agent = mesh(server, {
   version: "1.0.0",
   description: "{{ if .Description }}{{ .Description }}{{ else }}LLM Provider for {{ .Model }}{{ end }}",
   httpPort: {{ .Port }},
+  healthCheck,
+  // Also the detection latency in BOTH directions — outage and recovery.
+  healthCheckTtl: 30,
 });
 
 // ===== LLM PROVIDER =====

--- a/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
@@ -246,7 +246,7 @@ async function healthCheck(): Promise<MeshHealthResult> {
  *       headers: { Authorization: `Bearer ${apiKey}` },
  *       signal: AbortSignal.timeout(5_000),
  *     });
- *     return response.ok
+ *     return response.status === 200
  *       ? { status: "healthy", checks: { vendor_reachable: true } }
  *       : { status: "unhealthy", errors: [`vendor returned ${response.status}`] };
  *   } catch (err) {
@@ -275,7 +275,9 @@ const agent = mesh(server, {
   description: "{{ if .Description }}{{ .Description }}{{ else }}LLM Provider for {{ .Model }}{{ end }}",
   httpPort: {{ .Port }},
   healthCheck,
-  // Also the detection latency in BOTH directions — outage and recovery.
+  // The cadence of the check, not the end-to-end latency: withdrawal also
+  // costs the registry staleness window once heartbeats stop, and recovery
+  // needs a passing check plus the heartbeat resume and re-register round trip.
   healthCheckTtl: 30,
 });
 

--- a/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
@@ -21,24 +21,17 @@ const server = new FastMCP({
 // stops heartbeating, the registry withdraws it, and consumers fail over to
 // another provider — automatically restored when the check passes again.
 {{ if or (contains .Model "anthropic") (contains .Model "openai") (contains .Model "gemini") }}
-const HEALTH_PROBE_TIMEOUT_MS = 5_000;
-
 /**
- * True when the probe was CANCELLED rather than failing.
+ * Ceiling for one probe. `AbortSignal.timeout` rejects with a
+ * "TimeoutError", which lands in the same branch as DNS, connect and TLS
+ * failures: the vendor did not answer, which is the outage the mesh has
+ * to route around.
  *
- * A cancelled probe reached no conclusion about the vendor, so it is
- * reported "degraded" and the agent keeps heartbeating. A probe that
- * TIMED OUT is a different thing — `AbortSignal.timeout` rejects with a
- * "TimeoutError", which falls through to the unhealthy branch along with
- * DNS, connect and TLS failures.
+ * If you add cancellation of your own — an `AbortController` you abort on
+ * shutdown — handle its "AbortError" separately and report "degraded":
+ * a probe you cut short concluded nothing about the vendor.
  */
-function isProbeCancelled(err: unknown): boolean {
-  return (
-    typeof err === "object" &&
-    err !== null &&
-    (err as { name?: unknown }).name === "AbortError"
-  );
-}
+const HEALTH_PROBE_TIMEOUT_MS = 5_000;
 
 function describeError(err: unknown): string {
   return err instanceof Error ? err.message || err.name : String(err);
@@ -99,16 +92,6 @@ async function healthCheck(): Promise<MeshHealthResult> {
     };
   } catch (err) {
     checks.anthropic_api_reachable = false;
-    if (isProbeCancelled(err)) {
-      // Degraded, deliberately: the probe was cut short, which says
-      // nothing about the vendor. Withdrawing on an indeterminate result
-      // would take the agent out of the mesh on shutdown.
-      return {
-        status: "degraded",
-        checks,
-        errors: ["Anthropic API probe was cancelled"],
-      };
-    }
     // The vendor is not answering at all (DNS, connect, timeout, TLS).
     return {
       status: "unhealthy",
@@ -169,16 +152,6 @@ async function healthCheck(): Promise<MeshHealthResult> {
     };
   } catch (err) {
     checks.openai_api_reachable = false;
-    if (isProbeCancelled(err)) {
-      // Degraded, deliberately: the probe was cut short, which says
-      // nothing about the vendor. Withdrawing on an indeterminate result
-      // would take the agent out of the mesh on shutdown.
-      return {
-        status: "degraded",
-        checks,
-        errors: ["OpenAI API probe was cancelled"],
-      };
-    }
     // The vendor is not answering at all (DNS, connect, timeout, TLS).
     return {
       status: "unhealthy",
@@ -239,16 +212,6 @@ async function healthCheck(): Promise<MeshHealthResult> {
     };
   } catch (err) {
     checks.gemini_api_reachable = false;
-    if (isProbeCancelled(err)) {
-      // Degraded, deliberately: the probe was cut short, which says
-      // nothing about the vendor. Withdrawing on an indeterminate result
-      // would take the agent out of the mesh on shutdown.
-      return {
-        status: "degraded",
-        checks,
-        errors: ["Gemini API probe was cancelled"],
-      };
-    }
     // The vendor is not answering at all (DNS, connect, timeout, TLS).
     return {
       status: "unhealthy",
@@ -287,8 +250,9 @@ async function healthCheck(): Promise<MeshHealthResult> {
  *       ? { status: "healthy", checks: { vendor_reachable: true } }
  *       : { status: "unhealthy", errors: [`vendor returned ${response.status}`] };
  *   } catch (err) {
- *     // A cancelled probe is "degraded" — it concluded nothing. Everything
- *     // else (DNS, connect, timeout, TLS) is a real outage: "unhealthy".
+ *     // DNS, connect, timeout and TLS all mean the vendor did not answer:
+ *     // a real outage, so "unhealthy". Report "degraded" only for a probe
+ *     // YOU cut short (your own AbortController) — that concluded nothing.
  *     return { status: "unhealthy", errors: [`vendor unreachable: ${err}`] };
  *   }
  */

--- a/docs/concepts/health-discovery.md
+++ b/docs/concepts/health-discovery.md
@@ -117,7 +117,7 @@ While the check reports `unhealthy` the agent stops heartbeating. The registry's
 
 Only an explicit unhealthy result does that. A check that raises is recorded as `degraded` and keeps heartbeating, in all three runtimes: a bug in the health check must not be able to remove a working agent from the mesh.
 
-`degraded` splits the two surfaces: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider.
+`degraded` splits the two surfaces on Python and Java: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider. On TypeScript only the heartbeat side is wired - the verdict drives heartbeating, while `/ready` and `/health` still report runtime state alone (see the endpoint table below).
 
 Route (`@mesh.route` / `@MeshRoute` / `mesh.route`) and A2A agents are deliberately exempt. A gateway is a fan-out point that many requests enter through - withdrawing a provider is correct, withdrawing the gateway takes the application down.
 

--- a/docs/concepts/health-discovery.md
+++ b/docs/concepts/health-discovery.md
@@ -90,15 +90,36 @@ public MeshHealth healthCheck() {
 
 One no-argument method per agent, on any Spring bean. Returning `boolean` works too: `true` is healthy, `false` unhealthy. `MCP_MESH_HEALTH_CHECK_TTL` overrides `ttlSeconds`.
 
+### Custom Health Function (TypeScript)
+
+```typescript
+const agent = mesh(server, {
+  name: "my-agent",
+  httpPort: 9001,
+  healthCheckTtl: 30, // Re-run every 30s
+  healthCheck: async () => {
+    if (!db.isConnected()) {
+      return { status: "unhealthy", errors: ["db disconnected"] };
+    }
+    if (memoryUsage() > 90) {
+      return { status: "degraded", errors: ["high memory"] };
+    }
+    return { status: "healthy", checks: { db_connected: true } };
+  },
+});
+```
+
+One check per agent. Returning `boolean` works too: `true` is healthy, `false` unhealthy. `MCP_MESH_HEALTH_CHECK_TTL` overrides `healthCheckTtl`.
+
 ### What a Failing Check Does
 
 While the check reports `unhealthy` the agent stops heartbeating. The registry's staleness sweep then marks it unhealthy, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent - no restart, no redeploy. This is what lets a provider whose upstream vendor is down take itself out of rotation.
 
-Only an explicit unhealthy result does that. A check that raises is recorded as `degraded` and keeps heartbeating, on both Python and Java: a bug in the health check must not be able to remove a working agent from the mesh.
+Only an explicit unhealthy result does that. A check that raises is recorded as `degraded` and keeps heartbeating, in all three runtimes: a bug in the health check must not be able to remove a working agent from the mesh.
 
 `degraded` splits the two surfaces: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider.
 
-Route (`@mesh.route` / `@MeshRoute`) and A2A agents are deliberately exempt. A gateway is a fan-out point that many requests enter through - withdrawing a provider is correct, withdrawing the gateway takes the application down.
+Route (`@mesh.route` / `@MeshRoute` / `mesh.route`) and A2A agents are deliberately exempt. A gateway is a fan-out point that many requests enter through - withdrawing a provider is correct, withdrawing the gateway takes the application down.
 
 ### Kubernetes Probes
 
@@ -107,7 +128,7 @@ Every runtime serves three endpoints, and probes must not share one:
 | Endpoint  | Probe                             | Reports                                                                                             |
 | --------- | --------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `/livez`  | `livenessProbe`, `startupProbe`   | 200 for as long as the process is serving. Consults nothing else.                                     |
-| `/ready`  | `readinessProbe`                  | Whether traffic should be routed here. Reflects your health check on Python (`health_check`) and Java (`@MeshHealthCheck`); TypeScript has no user health check, so it reports only that the mesh runtime is running. |
+| `/ready`  | `readinessProbe`                  | Whether traffic should be routed here. Reflects your health check on Python (`health_check`) and Java (`@MeshHealthCheck`); on TypeScript the `healthCheck` verdict drives the heartbeat, while `/ready` still reports only that the mesh runtime is running. |
 | `/health` | none                              | Runtime-specific. Python and Java return the `/ready` signal plus `checks` and `errors`; TypeScript returns a fixed `healthy` and reflects nothing. |
 
 Never point liveness or startup at `/ready` or `/health`. On Python and Java, where `/ready` reflects your health check, that turns an upstream outage into a pod restart, which cannot fix the outage. On TypeScript, where `/ready` reports only runtime state, it still restarts pods that are merely still booting. The Helm chart is already wired this way.

--- a/docs/typescript/mesh-functions.md
+++ b/docs/typescript/mesh-functions.md
@@ -42,8 +42,12 @@ const agent = mesh(server, {
   host: "localhost",            // Host announced to registry
   namespace: "default",         // Namespace for isolation
   heartbeatInterval: 30,        // Heartbeat interval in seconds
+  healthCheck: myHealthCheck,   // Optional: decides whether this agent keeps traffic
+  healthCheckTtl: 30,           // How often it re-runs (default 15s)
 });
 ```
+
+`healthCheck` is what lets a provider take itself out of rotation. While it returns `{ status: "unhealthy" }` (or `false`) the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider — restored automatically when it passes again, with no restart. A check that throws is recorded as `degraded` and keeps heartbeating, so a bug in the check cannot remove a working agent. `MCP_MESH_HEALTH_CHECK_TTL` overrides `healthCheckTtl`. See [Health & Discovery](../concepts/health-discovery.md).
 
 > **Import `FastMCP` from `@mcpmesh/sdk`**, which re-exports it — not directly from `"fastmcp"`. A direct `"fastmcp"` import can trigger duplicate class-identity type errors under `tsc` against the SDK's own bundled copy.
 

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -227,10 +227,33 @@ TypeScript agents automatically expose health endpoints:
 There are three of them, and Kubernetes probes must not share one:
 
 - `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
-- `/ready` - `readinessProbe`. Whether traffic should be routed here. TypeScript has no user health check, so this reports only that the mesh runtime is running.
+- `/ready` - `readinessProbe`. Whether traffic should be routed here. Reports mesh runtime state only; your `healthCheck` drives the heartbeat, not this endpoint.
 - `/health` - no probe. A fixed `{ status: "healthy" }` that reflects nothing.
 
 `/ready` answers 503 until the mesh runtime is up, so pointing liveness or startup at it restarts pods that are merely still booting; `/health` never fails at all. The Helm chart is already wired this way.
+
+Pass a `healthCheck` to `mesh()` to say what "able to serve" means for this agent:
+
+```typescript
+const agent = mesh(server, {
+  name: "claude-provider",
+  httpPort: 9001,
+  healthCheckTtl: 30,
+  healthCheck: async () => {
+    const response = await fetch("https://api.anthropic.com/v1/models", {
+      headers: { "x-api-key": process.env.ANTHROPIC_API_KEY!, "anthropic-version": "2023-06-01" },
+      signal: AbortSignal.timeout(5_000),
+    });
+    return response.ok
+      ? { status: "healthy", checks: { vendor_api_reachable: true } }
+      : { status: "unhealthy", errors: [`vendor returned ${response.status}`] };
+  },
+});
+```
+
+While the check returns unhealthy the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider - restored automatically when the check passes, with no restart. Returning `boolean` works too: `true` is healthy, `false` unhealthy. A check that throws is recorded as `degraded` and keeps heartbeating, so a bug in the check cannot take a working agent out of the mesh. `MCP_MESH_HEALTH_CHECK_TTL` overrides `healthCheckTtl` (default 15s).
+
+Route (`mesh.route`) and A2A agents are the exception: they ignore `healthCheck` entirely. A gateway is a fan-out point, and withdrawing it takes the application down.
 
 ### Graceful Shutdown
 

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -240,11 +240,15 @@ const agent = mesh(server, {
   httpPort: 9001,
   healthCheckTtl: 30,
   healthCheck: async () => {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      return { status: "unhealthy", errors: ["ANTHROPIC_API_KEY not set"] };
+    }
     const response = await fetch("https://api.anthropic.com/v1/models", {
-      headers: { "x-api-key": process.env.ANTHROPIC_API_KEY!, "anthropic-version": "2023-06-01" },
+      headers: { "x-api-key": apiKey, "anthropic-version": "2023-06-01" },
       signal: AbortSignal.timeout(5_000),
     });
-    return response.ok
+    return response.status === 200
       ? { status: "healthy", checks: { vendor_api_reachable: true } }
       : { status: "unhealthy", errors: [`vendor returned ${response.status}`] };
   },

--- a/src/core/cli/man/content/health_typescript.md
+++ b/src/core/cli/man/content/health_typescript.md
@@ -31,6 +31,41 @@ MCP Mesh uses a dual-heartbeat system for fast failure detection and automatic t
 - Default threshold: 20 seconds (4 missed 5-second heartbeats)
 - Configurable via environment variables
 
+## Declaring Your Own Health Check
+
+Pass a `healthCheck` to `mesh()` to tell the mesh what "able to serve" means for this agent:
+
+```typescript
+const agent = mesh(server, {
+  name: "claude-provider",
+  httpPort: 9001,
+  healthCheckTtl: 30,
+  healthCheck: async () => {
+    const response = await fetch("https://api.anthropic.com/v1/models", {
+      headers: { "x-api-key": process.env.ANTHROPIC_API_KEY!, "anthropic-version": "2023-06-01" },
+      signal: AbortSignal.timeout(5_000),
+    });
+    return response.ok
+      ? { status: "healthy", checks: { vendor_api_reachable: true } }
+      : {
+          status: "unhealthy",
+          checks: { vendor_api_reachable: false },
+          errors: [`vendor returned ${response.status}`],
+        };
+  },
+});
+```
+
+One check per agent. Return `{ status, checks, errors }` for full detail, or a `boolean` for the terse form (`true` healthy, `false` unhealthy). `healthCheckTtl` is how often it re-runs (default 15); `MCP_MESH_HEALTH_CHECK_TTL` overrides it.
+
+### What a Failing Check Does
+
+While the check reports unhealthy the agent **stops heartbeating**. The registry marks it unhealthy after the staleness window, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent through the `410 Gone` re-register path - no restart. The TTL is the detection latency in both directions.
+
+Report `unhealthy` only for conditions the mesh should route around: the upstream this agent needs is genuinely not serving. A check that **throws**, or that could not reach a conclusion, is recorded as `degraded` and keeps heartbeating - a broken probe says nothing about the upstream, and withdrawing a working agent over one is the worse failure.
+
+`mesh.route` and A2A agents ignore `healthCheck`. They are fan-out points, so withdrawing one takes down every path that enters through it - declare the check on the agents behind the gateway instead.
+
 ## Registry Health Monitor
 
 Background process that:

--- a/src/core/cli/man/content/health_typescript.md
+++ b/src/core/cli/man/content/health_typescript.md
@@ -41,11 +41,19 @@ const agent = mesh(server, {
   httpPort: 9001,
   healthCheckTtl: 30,
   healthCheck: async () => {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      return {
+        status: "unhealthy",
+        checks: { vendor_api_key_present: false },
+        errors: ["ANTHROPIC_API_KEY not set"],
+      };
+    }
     const response = await fetch("https://api.anthropic.com/v1/models", {
-      headers: { "x-api-key": process.env.ANTHROPIC_API_KEY!, "anthropic-version": "2023-06-01" },
+      headers: { "x-api-key": apiKey, "anthropic-version": "2023-06-01" },
       signal: AbortSignal.timeout(5_000),
     });
-    return response.ok
+    return response.status === 200
       ? { status: "healthy", checks: { vendor_api_reachable: true } }
       : {
           status: "unhealthy",
@@ -60,7 +68,7 @@ One check per agent. Return `{ status, checks, errors }` for full detail, or a `
 
 ### What a Failing Check Does
 
-While the check reports unhealthy the agent **stops heartbeating**. The registry marks it unhealthy after the staleness window, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent through the `410 Gone` re-register path - no restart. The TTL is the detection latency in both directions.
+While the check reports unhealthy the agent **stops heartbeating**. The registry marks it unhealthy after the staleness window, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent through the `410 Gone` re-register path - no restart. The TTL is the cadence, not the end-to-end latency: it only bounds how long until the next check runs. Withdrawal costs that plus the registry's staleness window once heartbeats stop, and recovery costs it plus the heartbeat resume and re-register round trip.
 
 Report `unhealthy` only for conditions the mesh should route around: the upstream this agent needs is genuinely not serving. A check that **throws**, or that could not reach a conclusion, is recorded as `degraded` and keeps heartbeating - a broken probe says nothing about the upstream, and withdrawing a working agent over one is the worse failure.
 

--- a/src/core/cli/scaffold/health_check_template_test.go
+++ b/src/core/cli/scaffold/health_check_template_test.go
@@ -15,18 +15,30 @@ import (
 // shipped this INVERTED once — "unhealthy" for a missing API key but
 // "degraded" for an actual outage — which compiled, passed review, and left
 // every scaffolded provider unable to withdraw itself. That is exactly the
-// regression these tests exist to catch, in all three runtimes at once.
+// regression these tests exist to catch.
 //
-// The assertions are on the rendered vendor-outage BRANCH, not on the file
-// as a whole: a template that says "unhealthy" somewhere while returning
-// "degraded" for a 503 would still be broken.
+// The probe body is hand-duplicated nine times (three runtimes x three
+// vendors), so the guard runs the whole matrix: a fix applied to the
+// anthropic copy and forgotten in the openai one is the likeliest way this
+// regresses.
+//
+// The assertions are on the rendered BRANCH, not on the file as a whole: a
+// template that says "unhealthy" somewhere while returning "degraded" for a
+// 503 would still be broken.
+//
+// There is deliberately no "a cancelled probe is degraded" guard. The
+// templates create no AbortController and no interrupt of their own except
+// Java's, so on Python and TypeScript a cancel branch would be unreachable
+// code — `AbortSignal.timeout` rejects with a "TimeoutError", which is a
+// transport failure and belongs in the unhealthy branch asserted below.
 
 func templatesRoot(t *testing.T) string {
 	t.Helper()
 	root := filepath.Join(getProjectRoot(), "cmd", "meshctl", "templates")
-	if _, err := os.Stat(root); err != nil {
-		t.Skipf("templates not found at %s", root)
-	}
+	_, err := os.Stat(root)
+	// Not a skip: a guard that quietly does nothing when the templates move
+	// is worse than no guard, because the suite still reports green.
+	require.NoError(t, err, "templates not found at %s", root)
 	return root
 }
 
@@ -53,15 +65,21 @@ func renderProvider(t *testing.T, language, model, entry string) string {
 
 // section returns the text between marker and the next occurrence of end,
 // so an assertion can target one branch instead of the whole file.
+//
+// A missing end marker FAILS rather than returning the rest of the file: a
+// template refactor that drops one would otherwise widen the assertion
+// window until it matched some other branch's verdict and passed for the
+// wrong reason.
 func section(t *testing.T, content, marker, end string) string {
 	t.Helper()
 	start := strings.Index(content, marker)
 	require.GreaterOrEqual(t, start, 0, "marker %q not found in rendered output", marker)
 	rest := content[start:]
-	if stop := strings.Index(rest, end); stop > 0 {
-		return rest[:stop]
-	}
-	return rest
+	stop := strings.Index(rest[len(marker):], end)
+	require.GreaterOrEqual(t, stop, 0,
+		"end marker %q not found after %q — the branch boundary moved, and "+
+			"without it this assertion would silently cover the whole file", end, marker)
+	return rest[:len(marker)+stop]
 }
 
 // Entry file for a Java agent named "verdict-probe": the scaffolder derives
@@ -69,192 +87,138 @@ func section(t *testing.T, content, marker, end string) string {
 var javaEntry = filepath.Join(
 	"src", "main", "java", "com", "example", "verdictprobe", "VerdictProbeApplication.java")
 
+// The comments opening each branch are identical across the three runtimes
+// on purpose — they are what makes this guard a matrix rather than nine
+// hand-written cases.
+const (
+	outageMarker    = "vendor answered and it is not serving"
+	transportMarker = "The vendor is not answering at all"
+)
+
+// One runtime's rendering of the shared probe.
+type runtimeProbe struct {
+	language string
+	entry    string
+	// Where the vendor-outage branch ends.
+	outageEnd string
+	// Where the transport-failure branch ends.
+	transportEnd string
+	// The verdict both branches must produce.
+	wantVerdict string
+	// A verdict that would silently disable withdrawal.
+	bannedVerdict string
+	// Text proving the check is actually wired to the agent.
+	wiring []string
+}
+
+var runtimeProbes = []runtimeProbe{
+	{
+		language:      "python",
+		entry:         "main.py",
+		outageEnd:     "except Exception",
+		transportEnd:  "return {",
+		wantVerdict:   `status = "unhealthy"`,
+		bannedVerdict: `status = "degraded"`,
+		wiring:        []string{"health_check=health_check", "health_check_ttl="},
+	},
+	{
+		language:      "typescript",
+		entry:         filepath.Join("src", "index.ts"),
+		outageEnd:     "} catch (err)",
+		transportEnd:  "}\n}",
+		wantVerdict:   `status: "unhealthy"`,
+		bannedVerdict: `status: "degraded"`,
+		wiring:        []string{"  healthCheck,", "healthCheckTtl:"},
+	},
+	{
+		language: "java",
+		entry:    javaEntry,
+		// Java's transport branch is the LAST catch, after the
+		// InterruptedException one that is legitimately degraded.
+		outageEnd:     "catch (InterruptedException",
+		transportEnd:  "\n    }",
+		wantVerdict:   "MeshHealthStatus.UNHEALTHY",
+		bannedVerdict: "MeshHealthStatus.DEGRADED",
+		wiring:        []string{"@MeshHealthCheck(ttlSeconds ="},
+	},
+}
+
+// The vendors every runtime ships a real probe for. Anything else gets the
+// skeleton asserted by TestLlmProviderTemplates_UnknownVendorSkeletonWarns.
+var probeVendors = []struct {
+	name  string
+	model string
+}{
+	{"anthropic", "anthropic/claude-sonnet-5"},
+	{"openai", "openai/gpt-4o"},
+	{"gemini", "gemini/gemini-2.5-flash"},
+}
+
+// A vendor that answers with a non-200 is an OUTAGE: the branch must report
+// unhealthy so the heartbeat stops and consumers fail over.
 func TestLlmProviderTemplates_VendorOutageIsUnhealthy(t *testing.T) {
-	cases := []struct {
-		name     string
-		language string
-		model    string
-		entry    string
-		// Text opening the "vendor answered, and it is not serving" branch.
-		outageMarker string
-		// Where that branch ends.
-		outageEnd string
-		// The verdict the branch must produce.
-		wantVerdict string
-		// A verdict that would silently disable withdrawal.
-		bannedVerdict string
-	}{
-		{
-			name:          "python anthropic",
-			language:      "python",
-			model:         "anthropic/claude-sonnet-5",
-			entry:         "main.py",
-			outageMarker:  "vendor answered and it is not serving",
-			outageEnd:     "except Exception",
-			wantVerdict:   `status = "unhealthy"`,
-			bannedVerdict: `status = "degraded"`,
-		},
-		{
-			name:          "python openai",
-			language:      "python",
-			model:         "openai/gpt-4o",
-			entry:         "main.py",
-			outageMarker:  "vendor answered and it is not serving",
-			outageEnd:     "except Exception",
-			wantVerdict:   `status = "unhealthy"`,
-			bannedVerdict: `status = "degraded"`,
-		},
-		{
-			name:          "python gemini",
-			language:      "python",
-			model:         "gemini/gemini-2.5-flash",
-			entry:         "main.py",
-			outageMarker:  "vendor answered and it is not serving",
-			outageEnd:     "except Exception",
-			wantVerdict:   `status = "unhealthy"`,
-			bannedVerdict: `status = "degraded"`,
-		},
-		{
-			name:          "typescript anthropic",
-			language:      "typescript",
-			model:         "anthropic/claude-sonnet-5",
-			entry:         filepath.Join("src", "index.ts"),
-			outageMarker:  "vendor answered and it is not serving",
-			outageEnd:     "} catch (err)",
-			wantVerdict:   `status: "unhealthy"`,
-			bannedVerdict: `status: "degraded"`,
-		},
-		{
-			name:          "typescript openai",
-			language:      "typescript",
-			model:         "openai/gpt-4o",
-			entry:         filepath.Join("src", "index.ts"),
-			outageMarker:  "vendor answered and it is not serving",
-			outageEnd:     "} catch (err)",
-			wantVerdict:   `status: "unhealthy"`,
-			bannedVerdict: `status: "degraded"`,
-		},
-		{
-			name:          "typescript gemini",
-			language:      "typescript",
-			model:         "gemini/gemini-2.5-flash",
-			entry:         filepath.Join("src", "index.ts"),
-			outageMarker:  "vendor answered and it is not serving",
-			outageEnd:     "} catch (err)",
-			wantVerdict:   `status: "unhealthy"`,
-			bannedVerdict: `status: "degraded"`,
-		},
-		{
-			name:          "java anthropic",
-			language:      "java",
-			model:         "anthropic/claude-sonnet-5",
-			entry:         javaEntry,
-			outageMarker:  "vendor answered and it is not serving",
-			outageEnd:     "catch (InterruptedException",
-			wantVerdict:   "MeshHealthStatus.UNHEALTHY",
-			bannedVerdict: "MeshHealthStatus.DEGRADED",
-		},
-		{
-			name:          "java openai",
-			language:      "java",
-			model:         "openai/gpt-4o",
-			entry:         javaEntry,
-			outageMarker:  "vendor answered and it is not serving",
-			outageEnd:     "catch (InterruptedException",
-			wantVerdict:   "MeshHealthStatus.UNHEALTHY",
-			bannedVerdict: "MeshHealthStatus.DEGRADED",
-		},
-		{
-			name:          "java gemini",
-			language:      "java",
-			model:         "gemini/gemini-2.5-flash",
-			entry:         javaEntry,
-			outageMarker:  "vendor answered and it is not serving",
-			outageEnd:     "catch (InterruptedException",
-			wantVerdict:   "MeshHealthStatus.UNHEALTHY",
-			bannedVerdict: "MeshHealthStatus.DEGRADED",
-		},
-	}
+	for _, rt := range runtimeProbes {
+		for _, vendor := range probeVendors {
+			t.Run(rt.language+" "+vendor.name, func(t *testing.T) {
+				content := renderProvider(t, rt.language, vendor.model, rt.entry)
+				branch := section(t, content, outageMarker, rt.outageEnd)
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			content := renderProvider(t, tc.language, tc.model, tc.entry)
-			branch := section(t, content, tc.outageMarker, tc.outageEnd)
-
-			require.Contains(t, branch, tc.wantVerdict,
-				"a vendor that answers with a non-200 is an OUTAGE: the branch must "+
-					"report unhealthy so the heartbeat stops and consumers fail over")
-			require.NotContains(t, branch, tc.bannedVerdict,
-				"reporting degraded on a real outage keeps the heartbeat alive and "+
-					"makes the provider unable to withdraw itself — the whole point "+
-					"of the health check")
-		})
+				require.Contains(t, branch, rt.wantVerdict,
+					"a vendor that answers with a non-200 is an OUTAGE: the branch must "+
+						"report unhealthy so the heartbeat stops and consumers fail over")
+				require.NotContains(t, branch, rt.bannedVerdict,
+					"reporting degraded on a real outage keeps the heartbeat alive and "+
+						"makes the provider unable to withdraw itself — the whole point "+
+						"of the health check")
+			})
+		}
 	}
 }
 
 // The transport-failure branch (DNS, connect, timeout, TLS) is the other
 // half of the same contract: the vendor is not answering at all.
 func TestLlmProviderTemplates_TransportFailureIsUnhealthy(t *testing.T) {
-	t.Run("python", func(t *testing.T) {
-		content := renderProvider(t, "python", "anthropic/claude-sonnet-5", "main.py")
-		branch := section(t, content, "API unreachable", "return {")
-		require.Contains(t, branch, `status = "unhealthy"`)
-	})
+	for _, rt := range runtimeProbes {
+		for _, vendor := range probeVendors {
+			t.Run(rt.language+" "+vendor.name, func(t *testing.T) {
+				content := renderProvider(t, rt.language, vendor.model, rt.entry)
+				branch := section(t, content, transportMarker, rt.transportEnd)
 
-	t.Run("typescript", func(t *testing.T) {
-		content := renderProvider(t, "typescript", "anthropic/claude-sonnet-5",
-			filepath.Join("src", "index.ts"))
-		branch := section(t, content, "The vendor is not answering at all", "}\n}")
-		require.Contains(t, branch, `status: "unhealthy"`)
-	})
-}
-
-// A cancelled probe concluded NOTHING about the vendor, so it must keep the
-// heartbeat alive. This is the one place "degraded" is correct, and the
-// inverse mistake (unhealthy on cancellation) would withdraw agents during
-// ordinary shutdowns.
-func TestLlmProviderTemplates_CancelledProbeIsDegraded(t *testing.T) {
-	content := renderProvider(t, "typescript", "anthropic/claude-sonnet-5",
-		filepath.Join("src", "index.ts"))
-	branch := section(t, content, "if (isProbeCancelled(err))", "}\n    // The vendor")
-	require.Contains(t, branch, `status: "degraded"`)
+				require.Contains(t, branch, rt.wantVerdict,
+					"a vendor that does not answer at all is an OUTAGE: the branch must "+
+						"report unhealthy so the heartbeat stops and consumers fail over")
+				require.NotContains(t, branch, rt.bannedVerdict,
+					"reporting degraded when the vendor is unreachable keeps the "+
+						"heartbeat alive and makes the provider unable to withdraw itself")
+			})
+		}
+	}
 }
 
 // The scaffolded agent must actually WIRE the check up — a correct
 // healthCheck that nothing calls withdraws nothing.
 func TestLlmProviderTemplates_HealthCheckIsWired(t *testing.T) {
-	t.Run("python", func(t *testing.T) {
-		content := renderProvider(t, "python", "anthropic/claude-sonnet-5", "main.py")
-		require.Contains(t, content, "health_check=health_check")
-		require.Contains(t, content, "health_check_ttl=")
-	})
-
-	t.Run("typescript", func(t *testing.T) {
-		content := renderProvider(t, "typescript", "anthropic/claude-sonnet-5",
-			filepath.Join("src", "index.ts"))
-		require.Contains(t, content, "  healthCheck,")
-		require.Contains(t, content, "healthCheckTtl:")
-	})
-
-	t.Run("java", func(t *testing.T) {
-		content := renderProvider(t, "java", "anthropic/claude-sonnet-5", javaEntry)
-		require.Contains(t, content, "@MeshHealthCheck(ttlSeconds =")
-	})
+	for _, rt := range runtimeProbes {
+		for _, vendor := range probeVendors {
+			t.Run(rt.language+" "+vendor.name, func(t *testing.T) {
+				content := renderProvider(t, rt.language, vendor.model, rt.entry)
+				for _, marker := range rt.wiring {
+					require.Contains(t, content, marker,
+						"the health check is declared but never handed to the agent, so "+
+							"nothing ever runs it")
+				}
+			})
+		}
+	}
 }
 
 // An unknown vendor gets a skeleton that cannot detect an outage. That is
 // unavoidable — there is no generic reachability probe — but it must say so
 // loudly rather than look finished.
 func TestLlmProviderTemplates_UnknownVendorSkeletonWarns(t *testing.T) {
-	entries := map[string]string{
-		"python":     "main.py",
-		"typescript": filepath.Join("src", "index.ts"),
-		"java":       javaEntry,
-	}
-	for _, language := range []string{"python", "typescript", "java"} {
-		entry := entries[language]
-		t.Run(language, func(t *testing.T) {
-			content := renderProvider(t, language, "cohere/command-r-plus", entry)
+	for _, rt := range runtimeProbes {
+		t.Run(rt.language, func(t *testing.T) {
+			content := renderProvider(t, rt.language, "cohere/command-r-plus", rt.entry)
 			require.Contains(t, content, "CANNOT DETECT AN")
 			require.Contains(t, content, "NOT IMPLEMENTED")
 		})

--- a/src/core/cli/scaffold/health_check_template_test.go
+++ b/src/core/cli/scaffold/health_check_template_test.go
@@ -1,0 +1,262 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The llm-provider health check exists so a provider can WITHDRAW itself
+// while its vendor is down (issues #1472/#1474/#1476). Only an "unhealthy"
+// verdict suppresses the heartbeat, and the Python and Java templates both
+// shipped this INVERTED once — "unhealthy" for a missing API key but
+// "degraded" for an actual outage — which compiled, passed review, and left
+// every scaffolded provider unable to withdraw itself. That is exactly the
+// regression these tests exist to catch, in all three runtimes at once.
+//
+// The assertions are on the rendered vendor-outage BRANCH, not on the file
+// as a whole: a template that says "unhealthy" somewhere while returning
+// "degraded" for a 503 would still be broken.
+
+func templatesRoot(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(getProjectRoot(), "cmd", "meshctl", "templates")
+	if _, err := os.Stat(root); err != nil {
+		t.Skipf("templates not found at %s", root)
+	}
+	return root
+}
+
+// renderProvider scaffolds an llm-provider agent and returns its entry file.
+func renderProvider(t *testing.T, language, model, entry string) string {
+	t.Helper()
+	ctx := &ScaffoldContext{
+		Name:        "verdict-probe",
+		Description: "verdict probe",
+		Language:    language,
+		OutputDir:   t.TempDir(),
+		Port:        9400,
+		Model:       model,
+		Template:    "llm-provider",
+		TemplateDir: templatesRoot(t),
+	}
+	require.NoError(t, NewStaticProvider().Execute(ctx))
+
+	path := filepath.Join(ctx.OutputDir, ctx.Name, entry)
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "rendered entry file %s", path)
+	return string(content)
+}
+
+// section returns the text between marker and the next occurrence of end,
+// so an assertion can target one branch instead of the whole file.
+func section(t *testing.T, content, marker, end string) string {
+	t.Helper()
+	start := strings.Index(content, marker)
+	require.GreaterOrEqual(t, start, 0, "marker %q not found in rendered output", marker)
+	rest := content[start:]
+	if stop := strings.Index(rest, end); stop > 0 {
+		return rest[:stop]
+	}
+	return rest
+}
+
+// Entry file for a Java agent named "verdict-probe": the scaffolder derives
+// the package (com.example.verdictprobe) and the class name from the name.
+var javaEntry = filepath.Join(
+	"src", "main", "java", "com", "example", "verdictprobe", "VerdictProbeApplication.java")
+
+func TestLlmProviderTemplates_VendorOutageIsUnhealthy(t *testing.T) {
+	cases := []struct {
+		name     string
+		language string
+		model    string
+		entry    string
+		// Text opening the "vendor answered, and it is not serving" branch.
+		outageMarker string
+		// Where that branch ends.
+		outageEnd string
+		// The verdict the branch must produce.
+		wantVerdict string
+		// A verdict that would silently disable withdrawal.
+		bannedVerdict string
+	}{
+		{
+			name:          "python anthropic",
+			language:      "python",
+			model:         "anthropic/claude-sonnet-5",
+			entry:         "main.py",
+			outageMarker:  "vendor answered and it is not serving",
+			outageEnd:     "except Exception",
+			wantVerdict:   `status = "unhealthy"`,
+			bannedVerdict: `status = "degraded"`,
+		},
+		{
+			name:          "python openai",
+			language:      "python",
+			model:         "openai/gpt-4o",
+			entry:         "main.py",
+			outageMarker:  "vendor answered and it is not serving",
+			outageEnd:     "except Exception",
+			wantVerdict:   `status = "unhealthy"`,
+			bannedVerdict: `status = "degraded"`,
+		},
+		{
+			name:          "python gemini",
+			language:      "python",
+			model:         "gemini/gemini-2.5-flash",
+			entry:         "main.py",
+			outageMarker:  "vendor answered and it is not serving",
+			outageEnd:     "except Exception",
+			wantVerdict:   `status = "unhealthy"`,
+			bannedVerdict: `status = "degraded"`,
+		},
+		{
+			name:          "typescript anthropic",
+			language:      "typescript",
+			model:         "anthropic/claude-sonnet-5",
+			entry:         filepath.Join("src", "index.ts"),
+			outageMarker:  "vendor answered and it is not serving",
+			outageEnd:     "} catch (err)",
+			wantVerdict:   `status: "unhealthy"`,
+			bannedVerdict: `status: "degraded"`,
+		},
+		{
+			name:          "typescript openai",
+			language:      "typescript",
+			model:         "openai/gpt-4o",
+			entry:         filepath.Join("src", "index.ts"),
+			outageMarker:  "vendor answered and it is not serving",
+			outageEnd:     "} catch (err)",
+			wantVerdict:   `status: "unhealthy"`,
+			bannedVerdict: `status: "degraded"`,
+		},
+		{
+			name:          "typescript gemini",
+			language:      "typescript",
+			model:         "gemini/gemini-2.5-flash",
+			entry:         filepath.Join("src", "index.ts"),
+			outageMarker:  "vendor answered and it is not serving",
+			outageEnd:     "} catch (err)",
+			wantVerdict:   `status: "unhealthy"`,
+			bannedVerdict: `status: "degraded"`,
+		},
+		{
+			name:          "java anthropic",
+			language:      "java",
+			model:         "anthropic/claude-sonnet-5",
+			entry:         javaEntry,
+			outageMarker:  "vendor answered and it is not serving",
+			outageEnd:     "catch (InterruptedException",
+			wantVerdict:   "MeshHealthStatus.UNHEALTHY",
+			bannedVerdict: "MeshHealthStatus.DEGRADED",
+		},
+		{
+			name:          "java openai",
+			language:      "java",
+			model:         "openai/gpt-4o",
+			entry:         javaEntry,
+			outageMarker:  "vendor answered and it is not serving",
+			outageEnd:     "catch (InterruptedException",
+			wantVerdict:   "MeshHealthStatus.UNHEALTHY",
+			bannedVerdict: "MeshHealthStatus.DEGRADED",
+		},
+		{
+			name:          "java gemini",
+			language:      "java",
+			model:         "gemini/gemini-2.5-flash",
+			entry:         javaEntry,
+			outageMarker:  "vendor answered and it is not serving",
+			outageEnd:     "catch (InterruptedException",
+			wantVerdict:   "MeshHealthStatus.UNHEALTHY",
+			bannedVerdict: "MeshHealthStatus.DEGRADED",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			content := renderProvider(t, tc.language, tc.model, tc.entry)
+			branch := section(t, content, tc.outageMarker, tc.outageEnd)
+
+			require.Contains(t, branch, tc.wantVerdict,
+				"a vendor that answers with a non-200 is an OUTAGE: the branch must "+
+					"report unhealthy so the heartbeat stops and consumers fail over")
+			require.NotContains(t, branch, tc.bannedVerdict,
+				"reporting degraded on a real outage keeps the heartbeat alive and "+
+					"makes the provider unable to withdraw itself — the whole point "+
+					"of the health check")
+		})
+	}
+}
+
+// The transport-failure branch (DNS, connect, timeout, TLS) is the other
+// half of the same contract: the vendor is not answering at all.
+func TestLlmProviderTemplates_TransportFailureIsUnhealthy(t *testing.T) {
+	t.Run("python", func(t *testing.T) {
+		content := renderProvider(t, "python", "anthropic/claude-sonnet-5", "main.py")
+		branch := section(t, content, "API unreachable", "return {")
+		require.Contains(t, branch, `status = "unhealthy"`)
+	})
+
+	t.Run("typescript", func(t *testing.T) {
+		content := renderProvider(t, "typescript", "anthropic/claude-sonnet-5",
+			filepath.Join("src", "index.ts"))
+		branch := section(t, content, "The vendor is not answering at all", "}\n}")
+		require.Contains(t, branch, `status: "unhealthy"`)
+	})
+}
+
+// A cancelled probe concluded NOTHING about the vendor, so it must keep the
+// heartbeat alive. This is the one place "degraded" is correct, and the
+// inverse mistake (unhealthy on cancellation) would withdraw agents during
+// ordinary shutdowns.
+func TestLlmProviderTemplates_CancelledProbeIsDegraded(t *testing.T) {
+	content := renderProvider(t, "typescript", "anthropic/claude-sonnet-5",
+		filepath.Join("src", "index.ts"))
+	branch := section(t, content, "if (isProbeCancelled(err))", "}\n    // The vendor")
+	require.Contains(t, branch, `status: "degraded"`)
+}
+
+// The scaffolded agent must actually WIRE the check up — a correct
+// healthCheck that nothing calls withdraws nothing.
+func TestLlmProviderTemplates_HealthCheckIsWired(t *testing.T) {
+	t.Run("python", func(t *testing.T) {
+		content := renderProvider(t, "python", "anthropic/claude-sonnet-5", "main.py")
+		require.Contains(t, content, "health_check=health_check")
+		require.Contains(t, content, "health_check_ttl=")
+	})
+
+	t.Run("typescript", func(t *testing.T) {
+		content := renderProvider(t, "typescript", "anthropic/claude-sonnet-5",
+			filepath.Join("src", "index.ts"))
+		require.Contains(t, content, "  healthCheck,")
+		require.Contains(t, content, "healthCheckTtl:")
+	})
+
+	t.Run("java", func(t *testing.T) {
+		content := renderProvider(t, "java", "anthropic/claude-sonnet-5", javaEntry)
+		require.Contains(t, content, "@MeshHealthCheck(ttlSeconds =")
+	})
+}
+
+// An unknown vendor gets a skeleton that cannot detect an outage. That is
+// unavoidable — there is no generic reachability probe — but it must say so
+// loudly rather than look finished.
+func TestLlmProviderTemplates_UnknownVendorSkeletonWarns(t *testing.T) {
+	entries := map[string]string{
+		"python":     "main.py",
+		"typescript": filepath.Join("src", "index.ts"),
+		"java":       javaEntry,
+	}
+	for _, language := range []string{"python", "typescript", "java"} {
+		entry := entries[language]
+		t.Run(language, func(t *testing.T) {
+			content := renderProvider(t, language, "cohere/command-r-plus", entry)
+			require.Contains(t, content, "CANNOT DETECT AN")
+			require.Contains(t, content, "NOT IMPLEMENTED")
+		})
+	}
+}

--- a/src/runtime/core/src/napi.rs
+++ b/src/runtime/core/src/napi.rs
@@ -471,6 +471,42 @@ impl JsAgentHandle {
         Ok(handle.update_port_async(port).await)
     }
 
+    /// Report the agent's health verdict to the runtime loop (issue #1476).
+    ///
+    /// The napi counterpart of `AgentHandle::update_health` (pyo3:
+    /// `handle.update_health`) and of the C ABI's `mesh_update_health`. Call
+    /// this from the SDK's periodic health-check loop with the verdict of the
+    /// user-supplied `healthCheck`. While the status is `unhealthy` the runtime
+    /// stops heartbeating, so the registry's staleness sweep withdraws the agent
+    /// from dependency resolution; pushing `healthy` (or `degraded`) resumes
+    /// heartbeats and the registry restores it — with no process restart.
+    ///
+    /// Pushing the same status repeatedly is cheap and idempotent — the runtime
+    /// only acts on transitions — so SDKs push on every health-check tick.
+    ///
+    /// @param status - "healthy", "degraded", or "unhealthy"
+    /// @returns true if the update was queued successfully
+    #[napi]
+    pub async fn update_health(&self, status: String) -> Result<bool> {
+        // Strict parse, deliberately — same contract as the C ABI. Callers
+        // normalize an unrecognized status to "degraded" BEFORE crossing the
+        // boundary (a reporting defect must never withdraw a working agent);
+        // silently accepting junk here would hide the day they stop.
+        let health_status = match status.as_str() {
+            "healthy" => HealthStatus::Healthy,
+            "degraded" => HealthStatus::Degraded,
+            "unhealthy" => HealthStatus::Unhealthy,
+            other => {
+                return Err(Error::from_reason(format!(
+                    "Invalid health status '{}', expected: healthy, degraded, or unhealthy",
+                    other
+                )))
+            }
+        };
+        let handle = self.inner.lock().await;
+        Ok(handle.update_health_async(health_status).await)
+    }
+
     /// Update the A2A surfaces and agent_type registered with the registry
     /// (issue #938 — mid-flight `mesh.a2a.mount(...)` parity with Python's
     /// per-heartbeat `_build_a2a_surfaces`).
@@ -1022,7 +1058,72 @@ pub fn get_vendor_capabilities(provider: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::handle::HandleState;
+    use crate::runtime::RuntimeCommand;
     use crate::spec::AgentType;
+    use tokio::sync::{mpsc, RwLock};
+
+    /// Build a `JsAgentHandle` over a bare `AgentHandle`, returning the
+    /// command receiver so a test can observe what the binding enqueued.
+    fn js_handle() -> (JsAgentHandle, mpsc::Receiver<RuntimeCommand>) {
+        let (_event_tx, event_rx) = mpsc::channel(10);
+        let (shutdown_tx, _shutdown_rx) = mpsc::channel(1);
+        let (command_tx, command_rx) = mpsc::channel(10);
+        let state = Arc::new(RwLock::new(HandleState::default()));
+        let handle = RustAgentHandle::new(event_rx, state, shutdown_tx, command_tx);
+        (
+            JsAgentHandle {
+                inner: Arc::new(Mutex::new(handle)),
+            },
+            command_rx,
+        )
+    }
+
+    /// Issue #1476: the napi binding is the ONLY channel between a
+    /// TypeScript agent's health check and heartbeat suppression. Each
+    /// accepted verdict must reach the runtime as `UpdateHealth`.
+    #[tokio::test]
+    async fn test_1476_update_health_enqueues_command() {
+        for (input, expected) in [
+            ("unhealthy", HealthStatus::Unhealthy),
+            ("healthy", HealthStatus::Healthy),
+            ("degraded", HealthStatus::Degraded),
+        ] {
+            let (handle, mut command_rx) = js_handle();
+            assert!(
+                handle.update_health(input.to_string()).await.unwrap(),
+                "updateHealth({input}) must be queued"
+            );
+            match command_rx.try_recv() {
+                Ok(RuntimeCommand::UpdateHealth(got)) => assert_eq!(got, expected),
+                other => panic!("expected UpdateHealth({expected:?}), got {other:?}"),
+            }
+        }
+    }
+
+    /// Unknown statuses are rejected rather than coerced. The SDK maps
+    /// anything it cannot parse to "degraded" BEFORE calling this, so junk
+    /// arriving here means that mapping broke — silently accepting it would
+    /// hide the regression (and the C ABI rejects it for the same reason).
+    #[tokio::test]
+    async fn test_1476_update_health_rejects_unknown_status() {
+        for input in ["", "HEALTHY", "ok", "unknown", "down"] {
+            let (handle, mut command_rx) = js_handle();
+            let err = handle
+                .update_health(input.to_string())
+                .await
+                .expect_err("unknown status must be rejected");
+            assert!(
+                err.reason.contains("Invalid health status"),
+                "unhelpful error for {input:?}: {}",
+                err.reason
+            );
+            assert!(
+                command_rx.try_recv().is_err(),
+                "a rejected status must not enqueue a command"
+            );
+        }
+    }
 
     #[test]
     fn test_js_spec_conversion() {

--- a/src/runtime/typescript/src/__tests__/agent-health-publish.spec.ts
+++ b/src/runtime/typescript/src/__tests__/agent-health-publish.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * The `publish` bridge between the health refresh loop and the Rust core
+ * (issue #1476).
+ *
+ * `updateHealth` returns false when the verdict was NOT queued to the
+ * runtime, and the loop only checks for its own publish deadline — so a
+ * dropped verdict has to be reported here or nowhere. Left silent, an
+ * agent that reported `unhealthy` keeps heartbeating, is never withdrawn,
+ * and no log line anywhere says why.
+ *
+ * The shutdown path returns the same false and must stay silent: the
+ * handle is nulled by `shutdown()`, so warning there would make every
+ * clean exit print a spurious failure.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { MockInstance } from "vitest";
+
+import type {
+  HealthCheckLoop,
+  HealthCheckLoopOptions,
+  MeshHealthStatus,
+} from "../health-check.js";
+
+/** Captured `publish` from the most recent `startHealthCheckLoop` call. */
+let captured: HealthCheckLoopOptions | null = null;
+
+// Replace only the loop starter: it captures the options and starts
+// nothing, so `publish` can be driven directly instead of waiting a TTL.
+vi.mock("../health-check.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../health-check.js")>();
+  return {
+    ...actual,
+    startHealthCheckLoop: (options: HealthCheckLoopOptions): HealthCheckLoop => {
+      captured = options;
+      return {
+        latest: () => null,
+        stop: () => {},
+        seeded: async () => {},
+      };
+    },
+  };
+});
+
+const { MeshAgent } = await import("../agent.js");
+
+/**
+ * Drive the REAL private `startHealthRefresh` against a stub `this` and
+ * hand back the `publish` closure it built. Nothing here needs a
+ * constructed agent — the method reads five fields and calls the (mocked)
+ * loop starter.
+ */
+function buildPublish(stub: {
+  handle: { updateHealth: (s: MeshHealthStatus) => Promise<boolean> } | null;
+  shutdownRequested: boolean;
+}): (status: MeshHealthStatus) => boolean | Promise<boolean> {
+  const stubThis = {
+    ...stub,
+    agentId: "claude-provider-a1b2c3d4",
+    healthLoop: undefined,
+    config: { healthCheck: async () => true, healthCheckTtl: 30 },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const startHealthRefresh = (MeshAgent.prototype as any).startHealthRefresh;
+  startHealthRefresh.call(stubThis);
+  if (!captured) throw new Error("health refresh loop was never started");
+  return captured.publish;
+}
+
+describe("MeshAgent health publish — a dropped verdict is reported", () => {
+  let warnSpy: MockInstance;
+
+  beforeEach(() => {
+    captured = null;
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("warns when updateHealth reports the verdict was not queued", async () => {
+    const publish = buildPublish({
+      handle: { updateHealth: async () => false },
+      shutdownRequested: false,
+    });
+
+    await expect(publish("unhealthy")).resolves.toBe(false);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = String(warnSpy.mock.calls[0]?.[0]);
+    expect(message).toContain("[mesh-health]");
+    expect(message).toContain("unhealthy");
+    expect(message).toContain("claude-provider-a1b2c3d4");
+    expect(message).toContain("not queued");
+  });
+
+  it("stays silent when the verdict is queued", async () => {
+    const publish = buildPublish({
+      handle: { updateHealth: async () => true },
+      shutdownRequested: false,
+    });
+
+    await expect(publish("healthy")).resolves.toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("stays silent on the shutdown path", async () => {
+    // shutdown() sets the flag before it nulls the handle; both orderings
+    // are the same non-error, and neither may warn.
+    const shuttingDown = buildPublish({
+      handle: { updateHealth: async () => false },
+      shutdownRequested: true,
+    });
+    await expect(shuttingDown("unhealthy")).resolves.toBe(false);
+
+    const tornDown = buildPublish({ handle: null, shutdownRequested: false });
+    await expect(tornDown("unhealthy")).resolves.toBe(false);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/runtime/typescript/src/__tests__/config.test.ts
+++ b/src/runtime/typescript/src/__tests__/config.test.ts
@@ -194,3 +194,50 @@ describe("Issue #969: agent description plumbing", () => {
     expect(resolved.description).toBe("");
   });
 });
+
+// Issue #1476: the health check and its refresh period must survive
+// resolveConfig — the loop that can withdraw this agent from resolution
+// reads them off ResolvedAgentConfig and nowhere else.
+describe("Issue #1476: health check plumbing", () => {
+  it("passes the health check function through untouched", () => {
+    const healthCheck = async () => true;
+    const resolved = resolveConfig({
+      name: "provider",
+      httpPort: 9001,
+      healthCheck,
+    });
+    expect(resolved.healthCheck).toBe(healthCheck);
+  });
+
+  it("leaves healthCheck undefined when none is declared", () => {
+    const resolved = resolveConfig({ name: "provider", httpPort: 9001 });
+    expect(resolved.healthCheck).toBeUndefined();
+    // The TTL is always resolved, so the loop never has to null-guard it.
+    expect(resolved.healthCheckTtl).toBe(15);
+  });
+
+  it("honours a configured TTL", () => {
+    const resolved = resolveConfig({
+      name: "provider",
+      httpPort: 9001,
+      healthCheckTtl: 30,
+    });
+    expect(resolved.healthCheckTtl).toBe(30);
+  });
+
+  it("MCP_MESH_HEALTH_CHECK_TTL overrides the configured TTL", () => {
+    const previous = process.env.MCP_MESH_HEALTH_CHECK_TTL;
+    try {
+      process.env.MCP_MESH_HEALTH_CHECK_TTL = "4";
+      const resolved = resolveConfig({
+        name: "provider",
+        httpPort: 9001,
+        healthCheckTtl: 30,
+      });
+      expect(resolved.healthCheckTtl).toBe(4);
+    } finally {
+      if (previous === undefined) delete process.env.MCP_MESH_HEALTH_CHECK_TTL;
+      else process.env.MCP_MESH_HEALTH_CHECK_TTL = previous;
+    }
+  });
+});

--- a/src/runtime/typescript/src/__tests__/config.test.ts
+++ b/src/runtime/typescript/src/__tests__/config.test.ts
@@ -4,7 +4,7 @@
  * Tests configuration resolution utilities for MCP Mesh TypeScript SDK.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { generateAgentIdSuffix, resolveConfig } from "../config.js";
 import type { AgentConfig } from "../types.js";
 
@@ -199,6 +199,24 @@ describe("Issue #969: agent description plumbing", () => {
 // resolveConfig — the loop that can withdraw this agent from resolution
 // reads them off ResolvedAgentConfig and nowhere else.
 describe("Issue #1476: health check plumbing", () => {
+  // resolveConfig reads MCP_MESH_HEALTH_CHECK_TTL from the ambient
+  // environment, so a developer who exports it would otherwise flip the
+  // default and configured-value cases below.
+  let previousTtlEnv: string | undefined;
+
+  beforeEach(() => {
+    previousTtlEnv = process.env.MCP_MESH_HEALTH_CHECK_TTL;
+    delete process.env.MCP_MESH_HEALTH_CHECK_TTL;
+  });
+
+  afterEach(() => {
+    if (previousTtlEnv === undefined) {
+      delete process.env.MCP_MESH_HEALTH_CHECK_TTL;
+    } else {
+      process.env.MCP_MESH_HEALTH_CHECK_TTL = previousTtlEnv;
+    }
+  });
+
   it("passes the health check function through untouched", () => {
     const healthCheck = async () => true;
     const resolved = resolveConfig({
@@ -226,18 +244,12 @@ describe("Issue #1476: health check plumbing", () => {
   });
 
   it("MCP_MESH_HEALTH_CHECK_TTL overrides the configured TTL", () => {
-    const previous = process.env.MCP_MESH_HEALTH_CHECK_TTL;
-    try {
-      process.env.MCP_MESH_HEALTH_CHECK_TTL = "4";
-      const resolved = resolveConfig({
-        name: "provider",
-        httpPort: 9001,
-        healthCheckTtl: 30,
-      });
-      expect(resolved.healthCheckTtl).toBe(4);
-    } finally {
-      if (previous === undefined) delete process.env.MCP_MESH_HEALTH_CHECK_TTL;
-      else process.env.MCP_MESH_HEALTH_CHECK_TTL = previous;
-    }
+    process.env.MCP_MESH_HEALTH_CHECK_TTL = "4";
+    const resolved = resolveConfig({
+      name: "provider",
+      httpPort: 9001,
+      healthCheckTtl: 30,
+    });
+    expect(resolved.healthCheckTtl).toBe(4);
   });
 });

--- a/src/runtime/typescript/src/__tests__/health-check.spec.ts
+++ b/src/runtime/typescript/src/__tests__/health-check.spec.ts
@@ -244,6 +244,18 @@ describe("resolveHealthCheckTtl", () => {
     expect(resolveHealthCheckTtl(0, "0")).toBe(15);
   });
 
+  // A warning has to name the TTL the agent actually runs with. Warning
+  // "using 15s" while a valid env override goes on to win prints a number
+  // that appears nowhere in the agent's behaviour.
+  it("warns with the value that WINS, not the one it fell back to", () => {
+    expect(resolveHealthCheckTtl(0, "7")).toBe(7);
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const message = String(warnSpy.mock.calls[0][0]);
+    expect(message).toContain("healthCheckTtl=0");
+    expect(message).toContain("using 7s");
+    expect(message).not.toContain("using 15s");
+  });
+
   it("reads the environment via resolveHealthCheckTtlFromEnv", () => {
     const previous = process.env[HEALTH_CHECK_TTL_ENV];
     try {
@@ -387,6 +399,82 @@ describe("startHealthCheckLoop", () => {
     await loop.seeded();
     await vi.advanceTimersByTimeAsync(2_000);
     expect(publishCalls).toBe(2);
+
+    loop.stop();
+  });
+
+  // The failure a `finally`-based reschedule cannot catch: a promise that
+  // never settles never reaches the `finally` at all. `await fetch(url)`
+  // with no AbortSignal against a black-holed host is exactly this, and it
+  // would leave the agent running with a health check that never runs
+  // again — silently, since nothing more is ever logged.
+  it("abandons a check that never settles and keeps ticking", async () => {
+    const published: MeshHealthStatus[] = [];
+    let started = 0;
+    const loop = startHealthCheckLoop({
+      agentName: "provider",
+      healthCheck: () => {
+        started += 1;
+        return new Promise<boolean>(() => {
+          /* never settles, like a connect to a black hole */
+        });
+      },
+      ttlSeconds: 1,
+      publish: (status) => {
+        published.push(status);
+        return true;
+      },
+    });
+
+    // Nothing has been abandoned yet: the deadline is generous on purpose.
+    await vi.advanceTimersByTimeAsync(29_000);
+    expect(started).toBe(1);
+    expect(loop.latest()).toBeNull();
+
+    // 30s deadline (the floor, since one TTL is shorter) elapses: the run
+    // is abandoned, degraded so the agent keeps heartbeating, and the loop
+    // is rescheduled.
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(loop.latest()?.status).toBe("degraded");
+    expect(loop.latest()?.checks).toEqual({ health_check_completed: false });
+    expect(started).toBe(2);
+    expect(String(warnSpy.mock.calls[0][0])).toContain("did not finish");
+
+    // ...and the tick after that publishes, proving the loop is alive.
+    await vi.advanceTimersByTimeAsync(31_000);
+    expect(published).toEqual(["degraded"]);
+    expect(started).toBe(3);
+
+    loop.stop();
+  });
+
+  // `updateHealth` sends on a bounded command channel: a runtime that has
+  // stopped draining it makes the send wait, not fail.
+  it("abandons a publish that never settles and keeps ticking", async () => {
+    let publishCalls = 0;
+    let checkCalls = 0;
+    const loop = startHealthCheckLoop({
+      agentName: "provider",
+      healthCheck: () => {
+        checkCalls += 1;
+        return true;
+      },
+      ttlSeconds: 1,
+      publish: () => {
+        publishCalls += 1;
+        return new Promise<boolean>(() => {
+          /* never settles, like a full command channel */
+        });
+      },
+    });
+
+    await loop.seeded();
+    // 1s to the first publishing tick, then a 10s publish deadline, then
+    // 1s to the next tick: three publishes inside ~35s.
+    await vi.advanceTimersByTimeAsync(35_000);
+    expect(publishCalls).toBeGreaterThanOrEqual(3);
+    expect(checkCalls).toBeGreaterThanOrEqual(4);
+    expect(String(warnSpy.mock.calls[0][0])).toContain("did not complete");
 
     loop.stop();
   });

--- a/src/runtime/typescript/src/__tests__/health-check.spec.ts
+++ b/src/runtime/typescript/src/__tests__/health-check.spec.ts
@@ -1,0 +1,461 @@
+/**
+ * Health-check verdict, TTL resolution and refresh-loop tests (issue #1476).
+ *
+ * The verdict table is the contract shared with Python (#1473) and Java
+ * (#1475), and it is the part that has been shipped WRONG before: both
+ * scaffolds once returned `degraded` for a real vendor outage, which kept
+ * the heartbeat alive and made every scaffolded provider unable to
+ * withdraw itself — the entire point of the feature. `unhealthy` is the
+ * ONLY verdict that suppresses the heartbeat, so these tests pin exactly
+ * which conditions produce it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  normalizeHealthResult,
+  runHealthCheck,
+  resolveHealthCheckTtl,
+  resolveHealthCheckTtlFromEnv,
+  startHealthCheckLoop,
+  describeThrown,
+  DEFAULT_HEALTH_CHECK_TTL_SECONDS,
+  HEALTH_CHECK_TTL_ENV,
+  type MeshHealthStatus,
+} from "../health-check.js";
+
+describe("normalizeHealthResult — verdict table", () => {
+  it("true is healthy, false is unhealthy", () => {
+    expect(normalizeHealthResult(true).status).toBe("healthy");
+    expect(normalizeHealthResult(false).status).toBe("unhealthy");
+    expect(normalizeHealthResult(false).errors).toEqual([
+      "Health check returned false",
+    ]);
+  });
+
+  it("passes each declared status through verbatim", () => {
+    for (const status of ["healthy", "degraded", "unhealthy"] as const) {
+      expect(normalizeHealthResult({ status }).status).toBe(status);
+    }
+  });
+
+  it("accepts surrounding whitespace and mixed case", () => {
+    expect(normalizeHealthResult({ status: " UNHEALTHY " }).status).toBe(
+      "unhealthy",
+    );
+  });
+
+  it("a result with no status is reporting success (Python parity)", () => {
+    expect(normalizeHealthResult({ checks: { api: true } }).status).toBe(
+      "healthy",
+    );
+    expect(normalizeHealthResult({}).status).toBe("healthy");
+  });
+
+  it("carries checks and errors through untouched", () => {
+    const verdict = normalizeHealthResult({
+      status: "unhealthy",
+      checks: { api_reachable: false, key_present: true },
+      errors: ["vendor returned 503"],
+    });
+    expect(verdict.checks).toEqual({ api_reachable: false, key_present: true });
+    expect(verdict.errors).toEqual(["vendor returned 503"]);
+  });
+
+  // A reporting defect must never withdraw a working agent from the mesh:
+  // everything unparseable degrades, which keeps the heartbeat alive.
+  it.each([
+    ["unrecognized status string", { status: "down" }],
+    ["non-string status", { status: 503 }],
+    ["null", null],
+    ["undefined", undefined],
+    ["a number", 42],
+    ["a string", "healthy"],
+    ["an array", ["healthy"]],
+  ])("degrades on %s — never unhealthy", (_label, raw) => {
+    expect(normalizeHealthResult(raw).status).toBe("degraded");
+  });
+
+  it("tolerates non-object checks and non-array errors", () => {
+    const verdict = normalizeHealthResult({
+      status: "healthy",
+      checks: "nope" as unknown as Record<string, unknown>,
+      errors: "nope" as unknown as string[],
+    });
+    expect(verdict.checks).toEqual({});
+    expect(verdict.errors).toEqual([]);
+  });
+
+  it("stringifies non-string error entries instead of leaking them", () => {
+    const verdict = normalizeHealthResult({
+      status: "unhealthy",
+      errors: [new Error("boom"), 7] as unknown as string[],
+    });
+    expect(verdict.errors).toEqual(["boom", "7"]);
+  });
+});
+
+describe("runHealthCheck — a broken check degrades, it does not withdraw", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => warnSpy.mockRestore());
+
+  it("returns the normalized verdict of a sync check", async () => {
+    expect((await runHealthCheck(() => false, "a")).status).toBe("unhealthy");
+  });
+
+  it("awaits an async check", async () => {
+    const verdict = await runHealthCheck(
+      async () => ({ status: "unhealthy" as const, errors: ["vendor 500"] }),
+      "a",
+    );
+    expect(verdict.status).toBe("unhealthy");
+    expect(verdict.errors).toEqual(["vendor 500"]);
+  });
+
+  it("a check that throws is degraded", async () => {
+    const verdict = await runHealthCheck(() => {
+      throw new Error("boom");
+    }, "a");
+    expect(verdict.status).toBe("degraded");
+    expect(verdict.checks).toEqual({ health_check_execution: false });
+    expect(verdict.errors[0]).toContain("boom");
+  });
+
+  it("a check that rejects is degraded", async () => {
+    const verdict = await runHealthCheck(
+      async () => Promise.reject(new Error("async boom")),
+      "a",
+    );
+    expect(verdict.status).toBe("degraded");
+    expect(verdict.errors[0]).toContain("async boom");
+  });
+
+  it.each([
+    ["a string", "nope"],
+    ["a number", 7],
+    ["null", null],
+    ["undefined", undefined],
+  ])("survives a non-Error throw: %s", async (_label, thrown) => {
+    const verdict = await runHealthCheck(() => {
+      throw thrown;
+    }, "a");
+    expect(verdict.status).toBe("degraded");
+  });
+
+  it("survives a throw whose own toString throws", async () => {
+    const hostile = {
+      toString() {
+        throw new Error("nope");
+      },
+    };
+    const verdict = await runHealthCheck(() => {
+      throw hostile;
+    }, "a");
+    expect(verdict.status).toBe("degraded");
+    expect(verdict.errors[0]).toContain("<unprintable value>");
+  });
+
+  it("a check returning nothing degrades rather than crashing", async () => {
+    const verdict = await runHealthCheck(
+      (() => undefined) as unknown as () => boolean,
+      "a",
+    );
+    expect(verdict.status).toBe("degraded");
+  });
+});
+
+describe("describeThrown", () => {
+  it("prefers the message, falls back to the name", () => {
+    expect(describeThrown(new Error("msg"))).toBe("msg");
+    const bare = new TypeError("");
+    expect(describeThrown(bare)).toBe("TypeError");
+  });
+});
+
+describe("resolveHealthCheckTtl", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => warnSpy.mockRestore());
+
+  it("defaults to 15s", () => {
+    expect(resolveHealthCheckTtl()).toBe(DEFAULT_HEALTH_CHECK_TTL_SECONDS);
+    expect(resolveHealthCheckTtl(null, null)).toBe(15);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("takes a valid configured value", () => {
+    expect(resolveHealthCheckTtl(30)).toBe(30);
+    expect(resolveHealthCheckTtl(1)).toBe(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -5],
+    ["sub-second", 0.5],
+    ["non-integer", 2.5],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])("rejects a %s configured value and warns", (_label, configured) => {
+    expect(resolveHealthCheckTtl(configured)).toBe(15);
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+
+  it("the env var overrides the configured value", () => {
+    expect(resolveHealthCheckTtl(30, "5")).toBe(5);
+    expect(resolveHealthCheckTtl(30, "  7  ")).toBe(7);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("a blank or whitespace env var is 'not set', not an error", () => {
+    expect(resolveHealthCheckTtl(30, "")).toBe(30);
+    expect(resolveHealthCheckTtl(30, "   ")).toBe(30);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  // "15s" is the trap `parseInt` walks straight into: it yields 15 and
+  // silently accepts a format the other runtimes reject.
+  it.each([
+    ["a duration suffix", "15s"],
+    ["a float", "1.5"],
+    ["hex", "0x10"],
+    ["words", "fifteen"],
+    ["trailing junk", "10 seconds"],
+  ])("rejects %s in the env var and keeps the configured value", (_l, raw) => {
+    expect(resolveHealthCheckTtl(30, raw)).toBe(30);
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(String(warnSpy.mock.calls[0][0])).toContain("not an");
+  });
+
+  it.each([
+    ["zero", "0"],
+    ["negative", "-3"],
+  ])("rejects a %s env var and keeps the configured value", (_l, raw) => {
+    expect(resolveHealthCheckTtl(30, raw)).toBe(30);
+    expect(String(warnSpy.mock.calls[0][0])).toContain("below the 1s minimum");
+  });
+
+  it("falls back to the default when BOTH sources are invalid", () => {
+    expect(resolveHealthCheckTtl(0, "0")).toBe(15);
+  });
+
+  it("reads the environment via resolveHealthCheckTtlFromEnv", () => {
+    const previous = process.env[HEALTH_CHECK_TTL_ENV];
+    try {
+      process.env[HEALTH_CHECK_TTL_ENV] = "3";
+      expect(resolveHealthCheckTtlFromEnv(30)).toBe(3);
+      delete process.env[HEALTH_CHECK_TTL_ENV];
+      expect(resolveHealthCheckTtlFromEnv(30)).toBe(30);
+    } finally {
+      if (previous === undefined) delete process.env[HEALTH_CHECK_TTL_ENV];
+      else process.env[HEALTH_CHECK_TTL_ENV] = previous;
+    }
+  });
+});
+
+describe("startHealthCheckLoop", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    warnSpy.mockRestore();
+  });
+
+  it("seeds without publishing, then publishes every tick", async () => {
+    const published: MeshHealthStatus[] = [];
+    const loop = startHealthCheckLoop({
+      agentName: "provider",
+      healthCheck: () => true,
+      ttlSeconds: 10,
+      publish: (status) => {
+        published.push(status);
+        return true;
+      },
+    });
+
+    await loop.seeded();
+    // The agent registers and becomes visible first: the seed run stores a
+    // verdict but must not be able to withdraw a just-registered agent.
+    expect(published).toEqual([]);
+    expect(loop.latest()?.status).toBe("healthy");
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(published).toEqual(["healthy"]);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(published).toEqual(["healthy", "healthy"]);
+
+    loop.stop();
+  });
+
+  it("publishes unhealthy — the verdict that withdraws the agent", async () => {
+    const published: MeshHealthStatus[] = [];
+    let outage = true;
+    const loop = startHealthCheckLoop({
+      agentName: "provider",
+      healthCheck: () => (outage ? { status: "unhealthy" as const } : true),
+      ttlSeconds: 5,
+      publish: (status) => {
+        published.push(status);
+        return true;
+      },
+    });
+
+    await loop.seeded();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(published).toEqual(["unhealthy"]);
+
+    // Recovery is detected on the next tick and restores the heartbeat.
+    outage = false;
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(published).toEqual(["unhealthy", "healthy"]);
+
+    loop.stop();
+  });
+
+  // A tick that blows up must not silently end all future refreshes: the
+  // agent would keep running with a health check that never runs again,
+  // so it could never be withdrawn, and nothing after the first error
+  // would reach the logs.
+  it("keeps ticking after a check throws", async () => {
+    const published: MeshHealthStatus[] = [];
+    let calls = 0;
+    const loop = startHealthCheckLoop({
+      agentName: "provider",
+      healthCheck: () => {
+        calls += 1;
+        if (calls <= 2) throw new Error("probe exploded");
+        return true;
+      },
+      ttlSeconds: 1,
+      publish: (status) => {
+        published.push(status);
+        return true;
+      },
+    });
+
+    await loop.seeded();
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(published).toEqual(["degraded", "healthy", "healthy"]);
+
+    loop.stop();
+  });
+
+  it("keeps ticking after publish rejects", async () => {
+    let publishCalls = 0;
+    const loop = startHealthCheckLoop({
+      agentName: "provider",
+      healthCheck: () => true,
+      ttlSeconds: 1,
+      publish: async () => {
+        publishCalls += 1;
+        throw new Error("napi handle gone");
+      },
+    });
+
+    await loop.seeded();
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(publishCalls).toBe(3);
+
+    loop.stop();
+  });
+
+  it("keeps ticking after the verdict listener throws", async () => {
+    let publishCalls = 0;
+    const loop = startHealthCheckLoop({
+      agentName: "provider",
+      healthCheck: () => true,
+      ttlSeconds: 1,
+      publish: () => {
+        publishCalls += 1;
+        return true;
+      },
+      onVerdict: () => {
+        throw new Error("listener exploded");
+      },
+    });
+
+    await loop.seeded();
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(publishCalls).toBe(2);
+
+    loop.stop();
+  });
+
+  it("stop() ends the loop and is idempotent", async () => {
+    let publishCalls = 0;
+    const loop = startHealthCheckLoop({
+      agentName: "provider",
+      healthCheck: () => true,
+      ttlSeconds: 1,
+      publish: () => {
+        publishCalls += 1;
+        return true;
+      },
+    });
+
+    await loop.seeded();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(publishCalls).toBe(1);
+
+    loop.stop();
+    loop.stop();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(publishCalls).toBe(1);
+  });
+
+  it("does not block on a slow check — startup never waits for the vendor", async () => {
+    let resolveProbe: (() => void) | undefined;
+    const loop = startHealthCheckLoop({
+      agentName: "provider",
+      healthCheck: () =>
+        new Promise<boolean>((resolve) => {
+          resolveProbe = () => resolve(true);
+        }),
+      ttlSeconds: 1,
+      publish: () => true,
+    });
+
+    // The loop is already constructed and usable while the probe hangs.
+    expect(loop.latest()).toBeNull();
+    resolveProbe?.();
+    await loop.seeded();
+    expect(loop.latest()?.status).toBe("healthy");
+
+    loop.stop();
+  });
+
+  // Fixed DELAY, not fixed rate: a probe slower than its own TTL (a
+  // vendor timing out is exactly that) must not queue back-to-back runs
+  // against an already-struggling upstream.
+  it("waits a full TTL AFTER a slow check completes", async () => {
+    let running = 0;
+    let maxConcurrent = 0;
+    const loop = startHealthCheckLoop({
+      agentName: "provider",
+      healthCheck: async () => {
+        running += 1;
+        maxConcurrent = Math.max(maxConcurrent, running);
+        await new Promise((resolve) => setTimeout(resolve, 3_000));
+        running -= 1;
+        return true;
+      },
+      ttlSeconds: 1,
+      publish: () => true,
+    });
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(maxConcurrent).toBe(1);
+
+    loop.stop();
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -75,6 +75,12 @@ import {
 import { registerCancelRoute } from "./jobs-cancel-route.js";
 import { registerLivezRoute } from "./livez-route.js";
 import {
+  startHealthCheckLoop,
+  DEFAULT_HEALTH_CHECK_TTL_SECONDS,
+  type HealthCheckLoop,
+  type HealthVerdict,
+} from "./health-check.js";
+import {
   clusterStrictEnabled,
   normalizeSchemaWithPolicy,
 } from "./schema-normalize.js";
@@ -296,6 +302,12 @@ export class MeshAgent {
    */
   private llmProviderVendors: Map<string, string> = new Map();
   private handle: JsAgentHandle | null = null;
+  /**
+   * Issue #1476: the periodic health-check refresh, when the agent
+   * declared a `healthCheck`. Null otherwise — an agent without one
+   * starts no timer and behaves exactly as before.
+   */
+  private healthLoop: HealthCheckLoop | null = null;
   private httpsProxy?: import("node:https").Server;
   private started = false;
   private tracingEnabled = false;
@@ -423,6 +435,9 @@ export class MeshAgent {
         namespace: "default",
         registryUrl: "",
         heartbeatInterval: 0,
+        // Issue #1476: a worker thread never starts the refresh loop
+        // (no `_autoStart`), so this is a placeholder like the rest.
+        healthCheckTtl: DEFAULT_HEALTH_CHECK_TTL_SECONDS,
       };
       this.agentId = "";
       return;
@@ -1990,8 +2005,57 @@ export class MeshAgent {
     // registration" race).
     this.startClaimDispatchers();
 
+    // 3.6 Issue #1476: start the health-check refresh. AFTER the
+    // heartbeat, deliberately — the agent registers and becomes visible
+    // first, and only the refreshes that follow can withdraw it. Returns
+    // immediately; the seed run is scheduled, never awaited.
+    this.startHealthCheckLoop();
+
     // 4. Install signal handlers for graceful shutdown
     this.installSignalHandlers();
+  }
+
+  /**
+   * Issue #1476: run the user's `healthCheck` on a timer and report each
+   * verdict to the Rust core, which stops heartbeating while the agent is
+   * `unhealthy` so the registry withdraws it from dependency resolution.
+   *
+   * The process keeps running throughout: an upstream outage makes this
+   * agent invisible to resolution, not dead. When the check passes again
+   * heartbeats resume and the registry restores the agent through its
+   * `410 Gone` re-register path.
+   */
+  private startHealthCheckLoop(): void {
+    const healthCheck = this.config.healthCheck;
+    if (!healthCheck || this.healthLoop) return;
+
+    const ttlSeconds = this.config.healthCheckTtl;
+    console.log(
+      `Health check runs every ${ttlSeconds}s for agent ${this.agentId}; an ` +
+        `unhealthy verdict stops the heartbeat and withdraws this agent from ` +
+        `dependency resolution`,
+    );
+
+    this.healthLoop = startHealthCheckLoop({
+      agentName: this.agentId,
+      healthCheck,
+      ttlSeconds,
+      publish: async (status) => {
+        // The handle is nulled by shutdown(); a verdict landing after
+        // teardown has nowhere to go and is not an error.
+        const handle = this.handle;
+        if (!handle || this.shutdownRequested) return false;
+        return await handle.updateHealth(status);
+      },
+    });
+  }
+
+  /**
+   * Issue #1476: the latest health verdict, or null before the first run
+   * completes (or when no `healthCheck` is configured).
+   */
+  getHealthVerdict(): HealthVerdict | null {
+    return this.healthLoop?.latest() ?? null;
   }
 
   /**
@@ -2774,6 +2838,13 @@ export class MeshAgent {
     if (this.shutdownPromise) return this.shutdownPromise;
     this.shutdownRequested = true;
     this.shutdownPromise = (async () => {
+      // Issue #1476: stop the health refresh first. Its verdicts are only
+      // meaningful while the agent is serving, and a tick landing mid-
+      // teardown would push a status at a handle that is about to close.
+      if (this.healthLoop) {
+        this.healthLoop.stop();
+        this.healthLoop = null;
+      }
       // Phase 1 MeshJob substrate: stop claim dispatchers first so they
       // don't pull a fresh job mid-shutdown. Issue #1173: all dispatchers
       // drain CONCURRENTLY under one shared, hard-capped budget — never

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -2009,7 +2009,7 @@ export class MeshAgent {
     // heartbeat, deliberately — the agent registers and becomes visible
     // first, and only the refreshes that follow can withdraw it. Returns
     // immediately; the seed run is scheduled, never awaited.
-    this.startHealthCheckLoop();
+    this.startHealthRefresh();
 
     // 4. Install signal handlers for graceful shutdown
     this.installSignalHandlers();
@@ -2024,8 +2024,11 @@ export class MeshAgent {
    * agent invisible to resolution, not dead. When the check passes again
    * heartbeats resume and the registry restores the agent through its
    * `410 Gone` re-register path.
+   *
+   * Named `startHealthRefresh` rather than `startHealthCheckLoop` so it
+   * does not shadow the imported {@link startHealthCheckLoop} it calls.
    */
-  private startHealthCheckLoop(): void {
+  private startHealthRefresh(): void {
     const healthCheck = this.config.healthCheck;
     if (!healthCheck || this.healthLoop) return;
 

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -2045,10 +2045,22 @@ export class MeshAgent {
       ttlSeconds,
       publish: async (status) => {
         // The handle is nulled by shutdown(); a verdict landing after
-        // teardown has nowhere to go and is not an error.
+        // teardown has nowhere to go and is not an error, so it stays
+        // silent — every clean shutdown would otherwise warn.
         const handle = this.handle;
         if (!handle || this.shutdownRequested) return false;
-        return await handle.updateHealth(status);
+        const queued = await handle.updateHealth(status);
+        if (!queued) {
+          // The runtime is up but did not take the verdict. Left silent,
+          // an `unhealthy` agent would keep heartbeating with nothing in
+          // the logs to say why it was never withdrawn.
+          console.warn(
+            `[mesh-health] health status '${status}' for agent ` +
+              `'${this.agentId}' was not queued to the mesh runtime — this ` +
+              `verdict has not taken effect; the next refresh retries`,
+          );
+        }
+        return queued;
       },
     });
   }

--- a/src/runtime/typescript/src/config.ts
+++ b/src/runtime/typescript/src/config.ts
@@ -10,6 +10,7 @@
 import { randomBytes } from "crypto";
 import { createServer } from "net";
 import type { AgentConfig, ResolvedAgentConfig } from "./types.js";
+import { resolveHealthCheckTtlFromEnv } from "./health-check.js";
 import {
   resolveConfig as rustResolveConfig,
   resolveConfigInt,
@@ -186,6 +187,7 @@ export function generateAgentIdSuffix(): string {
  * - MCP_MESH_NAMESPACE: Override namespace
  * - MCP_MESH_REGISTRY_URL: Override registry URL
  * - MCP_MESH_HEALTH_INTERVAL: Override heartbeat interval
+ * - MCP_MESH_HEALTH_CHECK_TTL: Override health-check refresh period
  */
 export function resolveConfig(config: AgentConfig): ResolvedAgentConfig {
   // All config resolution via Rust core - ensures consistent ENV > param > default
@@ -214,6 +216,11 @@ export function resolveConfig(config: AgentConfig): ResolvedAgentConfig {
     namespace: resolvedNamespace,
     registryUrl: resolvedRegistryUrl,
     heartbeatInterval: resolvedHeartbeatInterval,
+    healthCheck: config.healthCheck,
+    // Issue #1476: resolved here (not in Rust core) because the TTL is an
+    // SDK-side timer, not part of the registration envelope — the same
+    // reason Java resolves MCP_MESH_HEALTH_CHECK_TTL in its own registry.
+    healthCheckTtl: resolveHealthCheckTtlFromEnv(config.healthCheckTtl),
   };
 }
 

--- a/src/runtime/typescript/src/express.ts
+++ b/src/runtime/typescript/src/express.ts
@@ -177,6 +177,20 @@ export class MeshExpress {
     // Generate unique service ID with suffix (e.g., "my-api-a1b2c3d4")
     this.serviceId = `${this.config.name}-${generateAgentIdSuffix()}`;
 
+    // Issue #1476: a route agent is a fan-out point — withdrawing a
+    // provider is correct, withdrawing a gateway takes down every path
+    // that enters through it. Python and Java draw the same line (no
+    // health-refresh loop on their API/A2A pipelines). Say so rather than
+    // accepting the option and quietly doing nothing with it.
+    if (config.healthCheck) {
+      console.warn(
+        `[mesh-health] healthCheck is IGNORED on MeshExpress ('${this.config.name}'): ` +
+          `a route agent is a fan-out point, so an unhealthy verdict must not ` +
+          `withdraw it from the mesh. Declare the check on the MCP agents behind ` +
+          `this gateway instead.`,
+      );
+    }
+
     // Add health check endpoint
     this.setupHealthEndpoints();
 

--- a/src/runtime/typescript/src/health-check.ts
+++ b/src/runtime/typescript/src/health-check.ts
@@ -8,8 +8,10 @@
  * stops selecting it — consumers fail over to a surviving provider.
  * Reporting `healthy` (or `degraded`) again resumes heartbeats and the
  * registry restores the agent through the `410 Gone` re-register path,
- * with no process restart. The TTL is therefore the detection latency in
- * BOTH directions: outage and recovery.
+ * with no process restart. The TTL is the CADENCE of that check, not the
+ * end-to-end latency in either direction: withdrawal costs up to one TTL
+ * plus the registry's staleness window once heartbeats stop, and recovery
+ * costs up to one TTL plus the heartbeat resume and re-register round trip.
  *
  * TypeScript half of the mechanism shipped for Python in #1472/#1473 and
  * for Java in #1474/#1475; the verdict vocabulary, the "a broken check

--- a/src/runtime/typescript/src/health-check.ts
+++ b/src/runtime/typescript/src/health-check.ts
@@ -203,14 +203,19 @@ export function resolveHealthCheckTtl(
   override?: string | null,
 ): number {
   let ttl = DEFAULT_HEALTH_CHECK_TTL_SECONDS;
+  // Collected, not logged inline: a warning names the value that is
+  // actually used, and that is not known until every source has been
+  // considered. Warning "using 15s" while a valid env override goes on to
+  // win would print a number the agent never runs with.
+  const rejected: string[] = [];
 
   if (configured !== undefined && configured !== null) {
     if (Number.isInteger(configured) && configured >= 1) {
       ttl = configured;
     } else {
-      console.warn(
-        `[mesh-health] healthCheckTtl=${describeThrown(configured)} is not a ` +
-          `whole number of seconds >= 1 — using ${ttl}s`,
+      rejected.push(
+        `healthCheckTtl=${describeThrown(configured)} is not a whole number ` +
+          `of seconds >= 1`,
       );
     }
   }
@@ -219,15 +224,19 @@ export function resolveHealthCheckTtl(
     const text = override.trim();
     const parsed = INTEGER_RE.test(text) ? Number(text) : Number.NaN;
     if (Number.isInteger(parsed) && parsed >= 1) {
-      return parsed;
+      ttl = parsed;
+    } else {
+      rejected.push(
+        Number.isInteger(parsed)
+          ? `${HEALTH_CHECK_TTL_ENV}=${override} is below the 1s minimum`
+          : `${HEALTH_CHECK_TTL_ENV}=${override} is not an integer number of ` +
+              `seconds`,
+      );
     }
-    console.warn(
-      Number.isInteger(parsed)
-        ? `[mesh-health] ${HEALTH_CHECK_TTL_ENV}=${override} is below the 1s ` +
-            `minimum — using ${ttl}s`
-        : `[mesh-health] ${HEALTH_CHECK_TTL_ENV}=${override} is not an ` +
-            `integer number of seconds — using ${ttl}s`,
-    );
+  }
+
+  for (const reason of rejected) {
+    console.warn(`[mesh-health] ${reason} — using ${ttl}s`);
   }
 
   return ttl;
@@ -236,6 +245,52 @@ export function resolveHealthCheckTtl(
 /** Read {@link HEALTH_CHECK_TTL_ENV} and resolve against it. */
 export function resolveHealthCheckTtlFromEnv(configured?: number | null): number {
   return resolveHealthCheckTtl(configured, process.env[HEALTH_CHECK_TTL_ENV]);
+}
+
+/**
+ * Floor for the deadline a single health check gets. The deadline is the
+ * larger of this and one TTL period, so a slow-but-working probe under a
+ * short TTL is not abandoned while it is still making progress.
+ */
+export const HEALTH_CHECK_TIMEOUT_FLOOR_MS = 30_000;
+
+/**
+ * Deadline for one publish to the mesh runtime.
+ *
+ * `updateHealth` sends on a bounded command channel; a runtime that has
+ * stopped draining it makes the send wait rather than fail, and without a
+ * deadline that wait would be permanent.
+ */
+export const HEALTH_PUBLISH_TIMEOUT_MS = 10_000;
+
+/** Race result marker — deliberately not a value any caller can produce. */
+const TIMED_OUT = Symbol("mesh-health-timed-out");
+
+/**
+ * Await `work`, giving up after `ms`.
+ *
+ * Abandoning is not cancelling: `work` keeps running, and if it settles
+ * later the result is dropped. `Promise.race` has already subscribed to
+ * it, so a late rejection is handled and cannot surface as an unhandled
+ * rejection.
+ */
+async function withDeadline<T>(
+  work: Promise<T>,
+  ms: number,
+): Promise<T | typeof TIMED_OUT> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<typeof TIMED_OUT>((resolve) => {
+        timer = setTimeout(() => resolve(TIMED_OUT), ms);
+        // A pending deadline must not hold a finished process open.
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 export interface HealthCheckLoopOptions {
@@ -291,6 +346,17 @@ export interface HealthCheckLoop {
  * be withdrawn, and nothing after the first error would appear in the
  * logs.
  *
+ * A promise that never settles would be the same silent death by another
+ * route, and it is easy to reach: `await fetch(url)` with no
+ * `AbortSignal` against a black-holed host hangs forever (Node applies no
+ * connect timeout of its own), and a publish waits on a bounded command
+ * channel the runtime may have stopped draining. Both are therefore
+ * bounded — see {@link HEALTH_CHECK_TIMEOUT_FLOOR_MS} and
+ * {@link HEALTH_PUBLISH_TIMEOUT_MS}. Passing the deadline logs and
+ * reschedules; an abandoned check reports `degraded`, because a probe
+ * that never answered concluded nothing about the upstream and must not
+ * withdraw the agent.
+ *
  * The timer is `unref`'d: a pending health refresh must not be the reason
  * a finished Node process stays alive.
  */
@@ -299,6 +365,7 @@ export function startHealthCheckLoop(
 ): HealthCheckLoop {
   const { agentName, healthCheck, ttlSeconds, publish, onVerdict } = options;
   const periodMs = ttlSeconds * 1000;
+  const checkTimeoutMs = Math.max(periodMs, HEALTH_CHECK_TIMEOUT_FLOOR_MS);
 
   let stopped = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -315,7 +382,30 @@ export function startHealthCheckLoop(
   };
 
   const tick = async (publishVerdict: boolean): Promise<void> => {
-    const verdict = await runHealthCheck(healthCheck, agentName);
+    const outcome = await withDeadline(
+      runHealthCheck(healthCheck, agentName),
+      checkTimeoutMs,
+    );
+
+    let verdict: HealthVerdict;
+    if (outcome === TIMED_OUT) {
+      console.warn(
+        `[mesh-health] health check for agent '${agentName}' did not finish ` +
+          `within ${Math.round(checkTimeoutMs / 1000)}s — abandoning this run ` +
+          `and reporting degraded (the agent keeps heartbeating); the next ` +
+          `refresh is scheduled as usual`,
+      );
+      verdict = {
+        status: "degraded",
+        checks: { health_check_completed: false },
+        errors: [
+          `Health check did not complete within ` +
+            `${Math.round(checkTimeoutMs / 1000)}s`,
+        ],
+      };
+    } else {
+      verdict = outcome;
+    }
     latest = verdict;
 
     if (onVerdict) {
@@ -339,7 +429,20 @@ export function startHealthCheckLoop(
     if (!publishVerdict || stopped) return;
 
     try {
-      await publish(verdict.status);
+      // The arrow turns a publish that throws synchronously into a
+      // rejection, so both failure modes land in the same catch.
+      const reported = await withDeadline(
+        (async () => publish(verdict.status))(),
+        HEALTH_PUBLISH_TIMEOUT_MS,
+      );
+      if (reported === TIMED_OUT) {
+        console.warn(
+          `[mesh-health] reporting health status '${verdict.status}' for agent ` +
+            `'${agentName}' to the mesh runtime did not complete within ` +
+            `${Math.round(HEALTH_PUBLISH_TIMEOUT_MS / 1000)}s — abandoning ` +
+            `this report; the next refresh is scheduled as usual`,
+        );
+      }
     } catch (err) {
       console.warn(
         `[mesh-health] failed to report health status '${verdict.status}' for ` +

--- a/src/runtime/typescript/src/health-check.ts
+++ b/src/runtime/typescript/src/health-check.ts
@@ -1,0 +1,376 @@
+/**
+ * Periodic health check that can withdraw this agent from dependency
+ * resolution while its own upstream is down (issue #1476).
+ *
+ * The verdict of the user's `healthCheck` is pushed to the Rust core on
+ * every tick. While it is `unhealthy` the core stops heartbeating, the
+ * registry's staleness sweep marks the agent unhealthy, and resolution
+ * stops selecting it — consumers fail over to a surviving provider.
+ * Reporting `healthy` (or `degraded`) again resumes heartbeats and the
+ * registry restores the agent through the `410 Gone` re-register path,
+ * with no process restart. The TTL is therefore the detection latency in
+ * BOTH directions: outage and recovery.
+ *
+ * TypeScript half of the mechanism shipped for Python in #1472/#1473 and
+ * for Java in #1474/#1475; the verdict vocabulary, the "a broken check
+ * degrades, it does not withdraw" rule, and the `checks`/`errors` keys
+ * are deliberately identical across the three.
+ *
+ * ## Only providers are gated
+ *
+ * This loop runs for MCP agents (`mesh(server, ...)`) only. `mesh.route`
+ * and A2A agents are fan-out points: withdrawing a provider is correct,
+ * withdrawing a gateway takes down every path that enters through it.
+ * Python encodes the same asymmetry by giving its API and A2A pipelines
+ * no health-refresh loop at all.
+ */
+
+/** The verdict vocabulary shared by all three runtimes. */
+export type MeshHealthStatus = "healthy" | "degraded" | "unhealthy";
+
+/**
+ * The rich shape a `healthCheck` may return. A bare `boolean` is also
+ * accepted (`true` → healthy, `false` → unhealthy).
+ */
+export interface MeshHealthResult {
+  /**
+   * `"healthy"`, `"degraded"` or `"unhealthy"`. Omitted means healthy —
+   * a result that carries only `checks` is reporting success (Python
+   * parity: `user_result.get("status", "healthy")`).
+   */
+  status?: MeshHealthStatus | string;
+  /** Named sub-probes, surfaced verbatim for operators. */
+  checks?: Record<string, unknown>;
+  /** Human-readable reasons, surfaced verbatim for operators. */
+  errors?: string[];
+}
+
+/**
+ * A user health check. May be sync or async.
+ *
+ * Return `unhealthy` only for conditions the mesh should route AROUND —
+ * the upstream this agent needs is genuinely not serving. An
+ * indeterminate probe (cancelled, cut short) says nothing about the
+ * upstream and must be `degraded`, which keeps the heartbeat alive.
+ */
+export type MeshHealthCheck = () =>
+  | boolean
+  | MeshHealthResult
+  | Promise<boolean | MeshHealthResult>;
+
+/** A normalized verdict — what the loop stores and publishes. */
+export interface HealthVerdict {
+  status: MeshHealthStatus;
+  checks: Record<string, unknown>;
+  errors: string[];
+}
+
+/** Python's `health_check_ttl` default, and Java's `DEFAULT_TTL_SECONDS`. */
+export const DEFAULT_HEALTH_CHECK_TTL_SECONDS = 15;
+
+/** Overrides the configured `healthCheckTtl` when set. */
+export const HEALTH_CHECK_TTL_ENV = "MCP_MESH_HEALTH_CHECK_TTL";
+
+/** Integers only — `"15s"`, `"1.5"` and `"0x10"` are all rejected. */
+const INTEGER_RE = /^[+-]?\d+$/;
+
+/**
+ * Render anything a `throw` can produce, including non-`Error` values and
+ * objects whose `toString` itself throws. The health loop must survive
+ * every one of them: a formatting failure here would take out the very
+ * mechanism whose job is to notice failures.
+ */
+export function describeThrown(err: unknown): string {
+  if (err instanceof Error) return err.message || err.name;
+  try {
+    return String(err);
+  } catch {
+    return "<unprintable value>";
+  }
+}
+
+/**
+ * Convert whatever a health check returned into a verdict.
+ *
+ * Never throws. Anything unrecognized becomes `degraded`, NOT
+ * `unhealthy`: an unparseable result is a reporting defect, and
+ * withdrawing a working agent from the mesh over one is a far worse
+ * failure than keeping it. Same rule as Java's `MeshHealthCheckRegistry.coerce`.
+ */
+export function normalizeHealthResult(raw: unknown): HealthVerdict {
+  if (typeof raw === "boolean") {
+    // Python parity: true → healthy, false → unhealthy.
+    return raw
+      ? { status: "healthy", checks: { health_check: true }, errors: [] }
+      : {
+          status: "unhealthy",
+          checks: { health_check: false },
+          errors: ["Health check returned false"],
+        };
+  }
+
+  if (raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
+    const result = raw as MeshHealthResult;
+    const rawStatus = result.status;
+    // A result with no `status` is reporting success (Python parity).
+    const status =
+      rawStatus === undefined || rawStatus === null
+        ? "healthy"
+        : toStatus(rawStatus);
+    if (status === null) {
+      return {
+        status: "degraded",
+        checks: { health_check_status_value: false },
+        errors: [`Unrecognized health status: ${describeThrown(rawStatus)}`],
+      };
+    }
+    return {
+      status,
+      checks: isPlainRecord(result.checks) ? result.checks : {},
+      errors: Array.isArray(result.errors)
+        ? result.errors.map((e) => (typeof e === "string" ? e : describeThrown(e)))
+        : [],
+    };
+  }
+
+  return {
+    status: "degraded",
+    checks: { health_check_return_type: false },
+    errors: [
+      `Invalid return type: ${raw === null ? "null" : typeof raw}. A health ` +
+        `check returns a boolean or { status, checks, errors }.`,
+    ],
+  };
+}
+
+function toStatus(value: unknown): MeshHealthStatus | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "healthy" ||
+    normalized === "degraded" ||
+    normalized === "unhealthy"
+    ? normalized
+    : null;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Run a health check and normalize its verdict. Never throws and never
+ * rejects.
+ *
+ * A check that THROWS becomes `degraded`, not `unhealthy`: a buggy health
+ * check must not be able to withdraw a working agent from the mesh.
+ */
+export async function runHealthCheck(
+  healthCheck: MeshHealthCheck,
+  agentName: string,
+): Promise<HealthVerdict> {
+  try {
+    return normalizeHealthResult(await healthCheck());
+  } catch (err) {
+    const reason = describeThrown(err);
+    console.warn(
+      `[mesh-health] health check for agent '${agentName}' threw — ` +
+        `reporting degraded (the agent keeps heartbeating): ${reason}`,
+    );
+    return {
+      status: "degraded",
+      checks: { health_check_execution: false },
+      errors: [`Health check failed: ${reason}`],
+    };
+  }
+}
+
+/**
+ * Resolve the refresh period, in seconds.
+ *
+ * Priority: `MCP_MESH_HEALTH_CHECK_TTL` > `healthCheckTtl` > 15s. Every
+ * rejected value warns and falls through to the next source rather than
+ * throwing — a malformed TTL must not stop an agent from booting, but it
+ * must not be silently rounded into something else either.
+ *
+ * `override` is a parameter rather than an ambient `process.env` read so
+ * the resolution rules are testable without mutating the environment.
+ *
+ * @param configured value from `AgentConfig.healthCheckTtl`
+ * @param override raw {@link HEALTH_CHECK_TTL_ENV} value, or null/undefined
+ */
+export function resolveHealthCheckTtl(
+  configured?: number | null,
+  override?: string | null,
+): number {
+  let ttl = DEFAULT_HEALTH_CHECK_TTL_SECONDS;
+
+  if (configured !== undefined && configured !== null) {
+    if (Number.isInteger(configured) && configured >= 1) {
+      ttl = configured;
+    } else {
+      console.warn(
+        `[mesh-health] healthCheckTtl=${describeThrown(configured)} is not a ` +
+          `whole number of seconds >= 1 — using ${ttl}s`,
+      );
+    }
+  }
+
+  if (typeof override === "string" && override.trim() !== "") {
+    const text = override.trim();
+    const parsed = INTEGER_RE.test(text) ? Number(text) : Number.NaN;
+    if (Number.isInteger(parsed) && parsed >= 1) {
+      return parsed;
+    }
+    console.warn(
+      Number.isInteger(parsed)
+        ? `[mesh-health] ${HEALTH_CHECK_TTL_ENV}=${override} is below the 1s ` +
+            `minimum — using ${ttl}s`
+        : `[mesh-health] ${HEALTH_CHECK_TTL_ENV}=${override} is not an ` +
+            `integer number of seconds — using ${ttl}s`,
+    );
+  }
+
+  return ttl;
+}
+
+/** Read {@link HEALTH_CHECK_TTL_ENV} and resolve against it. */
+export function resolveHealthCheckTtlFromEnv(configured?: number | null): number {
+  return resolveHealthCheckTtl(configured, process.env[HEALTH_CHECK_TTL_ENV]);
+}
+
+export interface HealthCheckLoopOptions {
+  agentName: string;
+  healthCheck: MeshHealthCheck;
+  /** Refresh period in seconds (already resolved). */
+  ttlSeconds: number;
+  /**
+   * Push the verdict to the mesh runtime. Not called for the seed run —
+   * see {@link startHealthCheckLoop}.
+   */
+  publish: (status: MeshHealthStatus) => boolean | Promise<boolean>;
+  /** Notified for every verdict, seed included. Must not throw. */
+  onVerdict?: (verdict: HealthVerdict) => void;
+}
+
+export interface HealthCheckLoop {
+  /** The most recent verdict, or null before the seed run completes. */
+  latest(): HealthVerdict | null;
+  /** Stop refreshing. Idempotent. */
+  stop(): void;
+  /**
+   * Resolves once the seed run (and its scheduling) has settled. Exposed
+   * for tests; production code never awaits it — see below.
+   */
+  seeded(): Promise<void>;
+}
+
+/**
+ * Start the refresh loop. Returns immediately.
+ *
+ * ## Startup ordering (deliberate)
+ *
+ * The seed run is scheduled, not awaited, and does NOT publish. Two
+ * reasons, both shared with Python and Java:
+ *
+ * 1. A scaffolded provider's check is an HTTP call to a vendor. Awaiting
+ *    it here would stall agent startup for as long as that vendor takes
+ *    to answer — a hung vendor would hang the boot.
+ * 2. A check that fails during boot (a pool not warm yet, a lazily built
+ *    client) must not withdraw an agent that has only just registered.
+ *    The agent registers and becomes visible first; the first PUBLISHED
+ *    verdict is one TTL later.
+ *
+ * ## Failure containment
+ *
+ * A tick can never stop the loop. `runHealthCheck` already converts a
+ * throwing check to `degraded`, and every remaining step — the verdict
+ * callback, the publish, and the formatting of their own errors — is
+ * guarded, with rescheduling in a `finally`. The failure this prevents is
+ * specific and silent: one unhandled rejection would leave the agent
+ * running with a health check that never runs again, so it could never
+ * be withdrawn, and nothing after the first error would appear in the
+ * logs.
+ *
+ * The timer is `unref`'d: a pending health refresh must not be the reason
+ * a finished Node process stays alive.
+ */
+export function startHealthCheckLoop(
+  options: HealthCheckLoopOptions,
+): HealthCheckLoop {
+  const { agentName, healthCheck, ttlSeconds, publish, onVerdict } = options;
+  const periodMs = ttlSeconds * 1000;
+
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let latest: HealthVerdict | null = null;
+
+  const scheduleNext = (): void => {
+    if (stopped) return;
+    timer = setTimeout(() => {
+      timer = null;
+      void run();
+    }, periodMs);
+    // `unref` is Node-only; a non-Node timer shim simply keeps a ref.
+    timer.unref?.();
+  };
+
+  const tick = async (publishVerdict: boolean): Promise<void> => {
+    const verdict = await runHealthCheck(healthCheck, agentName);
+    latest = verdict;
+
+    if (onVerdict) {
+      try {
+        onVerdict(verdict);
+      } catch (err) {
+        console.warn(
+          `[mesh-health] health verdict listener for agent '${agentName}' ` +
+            `threw: ${describeThrown(err)}`,
+        );
+      }
+    }
+
+    if (verdict.status === "unhealthy") {
+      console.warn(
+        `[mesh-health] agent '${agentName}' reports UNHEALTHY: ` +
+          `${verdict.errors.join("; ") || "(no detail)"}`,
+      );
+    }
+
+    if (!publishVerdict || stopped) return;
+
+    try {
+      await publish(verdict.status);
+    } catch (err) {
+      console.warn(
+        `[mesh-health] failed to report health status '${verdict.status}' for ` +
+          `agent '${agentName}' to the mesh runtime: ${describeThrown(err)}`,
+      );
+    }
+  };
+
+  const run = (publishVerdict = true): Promise<void> =>
+    tick(publishVerdict)
+      .catch((err) => {
+        // Defence in depth: `tick` is already total. Reaching here means
+        // the guarding itself broke, and the loop must still continue.
+        console.warn(
+          `[mesh-health] health refresh for agent '${agentName}' failed ` +
+            `unexpectedly: ${describeThrown(err)}`,
+        );
+      })
+      .finally(() => scheduleNext());
+
+  const seedPromise = run(false);
+
+  return {
+    latest: () => latest,
+    stop: () => {
+      stopped = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+    seeded: () => seedPromise,
+  };
+}

--- a/src/runtime/typescript/src/index.ts
+++ b/src/runtime/typescript/src/index.ts
@@ -198,6 +198,20 @@ export {
 // `A2ADependencies` are both aliases of `PositionalDependencies`.
 export type { PositionalDependencies } from "./positional-deps.js";
 
+// Health check (issue #1476) — an `unhealthy` verdict withdraws the agent
+// from dependency resolution until the check passes again.
+export {
+  DEFAULT_HEALTH_CHECK_TTL_SECONDS,
+  HEALTH_CHECK_TTL_ENV,
+  normalizeHealthResult,
+  resolveHealthCheckTtl,
+  runHealthCheck,
+  type MeshHealthCheck,
+  type MeshHealthResult,
+  type MeshHealthStatus,
+  type HealthVerdict,
+} from "./health-check.js";
+
 // Service views (RFC #1280) — consumer view factory + facade types.
 export {
   serviceView,

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -305,15 +305,19 @@ export interface AgentConfig {
    * ```typescript
    * healthCheck: async () => {
    *   const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
-   *   return res.ok ? true : { status: "unhealthy", errors: [`HTTP ${res.status}`] };
+   *   return res.status === 200
+   *     ? true
+   *     : { status: "unhealthy", errors: [`HTTP ${res.status}`] };
    * }
    * ```
    */
   healthCheck?: MeshHealthCheck;
   /**
    * Issue #1476: how often {@link healthCheck} runs, in seconds. This is
-   * also the detection latency in both directions — outage and recovery.
-   * Env: MCP_MESH_HEALTH_CHECK_TTL. Defaults to 15.
+   * the cadence, not the end-to-end latency: withdrawal costs up to one
+   * TTL plus the registry's staleness window once heartbeats stop, and
+   * recovery costs up to one TTL plus the heartbeat resume and re-register
+   * round trip. Env: MCP_MESH_HEALTH_CHECK_TTL. Defaults to 15.
    */
   healthCheckTtl?: number;
 }

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -4,6 +4,7 @@
 
 import { z } from "zod";
 import type { ServiceView } from "./service-view.js";
+import type { MeshHealthCheck } from "./health-check.js";
 
 /**
  * Metadata for media-typed tool parameters.
@@ -264,6 +265,7 @@ export interface ResolvedDependency {
  * - MCP_MESH_NAMESPACE: Override namespace
  * - MCP_MESH_REGISTRY_URL: Override registry URL
  * - MCP_MESH_HEALTH_INTERVAL: Override heartbeat interval
+ * - MCP_MESH_HEALTH_CHECK_TTL: Override health-check refresh period
  */
 export interface AgentConfig {
   /** Unique agent name/identifier. Env: MCP_MESH_AGENT_NAME */
@@ -280,6 +282,40 @@ export interface AgentConfig {
   namespace?: string;
   /** Heartbeat interval in seconds. Env: MCP_MESH_HEALTH_INTERVAL. Defaults to 5 */
   heartbeatInterval?: number;
+  /**
+   * Issue #1476: a check the agent runs on a timer to decide whether it
+   * should keep receiving traffic.
+   *
+   * While it reports `unhealthy` the agent stops heartbeating, so the
+   * registry withdraws it from dependency resolution and consumers fail
+   * over to a surviving provider. Reporting `healthy` (or `degraded`)
+   * again restores it — the process keeps running throughout.
+   *
+   * Return `unhealthy` only for conditions the mesh should route AROUND:
+   * the upstream this agent needs is genuinely not serving. A check that
+   * throws, or that could not reach a conclusion, is `degraded` and keeps
+   * the heartbeat alive — a broken probe says nothing about the upstream,
+   * and withdrawing a working agent over one is the worse failure.
+   *
+   * Honoured by MCP agents (`mesh(server, ...)`). `mesh.route` and A2A
+   * agents deliberately ignore it: they are fan-out points, and
+   * withdrawing a gateway takes down every path that enters through it.
+   *
+   * @example
+   * ```typescript
+   * healthCheck: async () => {
+   *   const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+   *   return res.ok ? true : { status: "unhealthy", errors: [`HTTP ${res.status}`] };
+   * }
+   * ```
+   */
+  healthCheck?: MeshHealthCheck;
+  /**
+   * Issue #1476: how often {@link healthCheck} runs, in seconds. This is
+   * also the detection latency in both directions — outage and recovery.
+   * Env: MCP_MESH_HEALTH_CHECK_TTL. Defaults to 15.
+   */
+  healthCheckTtl?: number;
 }
 
 /**
@@ -295,6 +331,10 @@ export interface ResolvedAgentConfig {
   namespace: string;
   registryUrl: string;
   heartbeatInterval: number;
+  /** Issue #1476: user health check, or undefined when none is declared. */
+  healthCheck?: MeshHealthCheck;
+  /** Issue #1476: resolved refresh period in seconds (env > config > 15). */
+  healthCheckTtl: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Python (#1472, #1473) and Java (#1474) can already stop heartbeating while their own health check fails, so the registry ages the agent out and consumers re-resolve to a surviving provider. TypeScript could not, so a TS provider kept attracting traffic straight through an upstream outage. This closes the last runtime gap.

- **Rust core** — napi binding for `updateHealth`, mirroring the pyo3 and C-ABI siblings. `RuntimeCommand::UpdateHealth` and `runtime.rs` are unchanged: only `Unhealthy` suppresses the heartbeat, `Degraded` beats exactly like `Healthy`.
- **TypeScript SDK** — `healthCheck` and `healthCheckTtl` on `AgentConfig`/`ResolvedAgentConfig`, resolved from `MCP_MESH_HEALTH_CHECK_TTL`, plus the periodic refresh loop. The seed run is scheduled rather than awaited so a hung vendor cannot hang boot; both the check and the publish are raced against a deadline so a never-settling promise cannot permanently stop the loop; unrecognized, null and partial returns degrade rather than withdraw.
- **Scaffold** — real probes for Anthropic, OpenAI and Gemini plus a skeleton for other vendors.
- `express.ts` warns that `healthCheck` is ignored on route agents instead of accepting it and doing nothing. Route and A2A agents stay ungated by design — they are fan-out points, and withdrawing one takes down every path entering through it.

Four doc surfaces asserted that TypeScript has no user health check and would otherwise have shipped false in the same release.

## Review notes

A cross-runtime scaffold guard (`health_check_template_test.go`) asserts across Python, TypeScript and Java × 3 vendors that the vendor-outage branch reports unhealthy. **Both the Java and Python templates shipped that mapping inverted** — a vendor outage returned `degraded`, which keeps heartbeating, so a scaffolded provider could never withdraw itself. It read as reasonable in review because what `degraded` *does* lives in a file those diffs never touched. This makes the regression mechanical to catch. Every extension was verified red before green: inverting Java's gemini transport branch fails only `java_gemini`, inverting Python's openai outage branch fails only `python_openai`.

Two things review found that could not fail, both removed rather than kept:

- `isProbeCancelled` in the TS template matched `AbortError`, but the generated code creates no `AbortController` and `AbortSignal.timeout` rejects with `TimeoutError` — the helper and three degraded branches were dead in every scaffolded agent, and the test covering them only asserted that dead text renders.
- `section()` in the guard silently widened its assertion window to the rest of the file when an end marker went missing; that now fails hard.

Known gaps, each with an issue and deliberately not addressed here:

- #1479 — the scaffold vendor gate over-matches `bedrock/anthropic.*` and `vertex_ai/gemini-*`, so those providers would withdraw themselves while healthy. Pre-existing on `main` in Python and Java; repo-wide fix. **This should gate 3.5.2.**
- #1478 — TS `/ready` and `/health` are FastMCP's built-ins and do not reflect the verdict. Mesh resolution is unaffected; k8s Service traffic and operator diagnostics are.
- #1480 — no integration coverage for the withdrawal/recovery chain in any runtime but Python.
- #1477 — Python maps a malformed health-check return to `UNHEALTHY` where TS and Java use `DEGRADED`.

Closes #1476

## Test plan

- [x] Rust 488 serial, 502 with `--features typescript` (+14 napi, incl. 2 `test_1476_*`)
- [x] TypeScript 1339 across 90 files; `tsc --noEmit` and the express5 typecheck clean
- [x] Go build clean; `go test ./src/core/cli/...` incl. 30 scaffold-guard subtests
- [x] Rendered TS scaffolds (claude/openai/gemini/skeleton) type-check against the built SDK
- [x] E2E: two providers + consumer, `healthCheckTtl: 3` — withdrawal, failover, recovery via `410 Gone` re-register, **provider process alive throughout** (pid unchanged)
- [x] Guard shown red on five deliberate inversions, each reverted byte-identical


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable TypeScript agent health checks with periodic monitoring and customizable refresh intervals.
  - Health results now support healthy, degraded, and unhealthy states, including automatic recovery and agent availability updates.
  - Added provider-specific health checks for Anthropic, OpenAI, and Gemini in generated TypeScript agents.
  - Added environment-variable support for overriding health-check intervals.

- **Documentation**
  - Expanded health-check configuration, runtime behavior, failure handling, and endpoint documentation.

- **Bug Fixes**
  - Route agents now warn when health checks are configured but ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->