### PR TITLE
fix(typescript): reflect the health verdict on /ready and /health

### DIFF
--- a/cmd/meshctl/templates/java/llm-provider/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/helm-values.yaml.tmpl
@@ -31,35 +31,54 @@ registry:
   host: "mcp-core-mcp-mesh-registry"
   port: "8000"
 
-# LLM provider needs API keys for the backend LLM service.
-# The refs below point to a secret named `llm-secrets` — update the `name:` values
-# below to match your cluster's secret, or create the secret:
+{{- /* Only the credential the SELECTED model actually authenticates with is
+     wired. Wiring all three vendor keys told a Gemini scaffold it needed
+     ANTHROPIC_API_KEY, and told a gateway scaffold to create exactly the
+     credentials its own README (correctly) says are the wrong ones —
+     issues #1479/#1483. `.ProbeVendor` is "" for gateway-prefixed and
+     long-tail models; do NOT gate this on `contains .Model "<vendor>"`,
+     which matches bedrock/anthropic.* and vertex_ai/gemini-*. */}}
+{{- $envVar := "" }}
+{{- $secretKey := "" }}
+{{- $keyExample := "" }}
+{{- if eq .ProbeVendor "anthropic" }}{{ $envVar = "ANTHROPIC_API_KEY" }}{{ $secretKey = "anthropic-api-key" }}{{ $keyExample = "sk-ant-..." }}
+{{- else if eq .ProbeVendor "openai" }}{{ $envVar = "OPENAI_API_KEY" }}{{ $secretKey = "openai-api-key" }}{{ $keyExample = "sk-..." }}
+{{- else if eq .ProbeVendor "gemini" }}{{ $envVar = "GOOGLE_API_KEY" }}{{ $secretKey = "google-api-key" }}{{ $keyExample = "AIza..." }}
+{{- end }}
+{{ if .ProbeVendor -}}
+# {{ .Model }} authenticates with {{ $envVar }}, and that is
+# the only credential wired below. The ref points to a secret named
+# `llm-secrets` — update the `name:` value to match your cluster's secret, or
+# create the secret:
 #   kubectl create secret generic llm-secrets \
-#     --from-literal=anthropic-api-key=sk-ant-... \
-#     --from-literal=openai-api-key=sk-... \
-#     --from-literal=google-api-key=...
+#     --from-literal={{ $secretKey }}={{ $keyExample }}
 env:
-  - name: ANTHROPIC_API_KEY
+  - name: {{ $envVar }}
     valueFrom:
       secretKeyRef:
         name: llm-secrets
-        key: anthropic-api-key
+        key: {{ $secretKey }}
         optional: true
-  - name: OPENAI_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: llm-secrets
-        key: openai-api-key
-        optional: true
-  - name: GOOGLE_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: llm-secrets
-        key: google-api-key
-        optional: true
+{{- else -}}
+# No credentials are wired here.
+# {{ .Model }} is not served by a direct
+# big-3 API, so there is no vendor key to reference: for a gateway-prefixed model
+# (bedrock/..., vertex_ai/..., databricks/...) it authenticates with the
+# gateway's own credentials — AWS credentials, ADC / Workload Identity, a
+# workspace token — not the underlying model vendor's API key, and this
+# template cannot know which. Create the secret described in the README, then
+# reference it here:
+#
+# env:
+#   - name: <VARIABLE>
+#     valueFrom:
+#       secretKeyRef:
+#         name: llm-secrets
+#         key: <credential-name>
+#         optional: true
+{{- end }}
 
 # Optional: Secrets (creates a K8s Secret, injected via envFrom)
 # Uncomment to add — leaving commented avoids overriding base values
 # secrets:
 #   DATABASE_URL: "postgres://user:pass@host:5432/db"
-#   API_KEY: "your-api-key"

--- a/cmd/meshctl/templates/python/llm-provider/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/helm-values.yaml.tmpl
@@ -31,32 +31,52 @@ registry:
   host: "mcp-core-mcp-mesh-registry"
   port: "8000"
 
-# LLM provider needs API keys for the backend LLM service.
-# The refs below point to a secret named `llm-secrets` — update the `name:` values
-# below to match your cluster's secret, or create the secret:
+{{- /* Only the credential the SELECTED model actually authenticates with is
+     wired. Wiring all three vendor keys told a Gemini scaffold it needed
+     ANTHROPIC_API_KEY, and told a gateway scaffold to create exactly the
+     credentials its own README (correctly) says are the wrong ones —
+     issues #1479/#1483. `.ProbeVendor` is "" for gateway-prefixed and
+     long-tail models; do NOT gate this on `contains .Model "<vendor>"`,
+     which matches bedrock/anthropic.* and vertex_ai/gemini-*. */}}
+{{- $envVar := "" }}
+{{- $secretKey := "" }}
+{{- $keyExample := "" }}
+{{- if eq .ProbeVendor "anthropic" }}{{ $envVar = "ANTHROPIC_API_KEY" }}{{ $secretKey = "anthropic-api-key" }}{{ $keyExample = "sk-ant-..." }}
+{{- else if eq .ProbeVendor "openai" }}{{ $envVar = "OPENAI_API_KEY" }}{{ $secretKey = "openai-api-key" }}{{ $keyExample = "sk-..." }}
+{{- else if eq .ProbeVendor "gemini" }}{{ $envVar = "GOOGLE_API_KEY" }}{{ $secretKey = "google-api-key" }}{{ $keyExample = "AIza..." }}
+{{- end }}
+{{ if .ProbeVendor -}}
+# {{ .Model }} authenticates with {{ $envVar }}, and that is
+# the only credential wired below. The ref points to a secret named
+# `llm-secrets` — update the `name:` value to match your cluster's secret, or
+# create the secret:
 #   kubectl create secret generic llm-secrets \
-#     --from-literal=anthropic-api-key=sk-ant-... \
-#     --from-literal=openai-api-key=sk-... \
-#     --from-literal=google-api-key=...
+#     --from-literal={{ $secretKey }}={{ $keyExample }}
 env:
-  - name: ANTHROPIC_API_KEY
+  - name: {{ $envVar }}
     valueFrom:
       secretKeyRef:
         name: llm-secrets
-        key: anthropic-api-key
+        key: {{ $secretKey }}
         optional: true
-  - name: OPENAI_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: llm-secrets
-        key: openai-api-key
-        optional: true
-  - name: GOOGLE_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: llm-secrets
-        key: google-api-key
-        optional: true
+{{- else -}}
+# No credentials are wired here.
+# {{ .Model }} is not served by a direct
+# big-3 API, so there is no vendor key to reference: for a gateway-prefixed model
+# (bedrock/..., vertex_ai/..., databricks/...) it authenticates with the
+# gateway's own credentials — AWS credentials, ADC / Workload Identity, a
+# workspace token — not the underlying model vendor's API key, and this
+# template cannot know which. Create the secret described in the README, then
+# reference it here:
+#
+# env:
+#   - name: <VARIABLE>
+#     valueFrom:
+#       secretKeyRef:
+#         name: llm-secrets
+#         key: <credential-name>
+#         optional: true
+{{- end }}
 
 # Optional: Configure model settings
 # - name: DEFAULT_MODEL
@@ -68,4 +88,3 @@ env:
 # Uncomment to add — leaving commented avoids overriding base values
 # secrets:
 #   DATABASE_URL: "postgres://user:pass@host:5432/db"
-#   API_KEY: "your-api-key"

--- a/cmd/meshctl/templates/typescript/llm-provider/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/helm-values.yaml.tmpl
@@ -31,35 +31,54 @@ registry:
   host: "mcp-core-mcp-mesh-registry"
   port: "8000"
 
