### PR TITLE
fix(meshctl): generated compose healthchecks probe /livez, not /health

### DIFF
--- a/src/core/cli/scaffold/compose.go
+++ b/src/core/cli/scaffold/compose.go
@@ -1119,8 +1119,12 @@ const agentServicesTemplate = `{{- range .Agents }}
     REDIS_URL: redis://redis:6379
     MCP_MESH_DISTRIBUTED_TRACING_ENABLED: "true"
 {{- end }}
+  # /livez means "this process is serving". /health carries the verdict — it
+  # 503s while a vendor is down, blocking dependents gated on depends_on and
+  # showing a live agent as unhealthy in docker compose ps (only Swarm or an
+  # autoheal sidecar restarts on that).
   healthcheck:
-    test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:{{ .Port }}/health').read()"]
+    test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:{{ .Port }}/livez').read()"]
     interval: 5s
     timeout: 3s
     retries: 10
@@ -1164,7 +1168,7 @@ const agentServicesTemplate = `{{- range .Agents }}
     MCP_MESH_DISTRIBUTED_TRACING_ENABLED: "true"
 {{- end }}
   healthcheck:
-    test: ["CMD", "wget", "--spider", "-q", "http://localhost:{{ .Port }}/health"]
+    test: ["CMD", "wget", "--spider", "-q", "http://localhost:{{ .Port }}/livez"]
     interval: 5s
     timeout: 3s
     retries: 10
