### PR TITLE
fix(meshctl): stop scaffolds advertising credentials and tags they do not have

### DIFF
--- a/cmd/meshctl/templates/java/api/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/java/api/helm-values.yaml.tmpl
@@ -38,4 +38,3 @@ registry:
 # Uncomment to add — leaving commented avoids overriding base values
 # secrets:
 #   DATABASE_URL: "postgres://user:pass@host:5432/db"
-#   API_KEY: "your-api-key"

--- a/cmd/meshctl/templates/java/basic/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/java/basic/helm-values.yaml.tmpl
@@ -38,4 +38,3 @@ registry:
 # Uncomment to add — leaving commented avoids overriding base values
 # secrets:
 #   DATABASE_URL: "postgres://user:pass@host:5432/db"
-#   API_KEY: "your-api-key"

--- a/cmd/meshctl/templates/java/llm-agent/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/helm-values.yaml.tmpl
@@ -31,28 +31,17 @@ registry:
   host: "mcp-core-mcp-mesh-registry"
   port: "8000"
 
-# LLM agent typically needs API keys.
-# The refs below point to a secret named `llm-secrets` — update the `name:` values
-# below to match your cluster's secret, or create the secret:
-#   kubectl create secret generic llm-secrets \
-#     --from-literal=anthropic-api-key=sk-ant-... \
-#     --from-literal=openai-api-key=sk-...
-env:
-  - name: ANTHROPIC_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: llm-secrets
-        key: anthropic-api-key
-        optional: true
-  - name: OPENAI_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: llm-secrets
-        key: openai-api-key
-        optional: true
+# This agent reaches its model through the mesh: it resolves an llm-provider
+# agent by capability, and that provider holds the vendor credentials. Nothing
+# vendor-specific belongs here — deploy the provider with its own credentials.
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"
 
 # Optional: Secrets (creates a K8s Secret, injected via envFrom)
 # Uncomment to add — leaving commented avoids overriding base values
 # secrets:
 #   DATABASE_URL: "postgres://user:pass@host:5432/db"
-#   API_KEY: "your-api-key"

--- a/cmd/meshctl/templates/python/api/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/python/api/helm-values.yaml.tmpl
@@ -41,4 +41,3 @@ registry:
 # Uncomment to add — leaving commented avoids overriding base values
 # secrets:
 #   DATABASE_URL: "postgres://user:pass@host:5432/db"
-#   API_KEY: "your-api-key"

--- a/cmd/meshctl/templates/python/basic/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/python/basic/helm-values.yaml.tmpl
@@ -41,4 +41,3 @@ registry:
 # Uncomment to add — leaving commented avoids overriding base values
 # secrets:
 #   DATABASE_URL: "postgres://user:pass@host:5432/db"
-#   API_KEY: "your-api-key"

--- a/cmd/meshctl/templates/python/llm-agent/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/helm-values.yaml.tmpl
@@ -31,28 +31,17 @@ registry:
   host: "mcp-core-mcp-mesh-registry"
   port: "8000"
 
-# LLM agent typically needs API keys.
-# The refs below point to a secret named `llm-secrets` — update the `name:` values
-# below to match your cluster's secret, or create the secret:
-#   kubectl create secret generic llm-secrets \
-#     --from-literal=anthropic-api-key=sk-ant-... \
-#     --from-literal=openai-api-key=sk-...
-env:
-  - name: ANTHROPIC_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: llm-secrets
-        key: anthropic-api-key
-        optional: true
-  - name: OPENAI_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: llm-secrets
-        key: openai-api-key
-        optional: true
+# This agent reaches its model through the mesh: it resolves an llm-provider
+# agent by capability, and that provider holds the vendor credentials. Nothing
+# vendor-specific belongs here — deploy the provider with its own credentials.
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"
 
 # Optional: Secrets (creates a K8s Secret, injected via envFrom)
 # Uncomment to add — leaving commented avoids overriding base values
 # secrets:
 #   DATABASE_URL: "postgres://user:pass@host:5432/db"
