### PR TITLE
fix(java): a failing health check must not take a gateway out of Service endpoints

### DIFF
--- a/docs/concepts/health-discovery.md
+++ b/docs/concepts/health-discovery.md
@@ -117,7 +117,7 @@ While the check reports `unhealthy` the agent stops heartbeating. The registry's
 
 Only an explicit unhealthy result does that. A check that raises is recorded as `degraded` and keeps heartbeating, in all three runtimes: a bug in the health check must not be able to remove a working agent from the mesh.
 
-`degraded` splits the two surfaces on Python and Java: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider. On TypeScript only the heartbeat side is wired - the verdict drives heartbeating, while `/ready` and `/health` still report runtime state alone (see the endpoint table below).
+`degraded` splits the two surfaces on all three runtimes: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider.
 
 Route (`@mesh.route` / `@MeshRoute` / `mesh.route`) and A2A agents are deliberately exempt, on both surfaces: the verdict never suppresses their heartbeat and never makes their `/ready` answer 503. A gateway is a fan-out point that many requests enter through - withdrawing a provider is correct, withdrawing the gateway takes the application down, and a 503 readiness probe drops it from its Service endpoints, which takes it down harder. On Java the verdict still shows on the gateway's `/health`; Python and TypeScript never run the check on a gateway at all.
 
@@ -128,10 +128,10 @@ Every runtime serves three endpoints, and probes must not share one:
 | Endpoint  | Probe                             | Reports                                                                                             |
 | --------- | --------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `/livez`  | `livenessProbe`, `startupProbe`   | 200 for as long as the process is serving. Consults nothing else.                                     |
-| `/ready`  | `readinessProbe`                  | Whether traffic should be routed here. Reflects your health check on Python (`health_check`) and Java (`@MeshHealthCheck`), except on a route or A2A agent, where it reports only that the mesh runtime is running; on TypeScript the `healthCheck` verdict drives the heartbeat, while `/ready` always reports only that the mesh runtime is running. |
-| `/health` | none                              | Runtime-specific. Python and Java return the `/ready` signal plus `checks` and `errors`; TypeScript returns a fixed `healthy` and reflects nothing. |
+| `/ready`  | `readinessProbe`                  | Whether traffic should be routed here. Reflects your health check on all three runtimes (`health_check`, `@MeshHealthCheck`, `healthCheck`) - 200 only while it reports `healthy` - except on a route or A2A agent, where it reports only that the mesh runtime is running. |
+| `/health` | none                              | The `/ready` verdict plus `checks` and `errors`, on all three runtimes. The two part company only on a gateway: a Java gateway's `/health` still carries its check's verdict while `/ready` ignores it, and Python and TypeScript never run a gateway's check at all. |
 
-Never point liveness or startup at `/ready` or `/health`. On Python and Java, where `/ready` reflects your health check, that turns an upstream outage into a pod restart, which cannot fix the outage. On TypeScript, where `/ready` reports only runtime state, it still restarts pods that are merely still booting. The Helm chart is already wired this way.
+Never point liveness or startup at `/ready` or `/health`. Both reflect your health check on all three runtimes, so sharing a URL turns an upstream outage into a pod restart, which cannot fix the outage - and while an agent is still coming up they answer 503 (or are not mounted yet), which restart-loops a slow boot. The Helm chart is already wired this way.
 
 ### Health States
 

--- a/docs/concepts/health-discovery.md
+++ b/docs/concepts/health-discovery.md
@@ -119,7 +119,7 @@ Only an explicit unhealthy result does that. A check that raises is recorded as 
 
 `degraded` splits the two surfaces on Python and Java: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider. On TypeScript only the heartbeat side is wired - the verdict drives heartbeating, while `/ready` and `/health` still report runtime state alone (see the endpoint table below).
 
-Route (`@mesh.route` / `@MeshRoute` / `mesh.route`) and A2A agents are deliberately exempt. A gateway is a fan-out point that many requests enter through - withdrawing a provider is correct, withdrawing the gateway takes the application down.
+Route (`@mesh.route` / `@MeshRoute` / `mesh.route`) and A2A agents are deliberately exempt, on both surfaces: the verdict never suppresses their heartbeat and never makes their `/ready` answer 503. A gateway is a fan-out point that many requests enter through - withdrawing a provider is correct, withdrawing the gateway takes the application down, and a 503 readiness probe drops it from its Service endpoints, which takes it down harder. On Java the verdict still shows on the gateway's `/health`; Python and TypeScript never run the check on a gateway at all.
 
 ### Kubernetes Probes
 
@@ -128,7 +128,7 @@ Every runtime serves three endpoints, and probes must not share one:
 | Endpoint  | Probe                             | Reports                                                                                             |
 | --------- | --------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `/livez`  | `livenessProbe`, `startupProbe`   | 200 for as long as the process is serving. Consults nothing else.                                     |
