### PR TITLE
fix(python): degrade on a malformed health-check return; correct TTL wording

### DIFF
--- a/src/core/cli/man/content/health_java.md
+++ b/src/core/cli/man/content/health_java.md
@@ -54,7 +54,7 @@ One check per agent, on any Spring bean. Return `MeshHealth` for full detail, or
 
 ### What a Failing Check Does
 
-While the check reports unhealthy the agent **stops heartbeating**. The registry marks it unhealthy after the staleness window, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent - no restart. The TTL is the detection latency in both directions.
+While the check reports unhealthy the agent **stops heartbeating**. The registry marks it unhealthy after the staleness window, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent through the `410 Gone` re-register path - no restart. The TTL is the cadence, not the end-to-end latency: it only bounds how long until the next check runs. Withdrawal costs that plus the registry's staleness window once heartbeats stop, and recovery costs it plus the heartbeat resume and re-register round trip.
 
 The verdict also drives the probe endpoints: `/ready` answers 503 while unhealthy, and `/health` carries the `checks` and `errors` the method returned. `/livez` never consults it - a restart cannot fix a vendor outage.
 

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealthCheck.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealthCheck.java
@@ -77,9 +77,10 @@ public @interface MeshHealthCheck {
      * How often the check is re-run, in seconds.
      *
      * <p>Mirrors Python's {@code health_check_ttl}, and the same default (15).
-     * This is the detection latency in <b>both</b> directions: an outage takes
-     * up to one TTL to be noticed, and a recovery takes up to one TTL to be
-     * published.
+     * This is the <b>cadence</b>, not the end-to-end latency: withdrawal costs
+     * up to one TTL plus the registry's staleness window once heartbeats stop,
+     * and recovery costs up to one TTL plus the heartbeat resume and
+     * re-register round trip.
      *
      * <p>Override with the {@code MCP_MESH_HEALTH_CHECK_TTL} environment
      * variable.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckScheduler.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckScheduler.java
@@ -18,9 +18,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * <p>Each tick stores the result for {@link MeshHealthController} and reports it
  * to the mesh runtime, where {@code unhealthy} suppresses the heartbeat so the
- * registry withdraws this agent from dependency resolution. The TTL is
- * therefore the detection latency in <b>both</b> directions — outage and
- * recovery. Mirrors Python's {@code update_health_result} refresh task.
+ * registry withdraws this agent from dependency resolution. The TTL is the
+ * <b>cadence</b> of that check, not the end-to-end latency in either
+ * direction: withdrawal costs up to one TTL plus the registry's staleness
+ * window once heartbeats stop, and recovery costs up to one TTL plus the
+ * heartbeat resume and re-register round trip. Mirrors Python's
+ * {@code update_health_result} refresh task.
  *
  * <h2>Why a ScheduledExecutorService and not {@code @Scheduled}</h2>
  *

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
@@ -446,8 +446,12 @@ class FastAPIServerSetupStep(PipelineStep):
                     Since issue #1472 this loop also drives dependency
                     resolution: each refresh reports its verdict to the
                     Rust core, which stops heartbeating while the agent
-                    is unhealthy. The TTL is therefore the detection
-                    latency for both directions — outage and recovery.
+                    is unhealthy. The TTL is the cadence of that check,
+                    not the end-to-end latency in either direction:
+                    withdrawal costs up to one TTL plus the registry's
+                    staleness window once heartbeats stop, and recovery
+                    costs up to one TTL plus the heartbeat resume and
+                    re-register round trip.
                     """
                     try:
                         await asyncio.wrap_future(ready_future)

--- a/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
+++ b/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
@@ -195,10 +195,25 @@ def _parse_health_result(
         errors = user_result.errors
 
     else:
-        logger.warning(f"Unexpected health check result type: {type(user_result)}")
-        status_type = HealthStatusType.UNHEALTHY
+        # Issue #1477: a wrong return TYPE degrades, it does not withdraw. It
+        # is deterministic — it recurs identically on every refresh — so
+        # UNHEALTHY would withdraw the agent permanently on a coding defect in
+        # the check, from an agent whose upstream is very likely fine. Java
+        # (#1475) and TypeScript (#1481) make the same call. Returning False,
+        # or a dict with "status": "unhealthy", still withdraws.
+        type_name = type(user_result).__name__
+        logger.warning(
+            "Unexpected health check return type '%s' — reporting degraded "
+            "(the agent keeps heartbeating). Return a bool, a "
+            "{status, checks, errors} dict, or a HealthStatus.",
+            type_name,
+        )
+        status_type = HealthStatusType.DEGRADED
         checks = {"health_check_return_type": False}
-        errors = [f"Invalid return type: {type(user_result)}"]
+        errors = [
+            f"Invalid return type: {type_name}. A health check returns a bool, "
+            f"a {{status, checks, errors}} dict, or a HealthStatus."
+        ]
 
     return status_type, checks, errors
 

--- a/src/runtime/python/tests/unit/test_health_check_manager.py
+++ b/src/runtime/python/tests/unit/test_health_check_manager.py
@@ -234,6 +234,81 @@ async def test_health_check_different_agents_independent_cache(agent_config):
     assert call_count_agent2 == 1
 
 
+class TestMalformedReturnDegrades:
+    """Issue #1477: a wrong return TYPE degrades, it does not withdraw.
+
+    A wrong return type is deterministic — it recurs identically on every
+    refresh, so mapping it to UNHEALTHY withdraws the agent permanently on a
+    coding defect in the check, from an agent whose upstream is very likely
+    fine. Java (#1475) and TypeScript (#1481) both degrade here.
+
+    Only ``unhealthy`` suppresses the heartbeat, so DEGRADED vs UNHEALTHY is a
+    behavioural difference, not a reporting one.
+    """
+
+    @pytest.mark.parametrize(
+        "bad_result",
+        [42, "healthy", None, ["healthy"], 1.5],
+        ids=["int", "str", "none", "list", "float"],
+    )
+    @pytest.mark.asyncio
+    async def test_unexpected_type_degrades(self, agent_config, bad_result):
+        async def bad_health_check() -> Any:
+            return bad_result
+
+        result = await get_health_status_with_cache(
+            agent_id=f"malformed-{type(bad_result).__name__}",
+            health_check_fn=bad_health_check,
+            agent_config=agent_config,
+            startup_context={},
+            ttl=15,
+        )
+
+        # The assertion that fails if the mapping is reverted to UNHEALTHY.
+        assert result.status == HealthStatusType.DEGRADED
+        assert result.status != HealthStatusType.UNHEALTHY
+
+        # A degraded verdict that says nothing is worse than an unhealthy one
+        # that does: the payload must still name the offending type.
+        assert result.checks["health_check_return_type"] is False
+        assert type(bad_result).__name__ in result.errors[0]
+
+    @pytest.mark.asyncio
+    async def test_false_still_withdraws(self, agent_config):
+        """Returning False is an explicit verdict and must keep withdrawing."""
+
+        async def unhealthy_check() -> bool:
+            return False
+
+        result = await get_health_status_with_cache(
+            agent_id="explicit-false",
+            health_check_fn=unhealthy_check,
+            agent_config=agent_config,
+            startup_context={},
+            ttl=15,
+        )
+
+        assert result.status == HealthStatusType.UNHEALTHY
+
+    @pytest.mark.asyncio
+    async def test_dict_unhealthy_still_withdraws(self, agent_config):
+        """An explicit ``{"status": "unhealthy"}`` must keep withdrawing."""
+
+        async def unhealthy_check() -> dict:
+            return {"status": "unhealthy", "errors": ["upstream down"]}
+
+        result = await get_health_status_with_cache(
+            agent_id="explicit-dict-unhealthy",
+            health_check_fn=unhealthy_check,
+            agent_config=agent_config,
+            startup_context={},
+            ttl=15,
+        )
+
+        assert result.status == HealthStatusType.UNHEALTHY
+        assert result.errors == ["upstream down"]
+
+
 def test_clear_health_cache_single_agent(agent_config):
     """Test clearing cache for a single agent."""
     clear_health_cache()


### PR DESCRIPTION
## Summary

Two small health-check follow-ups, bundled.

**#1477 — a malformed return should degrade, not withdraw.** An unrecognized return type from a user health check mapped to `UNHEALTHY`, which suppresses the heartbeat and withdraws the agent from resolution. Java (#1475) and TypeScript (#1481) map the same case to `DEGRADED`.

They are right. A wrong return *type* is deterministic — it recurs identically on every refresh — so `UNHEALTHY` withdraws the agent **permanently**, on a coding defect in the check, from an agent whose upstream is very likely fine. That turns a typo into a silent permanent outage of every capability the agent provides.

Only the malformed case changes. Returning `False`, or a dict with `"status": "unhealthy"`, still withdraws, and both now have explicit guard tests.

**#1482 — `healthCheckTtl` is the cadence, not the end-to-end detection latency.** Withdrawal also costs the registry staleness window once heartbeats stop; recovery needs a passing check *plus* the heartbeat resume and the `410 Gone` re-register round trip. Corrected in four surfaces — the Java man page, `MeshHealthCheckScheduler`, `MeshHealthCheck`'s public javadoc (IDE hover text for every Java user), and the Python refresh loop.

## Review notes

**The operator-visible signal does not weaken.** `build_health_response` returns 200 only for `"healthy"`, so a degraded verdict still answers **503 on `/health` and `/ready`** with the `checks` and `errors` attached. What changes is the heartbeat alone — which is the one bit that decides whether resolution keeps selecting the agent.

**No pre-existing test pinned `UNHEALTHY` for this case.** Searched `tests/` and both in-package test dirs for `_parse_health_result`, `health_check_return_type` and `Invalid return type`; the only other hit was a vendored copy under `tests/manual/scratch/.venv`. So nothing was rewritten to accommodate the change — only added. Had a test deliberately pinned the old behaviour, that would have been an argument to hear rather than an obstacle to edit.

**Red before green**: the five parametrized cases were written and run *before* the source edit, failing on exactly the assertion that reverting the mapping would break, while the two withdraw-guard tests passed on both sides.

Each #1482 site matches the register of its TypeScript counterpart from #1481 rather than inventing a fifth phrasing — man-page prose, javadoc, inline comment. A repo sweep confirms no copy remains in tracked source; the two hits under `target/apidocs/` are stale generated javadoc HTML (`.gitignore:79`). Adjacent surfaces were checked and are already correct: the scaffold templates say "runs every `ttlSeconds` seconds", which is cadence-accurate, and the Python man page has no equivalent paragraph.

Not included, deliberately: #1478 (TS `/ready` reflecting the verdict — a contained change, but a new module plus tests rather than a one-liner) and #1483 (gateway helm values, which needs a decision on the env/ServiceAccount shape before it is a coding task).

Closes #1477
Closes #1482

## Test plan

- [x] Python 2546 → 2553 passed, 7 skipped, 0 failed
- [x] Java `mvn -o test` on both touched modules — 998 tests, 0 failures (docs-only, counts unchanged)
- [x] `go build ./...` clean; `go test ./src/core/cli/...` all ok
- [x] Man goldens unmoved, as expected for a `_java` variant
- [x] Repo sweep: zero remaining copies in tracked source