-# LLM provider needs API keys for the backend LLM service.
-# The refs below point to a secret named `llm-secrets` — update the `name:` values
-# below to match your cluster's secret, or create the secret:
+{{- /* Only the credential the SELECTED model actually authenticates with is
+     wired. Wiring all three vendor keys told a Gemini scaffold it needed
+     ANTHROPIC_API_KEY, and told a gateway scaffold to create exactly the
+     credentials its own README (correctly) says are the wrong ones —
+     issues #1479/#1483. `.ProbeVendor` is "" for gateway-prefixed and
+     long-tail models; do NOT gate this on `contains .Model "<vendor>"`,
+     which matches bedrock/anthropic.* and vertex_ai/gemini-*. */}}
+{{- $envVar := "" }}
+{{- $secretKey := "" }}
+{{- $keyExample := "" }}
+{{- if eq .ProbeVendor "anthropic" }}{{ $envVar = "ANTHROPIC_API_KEY" }}{{ $secretKey = "anthropic-api-key" }}{{ $keyExample = "sk-ant-..." }}
+{{- else if eq .ProbeVendor "openai" }}{{ $envVar = "OPENAI_API_KEY" }}{{ $secretKey = "openai-api-key" }}{{ $keyExample = "sk-..." }}
+{{- else if eq .ProbeVendor "gemini" }}{{ $envVar = "GOOGLE_API_KEY" }}{{ $secretKey = "google-api-key" }}{{ $keyExample = "AIza..." }}
+{{- end }}
+{{ if .ProbeVendor -}}
+# {{ .Model }} authenticates with {{ $envVar }}, and that is
+# the only credential wired below. The ref points to a secret named
+# `llm-secrets` — update the `name:` value to match your cluster's secret, or
+# create the secret:
 #   kubectl create secret generic llm-secrets \
-#     --from-literal=anthropic-api-key=sk-ant-... \
-#     --from-literal=openai-api-key=sk-... \
-#     --from-literal=google-api-key=...
+#     --from-literal={{ $secretKey }}={{ $keyExample }}
 env:
-  - name: ANTHROPIC_API_KEY
+  - name: {{ $envVar }}
     valueFrom:
       secretKeyRef:
         name: llm-secrets
-        key: anthropic-api-key
+        key: {{ $secretKey }}
         optional: true
-  - name: OPENAI_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: llm-secrets
-        key: openai-api-key
-        optional: true
-  - name: GOOGLE_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: llm-secrets
-        key: google-api-key
-        optional: true
+{{- else -}}
+# No credentials are wired here.
+# {{ .Model }} is not served by a direct
+# big-3 API, so there is no vendor key to reference: for a gateway-prefixed model
+# (bedrock/..., vertex_ai/..., databricks/...) it authenticates with the
+# gateway's own credentials — AWS credentials, ADC / Workload Identity, a
+# workspace token — not the underlying model vendor's API key, and this
+# template cannot know which. Create the secret described in the README, then
+# reference it here:
+#
+# env:
+#   - name: <VARIABLE>
+#     valueFrom:
+#       secretKeyRef:
+#         name: llm-secrets
+#         key: <credential-name>
+#         optional: true
+{{- end }}
 
 # Optional: Secrets (creates a K8s Secret, injected via envFrom)
 # Uncomment to add — leaving commented avoids overriding base values
 # secrets:
 #   DATABASE_URL: "postgres://user:pass@host:5432/db"
-#   API_KEY: "your-api-key"

--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -315,9 +315,12 @@ agentCode:
 # runtime serves three endpoints with three different meanings:
 #
 #   /livez   always 200 while the process is serving. Nothing else.
-#   /ready   should traffic be routed here? On Python this consults the
-#            user's health_check, so an upstream vendor outage makes the
-#            agent unready and the registry evicts it from resolution.
+#   /ready   should traffic be routed here? All three runtimes consult
+#            the user's health check (Python #1472, Java #1474,
+#            TypeScript #1478), so an upstream vendor outage takes the
+#            pod out of the Service. The same verdict separately stops
+#            the heartbeat, and THAT is what evicts the agent from mesh
+#            resolution — the registry never reads this probe.
 #   /health  the diagnostic view for humans and `kubectl exec` curls.
 #            No probe points at it: it carries no consequence of its own.
 #

--- a/src/core/cli/scaffold/helm_values_template_test.go
+++ b/src/core/cli/scaffold/helm_values_template_test.go
@@ -1,0 +1,207 @@
+package scaffold
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #1483. `helm-values.yaml.tmpl` used to wire ANTHROPIC_API_KEY,
+// OPENAI_API_KEY and GOOGLE_API_KEY unconditionally, from a secret the header
+// comment told the operator to create with all three literals — plus a generic
+// `API_KEY: "your-api-key"` example lower down.
+//
+// Two false assertions came out of that, and they are the two pinned here:
+//
+//  1. a gateway scaffold (`bedrock/...`, `vertex_ai/...`, `databricks/...`) or a
+//     long-tail model shipped a manifest instructing exactly the credentials its
+//     own README — correctly, since #1484 — says are the wrong ones. The
+//     gateway's endpoint authenticates with the gateway's own credentials, so a
+//     manifest that names any vendor key is sending the operator to configure
+//     something nothing reads;
+//
+//  2. a Gemini scaffold claimed it needed ANTHROPIC_API_KEY. The READMEs already
+//     emit only the selected vendor's key; the helm values were the last place
+//     claiming otherwise.
+//
+// Both are SUBTRACTIVE fixes — stop asserting something false. This guard
+// deliberately does NOT pin any gateway-specific wiring (IRSA / AWS_ROLE_ARN, a
+// `serviceAccount:` annotation for Workload Identity, a Databricks host+token).
+// Modelling those is the additive half of #1483 and needs an owner decision on
+// the env / ServiceAccount shape; the goal here is a manifest that is SILENT
+// about credentials it cannot know, not one that guesses.
+
+// Every vendor key the file used to wire, so a render can be checked for the
+// ones it must NOT name.
+var allVendorKeys = []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"}
+
+var allVendorSecretKeys = []string{"anthropic-api-key", "openai-api-key", "google-api-key"}
+
+// helmLanguages is the whole matrix: the same defect was hand-copied into all
+// three files, and fixing two of them is how this regresses.
+var helmLanguages = []string{"python", "typescript", "java"}
+
+// renderHelmValues scaffolds an llm-provider agent and returns its rendered
+// helm-values.yaml.
+func renderHelmValues(t *testing.T, language, model string) string {
+	t.Helper()
+	return renderProvider(t, language, model, "helm-values.yaml")
+}
+
+// A gateway-prefixed or long-tail model has no direct vendor API and no vendor
+// key. The manifest must name none of them, and must not fall back to a generic
+// `API_KEY` / `api-key` either — that is the same fallback removed from the
+// TypeScript README in #1484.
+func TestHelmValues_GatewayModelWiresNoVendorCredentials(t *testing.T) {
+	gatewayOrLongTail := []string{
+		"bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+		"bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+		"bedrock/meta.llama3-70b-instruct-v1:0",
+		"vertex_ai/gemini-2.5-flash",
+		"databricks/anthropic.claude-3-7-sonnet",
+		// A plain long-tail model: no gateway prefix, still no probeable
+		// direct big-3 API and still no vendor key that applies.
+		"cohere/command-r-plus",
+	}
+
+	for _, language := range helmLanguages {
+		for _, model := range gatewayOrLongTail {
+			t.Run(language+" "+model, func(t *testing.T) {
+				content := renderHelmValues(t, language, model)
+
+				for _, key := range allVendorKeys {
+					require.NotContains(t, content, key,
+						"%s authenticates with its endpoint's own credentials: wiring %s "+
+							"tells the operator to create a secret nothing reads, in the "+
+							"same scaffold whose README says to use the gateway's "+
+							"credentials", model, key)
+				}
+				for _, key := range allVendorSecretKeys {
+					require.NotContains(t, content, key,
+						"the kubectl comment still instructs a %s literal for %s",
+						key, model)
+				}
+				require.NotContains(t, content, "API_KEY",
+					"%s authenticates with its endpoint's own credentials: naming any "+
+						"API key here, vendor-specific or generic, sends the operator to "+
+						"configure something nothing reads", model)
+				require.NotContains(t, content, "api-key",
+					"%s authenticates with its endpoint's own credentials, so no "+
+						"api-key secret name applies", model)
+
+				// Silent about the credential is not the same as silent about the
+				// SUBJECT: the operator still has to be told where to look.
+				require.Contains(t, content, "gateway",
+					"the manifest must still point at the gateway's own credentials "+
+						"rather than simply omitting the topic")
+			})
+		}
+	}
+}
+
+// The other half: narrowing the wiring must not have taken the real vendor keys
+// with it, and only the SELECTED vendor's key may appear.
+func TestHelmValues_Big3WiresOnlyTheSelectedVendorKey(t *testing.T) {
+	// Bare names, native prefixes and mixed case — `--model` is free-form, so
+	// the casing is the user's. A resolver that stopped lowercasing would drop
+	// to the gateway branch and silently ship a manifest with no key at all.
+	big3 := []struct {
+		model     string
+		wantKey   string
+		wantEnv   string
+		wantValue string
+	}{
+		{"claude-sonnet-5", "ANTHROPIC_API_KEY", "anthropic-api-key", "sk-ant-"},
+		{"anthropic/claude-sonnet-5", "ANTHROPIC_API_KEY", "anthropic-api-key", "sk-ant-"},
+		{"Claude-Opus-4-8", "ANTHROPIC_API_KEY", "anthropic-api-key", "sk-ant-"},
+		{"gpt-4o", "OPENAI_API_KEY", "openai-api-key", "sk-"},
+		{"openai/gpt-4o", "OPENAI_API_KEY", "openai-api-key", "sk-"},
+		{"OpenAI/GPT-4o", "OPENAI_API_KEY", "openai-api-key", "sk-"},
+		{"gemini-2.5-flash", "GOOGLE_API_KEY", "google-api-key", "AIza"},
+		{"gemini/gemini-2.5-flash", "GOOGLE_API_KEY", "google-api-key", "AIza"},
+		{"GEMINI/Gemini-2.5-Flash", "GOOGLE_API_KEY", "google-api-key", "AIza"},
+	}
+
+	for _, language := range helmLanguages {
+		for _, b := range big3 {
+			t.Run(language+" "+b.model, func(t *testing.T) {
+				content := renderHelmValues(t, language, b.model)
+
+				require.Contains(t, content, "name: "+b.wantKey,
+					"%s authenticates with %s: the manifest must wire it",
+					b.model, b.wantKey)
+				require.Contains(t, content, "key: "+b.wantEnv,
+					"the secretKeyRef must name the %s key", b.wantEnv)
+				require.Contains(t, content, "--from-literal="+b.wantEnv+"="+b.wantValue,
+					"the kubectl comment must create exactly the key the env wires")
+
+				for _, other := range allVendorKeys {
+					if other == b.wantKey {
+						continue
+					}
+					require.NotContains(t, content, other,
+						"a %s scaffold must not claim it needs %s — that is the "+
+							"assertion #1483 removes", b.model, other)
+				}
+				for _, other := range allVendorSecretKeys {
+					if other == b.wantEnv {
+						continue
+					}
+					require.NotContains(t, content, other,
+						"the kubectl comment must not instruct a %s literal for %s",
+						other, b.model)
+				}
+			})
+		}
+	}
+}
+
+// The generic `API_KEY: "your-api-key"` secrets example is gone from every
+// llm-provider render, not just the gateway ones: for a big-3 model the real key
+// is already wired above, so the example only offers a second, wrong name.
+//
+// Asserted on the whole file rather than a branch, and separately from the
+// matrices above, because a fix applied only to the gateway arm would leave the
+// big-3 renders still carrying it — and the big-3 matrix cannot see it, since
+// `API_KEY` is a substring of the key those renders legitimately wire.
+func TestHelmValues_NoGenericApiKeyExample(t *testing.T) {
+	models := []string{"claude-sonnet-5", "gpt-4o", "gemini-2.5-flash",
+		"bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", "cohere/command-r-plus"}
+
+	for _, language := range helmLanguages {
+		for _, model := range models {
+			t.Run(language+" "+model, func(t *testing.T) {
+				content := renderHelmValues(t, language, model)
+				require.NotContains(t, content, `API_KEY: "your-api-key"`,
+					"the generic API_KEY example is the same fallback removed from the "+
+						"TypeScript README in #1484 — it names a credential nothing reads")
+				require.NotContains(t, content, "your-api-key")
+			})
+		}
+	}
+}
+
+// The env block must be well-formed YAML in both branches. The gateway arm emits
+// no `env:` key at all (nothing to wire), and the big-3 arm emits exactly one
+// entry — a template whose whitespace control slipped could produce an `env:`
+// with no items, which helm renders as null and the chart then fails on.
+func TestHelmValues_EnvBlockShapePerBranch(t *testing.T) {
+	for _, language := range helmLanguages {
+		t.Run(language+" big-3", func(t *testing.T) {
+			content := renderHelmValues(t, language, "anthropic/claude-sonnet-5")
+			require.Contains(t, content, "\nenv:\n  - name: ANTHROPIC_API_KEY\n",
+				"the env list must open immediately with its single entry")
+			require.Equal(t, 1, strings.Count(content, "\n  - name: "),
+				"exactly one credential may be wired")
+		})
+		t.Run(language+" gateway", func(t *testing.T) {
+			content := renderHelmValues(t, language, "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0")
+			require.NotContains(t, content, "\nenv:\n",
+				"an empty `env:` key renders as null and breaks the chart — the "+
+					"gateway branch must omit the key entirely")
+			require.Contains(t, content, "# env:\n",
+				"the commented reference skeleton must survive")
+		})
+	}
+}

