### PR TITLE
fix(meshctl): scaffold vendor gate over-matches, withdrawing healthy providers

### DIFF
--- a/cmd/meshctl/templates/java/llm-provider/README.md.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/README.md.tmpl
@@ -16,10 +16,13 @@ This is a zero-code LLM provider agent that exposes {{ .Model }} to the mesh net
 
 ### Configuration
 
-Set your API key:
+Set the credentials for your model:
 
 ```bash
-{{ if contains .Model "anthropic" }}export ANTHROPIC_API_KEY=your-key-here{{ else if contains .Model "openai" }}export OPENAI_API_KEY=your-key-here{{ else }}# Set the appropriate API key for your model{{ end }}
+{{ if eq .ProbeVendor "anthropic" }}export ANTHROPIC_API_KEY=your-key-here{{ else if eq .ProbeVendor "openai" }}export OPENAI_API_KEY=your-key-here{{ else if eq .ProbeVendor "gemini" }}export GOOGLE_API_KEY=your-key-here{{ else }}# Set the credentials {{ .Model }} authenticates with. For a gateway-prefixed
+# model (bedrock/..., vertex_ai/..., databricks/...) those are the gateway's own
+# credentials — AWS credentials, ADC / Workload Identity, a workspace token —
+# not the underlying model vendor's API key.{{ end }}
 ```
 
 ### Running the Provider

--- a/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -9,7 +9,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 {{- $model := default "anthropic/claude-sonnet-5" .Model }}
-{{- if or (contains $model "anthropic") (contains $model "openai") (contains $model "gemini") }}
+{{- /* Which vendor API this model can actually be probed against, if any.
+     Resolved from $model rather than read off .ProbeVendor because $model
+     carries the default above. A substring test would send
+     bedrock/anthropic.* and vertex_ai/gemini-* into a probe of credentials
+     those deployments never have (issue #1479). */}}
+{{- $probeVendor := probeVendor $model }}
+{{- if $probeVendor }}
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -34,7 +40,7 @@ import java.time.Duration;
 @MeshLlmProvider(
     model = "{{ $model }}",
     capability = "llm",
-    tags = {{ "{" }}{{ if .Tags }}{{ range $i, $t := .Tags }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}{{ else if contains $model "anthropic" }}"llm", "claude", "anthropic", "provider"{{ else if contains $model "openai" }}"llm", "openai", "gpt", "provider"{{ else if contains $model "gemini" }}"llm", "gemini", "google", "provider"{{ else }}"llm", "provider"{{ end }}{{ "}" }},
+    tags = {{ "{" }}{{ if .Tags }}{{ range $i, $t := .Tags }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}{{ else if eq $probeVendor "anthropic" }}"llm", "claude", "anthropic", "provider"{{ else if eq $probeVendor "openai" }}"llm", "openai", "gpt", "provider"{{ else if eq $probeVendor "gemini" }}"llm", "gemini", "google", "provider"{{ else }}"llm", "provider"{{ end }}{{ "}" }},
     version = "1.0.0"
 )
 @SpringBootApplication
@@ -56,7 +62,7 @@ public class {{ .NamePascal }}Application {
     // Runs every ttlSeconds. While it returns unhealthy the agent stops
     // heartbeating, the registry withdraws it, and consumers fail over to
     // another provider — automatically restored when the check passes again.
-{{ if contains $model "anthropic" }}
+{{ if eq $probeVendor "anthropic" }}
     private static final HttpClient HTTP = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(5))
         .build();
@@ -125,7 +131,7 @@ public class {{ .NamePascal }}Application {
                 .withError("Anthropic API unreachable: " + e);
         }
     }
-{{ else if contains $model "openai" }}
+{{ else if eq $probeVendor "openai" }}
     private static final HttpClient HTTP = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(5))
         .build();
@@ -191,7 +197,7 @@ public class {{ .NamePascal }}Application {
                 .withError("OpenAI API unreachable: " + e);
         }
     }
-{{ else if contains $model "gemini" }}
+{{ else if eq $probeVendor "gemini" }}
     private static final HttpClient HTTP = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(5))
         .build();
