### PR TITLE
fix(python): honour MCP_MESH_HEALTH_CHECK_TTL

### DIFF
--- a/src/core/cli/man/content/health.md
+++ b/src/core/cli/man/content/health.md
@@ -138,7 +138,7 @@ class MyAgent:
     pass
 ```
 
-One check per agent. Return a `{"status", "checks", "errors"}` dict for full detail, or a `bool` for the terse form (`True` healthy, `False` unhealthy). `health_check_ttl` is how often it re-runs (default 15).
+One check per agent. Return a `{"status", "checks", "errors"}` dict for full detail, or a `bool` for the terse form (`True` healthy, `False` unhealthy). `health_check_ttl` is how often it re-runs (default 15); `MCP_MESH_HEALTH_CHECK_TTL` overrides it.
 
 ### What a Failing Check Does
 

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -230,8 +230,12 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // 5, `degraded` 3, route/A2A 2 = 25 added, 0 removed. The two list goldens held
 // because every added paragraph is prose — not one new bullet — and those tests
 // count only list lines.
+// #1492 follow-up: +1 / +0 / +0, in `health.md`. The Python runtime now honours
+// `MCP_MESH_HEALTH_CHECK_TTL`, so the default variant's `health_check_ttl`
+// sentence closes with the same override clause both siblings already carried;
+// that one new inline span is prose, so the list goldens hold.
 const (
-	wantInlineCodeSpans = 1723
+	wantInlineCodeSpans = 1724
 	wantListCodeSpans   = 516
 	wantMarkupListLines = 445
 )

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
@@ -323,9 +323,17 @@ class FastAPIServerSetupStep(PipelineStep):
         """
         from fastapi import Response
 
+        from ...shared.health_check_manager import resolve_health_check_ttl_from_env
+
         agent_name = agent_config.get("name", "mcp-mesh-agent")
         health_check_fn = agent_config.get("health_check")
-        health_check_ttl = agent_config.get("health_check_ttl", 15)
+        # Issue #1492: MCP_MESH_HEALTH_CHECK_TTL > decorator argument > 15,
+        # the precedence TypeScript and Java already use. The decorator
+        # argument is baked into the image; the env var can be retuned in
+        # Helm values against a live incident.
+        health_check_ttl = resolve_health_check_ttl_from_env(
+            agent_config.get("health_check_ttl")
+        )
 
         # Create a background task to update health check results periodically
         async def update_health_result(publish_to_core: bool = False):

--- a/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
+++ b/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
@@ -40,6 +40,40 @@ HEALTH_CHECK_TTL_ENV = "MCP_MESH_HEALTH_CHECK_TTL"
 _INTEGER_RE = re.compile(r"^[+-]?\d+$", re.ASCII)
 
 
+# Long enough to recognize the value that was rejected, short enough that a
+# warning stays one readable line.
+_WARNING_VALUE_LIMIT = 32
+
+
+def _for_warning(value: Any, *, quote: bool = False) -> str:
+    """Render a value for a rejection message without raising or flooding the log.
+
+    Interpolating a value is not safe by default here. Python 3.11 caps
+    int<->str conversion at 4300 digits, so ``f"{value}"`` raises ValueError on
+    a large enough int — inside the one function whose contract is that it
+    never raises, on the very path that exists to keep a malformed TTL from
+    stopping an agent from booting. Length is the second hazard: an env var is
+    an unbounded paste, and a 300,000-character warning is not a warning.
+
+    Every rejection message below goes through this, so a message added later
+    cannot reintroduce either hazard by being written the obvious way.
+    """
+    try:
+        text = repr(value) if quote or not isinstance(value, str) else value
+    except Exception:
+        # Broad: this only formats a log line, and no failure to describe a
+        # bad value is worth turning into a raise here. Ints report their
+        # magnitude, which str() is exactly what cannot do for them.
+        if isinstance(value, int):
+            digits = int(value.bit_length() * 0.30103) + 1
+            return f"<{type(value).__name__} with ~{digits} digits>"
+        return f"<unprintable {type(value).__name__}>"
+
+    if len(text) > _WARNING_VALUE_LIMIT:
+        return f"{text[:_WARNING_VALUE_LIMIT]}… ({len(text)} chars)"
+    return text
+
+
 def resolve_health_check_ttl(
     configured: Any = None, override: str | None = None
 ) -> int:
@@ -70,11 +104,13 @@ def resolve_health_check_ttl(
         # bool is an int subclass in Python; True is not 1 second.
         if isinstance(configured, bool) or not isinstance(configured, int):
             rejected.append(
-                f"health_check_ttl={configured!r} is not a whole number of seconds >= 1"
+                f"health_check_ttl={_for_warning(configured, quote=True)} "
+                f"is not a whole number of seconds >= 1"
             )
         elif configured < 1:
             rejected.append(
-                f"health_check_ttl={configured} is not a whole number of seconds >= 1"
+                f"health_check_ttl={_for_warning(configured)} "
+                f"is not a whole number of seconds >= 1"
             )
         else:
             ttl = configured
@@ -83,16 +119,30 @@ def resolve_health_check_ttl(
         text = override.strip()
         if not _INTEGER_RE.match(text):
             rejected.append(
-                f"{HEALTH_CHECK_TTL_ENV}={override} is not an integer number of seconds"
+                f"{HEALTH_CHECK_TTL_ENV}={_for_warning(override)} "
+                f"is not an integer number of seconds"
             )
         else:
-            parsed = int(text)
-            if parsed < 1:
+            try:
+                parsed = int(text)
+            except ValueError:
+                # Matching the regex is not enough: Python 3.11 caps
+                # string->int conversion at 4300 digits, so an all-digit paste
+                # reaches here and raises. Left unguarded it is the one
+                # malformed TTL that stops an agent from booting, which is
+                # exactly the case where falling back matters most.
                 rejected.append(
-                    f"{HEALTH_CHECK_TTL_ENV}={override} is below the 1s minimum"
+                    f"{HEALTH_CHECK_TTL_ENV}={_for_warning(text)} "
+                    f"is too large to parse as a number of seconds"
                 )
             else:
-                ttl = parsed
+                if parsed < 1:
+                    rejected.append(
+                        f"{HEALTH_CHECK_TTL_ENV}={_for_warning(override)} "
+                        f"is below the 1s minimum"
+                    )
+                else:
+                    ttl = parsed
 
     for reason in rejected:
         logger.warning("%s — using %ss", reason, ttl)

--- a/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
+++ b/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
@@ -6,6 +6,8 @@ generation into a single module.
 """
 
 import logging
+import os
+import re
 import time
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
@@ -14,6 +16,94 @@ from typing import Any
 from .support_types import HealthStatus, HealthStatusType
 
 logger = logging.getLogger(__name__)
+
+# =============================================================================
+# TTL Resolution (issue #1492)
+# =============================================================================
+
+# TypeScript's DEFAULT_HEALTH_CHECK_TTL_SECONDS and Java's DEFAULT_TTL_SECONDS.
+DEFAULT_HEALTH_CHECK_TTL_SECONDS = 15
+
+# Overrides the ``health_check_ttl`` decorator argument when set.
+HEALTH_CHECK_TTL_ENV = "MCP_MESH_HEALTH_CHECK_TTL"
+
+# Integers only — "15s", "1.5" and "0x10" are all rejected. Mirrors
+# TypeScript's INTEGER_RE and Java's Integer.parseInt, both of which take a
+# leading sign and nothing else. Bare `int()` would additionally accept
+# "1_0" and non-ASCII digits, neither of which TypeScript honours.
+#
+# re.ASCII is deliberate: Python's `\d` and `int()` both accept non-ASCII
+# digits ("١٥" -> 15), as does Java's Integer.parseInt, but TypeScript
+# rejects them. Following TypeScript — an env var carrying an Arabic-Indic
+# numeral is far likelier an encoding accident than an intent, and a loud
+# fallback beats silently running a TTL the operator cannot read back.
+_INTEGER_RE = re.compile(r"^[+-]?\d+$", re.ASCII)
+
+
+def resolve_health_check_ttl(
+    configured: Any = None, override: str | None = None
+) -> int:
+    """Resolve the health-check refresh period, in seconds.
+
+    Priority: ``MCP_MESH_HEALTH_CHECK_TTL`` > ``health_check_ttl`` > 15s.
+    Every rejected value warns and falls through to the next source rather
+    than raising — a malformed TTL must not stop an agent from booting, but
+    it must not be silently rounded into something else either.
+
+    ``override`` is a parameter rather than an ambient ``os.environ`` read so
+    the resolution rules are testable without mutating the environment (same
+    shape as TypeScript's ``resolveHealthCheckTtl`` and Java's
+    ``MeshHealthCheckRegistry.ttlSeconds(String)``).
+
+    Args:
+        configured: value from ``agent_config["health_check_ttl"]``
+        override: raw ``MCP_MESH_HEALTH_CHECK_TTL`` value, or None if unset
+    """
+    ttl = DEFAULT_HEALTH_CHECK_TTL_SECONDS
+    # Collected, not logged inline: a warning names the value that is
+    # actually used, and that is not known until every source has been
+    # considered. Warning "using 15s" while a valid env override goes on to
+    # win would print a number the agent never runs with.
+    rejected: list[str] = []
+
+    if configured is not None:
+        # bool is an int subclass in Python; True is not 1 second.
+        if isinstance(configured, bool) or not isinstance(configured, int):
+            rejected.append(
+                f"health_check_ttl={configured!r} is not a whole number of seconds >= 1"
+            )
+        elif configured < 1:
+            rejected.append(
+                f"health_check_ttl={configured} is not a whole number of seconds >= 1"
+            )
+        else:
+            ttl = configured
+
+    if isinstance(override, str) and override.strip():
+        text = override.strip()
+        if not _INTEGER_RE.match(text):
+            rejected.append(
+                f"{HEALTH_CHECK_TTL_ENV}={override} is not an integer number of seconds"
+            )
+        else:
+            parsed = int(text)
+            if parsed < 1:
+                rejected.append(
+                    f"{HEALTH_CHECK_TTL_ENV}={override} is below the 1s minimum"
+                )
+            else:
+                ttl = parsed
+
+    for reason in rejected:
+        logger.warning("%s — using %ss", reason, ttl)
+
+    return ttl
+
+
+def resolve_health_check_ttl_from_env(configured: Any = None) -> int:
+    """Read ``MCP_MESH_HEALTH_CHECK_TTL`` and resolve against it."""
+    return resolve_health_check_ttl(configured, os.environ.get(HEALTH_CHECK_TTL_ENV))
+
 
 # =============================================================================
 # Health Result Storage (moved from DecoratorRegistry)

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -1487,6 +1487,7 @@ def agent(
             Called before heartbeat and on /health endpoint with TTL caching
         health_check_ttl: Cache TTL for health check results in seconds (default: 15)
             Reduces expensive health check calls by caching results
+            Environment variable: MCP_MESH_HEALTH_CHECK_TTL (takes precedence)
         auto_run: Automatically start service and keep process alive (default: True)
             Environment variable: MCP_MESH_AUTO_RUN (takes precedence)
         auto_run_interval: Keep-alive heartbeat interval in seconds (default: 10)
@@ -1499,6 +1500,7 @@ def agent(
         MCP_MESH_HTTP_ENABLED: Override enable_http parameter (boolean: true/false)
         MCP_MESH_NAMESPACE: Override namespace parameter (string)
         MCP_MESH_HEALTH_INTERVAL: Override heartbeat_interval parameter (integer, ≥1)
+        MCP_MESH_HEALTH_CHECK_TTL: Override health_check_ttl parameter (integer, ≥1)
         MCP_MESH_AUTO_RUN: Override auto_run parameter (boolean: true/false)
         MCP_MESH_AUTO_RUN_INTERVAL: Override auto_run_interval parameter (integer, ≥1)
 

--- a/src/runtime/python/tests/unit/test_health_check_ttl_env_1492.py
+++ b/src/runtime/python/tests/unit/test_health_check_ttl_env_1492.py
@@ -1,0 +1,240 @@
+"""MCP_MESH_HEALTH_CHECK_TTL resolution (issue #1492).
+
+Parity with TypeScript's ``resolveHealthCheckTtl`` and Java's
+``MeshHealthCheckRegistry.ttlSeconds``: env > decorator argument > 15, with
+every rejected value warning and falling through to the next source instead
+of raising.
+
+The resolution rules are driven through the ``override`` parameter so they
+are exercised without mutating ``os.environ``; only the thin env-reading
+wrapper needs a monkeypatched environment.
+"""
+
+import logging
+
+import pytest
+from _mcp_mesh.shared.health_check_manager import (
+    DEFAULT_HEALTH_CHECK_TTL_SECONDS,
+    HEALTH_CHECK_TTL_ENV,
+    resolve_health_check_ttl,
+    resolve_health_check_ttl_from_env,
+)
+
+
+@pytest.fixture
+def warnings(caplog):
+    """Live view of the warning records emitted by the resolver.
+
+    ``caplog.records`` is per-phase, so the list is read inside the test
+    body rather than captured here during setup.
+    """
+    caplog.set_level(logging.WARNING, logger="_mcp_mesh.shared.health_check_manager")
+
+    class _Warnings:
+        @property
+        def records(self):
+            return [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+        def __len__(self):
+            return len(self.records)
+
+        def __getitem__(self, index):
+            return self.records[index]
+
+        def __eq__(self, other):
+            return self.records == other
+
+        def __repr__(self):
+            return repr([r.getMessage() for r in self.records])
+
+    return _Warnings()
+
+
+class TestResolveHealthCheckTtl:
+    """The env-free core."""
+
+    def test_defaults_to_15s(self, warnings):
+        assert resolve_health_check_ttl() == DEFAULT_HEALTH_CHECK_TTL_SECONDS
+        assert resolve_health_check_ttl(None, None) == 15
+        assert warnings == []
+
+    @pytest.mark.parametrize("configured", [30, 1, 3600])
+    def test_takes_a_valid_configured_value(self, configured, warnings):
+        assert resolve_health_check_ttl(configured) == configured
+        assert warnings == []
+
+    @pytest.mark.parametrize(
+        "label,configured",
+        [
+            ("zero", 0),
+            ("negative", -5),
+            ("sub-second", 0.5),
+            ("non-integer", 2.5),
+            ("string", "30"),
+            ("bool", True),
+            ("nan", float("nan")),
+            ("inf", float("inf")),
+        ],
+    )
+    def test_rejects_an_invalid_configured_value_and_warns(
+        self, label, configured, warnings
+    ):
+        assert resolve_health_check_ttl(configured) == 15
+        assert len(warnings) == 1
+
+    # --- env wins over the decorator argument -----------------------------
+
+    def test_env_overrides_the_configured_value(self, warnings):
+        assert resolve_health_check_ttl(30, "5") == 5
+        assert resolve_health_check_ttl(30, "  7  ") == 7
+        assert resolve_health_check_ttl(30, "+9") == 9
+        assert warnings == []
+
+    def test_env_overrides_the_default_with_no_configured_value(self, warnings):
+        assert resolve_health_check_ttl(None, "45") == 45
+        assert resolve_health_check_ttl(override="45") == 45
+        assert warnings == []
+
+    # --- rejected env forms fall through to the next source ---------------
+
+    @pytest.mark.parametrize("raw", ["", "   ", "\t\n"])
+    def test_blank_env_is_not_set_rather_than_an_error(self, raw, warnings):
+        assert resolve_health_check_ttl(30, raw) == 30
+        assert resolve_health_check_ttl(None, raw) == 15
+        assert warnings == []
+
+    @pytest.mark.parametrize(
+        "label,raw",
+        [
+            ("duration suffix", "15s"),
+            ("float", "1.5"),
+            ("hex", "0x10"),
+            ("words", "fifteen"),
+            ("trailing junk", "10 seconds"),
+            ("underscored int", "1_0"),
+            ("unicode digit", "١٥"),
+        ],
+    )
+    def test_rejects_a_non_integer_env_value(self, label, raw, warnings):
+        assert resolve_health_check_ttl(30, raw) == 30
+        assert len(warnings) == 1
+        assert "not an integer" in warnings[0].getMessage()
+
+    @pytest.mark.parametrize("raw", ["0", "-3", "-1"])
+    def test_rejects_a_sub_1s_env_value(self, raw, warnings):
+        assert resolve_health_check_ttl(30, raw) == 30
+        assert len(warnings) == 1
+        assert "below the 1s minimum" in warnings[0].getMessage()
+
+    def test_rejected_env_falls_back_to_the_default_without_a_configured_value(
+        self, warnings
+    ):
+        assert resolve_health_check_ttl(None, "0") == 15
+        assert resolve_health_check_ttl(None, "15s") == 15
+        assert len(warnings) == 2
+
+    def test_falls_back_to_the_default_when_both_sources_are_invalid(self, warnings):
+        assert resolve_health_check_ttl(0, "0") == 15
+        assert len(warnings) == 2
+
+    def test_warns_with_the_value_that_wins(self, warnings):
+        """A warning must name the TTL the agent actually runs with."""
+        assert resolve_health_check_ttl(0, "7") == 7
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "health_check_ttl=0" in message
+        assert "using 7s" in message
+        assert "using 15s" not in message
+
+    def test_never_raises_on_a_malformed_value(self):
+        """A malformed TTL must not stop an agent from booting."""
+        assert resolve_health_check_ttl(object(), object()) == 15
+
+
+class TestResolveHealthCheckTtlFromEnv:
+    """The thin env-reading wrapper."""
+
+    def test_env_absent_uses_the_configured_value(self, monkeypatch, warnings):
+        monkeypatch.delenv(HEALTH_CHECK_TTL_ENV, raising=False)
+        assert resolve_health_check_ttl_from_env(30) == 30
+        assert resolve_health_check_ttl_from_env() == 15
+        assert warnings == []
+
+    def test_env_present_wins(self, monkeypatch, warnings):
+        monkeypatch.setenv(HEALTH_CHECK_TTL_ENV, "3")
+        assert resolve_health_check_ttl_from_env(30) == 3
+        assert resolve_health_check_ttl_from_env() == 3
+        assert warnings == []
+
+    def test_invalid_env_falls_back_to_the_configured_value(self, monkeypatch):
+        monkeypatch.setenv(HEALTH_CHECK_TTL_ENV, "15s")
+        assert resolve_health_check_ttl_from_env(30) == 30
+
+
+class TestHealthEndpointWiring:
+    """The resolver is actually wired into the TTL the agent runs with."""
+
+    @staticmethod
+    async def _run(agent_config):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from _mcp_mesh.pipeline.mcp_startup.fastapiserver_setup import (
+            FastAPIServerSetupStep,
+        )
+
+        with (
+            patch(
+                "_mcp_mesh.shared.health_check_manager.get_health_status_with_cache",
+                new_callable=AsyncMock,
+            ) as mock_cache,
+            patch("_mcp_mesh.shared.tool_executor._start_workers"),
+            patch("_mcp_mesh.shared.tool_executor.get_worker_loops", return_value=[]),
+        ):
+            mock_cache.return_value = _healthy_status()
+            await FastAPIServerSetupStep()._add_k8s_endpoints(
+                MagicMock(), agent_config, {}, {}
+            )
+        return mock_cache.await_args.kwargs["ttl"]
+
+    @pytest.mark.asyncio
+    async def test_env_overrides_the_decorator_argument(self, monkeypatch):
+        monkeypatch.setenv(HEALTH_CHECK_TTL_ENV, "42")
+        ttl = await self._run(
+            {
+                "name": "ttl-agent",
+                "health_check": _health_check_fn,
+                "health_check_ttl": 30,
+            }
+        )
+        assert ttl == 42
+
+    @pytest.mark.asyncio
+    async def test_decorator_argument_without_env(self, monkeypatch):
+        monkeypatch.delenv(HEALTH_CHECK_TTL_ENV, raising=False)
+        ttl = await self._run(
+            {
+                "name": "ttl-agent",
+                "health_check": _health_check_fn,
+                "health_check_ttl": 30,
+            }
+        )
+        assert ttl == 30
+
+
+async def _health_check_fn():
+    return True
+
+
+def _healthy_status():
+    from datetime import UTC, datetime
+
+    from _mcp_mesh.shared.support_types import HealthStatus, HealthStatusType
+
+    return HealthStatus(
+        agent_name="ttl-agent",
+        status=HealthStatusType.HEALTHY,
+        capabilities=["ttl"],
+        timestamp=datetime.now(UTC),
+        checks={},
+        errors=[],
+    )

--- a/src/runtime/python/tests/unit/test_health_check_ttl_env_1492.py
+++ b/src/runtime/python/tests/unit/test_health_check_ttl_env_1492.py
@@ -11,6 +11,7 @@ wrapper needs a monkeypatched environment.
 """
 
 import logging
+from fractions import Fraction
 
 import pytest
 from _mcp_mesh.shared.health_check_manager import (
@@ -149,6 +150,90 @@ class TestResolveHealthCheckTtl:
     def test_never_raises_on_a_malformed_value(self):
         """A malformed TTL must not stop an agent from booting."""
         assert resolve_health_check_ttl(object(), object()) == 15
+
+    def test_rejects_an_env_value_too_long_to_convert(self, warnings):
+        """An all-digit string can still be unconvertible.
+
+        Python 3.11 caps string->int conversion at 4300 digits, so a pasted
+        or fat-fingered value matches the integer regex and then raises out
+        of ``int()``. That is the one input that could stop an agent from
+        booting, which is exactly where falling back matters most.
+        """
+        raw = "1" * 5000
+
+        assert resolve_health_check_ttl(30, raw) == 30
+        assert resolve_health_check_ttl(None, raw) == 15
+
+        assert len(warnings) == 2
+        message = warnings[0].getMessage()
+        assert "too large" in message
+        # The whole 5000-digit value must not land in the log.
+        assert raw not in message
+        assert len(message) < 200
+
+    def test_rejects_a_configured_value_too_long_to_render(self, warnings):
+        """Rendering the rejected value must not raise either.
+
+        The 4300-digit cap applies to int->str as well, so a huge *negative*
+        ``health_check_ttl`` is rejected for being < 1 and then raises while
+        being formatted into its own warning. Same hazard as the env branch,
+        one line away.
+        """
+        huge_negative = -(10**5000)
+
+        assert resolve_health_check_ttl(huge_negative) == 15
+
+        assert len(warnings) == 1
+        message = warnings[0].getMessage()
+        assert "not a whole number of seconds >= 1" in message
+        assert "int" in message  # says what it could not print
+        assert len(message) < 200
+
+    @pytest.mark.parametrize(
+        "label,configured",
+        [
+            # repr() on these hits the same int<->str cap, one indirection out.
+            ("fraction", Fraction(10**5000)),
+            # No raise, but a warning is useless at 300k characters.
+            ("long list", [0] * 100_000),
+            ("long string", "x" * 100_000),
+        ],
+        ids=["fraction", "long-list", "long-string"],
+    )
+    def test_bounds_an_unprintable_configured_value(self, label, configured, warnings):
+        """Every rejection message stays short and safe, whatever it names."""
+        assert resolve_health_check_ttl(configured) == 15
+
+        assert len(warnings) == 1
+        assert len(warnings[0].getMessage()) < 200
+
+    def test_bounds_an_oversized_env_value_in_every_rejection(self, warnings):
+        """The env branch's other two messages are bounded as well."""
+        # Not an integer at all, and enormous.
+        assert resolve_health_check_ttl(None, "x" * 100_000) == 15
+        # Matches the regex and converts, but is zero-padded to ~4300 chars.
+        assert resolve_health_check_ttl(None, "-" + "0" * 4290 + "5") == 15
+
+        assert len(warnings) == 2
+        assert "not an integer" in warnings[0].getMessage()
+        assert "below the 1s minimum" in warnings[1].getMessage()
+        assert all(len(record.getMessage()) < 200 for record in warnings.records)
+
+    def test_accepts_a_configured_value_too_long_to_convert(self, warnings):
+        """A huge ``health_check_ttl`` int is honoured, deliberately.
+
+        This is NOT the env case above: ``configured`` is already an int
+        object, so no string->int conversion happens and nothing can raise.
+        Neither TypeScript nor Java caps the TTL either, and asyncio schedules
+        arbitrarily large sleeps without overflowing, so rejecting this would
+        add a Python-only divergence for no runtime benefit. A huge TTL means
+        "effectively never re-run" — odd, but what the operator asked for.
+        Do not "fix" this into a rejection.
+        """
+        huge = 10**5000  # built by arithmetic; int(str) would hit the same cap
+
+        assert resolve_health_check_ttl(huge) == huge
+        assert warnings == []
 
 
 class TestResolveHealthCheckTtlFromEnv:


### PR DESCRIPTION
## Summary

TypeScript and Java both let an operator override the health-check cadence with `MCP_MESH_HEALTH_CHECK_TTL`. **Python read it nowhere** — the TTL came only from the `health_check_ttl` decorator argument, which is baked into the image.

So a TypeScript or Java operator could retune cadence against a live incident from Helm values, and a Python operator had to rebuild and redeploy. That matters most in the release that makes the TTL govern how fast a provider withdraws itself and how fast it comes back. Every other mesh knob has an env override, so the absence read as an omission rather than a decision.

`resolve_health_check_ttl(configured, override)` takes the override as a parameter with a thin env-reading wrapper, so every rule is unit-testable without mutating `os.environ`. Wired at the single site that reads `health_check_ttl`, which feeds both the cache window and the refresh loop's sleep.

Precedence and guards mirror the other two: **env > decorator > 15**; blank and whitespace mean "not set"; non-integer and sub-1s values warn and fall through rather than raising. The decorator value is validated too — Python needs that more than Java does, since Java's annotation member is an `int` while `agent_config` is a dict that can carry anything, so `bool` is rejected explicitly (it is an `int` subclass).

## Review notes

**TypeScript and Java genuinely disagree in two places**, so "match the others" had no single answer. Both are called out rather than silently resolved:

1. **Non-ASCII digits.** `Integer.parseInt` accepts `"١٥"` as 15 — `Character.digit` is Unicode-aware — while TypeScript's regex rejects it. Python's bare `\d` and `int()` would have *silently* sided with Java. Followed TypeScript with `re.ASCII`: such a value is far likelier an encoding accident than an intent, and a loud fallback beats running a TTL the operator cannot read back in the digits they typed. Commented at the regex, pinned by a test, and reversible if the other reading is preferred.
2. **Warning behaviour.** Java silently clamps a sub-1 annotation value without logging, and prints the pre-clamp fallback in its env warning. TypeScript warns for both sources and names the value that actually wins. Followed TypeScript as the strict superset; Java's is arguably a small bug.

**Red before green**: with `env=42` and `decorator=30` the decorator won; with `env=42` and no decorator the default won. Both pass after the change. No existing test asserted the variable was ignored.

**The documentation was the point, not an afterthought.** `health.md` omitted the `MCP_MESH_HEALTH_CHECK_TTL` clause its `_java` and `_typescript` siblings both carry — precisely because Python ignored the variable. It now reads identically to them. And `docs/concepts/health-discovery.md:253` advertises the variable with no runtime qualifier, which was wrong when written and becomes correct with this change; it needed no edit.

The man golden moved 1723 → 1724. Predicted before the edit and confirmed after: one new inline code span in prose, both list goldens unmoved because the sentence adds no bullet.

Closes #1492

## Test plan

- [x] Python 1573 → **1609** (+36), 0 failures, 1 pre-existing skip
- [x] Coverage: env absent → decorator; env > decorator; env > default with no decorator; and each rejected form (`0`, `-3`, `"15s"`, `"1.5"`, `0x10`, words, trailing junk, `""`, whitespace, `"1_0"`, unicode digits, invalid decorator values incl. `bool`/`NaN`/`inf`) falling through with exactly one warning
- [x] Two wiring tests asserting the TTL that actually reaches `get_health_status_with_cache`
- [x] `go build ./...`; `go test ./src/core/cli/... -count=1` — all five packages
- [x] `black --check` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring health-check refresh intervals through the `MCP_MESH_HEALTH_CHECK_TTL` environment variable.
  * Added validation and safe fallback behavior for invalid or unsupported health-check interval values.
  * Health endpoints now use the resolved refresh interval consistently.

* **Documentation**
  * Documented the new environment-variable override and its behavior in the CLI and agent documentation.

* **Tests**
  * Added coverage for defaults, overrides, validation, warnings, fallbacks, and endpoint behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->