--- a/src/runtime/typescript/src/__tests__/health-routes.spec.ts
+++ b/src/runtime/typescript/src/__tests__/health-routes.spec.ts
@@ -1,0 +1,414 @@
+/**
+ * Mesh-aware `/ready` and `/health` tests (issue #1478).
+ *
+ * The agent chart gates Service endpoints on `/ready` (#1468). Before this
+ * change both URLs were FastMCP's built-ins — `/ready` a hardcoded 200 in
+ * stateless mode, `/health` the literal string `✓ Ok` — so a TypeScript
+ * provider whose health check had withdrawn it from the mesh kept receiving
+ * direct Service traffic, and `/health` told an operator nothing.
+ *
+ * Three properties are pinned here, and the third is the one most likely to
+ * regress silently:
+ *
+ *   1. a non-healthy verdict answers 503 on BOTH endpoints, with detail;
+ *   2. a healthy verdict answers 200;
+ *   3. an agent with NO `healthCheck` configured is unaffected — it must
+ *      keep answering ready/healthy exactly as it did before. Only a
+ *      configured check may make these endpoints report not-ready.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { FastMCP } from "fastmcp";
+import {
+  registerHealthRoutes,
+  buildHealthBody,
+  buildReadyBody,
+  statusCodeFor,
+} from "../health-routes.js";
+import type { HealthVerdict } from "../health-check.js";
+import { MeshAgent } from "../agent.js";
+
+/** One `app.on(...)` call. */
+interface Registration {
+  methods: string[];
+  path: string;
+  handler: (c: unknown) => unknown;
+}
+
+/** What a handler passed to `c.json(body, status)`. */
+interface Answer {
+  body: Record<string, unknown>;
+  status: number;
+}
+
+/**
+ * A FastMCP stub whose Hono app records registrations, plus helpers to
+ * dispatch a request at one of them. Same shape as `livez-route.spec.ts`
+ * and `jobs-cancel-route.spec.ts`: hono is a transitive dependency of
+ * fastmcp rather than a declared one here, so the router is stubbed and
+ * the handler contract is asserted directly.
+ */
+function stubServer(): { server: FastMCP; routes: Registration[] } {
+  const routes: Registration[] = [];
+  const server = {
+    getApp: () => ({
+      on: (methods: string[], path: string, handler: (c: unknown) => unknown) => {
+        routes.push({ methods, path, handler });
+      },
+    }),
+  } as unknown as FastMCP;
+  return { server, routes };
+}
+
+/**
+ * Invoke a registered handler as `method` would. GET and HEAD share one
+ * handler by construction (`app.on(["GET", "HEAD"], ...)`), so dispatching
+ * either must produce the same status — the property a HEAD probe depends
+ * on.
+ */
+function dispatch(routes: Registration[], path: string, method: string): Answer {
+  const route = routes.find((r) => r.path === path);
+  if (!route) throw new Error(`no route registered for ${path}`);
+  expect(route.methods).toContain(method);
+  let answer: Answer | undefined;
+  route.handler({
+    req: { method },
+    json: (body: Record<string, unknown>, status = 200) => {
+      answer = { body, status };
+      return body;
+    },
+  });
+  if (!answer) throw new Error(`handler for ${path} never answered`);
+  return answer;
+}
+
+const unhealthy: HealthVerdict = {
+  status: "unhealthy",
+  checks: { vendor_api_reachable: false },
+  errors: ["vendor returned 503"],
+};
+const degraded: HealthVerdict = {
+  status: "degraded",
+  checks: { health_check_execution: false },
+  errors: ["Health check failed: boom"],
+};
+const healthy: HealthVerdict = {
+  status: "healthy",
+  checks: { vendor_api_reachable: true },
+  errors: [],
+};
+
+describe("registerHealthRoutes — registration", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("registers GET and HEAD for both /ready and /health", () => {
+    const { server, routes } = stubServer();
+    expect(registerHealthRoutes(server, "my-agent", () => null)).toBe(true);
+
+    expect(routes.map((r) => r.path).sort()).toEqual(["/health", "/ready"]);
+    for (const route of routes) {
+      expect(route.methods).toEqual(["GET", "HEAD"]);
+    }
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs at console.error when getApp() throws", () => {
+    const server = {
+      getApp: () => {
+        throw new Error("FastMCP server not started");
+      },
+    } as unknown as FastMCP;
+
+    expect(registerHealthRoutes(server, "my-agent", () => null)).toBe(false);
+    expect(errorSpy).toHaveBeenCalledOnce();
+    const msg = errorSpy.mock.calls[0][0] as string;
+    expect(msg).toContain("/ready and /health routes NOT registered");
+    expect(msg).toContain("FastMCP server not started");
+  });
+
+  it("logs at console.error when getApp() returns null", () => {
+    const server = { getApp: () => null } as unknown as FastMCP;
+
+    expect(registerHealthRoutes(server, "my-agent", () => null)).toBe(false);
+    expect(errorSpy.mock.calls[0][0] as string).toContain("returned null");
+  });
+
+  it("logs at console.error when app.on() raises", () => {
+    const server = {
+      getApp: () => ({
+        on: () => {
+          throw new Error("hono internal: route conflict");
+        },
+      }),
+    } as unknown as FastMCP;
+
+    expect(registerHealthRoutes(server, "my-agent", () => null)).toBe(false);
+    expect(errorSpy.mock.calls[0][0] as string).toContain(
+      "hono internal: route conflict",
+    );
+  });
+});
+
+describe("the verdict drives both endpoints", () => {
+  it("an unhealthy verdict answers 503 on /ready with the reason and errors", () => {
+    const { server, routes } = stubServer();
+    registerHealthRoutes(server, "provider-a", () => unhealthy);
+
+    const { body, status } = dispatch(routes, "/ready", "GET");
+    expect(status).toBe(503);
+    expect(body.ready).toBe(false);
+    expect(body.agent).toBe("provider-a");
+    expect(body.status).toBe("unhealthy");
+    expect(body.reason).toBe("Service is unhealthy");
+    expect(body.errors).toEqual(["vendor returned 503"]);
+  });
+
+  it("an unhealthy verdict answers 503 on /health carrying checks and errors", () => {
+    const { server, routes } = stubServer();
+    registerHealthRoutes(server, "provider-a", () => unhealthy);
+
+    const { body, status } = dispatch(routes, "/health", "GET");
+    expect(status).toBe(503);
+    expect(body.status).toBe("unhealthy");
+    expect(body.agent).toBe("provider-a");
+    expect(body.checks).toEqual({ vendor_api_reachable: false });
+    expect(body.errors).toEqual(["vendor returned 503"]);
+    expect(typeof body.timestamp).toBe("string");
+  });
+
+  // Python's `200 if status == "healthy" else 503` and Java's `serving()`
+  // both answer 503 for degraded. The heartbeat keeps running (degraded
+  // never withdraws), but a load balancer is told to stop adding load.
+  it("a degraded verdict answers 503 on both endpoints", () => {
+    const { server, routes } = stubServer();
+    registerHealthRoutes(server, "provider-a", () => degraded);
+
+    expect(dispatch(routes, "/ready", "GET").status).toBe(503);
+    expect(dispatch(routes, "/health", "GET").status).toBe(503);
+    expect(dispatch(routes, "/health", "GET").body.status).toBe("degraded");
+  });
+
+  it("a healthy verdict answers 200 on both endpoints", () => {
+    const { server, routes } = stubServer();
+    registerHealthRoutes(server, "provider-a", () => healthy);
+
+    const ready = dispatch(routes, "/ready", "GET");
+    expect(ready.status).toBe(200);
+    expect(ready.body.ready).toBe(true);
+    expect(ready.body.reason).toBeUndefined();
+
+    const health = dispatch(routes, "/health", "GET");
+    expect(health.status).toBe(200);
+    expect(health.body.status).toBe("healthy");
+    expect(health.body.checks).toEqual({ vendor_api_reachable: true });
+  });
+
+  // THE compatibility guarantee. Making these endpoints mesh-aware must not
+  // change what an agent WITHOUT a health check answers — every existing
+  // TypeScript agent is in that category, and a regression here would make
+  // the whole fleet unready on upgrade.
+  it("no healthCheck configured (null verdict) answers exactly as before: 200", () => {
+    const { server, routes } = stubServer();
+    registerHealthRoutes(server, "plain-agent", () => null);
+
+    const ready = dispatch(routes, "/ready", "GET");
+    expect(ready.status).toBe(200);
+    expect(ready.body.ready).toBe(true);
+    expect(ready.body.status).toBe("healthy");
+    expect(ready.body.agent).toBe("plain-agent");
+    expect(ready.body.mcp_wrappers).toBe(1);
+    expect(ready.body.reason).toBeUndefined();
+
+    const health = dispatch(routes, "/health", "GET");
+    expect(health.status).toBe(200);
+    expect(health.body.status).toBe("healthy");
+    expect(health.body.checks).toEqual({});
+    expect(health.body.errors).toEqual([]);
+  });
+
+  it("HEAD answers the same status as GET on both endpoints", () => {
+    const { server, routes } = stubServer();
+    registerHealthRoutes(server, "provider-a", () => unhealthy);
+
+    expect(dispatch(routes, "/ready", "HEAD").status).toBe(503);
+    expect(dispatch(routes, "/health", "HEAD").status).toBe(503);
+
+    const { server: ok, routes: okRoutes } = stubServer();
+    registerHealthRoutes(ok, "provider-a", () => null);
+    expect(dispatch(okRoutes, "/ready", "HEAD").status).toBe(200);
+    expect(dispatch(okRoutes, "/health", "HEAD").status).toBe(200);
+  });
+
+  // The verdict is re-read per request, not captured at registration: the
+  // loop rewrites it every TTL and a route that cached the boot value would
+  // answer 200 forever.
+  it("reads the verdict per request rather than caching it", () => {
+    const { server, routes } = stubServer();
+    let current: HealthVerdict | null = null;
+    registerHealthRoutes(server, "provider-a", () => current);
+
+    expect(dispatch(routes, "/ready", "GET").status).toBe(200);
+    current = unhealthy;
+    expect(dispatch(routes, "/ready", "GET").status).toBe(503);
+    current = healthy;
+    expect(dispatch(routes, "/ready", "GET").status).toBe(200);
+  });
+
+  // One snapshot per request. Reading the source twice could mix two
+  // verdicts into one response — a 200 status line over an unhealthy body.
+  it("takes one verdict snapshot per request", () => {
+    const { server, routes } = stubServer();
+    const source = vi.fn(() => unhealthy);
+    registerHealthRoutes(server, "provider-a", source);
+
+    dispatch(routes, "/health", "GET");
+    expect(source).toHaveBeenCalledOnce();
+  });
+
+  // A probe that cannot answer is not evidence the agent is broken, and a
+  // 500 here would pull a working pod out of the Service.
+  it("a throwing verdict source answers as if no check were configured", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { server, routes } = stubServer();
+    registerHealthRoutes(server, "provider-a", () => {
+      throw new Error("verdict source exploded");
+    });
+
+    expect(dispatch(routes, "/ready", "GET").status).toBe(200);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+describe("body builders match the Python contract", () => {
+  it("/health carries status, agent, checks, errors and timestamp", () => {
+    expect(Object.keys(buildHealthBody("a", unhealthy)).sort()).toEqual([
+      "agent",
+      "checks",
+      "errors",
+      "status",
+      "timestamp",
+    ]);
+  });
+
+  it("/ready carries ready, agent, status, mcp_wrappers and timestamp", () => {
+    expect(Object.keys(buildReadyBody("a", healthy)).sort()).toEqual([
+      "agent",
+      "mcp_wrappers",
+      "ready",
+      "status",
+      "timestamp",
+    ]);
+  });
+
+  it("statusCodeFor is 200 only for healthy", () => {
+    expect(statusCodeFor(null)).toBe(200);
+    expect(statusCodeFor(healthy)).toBe(200);
+    expect(statusCodeFor(degraded)).toBe(503);
+    expect(statusCodeFor(unhealthy)).toBe(503);
+  });
+});
+
+describe("_autoStart aborts when /ready and /health cannot be registered", () => {
+  // Same fail-loud posture as /livez: an unregistered route here does NOT
+  // fall back to something harmless — FastMCP's built-in answers a
+  // hardcoded 200, so the agent would serve while lying about readiness,
+  // which is the bug #1478 fixes. Silence would ship the regression.
+  //
+  // The auto-scheduled `_autoStart` tick from the constructor is stubbed
+  // out (existing convention) — its rejection handler calls
+  // `process.exit(1)`, which would take the test runner down. The ORIGINAL
+  // method is captured and invoked explicitly instead.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const originalAutoStart = (MeshAgent.prototype as any)._autoStart;
+  const spies: ReturnType<typeof vi.spyOn>[] = [];
+
+  function stubPrototype(name: string, impl: () => unknown = () => undefined) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spies.push(vi.spyOn(MeshAgent.prototype as any, name).mockImplementation(impl));
+  }
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    stubPrototype("_autoStart", async () => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    spies.length = 0;
+  });
+
+  /**
+   * `/livez` registers first, so a getApp() that fails outright aborts
+   * there and never reaches the health routes. To exercise THIS branch the
+   * app must accept the `/livez` registration and reject the later ones.
+   */
+  function newAgent(failFrom: number): MeshAgent {
+    let calls = 0;
+    const server = {
+      addTool: vi.fn(),
+      start: vi.fn().mockResolvedValue(undefined),
+      getApp: () => ({
+        on: (_methods: string[], path: string) => {
+          if (++calls > failFrom) {
+            throw new Error(`hono internal: route conflict on ${path}`);
+          }
+        },
+        post: vi.fn(),
+      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    return new MeshAgent(server, { name: "ready-abort-test", httpPort: 0 });
+  }
+
+  it("rejects with an actionable message when the routes cannot be mounted", async () => {
+    const agent = newAgent(1); // /livez succeeds, /ready fails
+
+    const err = await originalAutoStart
+      .call(agent)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .catch((e: any) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toMatch(/\/ready and \/health routes failed to register/);
+    expect(err.message).toContain("ready-abort-test");
+    expect(err.message).toContain("cannot start");
+  });
+
+  it("registers /livez, /ready and /health when the app accepts them", async () => {
+    const on = vi.fn();
+    const server = {
+      addTool: vi.fn(),
+      start: vi.fn().mockResolvedValue(undefined),
+      getApp: () => ({ on, post: vi.fn() }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const agent = new MeshAgent(server, {
+      name: "ready-ok-test",
+      httpPort: 0,
+    });
+    // Everything after route registration reaches the registry, the napi
+    // handle and process-wide signal handlers — out of scope here.
+    stubPrototype("registerLlmTools");
+    stubPrototype("registerJobsHelperTools");
+    stubPrototype("startHeartbeat", async () => undefined);
+    stubPrototype("startClaimDispatchers");
+    stubPrototype("startHealthRefresh");
+    stubPrototype("installSignalHandlers");
+
+    await expect(originalAutoStart.call(agent)).resolves.toBeUndefined();
+    for (const path of ["/livez", "/ready", "/health"]) {
+      expect(on).toHaveBeenCalledWith(
+        ["GET", "HEAD"],
+        path,
+        expect.any(Function),
+      );
+    }
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -74,6 +74,7 @@ import {
 } from "./jobs-helper-tools.js";
 import { registerCancelRoute } from "./jobs-cancel-route.js";
 import { registerLivezRoute } from "./livez-route.js";
+import { registerHealthRoutes } from "./health-routes.js";
 import {
   startHealthCheckLoop,
   DEFAULT_HEALTH_CHECK_TTL_SECONDS,
@@ -1965,6 +1966,40 @@ export class MeshAgent {
       );
     }
 
+    // 1.6 Issue #1478: take over GET|HEAD /ready and /health from FastMCP's
+    // built-ins so both reflect the user health check's verdict, matching
+    // Python (#1472) and Java (#1474). Before this, `/ready` answered a
+    // hardcoded 200 and `/health` the literal string `✓ Ok`, so a TS
+    // provider whose vendor was down kept receiving direct Service traffic
+    // that mesh consumers had already routed away from, and `kubectl exec
+    // curl /health` told an operator nothing.
+    //
+    // Owning /ready also removes a latent trap: FastMCP's built-in returns
+    // 503 when `totalSessions === 0` in STATEFUL mode, and mesh escapes it
+    // today only because the server above is started with `stateless: true`
+    // (where the built-in is hardcoded 200). Flipping that flag would
+    // otherwise have made every TypeScript agent unready in Kubernetes
+    // until its first session.
+    //
+    // Fail-fast for the same reason as /livez, one step up: the agent chart
+    // gates Service endpoints on /ready (#1468). An unregistered route here
+    // is not a silent fallback to the built-in — the built-in is the wrong
+    // answer (always-200), so the agent would serve traffic while lying
+    // about its readiness, which is precisely the bug this fixes. Throwing
+    // makes the cause visible instead of shipping the regression.
+    if (
+      !registerHealthRoutes(this.server, this.config.name, () =>
+        this.getHealthVerdict(),
+      )
+    ) {
+      throw new Error(
+        `agent ${this.agentId} cannot start: the /ready and /health routes ` +
+          `failed to register (cause logged above). Kubernetes gates Service ` +
+          `endpoints on /ready, so serving without them would keep sending ` +
+          `traffic to this agent after its health check reported it unhealthy.`,
+      );
+    }
+
     // 2. Register LLM tools from LlmToolRegistry
     this.registerLlmTools();
 
@@ -2068,6 +2103,10 @@ export class MeshAgent {
   /**
    * Issue #1476: the latest health verdict, or null before the first run
    * completes (or when no `healthCheck` is configured).
+   *
+   * Read per request by the `/ready` and `/health` routes (#1478); null
+   * is answered as healthy there, so an agent with no `healthCheck` is
+   * unaffected by those endpoints becoming mesh-aware.
    */
   getHealthVerdict(): HealthVerdict | null {
     return this.healthLoop?.latest() ?? null;

--- a/src/runtime/typescript/src/health-routes.ts
+++ b/src/runtime/typescript/src/health-routes.ts
@@ -1,0 +1,228 @@
+/**
+ * Mount the mesh-aware readiness and health routes (`GET|HEAD /ready` and
+ * `GET|HEAD /health`) on the agent's HTTP server (issue #1478).
+ *
+ * Until this landed both URLs were FastMCP's own built-ins: `/ready`
+ * answered a hardcoded 200 in stateless mode and `/health` returned the
+ * literal `text/plain` string `✓ Ok`. A TypeScript provider whose vendor
+ * was down therefore kept receiving direct Kubernetes Service traffic
+ * long after mesh consumers had failed over (#1468 made `/ready` gate
+ * Service endpoints), and an operator who curled `/health` learned
+ * nothing. Python (#1472) and Java (#1474) both answer 503 with detail;
+ * this is the TypeScript half of that contract.
+ *
+ * ## Why registering here shadows FastMCP
+ *
+ * `server.getApp()` returns FastMCP's Hono app, and FastMCP matches Hono
+ * routes FIRST — its built-in health handling only runs after the
+ * "Hono route not matched" catch. So a route registered here wins, which
+ * is the same mechanism `/livez` (#1467) and the MeshJob cancel route
+ * already rely on.
+ *
+ * ## Owning /ready also removes a latent trap
+ *
+ * FastMCP's built-in `/ready` returns **503 when `totalSessions === 0`**
+ * in stateful mode. Mesh escapes that today only because `agent.ts`
+ * starts FastMCP with `stateless: true`, where the built-in is hardcoded
+ * 200 — flipping that flag would have silently made every TypeScript
+ * agent unready in Kubernetes until the first session arrived. Owning
+ * the route removes the dependency on that flag entirely.
+ *
+ * ## An agent with no health check is unaffected
+ *
+ * A null verdict means "no `healthCheck` configured, or the seed run has
+ * not finished yet" and is treated as HEALTHY. Only a configured check
+ * that reports a non-healthy verdict can make an agent unready.
+ *
+ * This MATCHES the other two runtimes; it is not a divergence from them:
+ *
+ *   - Java's `MeshHealthController.effectiveStatus` returns `HEALTHY`
+ *     outright when `latest` is null and the runtime is running;
+ *   - Python reaches the same answer one step earlier. Its startup seed
+ *     stores a default result for an agent with no `health_check` at all
+ *     (`{"status": "healthy", ...}` in `fastapiserver_setup.py`), so
+ *     `build_ready_response` / `build_health_response` see a stored
+ *     healthy status and answer 200. Its no-stored-result branch is
+ *     `# No health check configured - assume ready` → 200 as well.
+ *
+ * Python's `"starting"` 503 in `build_health_response` is NOT the
+ * check-less case: it is the window before the seed has stored anything,
+ * i.e. an agent that is genuinely still starting. Do not read it as a
+ * runtime disagreement and "fix" this branch to match it — that would
+ * make every check-less agent, on every runtime, unready.
+ *
+ * `/livez` is unchanged and stays in `livez-route.ts` — liveness must
+ * never consult the verdict, or a vendor outage becomes a pod restart.
+ */
+import type { FastMCP } from "fastmcp";
+import type { HealthVerdict } from "./health-check.js";
+
+/** The latest verdict, or null when there is none. */
+export type HealthVerdictSource = () => HealthVerdict | null;
+
+/**
+ * Only `healthy` answers 200 — the same rule as Python's
+ * `build_health_response` / `build_ready_response` (`200 if status ==
+ * "healthy" else 503`) and Java's `MeshHealthController.serving`.
+ *
+ * So `degraded` answers 503 here while the agent keeps heartbeating and
+ * stays in dependency resolution. That asymmetry is deliberate on all
+ * three runtimes: readiness is a load-balancer decision about NEW
+ * external traffic, while the heartbeat states whether this agent is
+ * still a valid provider for the mesh. An impaired agent can honestly
+ * say "stop adding load" without withdrawing itself from a mesh that may
+ * have no other provider.
+ */
+function serving(status: string): boolean {
+  return status === "healthy";
+}
+
+/**
+ * `/health` body — the `{status, agent, checks, errors, timestamp}` shape
+ * Python stores and returns for a configured `health_check`
+ * (`fastapiserver_setup.py` builds exactly those five keys, and
+ * `build_health_response` returns the stored dict verbatim).
+ *
+ * The three runtimes agree on that shape but not on what they OMIT when
+ * there is no verdict to report: Python's check-less default result
+ * carries only `status`/`agent`/`timestamp`, and Java's `/health` adds
+ * `checks`/`errors`/`timestamp` only when a result exists. This always
+ * emits all five, with `checks: {}` and `errors: []` — a superset, so a
+ * reader written against any of the three still parses it.
+ */
+export function buildHealthBody(
+  agentName: string,
+  verdict: HealthVerdict | null,
+): Record<string, unknown> {
+  return {
+    status: verdict ? verdict.status : "healthy",
+    agent: agentName,
+    checks: verdict ? verdict.checks : {},
+    errors: verdict ? verdict.errors : [],
+    timestamp: new Date().toISOString(),
+  };
+}
+
+/**
+ * `/ready` body — Python's `build_ready_response` keys.
+ *
+ * Python varies them per branch: `{ready, agent, status, mcp_wrappers,
+ * timestamp}` when ready, `{ready, agent, status, reason, errors}` when
+ * not (no `timestamp`), and no `status` at all in its no-stored-result
+ * branch. This emits the common keys unconditionally and adds
+ * `reason`/`errors` when not ready — again a superset, so nothing a
+ * Python-shaped reader looks for is missing.
+ *
+ * `mcp_wrappers` counts the MCP servers this agent fronts. A TypeScript
+ * agent wraps exactly one FastMCP server, so the honest constant is 1.
+ * Python's helper takes an `mcp_wrappers_count` parameter, but its only
+ * wired call site (`mesh/decorators.py`) passes none, so Python reports
+ * 0 in practice — do NOT treat that 0 as a contract to copy. The field
+ * is kept rather than dropped because operators and dashboards read one
+ * key set across the runtimes.
+ */
+export function buildReadyBody(
+  agentName: string,
+  verdict: HealthVerdict | null,
+): Record<string, unknown> {
+  const status = verdict ? verdict.status : "healthy";
+  const ready = serving(status);
+  const body: Record<string, unknown> = {
+    ready,
+    agent: agentName,
+    status,
+    mcp_wrappers: 1,
+    timestamp: new Date().toISOString(),
+  };
+  if (!ready) {
+    body.reason = `Service is ${status}`;
+    body.errors = verdict ? verdict.errors : [];
+  }
+  return body;
+}
+
+/** HTTP status for a verdict: 200 healthy, 503 otherwise. */
+export function statusCodeFor(verdict: HealthVerdict | null): 200 | 503 {
+  return serving(verdict ? verdict.status : "healthy") ? 200 : 503;
+}
+
+/**
+ * Register `GET|HEAD /ready` and `GET|HEAD /health` on the FastMCP
+ * server's Hono app. Returns `true` iff BOTH routes were registered.
+ * `server.getApp()` throws before the server has started, so this must
+ * be called after `server.start()`.
+ *
+ * Each failure branch logs the CAUSE only. The consequence is stated
+ * once, by the caller that throws (see `agent.ts`).
+ *
+ * `getVerdict` is a callback rather than a value because the routes are
+ * mounted during startup, before the health-check loop has produced (or
+ * even been started with) anything.
+ */
+export function registerHealthRoutes(
+  server: FastMCP,
+  agentName: string,
+  getVerdict: HealthVerdictSource,
+): boolean {
+  let app: ReturnType<FastMCP["getApp"]> | null = null;
+  try {
+    app = server.getApp();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[mesh] /ready and /health routes NOT registered — FastMCP.getApp() ` +
+        `unavailable: ${reason}`,
+    );
+    return false;
+  }
+  if (!app) {
+    console.error(
+      `[mesh] /ready and /health routes NOT registered — FastMCP.getApp() ` +
+        `returned null`,
+    );
+    return false;
+  }
+
+  // ONE snapshot per request. `getVerdict()` is rewritten by the
+  // health-check loop between calls, so reading it twice while building a
+  // response can mix two verdicts — a body whose `status` came from one
+  // and whose `errors` came from the next, or a 200 status line over an
+  // unhealthy body. Java's `latestResult()` exists for the same reason.
+  //
+  // A verdict source that THROWS must not take the endpoint down with
+  // it: a probe that cannot answer is not evidence the agent is broken,
+  // and a 500 here would fail the readiness probe and pull a working pod
+  // out of the Service. Falling back to null answers exactly as an agent
+  // with no health check does.
+  const snapshot = (): HealthVerdict | null => {
+    try {
+      return getVerdict();
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[mesh-health] reading the health verdict for agent '${agentName}' ` +
+          `threw — answering as if no health check were configured: ${reason}`,
+      );
+      return null;
+    }
+  };
+
+  try {
+    app.on(["GET", "HEAD"], "/ready", (c) => {
+      const verdict = snapshot();
+      return c.json(buildReadyBody(agentName, verdict), statusCodeFor(verdict));
+    });
+    app.on(["GET", "HEAD"], "/health", (c) => {
+      const verdict = snapshot();
+      return c.json(buildHealthBody(agentName, verdict), statusCodeFor(verdict));
+    });
+    return true;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[mesh] /ready and /health routes NOT registered — app.on() raised: ` +
+        `${reason}`,
+    );
+    return false;
+  }
+}

--- a/tests/integration/suites/uc41_health_check_withdrawal/tc03_typescript_withdraw_failover_recover/test.yaml
+++ b/tests/integration/suites/uc41_health_check_withdrawal/tc03_typescript_withdraw_failover_recover/test.yaml
@@ -24,13 +24,19 @@
 # the process or tears down the server would satisfy the failover assertions
 # and be caught here and by the pid.
 #
-# WHY THE VERDICT IS READ FROM THE LOG AND NOT FROM /health
+# THE VERDICT IS READ FROM /health, NOT FROM THE LOG
 #
-# Unlike Python and Java, TypeScript's `/health` and `/ready` are FastMCP's
-# built-ins and do NOT reflect the user health check's verdict — that is
-# #1478, known and deliberately out of scope for #1481. So the TS tests read
-# the verdict from the runtime's own `[mesh-health]` log line instead. If
-# #1478 lands, this is the assertion to move onto /health.
+# Since #1478 TypeScript's `/ready` and `/health` are mesh-owned routes that
+# reflect the user health check's verdict, exactly as Python's and Java's do.
+# That is what is asserted here, and it is strictly stronger than the log line
+# it replaced: a runtime that printed `[mesh-health] ... reports UNHEALTHY`
+# while serving a 200 `/ready` would still be shipping the #1478 bug — direct
+# Kubernetes Service traffic keeps arriving at a provider mesh consumers have
+# already abandoned — and the log grep could not see it.
+#
+# `/ready` is checked by STATUS CODE rather than body text because that is the
+# only thing the kubelet reads: #1468 made the agent chart gate Service
+# endpoints on it, so a 200 here is the outage this test exists to catch.
 #
 # The rest of the design (file-toggled flag, poll-for-the-condition rather
 # than fixed waits, provider B as the control) is documented in tc01.
@@ -236,25 +242,20 @@ test:
     capture: withdrawal
     timeout: 120
 
-  # The verdict, read from the runtime's own log rather than /health — see the
-  # #1478 note in the header.
+  # The verdict, read from provider A's own endpoints (#1478) — see the header.
   #
-  # Every log is grepped rather than `meshctl logs <agent>`, because meshctl
-  # names the log file from its own static analysis of the entrypoint and for
-  # this TS agent that comes out as `probe_a.log` (the first tool's name), not
-  # the registered agent name. Grepping all of them is name-proof AND still
-  # specific: provider A is the only agent here with a health check, so a
-  # `[mesh-health]` line can only be its output.
-  - name: "Phase B: the runtime must have logged the UNHEALTHY verdict"
+  # `/ready` is captured as a bare status code: `curl -o /dev/null -w` prints
+  # nothing else, so the assertion below matches an exact `READY_HTTP_CODE: 503`
+  # rather than a substring that a body could satisfy by accident. `--max-time`
+  # on both so a hung server fails the step instead of the whole run.
+  - name: "Phase B: A's own /health and /ready must report the unhealthy verdict, not a crash"
     handler: shell
     workdir: /workspace
     command: |
-      LOG=$(cat ~/.mcp-mesh/logs/*.log 2>/dev/null || true)
-      N=$(printf '%s' "$LOG" | grep -c "reports UNHEALTHY" || true)
-      echo "UNHEALTHY_LOG_LINES: $N"
-      printf '%s' "$LOG" | grep 'mesh-health' | tail -10 || echo 'NO_MESH_HEALTH_LINES'
-    capture: verdict_log
-    ignore_errors: true
+      echo "HEALTH_BODY: $(curl -s --max-time 5 http://localhost:3421/health || echo 'HEALTH_UNREACHABLE')"
+      echo "READY_HTTP_CODE: $(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:3421/ready || echo 'READY_UNREACHABLE')"
+      echo "READY_BODY: $(curl -s --max-time 5 http://localhost:3421/ready || echo 'READY_UNREACHABLE')"
+    capture: provider_a_health_during_outage
 
   - name: "Phase B: poll until the consumer fails over to provider B"
     handler: shell
@@ -389,8 +390,23 @@ assertions:
   - expr: "${captured.withdrawal} contains 'LIVEZ_FAILURES: 0'"
     message: "WITHDRAWAL: provider A's process must stay alive and serving /livez for the ENTIRE outage — withdrawn is not dead"
 
-  - expr: "${captured.verdict_log} not contains 'UNHEALTHY_LOG_LINES: 0'"
-    message: "WITHDRAWAL: the runtime must log the UNHEALTHY verdict, proving the withdrawal came from the user's healthCheck (TS /health cannot be used — see #1478)"
+  # #1478. /health carries the verdict and /ready answers 503, so this is the
+  # same statement Python's tc01 and Java's tc05 make.
+  - expr: "${captured.provider_a_health_during_outage} contains 'unhealthy'"
+    message: "WITHDRAWAL: provider A's own /health must report the unhealthy verdict while withdrawn"
+  - expr: "${captured.provider_a_health_during_outage} contains 'simulated vendor outage'"
+    message: "WITHDRAWAL: /health must carry the health check's own error string, proving the verdict came from the user check rather than a generic failure"
+  - expr: "${captured.provider_a_health_during_outage} not contains 'HEALTH_UNREACHABLE'"
+    message: "WITHDRAWAL: provider A's HTTP server must still answer /health while withdrawn — withdrawn is not dead"
+
+  # The Kubernetes half, and the reason #1478 was a bug rather than a cosmetic
+  # gap: #1468 gates Service endpoints on /ready, so a provider that keeps
+  # answering 200 here goes on receiving direct traffic that mesh consumers
+  # have already routed away from.
+  - expr: "${captured.provider_a_health_during_outage} contains 'READY_HTTP_CODE: 503'"
+    message: "WITHDRAWAL: /ready must answer 503 while the health check reports unhealthy — a 200 keeps the pod in the Service and sends direct traffic to a provider the mesh has abandoned"
+  - expr: "${captured.provider_a_health_during_outage} not contains 'READY_UNREACHABLE'"
+    message: "WITHDRAWAL: provider A must still answer /ready while withdrawn — an unreachable endpoint is a different failure from an honest 503"
 
   - expr: "${captured.fault_trace} not contains 'FAIL_TICKS: 0'"
     message: "WITHDRAWAL: the health check must have been invoked at least once while the flag said fail"

--- a/tests/integration/suites/uc41_health_check_withdrawal/tc04_typescript_throwing_check_degrades/test.yaml
+++ b/tests/integration/suites/uc41_health_check_withdrawal/tc04_typescript_throwing_check_degrades/test.yaml
@@ -24,12 +24,18 @@
 #
 #   1. the invocation trace shows the check ran REPEATEDLY while the flag
 #      said `throw` (the loop survived the throw and kept rescheduling);
-#   2. the runtime logged the degrade decision naming this agent;
+#   2. the agent's own `/health` reports `degraded` and carries the thrown
+#      message, and the mesh core recorded the matching transition;
 #   3. only then: the registry never moves A off `healthy`, and the consumer
 #      is still routed to A.
 #
-# Unlike Python and Java, TS `/health` is FastMCP's built-in and does not
-# reflect the verdict (#1478), so (2) is read from the `[mesh-health]` log.
+# Since #1478 TS `/health` reflects the verdict, exactly as Python's and
+# Java's do, so (2) is read from the endpoint rather than from a log line.
+# The core-transition grep stays alongside it: `/health` is what the runtime
+# BELIEVES, and `Health status changed: Healthy -> Degraded` is what actually
+# crossed the napi boundary and became the core's state. A runtime that
+# rendered `degraded` in its body while publishing something else would
+# satisfy the first and fail the second.
 #
 # WHY THE WATCH IS 30s AND WHY IT IS NOT A SLEEP
 #
@@ -229,9 +235,28 @@ test:
       tail -12 /workspace/hc-invocations.log 2>/dev/null || echo 'NO_TRACE'
     capture: throw_trace
 
-  # Non-vacuity, part 2: the runtime saw the throw and classified it as
-  # degraded. Read from the log because TS /health does not carry the verdict
-  # (#1478).
+  # Non-vacuity, part 2a: the runtime saw the throw and classified it as
+  # degraded, read from the agent's own endpoint (#1478).
+  #
+  # /ready is captured as a bare status code alongside it. `degraded` answers
+  # 503 there on all three runtimes — deliberately: readiness is a load
+  # balancer's "stop adding load", while the heartbeat below keeps running so
+  # the mesh can still resolve an impaired provider that may be the only one.
+  - name: "A's /health must report degraded, carrying the thrown message"
+    handler: shell
+    workdir: /workspace
+    command: |
+      echo "HEALTH_BODY: $(curl -s --max-time 5 http://localhost:3421/health || echo 'HEALTH_UNREACHABLE')"
+      echo "READY_HTTP_CODE: $(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:3421/ready || echo 'READY_UNREACHABLE')"
+    capture: provider_a_health
+
+  # Non-vacuity, part 2b: the degraded verdict crossed the napi boundary and
+  # became the CORE's state, not just the runtime's rendering of it.
+  #
+  # THREW_LOG_LINES and DEGRADE_CLASSIFIED_LINES are still printed but no
+  # longer asserted: /health above makes both statements more directly, and
+  # about the verdict the agent is actually SERVING rather than one it once
+  # logged. They stay because a failing run wants them.
   #
   # Every log is grepped rather than `meshctl logs <agent>`, because meshctl
   # names the log file from its own static analysis of the entrypoint and for
@@ -239,7 +264,7 @@ test:
   # the registered agent name. Grepping all of them is name-proof AND still
   # specific: provider A is the only agent here with a health check, so a
   # `[mesh-health]` line can only be its output.
-  - name: "The runtime must have logged the degrade decision for this agent"
+  - name: "The degraded verdict must have reached the mesh core"
     handler: shell
     workdir: /workspace
     command: |
@@ -320,17 +345,22 @@ assertions:
   # one of the neuters this file is meant to catch. So the verdict has to be
   # asserted in the affirmative, at two points on the chain:
   #
-  #   - `[mesh-health] ... threw — reporting degraded ...` (health-check.ts's
-  #     catch): the loop caught THIS throw and took the degrade branch;
+  #   - `/health` (#1478): the endpoint reports `degraded` and carries the
+  #     thrown exception's own message, so the loop caught THIS throw and took
+  #     the degrade branch;
   #   - `Health status changed: Healthy -> Degraded` (mcp_mesh_core::heartbeat,
   #     logged only on a real transition): the degraded verdict crossed the
   #     napi boundary and became the core's state. This one is computed from
   #     the verdict rather than printed alongside it, so a throw branch that
   #     returns `healthy` produces NO such line and fails here.
-  - expr: "${captured.degrade_log} not contains 'THREW_LOG_LINES: 0'"
-    message: "CLASSIFICATION: the runtime must log that the check threw — proving it caught THIS throw rather than never running"
-  - expr: "${captured.degrade_log} not contains 'DEGRADE_CLASSIFIED_LINES: 0'"
-    message: "CLASSIFICATION: a throwing healthCheck must be classified DEGRADED by the runtime — 'not unhealthy' is also true of a runtime that wrongly called it healthy"
+  - expr: "${captured.provider_a_health} contains 'degraded'"
+    message: "CLASSIFICATION: a healthCheck that throws must be recorded as DEGRADED, not healthy and not unhealthy"
+  - expr: "${captured.provider_a_health} contains 'simulated broken health check'"
+    message: "CLASSIFICATION: /health must carry the thrown error's own message, proving the runtime caught THIS throw"
+  - expr: "${captured.provider_a_health} not contains 'HEALTH_UNREACHABLE'"
+    message: "CLASSIFICATION: provider A's HTTP server must still answer /health while its check is throwing"
+  - expr: "${captured.provider_a_health} contains 'READY_HTTP_CODE: 503'"
+    message: "CLASSIFICATION: /ready must answer 503 for a degraded agent — a load balancer is told to stop adding load even though the mesh keeps resolving it"
   - expr: "${captured.degrade_log} not contains 'CORE_DEGRADE_TRANSITIONS: 0'"
     message: "CLASSIFICATION: the degraded verdict must reach the mesh core (Health status changed: Healthy -> Degraded) — otherwise the runtime only printed the word and published something else"
   - expr: "${captured.degrade_log} contains 'UNHEALTHY_LOG_LINES: 0'"


### PR DESCRIPTION
## Summary

3.5.2's claim is that **a provider withdraws itself when its vendor is down**. On Kubernetes that was true for only two of three runtimes. TypeScript served FastMCP's built-ins — `/ready` answered a hardcoded 200, `/health` returned the literal `text/plain` string `✓ Ok` — so a TS provider with a dead vendor kept receiving direct Service traffic after mesh consumers had already failed over, and an operator running `kubectl get pods` or curling `/health` saw nothing wrong. Python and Java both answer 503 with the diagnosis.

`registerHealthRoutes` mounts `GET|HEAD /ready` and `/health` on FastMCP's Hono app, which FastMCP matches **before** its own health handling — the mechanism `/livez` already uses. Payloads and status codes mirror Python's builders: 200 only for `healthy`, 503 otherwise. So `degraded` is unready to a load balancer while still heartbeating and resolvable in the mesh, which is Python's and Java's existing rule. `getHealthVerdict()` is no longer dead code.

**An agent with no `healthCheck` is unaffected** — a null verdict is healthy, matching Java's `effectiveStatus` and Python, which seeds a healthy stored result for exactly that case. Explicitly tested, because the alternative would have made every check-less TS agent unready on upgrade.

Owning `/ready` also removes a latent trap: FastMCP's built-in returns **503 when `totalSessions === 0`** in stateful mode, and mesh escapes that today only because it starts FastMCP with `stateless: true`.

Also the **subtractive half of #1483**: the scaffold helm values wired all three vendor API keys unconditionally, so a Gemini scaffold claimed it needed `ANTHROPIC_API_KEY` and a Bedrock one instructed exactly the credentials its own README (since #1484) says are wrong. Now only the selected vendor's key, and **nothing at all** for gateway or long-tail models. No IRSA, Workload Identity or Databricks wiring — that modelling stays open on #1483, along with the `llm-agent` and `api`/`basic` templates, which have no `.ProbeVendor` and need their own decision.

## Review notes

**The moved assertions close a real hole, not a cosmetic one.** uc41's tc03/tc04 carried explicit markers saying they should read `/health` once this landed. With the verdict blocked from the routes, the new assertions fail — while `THREW_LOG_LINES: 16`, `DEGRADE_CLASSIFIED_LINES: 16`, `CORE_DEGRADE_TRANSITIONS: 1` and `UNHEALTHY_LOG_LINES: 0` all stay green in the same run. The log scraping the suite was forced into is provably blind to a regression the endpoints catch.

**A docblock audit found four wrong cross-runtime claims** in the new file, all plausible, none behaviour-affecting, so no test could have caught them. The worst asserted TypeScript deliberately diverges from "Python's `starting` 503 fallback" for check-less agents — Python does the opposite, and such agents never reach that branch anyway because the pipeline seeds a healthy result. A comment claiming a deliberate divergence invites someone to "fix" it and break check-less agents. Also corrected: `mcp_wrappers` (Python reports 0 in practice, since its only wired call site passes no count) and two "same shape as Python" claims that are supersets rather than identities.

**The chart's own probe documentation was wrong in two ways** and shipped to users: it said `/ready` consults the health check *"On Python"* — in the release that makes it universal — and it hung registry eviction off that probe. The registry never reads `/ready`; eviction is heartbeat staleness. The two are parallel effects of one verdict, not a chain. Verified against `src/core/registry/` rather than assumed. Comment-only, proven mechanically: **0** non-comment changed lines.

## Release-note items

1. **TS `/health` is now JSON**, not `text/plain "✓ Ok"`. Anything string-matching that breaks; status-code checks still work.
2. **TS `/ready` and `/health` return 503** when a configured check reports `unhealthy` *or* `degraded`. Matches Python and Java. Agents with no `healthCheck` unchanged.
3. **Scaffold helm values wire only the selected vendor's key**, none for gateway models. The unused arms were `optional: true`, so no runtime effect.

Closes #1478

## Test plan

- [x] TypeScript 1342 → 1360 (92 files); `tsc --noEmit` and express5 typecheck clean
- [x] `src/core/cli/scaffold` subtests 453 → 519, incl. 66 new helm-values guards
- [x] `go build ./...` clean; `go test ./src/core/cli/...` all packages pass
- [x] `tsuite run --suite-path tests/src-tests` — 12/12, image rebuilt
- [x] `tsuite run --suite-path tests/integration --uc uc41 --parallel 6` — 6/6
- [x] Red-state: verdict blocked from the routes → tc03/tc04 fail on the new assertions while every old log signal stays green; `agent.ts` restored byte-identically (sha256 verified) and re-run green
- [x] Helm render matrix, 3 languages × 15 models: correct key or none, no render names a key it cannot use


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - TypeScript providers now expose mesh-aware `/health` and `/ready` endpoints.
  - Readiness returns HTTP 503 when health checks report withdrawal or degradation.
  - Startup now validates health-route registration.
  - Helm scaffolds inject only the selected direct provider credential; gateway models provide configuration guidance without enabling vendor credentials.
  - Probe documentation now explains how readiness affects traffic routing and mesh heartbeat eviction.

- **Tests**
  - Expanded health-route, credential-rendering, and integration coverage across supported runtimes and model types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->