-#   API_KEY: "your-api-key"

--- a/cmd/meshctl/templates/python/llm-provider/README.md.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/README.md.tmpl
@@ -63,7 +63,7 @@ The provider will start on port {{ .Port }} by default.
 |-----------|-------|-------------|
 | Model | {{ .Model }} | LiteLLM model identifier |
 | Port | {{ .Port }} | HTTP server port |
-| Tags | {{ join .Tags ", " }} | Discovery tags |
+| Tags | {{ if .Tags }}{{ join .Tags ", " }}{{ else }}{{ join (providerTags .Model) ", " }}{{ end }} | Discovery tags |
 
 ## How It Works
 
@@ -80,7 +80,7 @@ Other agents can use this provider with the `@mesh.llm` decorator:
 
 ```python
 @mesh.llm(
-    provider={"capability": "llm", "tags": {{ toJSON .Tags }}},
+    provider={"capability": "llm", "tags": {{ if .Tags }}{{ toJSON .Tags }}{{ else }}[{{ range $i, $t := providerTags .Model }}{{ if $i }}, {{ end }}"{{ $t }}"{{ end }}]{{ end }}},
     max_iterations=5,
     system_prompt="You are a helpful assistant.",
     context_param="ctx",

--- a/cmd/meshctl/templates/typescript/api/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/typescript/api/helm-values.yaml.tmpl
@@ -41,4 +41,3 @@ registry:
 # Uncomment to add — leaving commented avoids overriding base values
 # secrets:
 #   DATABASE_URL: "postgres://user:pass@host:5432/db"
-#   API_KEY: "your-api-key"

--- a/cmd/meshctl/templates/typescript/basic/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/helm-values.yaml.tmpl
@@ -41,4 +41,3 @@ registry:
 # Uncomment to add — leaving commented avoids overriding base values
 # secrets:
 #   DATABASE_URL: "postgres://user:pass@host:5432/db"
-#   API_KEY: "your-api-key"

--- a/cmd/meshctl/templates/typescript/llm-agent/helm-values.yaml.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/helm-values.yaml.tmpl
@@ -31,28 +31,17 @@ registry:
   host: "mcp-core-mcp-mesh-registry"
   port: "8000"
 
-# LLM agent typically needs API keys.
-# The refs below point to a secret named `llm-secrets` — update the `name:` values
-# below to match your cluster's secret, or create the secret:
-#   kubectl create secret generic llm-secrets \
-#     --from-literal=anthropic-api-key=sk-ant-... \
-#     --from-literal=openai-api-key=sk-...
-env:
-  - name: ANTHROPIC_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: llm-secrets
-        key: anthropic-api-key
-        optional: true
-  - name: OPENAI_API_KEY
-    valueFrom:
-      secretKeyRef:
-        name: llm-secrets
-        key: openai-api-key
-        optional: true
+# This agent reaches its model through the mesh: it resolves an llm-provider
+# agent by capability, and that provider holds the vendor credentials. Nothing
+# vendor-specific belongs here — deploy the provider with its own credentials.
+
+# Optional: Additional environment variables
+# Uncomment to add — leaving commented avoids overriding base values
+# env:
+#   - name: LOG_LEVEL
+#     value: "INFO"
 
 # Optional: Secrets (creates a K8s Secret, injected via envFrom)
 # Uncomment to add — leaving commented avoids overriding base values
 # secrets:
 #   DATABASE_URL: "postgres://user:pass@host:5432/db"
-#   API_KEY: "your-api-key"

--- a/src/core/cli/scaffold/helm_values_template_test.go
+++ b/src/core/cli/scaffold/helm_values_template_test.go
@@ -1,10 +1,13 @@
 package scaffold
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 // Issue #1483. `helm-values.yaml.tmpl` used to wire ANTHROPIC_API_KEY,
@@ -203,5 +206,106 @@ func TestHelmValues_EnvBlockShapePerBranch(t *testing.T) {
 			require.Contains(t, content, "# env:\n",
 				"the commented reference skeleton must survive")
 		})
+	}
+}
+
+// The other half of #1483: llm-provider was not the only template wiring vendor
+// keys. `llm-agent`, `api` and `basic` shipped the same `llm-secrets` block (and
+// a generic `API_KEY: "your-api-key"` secrets example) in all three languages.
+//
+// `api` and `basic` are not LLM agents at all. `llm-agent` is one, but it reaches
+// its model through mesh DI — `@mesh.llm(provider={"capability": "llm", ...})`,
+// `mesh.llm({provider: {capability: "llm"}})`, `@MeshLlm(providerSelector =
+// @Selector(capability = "llm"))`. The credential lives on the llm-provider agent
+// it resolves to, and none of the three carries a vendor SDK in its dependency
+// manifest to use one with. A key wired into the CONSUMER's pod is read by
+// nothing.
+//
+// So the assertion is flat: a template that is not llm-provider may not name a
+// vendor key, because none of them is in a position to know one. Same subtractive
+// shape as the guards above — stop asserting something false.
+var nonProviderTemplates = []string{"llm-agent", "api", "basic", "a2a-consumer"}
+
+// renderNonProviderHelmValues scaffolds one of the non-llm-provider templates and
+// returns its rendered helm-values.yaml. Defaults come from NewScaffoldContext so
+// the render matches what `meshctl scaffold -t <template>` actually produces.
+func renderNonProviderHelmValues(t *testing.T, language, template string) string {
+	t.Helper()
+	ctx := NewScaffoldContext()
+	ctx.Name = "credential-guard"
+	ctx.Description = "credential guard"
+	ctx.Language = language
+	ctx.OutputDir = t.TempDir()
+	ctx.Port = 9400
+	ctx.Template = template
+	ctx.TemplateDir = templatesRoot(t)
+	ctx.AgentType = ""
+	ctx.ProviderTags = []string{"llm", "+claude"}
+	require.NoError(t, NewStaticProvider().Execute(ctx))
+
+	path := filepath.Join(ctx.OutputDir, ctx.Name, "helm-values.yaml")
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "rendered helm values %s", path)
+	return string(content)
+}
+
+func TestHelmValues_NonProviderTemplatesWireNoVendorCredentials(t *testing.T) {
+	for _, language := range helmLanguages {
+		for _, template := range nonProviderTemplates {
+			t.Run(language+" "+template, func(t *testing.T) {
+				content := renderNonProviderHelmValues(t, language, template)
+
+				for _, key := range allVendorKeys {
+					require.NotContains(t, content, key,
+						"a %s/%s scaffold has no vendor credential to hold: an "+
+							"llm-agent resolves its provider through the mesh and "+
+							"api/basic are not LLM agents at all, so wiring %s "+
+							"sends the operator to configure something nothing reads",
+						language, template, key)
+				}
+				for _, key := range allVendorSecretKeys {
+					require.NotContains(t, content, key,
+						"the kubectl comment still instructs a %s literal for %s/%s",
+						key, language, template)
+				}
+				require.NotContains(t, content, "API_KEY",
+					"naming any API key here, vendor-specific or generic, is the "+
+						"assertion #1483 removes from %s/%s", language, template)
+				require.NotContains(t, content, "your-api-key",
+					"the generic secrets example names a credential nothing reads")
+			})
+		}
+	}
+}
+
+// Removing the block must leave valid YAML, and specifically must not leave an
+// `env:` key with nothing under it: helm parses that as null and the chart's
+// range over it fails. The whole point of these files is to be applied, so they
+// are parsed here rather than pattern-matched.
+func TestHelmValues_NonProviderTemplatesParseWithNoEmptyEnv(t *testing.T) {
+	for _, language := range helmLanguages {
+		for _, template := range nonProviderTemplates {
+			t.Run(language+" "+template, func(t *testing.T) {
+				content := renderNonProviderHelmValues(t, language, template)
+
+				var values map[string]interface{}
+				require.NoError(t, yaml.Unmarshal([]byte(content), &values),
+					"%s/%s helm values must parse", language, template)
+
+				if env, ok := values["env"]; ok {
+					require.NotNil(t, env,
+						"`env:` with no items parses as null and breaks the chart — "+
+							"omit the key instead of leaving it bare")
+				}
+				if secrets, ok := values["secrets"]; ok {
+					require.NotNil(t, secrets,
+						"`secrets:` with no items parses as null and breaks the chart")
+				}
+				require.NotContains(t, content, "\nenv:\n",
+					"%s/%s must keep its env skeleton commented out — an active but "+
+						"empty `env:` overrides the chart's base values with null",
+					language, template)
+			})
+		}
 	}
 }

