### PR TITLE
fix(python): route and A2A agents serve /livez, /ready and /health

### DIFF
--- a/src/core/cli/man/content/health.md
+++ b/src/core/cli/man/content/health.md
@@ -158,6 +158,8 @@ A check that **raises** is recorded as `degraded`, not unhealthy, and keeps hear
 
 `@mesh.route` and `@mesh.a2a` agents never run the check at all - their startup pipelines have no health-refresh loop, so there is no verdict to suppress a heartbeat or to show anywhere. A gateway is a fan-out point that many requests enter through: withdrawing a provider is correct, withdrawing the gateway takes the application down. Declare the check on the agents behind the gateway instead.
 
+They still serve all three probe endpoints, on your own FastAPI app: `/livez` answers 200 for as long as the process serves, `/ready` reports only whether the mesh runtime is running, and `/health` is a diagnostic view that never answers 503. If your app already defines one of those paths, yours is left alone and the other two are still added.
+
 ## Graceful Failure
 
 The mesh handles failures gracefully:

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -234,8 +234,16 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // `MCP_MESH_HEALTH_CHECK_TTL`, so the default variant's `health_check_ttl`
 // sentence closes with the same override clause both siblings already carried;
 // that one new inline span is prose, so the list goldens hold.
+// #1491 follow-up: +3 / +0 / +0, in `health.md`. A Python `@mesh.route` /
+// `@mesh.a2a` gateway served none of the three probe endpoints, so the
+// route/A2A section could only say the health check never runs there — it
+// could not say what a probe hits. Now that both gateway pipelines register
+// them on the user's own FastAPI app, that section states what each one
+// reports (`/livez`, `/ready`, `/health` — the whole delta) and that a path
+// the application already defines wins. Both sentences are prose, so the list
+// goldens hold.
 const (
-	wantInlineCodeSpans = 1724
+	wantInlineCodeSpans = 1727
 	wantListCodeSpans   = 516
 	wantMarkupListLines = 445
 )