-| `/ready`  | `readinessProbe`                  | Whether traffic should be routed here. Reflects your health check on Python (`health_check`) and Java (`@MeshHealthCheck`); on TypeScript the `healthCheck` verdict drives the heartbeat, while `/ready` still reports only that the mesh runtime is running. |
+| `/ready`  | `readinessProbe`                  | Whether traffic should be routed here. Reflects your health check on Python (`health_check`) and Java (`@MeshHealthCheck`), except on a route or A2A agent, where it reports only that the mesh runtime is running; on TypeScript the `healthCheck` verdict drives the heartbeat, while `/ready` always reports only that the mesh runtime is running. |
 | `/health` | none                              | Runtime-specific. Python and Java return the `/ready` signal plus `checks` and `errors`; TypeScript returns a fixed `healthy` and reflects nothing. |
 
 Never point liveness or startup at `/ready` or `/health`. On Python and Java, where `/ready` reflects your health check, that turns an upstream outage into a pod restart, which cannot fix the outage. On TypeScript, where `/ready` reports only runtime state, it still restarts pods that are merely still booting. The Helm chart is already wired this way.

--- a/docs/typescript/mesh-functions.md
+++ b/docs/typescript/mesh-functions.md
@@ -47,7 +47,7 @@ const agent = mesh(server, {
 });
 ```
 
-`healthCheck` is what lets a provider take itself out of rotation. While it returns `{ status: "unhealthy" }` (or `false`) the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider — restored automatically when it passes again, with no restart. A check that throws is recorded as `degraded` and keeps heartbeating, so a bug in the check cannot remove a working agent. `MCP_MESH_HEALTH_CHECK_TTL` overrides `healthCheckTtl`. See [Health & Discovery](../concepts/health-discovery.md).
+`healthCheck` is what lets a provider take itself out of rotation. While it returns `{ status: "unhealthy" }` (or `false`) the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider — restored automatically when it passes again, with no restart. A check that throws is recorded as `degraded` and keeps heartbeating, so a bug in the check cannot remove a working agent. The verdict also drives the probe endpoints: `/ready` and `/health` answer 200 only while it reports `healthy`. `MCP_MESH_HEALTH_CHECK_TTL` overrides `healthCheckTtl`. See [Health & Discovery](../concepts/health-discovery.md).
 
 > **Import `FastMCP` from `@mcpmesh/sdk`**, which re-exports it — not directly from `"fastmcp"`. A direct `"fastmcp"` import can trigger duplicate class-identity type errors under `tsc` against the SDK's own bundled copy.
 

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -274,7 +274,7 @@ Spring Boot agents automatically expose `/actuator/health`. The MCP Mesh starter
 The starter also serves the three mesh endpoints, and Kubernetes probes must not share one:
 
 - `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
-- `/ready` - `readinessProbe`. Whether traffic should be routed here; reflects your `@MeshHealthCheck` on top of the mesh runtime state.
+- `/ready` - `readinessProbe`. Whether traffic should be routed here; reflects your `@MeshHealthCheck` on top of the mesh runtime state, except on a route-only (`api`) or A2A agent, where only the runtime state counts.
 - `/health` - no probe. The `/ready` signal plus the `checks` and `errors` your check returned.
 
 Both `/health` and `/ready` answer 503 until the mesh runtime is up, so pointing liveness or startup at either restarts pods that are merely still booting. The Helm chart is already wired this way.