--- a/src/core/cli/scaffold/provider_readme_tags_test.go
+++ b/src/core/cli/scaffold/provider_readme_tags_test.go
@@ -1,0 +1,80 @@
+package scaffold
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Issue #1483. The Python llm-provider README rendered its two tag sites from
+// `.Tags` — the raw CONTEXT tags, which the `--template llm-provider` path never
+// populates. The config table showed an empty Tags cell and the consumer example
+// showed `"tags": null`, in a directory whose `main.py` beside it registered the
+// real family tags.
+//
+// The fix routes both sites through the same `providerTags` func `main.py.tmpl`
+// uses, so the README cannot state a different answer from the code it documents.
+// That is what is pinned here: not a literal tag list (model_dispatch_test owns
+// those), but the AGREEMENT between the two files in the same scaffold.
+
+// readmeTagModels covers both resolver branches, because the two files could
+// agree in one and diverge in the other: a big-3 family, a gateway model whose
+// family survives the prefix, and a gateway model with no family at all.
+var readmeTagModels = []struct {
+	model    string
+	wantTags []string
+}{
+	{"anthropic/claude-sonnet-5", []string{"llm", "claude", "anthropic", "provider"}},
+	{"gpt-4o", []string{"llm", "openai", "gpt", "provider"}},
+	{"gemini-2.5-flash", []string{"llm", "gemini", "google", "provider"}},
+	{"bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", []string{"llm", "claude", "anthropic", "provider"}},
+	{"vertex_ai/gemini-2.5-flash", []string{"llm", "gemini", "google", "provider"}},
+	{"bedrock/meta.llama3-70b-instruct-v1:0", []string{"llm", "provider"}},
+	{"cohere/command-r-plus", []string{"llm", "provider"}},
+}
+
+func TestPythonProviderReadme_ShowsTheTagsTheAgentRegisters(t *testing.T) {
+	for _, m := range readmeTagModels {
+		t.Run(m.model, func(t *testing.T) {
+			readme := renderProvider(t, "python", m.model, "README.md")
+			main := renderProvider(t, "python", m.model, "main.py")
+
+			// What the agent actually registers. Asserted against main.py first
+			// so a change to the tag source fails here rather than silently
+			// re-pointing the README at a new wrong answer.
+			registered := tagsMarker("python", m.wantTags)
+			require.Contains(t, main, registered,
+				"main.py must register the %v tags for %s", m.wantTags, m.model)
+
+			// The config table.
+			require.Contains(t, readme,
+				"| Tags | "+strings.Join(m.wantTags, ", ")+" | Discovery tags |",
+				"the config table must list the tags main.py registers, not the "+
+					"raw context tags — the llm-provider path leaves those empty, "+
+					"which is how the cell rendered blank")
+
+			// The consumer example. The literal is rendered by the same
+			// expression main.py uses, so it must come out byte-identical to the
+			// list in the decorator beside it.
+			require.Contains(t, readme, `"tags": [`+quotedTagList(m.wantTags)+`]`,
+				"the consumer example must pin the tags this provider registers; "+
+					"`\"tags\": null` is what the raw context rendered")
+
+			require.NotContains(t, readme, `"tags": null`,
+				"the README read tags off a field the llm-provider path never sets")
+			require.NotContains(t, readme, "| Tags |  |",
+				"an empty Tags cell is the same defect wearing the table's clothes")
+		})
+	}
+}
+
+// quotedTagList renders `"a", "b"` — the inner text shared by the Python
+// decorator literal and the README's consumer example.
+func quotedTagList(tags []string) string {
+	quoted := make([]string, len(tags))
+	for i, tag := range tags {
+		quoted[i] = `"` + tag + `"`
+	}
+	return strings.Join(quoted, ", ")
+}