--- a/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/a2a_pipeline.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/a2a_startup/a2a_pipeline.py
@@ -12,7 +12,8 @@ Pipeline shape:
   1. A2A surface collection      (read ``mesh_a2a`` markers from registry)
   2. FastAPI app discovery       (locate the user's FastAPI instance)
   3. Tracing middleware          (attach distributed-tracing middleware)
-  4. A2A server setup            (heartbeat config + ``service_type=a2a``)
+  4. Health endpoints            (``/livez``, ``/ready``, ``/health``)
+  5. A2A server setup            (heartbeat config + ``service_type=a2a``)
 
 DI is wired by the ``@mesh.a2a`` decorator itself at module import (mirrors
 ``@mesh.route``), so this pipeline has no equivalent of
@@ -23,6 +24,7 @@ import logging
 
 from ..api_startup.middleware_integration import \
     TracingMiddlewareIntegrationStep
+from ..shared import HealthEndpointsStep
 from ..shared.mesh_pipeline import MeshPipeline
 from .a2a_server_setup import A2AServerSetupStep
 from .a2a_surface_collection import A2ASurfaceCollectionStep
@@ -39,7 +41,8 @@ class A2APipeline(MeshPipeline):
     1. A2A surface collection (read ``mesh_a2a`` markers)
     2. FastAPI app discovery (locate the user's FastAPI instance)
     3. Tracing middleware integration (shared with api_startup)
-    4. A2A server setup (heartbeat metadata + ``service_type=a2a``)
+    4. Health endpoints (``/livez``, ``/ready``, ``/health``; shared step)
+    5. A2A server setup (heartbeat metadata + ``service_type=a2a``)
 
     Like ``APIPipeline``, this is a consumer-style pipeline:
     - No FastAPI server is created (user owns the app + uvicorn).
@@ -57,6 +60,10 @@ class A2APipeline(MeshPipeline):
             A2ASurfaceCollectionStep(),  # Collect mesh_a2a markers
             A2AFastAPIDiscoveryStep(),  # Find user's FastAPI app
             TracingMiddlewareIntegrationStep(),  # Add tracing middleware
+            # Issue #1491: same probe endpoints as the api pipeline — an A2A
+            # gateway is deployed with the same Helm chart and was 404ing
+            # /livez and /ready just as hard.
+            HealthEndpointsStep(service_type="a2a"),
             A2AServerSetupStep(),  # Heartbeat + service_type=a2a
         ]
 

--- a/src/runtime/python/_mcp_mesh/pipeline/api_startup/api_pipeline.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_startup/api_pipeline.py
@@ -8,7 +8,7 @@ route integration, and service registration.
 
 import logging
 
-from ..shared import TracePublisherInitStep
+from ..shared import HealthEndpointsStep, TracePublisherInitStep
 from ..shared.mesh_pipeline import MeshPipeline
 from .api_server_setup import APIServerSetupStep
 from .fastapi_discovery import FastAPIAppDiscoveryStep
@@ -28,7 +28,8 @@ class APIPipeline(MeshPipeline):
     2. FastAPI app discovery (find user's FastAPI instances)
     3. Route integration (apply dependency injection)
     4. Tracing middleware integration (add telemetry to FastAPI apps)
-    5. API server setup (service registration metadata)
+    5. Health endpoints (/livez, /ready, /health for Kubernetes probes)
+    6. API server setup (service registration metadata)
 
     Unlike MCP agents, API services are consumers so we focus on:
     - Dependency injection into route handlers
@@ -48,6 +49,10 @@ class APIPipeline(MeshPipeline):
             FastAPIAppDiscoveryStep(),  # Find user's FastAPI app instances
             RouteIntegrationStep(),  # Apply dependency injection to routes
             TracingMiddlewareIntegrationStep(),  # Add tracing middleware to FastAPI apps
+            # Issue #1491: /livez, /ready, /health on the user's app — the agent
+            # Helm chart probes the first two, and a gateway that serves neither
+            # is restart-looped by the kubelet.
+            HealthEndpointsStep(service_type="api"),
             # Issue #1363: build the Redis trace publisher here (off the request
             # path) so the sync block_on Redis connect never runs on the serving
             # event loop at first-span time. No-op when tracing is disabled.

--- a/src/runtime/python/_mcp_mesh/pipeline/shared/__init__.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/shared/__init__.py
@@ -8,8 +8,9 @@ from .base_step import PipelineStep
 from .mesh_pipeline import MeshPipeline
 from .pipeline_types import PipelineResult, PipelineStatus
 
-# NB: imported after the base symbols above — TracePublisherInitStep imports
+# NB: imported after the base symbols above — these steps import
 # PipelineStep/PipelineResult from this package.
+from .health_endpoints import HealthEndpointsStep
 from .trace_publisher_init import TracePublisherInitStep
 
 __all__ = [
@@ -17,5 +18,6 @@ __all__ = [
     "PipelineStep",
     "PipelineResult",
     "PipelineStatus",
+    "HealthEndpointsStep",
     "TracePublisherInitStep",
 ]

--- a/src/runtime/python/_mcp_mesh/pipeline/shared/health_endpoints.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/shared/health_endpoints.py
@@ -1,0 +1,293 @@
+"""Kubernetes probe endpoints for gateway pipelines (issue #1491).
+
+``@mesh.agent`` agents get ``/livez``, ``/ready`` and ``/health`` from
+``_start_uvicorn_immediately`` because mesh owns the server it starts. A
+``@mesh.route`` (api) or ``@mesh.a2a`` (a2a) gateway owns its own FastAPI app
+and its own uvicorn, so nothing registered those paths — and the agent Helm
+chart points ``startupProbe``/``livenessProbe`` at ``/livez`` and
+``readinessProbe`` at ``/ready`` (#1468). A Python gateway therefore 404'd
+every probe and the kubelet restart-looped a perfectly working process.
+
+Semantics (matching TypeScript's ``express.ts`` ``setupHealthEndpoints``):
+
+``/livez``
+    Unconditional 200 while the process serves. Consults nothing. Liveness
+    must not share a verdict with readiness, or a dependency outage that
+    should only make the service unready restarts the pod instead.
+
+``/ready``
+    Whether the **mesh runtime** is up — a live Rust core handle exists and
+    shutdown has not been requested — and nothing else.
+
+``/health``
+    The diagnostic view. Always 200; no probe points at it.
+
+The user's ``health_check`` is deliberately NOT consulted by any of the three.
+A gateway is an entry point: mesh injects dependencies *into* it, but nothing
+resolves *to* it, so an unhealthy verdict could only subtract — withdrawing a
+fan-out point takes down every path that enters through it (#1473, #1488).
+For the same reason there is no health-refresh loop on these pipelines.
+
+The app is the user's, so each path is registered only if the application has
+not already defined it (``examples/python/mesh-api/main.py`` hand-rolls
+``/health`` precisely because mesh never did). The three are registered
+independently: an app that defines only ``/health`` still gets ``/livez`` and
+``/ready``. The check is an explicit route walk rather than a reliance on
+Starlette's first-match-wins ordering — behaviour that depends on registration
+order is behaviour nobody can predict from reading the code.
+"""
+
+import logging
+from datetime import UTC, datetime
+from typing import Any, Optional
+
+from ...shared.config_resolver import ValidationRule, get_config_value
+from ...shared.fastapi_routes import iter_app_routes
+from .base_step import PipelineStep
+from .pipeline_types import PipelineResult, PipelineStatus
+
+logger = logging.getLogger(__name__)
+
+LIVEZ_PATH = "/livez"
+READY_PATH = "/ready"
+HEALTH_PATH = "/health"
+
+# Stamped on the handlers mesh registers so a second pipeline pass (or a
+# second discovered app object that shares a router) can tell its own
+# endpoints apart from a path the application defined. Without it, a re-run
+# would log "the application already defines /livez" about mesh's own route.
+MESH_PROBE_ATTR = "_mcp_mesh_probe_endpoint"
+
+# Outcome values reported per path.
+OUTCOME_REGISTERED = "registered"
+OUTCOME_USER_DEFINED = "user_defined"
+OUTCOME_ALREADY_MESH = "already_registered"
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _agent_name(default: str = "mcp-mesh-gateway") -> str:
+    """Best-effort display name, resolved per request.
+
+    Late-bound on purpose: the pipeline registers these endpoints before the
+    server-setup step writes the resolved service name/id into the decorator
+    registry, so reading it at request time reports the real name instead of
+    a placeholder captured too early.
+    """
+    try:
+        from ...engine.decorator_registry import DecoratorRegistry
+
+        config = DecoratorRegistry.get_resolved_agent_config() or {}
+        return config.get("name") or config.get("agent_id") or default
+    except Exception:  # pragma: no cover - defensive, name is cosmetic
+        return default
+
+
+def runtime_state(standalone: bool = False) -> tuple[bool, str]:
+    """Report whether the mesh runtime is up, and in what state.
+
+    ``standalone`` mode never starts a Rust core (registry communication is
+    switched off by configuration), so the gateway is ready as soon as it
+    serves — the absence of a handle is the configured outcome, not a
+    startup that has not finished.
+    """
+    if standalone:
+        return True, "standalone"
+
+    from ...shared.simple_shutdown import (
+        get_active_rust_agent_handles,
+        should_stop_heartbeat,
+    )
+
+    if should_stop_heartbeat():
+        return False, "shutting_down"
+    if get_active_rust_agent_handles():
+        return True, "up"
+    return False, "starting"
+
+
+_NOT_READY_REASON = {
+    "starting": "Mesh runtime has not started yet",
+    "shutting_down": "Mesh runtime is shutting down",
+}
+
+
+def _find_route(app: Any, path: str) -> Optional[Any]:
+    """Return the first route ``app`` serves at ``path``, or None.
+
+    Path-level, not method-level: an application that owns ``/health`` owns
+    it for every method, and mesh adding a second handler for the verbs the
+    application left free would make the response depend on the verb.
+    """
+    for ref in iter_app_routes(app):
+        if ref.path == path:
+            return ref
+    return None
+
+
+def register_health_endpoints(
+    app: Any,
+    *,
+    service_type: str,
+    standalone: bool = False,
+) -> dict[str, str]:
+    """Register ``/livez``, ``/ready`` and ``/health`` on a user-owned app.
+
+    Args:
+        app: the user's FastAPI application
+        service_type: ``"api"`` or ``"a2a"``, reported in the bodies
+        standalone: MCP_MESH_STANDALONE — no registry, hence no Rust handle
+
+    Returns:
+        ``{path: outcome}`` for all three paths, where outcome is one of
+        ``registered`` / ``user_defined`` / ``already_registered``.
+
+    Raises:
+        Whatever the route walk raises. Registering without knowing what the
+        app already serves would put mesh back on first-match-wins ordering,
+        so an undeterminable app is left untouched and the caller reports it.
+    """
+    from fastapi.responses import JSONResponse
+
+    async def livez():
+        # Consults NOTHING — see module docstring.
+        from ...shared.health_check_manager import build_livez_response
+
+        return JSONResponse(
+            status_code=200,
+            content=build_livez_response(agent_name=_agent_name()),
+        )
+
+    async def ready():
+        is_ready, state = runtime_state(standalone)
+        body: dict[str, Any] = {
+            "ready": is_ready,
+            "agent": _agent_name(),
+            "service_type": service_type,
+            "runtime": state,
+            "timestamp": _now(),
+        }
+        if not is_ready:
+            body["reason"] = _NOT_READY_REASON.get(state, f"Mesh runtime is {state}")
+        return JSONResponse(status_code=200 if is_ready else 503, content=body)
+
+    async def health():
+        # Diagnostic only. A gateway's own health never withdraws it, so this
+        # is a fixed "healthy" plus the runtime detail — no health_check, no
+        # stored health-check result, no 503.
+        is_ready, state = runtime_state(standalone)
+        return JSONResponse(
+            status_code=200,
+            content={
+                "status": "healthy",
+                "agent": _agent_name(),
+                "service_type": service_type,
+                "runtime": state,
+                "mesh_ready": is_ready,
+                "timestamp": _now(),
+            },
+        )
+
+    handlers = ((LIVEZ_PATH, livez), (READY_PATH, ready), (HEALTH_PATH, health))
+
+    outcomes: dict[str, str] = {}
+    for path, handler in handlers:
+        existing = _find_route(app, path)
+        if existing is not None:
+            if getattr(existing.endpoint, MESH_PROBE_ATTR, False):
+                outcomes[path] = OUTCOME_ALREADY_MESH
+                logger.debug("🩺 %s already registered by mesh - skipping", path)
+            else:
+                outcomes[path] = OUTCOME_USER_DEFINED
+                logger.info(
+                    "🩺 %s is defined by the application - mesh is not registering "
+                    "its own (the application's handler answers the probe)",
+                    path,
+                )
+            continue
+
+        setattr(handler, MESH_PROBE_ATTR, True)
+        app.get(path, include_in_schema=False)(handler)
+        app.head(path, include_in_schema=False)(handler)
+        outcomes[path] = OUTCOME_REGISTERED
+
+    return outcomes
+
+
+class HealthEndpointsStep(PipelineStep):
+    """Add the K8s probe endpoints to every discovered FastAPI app.
+
+    Shared by the api (``@mesh.route``) and a2a (``@mesh.a2a``) pipelines —
+    both hand mesh an app they do not own, and both are deployed with the
+    agent Helm chart that probes ``/livez`` and ``/ready``.
+
+    Optional (``required=False``): a failure here must not stop the gateway
+    from starting. It is loud instead — the alternative, aborting startup,
+    trades a missing probe for no service at all.
+    """
+
+    def __init__(self, service_type: str):
+        super().__init__(
+            name="health-endpoints",
+            required=False,
+            description="Register /livez, /ready and /health on the user's FastAPI app",
+        )
+        self.service_type = service_type
+
+    async def execute(self, context: dict[str, Any]) -> PipelineResult:
+        result = PipelineResult(message="Health endpoints registered")
+
+        fastapi_apps = context.get("fastapi_apps", {})
+        if not fastapi_apps:
+            result.status = PipelineStatus.SKIPPED
+            result.message = "No FastAPI applications found for health endpoints"
+            self.logger.debug("🩺 No FastAPI apps to add health endpoints to")
+            return result
+
+        standalone = get_config_value(
+            "MCP_MESH_STANDALONE",
+            default=False,
+            rule=ValidationRule.TRUTHY_RULE,
+        )
+
+        registered = 0
+        skipped: list[str] = []
+        try:
+            for app_id, app_info in fastapi_apps.items():
+                app_title = app_info.get("title", "Unknown App")
+                outcomes = register_health_endpoints(
+                    app_info["instance"],
+                    service_type=self.service_type,
+                    standalone=bool(standalone),
+                )
+                for path, outcome in outcomes.items():
+                    if outcome == OUTCOME_REGISTERED:
+                        registered += 1
+                    elif outcome == OUTCOME_USER_DEFINED:
+                        skipped.append(path)
+
+                self.logger.info(
+                    "🩺 Health endpoints on '%s': %s",
+                    app_title,
+                    ", ".join(f"{p}={o}" for p, o in outcomes.items()),
+                )
+                result.add_context(f"health_endpoints_{app_id}", outcomes)
+
+        except Exception as e:
+            result.status = PipelineStatus.FAILED
+            result.message = f"Health endpoint registration failed: {e}"
+            result.add_error(str(e))
+            self.logger.error(
+                "🩺 Could not register health endpoints - Kubernetes probes on "
+                "/livez and /ready will 404: %s",
+                e,
+            )
+            return result
+
+        result.add_context("health_endpoints_registered", registered)
+        result.message = f"Registered {registered} health endpoint(s)" + (
+            f"; application already defines {', '.join(skipped)}" if skipped else ""
+        )
+        return result

--- a/src/runtime/python/tests/unit/test_gateway_health_endpoints_1491.py
+++ b/src/runtime/python/tests/unit/test_gateway_health_endpoints_1491.py
@@ -1,0 +1,418 @@
+"""Probe endpoints on Python gateways — issue #1491.
+
+``@mesh.route`` (api) and ``@mesh.a2a`` (a2a) gateways served none of
+``/livez``, ``/ready`` or ``/health``: the builders were wired only from
+``_start_uvicorn_immediately``, which only the ``@mesh.agent`` decorator calls.
+The agent Helm chart probes ``/livez`` (startup, liveness) and ``/ready``
+(readiness) since #1468, so a Python gateway 404'd every probe and the kubelet
+restart-looped a working process.
+
+These tests deliberately reach the step through the *real* pipelines
+(``APIPipeline`` / ``A2APipeline``) by name rather than importing it, so the
+file is red against the pre-fix tree for the reason that matters — nothing
+registers the endpoints — rather than on an import error.
+
+Semantics under test (TypeScript's ``express.ts`` is the reference):
+  * ``/livez``  — unconditional 200, consults nothing
+  * ``/ready``  — mesh runtime state only
+  * ``/health`` — diagnostic, always 200, never consults ``health_check``
+"""
+
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from _mcp_mesh.pipeline.a2a_startup.a2a_pipeline import A2APipeline
+from _mcp_mesh.pipeline.api_startup.api_pipeline import APIPipeline
+
+HEALTH_STEP_NAME = "health-endpoints"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _health_step(pipeline):
+    """The wired health-endpoint step, or fail loudly if the pipeline lacks one."""
+    for step in pipeline.steps:
+        if step.name == HEALTH_STEP_NAME:
+            return step
+    raise AssertionError(
+        f"'{HEALTH_STEP_NAME}' step is not wired into {pipeline.name} "
+        f"(steps: {pipeline.list_steps()})"
+    )
+
+
+def _run_step(pipeline, app, title="Gateway App"):
+    step = _health_step(pipeline)
+    context = {
+        "fastapi_apps": {
+            "app-1": {"instance": app, "title": title},
+        }
+    }
+    return asyncio.run(step.execute(context))
+
+
+def _paths(app):
+    return {route.path for route in app.router.routes}
+
+
+@pytest.fixture
+def api_app():
+    app = FastAPI(title="Gateway App")
+    _run_step(APIPipeline(), app)
+    return app
+
+
+@pytest.fixture
+def runtime_up(monkeypatch):
+    """Pretend a live Rust core handle exists (mesh runtime is up)."""
+    from _mcp_mesh.shared import simple_shutdown
+
+    monkeypatch.setattr(
+        simple_shutdown, "get_active_rust_agent_handles", lambda: [object()]
+    )
+    monkeypatch.setattr(simple_shutdown, "should_stop_heartbeat", lambda: False)
+
+
+@pytest.fixture
+def runtime_down(monkeypatch):
+    """No Rust core handle — the runtime has not started."""
+    from _mcp_mesh.shared import simple_shutdown
+
+    monkeypatch.setattr(simple_shutdown, "get_active_rust_agent_handles", list)
+    monkeypatch.setattr(simple_shutdown, "should_stop_heartbeat", lambda: False)
+
+
+@pytest.fixture
+def declared_health_check(monkeypatch):
+    """A gateway that declared a health check, and a failing stored result.
+
+    Both of the things a health check produces: the callable itself (which must
+    never be invoked from these endpoints) and the stored ``unhealthy`` verdict
+    that ``build_health_response`` / ``build_ready_response`` would turn into a
+    503. Neither may reach a gateway probe.
+    """
+    from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+    from _mcp_mesh.shared import health_check_manager
+
+    calls = []
+
+    async def never_called():
+        calls.append(1)
+        raise AssertionError("gateway probes must not run the user's health_check")
+
+    monkeypatch.setattr(
+        DecoratorRegistry,
+        "_cached_agent_config",
+        {
+            "agent_id": "gateway-abcd1234",
+            "name": "gateway",
+            "health_check": never_called,
+            "health_check_ttl": 15,
+        },
+    )
+    health_check_manager.store_health_check_result(
+        {
+            "status": "unhealthy",
+            "agent": "gateway",
+            "errors": ["database down"],
+        }
+    )
+    yield calls
+    health_check_manager.clear_health_check_result()
+
+
+# ---------------------------------------------------------------------------
+# Wiring — both gateway pipelines
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineWiring:
+    def test_api_pipeline_wires_the_health_step(self):
+        assert HEALTH_STEP_NAME in APIPipeline().list_steps()
+
+    def test_a2a_pipeline_wires_the_health_step(self):
+        assert HEALTH_STEP_NAME in A2APipeline().list_steps()
+
+    def test_both_pipelines_share_one_step_implementation(self):
+        assert type(_health_step(APIPipeline())) is type(_health_step(A2APipeline()))
+
+    @pytest.mark.parametrize(
+        "pipeline_cls,service_type",
+        [(APIPipeline, "api"), (A2APipeline, "a2a")],
+    )
+    def test_all_three_registered_on_a_bare_app(
+        self, pipeline_cls, service_type, runtime_up
+    ):
+        app = FastAPI(title="Bare Gateway")
+        result = _run_step(pipeline_cls(), app)
+        assert result.status.value != "failed", result.errors
+
+        assert {"/livez", "/ready", "/health"} <= _paths(app)
+
+        client = TestClient(app)
+        assert client.get("/livez").status_code == 200
+        assert client.get("/ready").status_code == 200
+        assert client.get("/health").status_code == 200
+        assert client.get("/health").json()["service_type"] == service_type
+
+    def test_step_is_skipped_without_a_discovered_app(self):
+        step = _health_step(APIPipeline())
+        result = asyncio.run(step.execute({}))
+        assert result.status.value == "skipped"
+
+    def test_registration_is_idempotent(self, runtime_up):
+        """A second pass must not stack a duplicate handler per path."""
+        app = FastAPI(title="Bare Gateway")
+        _run_step(APIPipeline(), app)
+        before = len(app.router.routes)
+        _run_step(APIPipeline(), app)
+        assert len(app.router.routes) == before
+        assert TestClient(app).get("/livez").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# The app is the user's — collisions
+# ---------------------------------------------------------------------------
+
+
+class TestUserDefinedPathsWin:
+    @pytest.mark.parametrize("owned", ["/livez", "/ready", "/health"])
+    def test_user_route_is_kept_and_the_other_two_are_registered(
+        self, owned, runtime_up
+    ):
+        app = FastAPI(title="Hand-rolled Gateway")
+
+        @app.get(owned)
+        async def user_endpoint():
+            return {"mine": True}
+
+        _run_step(APIPipeline(), app)
+
+        client = TestClient(app)
+        # The application's handler still answers, unmodified.
+        assert client.get(owned).json() == {"mine": True}
+
+        # The other two are mesh's, and they answer.
+        for path in ("/livez", "/ready", "/health"):
+            if path == owned:
+                continue
+            response = client.get(path)
+            assert response.status_code == 200, path
+            assert "mine" not in response.json(), path
+
+    def test_mesh_api_example_shape_still_gets_livez_and_ready(self, runtime_up):
+        """``examples/python/mesh-api/main.py`` hand-rolls ``/health``."""
+        app = FastAPI(title="MCP Mesh FastAPI Example")
+
+        @app.get("/health")
+        async def health_check():
+            return {"status": "healthy", "service": "mesh-api"}
+
+        _run_step(APIPipeline(), app)
+
+        client = TestClient(app)
+        assert client.get("/health").json() == {
+            "status": "healthy",
+            "service": "mesh-api",
+        }
+        assert client.get("/livez").json()["alive"] is True
+        assert client.get("/ready").json()["ready"] is True
+
+    def test_user_path_on_an_included_router_is_detected(self, runtime_up):
+        """Collision detection must see through ``include_router()`` (#1396)."""
+        from fastapi import APIRouter
+
+        router = APIRouter()
+
+        @router.get("/health")
+        async def user_health():
+            return {"mine": True}
+
+        app = FastAPI(title="Router Gateway")
+        app.include_router(router)
+
+        _run_step(APIPipeline(), app)
+
+        client = TestClient(app)
+        assert client.get("/health").json() == {"mine": True}
+        assert client.get("/livez").status_code == 200
+
+    def test_prefixed_router_is_a_different_path_and_does_not_pre_empt(
+        self, runtime_up
+    ):
+        """A router mounted at ``/ops`` serves ``/ops/health``, not ``/health``.
+
+        The check compares *effective* paths — the paths the app actually
+        serves — so a prefixed ``/health`` is a different endpoint and must not
+        stop mesh registering the top-level one. Comparing the router's own
+        unprefixed path instead would silently leave the gateway without a
+        ``/health`` because of an unrelated ops route.
+        """
+        from fastapi import APIRouter
+
+        router = APIRouter(prefix="/ops")
+
+        @router.get("/health")
+        async def ops_health():
+            return {"mine": True}
+
+        app = FastAPI(title="Prefixed Router Gateway")
+        app.include_router(router)
+
+        _run_step(APIPipeline(), app)
+
+        client = TestClient(app)
+        # The user's route keeps its own path...
+        assert client.get("/ops/health").json() == {"mine": True}
+        # ...and mesh still owns the top-level one.
+        top_level = client.get("/health")
+        assert top_level.status_code == 200
+        assert top_level.json()["status"] == "healthy"
+        assert top_level.json()["service_type"] == "api"
+
+    def test_collision_is_reported_at_info_naming_the_path(self, caplog, runtime_up):
+        app = FastAPI(title="Hand-rolled Gateway")
+
+        @app.get("/health")
+        async def user_health():
+            return {"mine": True}
+
+        with caplog.at_level("INFO"):
+            _run_step(APIPipeline(), app)
+
+        messages = [r.getMessage() for r in caplog.records if r.levelname == "INFO"]
+        assert any("/health" in m and "application" in m for m in messages), messages
+
+
+# ---------------------------------------------------------------------------
+# /livez — unconditional
+# ---------------------------------------------------------------------------
+
+
+class TestLivez:
+    def test_200_while_the_runtime_is_up(self, api_app, runtime_up):
+        response = TestClient(api_app).get("/livez")
+        assert response.status_code == 200
+        assert response.json()["alive"] is True
+
+    def test_200_while_the_runtime_is_down(self, api_app, runtime_down):
+        response = TestClient(api_app).get("/livez")
+        assert response.status_code == 200
+        assert response.json()["alive"] is True
+
+    def test_200_while_shutting_down(self, api_app, monkeypatch):
+        from _mcp_mesh.shared import simple_shutdown
+
+        monkeypatch.setattr(simple_shutdown, "should_stop_heartbeat", lambda: True)
+        assert TestClient(api_app).get("/livez").status_code == 200
+
+    def test_200_with_a_failing_declared_health_check(
+        self, api_app, runtime_down, declared_health_check
+    ):
+        assert TestClient(api_app).get("/livez").status_code == 200
+        assert declared_health_check == []
+
+
+# ---------------------------------------------------------------------------
+# /ready — mesh runtime state, and nothing else
+# ---------------------------------------------------------------------------
+
+
+class TestReady:
+    def test_200_when_the_runtime_is_up(self, api_app, runtime_up):
+        response = TestClient(api_app).get("/ready")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["ready"] is True
+        assert body["runtime"] == "up"
+
+    def test_503_before_the_runtime_starts(self, api_app, runtime_down):
+        response = TestClient(api_app).get("/ready")
+        assert response.status_code == 503
+        body = response.json()
+        assert body["ready"] is False
+        assert body["runtime"] == "starting"
+        assert body["reason"]
+
+    def test_503_while_shutting_down(self, api_app, monkeypatch):
+        from _mcp_mesh.shared import simple_shutdown
+
+        monkeypatch.setattr(
+            simple_shutdown, "get_active_rust_agent_handles", lambda: [object()]
+        )
+        monkeypatch.setattr(simple_shutdown, "should_stop_heartbeat", lambda: True)
+
+        response = TestClient(api_app).get("/ready")
+        assert response.status_code == 503
+        assert response.json()["runtime"] == "shutting_down"
+
+    def test_ready_in_standalone_mode_without_any_handle(
+        self, monkeypatch, runtime_down
+    ):
+        monkeypatch.setenv("MCP_MESH_STANDALONE", "true")
+        app = FastAPI(title="Standalone Gateway")
+        _run_step(APIPipeline(), app)
+
+        response = TestClient(app).get("/ready")
+        assert response.status_code == 200
+        assert response.json()["runtime"] == "standalone"
+
+    def test_a_failing_declared_health_check_does_not_make_it_unready(
+        self, api_app, runtime_up, declared_health_check
+    ):
+        """#1473/#1488: a gateway is a fan-out point — its own check must not
+        withdraw it. A stored ``unhealthy`` verdict would 503 through
+        ``build_ready_response``; this endpoint must not consult it."""
+        response = TestClient(api_app).get("/ready")
+        assert response.status_code == 200
+        assert response.json()["ready"] is True
+        assert declared_health_check == []
+
+
+# ---------------------------------------------------------------------------
+# /health — diagnostic only
+# ---------------------------------------------------------------------------
+
+
+class TestHealth:
+    def test_200_healthy_when_the_runtime_is_up(self, api_app, runtime_up):
+        response = TestClient(api_app).get("/health")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "healthy"
+        assert body["runtime"] == "up"
+        assert body["mesh_ready"] is True
+
+    def test_200_before_the_runtime_starts(self, api_app, runtime_down):
+        """No probe points at /health, so it never 503s — it reports."""
+        response = TestClient(api_app).get("/health")
+        assert response.status_code == 200
+        assert response.json()["mesh_ready"] is False
+        assert response.json()["runtime"] == "starting"
+
+    def test_never_consults_the_declared_health_check(
+        self, api_app, runtime_up, declared_health_check
+    ):
+        response = TestClient(api_app).get("/health")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "healthy"
+        assert "errors" not in body
+        assert declared_health_check == []
+
+    def test_declaring_a_health_check_changes_none_of_the_three(
+        self, runtime_up, declared_health_check
+    ):
+        app = FastAPI(title="Gateway With Health Check")
+        _run_step(APIPipeline(), app)
+
+        client = TestClient(app)
+        assert client.get("/livez").status_code == 200
+        assert client.get("/ready").status_code == 200
+        assert client.get("/health").status_code == 200
+        assert declared_health_check == []


### PR DESCRIPTION
## Summary

`/livez`, `/ready` and `/health` were wired only from `mesh/decorators.py` inside `_start_uvicorn_immediately`, whose sole caller is `@mesh.agent`. The `api_startup` and `a2a_startup` pipelines registered **none** of them.

So a Python route or A2A agent deployed with the agent chart — which has probed `/livez` (startup, liveness) and `/ready` (readiness) since #1468 — **404s on every probe and gets restart-looped by the kubelet.** A working gateway killed for having no endpoint, which is the #1468 failure arriving by a third route: not "a dependency outage restarts the pod", but "no endpoint at all restarts the pod".

It went unnoticed because the examples hand-roll their own `/health` — `examples/python/mesh-api/main.py:24` does exactly that, almost certainly *because* mesh never provided one.

## Design

A gateway is an entry point. Mesh injects dependencies **into** it, but nothing resolves **to** it, so withdrawing it from resolution can only subtract. Its health is therefore a **Kubernetes concern**, and it gets standard app semantics:

- `/livez` — unconditional 200, consults nothing
- `/ready` — mesh runtime state alone
- `/health` — diagnostic, always 200

The user's `health_check` is consulted **nowhere**, and no health-refresh loop is added to either pipeline. This matches TypeScript's `express.ts`, which is the in-repo reference; this is a parity fix, not a new design.

## Review notes

**`/ready` deliberately does not call `build_ready_response`.** Its no-stored-result branch happens to return 200 for a gateway, but that correctness is accidental — it holds only while nothing ever stores a result, and would flip silently the day something did. Registry *reachability* is not readiness either, per the #1131 invariant.

**Mesh does not own the app here.** `api_startup` discovers an app the user already built, so each path is checked before registering and skipped with an INFO naming it if the user got there first. Three properties worth noting:

- Paths are decided **independently**, so an app that hand-rolled only `/health` still gets `/livez` and `/ready` — the two the chart actually probes.
- The check compares **effective** paths, so a router mounted at `/ops` carrying a `/health` serves `/ops/health` and does not pre-empt the top-level one. Tested both directions.
- First-match-wins ordering is deliberately **not** relied on. Behaviour that depends on registration order is behaviour nobody can predict from reading the code, and it would invert silently if discovery timing changed.

One shared step serves both pipelines — they needed no different treatment, differing only in a `service_type` string. It is `required=False`: a failure logs the consequence and lets the gateway start, rather than trading a missing probe for no service at all.

**Known limitation, pre-existing:** `_iter_included` in the shared route walk has a fallback branch for an entry exposing `original_router` without `effective_route_contexts`, which yields unprefixed paths — a `/ops`-prefixed `/health` would wrongly pre-empt there. No released FastAPI reaches that branch, and it is existing behaviour of the shared walk rather than something introduced here.

**Verification honesty:** the prefixed-router behaviour was executed against the installed FastAPI 0.136.1. The ≥0.137 path is reasoned from `fastapi_routes.py`'s documented contract, not executed — stated rather than implied.

Closes #1491

## Test plan

- [x] Python `tests/` 1615 → 1642; full incl. in-package dirs **1694 passed**, 1 pre-existing skip; green in fixed and random order
- [x] All 26 tests verified **red first**, failing on the step being absent from both pipelines *by name* rather than on an import error
- [x] Coverage: wiring in both pipelines, all three on a bare app for both service types, each path individually pre-empted with the other two still registered, `include_router` prefixed and unprefixed, idempotent re-run, `/livez` 200 under runtime-down and shutting-down, `/ready` up/down/shutdown/standalone, and a declared `health_check` (a callable that raises if invoked) changing none of it
- [x] `go build ./...`; `go test ./src/core/cli/... -count=1` — all five packages; man golden 1724 → 1727 with both list goldens verified unmoved *before* the constant was touched
- [x] Live: `examples/python/mesh-api` — `/health=user_defined`, `/livez` and `/ready` registered, probes absent from the user's OpenAPI schema; and `examples/a2a/date_a2a_agent.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes-compatible `/livez`, `/ready`, and `/health` endpoints to API and A2A gateways.
  * Liveness remains available while running, readiness reflects runtime status, and health provides diagnostics with a successful response.
  * Existing application routes take precedence, preventing probe endpoints from overriding user-defined routes.

* **Documentation**
  * Documented health probe behavior and updated man-page references.

* **Tests**
  * Added coverage for endpoint registration, route conflicts, readiness states, shutdown behavior, and standalone mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->