@@ -294,7 +294,7 @@ public MeshHealth healthCheck() {
 
 While the check returns unhealthy the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider - restored automatically when the check passes, with no restart. Returning `boolean` works too: `true` is healthy, `false` unhealthy. A check that throws is recorded as `degraded` and keeps heartbeating, so a bug in the check cannot take a working agent out of the mesh. `MCP_MESH_HEALTH_CHECK_TTL` overrides `ttlSeconds`.
 
-Route-only (`api`) and A2A agents are the exception: their check feeds the probes but never suppresses the heartbeat. A gateway is a fan-out point, and withdrawing it takes the application down.
+Route-only (`api`) and A2A agents are the exception: their check feeds `/health` only - it never suppresses the heartbeat and never makes `/ready` answer 503. A gateway is a fan-out point, and taking it out of rotation takes the application down.
 
 ### Graceful Shutdown
 

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -275,7 +275,7 @@ The starter also serves the three mesh endpoints, and Kubernetes probes must not
 
 - `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
 - `/ready` - `readinessProbe`. Whether traffic should be routed here; reflects your `@MeshHealthCheck` on top of the mesh runtime state, except on a route-only (`api`) or A2A agent, where only the runtime state counts.
-- `/health` - no probe. The `/ready` signal plus the `checks` and `errors` your check returned.
+- `/health` - no probe. The `/ready` signal plus the `checks` and `errors` your check returned - except on a route-only (`api`) or A2A agent, where `/ready` ignores the check but `/health` still reports its verdict.
 
 Both `/health` and `/ready` answer 503 until the mesh runtime is up, so pointing liveness or startup at either restarts pods that are merely still booting. The Helm chart is already wired this way.
 

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -221,16 +221,16 @@ TypeScript agents automatically expose health endpoints:
 
 ```typescript
 // Automatic health check at /health
-// Returns: { status: "healthy", agentId: "my-agent-abc123" }
+// Returns: { status: "healthy", agent: "my-agent", checks: {}, errors: [], timestamp: "..." }
 ```
 
 There are three of them, and Kubernetes probes must not share one:
 
 - `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
-- `/ready` - `readinessProbe`. Whether traffic should be routed here. Reports mesh runtime state only; your `healthCheck` drives the heartbeat, not this endpoint.
-- `/health` - no probe. A fixed `{ status: "healthy" }` that reflects nothing.
+- `/ready` - `readinessProbe`. Whether traffic should be routed here; reflects your `healthCheck`, answering 200 only while it reports `healthy`. An agent with no `healthCheck` - or one whose first run has not finished - is healthy, so it is unaffected.
+- `/health` - no probe. The same verdict as `/ready`, plus the `checks` and `errors` your check returned.
 
-`/ready` answers 503 until the mesh runtime is up, so pointing liveness or startup at it restarts pods that are merely still booting; `/health` never fails at all. The Helm chart is already wired this way.
+Both answer 503 while the check reports `degraded` or `unhealthy`, so pointing liveness or startup at either turns a vendor outage into a pod restart, which cannot fix it. The Helm chart is already wired this way.
 
 Pass a `healthCheck` to `mesh()` to say what "able to serve" means for this agent:
 
@@ -257,7 +257,7 @@ const agent = mesh(server, {
 
 While the check returns unhealthy the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider - restored automatically when the check passes, with no restart. Returning `boolean` works too: `true` is healthy, `false` unhealthy. A check that throws is recorded as `degraded` and keeps heartbeating, so a bug in the check cannot take a working agent out of the mesh. `MCP_MESH_HEALTH_CHECK_TTL` overrides `healthCheckTtl` (default 15s).
 
-Route (`mesh.route`) and A2A agents are the exception: they ignore `healthCheck` entirely. A gateway is a fan-out point, and withdrawing it takes the application down.
+Route (`mesh.route`) and A2A agents are the exception: they ignore `healthCheck` entirely, and their `/ready` reports only whether the mesh runtime is up. A gateway is a fan-out point, and withdrawing it takes the application down.
 
 ### Graceful Shutdown
 

--- a/src/core/cli/man/content/health.md
+++ b/src/core/cli/man/content/health.md
@@ -110,9 +110,9 @@ def my_tool(date_svc: mesh.McpMeshTool = None):
     return date_svc()
 ```
 
-## Custom Health Checks
+## Declaring Your Own Health Check
 
-Add custom health checks to your agent:
+Pass a `health_check` to `@mesh.agent` to tell the mesh what "able to serve" means for this agent:
 
 ```python
 async def my_health_check() -> dict:
@@ -137,6 +137,26 @@ async def my_health_check() -> dict:
 class MyAgent:
     pass
 ```
+
+One check per agent. Return a `{"status", "checks", "errors"}` dict for full detail, or a `bool` for the terse form (`True` healthy, `False` unhealthy). `health_check_ttl` is how often it re-runs (default 15).
+
+### What a Failing Check Does
+
+While the check reports unhealthy the agent **stops heartbeating**. The registry marks it unhealthy after the staleness window, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent - no restart, no redeploy. The TTL is the cadence, not the end-to-end latency: it only bounds how long until the next check runs, and withdrawal costs that plus the registry's staleness window once heartbeats stop.
+
+The check that runs during startup is deliberately exempt: it seeds `/health` but is never reported to the core, so an agent registers and becomes visible first. The first refresh, one TTL later, is the earliest a check can withdraw it.
+
+The verdict also drives the probe endpoints: `/ready` and `/health` answer 200 only while the check reports `healthy`, and `/health` carries the `checks` and `errors` it returned. `/livez` never consults it - a restart cannot fix a vendor outage.
+
+### Only an Explicit Unhealthy Withdraws the Agent
+
+A check that **raises** is recorded as `degraded`, not unhealthy, and keeps heartbeating. So is one that returns something other than a dict, a `bool` or a `HealthStatus`. A bug in a health check must not be able to remove a working agent from the mesh. Return `False` or `{"status": "unhealthy"}` to actually withdraw.
+
+`degraded` splits the two surfaces on purpose: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider.
+
+### Route and A2A Agents
+
+`@mesh.route` and `@mesh.a2a` agents never run the check at all - their startup pipelines have no health-refresh loop, so there is no verdict to suppress a heartbeat or to show anywhere. A gateway is a fan-out point that many requests enter through: withdrawing a provider is correct, withdrawing the gateway takes the application down. Declare the check on the agents behind the gateway instead.
 
 ## Graceful Failure
 

--- a/src/core/cli/man/content/health_java.md
+++ b/src/core/cli/man/content/health_java.md
@@ -56,7 +56,7 @@ One check per agent, on any Spring bean. Return `MeshHealth` for full detail, or
 
 While the check reports unhealthy the agent **stops heartbeating**. The registry marks it unhealthy after the staleness window, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent through the `410 Gone` re-register path - no restart. The TTL is the cadence, not the end-to-end latency: it only bounds how long until the next check runs. Withdrawal costs that plus the registry's staleness window once heartbeats stop, and recovery costs it plus the heartbeat resume and re-register round trip.
 
-The verdict also drives the probe endpoints: `/ready` answers 503 while unhealthy, and `/health` carries the `checks` and `errors` the method returned. `/livez` never consults it - a restart cannot fix a vendor outage.
+The verdict also drives the probe endpoints: `/ready` answers 503 while unhealthy, and `/health` carries the `checks` and `errors` the method returned. `/livez` never consults it - a restart cannot fix a vendor outage. On a route (`api`) or A2A agent `/ready` is exempt too - see below.
 
 ### Only an Explicit Unhealthy Withdraws the Agent
 
@@ -66,7 +66,7 @@ A check that **throws** is recorded as `degraded`, not unhealthy, and keeps hear
 
 ### Route and A2A Agents
 
-On a route-only (`api`) or A2A agent the check feeds `/health` and `/ready` but **never** suppresses the heartbeat. A gateway is a fan-out point that many requests enter through: withdrawing a provider is correct, withdrawing the gateway takes the application down. This matches Python, whose API and A2A pipelines have no health-refresh loop at all.
+On a route-only (`api`) or A2A agent the check feeds `/health` only. It **never** suppresses the heartbeat and **never** affects `/ready`, which reports whether the mesh runtime is up and nothing else. A gateway is a fan-out point that many requests enter through: withdrawing a provider is correct, withdrawing the gateway takes the application down - and a 503 on `/ready` drops it from its Kubernetes Service endpoints, which takes it down harder. `/health` is where you see what a gateway's check reports. This matches Python, whose API and A2A pipelines have no health-refresh loop at all.
 
 ## Checking Dependency Health
 

--- a/src/core/cli/man/content/health_typescript.md
+++ b/src/core/cli/man/content/health_typescript.md
@@ -66,11 +66,15 @@ const agent = mesh(server, {
 
 One check per agent. Return `{ status, checks, errors }` for full detail, or a `boolean` for the terse form (`true` healthy, `false` unhealthy). `healthCheckTtl` is how often it re-runs (default 15); `MCP_MESH_HEALTH_CHECK_TTL` overrides it.
 
+The verdict also drives the probe endpoints: `/ready` and `/health` answer 200 only while the check reports `healthy`, and `/health` carries the `checks` and `errors` it returned. `/livez` never consults it - a restart cannot fix a vendor outage. On a `mesh.route` or A2A agent the check is ignored entirely - see below.
+
 ### What a Failing Check Does
 
 While the check reports unhealthy the agent **stops heartbeating**. The registry marks it unhealthy after the staleness window, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent through the `410 Gone` re-register path - no restart. The TTL is the cadence, not the end-to-end latency: it only bounds how long until the next check runs. Withdrawal costs that plus the registry's staleness window once heartbeats stop, and recovery costs it plus the heartbeat resume and re-register round trip.
 
 Report `unhealthy` only for conditions the mesh should route around: the upstream this agent needs is genuinely not serving. A check that **throws**, or that could not reach a conclusion, is recorded as `degraded` and keeps heartbeating - a broken probe says nothing about the upstream, and withdrawing a working agent over one is the worse failure.
+
+`degraded` splits the two surfaces on purpose, the same way it does on Python and Java: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider.
 
 `mesh.route` and A2A agents ignore `healthCheck`. They are fan-out points, so withdrawing one takes down every path that enters through it - declare the check on the agents behind the gateway instead.
 
@@ -164,12 +168,21 @@ agent.addTool({
 
 ## Health Endpoints
 
-TypeScript agents automatically expose health endpoints:
+TypeScript agents automatically expose three endpoints, and Kubernetes probes must not share one:
+
+- `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
+- `/ready` - `readinessProbe`. 200 only while your `healthCheck` reports `healthy`; 503 on `degraded` or `unhealthy`. An agent with no `healthCheck` is healthy.
+- `/health` - no probe. The same verdict, plus the `checks` and `errors` the check returned.
 
 ```typescript
-// Automatic health check at /health
-// Returns: { status: "healthy", agentId: "my-agent-abc123" }
+// GET /health
+// { status: "healthy", agent: "my-agent", checks: { vendor_api_reachable: true }, errors: [], timestamp: "..." }
+
+// GET /ready
+// { ready: true, agent: "my-agent", status: "healthy", mcp_wrappers: 1, timestamp: "..." }
 ```
+
+A `mesh.route` or A2A agent serves the same three URLs, but its `/ready` reports only whether the mesh runtime is up and its `/health` is a fixed `healthy` - the `healthCheck` is ignored there.
 
 ## Graceful Shutdown
 

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -210,12 +210,28 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // names the two paths a liveness probe must not use. The `_java` and
 // `_typescript` variants carry the same three bullets, but their `/ready` and
 // `/health` lines and their closing reason are written to what those runtimes
-// actually return (no user health check; TypeScript's `/health` is a fixed
-// 200). None of that moves these constants: they sample only the default
-// variant, so edits confined to a `_java` / `_typescript` file are invisible
-// here and a review of those files cannot lean on this test.
+// actually return. That was "no user health check; TypeScript's `/health` is a
+// fixed 200" when this landed and is no longer true of either: #1474/#1475 gave
+// Java a user check, #1478/#1487 made TypeScript's `/ready` and `/health`
+// reflect its verdict, and #1488 exempted a Java gateway's `/ready` from it.
+// The variants have been rewritten to match; do not read the superseded
+// parenthetical as current behaviour. None of that moves these constants: they
+// sample only the default variant, so edits confined to a `_java` /
+// `_typescript` file are invisible here and a review of those files cannot lean
+// on this test.
+// #1472 follow-up: +25 / +0 / +0, all in `health.md`. The default variant
+// documented `health_check` without saying what an unhealthy verdict DOES,
+// while both siblings covered it — so the most-read page for the primary
+// runtime omitted the whole feature. It gains four sections: withdrawal (the
+// heartbeat stops, the registry withdraws, resolution reroutes) with the
+// startup-seed exemption, the probe endpoints, `degraded` splitting the two
+// surfaces, and the route/A2A case. Itemised so the next mover knows the bar:
+// intro 2, "one check per agent" 5, startup seed 1, probes 7, explicit-unhealthy
+// 5, `degraded` 3, route/A2A 2 = 25 added, 0 removed. The two list goldens held
+// because every added paragraph is prose — not one new bullet — and those tests
+// count only list lines.
 const (
-	wantInlineCodeSpans = 1698
+	wantInlineCodeSpans = 1723
 	wantListCodeSpans   = 516
 	wantMarkupListLines = 445
 )

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAgentTypes.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAgentTypes.java
@@ -1,0 +1,67 @@
+package io.mcpmesh.spring;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+/**
+ * The "is this agent a gateway" rule, in ONE place (issue #1488).
+ *
+ * <p>Two mechanisms act on a failing {@link io.mcpmesh.MeshHealthCheck} — the
+ * heartbeat in {@link MeshHealthCheckScheduler} and the readiness probe in
+ * {@link MeshHealthController} — and both must exempt the same agent types. When
+ * only the scheduler knew the rule, a gateway with a failing check kept
+ * heartbeating (correct) but answered 503 on {@code /ready}, so Kubernetes
+ * dropped it from its Service endpoints: the same outcome the exemption exists
+ * to prevent, reached by another route. Two copies of the rule is how that
+ * happens, so there is one.
+ */
+final class MeshAgentTypes {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshAgentTypes.class);
+
+    /**
+     * Agent types whose own health verdict must never take them out of service.
+     *
+     * <p>A route ({@code api}) or A2A agent is a fan-out point that many
+     * requests enter through: withdrawing a provider is correct, withdrawing the
+     * gateway takes the application down — and removing it from Service
+     * endpoints takes it down harder, because the gateway is where requests
+     * enter. Python encodes the same asymmetry by giving its API and A2A
+     * pipelines no health-refresh loop at all, and TypeScript by ignoring
+     * {@code healthCheck} in {@code express.ts}.
+     */
+    private static final Set<String> GATEWAY_TYPES = Set.of("api", "a2a");
+
+    private MeshAgentTypes() {
+    }
+
+    static boolean isGateway(String agentType) {
+        return GATEWAY_TYPES.contains(agentType);
+    }
+
+    static boolean isGateway(MeshRuntime runtime) {
+        return isGateway(agentTypeOf(runtime));
+    }
+
+    /**
+     * The agent's declared type, or {@code ""} when it cannot be read.
+     *
+     * <p>Never throws: {@code runtime} is a lazy bean proxy that can raise while
+     * the context is still coming up, and neither a probe nor the health-check
+     * thread may fail because of it. An unknown type is treated as NOT a
+     * gateway, which is the pre-existing behaviour for every other agent.
+     */
+    static String agentTypeOf(MeshRuntime runtime) {
+        try {
+            if (runtime != null && runtime.getAgentSpec() != null) {
+                String type = runtime.getAgentSpec().getAgentType();
+                return type == null ? "" : type;
+            }
+        } catch (Exception e) {
+            log.debug("Could not read agent type: {}", e.toString());
+        }
+        return "";
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckScheduler.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckScheduler.java
@@ -6,7 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 
-import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -48,16 +47,6 @@ public class MeshHealthCheckScheduler implements SmartLifecycle {
     /** After {@link MeshRuntime} (MAX-100) and {@link MeshEventProcessor} (MAX-50). */
     private static final int LIFECYCLE_PHASE = Integer.MAX_VALUE - 40;
 
-    /**
-     * Agent types whose health verdict must never suppress the heartbeat.
-     *
-     * <p>A route ({@code api}) or A2A agent is a fan-out point that many
-     * requests enter through: withdrawing a provider is correct, withdrawing
-     * the gateway takes the application down. Python encodes the same asymmetry
-     * by giving its API and A2A pipelines no health-refresh loop at all.
-     */
-    private static final Set<String> NEVER_WITHDRAWN = Set.of("api", "a2a");
-
     private final MeshRuntime runtime;
     private final MeshHealthCheckRegistry registry;
     private final AtomicBoolean running = new AtomicBoolean(false);
@@ -86,7 +75,8 @@ public class MeshHealthCheckScheduler implements SmartLifecycle {
             return;
         }
 
-        this.publishToRuntime = !NEVER_WITHDRAWN.contains(agentType());
+        String agentType = MeshAgentTypes.agentTypeOf(runtime);
+        this.publishToRuntime = !MeshAgentTypes.isGateway(agentType);
         int ttl = registry.ttlSeconds();
 
         if (publishToRuntime) {
@@ -94,10 +84,11 @@ public class MeshHealthCheckScheduler implements SmartLifecycle {
                 + "and withdraws this agent from dependency resolution",
                 registry.registration().describe(), ttl);
         } else {
-            log.info("Health check {} runs every {}s and feeds /health and /ready only — the "
-                + "heartbeat is never suppressed on an '{}' agent (a gateway is a fan-out "
-                + "point; withdrawing it takes the application down)",
-                registry.registration().describe(), ttl, agentType());
+            log.info("Health check {} runs every {}s and feeds /health only — on an '{}' agent "
+                + "neither the heartbeat nor /ready is affected (a gateway is a fan-out point; "
+                + "withdrawing it takes the application down, and dropping it from the Service "
+                + "endpoints takes it down harder)",
+                registry.registration().describe(), ttl, agentType);
         }
 
         executor = Executors.newSingleThreadScheduledExecutor(r -> {
@@ -198,17 +189,5 @@ public class MeshHealthCheckScheduler implements SmartLifecycle {
             log.warn("Failed to report health status '{}' to the mesh runtime: {}",
                 health.status(), t.toString());
         }
-    }
-
-    private String agentType() {
-        try {
-            if (runtime != null && runtime.getAgentSpec() != null) {
-                String type = runtime.getAgentSpec().getAgentType();
-                return type == null ? "" : type;
-            }
-        } catch (Exception e) {
-            log.debug("Could not read agent type: {}", e.toString());
-        }
-        return "";
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
@@ -31,6 +31,13 @@ import java.util.Map;
  * {@code checks} and {@code errors} so an operator can see WHICH probe failed.
  * The runtime state remains the floor: an agent whose mesh runtime is not up is
  * not ready regardless of what the user's check says.
+ *
+ * <p>On a gateway ({@link MeshAgentTypes#isGateway}) the verdict does NOT reach
+ * {@code /ready} (issue #1488): readiness there reports only whether the mesh
+ * runtime is up, exactly as Python's {@code build_ready_response} and
+ * TypeScript's {@code express.ts} do. The verdict still shows on {@code /health}
+ * — nothing probes it, so it costs nothing and it is where an operator can see
+ * what a gateway's check reports.
  */
 @Controller
 public class MeshHealthController {
@@ -63,6 +70,28 @@ public class MeshHealthController {
             return MeshHealthStatus.UNHEALTHY;
         }
         return latest == null ? MeshHealthStatus.HEALTHY : latest.status();
+    }
+
+    /**
+     * The readiness verdict: the effective status, except on a gateway, where
+     * the user's check is ignored and only the runtime floor applies.
+     *
+     * <p>A route ({@code api}) or A2A agent is exempt from withdrawal by its own
+     * check — {@link MeshAgentTypes} carries that rule for both this controller
+     * and {@link MeshHealthCheckScheduler}. Answering 503 here would evade the
+     * exemption: the chart's readiness probe points at {@code /ready}, so a 503
+     * drops the gateway from its Kubernetes Service endpoints, which takes the
+     * application down harder than withdrawing it from dependency resolution
+     * would have. The runtime floor still applies — a gateway whose mesh runtime
+     * is not up genuinely cannot serve.
+     */
+    private MeshHealthStatus readyStatus(MeshHealth latest) {
+        if (MeshAgentTypes.isGateway(runtime)) {
+            return runtime != null && runtime.isRunning()
+                ? MeshHealthStatus.HEALTHY
+                : MeshHealthStatus.UNHEALTHY;
+        }
+        return effectiveStatus(latest);
     }
 
     /**
@@ -129,14 +158,15 @@ public class MeshHealthController {
      *
      * <p>Reports whether traffic should be routed here: the mesh runtime is up
      * AND the user's {@link io.mcpmesh.MeshHealthCheck} (if any) is not
-     * reporting unhealthy. It does NOT restart anything — see the class comment
-     * on why this is a separate endpoint from {@code /livez}.
+     * reporting unhealthy — except on a gateway, where only the runtime counts
+     * (see {@link #readyStatus}). It does NOT restart anything — see the class
+     * comment on why this is a separate endpoint from {@code /livez}.
      */
     @GetMapping("/ready")
     public ResponseEntity<Map<String, Object>> ready() {
         boolean running = runtime != null && runtime.isRunning();
         MeshHealth latest = healthOf(latestResult());
-        MeshHealthStatus status = effectiveStatus(latest);
+        MeshHealthStatus status = readyStatus(latest);
         boolean ready = serving(status);
 
         Map<String, Object> body = new LinkedHashMap<>();
@@ -155,8 +185,10 @@ public class MeshHealthController {
 
     @RequestMapping(value = "/ready", method = RequestMethod.HEAD)
     public ResponseEntity<Void> readyHead() {
+        // Same verdict as GET — a HEAD probe that disagreed with the GET would
+        // be the #1488 bug again for anyone who configured HEAD.
         return ResponseEntity.status(
-            serving(effectiveStatus(healthOf(latestResult()))) ? 200 : 503).build();
+            serving(readyStatus(healthOf(latestResult()))) ? 200 : 503).build();
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckSchedulerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckSchedulerTest.java
@@ -198,7 +198,8 @@ class MeshHealthCheckSchedulerTest {
                 assertTrue(published.isEmpty(),
                     "'" + agentType + "' agent must never suppress its heartbeat");
                 assertEquals(MeshHealthStatus.UNHEALTHY, registry.latest().health().status(),
-                    "'" + agentType + "' agent must still reflect the verdict on its probes");
+                    "'" + agentType + "' agent must still reflect the verdict on /health "
+                        + "(but not on /ready — issue #1488)");
             } finally {
                 scheduler.stop();
             }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthControllerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthControllerTest.java
@@ -24,6 +24,17 @@ class MeshHealthControllerTest {
         return runtime;
     }
 
+    /** A runtime of a given agent type, as the probes see it. */
+    private static MeshRuntime runtimeOf(String agentType, boolean running) {
+        MeshRuntime runtime = mock(MeshRuntime.class);
+        when(runtime.isRunning()).thenReturn(running);
+        io.mcpmesh.core.AgentSpec spec = new io.mcpmesh.core.AgentSpec();
+        spec.setName("gateway");
+        spec.setAgentType(agentType);
+        when(runtime.getAgentSpec()).thenReturn(spec);
+        return runtime;
+    }
+
     @Test
     void livez_is200_whenRuntimeIsRunning() {
         MeshHealthController controller = new MeshHealthController(runtimeWith(true));
@@ -211,6 +222,98 @@ class MeshHealthControllerTest {
         assertEquals(200, controller.ready().getStatusCode().value());
         assertEquals(200, controller.health().getStatusCode().value());
         assertFalse(controller.health().getBody().containsKey("checks"));
+    }
+
+    // ---- gateways are never taken out of Service endpoints (issue #1488) ----
+
+    @Test
+    void gateway_ready_is200_whenTheUserHealthCheckIsUnhealthy() {
+        // A gateway is a fan-out point. Suppressing its heartbeat is already
+        // forbidden (MeshAgentTypes.isGateway); answering 503 on /ready reaches the same
+        // outcome by another route, because the chart's readiness probe points
+        // there and Kubernetes drops the pod from its Service endpoints.
+        for (String agentType : java.util.List.of("api", "a2a")) {
+            MeshHealthController controller = new MeshHealthController(
+                runtimeOf(agentType, true),
+                withVerdict(io.mcpmesh.MeshHealth.unhealthy("upstream down")));
+
+            ResponseEntity<Map<String, Object>> response = controller.ready();
+
+            assertEquals(200, response.getStatusCode().value(),
+                "'" + agentType + "' agent must stay in Service endpoints");
+            assertEquals(Boolean.TRUE, response.getBody().get("ready"));
+            assertEquals(200, controller.readyHead().getStatusCode().value(),
+                "HEAD /ready must agree with GET on an '" + agentType + "' agent");
+        }
+    }
+
+    @Test
+    void gateway_ready_is200_whenTheUserHealthCheckIsDegraded() {
+        for (String agentType : java.util.List.of("api", "a2a")) {
+            MeshHealthController controller = new MeshHealthController(
+                runtimeOf(agentType, true),
+                withVerdict(io.mcpmesh.MeshHealth.degraded("elevated latency")));
+
+            assertEquals(200, controller.ready().getStatusCode().value(),
+                "'" + agentType + "' agent must stay in Service endpoints");
+            assertEquals(200, controller.readyHead().getStatusCode().value());
+        }
+    }
+
+    @Test
+    void gateway_health_stillCarriesTheVerdict() {
+        // /health is the one place an operator can see what a gateway's check
+        // reports. Nothing probes it — the chart points startup and liveness at
+        // /livez and readiness at /ready — so carrying the verdict costs nothing.
+        for (String agentType : java.util.List.of("api", "a2a")) {
+            MeshHealthController controller = new MeshHealthController(
+                runtimeOf(agentType, true),
+                withVerdict(io.mcpmesh.MeshHealth.unhealthy("upstream down")
+                    .withCheck("upstream_reachable", false)));
+
+            ResponseEntity<Map<String, Object>> response = controller.health();
+
+            assertEquals(503, response.getStatusCode().value());
+            assertEquals("unhealthy", response.getBody().get("status"));
+            assertEquals(Map.of("upstream_reachable", false),
+                response.getBody().get("checks"));
+            assertEquals(java.util.List.of("upstream down"),
+                response.getBody().get("errors"));
+            assertEquals(503, controller.healthHead().getStatusCode().value());
+        }
+    }
+
+    @Test
+    void gateway_ready_is503_whenTheRuntimeIsNotRunning() {
+        // The runtime state is still the floor: a gateway whose mesh runtime is
+        // down cannot serve, and that is not the user's check talking.
+        MeshHealthController controller = new MeshHealthController(
+            runtimeOf("api", false), withVerdict(io.mcpmesh.MeshHealth.healthy()));
+
+        ResponseEntity<Map<String, Object>> response = controller.ready();
+
+        assertEquals(503, response.getStatusCode().value());
+        assertEquals("mesh runtime is not running", response.getBody().get("reason"));
+        assertEquals(503, controller.readyHead().getStatusCode().value());
+    }
+
+    @Test
+    void nonGateway_ready_is503_whenTheUserHealthCheckIsUnhealthy() {
+        // Guards against over-correcting: an mcp agent is a provider, and
+        // withdrawing ONE provider is exactly what the mechanism is for.
+        for (String agentType : java.util.List.of("mcp", "mcp_agent")) {
+            MeshHealthController controller = new MeshHealthController(
+                runtimeOf(agentType, true),
+                withVerdict(io.mcpmesh.MeshHealth.unhealthy("vendor 503")));
+
+            ResponseEntity<Map<String, Object>> response = controller.ready();
+
+            assertEquals(503, response.getStatusCode().value(),
+                "'" + agentType + "' agent must still leave rotation");
+            assertEquals(Boolean.FALSE, response.getBody().get("ready"));
+            assertEquals("service is unhealthy", response.getBody().get("reason"));
+            assertEquals(503, controller.readyHead().getStatusCode().value());
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

`MeshHealthCheckScheduler.NEVER_WITHDRAWN` gated only the **heartbeat publish**. `MeshHealthController.ready()` consulted the verdict unconditionally, so a Java `api` or `a2a` agent with a failing `@MeshHealthCheck`:

- kept heartbeating, so it stayed in dependency resolution — correct, and what the exemption intends;
- answered **503 on `/ready`**, and since #1468 pointed the readiness probe there, Kubernetes dropped it from its Service endpoints.

That is the outcome the exemption exists to prevent, reached by a different mechanism — and a worse one. A gateway is where requests *enter*, so removing it from the ingress path takes the application down harder than withdrawing it from resolution would have.

Python and TypeScript gateways both stay at 200: Python's `api_startup` pipeline has no health-refresh loop so the check never runs, and TypeScript's `express.ts` ignores `healthCheck` outright. **Java was the outlier.** This makes it match them rather than propagating its behaviour outward — three runtimes, two behaviours, and the ruling is that gateways are never withdrawn.

`/ready` now reports only whether the mesh runtime is up on a gateway. The runtime floor is preserved — a gateway whose runtime is down still answers 503. `/health` keeps carrying the verdict on **every** agent type: nothing probes it (the chart points startup and liveness at `/livez`), so it costs nothing and it is the one place an operator can still see what a gateway's check reports.

## Review notes

**One source of truth.** The rule now lives in `MeshAgentTypes` and is consulted by both the scheduler and the controller. `NEVER_WITHDRAWN` and the scheduler's private `agentType()` are gone. Two copies of "is this a gateway" is exactly how they drift apart.

**The log line was asserting the old behaviour.** It said the check "runs every Ns and feeds `/health` and `/ready` only" on a gateway — which this change makes false. Now `/health` only. A log message describing behaviour the code no longer has is the same defect class this codebase keeps surfacing.

**Written red first.** Against unmodified code, 22 run / 2 fail — exactly the two gateway cases:

```
gateway_ready_is200_whenTheUserHealthCheckIsUnhealthy:242
  'api' agent must stay in Service endpoints ==> expected: <200> but was: <503>
gateway_ready_is200_whenTheUserHealthCheckIsDegraded:257
```

The other three new tests — a gateway's `/health` still carrying the verdict, a gateway with a dead runtime still 503, and a **non-gateway still 503** — passed against the old code too, which is what makes them regression guards rather than the fix's own scaffolding. That last one guards the opposite failure: over-correcting and silently disabling readiness gating everywhere.

**No existing test asserted the old behaviour.** Checked both directions: `MeshHealthCheckSchedulerTest.aRouteAgentIsNeverWithdrawnByItsOwnCheck` only asserts the verdict is stored in the registry and never calls the controller (its message string was corrected); and uc41 tc01–tc06 all use plain MCP provider/consumer agents, so no integration case exercises a gateway with a health check.

**Timing.** Found while preparing the 3.5.2 release notes. #1475 is unreleased, so this behaviour would have reached users for the first time in that release.

Known gap, not addressed here: there is no integration coverage for a Java gateway with a `@MeshHealthCheck` at all — uc41 is provider-only. A tc07 asserting `/ready` stays 200 while `/health` reports the verdict would pin this at the wire level; the unit tests pin it at the controller.

Closes #1488

## Test plan

- [x] `MeshHealthControllerTest` 17 → 22; starter module 870 → **875**, 0 failures
- [x] Full Java reactor `mvn -o test` — BUILD SUCCESS across all 7 modules
- [x] `go build ./...` clean; `go test ./src/core/cli/...` all ok, including `cli/man` which embeds the edited content
- [x] Red-state verified before the fix; the three regression guards pass on both sides


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gateway agents remain ready based on runtime availability, even when user health checks are unhealthy or degraded.
  * Gateway health-check results remain available through `/health` without affecting readiness or heartbeat behavior.
  * Readiness becomes unavailable when the gateway runtime is stopped.

* **Documentation**
  * Updated health and deployment guidance to clarify gateway-specific `/health` and `/ready` behavior across supported runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->