### PR DESCRIPTION
## Summary

The last of #1483, after #1487 fixed the `llm-provider` half.

**Nine templates advertised vendor credentials for agents that need none** — `api`, `basic` and `llm-agent` across all three languages, wiring `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` into helm values or offering a generic `API_KEY: "your-api-key"` example.

`api` and `basic` are not LLM agents at all. **`llm-agent` looked like the arguable case and isn't** — verified in all three languages rather than inferred from Python:

| | delegation | vendor SDK in dependency manifest |
|---|---|---|
| Python | `provider={"capability": "llm", ...}` | none |
| TypeScript | `provider: { capability: "llm", ... }` | none |
| Java | `@MeshLlm(providerSelector = @Selector(capability = "llm"))` | none — `mcp-mesh-spring-ai` is the delegation bridge, and `application.yml` sets no `spring.ai.*` model config |

All three resolve a provider through mesh DI. The provider holds the credentials; the consumer resolves it. The *name* was the only thing suggesting otherwise, which makes `llm-agent` the most misleading of the three.

Same subtractive fix as #1487: a manifest should be silent about credentials it cannot know rather than guess at them. The `llm-agent` `env:` blocks contained *only* the two vendor entries, so they became the commented skeleton `api` and `basic` already use, with a note saying the provider holds the credentials. `api` and `basic` lost one commented example line each and kept everything else.