@@ -273,6 +279,16 @@ public class {{ .NamePascal }}Application {
      * call to your provider — a models/list endpoint or equivalent, NOT a
      * completion — and return MeshHealth.unhealthy(...) when it fails. That is
      * what makes the mesh withdraw this agent and fail consumers over.
+     *
+     * Probe the gateway you actually authenticate against. For a
+     * gateway-prefixed model (bedrock/..., vertex_ai/..., databricks/..., an
+     * OpenAI-compatible proxy) that is the gateway's own endpoint and the
+     * gateway's own credentials — AWS SigV4, ADC / Workload Identity, your
+     * proxy's token. It is NOT the underlying model vendor's public API: that
+     * endpoint can be perfectly healthy while your gateway is down, and the
+     * vendor API key it wants is one your deployment never sets, so a check
+     * gated on it would report unhealthy forever and withdraw this agent
+     * permanently.
      */
     @MeshHealthCheck(ttlSeconds = 30)
     public MeshHealth healthCheck() {

--- a/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -15,6 +15,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
      bedrock/anthropic.* and vertex_ai/gemini-* into a probe of credentials
      those deployments never have (issue #1479). */}}
 {{- $probeVendor := probeVendor $model }}
+{{- /* Which big-3 family built this model, if any. A DIFFERENT question from
+     $probeVendor, and the answers diverge on gateways: bedrock/anthropic.* is
+     genuinely Claude and must keep the claude/anthropic discovery tags a
+     `--vendor claude` consumer pins with +claude, while having no probeable
+     direct vendor API. */}}
+{{- $family := modelFamily $model }}
 {{- if $probeVendor }}
 
 import java.net.URI;
@@ -40,7 +46,7 @@ import java.time.Duration;
 @MeshLlmProvider(
     model = "{{ $model }}",
     capability = "llm",
-    tags = {{ "{" }}{{ if .Tags }}{{ range $i, $t := .Tags }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}{{ else if eq $probeVendor "anthropic" }}"llm", "claude", "anthropic", "provider"{{ else if eq $probeVendor "openai" }}"llm", "openai", "gpt", "provider"{{ else if eq $probeVendor "gemini" }}"llm", "gemini", "google", "provider"{{ else }}"llm", "provider"{{ end }}{{ "}" }},
+    tags = {{ "{" }}{{ if .Tags }}{{ range $i, $t := .Tags }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}{{ else if eq $family "anthropic" }}"llm", "claude", "anthropic", "provider"{{ else if eq $family "openai" }}"llm", "openai", "gpt", "provider"{{ else if eq $family "gemini" }}"llm", "gemini", "google", "provider"{{ else }}"llm", "provider"{{ end }}{{ "}" }},
     version = "1.0.0"
 )
 @SpringBootApplication

--- a/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -15,12 +15,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
      bedrock/anthropic.* and vertex_ai/gemini-* into a probe of credentials
      those deployments never have (issue #1479). */}}
 {{- $probeVendor := probeVendor $model }}
-{{- /* Which big-3 family built this model, if any. A DIFFERENT question from
+{{- /* The discovery tags below come from `providerTags`, which resolves the
+     big-3 FAMILY that built the model - a DIFFERENT question from
      $probeVendor, and the answers diverge on gateways: bedrock/anthropic.* is
      genuinely Claude and must keep the claude/anthropic discovery tags a
      `--vendor claude` consumer pins with +claude, while having no probeable
-     direct vendor API. */}}
-{{- $family := modelFamily $model }}
+     direct vendor API. The tag lists themselves live in Go
+     (providerTagsByFamily) so the three language templates cannot drift. */}}
 {{- if $probeVendor }}
 
 import java.net.URI;
@@ -46,7 +47,7 @@ import java.time.Duration;
 @MeshLlmProvider(
     model = "{{ $model }}",
     capability = "llm",
-    tags = {{ "{" }}{{ if .Tags }}{{ range $i, $t := .Tags }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}{{ else if eq $family "anthropic" }}"llm", "claude", "anthropic", "provider"{{ else if eq $family "openai" }}"llm", "openai", "gpt", "provider"{{ else if eq $family "gemini" }}"llm", "gemini", "google", "provider"{{ else }}"llm", "provider"{{ end }}{{ "}" }},
+    tags = {{ "{" }}{{ if .Tags }}{{ range $i, $t := .Tags }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}{{ else }}{{ range $i, $t := providerTags $model }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}{{ end }}{{ "}" }},
     version = "1.0.0"
 )
 @SpringBootApplication

--- a/cmd/meshctl/templates/python/llm-provider/README.md.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/README.md.tmpl
@@ -14,7 +14,7 @@ This is a zero-code LLM provider that exposes {{ .Model }} to other MCP Mesh age
 - MCP Mesh SDK
 - FastMCP
 - LiteLLM
-{{ if contains .Model "anthropic" }}- ANTHROPIC_API_KEY environment variable{{ else if contains .Model "openai" }}- OPENAI_API_KEY environment variable{{ else if contains .Model "gemini" }}- GOOGLE_API_KEY environment variable{{ end }}
+{{ if eq .ProbeVendor "anthropic" }}- ANTHROPIC_API_KEY environment variable{{ else if eq .ProbeVendor "openai" }}- OPENAI_API_KEY environment variable{{ else if eq .ProbeVendor "gemini" }}- GOOGLE_API_KEY environment variable{{ else }}- Credentials for {{ .Model }}{{ end }}
 
 ### Installation
 
@@ -24,20 +24,23 @@ pip install -r requirements.txt
 
 ### Environment Variables
 
-{{ if contains .Model "anthropic" }}
+{{ if eq .ProbeVendor "anthropic" }}
 ```bash
 export ANTHROPIC_API_KEY="your-api-key"
 ```
-{{ else if contains .Model "openai" }}
+{{ else if eq .ProbeVendor "openai" }}
 ```bash
 export OPENAI_API_KEY="your-api-key"
 ```
-{{ else if contains .Model "gemini" }}
+{{ else if eq .ProbeVendor "gemini" }}
 ```bash
 export GOOGLE_API_KEY="your-api-key"
 ```
 {{ else }}
-Set the appropriate API key for your LLM provider.
+Set the credentials {{ .Model }} authenticates with. For a gateway-prefixed
+model (`bedrock/...`, `vertex_ai/...`, `databricks/...`) those are the
+gateway's own credentials - AWS credentials, ADC / Workload Identity, a
+workspace token - not the underlying model vendor's API key.
 {{ end }}
 
 ### Running the Provider
@@ -101,17 +104,19 @@ def my_llm_tool(ctx: MyContext, llm: mesh.MeshLlmAgent = None):
 ## Health Check
 
 The provider includes a health check that validates:
-{{ if contains .Model "anthropic" }}
+{{ if eq .ProbeVendor "anthropic" }}
 - ANTHROPIC_API_KEY is set
 - Anthropic API is reachable
-{{ else if contains .Model "openai" }}
+{{ else if eq .ProbeVendor "openai" }}
 - OPENAI_API_KEY is set
 - OpenAI API is reachable
-{{ else if contains .Model "gemini" }}
+{{ else if eq .ProbeVendor "gemini" }}
 - GOOGLE_API_KEY is set
 - Google Gemini API is reachable
 {{ else }}
-- Provider is configured correctly
+- Nothing yet: `health_check()` in `main.py` is a skeleton that always reports
+  healthy. Implement it against the endpoint {{ .Model }} is actually served
+  from, or this agent cannot withdraw itself when that endpoint is down.
 {{ end }}
 
 Health status is cached for 30 seconds.

--- a/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
@@ -247,7 +247,11 @@ async def health_check() -> dict:
 @mesh.llm_provider(
     model="{{ .Model }}",
     capability="llm",
-    tags={{ if .Tags }}{{ toJSON .Tags }}{{ else if eq .ProbeVendor "anthropic" }}["llm", "claude", "anthropic", "provider"]{{ else if eq .ProbeVendor "openai" }}["llm", "openai", "gpt", "provider"]{{ else if eq .ProbeVendor "gemini" }}["llm", "gemini", "google", "provider"]{{ else }}["llm", "provider"]{{ end }},
+    {{/* Tags follow the model FAMILY, not the probeable vendor: a
+         bedrock/anthropic.claude-* provider is still Claude and must stay
+         discoverable by a consumer pinning +claude, even though it has no
+         probeable direct vendor API (issue #1479). */ -}}
+    tags={{ if .Tags }}{{ toJSON .Tags }}{{ else if eq .ModelFamily "anthropic" }}["llm", "claude", "anthropic", "provider"]{{ else if eq .ModelFamily "openai" }}["llm", "openai", "gpt", "provider"]{{ else if eq .ModelFamily "gemini" }}["llm", "gemini", "google", "provider"]{{ else }}["llm", "provider"]{{ end }},
     version="1.0.0",
 )
 def {{ toSnakeCase .Name }}():

--- a/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
@@ -17,7 +17,7 @@ app = FastMCP("{{ toPascalCase .Name }}")
 
 
 # ===== HEALTH CHECK =====
-{{ if contains .Model "anthropic" }}
+{{ if eq .ProbeVendor "anthropic" }}
 async def health_check() -> dict:
     """
     Health check for {{ .Name }}.
@@ -82,7 +82,7 @@ async def health_check() -> dict:
         "checks": checks,
         "errors": errors,
     }
-{{ else if contains .Model "openai" }}
+{{ else if eq .ProbeVendor "openai" }}
 async def health_check() -> dict:
     """
     Health check for {{ .Name }}.
@@ -144,7 +144,7 @@ async def health_check() -> dict:
         "checks": checks,
         "errors": errors,
     }
-{{ else if contains .Model "gemini" }}
+{{ else if eq .ProbeVendor "gemini" }}
 async def health_check() -> dict:
     """
     Health check for {{ .Name }}.
@@ -221,6 +221,16 @@ async def health_check() -> dict:
     completion - and return {"status": "unhealthy", ...} when it fails. That is
     what makes the mesh withdraw this agent and fail consumers over.
 
+    Probe the gateway you actually authenticate against. For a
+    gateway-prefixed model (bedrock/..., vertex_ai/..., databricks/..., an
+    OpenAI-compatible proxy) that is the gateway's own endpoint and the
+    gateway's own credentials - AWS SigV4, ADC / Workload Identity, your
+    proxy's token. It is NOT the underlying model vendor's public API: that
+    endpoint can be perfectly healthy while your gateway is down, and the
+    vendor API key it wants is one your deployment never sets, so a check
+    gated on it would report unhealthy forever and withdraw this agent
+    permanently.
+
     Returns:
         dict: Health status
     """
@@ -237,7 +247,7 @@ async def health_check() -> dict:
 @mesh.llm_provider(
     model="{{ .Model }}",
     capability="llm",
-    tags={{ if .Tags }}{{ toJSON .Tags }}{{ else if contains .Model "anthropic" }}["llm", "claude", "anthropic", "provider"]{{ else if contains .Model "openai" }}["llm", "openai", "gpt", "provider"]{{ else if contains .Model "gemini" }}["llm", "gemini", "google", "provider"]{{ else }}["llm", "provider"]{{ end }},
+    tags={{ if .Tags }}{{ toJSON .Tags }}{{ else if eq .ProbeVendor "anthropic" }}["llm", "claude", "anthropic", "provider"]{{ else if eq .ProbeVendor "openai" }}["llm", "openai", "gpt", "provider"]{{ else if eq .ProbeVendor "gemini" }}["llm", "gemini", "google", "provider"]{{ else }}["llm", "provider"]{{ end }},
     version="1.0.0",
 )
 def {{ toSnakeCase .Name }}():

--- a/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
@@ -251,7 +251,7 @@ async def health_check() -> dict:
          bedrock/anthropic.claude-* provider is still Claude and must stay
          discoverable by a consumer pinning +claude, even though it has no
          probeable direct vendor API (issue #1479). */ -}}
-    tags={{ if .Tags }}{{ toJSON .Tags }}{{ else if eq .ModelFamily "anthropic" }}["llm", "claude", "anthropic", "provider"]{{ else if eq .ModelFamily "openai" }}["llm", "openai", "gpt", "provider"]{{ else if eq .ModelFamily "gemini" }}["llm", "gemini", "google", "provider"]{{ else }}["llm", "provider"]{{ end }},
+    tags={{ if .Tags }}{{ toJSON .Tags }}{{ else }}[{{ range $i, $t := providerTags .Model }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}]{{ end }},
     version="1.0.0",
 )
 def {{ toSnakeCase .Name }}():

--- a/cmd/meshctl/templates/typescript/llm-provider/README.md.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/README.md.tmpl
@@ -42,9 +42,13 @@ server.addTool(
 
 ```bash
 docker build -t {{ .Name }}:latest .
+{{ if .ProbeVendor }}docker run -p {{ .Port }}:{{ .Port }} \
+  -e {{ if eq .ProbeVendor "anthropic" }}ANTHROPIC_API_KEY{{ else if eq .ProbeVendor "openai" }}OPENAI_API_KEY{{ else if eq .ProbeVendor "gemini" }}GOOGLE_API_KEY{{ end }}=${{ if eq .ProbeVendor "anthropic" }}ANTHROPIC_API_KEY{{ else if eq .ProbeVendor "openai" }}OPENAI_API_KEY{{ else if eq .ProbeVendor "gemini" }}GOOGLE_API_KEY{{ end }} \
+  {{ .Name }}:latest{{ else }}# Pass in the credentials {{ .Model }} authenticates with (for a gateway-prefixed
+# model those are the gateway's own - AWS credentials, ADC, a workspace token),
+# as -e vars or a mounted credential file.
 docker run -p {{ .Port }}:{{ .Port }} \
-  -e {{ if eq .ProbeVendor "anthropic" }}ANTHROPIC_API_KEY{{ else if eq .ProbeVendor "openai" }}OPENAI_API_KEY{{ else if eq .ProbeVendor "gemini" }}GOOGLE_API_KEY{{ else }}API_KEY{{ end }}=${{ if eq .ProbeVendor "anthropic" }}ANTHROPIC_API_KEY{{ else if eq .ProbeVendor "openai" }}OPENAI_API_KEY{{ else if eq .ProbeVendor "gemini" }}GOOGLE_API_KEY{{ else }}API_KEY{{ end }} \
-  {{ .Name }}:latest
+  {{ .Name }}:latest{{ end }}
 ```
 
 ## Kubernetes
@@ -52,8 +56,12 @@ docker run -p {{ .Port }}:{{ .Port }} \
 Create a secret first:
 
 ```bash
+{{ if .ProbeVendor }}kubectl create secret generic llm-secrets \
+  --from-literal={{ if eq .ProbeVendor "anthropic" }}anthropic-api-key{{ else if eq .ProbeVendor "openai" }}openai-api-key{{ else if eq .ProbeVendor "gemini" }}google-api-key{{ end }}=${{ if eq .ProbeVendor "anthropic" }}ANTHROPIC_API_KEY{{ else if eq .ProbeVendor "openai" }}OPENAI_API_KEY{{ else if eq .ProbeVendor "gemini" }}GOOGLE_API_KEY{{ end }}{{ else }}# The secret holds the credentials {{ .Model }} authenticates with (for a
+# gateway-prefixed model those are the gateway's own - AWS credentials, ADC, a
+# workspace token). Reference it from helm-values.yaml.
 kubectl create secret generic llm-secrets \
-  --from-literal={{ if eq .ProbeVendor "anthropic" }}anthropic-api-key{{ else if eq .ProbeVendor "openai" }}openai-api-key{{ else if eq .ProbeVendor "gemini" }}google-api-key{{ else }}api-key{{ end }}=${{ if eq .ProbeVendor "anthropic" }}ANTHROPIC_API_KEY{{ else if eq .ProbeVendor "openai" }}OPENAI_API_KEY{{ else if eq .ProbeVendor "gemini" }}GOOGLE_API_KEY{{ else }}API_KEY{{ end }}
+  --from-literal=<credential-name>=<credential-value>{{ end }}
 ```
 
 Then deploy:

--- a/cmd/meshctl/templates/typescript/llm-provider/README.md.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/README.md.tmpl
@@ -6,7 +6,8 @@
 
 ```bash
 # Set API key
-{{ if contains .Model "anthropic" }}export ANTHROPIC_API_KEY=your-key{{ else if contains .Model "openai" }}export OPENAI_API_KEY=your-key{{ else if contains .Model "gemini" }}export GOOGLE_API_KEY=your-key{{ end }}
+{{ if eq .ProbeVendor "anthropic" }}export ANTHROPIC_API_KEY=your-key{{ else if eq .ProbeVendor "openai" }}export OPENAI_API_KEY=your-key{{ else if eq .ProbeVendor "gemini" }}export GOOGLE_API_KEY=your-key{{ else }}# Set the credentials {{ .Model }} authenticates with (for a gateway-prefixed
+# model those are the gateway's own - AWS credentials, ADC, a workspace token){{ end }}
 
 # Install dependencies
 npm install
@@ -31,7 +32,7 @@ Other agents can use this provider via `mesh.llm()`:
 server.addTool(
   mesh.llm({
     name: "my_tool",
-    provider: { capability: "llm", tags: {{ if contains .Model "anthropic" }}["claude"]{{ else if contains .Model "openai" }}["gpt"]{{ else if contains .Model "gemini" }}["gemini"]{{ else }}["llm"]{{ end }} },
+    provider: { capability: "llm", tags: {{ if eq .ProbeVendor "anthropic" }}["claude"]{{ else if eq .ProbeVendor "openai" }}["gpt"]{{ else if eq .ProbeVendor "gemini" }}["gemini"]{{ else }}["llm"]{{ end }} },
     // ... rest of config
   })
 );
@@ -42,7 +43,7 @@ server.addTool(
 ```bash
 docker build -t {{ .Name }}:latest .
 docker run -p {{ .Port }}:{{ .Port }} \
-  -e {{ if contains .Model "anthropic" }}ANTHROPIC_API_KEY{{ else if contains .Model "openai" }}OPENAI_API_KEY{{ else if contains .Model "gemini" }}GOOGLE_API_KEY{{ else }}API_KEY{{ end }}=${{ if contains .Model "anthropic" }}ANTHROPIC_API_KEY{{ else if contains .Model "openai" }}OPENAI_API_KEY{{ else if contains .Model "gemini" }}GOOGLE_API_KEY{{ else }}API_KEY{{ end }} \
+  -e {{ if eq .ProbeVendor "anthropic" }}ANTHROPIC_API_KEY{{ else if eq .ProbeVendor "openai" }}OPENAI_API_KEY{{ else if eq .ProbeVendor "gemini" }}GOOGLE_API_KEY{{ else }}API_KEY{{ end }}=${{ if eq .ProbeVendor "anthropic" }}ANTHROPIC_API_KEY{{ else if eq .ProbeVendor "openai" }}OPENAI_API_KEY{{ else if eq .ProbeVendor "gemini" }}GOOGLE_API_KEY{{ else }}API_KEY{{ end }} \
   {{ .Name }}:latest
 ```
 
@@ -52,7 +53,7 @@ Create a secret first:
 
 ```bash
 kubectl create secret generic llm-secrets \
-  --from-literal={{ if contains .Model "anthropic" }}anthropic-api-key{{ else if contains .Model "openai" }}openai-api-key{{ else if contains .Model "gemini" }}google-api-key{{ else }}api-key{{ end }}=${{ if contains .Model "anthropic" }}ANTHROPIC_API_KEY{{ else if contains .Model "openai" }}OPENAI_API_KEY{{ else if contains .Model "gemini" }}GOOGLE_API_KEY{{ else }}API_KEY{{ end }}
+  --from-literal={{ if eq .ProbeVendor "anthropic" }}anthropic-api-key{{ else if eq .ProbeVendor "openai" }}openai-api-key{{ else if eq .ProbeVendor "gemini" }}google-api-key{{ else }}api-key{{ end }}=${{ if eq .ProbeVendor "anthropic" }}ANTHROPIC_API_KEY{{ else if eq .ProbeVendor "openai" }}OPENAI_API_KEY{{ else if eq .ProbeVendor "gemini" }}GOOGLE_API_KEY{{ else }}API_KEY{{ end }}
 ```
 
 Then deploy:

--- a/cmd/meshctl/templates/typescript/llm-provider/README.md.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/README.md.tmpl
@@ -32,7 +32,7 @@ Other agents can use this provider via `mesh.llm()`:
 server.addTool(
   mesh.llm({
     name: "my_tool",
-    provider: { capability: "llm", tags: {{ if eq .ProbeVendor "anthropic" }}["claude"]{{ else if eq .ProbeVendor "openai" }}["gpt"]{{ else if eq .ProbeVendor "gemini" }}["gemini"]{{ else }}["llm"]{{ end }} },
+    provider: { capability: "llm", tags: {{ if eq .ModelFamily "anthropic" }}["claude"]{{ else if eq .ModelFamily "openai" }}["gpt"]{{ else if eq .ModelFamily "gemini" }}["gemini"]{{ else }}["llm"]{{ end }} },
     // ... rest of config
   })
 );

--- a/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
@@ -20,7 +20,7 @@ const server = new FastMCP({
 // Runs every healthCheckTtl seconds. While it returns "unhealthy" the agent
 // stops heartbeating, the registry withdraws it, and consumers fail over to
 // another provider — automatically restored when the check passes again.
-{{ if or (contains .Model "anthropic") (contains .Model "openai") (contains .Model "gemini") }}
+{{ if .ProbeVendor }}
 /**
  * Ceiling for one probe. `AbortSignal.timeout` rejects with a
  * "TimeoutError", which lands in the same branch as DNS, connect and TLS
@@ -37,7 +37,7 @@ function describeError(err: unknown): string {
   return err instanceof Error ? err.message || err.name : String(err);
 }
 {{ end }}
-{{- if contains .Model "anthropic" }}
+{{- if eq .ProbeVendor "anthropic" }}
 /**
  * Health check for {{ .Name }}.
  *
@@ -100,7 +100,7 @@ async function healthCheck(): Promise<MeshHealthResult> {
     };
   }
 }
-{{- else if contains .Model "openai" }}
+{{- else if eq .ProbeVendor "openai" }}
 /**
  * Health check for {{ .Name }}.
  *
@@ -160,7 +160,7 @@ async function healthCheck(): Promise<MeshHealthResult> {
     };
   }
 }
-{{- else if contains .Model "gemini" }}
+{{- else if eq .ProbeVendor "gemini" }}
 /**
  * Health check for {{ .Name }}.
  *
@@ -255,6 +255,15 @@ async function healthCheck(): Promise<MeshHealthResult> {
  *     // YOU cut short (your own AbortController) — that concluded nothing.
  *     return { status: "unhealthy", errors: [`vendor unreachable: ${err}`] };
  *   }
+ *
+ * Probe the gateway you actually authenticate against. For a gateway-prefixed
+ * model (bedrock/..., vertex_ai/..., databricks/..., an OpenAI-compatible
+ * proxy) that is the gateway's own endpoint and the gateway's own credentials
+ * - AWS SigV4, ADC / Workload Identity, your proxy's token. It is NOT the
+ * underlying model vendor's public API: that endpoint can be perfectly healthy
+ * while your gateway is down, and the vendor API key it wants is one your
+ * deployment never sets, so a check gated on it would report unhealthy forever
+ * and withdraw this agent permanently.
  */
 async function healthCheck(): Promise<MeshHealthResult> {
   return { status: "healthy", checks: { provider_configured: true }, errors: [] };
@@ -298,7 +307,7 @@ const agent = mesh(server, {
 agent.addLlmProvider({
   model: "{{ .Model }}",
   capability: "llm",
-  tags: {{ if .Tags }}{{ toJSON .Tags }}{{ else if contains .Model "anthropic" }}["llm", "claude", "anthropic", "provider"]{{ else if contains .Model "openai" }}["llm", "openai", "gpt", "provider"]{{ else if contains .Model "gemini" }}["llm", "gemini", "google", "provider"]{{ else }}["llm", "provider"]{{ end }},
+  tags: {{ if .Tags }}{{ toJSON .Tags }}{{ else if eq .ProbeVendor "anthropic" }}["llm", "claude", "anthropic", "provider"]{{ else if eq .ProbeVendor "openai" }}["llm", "openai", "gpt", "provider"]{{ else if eq .ProbeVendor "gemini" }}["llm", "gemini", "google", "provider"]{{ else }}["llm", "provider"]{{ end }},
   version: "1.0.0",
   description: "{{ if .Description }}{{ .Description }}{{ else }}LLM provider via {{ .Model }}{{ end }}",
   maxOutputTokens: 4096,

--- a/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
@@ -307,7 +307,11 @@ const agent = mesh(server, {
 agent.addLlmProvider({
   model: "{{ .Model }}",
   capability: "llm",
-  tags: {{ if .Tags }}{{ toJSON .Tags }}{{ else if eq .ProbeVendor "anthropic" }}["llm", "claude", "anthropic", "provider"]{{ else if eq .ProbeVendor "openai" }}["llm", "openai", "gpt", "provider"]{{ else if eq .ProbeVendor "gemini" }}["llm", "gemini", "google", "provider"]{{ else }}["llm", "provider"]{{ end }},
+  {{/* Tags follow the model FAMILY, not the probeable vendor: a
+       bedrock/anthropic.claude-* provider is still Claude and must stay
+       discoverable by a consumer pinning +claude, even though it has no
+       probeable direct vendor API (issue #1479). */ -}}
+  tags: {{ if .Tags }}{{ toJSON .Tags }}{{ else if eq .ModelFamily "anthropic" }}["llm", "claude", "anthropic", "provider"]{{ else if eq .ModelFamily "openai" }}["llm", "openai", "gpt", "provider"]{{ else if eq .ModelFamily "gemini" }}["llm", "gemini", "google", "provider"]{{ else }}["llm", "provider"]{{ end }},
   version: "1.0.0",
   description: "{{ if .Description }}{{ .Description }}{{ else }}LLM provider via {{ .Model }}{{ end }}",
   maxOutputTokens: 4096,

--- a/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
@@ -311,7 +311,7 @@ agent.addLlmProvider({
        bedrock/anthropic.claude-* provider is still Claude and must stay
        discoverable by a consumer pinning +claude, even though it has no
        probeable direct vendor API (issue #1479). */ -}}
-  tags: {{ if .Tags }}{{ toJSON .Tags }}{{ else if eq .ModelFamily "anthropic" }}["llm", "claude", "anthropic", "provider"]{{ else if eq .ModelFamily "openai" }}["llm", "openai", "gpt", "provider"]{{ else if eq .ModelFamily "gemini" }}["llm", "gemini", "google", "provider"]{{ else }}["llm", "provider"]{{ end }},
+  tags: {{ if .Tags }}{{ toJSON .Tags }}{{ else }}[{{ range $i, $t := providerTags .Model }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}]{{ end }},
   version: "1.0.0",
   description: "{{ if .Description }}{{ .Description }}{{ else }}LLM provider via {{ .Model }}{{ end }}",
   maxOutputTokens: 4096,

--- a/src/core/cli/scaffold/health_check_template_test.go
+++ b/src/core/cli/scaffold/health_check_template_test.go
@@ -224,3 +224,129 @@ func TestLlmProviderTemplates_UnknownVendorSkeletonWarns(t *testing.T) {
 		})
 	}
 }
+
+// Issue #1479. A gateway-prefixed model reaches a big-3 model through someone
+// else's endpoint, with someone else's credentials: `bedrock/anthropic.claude-*`
+// is served by AWS, `vertex_ai/gemini-*` by a Google Cloud project under ADC /
+// Workload Identity. The templates used to select the probe with a
+// case-sensitive substring test, so both strings selected a direct vendor probe
+// gated on an API key those deployments never set.
+//
+// That is not cosmetic. The probe reports unhealthy on its first tick, which
+// suppresses the heartbeat, and the registry withdraws an agent that is serving
+// fine — permanently, because the missing key never appears. Falling through to
+// the skeleton leaves the operator with a TODO; guessing a probe takes their
+// working provider off the mesh.
+//
+// Uppercase is in the matrix because --model is free-form and the old gate was
+// case-sensitive: a resolver that lowercases one side only would pass the two
+// lowercase cases and still ship the bug.
+var gatewayModels = []struct {
+	name string
+	// The probe that must NOT be selected, and the credential that proves it.
+	model     string
+	bannedAPI string
+	bannedKey string
+}{
+	{
+		name:      "bedrock claude",
+		model:     "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+		bannedAPI: "api.anthropic.com",
+		bannedKey: "ANTHROPIC_API_KEY",
+	},
+	{
+		name:      "vertex gemini",
+		model:     "vertex_ai/gemini-2.5-flash",
+		bannedAPI: "generativelanguage.googleapis.com",
+		bannedKey: "GOOGLE_API_KEY",
+	},
+	{
+		name:      "vertex gemini uppercase",
+		model:     "VERTEX_AI/gemini-2.5-flash",
+		bannedAPI: "generativelanguage.googleapis.com",
+		bannedKey: "GOOGLE_API_KEY",
+	},
+	{
+		name:      "databricks claude",
+		model:     "databricks/anthropic.claude-3-7-sonnet",
+		bannedAPI: "api.anthropic.com",
+		bannedKey: "ANTHROPIC_API_KEY",
+	},
+}
+
+func TestLlmProviderTemplates_GatewayModelGetsSkeletonNotVendorProbe(t *testing.T) {
+	for _, rt := range runtimeProbes {
+		for _, gw := range gatewayModels {
+			t.Run(rt.language+" "+gw.name, func(t *testing.T) {
+				content := renderProvider(t, rt.language, gw.model, rt.entry)
+
+				require.Contains(t, content, "NOT IMPLEMENTED",
+					"a gateway-prefixed model has no probeable direct vendor API, so "+
+						"the skeleton is the only honest rendering")
+				require.Contains(t, content, "CANNOT DETECT AN")
+
+				require.NotContains(t, content, gw.bannedAPI,
+					"%s is served by its gateway, not by %s — probing that endpoint "+
+						"reports on an API this agent never calls", gw.model, gw.bannedAPI)
+				require.NotContains(t, content, gw.bannedKey,
+					"%s never sets %s, so a check gated on it returns unhealthy "+
+						"forever and the registry withdraws a working provider",
+					gw.model, gw.bannedKey)
+			})
+		}
+	}
+}
+
+// The same defect sat on the tags and the README env-var instructions. They do
+// not withdraw anything, but leaving one `contains` beside the fixed probe is
+// how this class of bug survives, so one resolver governs all of them.
+func TestLlmProviderTemplates_GatewayModelGetsGenericTagsAndReadme(t *testing.T) {
+	tagsMarker := map[string]string{
+		"python":     `tags=["llm", "provider"]`,
+		"typescript": `tags: ["llm", "provider"]`,
+		"java":       `tags = {"llm", "provider"}`,
+	}
+
+	for _, rt := range runtimeProbes {
+		for _, gw := range gatewayModels {
+			t.Run(rt.language+" "+gw.name, func(t *testing.T) {
+				content := renderProvider(t, rt.language, gw.model, rt.entry)
+				require.Contains(t, content, tagsMarker[rt.language],
+					"a gateway model must not advertise the underlying vendor's tags")
+
+				readme := renderProvider(t, rt.language, gw.model, "README.md")
+				require.NotContains(t, readme, "export "+gw.bannedKey,
+					"the README tells the operator to export a key the gateway "+
+						"does not use")
+			})
+		}
+	}
+}
+
+// The big-3 matrix is the other half: narrowing the gate must not have taken
+// the real probes with it.
+func TestLlmProviderTemplates_BareBig3NameStillProbes(t *testing.T) {
+	bare := []struct {
+		model     string
+		wantAPI   string
+		wantKey   string
+		wantTagIn string
+	}{
+		{"claude-sonnet-5", "api.anthropic.com", "ANTHROPIC_API_KEY", "anthropic"},
+		{"gpt-4o", "api.openai.com", "OPENAI_API_KEY", "openai"},
+		{"gemini-2.5-flash", "generativelanguage.googleapis.com", "GOOGLE_API_KEY", "gemini"},
+	}
+
+	for _, rt := range runtimeProbes {
+		for _, b := range bare {
+			t.Run(rt.language+" "+b.model, func(t *testing.T) {
+				content := renderProvider(t, rt.language, b.model, rt.entry)
+				require.Contains(t, content, b.wantAPI)
+				require.Contains(t, content, b.wantKey)
+				require.Contains(t, content, b.wantTagIn)
+				require.NotContains(t, content, "NOT IMPLEMENTED",
+					"an unprefixed big-3 name is probeable and must get the real probe")
+			})
+		}
+	}
+}

--- a/src/core/cli/scaffold/health_check_template_test.go
+++ b/src/core/cli/scaffold/health_check_template_test.go
@@ -358,6 +358,21 @@ func TestLlmProviderTemplates_GatewayModelKeepsFamilyTagsButNotVendorCredentials
 				require.NotContains(t, readme, "export "+gw.bannedKey,
 					"the README tells the operator to export a key the gateway "+
 						"does not use")
+
+				// Not just the vendor's key: a generic `API_KEY` / `api-key`
+				// fallback is no better. The TypeScript README's Docker and
+				// kubectl blocks ended their vendor chain with one, so a Bedrock
+				// scaffold told the operator to pass `API_KEY=$API_KEY` and
+				// create a secret keyed `api-key` — names neither gateway reads,
+				// in the same file whose prose says to use the gateway's own
+				// credentials.
+				require.NotContains(t, readme, "API_KEY",
+					"%s authenticates with its gateway's credentials: naming any "+
+						"API key here, vendor-specific or generic, sends the "+
+						"operator to configure something nothing reads", gw.model)
+				require.NotContains(t, readme, "api-key",
+					"%s authenticates with its gateway's credentials, so no "+
+						"api-key secret name applies", gw.model)
 			})
 		}
 	}
@@ -374,21 +389,25 @@ func TestLlmProviderTemplates_GatewayModelKeepsFamilyTagsButNotVendorCredentials
 // degrades a real probe into the skeleton, which is the case that takes a
 // working health check away.
 func TestLlmProviderTemplates_BareBig3NameStillProbes(t *testing.T) {
+	// wantTags is the whole rendered tag literal, matched via tagsMarker, not a
+	// bare family word: "anthropic" appears in the API host, the import path and
+	// the comments of every Anthropic render, so `Contains(content, "anthropic")`
+	// holds even with the tag list absent or carrying another family's tags.
 	bare := []struct {
-		model     string
-		wantAPI   string
-		wantKey   string
-		wantTagIn string
+		model    string
+		wantAPI  string
+		wantKey  string
+		wantTags []string
 	}{
-		{"claude-sonnet-5", "api.anthropic.com", "ANTHROPIC_API_KEY", "anthropic"},
-		{"gpt-4o", "api.openai.com", "OPENAI_API_KEY", "openai"},
-		{"gemini-2.5-flash", "generativelanguage.googleapis.com", "GOOGLE_API_KEY", "gemini"},
+		{"claude-sonnet-5", "api.anthropic.com", "ANTHROPIC_API_KEY", []string{"llm", "claude", "anthropic", "provider"}},
+		{"gpt-4o", "api.openai.com", "OPENAI_API_KEY", []string{"llm", "openai", "gpt", "provider"}},
+		{"gemini-2.5-flash", "generativelanguage.googleapis.com", "GOOGLE_API_KEY", []string{"llm", "gemini", "google", "provider"}},
 
 		// --model is free-form, so the casing is the user's.
-		{"ANTHROPIC/claude-sonnet-5", "api.anthropic.com", "ANTHROPIC_API_KEY", "anthropic"},
-		{"Claude-Sonnet-5", "api.anthropic.com", "ANTHROPIC_API_KEY", "anthropic"},
-		{"OpenAI/GPT-4o", "api.openai.com", "OPENAI_API_KEY", "openai"},
-		{"GEMINI/Gemini-2.5-Flash", "generativelanguage.googleapis.com", "GOOGLE_API_KEY", "gemini"},
+		{"ANTHROPIC/claude-sonnet-5", "api.anthropic.com", "ANTHROPIC_API_KEY", []string{"llm", "claude", "anthropic", "provider"}},
+		{"Claude-Sonnet-5", "api.anthropic.com", "ANTHROPIC_API_KEY", []string{"llm", "claude", "anthropic", "provider"}},
+		{"OpenAI/GPT-4o", "api.openai.com", "OPENAI_API_KEY", []string{"llm", "openai", "gpt", "provider"}},
+		{"GEMINI/Gemini-2.5-Flash", "generativelanguage.googleapis.com", "GOOGLE_API_KEY", []string{"llm", "gemini", "google", "provider"}},
 	}
 
 	for _, rt := range runtimeProbes {
@@ -397,7 +416,9 @@ func TestLlmProviderTemplates_BareBig3NameStillProbes(t *testing.T) {
 				content := renderProvider(t, rt.language, b.model, rt.entry)
 				require.Contains(t, content, b.wantAPI)
 				require.Contains(t, content, b.wantKey)
-				require.Contains(t, content, b.wantTagIn)
+				require.Contains(t, content, tagsMarker(rt.language, b.wantTags),
+					"%s must register its family's discovery tags, or a consumer "+
+						"pinning +claude / +gpt / +gemini stops resolving it", b.model)
 				require.NotContains(t, content, "NOT IMPLEMENTED",
 					"an unprefixed big-3 name is probeable and must get the real probe")
 			})

--- a/src/core/cli/scaffold/health_check_template_test.go
+++ b/src/core/cli/scaffold/health_check_template_test.go
@@ -238,40 +238,79 @@ func TestLlmProviderTemplates_UnknownVendorSkeletonWarns(t *testing.T) {
 // the skeleton leaves the operator with a TODO; guessing a probe takes their
 // working provider off the mesh.
 //
-// Uppercase is in the matrix because --model is free-form and the old gate was
-// case-sensitive: a resolver that lowercases one side only would pass the two
-// lowercase cases and still ship the bug.
+// The probe is only half of it. A gateway model still HAS a family — Bedrock
+// Claude is Claude — so the discovery tags must keep naming it, or a consumer
+// scaffolded with `--vendor claude` (which pins `+claude`) stops resolving this
+// provider. wantTags below is the independent half: skeleton probe, real tags.
 var gatewayModels = []struct {
 	name string
 	// The probe that must NOT be selected, and the credential that proves it.
 	model     string
 	bannedAPI string
 	bannedKey string
+	// The discovery tags the model's FAMILY earns, despite the skeleton probe.
+	wantTags []string
 }{
 	{
 		name:      "bedrock claude",
 		model:     "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
 		bannedAPI: "api.anthropic.com",
 		bannedKey: "ANTHROPIC_API_KEY",
+		wantTags:  []string{"llm", "claude", "anthropic", "provider"},
+	},
+	{
+		// A cross-region inference profile: the family sits behind a region
+		// segment, so a resolver that only looks at the first dot segment
+		// ("us") drops the claude tags.
+		name:      "bedrock claude cross-region profile",
+		model:     "bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+		bannedAPI: "api.anthropic.com",
+		bannedKey: "ANTHROPIC_API_KEY",
+		wantTags:  []string{"llm", "claude", "anthropic", "provider"},
 	},
 	{
 		name:      "vertex gemini",
 		model:     "vertex_ai/gemini-2.5-flash",
 		bannedAPI: "generativelanguage.googleapis.com",
 		bannedKey: "GOOGLE_API_KEY",
-	},
-	{
-		name:      "vertex gemini uppercase",
-		model:     "VERTEX_AI/gemini-2.5-flash",
-		bannedAPI: "generativelanguage.googleapis.com",
-		bannedKey: "GOOGLE_API_KEY",
+		wantTags:  []string{"llm", "gemini", "google", "provider"},
 	},
 	{
 		name:      "databricks claude",
 		model:     "databricks/anthropic.claude-3-7-sonnet",
 		bannedAPI: "api.anthropic.com",
 		bannedKey: "ANTHROPIC_API_KEY",
+		wantTags:  []string{"llm", "claude", "anthropic", "provider"},
 	},
+	{
+		// A gateway model with no big-3 family at all: no probe AND no vendor
+		// tags. Without this row every gateway case expects vendor tags, and a
+		// family resolver that simply always answered "anthropic" would pass.
+		name:      "bedrock llama",
+		model:     "bedrock/meta.llama3-70b-instruct-v1:0",
+		bannedAPI: "api.anthropic.com",
+		bannedKey: "ANTHROPIC_API_KEY",
+		wantTags:  []string{"llm", "provider"},
+	},
+}
+
+// tagsMarker renders a tag list in one runtime's literal syntax, so the matrix
+// can assert on tags without hand-writing three copies per case.
+func tagsMarker(language string, tags []string) string {
+	quoted := make([]string, len(tags))
+	for i, tag := range tags {
+		quoted[i] = `"` + tag + `"`
+	}
+	joined := strings.Join(quoted, ", ")
+
+	switch language {
+	case "python":
+		return "tags=[" + joined + "]"
+	case "typescript":
+		return "tags: [" + joined + "]"
+	default:
+		return "tags = {" + joined + "}"
+	}
 }
 
 func TestLlmProviderTemplates_GatewayModelGetsSkeletonNotVendorProbe(t *testing.T) {
@@ -297,22 +336,23 @@ func TestLlmProviderTemplates_GatewayModelGetsSkeletonNotVendorProbe(t *testing.
 	}
 }
 
-// The same defect sat on the tags and the README env-var instructions. They do
-// not withdraw anything, but leaving one `contains` beside the fixed probe is
-// how this class of bug survives, so one resolver governs all of them.
-func TestLlmProviderTemplates_GatewayModelGetsGenericTagsAndReadme(t *testing.T) {
-	tagsMarker := map[string]string{
-		"python":     `tags=["llm", "provider"]`,
-		"typescript": `tags: ["llm", "provider"]`,
-		"java":       `tags = {"llm", "provider"}`,
-	}
-
+// The README env-var instructions follow the PROBE: a gateway authenticates
+// with its own credentials, so the README must not tell the operator to export
+// the underlying vendor's API key.
+//
+// The tags follow the FAMILY instead, and asserting both here is the point —
+// they are answers to different questions and a template that wires one arm to
+// the other resolver breaks exactly one of these two assertions.
+func TestLlmProviderTemplates_GatewayModelKeepsFamilyTagsButNotVendorCredentials(t *testing.T) {
 	for _, rt := range runtimeProbes {
 		for _, gw := range gatewayModels {
 			t.Run(rt.language+" "+gw.name, func(t *testing.T) {
 				content := renderProvider(t, rt.language, gw.model, rt.entry)
-				require.Contains(t, content, tagsMarker[rt.language],
-					"a gateway model must not advertise the underlying vendor's tags")
+				require.Contains(t, content, tagsMarker(rt.language, gw.wantTags),
+					"%s is served by a gateway but it is still a %s model: wiring the "+
+						"tags to the probe resolver de-registers the vendor tags and a "+
+						"consumer pinning +claude / +gemini stops resolving it",
+					gw.model, gw.wantTags)
 
 				readme := renderProvider(t, rt.language, gw.model, "README.md")
 				require.NotContains(t, readme, "export "+gw.bannedKey,
@@ -325,6 +365,14 @@ func TestLlmProviderTemplates_GatewayModelGetsGenericTagsAndReadme(t *testing.T)
 
 // The big-3 matrix is the other half: narrowing the gate must not have taken
 // the real probes with it.
+//
+// The uppercase rows are what pin case-insensitivity, and they sit HERE rather
+// than in the gateway matrix because this is the direction that can actually
+// regress. `VERTEX_AI/...` in the gateway matrix proves nothing: a resolver
+// that stopped lowercasing would miss the map, return "", emit the skeleton and
+// pass. `ANTHROPIC/claude-sonnet-5` fails loudly instead — the miss silently
+// degrades a real probe into the skeleton, which is the case that takes a
+// working health check away.
 func TestLlmProviderTemplates_BareBig3NameStillProbes(t *testing.T) {
 	bare := []struct {
 		model     string
@@ -335,6 +383,12 @@ func TestLlmProviderTemplates_BareBig3NameStillProbes(t *testing.T) {
 		{"claude-sonnet-5", "api.anthropic.com", "ANTHROPIC_API_KEY", "anthropic"},
 		{"gpt-4o", "api.openai.com", "OPENAI_API_KEY", "openai"},
 		{"gemini-2.5-flash", "generativelanguage.googleapis.com", "GOOGLE_API_KEY", "gemini"},
+
+		// --model is free-form, so the casing is the user's.
+		{"ANTHROPIC/claude-sonnet-5", "api.anthropic.com", "ANTHROPIC_API_KEY", "anthropic"},
+		{"Claude-Sonnet-5", "api.anthropic.com", "ANTHROPIC_API_KEY", "anthropic"},
+		{"OpenAI/GPT-4o", "api.openai.com", "OPENAI_API_KEY", "openai"},
+		{"GEMINI/Gemini-2.5-Flash", "generativelanguage.googleapis.com", "GOOGLE_API_KEY", "gemini"},
 	}
 
 	for _, rt := range runtimeProbes {

--- a/src/core/cli/scaffold/interactive.go
+++ b/src/core/cli/scaffold/interactive.go
@@ -447,14 +447,14 @@ func promptLLMProviderConfig(config *InteractiveConfig) error {
 		config.Model = strings.Split(model, " - ")[0]
 	}
 
-	// Set tags based on model
-	if strings.Contains(config.Model, "anthropic") {
-		config.Tags = []string{"llm", "claude", "anthropic", "provider"}
-	} else if strings.Contains(config.Model, "openai") {
-		config.Tags = []string{"llm", "openai", "gpt", "provider"}
-	} else {
-		config.Tags = []string{"llm", "provider"}
-	}
+	// Set tags from the model FAMILY.
+	//
+	// This used to be a case-sensitive `strings.Contains` with no gemini arm at
+	// all, so `Claude-Sonnet-5` and every gemini model fell through to the
+	// generic tags. It also mattered more than it looked: the templates gate
+	// their own tag arms on `{{ if .Tags }}` first, so whatever is set here wins
+	// outright and the resolvers are never consulted (issue #1479).
+	config.Tags = ProviderTagsForModel(config.Model)
 
 	// Allow adding custom tags
 	addTags := false

--- a/src/core/cli/scaffold/model_dispatch.go
+++ b/src/core/cli/scaffold/model_dispatch.go
@@ -152,3 +152,101 @@ func DirectProbeVendor(model string) string {
 	}
 	return inferBig3VendorFromBareName(m)
 }
+
+// big3FamilyNames are the names a big-3 model FAMILY goes by when it appears as
+// a segment of a model id — the vendor that built the model, regardless of who
+// serves it.
+//
+// Deliberately separate from directProbeVendorPrefixes even though the three
+// names coincide today: that map answers "may a health check call this vendor's
+// own API", this one answers "whose model is this". They are allowed to
+// diverge, and TestModelFamilyAndProbeVendorDivergeOnGateways pins the models
+// where they already do.
+var big3FamilyNames = map[string]string{
+	"anthropic": "anthropic",
+	"openai":    "openai",
+	"gemini":    "gemini",
+}
+
+// ModelFamily resolves model to the big-3 family that built it — "anthropic",
+// "openai", "gemini" — or "" for anything else.
+//
+// This is NOT DirectProbeVendor, and conflating the two is the mistake this
+// function exists to prevent. `bedrock/anthropic.claude-3-5-sonnet-...` IS a
+// Claude model: it must register the claude/anthropic discovery tags, or a
+// consumer scaffolded with `--vendor claude` (which pins `+claude`) stops
+// resolving it. What it must NOT get is a probe of api.anthropic.com gated on
+// ANTHROPIC_API_KEY, because AWS serves it with AWS credentials — that is
+// DirectProbeVendor's answer, and it is "" (issue #1479).
+//
+// Matching is case-insensitive and segment-based, never a substring test. A
+// gateway carries the family in the segment AFTER its own prefix, separated by
+// either "/" or "." depending on the gateway:
+//
+//	bedrock/anthropic.claude-3-5-sonnet-...  -> anthropic
+//	bedrock/us.anthropic.claude-3-5-sonnet   -> anthropic (cross-region profile)
+//	vertex_ai/gemini-2.5-flash               -> gemini    (bare-name inference)
+//	azure/openai/gpt-4o                      -> openai
+//	bedrock/meta.llama3-70b-instruct-v1:0    -> ""        (not a big-3 family)
+func ModelFamily(model string) string {
+	return big3Family(strings.ToLower(strings.TrimSpace(model)))
+}
+
+// big3Family resolves an already-lowercased, already-trimmed model id.
+func big3Family(m string) string {
+	if m == "" {
+		return ""
+	}
+
+	// `vendor/rest`: the prefix names the family for a native vendor
+	// (anthropic/, openai/, gemini/). For everything else the prefix is a
+	// gateway, and the family — if any — lives in the remainder.
+	if idx := strings.Index(m, "/"); idx >= 0 {
+		if family := big3FamilyNames[m[:idx]]; family != "" {
+			return family
+		}
+		return big3Family(m[idx+1:])
+	}
+
+	// Gateway model ids namespace with "." rather than "/": `anthropic.claude-*`
+	// on Bedrock, `us.anthropic.claude-*` for a cross-region inference profile.
+	// Each dot-delimited segment is matched WHOLE, so "meta.llama3" stays "" and
+	// a hypothetical "openai-clone" never matches "openai".
+	if strings.Contains(m, ".") {
+		for _, segment := range strings.Split(m, ".") {
+			if family := big3FamilyNames[segment]; family != "" {
+				return family
+			}
+		}
+	}
+
+	// No vendor segment to go on: fall back to the same conservative bare-name
+	// rules the Python runtime uses, so `claude-sonnet-5`, `gpt-4o` and
+	// `gemini-2.5-flash` resolve whether they arrived bare or as a gateway
+	// remainder. Note this also covers dotted names with no vendor segment
+	// (e.g. "gpt-4.1"), which the loop above deliberately leaves alone.
+	return inferBig3VendorFromBareName(m)
+}
+
+// providerTagsByFamily are the discovery tags a scaffolded provider registers
+// for each big-3 family. The templates emit the same lists in their own syntax;
+// this copy serves the Go-side callers (the interactive wizard).
+var providerTagsByFamily = map[string][]string{
+	"anthropic": {"llm", "claude", "anthropic", "provider"},
+	"openai":    {"llm", "openai", "gpt", "provider"},
+	"gemini":    {"llm", "gemini", "google", "provider"},
+}
+
+// ProviderTagsForModel returns the discovery tags an llm-provider should
+// register for model: the family tags when the model belongs to a big-3 family,
+// otherwise the generic ["llm", "provider"].
+//
+// Keyed on ModelFamily, never on a substring of the model string: a
+// case-sensitive `strings.Contains(model, "anthropic")` both misses
+// `Claude-Sonnet-5` and has no gemini answer at all.
+func ProviderTagsForModel(model string) []string {
+	if tags, ok := providerTagsByFamily[ModelFamily(model)]; ok {
+		return append([]string{}, tags...)
+	}
+	return []string{"llm", "provider"}
+}

--- a/src/core/cli/scaffold/model_dispatch.go
+++ b/src/core/cli/scaffold/model_dispatch.go
@@ -103,3 +103,52 @@ func IsNativeDispatchModel(model string) bool {
 func RequiresLiteLLM(model string) bool {
 	return !IsNativeDispatchModel(model)
 }
+
+// directProbeVendorPrefixes are the `vendor/` prefixes a scaffolded health
+// check can probe by calling the vendor's own public API with the vendor's own
+// API key.
+//
+// This is deliberately NOT nativeVendorPrefixes, and the difference is the
+// whole point of issue #1479: "which native adapter dispatches this model" and
+// "which direct API can a health check probe for it" are different questions.
+//
+// `vertex_ai` is native dispatch — it routes through the bundled google-genai
+// SDK exactly like `gemini/*` — but it authenticates with ADC / Workload
+// Identity against a Google Cloud project endpoint, not with an AI Studio
+// GOOGLE_API_KEY against generativelanguage.googleapis.com. Probing the AI
+// Studio endpoint for a Vertex deployment tests an API the agent does not use,
+// with a key it does not have, so it is omitted here and falls through to the
+// generic skeleton.
+var directProbeVendorPrefixes = map[string]string{
+	"anthropic": "anthropic",
+	"openai":    "openai",
+	"gemini":    "gemini",
+}
+
+// DirectProbeVendor resolves model to the vendor whose direct public API a
+// scaffolded health check may probe: "anthropic", "openai", "gemini", or "" if
+// no direct probe is valid.
+//
+// "" means the scaffolder must emit the generic skeleton rather than guess.
+// That covers gateway-prefixed models (`bedrock/*`, `vertex_ai/*`,
+// `databricks/*`, ...), which reach the model through a gateway that
+// authenticates with its own credentials, every other long-tail vendor, any
+// unrecognized bare name, and the empty model.
+//
+// The matching is prefix-based and case-insensitive, NOT a substring test.
+// `bedrock/anthropic.claude-3-5-sonnet-...` contains "anthropic" but is served
+// by AWS: api.anthropic.com being reachable says nothing about that agent's
+// health, and ANTHROPIC_API_KEY is never set for it. A health check gated on
+// that key returns unhealthy on the first tick, which suppresses the heartbeat
+// and makes the registry withdraw a provider that is working fine — and since
+// the key never appears, it never comes back (issue #1479).
+func DirectProbeVendor(model string) string {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if m == "" {
+		return ""
+	}
+	if idx := strings.Index(m, "/"); idx >= 0 {
+		return directProbeVendorPrefixes[m[:idx]]
+	}
+	return inferBig3VendorFromBareName(m)
+}

--- a/src/core/cli/scaffold/model_dispatch.go
+++ b/src/core/cli/scaffold/model_dispatch.go
@@ -229,8 +229,11 @@ func big3Family(m string) string {
 }
 
 // providerTagsByFamily are the discovery tags a scaffolded provider registers
-// for each big-3 family. The templates emit the same lists in their own syntax;
-// this copy serves the Go-side callers (the interactive wizard).
+// for each big-3 family. Single source of truth for every caller: the Go-side
+// ones (the interactive wizard) go through ProviderTagsForModel directly, and
+// the three language templates reach the same function through the
+// `providerTags` template func. Each template supplies only its own literal
+// syntax around the list — none of them restates the tags.
 var providerTagsByFamily = map[string][]string{
 	"anthropic": {"llm", "claude", "anthropic", "provider"},
 	"openai":    {"llm", "openai", "gpt", "provider"},

--- a/src/core/cli/scaffold/model_dispatch_test.go
+++ b/src/core/cli/scaffold/model_dispatch_test.go
@@ -185,6 +185,193 @@ func TestDirectProbeVendorIsNarrowerThanNativeDispatch(t *testing.T) {
 	assert.Empty(t, DirectProbeVendor("vertex_ai/gemini-2.5-flash"))
 }
 
+// Issue #1479, second half. The templates' TAG arms answer a different question
+// from the probe arms: not "which vendor's API can this be probed against" but
+// "which family built this model". Wiring the tags to DirectProbeVendor drops
+// the vendor tags from every gateway provider, and a consumer scaffolded with
+// `--vendor claude` pins `+claude` — so a Bedrock Claude provider silently stops
+// resolving for it.
+func TestModelFamily(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		expected string
+	}{
+		// --- big-3, explicit vendor/ prefix ------------------------------
+		{"anthropic prefixed", "anthropic/claude-sonnet-5", "anthropic"},
+		{"openai prefixed", "openai/gpt-4o", "openai"},
+		{"gemini prefixed", "gemini/gemini-2.5-flash", "gemini"},
+
+		// --- big-3, bare names -------------------------------------------
+		{"bare claude", "claude-sonnet-5", "anthropic"},
+		{"bare gpt", "gpt-4o", "openai"},
+		{"bare chatgpt", "chatgpt-4o-latest", "openai"},
+		{"bare o1", "o1", "openai"},
+		{"bare o3-mini", "o3-mini", "openai"},
+		{"bare gemini", "gemini-3-pro-preview", "gemini"},
+
+		// --- gateways: the family lives AFTER the gateway prefix ----------
+		// Bedrock and Databricks namespace with a "." rather than a "/", so
+		// the family is not the second path segment but the first dotted one.
+		{"bedrock claude", "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", "anthropic"},
+		{"databricks claude", "databricks/anthropic.claude-3-7-sonnet", "anthropic"},
+		// Cross-region inference profiles put a region ahead of the vendor.
+		{"bedrock cross-region claude", "bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0", "anthropic"},
+		{"bedrock eu cross-region claude", "bedrock/eu.anthropic.claude-3-7-sonnet-v1:0", "anthropic"},
+		// vertex_ai and azure leave a bare big-3 name as the remainder.
+		{"vertex gemini", "vertex_ai/gemini-2.5-flash", "gemini"},
+		{"azure gpt", "azure/gpt-4o", "openai"},
+		// A doubly-prefixed remainder resolves on its own vendor segment.
+		{"azure openai path", "azure/openai/gpt-4o", "openai"},
+		{"openrouter openai", "openrouter/openai/gpt-4o", "openai"},
+
+		// --- gateways carrying a NON-big-3 model --------------------------
+		{"bedrock llama", "bedrock/meta.llama3-70b-instruct-v1:0", ""},
+		{"bedrock mistral", "bedrock/mistral.mistral-large-2402-v1:0", ""},
+		{"bedrock titan", "bedrock/amazon.titan-text-express-v1", ""},
+
+		// --- long-tail vendors -------------------------------------------
+		{"cohere", "cohere/command-r-plus", ""},
+		{"ollama", "ollama/llama3", ""},
+		{"groq llama", "groq/llama-3.1-70b-versatile", ""},
+		{"unknown vendor", "acme-llm/frobnicator-9", ""},
+
+		// --- bare names that are NOT big-3 -------------------------------
+		{"bare llama", "llama-3-70b", ""},
+		{"bare mistral", "mistral-large-latest", ""},
+		{"o3-lookalike", "o3xyz", ""},
+
+		// Segments are matched WHOLE, never as substrings: a vendor-lookalike
+		// name is not the vendor.
+		{"vendor lookalike segment", "gateway/openai-clone.some-model", ""},
+		{"vendor as substring only", "notanthropicreally-v1", ""},
+
+		// A dot inside a bare version number is not a vendor segment, and
+		// must not stop the bare-name rules from applying.
+		{"dotted version bare name", "gpt-4.1", "openai"},
+		{"dotted version claude", "claude-3.5-sonnet", "anthropic"},
+
+		// --- empty / unset ------------------------------------------------
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ModelFamily(tt.model),
+				"ModelFamily(%q)", tt.model)
+		})
+	}
+}
+
+// --model is free-form, so casing is the user's, not ours.
+func TestModelFamilyIsCaseInsensitive(t *testing.T) {
+	assert.Equal(t, "anthropic", ModelFamily("Anthropic/Claude-Sonnet-5"))
+	assert.Equal(t, "anthropic", ModelFamily("Claude-Opus-4-8"))
+	assert.Equal(t, "openai", ModelFamily("OpenAI/GPT-4o"))
+	assert.Equal(t, "gemini", ModelFamily("VERTEX_AI/Gemini-2.5-Flash"))
+	assert.Equal(t, "anthropic", ModelFamily("Bedrock/Anthropic.Claude-3"))
+}
+
+func TestModelFamilyTrimsWhitespace(t *testing.T) {
+	assert.Equal(t, "anthropic", ModelFamily("  anthropic/claude-sonnet-5  "))
+	assert.Equal(t, "anthropic", ModelFamily("\tbedrock/anthropic.claude-3\n"))
+}
+
+// THE guard against "these two look the same, let's merge them".
+//
+// Every model below is genuinely a big-3 model reached through someone else's
+// endpoint. It must keep its family (so its discovery tags still name the
+// vendor a consumer pins) while having NO probeable direct vendor API (so the
+// health check falls through to the skeleton instead of demanding a credential
+// the deployment never sets). Collapsing either resolver into the other breaks
+// exactly one of those halves — and each break is silent in production.
+func TestModelFamilyAndProbeVendorDivergeOnGateways(t *testing.T) {
+	diverging := []struct {
+		model      string
+		wantFamily string
+	}{
+		{"bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", "anthropic"},
+		{"bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0", "anthropic"},
+		{"databricks/anthropic.claude-3-7-sonnet", "anthropic"},
+		{"vertex_ai/gemini-2.5-flash", "gemini"},
+		{"azure/gpt-4o", "openai"},
+		{"openrouter/openai/gpt-4o", "openai"},
+	}
+
+	for _, d := range diverging {
+		t.Run(d.model, func(t *testing.T) {
+			assert.Equal(t, d.wantFamily, ModelFamily(d.model),
+				"a gateway-served %s model is still a %s model: the discovery tags "+
+					"must keep naming the family or a `--vendor` consumer stops "+
+					"resolving it", d.wantFamily, d.wantFamily)
+			assert.Empty(t, DirectProbeVendor(d.model),
+				"a gateway authenticates with its own credentials: probing the "+
+					"vendor's public API withdraws a working provider for good")
+		})
+	}
+
+	// Where they must NOT diverge: a model reached directly gets both answers.
+	for _, model := range []string{
+		"anthropic/claude-sonnet-5", "openai/gpt-4o", "gemini/gemini-2.5-flash",
+		"claude-sonnet-5", "gpt-4o", "gemini-2.5-flash",
+	} {
+		assert.Equal(t, ModelFamily(model), DirectProbeVendor(model),
+			"a directly-reachable big-3 model: %q", model)
+		assert.NotEmpty(t, ModelFamily(model), model)
+	}
+
+	// And where both must be empty: no family, no probe.
+	for _, model := range []string{
+		"bedrock/meta.llama3-70b-instruct-v1:0", "cohere/command-r-plus",
+		"ollama/llama3", "mistral-large-latest", "",
+	} {
+		assert.Empty(t, ModelFamily(model), model)
+		assert.Empty(t, DirectProbeVendor(model), model)
+	}
+}
+
+// The interactive wizard sets ctx.Tags from this, and the templates' own tag
+// arms are skipped entirely when ctx.Tags is non-empty — so a wrong answer here
+// is not overridden by the (correct) template arms, it replaces them.
+func TestProviderTagsForModel(t *testing.T) {
+	assert.Equal(t, []string{"llm", "claude", "anthropic", "provider"},
+		ProviderTagsForModel("anthropic/claude-sonnet-5"))
+	assert.Equal(t, []string{"llm", "openai", "gpt", "provider"},
+		ProviderTagsForModel("openai/gpt-4o"))
+
+	// The wizard's old `contains` chain had no gemini arm at all, so every
+	// gemini provider it scaffolded advertised the generic tags.
+	assert.Equal(t, []string{"llm", "gemini", "google", "provider"},
+		ProviderTagsForModel("gemini/gemini-2.5-flash"))
+
+	// ...and it was case-sensitive, so a hand-typed custom model missed.
+	assert.Equal(t, []string{"llm", "claude", "anthropic", "provider"},
+		ProviderTagsForModel("Claude-Sonnet-5"))
+
+	// Gateway models keep the family tags: same reasoning as the templates.
+	assert.Equal(t, []string{"llm", "claude", "anthropic", "provider"},
+		ProviderTagsForModel("bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0"))
+	assert.Equal(t, []string{"llm", "gemini", "google", "provider"},
+		ProviderTagsForModel("vertex_ai/gemini-2.5-flash"))
+
+	// No family, generic tags.
+	assert.Equal(t, []string{"llm", "provider"},
+		ProviderTagsForModel("bedrock/meta.llama3-70b-instruct-v1:0"))
+	assert.Equal(t, []string{"llm", "provider"}, ProviderTagsForModel("cohere/command-r-plus"))
+	assert.Equal(t, []string{"llm", "provider"}, ProviderTagsForModel(""))
+}
+
+// The returned slice must not alias the package-level table: callers append to
+// it (the wizard adds user-supplied tags).
+func TestProviderTagsForModelReturnsACopy(t *testing.T) {
+	first := ProviderTagsForModel("anthropic/claude-sonnet-5")
+	first = append(first, "mutated")
+	require.Equal(t, []string{"llm", "claude", "anthropic", "provider"},
+		ProviderTagsForModel("anthropic/claude-sonnet-5"))
+	require.Len(t, first, 5)
+}
+
 // The template data map is what the requirements.txt template branches on.
 func TestTemplateDataCarriesRequiresLiteLLM(t *testing.T) {
 	native := TemplateDataFromContext(&ScaffoldContext{
@@ -230,9 +417,43 @@ func TestTemplateDataCarriesProbeVendor(t *testing.T) {
 	assert.Equal(t, "", none["ProbeVendor"])
 }
 
+// The tags arms gate on this key (issue #1479).
+func TestTemplateDataCarriesModelFamily(t *testing.T) {
+	direct := TemplateDataFromContext(&ScaffoldContext{
+		Name:  "claude-provider",
+		Model: "anthropic/claude-sonnet-5",
+	})
+	assert.Equal(t, "anthropic", direct["ModelFamily"])
+
+	gateway := TemplateDataFromContext(&ScaffoldContext{
+		Name:  "bedrock-provider",
+		Model: "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+	})
+	assert.Equal(t, "anthropic", gateway["ModelFamily"],
+		"Bedrock serves it, Anthropic built it — the tags follow the family")
+	assert.Equal(t, "", gateway["ProbeVendor"],
+		"...while the probe follows the credentials, which are AWS's")
+
+	vertex := TemplateDataFromContext(&ScaffoldContext{
+		Name:  "vertex-provider",
+		Model: "vertex_ai/gemini-2.5-flash",
+	})
+	assert.Equal(t, "gemini", vertex["ModelFamily"])
+	assert.Equal(t, "", vertex["ProbeVendor"])
+
+	longTail := TemplateDataFromContext(&ScaffoldContext{
+		Name:  "llama-provider",
+		Model: "bedrock/meta.llama3-70b-instruct-v1:0",
+	})
+	assert.Equal(t, "", longTail["ModelFamily"])
+
+	none := TemplateDataFromContext(&ScaffoldContext{Name: "basic-agent"})
+	assert.Equal(t, "", none["ModelFamily"])
+}
+
 // Java's llm-provider computes its own $model (it defaults an empty .Model),
-// so it resolves the vendor through this function rather than the data key.
-func TestProbeVendorTemplateFunc(t *testing.T) {
+// so it resolves both answers through these functions rather than the data keys.
+func TestProbeVendorAndModelFamilyTemplateFuncs(t *testing.T) {
 	r := NewTemplateRenderer()
 	render := func(tmpl string) string {
 		out, err := r.RenderString(tmpl, map[string]interface{}{})
@@ -243,4 +464,9 @@ func TestProbeVendorTemplateFunc(t *testing.T) {
 	assert.Equal(t, "anthropic", render(`{{ probeVendor "anthropic/claude-sonnet-5" }}`))
 	assert.Equal(t, "", render(`{{ probeVendor "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0" }}`))
 	assert.Equal(t, "", render(`{{ probeVendor "vertex_ai/gemini-2.5-flash" }}`))
+
+	assert.Equal(t, "anthropic", render(`{{ modelFamily "anthropic/claude-sonnet-5" }}`))
+	assert.Equal(t, "anthropic", render(`{{ modelFamily "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0" }}`))
+	assert.Equal(t, "gemini", render(`{{ modelFamily "vertex_ai/gemini-2.5-flash" }}`))
+	assert.Equal(t, "", render(`{{ modelFamily "bedrock/meta.llama3-70b-instruct-v1:0" }}`))
 }

--- a/src/core/cli/scaffold/model_dispatch_test.go
+++ b/src/core/cli/scaffold/model_dispatch_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Issue #1383: the generated requirements.txt pins mcp-mesh[litellm] only for
@@ -87,6 +88,103 @@ func TestInferBig3VendorFromBareName(t *testing.T) {
 	assert.Equal(t, "", inferBig3VendorFromBareName(""))
 }
 
+// Issue #1479: the llm-provider templates pick a health-check probe from the
+// model string. Picking the wrong one is not cosmetic — the probe reports
+// unhealthy on the first tick, the heartbeat stops, the registry withdraws the
+// agent, and because the credential it asks for is one that deployment never
+// sets, the verdict never flips back. A working provider disappears for good.
+//
+// So this is deliberately NOT IsNativeDispatchModel. `vertex_ai/*` IS native
+// dispatch (bundled google-genai SDK) but authenticates with ADC / Workload
+// Identity, so the AI Studio probe is wrong for it.
+func TestDirectProbeVendor(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		expected string
+	}{
+		// --- big-3, explicit vendor/ prefix ------------------------------
+		{"anthropic prefixed", "anthropic/claude-sonnet-5", "anthropic"},
+		{"openai prefixed", "openai/gpt-4o", "openai"},
+		{"gemini prefixed", "gemini/gemini-2.5-flash", "gemini"},
+
+		// --- big-3, bare names -------------------------------------------
+		{"bare claude", "claude-sonnet-5", "anthropic"},
+		{"bare gpt", "gpt-4o", "openai"},
+		{"bare chatgpt", "chatgpt-4o-latest", "openai"},
+		{"bare o1", "o1", "openai"},
+		{"bare o3-mini", "o3-mini", "openai"},
+		{"bare o4-mini", "o4-mini", "openai"},
+		{"bare gemini", "gemini-3-pro-preview", "gemini"},
+		{"o3-lookalike", "o3xyz", ""},
+		{"bare llama", "llama-3-70b", ""},
+
+		// --- native dispatch, but NOT directly probeable ------------------
+		// vertex_ai routes through the same google-genai SDK as gemini/*,
+		// so IsNativeDispatchModel says true — but it authenticates with
+		// ADC / Workload Identity against a Google Cloud project endpoint.
+		// Probing AI Studio with a GOOGLE_API_KEY tests an API this agent
+		// never calls, with a key it does not have.
+		{"vertex_ai prefixed", "vertex_ai/gemini-2.5-flash", ""},
+
+		// --- gateways whose model id embeds a big-3 vendor name -----------
+		// The exact strings that made the old substring gate misfire.
+		{"bedrock claude", "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", ""},
+		{"databricks claude", "databricks/anthropic.claude-3-7-sonnet", ""},
+		{"azure openai", "azure/gpt-4o", ""},
+		{"openrouter openai", "openrouter/openai/gpt-4o", ""},
+
+		// --- long-tail vendors -------------------------------------------
+		{"cohere", "cohere/command-r-plus", ""},
+		{"ollama", "ollama/llama3", ""},
+		{"unknown vendor", "acme-llm/frobnicator-9", ""},
+
+		// --- empty / unset ------------------------------------------------
+		// Nothing is known about the model; emit the skeleton, never a probe
+		// chosen on a guess.
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, DirectProbeVendor(tt.model),
+				"DirectProbeVendor(%q)", tt.model)
+		})
+	}
+}
+
+// --model is free-form, so casing is the user's, not ours.
+func TestDirectProbeVendorIsCaseInsensitive(t *testing.T) {
+	assert.Equal(t, "anthropic", DirectProbeVendor("Anthropic/Claude-Sonnet-5"))
+	assert.Equal(t, "openai", DirectProbeVendor("OpenAI/GPT-4o"))
+	assert.Equal(t, "gemini", DirectProbeVendor("GEMINI/gemini-2.5-flash"))
+	assert.Equal(t, "anthropic", DirectProbeVendor("Claude-Opus-4-8"))
+	assert.Equal(t, "", DirectProbeVendor("VERTEX_AI/gemini-2.5-flash"))
+	assert.Equal(t, "", DirectProbeVendor("Bedrock/Anthropic.Claude-3"))
+}
+
+func TestDirectProbeVendorTrimsWhitespace(t *testing.T) {
+	assert.Equal(t, "anthropic", DirectProbeVendor("  anthropic/claude-sonnet-5  "))
+	assert.Equal(t, "openai", DirectProbeVendor("\tgpt-4o\n"))
+	assert.Equal(t, "", DirectProbeVendor("  bedrock/anthropic.claude-3  "))
+}
+
+// A probeable model is always native dispatch; the converse does not hold, and
+// vertex_ai is the whole reason the two questions need separate answers.
+func TestDirectProbeVendorIsNarrowerThanNativeDispatch(t *testing.T) {
+	for _, model := range []string{
+		"anthropic/claude-sonnet-5", "openai/gpt-4o", "gemini/gemini-2.5-flash",
+		"claude-sonnet-5", "gpt-4o", "gemini-2.5-flash",
+	} {
+		assert.NotEmpty(t, DirectProbeVendor(model), "probeable: %q", model)
+		assert.True(t, IsNativeDispatchModel(model), "native: %q", model)
+	}
+
+	assert.True(t, IsNativeDispatchModel("vertex_ai/gemini-2.5-flash"))
+	assert.Empty(t, DirectProbeVendor("vertex_ai/gemini-2.5-flash"))
+}
+
 // The template data map is what the requirements.txt template branches on.
 func TestTemplateDataCarriesRequiresLiteLLM(t *testing.T) {
 	native := TemplateDataFromContext(&ScaffoldContext{
@@ -103,4 +201,46 @@ func TestTemplateDataCarriesRequiresLiteLLM(t *testing.T) {
 
 	none := TemplateDataFromContext(&ScaffoldContext{Name: "basic-agent"})
 	assert.Equal(t, false, none["RequiresLiteLLM"])
+}
+
+// The llm-provider templates gate the health-check probe on this key, so it
+// has to reach them (issue #1479).
+func TestTemplateDataCarriesProbeVendor(t *testing.T) {
+	probeable := TemplateDataFromContext(&ScaffoldContext{
+		Name:  "claude-provider",
+		Model: "anthropic/claude-sonnet-5",
+	})
+	assert.Equal(t, "anthropic", probeable["ProbeVendor"])
+
+	gateway := TemplateDataFromContext(&ScaffoldContext{
+		Name:  "bedrock-provider",
+		Model: "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+	})
+	assert.Equal(t, "", gateway["ProbeVendor"],
+		"a Bedrock deployment has AWS credentials, not ANTHROPIC_API_KEY")
+
+	vertex := TemplateDataFromContext(&ScaffoldContext{
+		Name:  "vertex-provider",
+		Model: "vertex_ai/gemini-2.5-flash",
+	})
+	assert.Equal(t, "", vertex["ProbeVendor"],
+		"Vertex authenticates with ADC / Workload Identity, not an AI Studio key")
+
+	none := TemplateDataFromContext(&ScaffoldContext{Name: "basic-agent"})
+	assert.Equal(t, "", none["ProbeVendor"])
+}
+
+// Java's llm-provider computes its own $model (it defaults an empty .Model),
+// so it resolves the vendor through this function rather than the data key.
+func TestProbeVendorTemplateFunc(t *testing.T) {
+	r := NewTemplateRenderer()
+	render := func(tmpl string) string {
+		out, err := r.RenderString(tmpl, map[string]interface{}{})
+		require.NoError(t, err)
+		return out
+	}
+
+	assert.Equal(t, "anthropic", render(`{{ probeVendor "anthropic/claude-sonnet-5" }}`))
+	assert.Equal(t, "", render(`{{ probeVendor "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0" }}`))
+	assert.Equal(t, "", render(`{{ probeVendor "vertex_ai/gemini-2.5-flash" }}`))
 }

--- a/src/core/cli/scaffold/provider.go
+++ b/src/core/cli/scaffold/provider.go
@@ -6,6 +6,7 @@ package scaffold
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -147,7 +148,14 @@ func (ctx *ScaffoldContext) Validate() error {
 	// set gateway credentials instead, and the agent withdrew itself for good
 	// (issue #1479). There is no correct rendering of an llm-provider without a
 	// model, so it is rejected before any template runs.
-	if (ctx.AgentType == "llm-provider" || ctx.Template == "llm-provider") && ctx.Model == "" {
+	//
+	// Trimmed first: `--model "   "` is the same empty case wearing a disguise.
+	// ModelFamily and DirectProbeVendor both trim before resolving, so a
+	// whitespace-only model answers "" to every question the templates ask —
+	// same skeleton, same missing family tags — while the decorator gets the
+	// blank string embedded as its model id.
+	if (ctx.AgentType == "llm-provider" || ctx.Template == "llm-provider") &&
+		strings.TrimSpace(ctx.Model) == "" {
 		return fmt.Errorf("model is required for the llm-provider template (e.g. --model anthropic/claude-sonnet-5)")
 	}
 

--- a/src/core/cli/scaffold/provider.go
+++ b/src/core/cli/scaffold/provider.go
@@ -136,9 +136,19 @@ func (ctx *ScaffoldContext) Validate() error {
 		return fmt.Errorf("unsupported agent type: %s (supported: %v)", ctx.AgentType, supportedAgentTypes)
 	}
 
-	// Validate LLM-provider specific fields
-	if ctx.AgentType == "llm-provider" && ctx.Model == "" {
-		return fmt.Errorf("model is required for llm-provider agent type")
+	// Validate LLM-provider specific fields.
+	//
+	// Gated on the TEMPLATE as well as the agent type. `meshctl scaffold --name x
+	// --lang java --template llm-provider` leaves AgentType empty (it was dropped
+	// as a flag in #957), so an agent-type-only check let a provider scaffold
+	// through with no model at all — and the Java template then defaulted the
+	// model for its code while the README described the raw, empty one. The
+	// generated probe demanded ANTHROPIC_API_KEY, the README told the operator to
+	// set gateway credentials instead, and the agent withdrew itself for good
+	// (issue #1479). There is no correct rendering of an llm-provider without a
+	// model, so it is rejected before any template runs.
+	if (ctx.AgentType == "llm-provider" || ctx.Template == "llm-provider") && ctx.Model == "" {
+		return fmt.Errorf("model is required for the llm-provider template (e.g. --model anthropic/claude-sonnet-5)")
 	}
 
 	return nil

--- a/src/core/cli/scaffold/provider_test.go
+++ b/src/core/cli/scaffold/provider_test.go
@@ -173,6 +173,22 @@ func TestScaffoldContext_Validate(t *testing.T) {
 			errMsg:  "model is required",
 		},
 		{
+			// A whitespace-only --model is the same "no model" case wearing a
+			// disguise: ModelFamily and DirectProbeVendor both trim before
+			// resolving, so it answers "" for every question the templates ask
+			// and renders the skeleton — with the blank string embedded in the
+			// decorator as the model id.
+			name: "llm-provider template with whitespace-only model",
+			ctx: &ScaffoldContext{
+				Name:     "my-provider",
+				Language: "java",
+				Template: "llm-provider",
+				Model:    "   ",
+			},
+			wantErr: true,
+			errMsg:  "model is required",
+		},
+		{
 			name: "llm-provider template with model",
 			ctx: &ScaffoldContext{
 				Name:     "my-provider",

--- a/src/core/cli/scaffold/provider_test.go
+++ b/src/core/cli/scaffold/provider_test.go
@@ -142,6 +142,57 @@ func TestScaffoldContext_Validate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+
+		// --- llm-provider needs a model, whichever way it was selected ----
+		//
+		// Issue #1479. `meshctl scaffold --template llm-provider` never sets
+		// AgentType (the flag was dropped in #957), so an agent-type-only
+		// check let a modelless provider render. There is no correct
+		// rendering of one: the Java template defaults the model for its code
+		// while the README describes the raw, empty one, so the operator is
+		// told to configure gateway credentials while the generated probe
+		// demands ANTHROPIC_API_KEY — and the agent withdraws itself for good.
+		{
+			name: "llm-provider agent type without model",
+			ctx: &ScaffoldContext{
+				Name:      "my-provider",
+				Language:  "python",
+				AgentType: "llm-provider",
+			},
+			wantErr: true,
+			errMsg:  "model is required",
+		},
+		{
+			name: "llm-provider template without model",
+			ctx: &ScaffoldContext{
+				Name:     "my-provider",
+				Language: "java",
+				Template: "llm-provider",
+			},
+			wantErr: true,
+			errMsg:  "model is required",
+		},
+		{
+			name: "llm-provider template with model",
+			ctx: &ScaffoldContext{
+				Name:     "my-provider",
+				Language: "java",
+				Template: "llm-provider",
+				Model:    "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+			},
+			wantErr: false,
+		},
+		{
+			// The requirement is scoped to the provider template: every other
+			// template renders with an empty Model and must keep working.
+			name: "basic template without model",
+			ctx: &ScaffoldContext{
+				Name:     "my-agent",
+				Language: "python",
+				Template: "basic",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/src/core/cli/scaffold/renderer.go
+++ b/src/core/cli/scaffold/renderer.go
@@ -42,6 +42,11 @@ func NewTemplateRenderer() *TemplateRenderer {
 			"join":             strings.Join,
 			"split":            strings.Split,
 			"toJSON":           toJSON,
+			// Same resolver as the .ProbeVendor data field, exposed as a
+			// function for templates that compute their own model string
+			// (the Java llm-provider defaults $model when .Model is empty and
+			// must gate on that value, not on the raw context).
+			"probeVendor": DirectProbeVendor,
 		},
 	}
 }
@@ -282,6 +287,17 @@ func TemplateDataFromContext(ctx *ScaffoldContext) map[string]interface{} {
 		// rather than a bundled native SDK adapter, i.e. when the generated
 		// requirements.txt must pin mcp-mesh[litellm] (issue #1383).
 		"RequiresLiteLLM": RequiresLiteLLM(ctx.Model),
+
+		// "anthropic" / "openai" / "gemini" when a scaffolded health check may
+		// probe that vendor's own API for this model, "" when it may not and
+		// the generic skeleton must be emitted instead (issue #1479).
+		//
+		// Templates MUST gate the health probe (and the vendor-specific tags,
+		// env vars and README text that go with it) on this, never on
+		// `contains .Model "<vendor>"` — a substring test routes
+		// bedrock/anthropic.* and vertex_ai/gemini-* into a probe of
+		// credentials those deployments do not have.
+		"ProbeVendor": DirectProbeVendor(ctx.Model),
 
 		// Tool fields
 		"ToolName":        ctx.ToolName,

--- a/src/core/cli/scaffold/renderer.go
+++ b/src/core/cli/scaffold/renderer.go
@@ -42,11 +42,12 @@ func NewTemplateRenderer() *TemplateRenderer {
 			"join":             strings.Join,
 			"split":            strings.Split,
 			"toJSON":           toJSON,
-			// Same resolver as the .ProbeVendor data field, exposed as a
-			// function for templates that compute their own model string
-			// (the Java llm-provider defaults $model when .Model is empty and
-			// must gate on that value, not on the raw context).
+			// Same resolvers as the .ProbeVendor / .ModelFamily data fields,
+			// exposed as functions for templates that compute their own model
+			// string (the Java llm-provider defaults $model when .Model is
+			// empty and must gate on that value, not on the raw context).
 			"probeVendor": DirectProbeVendor,
+			"modelFamily": ModelFamily,
 		},
 	}
 }
@@ -292,12 +293,25 @@ func TemplateDataFromContext(ctx *ScaffoldContext) map[string]interface{} {
 		// probe that vendor's own API for this model, "" when it may not and
 		// the generic skeleton must be emitted instead (issue #1479).
 		//
-		// Templates MUST gate the health probe (and the vendor-specific tags,
-		// env vars and README text that go with it) on this, never on
+		// Templates MUST gate the health probe (and the env vars and README
+		// credential text that go with it) on this, never on
 		// `contains .Model "<vendor>"` — a substring test routes
 		// bedrock/anthropic.* and vertex_ai/gemini-* into a probe of
 		// credentials those deployments do not have.
+		//
+		// Discovery TAGS are not part of that set: they follow ModelFamily
+		// below, because "who serves it" and "who built it" are different
+		// questions and a gateway model still belongs to its family.
 		"ProbeVendor": DirectProbeVendor(ctx.Model),
+
+		// "anthropic" / "openai" / "gemini" when the model belongs to that
+		// big-3 family, "" otherwise — a different question from ProbeVendor,
+		// and the two answers diverge on gateway models. Templates gate the
+		// DISCOVERY TAGS on this: `bedrock/anthropic.claude-*` is genuinely a
+		// Claude model and must keep advertising the claude/anthropic tags a
+		// `--vendor claude` consumer pins with `+claude`, even though it has no
+		// probeable direct vendor API (issue #1479).
+		"ModelFamily": ModelFamily(ctx.Model),
 
 		// Tool fields
 		"ToolName":        ctx.ToolName,

--- a/src/core/cli/scaffold/renderer.go
+++ b/src/core/cli/scaffold/renderer.go
@@ -48,6 +48,16 @@ func NewTemplateRenderer() *TemplateRenderer {
 			// empty and must gate on that value, not on the raw context).
 			"probeVendor": DirectProbeVendor,
 			"modelFamily": ModelFamily,
+			// The discovery tags an llm-provider registers for a model, so the
+			// three language templates render one Go-side list instead of
+			// hand-writing four family arms each. Each template still supplies
+			// its own literal syntax (`[...]` vs `{...}`) around the range;
+			// only the tag CONTENT comes from here.
+			//
+			// The templates used to duplicate these lists, which is exactly the
+			// copy-divergence shape that let the inverted health-check verdict
+			// propagate from Python to Java unnoticed (issues #1476/#1479).
+			"providerTags": ProviderTagsForModel,
 		},
 	}
 }

--- a/src/core/cli/scaffold/static_test.go
+++ b/src/core/cli/scaffold/static_test.go
@@ -107,6 +107,30 @@ func TestStaticProvider_Validate(t *testing.T) {
 			wantErr: true,
 			errMsg:  "name is required",
 		},
+		{
+			// This is the path `meshctl scaffold --name x --lang java
+			// --template llm-provider --no-interactive` takes: AgentType is
+			// left empty, so before #1479 the modelless provider rendered and
+			// shipped a README that contradicted its own generated code.
+			name: "llm-provider template without model is rejected here",
+			ctx: &ScaffoldContext{
+				Name:     "my-provider",
+				Language: "java",
+				Template: "llm-provider",
+			},
+			wantErr: true,
+			errMsg:  "model is required",
+		},
+		{
+			name: "llm-provider template with model passes",
+			ctx: &ScaffoldContext{
+				Name:     "my-provider",
+				Language: "java",
+				Template: "llm-provider",
+				Model:    "anthropic/claude-sonnet-5",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

The `llm-provider` scaffolds selected the health-check body with `contains .Model "anthropic"` — a case-sensitive substring test. `--model` is free-form and the repo supports gateway-prefixed models, so `bedrock/anthropic.claude-…` matched "anthropic" and emitted a probe of `api.anthropic.com` gated on `ANTHROPIC_API_KEY`. A Bedrock deployment supplies AWS credentials, not that key, so the check returned unhealthy on the first tick, the heartbeat stopped, and the registry withdrew a **fully working provider** — permanently, since the missing env var never appears.

Harmless before the health check existed; load-bearing since #1473/#1474, and 3.5.2 is the release that makes it so in all three runtimes.

Two resolvers now answer two genuinely different questions, both prefix-based and case-insensitive:

- **`DirectProbeVendor`** — which vendor's own API can this model's own key probe. Gates the health probe and the credential docs.
- **`ModelFamily`** — which model family is this. Gates the discovery tags.

They agree for the big three and diverge on exactly the gateway models. `bedrock/anthropic.claude-*` gets the **generic skeleton probe** *and* the **claude tags**.

`vertex_ai` is the subtle case. It **is** native dispatch — `nativeVendorPrefixes` includes it and it routes through the bundled google-genai SDK like `gemini/*` — but it authenticates with ADC / Workload Identity rather than an AI Studio key. Reusing `IsNativeDispatchModel` would have looked correct and kept the bug alive through a second path. `TestDirectProbeVendorIsNarrowerThanNativeDispatch` and `TestModelFamilyAndProbeVendorDivergeOnGateways` pin both divergences so a future "these look the same, let's merge them" fails loudly.

Gateway and long-tail models fall through to the generic skeleton, whose comment points at the gateway the operator actually authenticates against. No Bedrock or Vertex probes are invented.

All 21 substring gates across the six templates are converted, plus the last one in Go (`interactive.go`, which had no gemini arm at all and — by setting `Tags` non-empty — made the templates' `{{ if .Tags }}` arm win outright, so neither resolver was ever consulted).

`ModelFamily` handles two real-world shapes worth naming: **cross-region inference profiles** (`bedrock/us.anthropic.claude-*`), which a first-dot-only implementation silently strips, and **dotted version names** (`gpt-4.1`), which must fall through to bare-name inference. `bedrock/meta.llama-*` resolves to `""` — a negative case a second substring match could not satisfy.

## Review notes

**Behaviour change beyond the stated intent, called out deliberately.** Bare big-3 names now render a real probe where they previously rendered the skeleton: `--model claude-sonnet-5` moves from "always healthy" to "withdraws unless `ANTHROPIC_API_KEY` is set". This is consistent with `inferBig3VendorFromBareName` and how those models actually dispatch, but it is a widening and anyone scaffolding that way should know.

Also fixed from review: `scaffold --template llm-provider` accepted an empty model, because the model check was gated on *agent type*, which only the `llm provider` subcommand sets. Java's template then defaulted the code to `anthropic/claude-sonnet-5` while its README computed from the raw empty model — so the README told the operator to set gateway credentials while the code required `ANTHROPIC_API_KEY`, reintroducing this PR's own failure mode. Fixed at the root by validating on the template too.

One test was asserting the wrong thing: the uppercase `VERTEX_AI/…` row could not catch what its comment claimed (a resolver that never lowercased would miss the map and pass anyway). Uppercase coverage moved to the direction that can regress — `ANTHROPIC/claude-sonnet-5` must still probe.

Known gap, not addressed here: #1483 — gateway scaffolds still ship helm values wiring the three vendor API keys, contradicting their own README. Harmless today (`optional: true`), but the honest fix needs per-gateway deployment knowledge (IRSA, Workload Identity ServiceAccount annotations, Databricks host+token) that the templates don't model yet.

Closes #1479

## Test plan

- [x] CLI tests 799 → 869
- [x] Every new assertion verified **red before green**: aliasing `ModelFamily` to `DirectProbeVendor` fails 26 subtests; reverting it to substring fails 25 assertions; loosening the validation fails both new cases
- [x] Restoring the original substring gate fails 24/24 gateway template cases, with the Python bedrock render emitting `ANTHROPIC_API_KEY` and `api.anthropic.com` — the live bug, reproduced on demand
- [x] Render matrix 8 models × 3 languages: probe and tags correct **and independent** in every cell
- [x] Gateway/long-tail renders grep clean of all three API key names and all three API hosts
- [x] `py_compile` 8/8, `tsc --noEmit` 8/8, `javac` 8/8 plus `mvn compile` on three representative Java renders
- [x] `meshctl scaffold --template llm-provider` with no model now exits 1 and creates nothing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved model detection for scaffolded LLM providers.
  * Gateway-prefixed models now retain family-based discovery tags while using gateway-specific health checks and credentials.
  * Direct health checks and credentials are selected for supported Anthropic, OpenAI, and Gemini models.
  * Added generic guidance for configuring gateway endpoints and credentials.

* **Bug Fixes**
  * Prevented gateway deployments from incorrectly probing underlying vendor APIs.
  * LLM-provider scaffolding now requires a model to be specified, whether selected by agent type or template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->