@@ -1206,7 +1210,7 @@ const agentServicesTemplate = `{{- range .Agents }}
     MCP_MESH_DISTRIBUTED_TRACING_ENABLED: "true"
 {{- end }}
   healthcheck:
-    test: ["CMD", "wget", "--spider", "-q", "http://localhost:{{ .Port }}/health"]
+    test: ["CMD", "wget", "--spider", "-q", "http://localhost:{{ .Port }}/livez"]
     interval: 5s
     timeout: 3s
     retries: 10
@@ -1997,8 +2001,12 @@ services:
       REDIS_URL: redis://redis:6379
       MCP_MESH_DISTRIBUTED_TRACING_ENABLED: "true"
 {{- end }}
+    # /livez means "this process is serving". /health carries the verdict — it
+    # 503s while a vendor is down, blocking dependents gated on depends_on and
+    # showing a live agent as unhealthy in docker compose ps (only Swarm or an
+    # autoheal sidecar restarts on that).
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:{{ .Port }}/health').read()"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:{{ .Port }}/livez').read()"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -2043,7 +2051,7 @@ services:
       MCP_MESH_DISTRIBUTED_TRACING_ENABLED: "true"
 {{- end }}
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:{{ .Port }}/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:{{ .Port }}/livez"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -2086,7 +2094,7 @@ services:
       MCP_MESH_DISTRIBUTED_TRACING_ENABLED: "true"
 {{- end }}
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:{{ .Port }}/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:{{ .Port }}/livez"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/src/core/cli/scaffold/compose_healthcheck_probe_test.go
+++ b/src/core/cli/scaffold/compose_healthcheck_probe_test.go
@@ -1,0 +1,182 @@
+package scaffold
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// Issue #1490. A generated agent healthcheck must probe /livez, never /health.
+//
+// A container-level health signal should mean "this process is serving", not
+// "everything it depends on is reachable". /health carries the health-check
+// verdict and answers 503 while a dependency (an LLM vendor, say) is down, so
+// probing it there has two real consequences in plain Compose:
+//
+//   - `depends_on: condition: service_healthy` BLOCKS dependents. One agent
+//     whose vendor is down stops unrelated agents from starting.
+//   - `docker compose ps` reports a live, serving process as unhealthy, so the
+//     signal operators triage from is wrong.
+//
+// It does NOT restart the container: `restart:` acts on process exit, not on
+// health status — verified with `--restart unless-stopped --health-cmd 'exit
+// 1'`, which sat unhealthy with zero restarts. Only Swarm reschedules unhealthy
+// tasks, and autoheal sidecars do it explicitly. Do not reintroduce the restart
+// claim; it was in the first draft of this fix and in issue #1490, and it is
+// wrong for the runtime the scaffolder targets.
+//
+// Compose has one healthcheck per service, so it cannot carry both meanings the
+// way k8s splits liveness (#1468) from readiness; "is it serving" wins, and
+// real readiness gating is the thing that gives.
+//
+// The healthcheck line is hand-duplicated SIX times — three runtimes across two
+// templates (`agentServicesTemplate`, used when merging into an existing
+// compose file, and `composeTemplate`, used for a fresh one). A revert of a
+// single copy is the likeliest regression, so this guard renders through BOTH
+// paths for all three languages and names the path and language that failed.
+//
+// The registry is asserted to still probe /health on purpose: its handler is a
+// static 200 that consults nothing, which is why the registry chart keeps both
+// probes there. A sweeping s/health/livez/ across this file would break it, and
+// the registry serves no /livez at all.
+
+type composeHealthcheck struct {
+	Test []string `yaml:"test"`
+}
+
+type composeService struct {
+	Healthcheck composeHealthcheck `yaml:"healthcheck"`
+}
+
+type composeDoc struct {
+	Services map[string]composeService `yaml:"services"`
+}
+
+// probeAgents is the agent set every render in this file uses: one per
+// runtime, so a single render covers all three per-language template branches.
+var probeAgents = []DetectedAgent{
+	{Name: "probe-python", Port: 9401, Dir: "probe-python", Language: "python"},
+	{Name: "probe-typescript", Port: 9402, Dir: "probe-typescript", Language: "typescript"},
+	{Name: "probe-java", Port: 9403, Dir: "probe-java", Language: "java"},
+}
+
+// parseCompose reads the generated docker-compose.yml and returns its services.
+func parseCompose(t *testing.T, dir string) composeDoc {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, "docker-compose.yml"))
+	require.NoError(t, err, "generated compose file")
+
+	var doc composeDoc
+	require.NoError(t, yaml.Unmarshal(raw, &doc), "generated compose is not valid YAML")
+	require.NotEmpty(t, doc.Services, "generated compose has no services")
+	return doc
+}
+
+// renderFreshCompose renders through composeTemplate (no pre-existing file).
+func renderFreshCompose(t *testing.T, observability bool) composeDoc {
+	t.Helper()
+	dir := t.TempDir()
+	_, err := GenerateDockerCompose(&ComposeConfig{
+		Agents:        probeAgents,
+		Observability: observability,
+		ProjectName:   "probe-project",
+	}, dir)
+	require.NoError(t, err)
+	return parseCompose(t, dir)
+}
+
+// renderMergedCompose renders through agentServicesTemplate by seeding a
+// compose file the generator has to merge into.
+func renderMergedCompose(t *testing.T) composeDoc {
+	t.Helper()
+	dir := t.TempDir()
+	existing := `services:
+  postgres:
+    image: postgres:15-alpine
+  registry:
+    image: mcpmesh/registry:latest
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8000/health"]
+networks:
+  probe-network:
+    driver: bridge
+`
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "docker-compose.yml"), []byte(existing), 0644))
+
+	result, err := GenerateDockerCompose(&ComposeConfig{
+		Agents:      probeAgents,
+		ProjectName: "probe-project",
+		NetworkName: "probe-network",
+	}, dir)
+	require.NoError(t, err)
+	require.True(t, result.WasMerged,
+		"this case must exercise the MERGE path (agentServicesTemplate); a fresh "+
+			"render here would leave three of the six healthcheck copies unguarded")
+	return parseCompose(t, dir)
+}
+
+// assertAgentProbesLivez checks one agent service in one rendered document.
+func assertAgentProbesLivez(t *testing.T, site string, svc composeService, port int) {
+	t.Helper()
+	probe := strings.Join(svc.Healthcheck.Test, " ")
+
+	require.NotEmpty(t, svc.Healthcheck.Test,
+		"%s: the agent service has no healthcheck at all — an assertion that it "+
+			"does not probe /health would pass for the wrong reason", site)
+	require.NotContains(t, probe, "/health",
+		"%s: the agent healthcheck probes /health, which answers 503 on a "+
+			"dependency outage. That marks a live, serving agent unhealthy: it "+
+			"blocks every dependent gated on depends_on: service_healthy and "+
+			"misreports the agent in docker compose ps. Probe /livez, which "+
+			"answers 200 while the process serves (#1490).", site)
+	require.Contains(t, probe, fmt.Sprintf("localhost:%d/livez", port),
+		"%s: the agent healthcheck must probe /livez on the agent's own port", site)
+}
+
+// Every agent service, in every render path, probes /livez and nothing else.
+func TestComposeHealthchecks_AgentsProbeLivez(t *testing.T) {
+	paths := []struct {
+		name   string
+		render func(t *testing.T) composeDoc
+	}{
+		{"fresh", func(t *testing.T) composeDoc { return renderFreshCompose(t, false) }},
+		{"fresh+observability", func(t *testing.T) composeDoc { return renderFreshCompose(t, true) }},
+		{"merged", renderMergedCompose},
+	}
+
+	for _, path := range paths {
+		t.Run(path.name, func(t *testing.T) {
+			doc := path.render(t)
+			for _, agent := range probeAgents {
+				t.Run(agent.Language, func(t *testing.T) {
+					svc, ok := doc.Services[agent.Name]
+					require.True(t, ok,
+						"%s/%s: no service was rendered for this agent, so its "+
+							"healthcheck is unguarded", path.name, agent.Language)
+					assertAgentProbesLivez(t,
+						path.name+"/"+agent.Language, svc, agent.Port)
+				})
+			}
+		})
+	}
+}
+
+// The registry keeps /health: its handler is a static 200 that consults
+// nothing, and it serves no /livez. This is the counterweight to the test
+// above — it fails a blanket search-and-replace.
+func TestComposeHealthchecks_RegistryKeepsHealth(t *testing.T) {
+	doc := renderFreshCompose(t, false)
+
+	registry, ok := doc.Services["registry"]
+	require.True(t, ok, "no registry service was rendered")
+	probe := strings.Join(registry.Healthcheck.Test, " ")
+	require.Contains(t, probe, "localhost:8000/health",
+		"the registry healthcheck must stay on /health: its handler is a static "+
+			"200 that consults nothing, and the registry serves no /livez")
+}