**The Python `llm-provider` README rendered tags the agent never registers** — its Tags row and consumer example read from the *context* tags, which the `--template llm-provider` path never populates, so it showed an empty cell and `"tags": null` beside a `main.py` registering the real family tags. Both now resolve through `providerTags`, and the example expression is **byte-identical** to `main.py`'s, so the two literals cannot render differently.

## Review notes

Java's README has no tags to render — nothing to fix. TypeScript's renders a correct but hand-written four-arm chain off `.ModelFamily`; every arm is a valid subset of what the provider registers, including the gateway case, so it is not broken and was left alone. Flagging it as a **follow-up**: it is the last duplicated tag list that can silently drift from `providerTagsByFamily`, which is exactly what `providerTags` was added in #1484 to eliminate.

The YAML-parse guard exists because an empty `env:` block renders as null and breaks the chart — that was the failure mode #1487 hit, and it is the obvious way this particular change goes wrong.

Closes #1483

## Test plan

- [x] 24 new subtests over a 3×4 matrix (`llm-agent`, `api`, `basic`, `a2a-consumer`) asserting no non-provider template names a vendor key, vendor secret key, `API_KEY` or `your-api-key`
- [x] A YAML-parse assertion that `env:` and `secrets:` are never null
- [x] 7 new subtests pinning the README against `main.py` across both resolver branches
- [x] All verified **red** by reinstating each removal in turn: the TypeScript `llm-agent` env block fired both guards; `java/basic`'s `API_KEY` line fired the credential guard; reverting the README fired all 7
- [x] 18 rendered helm values parse clean with no null blocks; the only renders still naming a vendor key are the big-3 `llm-provider` ones, which #1487 pins
- [x] `go build ./...`; `go test ./src/core/cli/... -count=1` — all five packages; scaffold package 567 subtests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM agents now resolve model providers through the mesh instead of defaulting to vendor API credentials.
  * Provider documentation automatically displays model discovery tags when explicit tags are not provided.

* **Documentation**
  * Updated deployment examples to clarify mesh-based provider configuration and optional environment settings.
  * Simplified optional secret examples by removing generic API key entries.

* **Tests**
  * Added validation for credential-free Helm templates, valid YAML, and accurate provider discovery tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->