### PR DESCRIPTION
## Summary

`/health` answers 503 while a declared health check reports `degraded` or `unhealthy` — Python always did, Java since #1475, TypeScript since #1487. Generated compose healthchecks pointed there, so a vendor outage marked a **live, serving agent** unhealthy.

Six sites now probe `/livez`, which answers 200 while the process serves and consults nothing.

## The reasoning, corrected

**This issue's original claim was wrong and I wrote it.** #1490 said a restart policy would restart the unhealthy container. I tested it:

```
docker run -d --restart unless-stopped --health-cmd 'exit 1' --health-interval 2s alpine sleep 120
t=4s   health=unhealthy  restarts=0
t=16s  health=unhealthy  restarts=0
```

Docker standalone **does not restart a container for being unhealthy**. `restart:` acts on process *exit*; health status does not feed it. Only Swarm reschedules unhealthy tasks, and autoheal sidecars do it explicitly — neither is what the scaffolder targets.

The change stands on the consequences that are real:

1. **`depends_on: condition: service_healthy` blocks dependents.** One agent's vendor outage stops *unrelated* agents from starting. This is the actual harm, and the one I had underweighted while leading with a mechanism that doesn't fire.
2. **Status is misreported.** `docker compose ps` shows a serving process as unhealthy, so the signal an operator triages from is wrong.

The principle is unchanged: a container-level health signal should mean "this process is serving", not "everything it depends on is reachable". Compose has one healthcheck per service driving both restart and dependency gating, so unlike Kubernetes it cannot carry both meanings — "is it serving" wins, and real readiness gating is what gives.

The disproof is recorded **in the guard test**, not only in the issue thread. The wrong claim is still the first thing #1490 says, so it is what the next reader — human or model — will re-derive.

## Review notes

**Six sites, not the five originally identified.** The sweep found the Python fresh-scaffold path, which is the most common scaffold of all; leaving it would have kept the defect for the majority case.

**The registry keeps `/health` deliberately** — verified, not assumed: `ent_handlers.go` builds a static response from process uptime and cannot 503, and it serves no `/livez`, so switching it would break the probe outright. Grafana, Tempo, Postgres and Redis are untouched.

**`/livez` confirmed present in all three runtimes** for every scaffolded shape, read from code rather than changelogs — Python `decorators.py:476`, TypeScript `livez-route.ts` via `agent.ts` (fail-fast), Java `MeshHealthController` via starter autoconfiguration. Gateway shapes got it in #1494, which is in this tree.

**A rendering divergence fixed along the way**: the merge path re-marshals through `yaml.Node` and re-indents from 2 to 4 spaces, so comment text that fit in the template overflowed to ~83 columns in the user's file. Both copies now wrap at the rendered indent and are byte-identical in output.

Known follow-up, deliberately not taken: checked-in example compose files carry the same shape — `examples/tutorial/trip-planner/day-08/python/docker-compose.yml` (15 probes) and `examples/docker-examples/docker-compose.llm-tests.yml` (8). The first is scaffolder output committed as a tutorial artifact and should be regenerated; the second is test infrastructure and needs checking before changing.

Closes #1490

## Test plan

- [x] `go build ./...`; `go test ./src/core/cli/... -count=1` — all five packages
- [x] Guard renders fresh, fresh+observability and merged paths, asserting per agent that no healthcheck probes `/health` and each probes `/livez`
- [x] The guard requires a non-empty healthcheck first, so a service that loses one fails loudly rather than passing "no `/health`" vacuously; and asserts `WasMerged`, so the merge case cannot degrade into a second fresh render and leave three copies unguarded
- [x] A second test pins the registry keeping `/health` — what fails a blanket search-and-replace
- [x] Verified red by reverting one site alone, twice (before and after the comment rewrite)
- [x] Real `meshctl` render through both paths: agents on `/livez`, registry still `:8000/health`, longest rendered comment line 80 columns
