### PR TITLE
feat: add the startup_check hook and /startupz, in all three runtimes

### DIFF
--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshStartupCheck.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshStartupCheck.java
@@ -1,0 +1,79 @@
+package io.mcpmesh;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as this agent's startup check (RFC #1502).
+ *
+ * <p>{@link MeshHealthCheck} answers "can I serve <b>right now</b>?" — a transient
+ * answer, and a failing one only pauses the heartbeat so the registry stops
+ * selecting this agent until it recovers. {@code @MeshStartupCheck} answers the
+ * other question: "is this agent configured such that it can <b>ever</b> serve?"
+ * A missing API key is not going to fix itself, and without this hook it looks
+ * exactly like a vendor outage — the agent sits unregistered, the pod runs, and
+ * nothing is loud.
+ *
+ * <p>The verdict is served from {@code GET}/{@code HEAD} {@code /startupz}, which
+ * the agent Helm chart's {@code startupProbe} polls. A pod whose startup check
+ * never passes never becomes ready, never registers, and ends up in
+ * {@code CrashLoopBackOff} — which is the point.
+ *
+ * <h2>Shape</h2>
+ *
+ * <p>Annotate exactly one no-argument method on a Spring bean. The return type
+ * must be either {@code boolean} ({@code true} = start, {@code false} = do not)
+ * or {@link MeshHealth}, whose {@link MeshHealthStatus#HEALTHY} is the only
+ * status that passes. Anything else fails the boot with an actionable message
+ * rather than being silently ignored.
+ *
+ * <p>Escaped as {@code &#64;} rather than wrapped in {@code {@code ...}}: an
+ * annotation is the first token on those lines, and Javadoc reads a leading
+ * {@code @} as a block tag even inside a code block.
+ *
+ * <pre>
+ * &#64;Component
+ * public class VendorStartup {
+ *
+ *     &#64;MeshStartupCheck
+ *     public boolean configured() {
+ *         return System.getenv("ANTHROPIC_API_KEY") != null;
+ *     }
+ * }
+ * </pre>
+ *
+ * <h2>The verdict rules are the OPPOSITE of {@link MeshHealthCheck}'s</h2>
+ *
+ * <p>A check that <b>throws</b> FAILS the probe here; the same throw from a
+ * health check is {@link MeshHealthStatus#DEGRADED} and keeps the agent
+ * heartbeating. Both rules follow from the same principle applied to different
+ * questions: a buggy probe must not withdraw a working provider from a mesh
+ * that may have no other one, but an indeterminate answer at boot is not a
+ * reason to let a possibly-misconfigured agent through. The cost of being wrong
+ * is also asymmetric — a false failure crash-loops one pod that was never
+ * serving, a false pass silently registers a broken one.
+ *
+ * <p>For the same reason there is no partial credit: {@code DEGRADED},
+ * {@code UNKNOWN} and an unrecognized return all fail.
+ *
+ * <h2>Every agent type, and no cache</h2>
+ *
+ * <p>Unlike {@link MeshHealthCheck}, this hook is honoured on {@code api}
+ * (route) and {@code a2a} agents too. It never withdraws a running fan-out
+ * point; it only stops a misconfigured one from coming up, and a gateway with a
+ * broken config should never come up.
+ *
+ * <p>The check runs once per probe hit. {@code startupProbe} stops polling after
+ * its first success, so it runs a handful of times at most and there is nothing
+ * to cache — hence no {@code ttlSeconds} here. Keep it fast: the chart's probe
+ * {@code timeoutSeconds} is 5.
+ *
+ * @see MeshHealthCheck
+ * @see MeshHealth
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MeshStartupCheck {
+}

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshStartupCheck.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshStartupCheck.java
@@ -16,10 +16,22 @@ import java.lang.annotation.Target;
  * exactly like a vendor outage — the agent sits unregistered, the pod runs, and
  * nothing is loud.
  *
- * <p>The verdict is served from {@code GET}/{@code HEAD} {@code /startupz}, which
- * the agent Helm chart's {@code startupProbe} polls. A pod whose startup check
- * never passes never becomes ready, never registers, and ends up in
+ * <h2>What ships today (RFC #1502 step 1)</h2>
+ *
+ * <p>The verdict is served from {@code GET}/{@code HEAD} {@code /startupz}, and
+ * that is the whole effect: a failing check answers 503 there. Nothing else
+ * changes — the agent is not withdrawn, the heartbeat is untouched, and
+ * {@code /livez} and {@code /ready} answer exactly as they did.
+ *
+ * <p>The agent Helm chart's {@code startupProbe} still points at {@code /livez},
+ * so nothing acts on the verdict yet. Repointing it at {@code /startupz} is
+ * step 2, and it is what this hook exists for: a pod whose startup check never
+ * passes then never becomes ready, never registers, and ends up in
  * {@code CrashLoopBackOff} — which is the point.
+ *
+ * <p>The message on a failing verdict is served to any caller who can reach the
+ * pod, so name the setting that is missing without including its value:
+ * {@code "ANTHROPIC_API_KEY is not set"}, never the key itself.
  *
  * <h2>Shape</h2>
  *
@@ -65,7 +77,7 @@ import java.lang.annotation.Target;
  * point; it only stops a misconfigured one from coming up, and a gateway with a
  * broken config should never come up.
  *
- * <p>The check runs once per probe hit. {@code startupProbe} stops polling after
+ * <p>The check runs once per request. A {@code startupProbe} stops polling after
  * its first success, so it runs a handful of times at most and there is nothing
  * to cache — hence no {@code ttlSeconds} here. Keep it fast: the chart's probe
  * {@code timeoutSeconds} is 5.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -704,8 +704,9 @@ public class MeshAutoConfiguration {
     @ConditionalOnMissingBean
     public MeshHealthController meshHealthController(
             @org.springframework.context.annotation.Lazy MeshRuntime runtime,
-            MeshHealthCheckRegistry healthCheckRegistry) {
-        return new MeshHealthController(runtime, healthCheckRegistry);
+            MeshHealthCheckRegistry healthCheckRegistry,
+            MeshStartupCheckRegistry startupCheckRegistry) {
+        return new MeshHealthController(runtime, healthCheckRegistry, startupCheckRegistry);
     }
 
     /**
@@ -730,6 +731,29 @@ public class MeshAutoConfiguration {
     public static MeshHealthCheckBeanPostProcessor meshHealthCheckBeanPostProcessor(
             MeshHealthCheckRegistry registry) {
         return new MeshHealthCheckBeanPostProcessor(registry);
+    }
+
+    /**
+     * RFC #1502: holds the agent's {@code @MeshStartupCheck}. A plain holder
+     * with no collaborators and no scheduler — {@code startupProbe} stops
+     * polling after its first success, so the check runs on demand from
+     * {@code /startupz} and there is nothing to refresh or cache.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public static MeshStartupCheckRegistry meshStartupCheckRegistry() {
+        return new MeshStartupCheckRegistry();
+    }
+
+    /**
+     * RFC #1502: scans beans for {@code @MeshStartupCheck}. Static factory so
+     * the processor is instantiated before user beans.
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public static MeshStartupCheckBeanPostProcessor meshStartupCheckBeanPostProcessor(
+            MeshStartupCheckRegistry registry) {
+        return new MeshStartupCheckBeanPostProcessor(registry);
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAutoConfiguration.java
@@ -735,7 +735,7 @@ public class MeshAutoConfiguration {
 
     /**
      * RFC #1502: holds the agent's {@code @MeshStartupCheck}. A plain holder
-     * with no collaborators and no scheduler — {@code startupProbe} stops
+     * with no collaborators and no scheduler — a {@code startupProbe} stops
      * polling after its first success, so the check runs on demand from
      * {@code /startupz} and there is nothing to refresh or cache.
      */

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
@@ -264,17 +264,20 @@ public class MeshHealthController {
      * Kubernetes startup probe (RFC #1502).
      *
      * <p>Reports whether this agent is configured well enough to serve at all,
-     * as opposed to {@code /ready}'s "should traffic reach me now". A pod whose
-     * startup check never passes never becomes ready, never registers, and ends
-     * up in {@code CrashLoopBackOff} where a misconfiguration is visible instead
-     * of looking like a vendor outage.
+     * as opposed to {@code /ready}'s "should traffic reach me now". Step 1 of
+     * RFC #1502 is this endpoint and nothing else: a failing check answers 503
+     * here, and {@code /livez}, {@code /ready} and the heartbeat are unchanged.
+     * Pointing the chart's {@code startupProbe} at it — after which a check
+     * that never passes keeps the pod from ever becoming ready and lands it in
+     * {@code CrashLoopBackOff}, where a misconfiguration is visible instead of
+     * looking like a vendor outage — is step 2.
      *
      * <p>A NEW endpoint rather than a reuse of {@code /livez}: the chart points
      * both {@code startupProbe} and {@code livenessProbe} at {@code /livez}, and
      * an endpoint cannot tell which probe called it, so sharing one would let a
      * failing startup check kill a running pod every ten seconds.
      *
-     * <p>The check runs on every hit. {@code startupProbe} stops polling after
+     * <p>The check runs on every hit. A {@code startupProbe} stops polling after
      * its first success, so there is nothing to cache.
      */
     @GetMapping("/startupz")

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
@@ -15,9 +15,15 @@ import java.util.Map;
 /**
  * Health endpoint controller for MCP Mesh Java agents.
  *
- * <p>Provides {@code GET}/{@code HEAD} for {@code /health}, {@code /ready} and
- * {@code /livez} for Kubernetes probes, load balancers, and Docker Compose
- * healthchecks.
+ * <p>Provides {@code GET}/{@code HEAD} for {@code /health}, {@code /ready},
+ * {@code /livez} and {@code /startupz} for Kubernetes probes, load balancers,
+ * and Docker Compose healthchecks.
+ *
+ * <p>Unlike Python and TypeScript, which serve their provider and gateway
+ * probes from two different places, Java serves every agent type from this one
+ * controller — the starter mounts it whatever the agent is. Where the other two
+ * runtimes have to keep two sites in step, the per-agent-type rules here are
+ * expressed as branches ({@link #readyStatus}) instead.
  *
  * <p>Liveness and readiness are deliberately DIFFERENT endpoints (issue #1467).
  * When both probes share a URL, anything that makes an agent unready also makes
@@ -44,14 +50,22 @@ public class MeshHealthController {
 
     private final MeshRuntime runtime;
     private final MeshHealthCheckRegistry healthChecks;
+    private final MeshStartupCheckRegistry startupChecks;
 
     public MeshHealthController(MeshRuntime runtime) {
-        this(runtime, null);
+        this(runtime, null, null);
     }
 
     public MeshHealthController(MeshRuntime runtime, MeshHealthCheckRegistry healthChecks) {
+        this(runtime, healthChecks, null);
+    }
+
+    public MeshHealthController(MeshRuntime runtime,
+                                MeshHealthCheckRegistry healthChecks,
+                                MeshStartupCheckRegistry startupChecks) {
         this.runtime = runtime;
         this.healthChecks = healthChecks;
+        this.startupChecks = startupChecks;
     }
 
     /**
@@ -222,5 +236,78 @@ public class MeshHealthController {
     @RequestMapping(value = "/livez", method = RequestMethod.HEAD)
     public ResponseEntity<Void> livezHead() {
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Run the agent's {@link io.mcpmesh.MeshStartupCheck}, or pass when none is
+     * declared.
+     *
+     * <p>Never throws: {@link MeshStartupCheckRegistry#execute} already turns a
+     * throwing check into a failing verdict, and a missing registry (the
+     * two-argument constructor, used by tests and by anyone wiring this
+     * controller by hand) means no check, which passes.
+     *
+     * <p>Deliberately does NOT consult {@link MeshRuntime#isRunning()}. The mesh
+     * runtime starts late in the Spring lifecycle, and {@code startupProbe}
+     * exists precisely to cover that window — flooring the startup verdict on
+     * the runtime would make the probe fail for the entire boot it is supposed
+     * to be waiting through.
+     */
+    private MeshStartupCheckRegistry.Verdict startupVerdict() {
+        if (startupChecks == null) {
+            return MeshStartupCheckRegistry.Verdict.pass();
+        }
+        return startupChecks.execute();
+    }
+
+    /**
+     * Kubernetes startup probe (RFC #1502).
+     *
+     * <p>Reports whether this agent is configured well enough to serve at all,
+     * as opposed to {@code /ready}'s "should traffic reach me now". A pod whose
+     * startup check never passes never becomes ready, never registers, and ends
+     * up in {@code CrashLoopBackOff} where a misconfiguration is visible instead
+     * of looking like a vendor outage.
+     *
+     * <p>A NEW endpoint rather than a reuse of {@code /livez}: the chart points
+     * both {@code startupProbe} and {@code livenessProbe} at {@code /livez}, and
+     * an endpoint cannot tell which probe called it, so sharing one would let a
+     * failing startup check kill a running pod every ten seconds.
+     *
+     * <p>The check runs on every hit. {@code startupProbe} stops polling after
+     * its first success, so there is nothing to cache.
+     */
+    @GetMapping("/startupz")
+    public ResponseEntity<Map<String, Object>> startupz() {
+        MeshStartupCheckRegistry.Verdict verdict = startupVerdict();
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("started", verdict.passed());
+        // Best-effort agent name, for the same reason as /livez: `runtime` is a
+        // lazy proxy and resolving it can raise while the context comes up —
+        // which is exactly when the startup probe fires.
+        try {
+            if (runtime != null && runtime.getAgentSpec() != null) {
+                body.put("agent", runtime.getAgentSpec().getName());
+            }
+        } catch (Exception ignored) {
+            // Name is decoration; the verdict is not conditional on it.
+        }
+        if (!verdict.checks().isEmpty()) {
+            body.put("checks", verdict.checks());
+        }
+        if (!verdict.passed()) {
+            body.put("reason", "Startup check failed");
+            body.put("errors", verdict.errors());
+        }
+        body.put("timestamp", Instant.now().toString());
+        return ResponseEntity.status(verdict.passed() ? 200 : 503).body(body);
+    }
+
+    @RequestMapping(value = "/startupz", method = RequestMethod.HEAD)
+    public ResponseEntity<Void> startupzHead() {
+        // Same verdict as GET — a HEAD probe that disagreed with the GET would
+        // be the #1488 bug again for anyone who configured HEAD.
+        return ResponseEntity.status(startupVerdict().passed() ? 200 : 503).build();
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshStartupCheckBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshStartupCheckBeanPostProcessor.java
@@ -26,9 +26,10 @@ import java.util.Map;
  *
  * <p>The signature is checked here rather than coerced at runtime — and it
  * matters more for this hook than for the health check. A startup check with a
- * wrong shape would fail its probe forever, which is a {@code CrashLoopBackOff}
- * whose only stated cause is "startup probe failed". Failing the boot names the
- * method instead.
+ * wrong shape would fail its endpoint forever, and once the chart's
+ * {@code startupProbe} points at {@code /startupz} (RFC #1502 step 2) that is a
+ * {@code CrashLoopBackOff} whose only stated cause is "startup probe failed".
+ * Failing the boot names the method instead.
  */
 public class MeshStartupCheckBeanPostProcessor implements BeanPostProcessor, Ordered {
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshStartupCheckBeanPostProcessor.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshStartupCheckBeanPostProcessor.java
@@ -1,0 +1,96 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshStartupCheck;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.framework.AopProxyUtils;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.MethodIntrospector;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationUtils;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+/**
+ * Discovers the {@link MeshStartupCheck} method (RFC #1502).
+ *
+ * <p>Same shape as {@link MeshHealthCheckBeanPostProcessor}, including the
+ * proxy-unwrapping rule: reflect on, and invoke against, the SAME object, or a
+ * JDK dynamic proxy's method cannot be invoked with the proxy as receiver.
+ *
+ * <h2>Boot-time validation</h2>
+ *
+ * <p>The signature is checked here rather than coerced at runtime — and it
+ * matters more for this hook than for the health check. A startup check with a
+ * wrong shape would fail its probe forever, which is a {@code CrashLoopBackOff}
+ * whose only stated cause is "startup probe failed". Failing the boot names the
+ * method instead.
+ */
+public class MeshStartupCheckBeanPostProcessor implements BeanPostProcessor, Ordered {
+
+    private static final Logger log =
+        LoggerFactory.getLogger(MeshStartupCheckBeanPostProcessor.class);
+
+    private final MeshStartupCheckRegistry registry;
+
+    public MeshStartupCheckBeanPostProcessor(MeshStartupCheckRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        Object receiver = AopProxyUtils.getSingletonTarget(bean);
+        if (receiver == null) {
+            receiver = bean;
+        }
+        Class<?> targetClass = AopUtils.getTargetClass(receiver);
+        if (!targetClass.isInstance(receiver)) {
+            targetClass = receiver.getClass();
+        }
+
+        Map<Method, MeshStartupCheck> annotated = MethodIntrospector.selectMethods(targetClass,
+            (MethodIntrospector.MetadataLookup<MeshStartupCheck>) method ->
+                AnnotationUtils.findAnnotation(method, MeshStartupCheck.class));
+
+        Object registrationTarget = receiver;
+        Class<?> registrationClass = targetClass;
+        annotated.forEach((method, annotation) -> {
+            validate(registrationClass, method);
+            registry.register(registrationTarget, method);
+        });
+
+        return bean;
+    }
+
+    private static void validate(Class<?> targetClass, Method method) {
+        String where = "@MeshStartupCheck on '" + targetClass.getName() + "#" + method.getName() + "'";
+
+        if (method.getParameterCount() != 0) {
+            throw new IllegalStateException(where + " must take no parameters — it is called by "
+                + "the startup probe with nothing to pass it. Read what it needs from the "
+                + "enclosing bean.");
+        }
+
+        Class<?> returnType = method.getReturnType();
+        boolean supported = boolean.class.equals(returnType)
+            || Boolean.class.equals(returnType)
+            || MeshHealth.class.equals(returnType);
+        if (!supported) {
+            throw new IllegalStateException(where + " returns " + returnType.getName()
+                + ", which the runtime cannot read as a startup verdict. Return boolean "
+                + "(true = start, false = do not) or " + MeshHealth.class.getName()
+                + " (only HEALTHY passes).");
+        }
+
+        log.debug("Found {} returning {}", where, returnType.getSimpleName());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshStartupCheckRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshStartupCheckRegistry.java
@@ -20,7 +20,7 @@ import java.util.Map;
  * differences that both follow from what {@code startupProbe} does:
  *
  * <ul>
- *   <li><b>No stored latest result and no scheduler.</b> {@code startupProbe}
+ *   <li><b>No stored latest result and no scheduler.</b> A {@code startupProbe}
  *       stops polling after its first success, so the check runs a handful of
  *       times at most. A cached verdict would only add a way for
  *       {@code /startupz} to answer with a result older than the probe that

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshStartupCheckRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshStartupCheckRegistry.java
@@ -1,0 +1,147 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthStatus;
+import io.mcpmesh.MeshStartupCheck;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Holds the agent's single {@link MeshStartupCheck} and runs it on demand
+ * (RFC #1502).
+ *
+ * <p>The sibling of {@link MeshHealthCheckRegistry}, with two structural
+ * differences that both follow from what {@code startupProbe} does:
+ *
+ * <ul>
+ *   <li><b>No stored latest result and no scheduler.</b> {@code startupProbe}
+ *       stops polling after its first success, so the check runs a handful of
+ *       times at most. A cached verdict would only add a way for
+ *       {@code /startupz} to answer with a result older than the probe that
+ *       asked for it.</li>
+ *   <li><b>A throw FAILS.</b> {@link MeshHealthCheckRegistry#execute} records a
+ *       throw as {@link MeshHealthStatus#DEGRADED} so a buggy probe cannot
+ *       withdraw a working provider. Here the question is whether a
+ *       possibly-misconfigured agent may come up at all, and an indeterminate
+ *       answer at boot is not a reason to let it through.</li>
+ * </ul>
+ */
+public class MeshStartupCheckRegistry {
+
+    private static final Logger log = LoggerFactory.getLogger(MeshStartupCheckRegistry.class);
+
+    private volatile Registration registration;
+
+    /** One discovered startup check. */
+    public record Registration(Object bean, Method method) {
+        public String describe() {
+            return method.getDeclaringClass().getName() + "#" + method.getName();
+        }
+    }
+
+    /** A startup verdict: whether the agent may come up, plus why not. */
+    public record Verdict(boolean passed, Map<String, Object> checks, List<String> errors) {
+
+        public static Verdict pass() {
+            return new Verdict(true, Map.of(), List.of());
+        }
+
+        public static Verdict fail(String error, Map<String, Object> checks) {
+            return new Verdict(false, checks, List.of(error));
+        }
+    }
+
+    /**
+     * Record the agent's startup check.
+     *
+     * @throws IllegalStateException when a second one is declared — silently
+     *     picking one of two would make whether the pod comes up depend on bean
+     *     order.
+     */
+    public void register(Object bean, Method method) {
+        Registration existing = this.registration;
+        if (existing != null) {
+            throw new IllegalStateException(
+                "Two @MeshStartupCheck methods found (" + existing.describe() + " and "
+                    + method.getDeclaringClass().getName() + "#" + method.getName()
+                    + "). An agent has exactly one startup check — it is a single verdict "
+                    + "about whether this agent is configured well enough to start. Combine "
+                    + "the probes into one method returning MeshHealth.");
+        }
+        method.setAccessible(true);
+        this.registration = new Registration(bean, method);
+        log.info("Registered @MeshStartupCheck {}", this.registration.describe());
+    }
+
+    public boolean hasStartupCheck() {
+        return registration != null;
+    }
+
+    public Registration registration() {
+        return registration;
+    }
+
+    /**
+     * Run the registered check and reduce whatever it returned to a verdict.
+     *
+     * <p>Never throws. An agent that declared no check passes — default-true is
+     * what makes this purely additive.
+     */
+    public Verdict execute() {
+        Registration reg = registration;
+        if (reg == null) {
+            return Verdict.pass();
+        }
+        Object raw;
+        try {
+            raw = reg.method().invoke(reg.bean());
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            log.warn("@MeshStartupCheck {} threw — failing the startup probe: {}",
+                reg.describe(), cause.toString());
+            return Verdict.fail("Startup check failed: " + cause,
+                Map.of("startup_check_execution", false));
+        } catch (Exception e) {
+            log.warn("@MeshStartupCheck {} could not be invoked — failing the startup probe: {}",
+                reg.describe(), e.toString());
+            return Verdict.fail("Startup check failed: " + e,
+                Map.of("startup_check_execution", false));
+        }
+        return coerce(raw);
+    }
+
+    /**
+     * Convert a startup-check return value. The accepted shapes are enforced at
+     * boot by {@link MeshStartupCheckBeanPostProcessor}, so the fallback here is
+     * defence in depth — and unlike the health path it fails rather than
+     * degrading, because there is no partial credit for "am I configured".
+     */
+    static Verdict coerce(Object raw) {
+        if (raw instanceof Boolean ok) {
+            return ok
+                ? new Verdict(true, Map.of("startup_check", true), List.of())
+                : Verdict.fail("Startup check returned false",
+                    Map.of("startup_check", false));
+        }
+        if (raw instanceof MeshHealth health) {
+            if (health.status() == MeshHealthStatus.HEALTHY) {
+                return new Verdict(true, health.checks(), List.of());
+            }
+            List<String> errors = health.errors().isEmpty()
+                ? List.of("Startup check reported '" + health.status().wireValue() + "'")
+                : health.errors();
+            return new Verdict(false, health.checks(), errors);
+        }
+        String typeName = raw == null ? "null" : raw.getClass().getName();
+        Map<String, Object> checks = new LinkedHashMap<>();
+        checks.put("startup_check_return_type", false);
+        return Verdict.fail("Invalid return type: " + typeName
+            + ". A startup check returns boolean or " + MeshHealth.class.getName() + ".", checks);
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshStartupCheckBeanPostProcessorTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshStartupCheckBeanPostProcessorTest.java
@@ -23,6 +23,14 @@ class MeshStartupCheckBeanPostProcessorTest {
         }
     }
 
+    /** {@code Boolean} and {@code boolean} are different types to reflection. */
+    static class ValidBoxedBoolean {
+        @MeshStartupCheck
+        public Boolean check() {
+            return Boolean.TRUE;
+        }
+    }
+
     static class ValidMeshHealth {
         @MeshStartupCheck
         public MeshHealth check() {
@@ -93,6 +101,16 @@ class MeshStartupCheckBeanPostProcessorTest {
         MeshStartupCheckRegistry registry = process(new ValidBoolean());
         assertTrue(registry.hasStartupCheck());
         assertEquals("check", registry.registration().method().getName());
+    }
+
+    @Test
+    void discoversABoxedBooleanCheck() {
+        // `Method.getReturnType()` reports `Boolean` and `boolean` as distinct
+        // classes, so accepting one says nothing about the other — and a method
+        // that reads a nullable config field is naturally written boxed.
+        MeshStartupCheckRegistry registry = process(new ValidBoxedBoolean());
+        assertTrue(registry.hasStartupCheck());
+        assertTrue(registry.execute().passed());
     }
 
     @Test

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshStartupCheckBeanPostProcessorTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshStartupCheckBeanPostProcessorTest.java
@@ -1,0 +1,144 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshStartupCheck;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Discovery and boot-time validation of {@code @MeshStartupCheck} (RFC #1502).
+ *
+ * <p>The shape is rejected at BOOT, not coerced at runtime — and it matters
+ * more here than for the health check: a startup check with the wrong shape
+ * fails its probe forever, which is a CrashLoopBackOff whose only stated cause
+ * is "startup probe failed".
+ */
+class MeshStartupCheckBeanPostProcessorTest {
+
+    static class ValidBoolean {
+        @MeshStartupCheck
+        public boolean check() {
+            return true;
+        }
+    }
+
+    static class ValidMeshHealth {
+        @MeshStartupCheck
+        public MeshHealth check() {
+            return MeshHealth.healthy();
+        }
+    }
+
+    static class TakesParameters {
+        @MeshStartupCheck
+        public boolean check(String why) {
+            return true;
+        }
+    }
+
+    static class WrongReturnType {
+        @MeshStartupCheck
+        public String check() {
+            return "ok";
+        }
+    }
+
+    static class VoidReturn {
+        @MeshStartupCheck
+        public void check() {
+        }
+    }
+
+    static class TwoChecks {
+        @MeshStartupCheck
+        public boolean first() {
+            return true;
+        }
+
+        @MeshStartupCheck
+        public MeshHealth second() {
+            return MeshHealth.healthy();
+        }
+    }
+
+    static class NoAnnotation {
+        public boolean check() {
+            return true;
+        }
+    }
+
+    /** Both hooks on one bean: they are independent verdicts. */
+    static class BothHooks {
+        @io.mcpmesh.MeshHealthCheck
+        public boolean health() {
+            return true;
+        }
+
+        @MeshStartupCheck
+        public boolean startup() {
+            return true;
+        }
+    }
+
+    private static MeshStartupCheckRegistry process(Object bean) {
+        MeshStartupCheckRegistry registry = new MeshStartupCheckRegistry();
+        new MeshStartupCheckBeanPostProcessor(registry)
+            .postProcessAfterInitialization(bean, "bean");
+        return registry;
+    }
+
+    @Test
+    void discoversABooleanCheck() {
+        MeshStartupCheckRegistry registry = process(new ValidBoolean());
+        assertTrue(registry.hasStartupCheck());
+        assertEquals("check", registry.registration().method().getName());
+    }
+
+    @Test
+    void discoversAMeshHealthCheck() {
+        assertTrue(process(new ValidMeshHealth()).hasStartupCheck());
+    }
+
+    @Test
+    void ignoresBeansWithoutTheAnnotation() {
+        assertFalse(process(new NoAnnotation()).hasStartupCheck());
+    }
+
+    @Test
+    void rejectsAMethodWithParameters() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+            () -> process(new TakesParameters()));
+        assertTrue(e.getMessage().contains("must take no parameters"), e.getMessage());
+    }
+
+    @Test
+    void rejectsAnUnreadableReturnType() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+            () -> process(new WrongReturnType()));
+        assertTrue(e.getMessage().contains("cannot read as a startup verdict"), e.getMessage());
+        assertThrows(IllegalStateException.class, () -> process(new VoidReturn()));
+    }
+
+    @Test
+    void rejectsTwoChecksOnOneBean() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+            () -> process(new TwoChecks()));
+        assertTrue(e.getMessage().contains("Two @MeshStartupCheck methods"), e.getMessage());
+    }
+
+    @Test
+    void theTwoHooksAreIndependent() {
+        BothHooks bean = new BothHooks();
+
+        MeshStartupCheckRegistry startup = new MeshStartupCheckRegistry();
+        new MeshStartupCheckBeanPostProcessor(startup)
+            .postProcessAfterInitialization(bean, "bean");
+        MeshHealthCheckRegistry health = new MeshHealthCheckRegistry();
+        new MeshHealthCheckBeanPostProcessor(health)
+            .postProcessAfterInitialization(bean, "bean");
+
+        assertEquals("startup", startup.registration().method().getName());
+        assertEquals("health", health.registration().method().getName());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshStartupCheckRegistryTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshStartupCheckRegistryTest.java
@@ -1,0 +1,159 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshStartupCheck;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The startup verdict rules (RFC #1502).
+ *
+ * <p>Each is the OPPOSITE of the corresponding {@code @MeshHealthCheck} rule,
+ * and that is the point of the file: a throw FAILS here (it degrades there),
+ * and there is no partial credit for {@code DEGRADED}. See
+ * {@link MeshStartupCheckRegistry} for why.
+ */
+class MeshStartupCheckRegistryTest {
+
+    static class Checks {
+
+        @MeshStartupCheck
+        public boolean passes() {
+            return true;
+        }
+
+        @MeshStartupCheck
+        public boolean fails() {
+            return false;
+        }
+
+        @MeshStartupCheck
+        public boolean throwsUp() {
+            throw new IllegalStateException("ANTHROPIC_API_KEY is not set");
+        }
+
+        @MeshStartupCheck
+        public MeshHealth healthy() {
+            return MeshHealth.healthy().withCheck("api_key_present", true);
+        }
+
+        @MeshStartupCheck
+        public MeshHealth unhealthy() {
+            return MeshHealth.unhealthy("no key").withCheck("api_key_present", false);
+        }
+
+        @MeshStartupCheck
+        public MeshHealth degraded() {
+            return new MeshHealth(io.mcpmesh.MeshHealthStatus.DEGRADED, null, null);
+        }
+    }
+
+    private static MeshStartupCheckRegistry registryFor(String methodName) throws Exception {
+        MeshStartupCheckRegistry registry = new MeshStartupCheckRegistry();
+        Method method = Checks.class.getMethod(methodName);
+        registry.register(new Checks(), method);
+        return registry;
+    }
+
+    @Test
+    void noCheckDeclared_passes() {
+        MeshStartupCheckRegistry registry = new MeshStartupCheckRegistry();
+        assertFalse(registry.hasStartupCheck());
+        assertTrue(registry.execute().passed(),
+            "an agent that declares no startup check must behave exactly as it does today");
+    }
+
+    @Test
+    void trueReturn_passes() throws Exception {
+        MeshStartupCheckRegistry.Verdict verdict = registryFor("passes").execute();
+        assertTrue(verdict.passed());
+        assertTrue(verdict.errors().isEmpty());
+    }
+
+    @Test
+    void falseReturn_fails() throws Exception {
+        MeshStartupCheckRegistry.Verdict verdict = registryFor("fails").execute();
+        assertFalse(verdict.passed());
+        assertEquals("Startup check returned false", verdict.errors().get(0));
+        assertEquals(Boolean.FALSE, verdict.checks().get("startup_check"));
+    }
+
+    @Test
+    void aThrow_failsRatherThanDegrading() throws Exception {
+        // The opposite of MeshHealthCheckRegistry.execute(), where a throw is
+        // DEGRADED so a buggy probe cannot withdraw a working provider. At boot
+        // an indeterminate answer is not a reason to let a possibly
+        // misconfigured agent through.
+        MeshStartupCheckRegistry.Verdict verdict = registryFor("throwsUp").execute();
+        assertFalse(verdict.passed());
+        assertEquals(Boolean.FALSE, verdict.checks().get("startup_check_execution"));
+        assertTrue(verdict.errors().get(0).contains("ANTHROPIC_API_KEY is not set"));
+    }
+
+    @Test
+    void meshHealthHealthy_passesAndCarriesItsChecks() throws Exception {
+        MeshStartupCheckRegistry.Verdict verdict = registryFor("healthy").execute();
+        assertTrue(verdict.passed());
+        assertEquals(Boolean.TRUE, verdict.checks().get("api_key_present"));
+    }
+
+    @Test
+    void meshHealthUnhealthy_fails() throws Exception {
+        MeshStartupCheckRegistry.Verdict verdict = registryFor("unhealthy").execute();
+        assertFalse(verdict.passed());
+        assertEquals("no key", verdict.errors().get(0));
+    }
+
+    @Test
+    void degraded_failsThereIsNoPartialCredit() throws Exception {
+        MeshStartupCheckRegistry.Verdict verdict = registryFor("degraded").execute();
+        assertFalse(verdict.passed());
+        assertEquals("Startup check reported 'degraded'", verdict.errors().get(0));
+    }
+
+    @Test
+    void anUnrecognizedReturn_fails() {
+        MeshStartupCheckRegistry.Verdict verdict = MeshStartupCheckRegistry.coerce("yes");
+        assertFalse(verdict.passed());
+        assertEquals(Boolean.FALSE, verdict.checks().get("startup_check_return_type"));
+        assertTrue(verdict.errors().get(0).contains("java.lang.String"));
+    }
+
+    @Test
+    void nullReturn_fails() {
+        assertFalse(MeshStartupCheckRegistry.coerce(null).passed());
+    }
+
+    @Test
+    void theCheckRunsOnEveryCall_thereIsNoCache() throws Exception {
+        class Counting {
+            int calls;
+
+            @MeshStartupCheck
+            public boolean check() {
+                calls++;
+                return true;
+            }
+        }
+        Counting bean = new Counting();
+        MeshStartupCheckRegistry registry = new MeshStartupCheckRegistry();
+        registry.register(bean, Counting.class.getMethod("check"));
+
+        registry.execute();
+        registry.execute();
+        registry.execute();
+        assertEquals(3, bean.calls,
+            "startupProbe stops polling on first success — there is nothing to cache");
+    }
+
+    @Test
+    void twoChecks_isRejected() throws Exception {
+        MeshStartupCheckRegistry registry = registryFor("passes");
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+            () -> registry.register(new Checks(), Checks.class.getMethod("fails")));
+        assertTrue(e.getMessage().contains("Two @MeshStartupCheck methods"));
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshStartupzControllerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshStartupzControllerTest.java
@@ -1,0 +1,199 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshStartupCheck;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * {@code GET}/{@code HEAD} {@code /startupz} — RFC #1502.
+ *
+ * <p>Java serves every agent type from one controller, so unlike Python and
+ * TypeScript there is a single site to pin. What that costs is that the
+ * per-agent-type rules live in branches rather than in separate files — the
+ * gateway case below is asserted here rather than in a second test class.
+ */
+class MeshStartupzControllerTest {
+
+    static class Checks {
+
+        @MeshStartupCheck
+        public boolean passes() {
+            return true;
+        }
+
+        @MeshStartupCheck
+        public boolean fails() {
+            return false;
+        }
+
+        @MeshStartupCheck
+        public boolean throwsUp() {
+            throw new IllegalStateException("ANTHROPIC_API_KEY is not set");
+        }
+
+        @MeshStartupCheck
+        public MeshHealth unhealthyWithDetail() {
+            return MeshHealth.unhealthy("no key").withCheck("api_key_present", false);
+        }
+    }
+
+    private static MeshStartupCheckRegistry withCheck(String methodName) {
+        try {
+            MeshStartupCheckRegistry registry = new MeshStartupCheckRegistry();
+            Method method = Checks.class.getMethod(methodName);
+            registry.register(new Checks(), method);
+            return registry;
+        } catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static MeshRuntime runtimeOf(String agentType, boolean running) {
+        MeshRuntime runtime = mock(MeshRuntime.class);
+        when(runtime.isRunning()).thenReturn(running);
+        io.mcpmesh.core.AgentSpec spec = new io.mcpmesh.core.AgentSpec();
+        spec.setName("agent");
+        spec.setAgentType(agentType);
+        when(runtime.getAgentSpec()).thenReturn(spec);
+        return runtime;
+    }
+
+    private static MeshHealthController controller(MeshStartupCheckRegistry startup) {
+        return new MeshHealthController(runtimeOf("mcp", true), null, startup);
+    }
+
+    @Test
+    void noCheckDeclared_is200() {
+        MeshHealthController c = controller(new MeshStartupCheckRegistry());
+        ResponseEntity<Map<String, Object>> response = c.startupz();
+
+        assertEquals(200, response.getStatusCode().value(),
+            "an agent that declares no startup check must behave exactly as it does today");
+        assertEquals(Boolean.TRUE, response.getBody().get("started"));
+        assertEquals("agent", response.getBody().get("agent"));
+        assertNotNull(response.getBody().get("timestamp"));
+    }
+
+    @Test
+    void noRegistryAtAll_is200() {
+        // The two-argument constructor (tests, hand-wiring) means no check.
+        MeshHealthController c = new MeshHealthController(runtimeOf("mcp", true), null);
+        assertEquals(200, c.startupz().getStatusCode().value());
+        assertEquals(200, c.startupzHead().getStatusCode().value());
+    }
+
+    @Test
+    void passingCheck_is200() {
+        assertEquals(200, controller(withCheck("passes")).startupz().getStatusCode().value());
+    }
+
+    @Test
+    void failingCheck_is503WithAReason() {
+        ResponseEntity<Map<String, Object>> response =
+            controller(withCheck("fails")).startupz();
+
+        assertEquals(503, response.getStatusCode().value());
+        assertEquals(Boolean.FALSE, response.getBody().get("started"));
+        assertEquals("Startup check failed", response.getBody().get("reason"));
+        assertNotNull(response.getBody().get("errors"));
+    }
+
+    @Test
+    void throwingCheck_is503_notA500() {
+        // The endpoint must not propagate the throw, and unlike health_check a
+        // throw does NOT degrade into a pass.
+        ResponseEntity<Map<String, Object>> response =
+            controller(withCheck("throwsUp")).startupz();
+
+        assertEquals(503, response.getStatusCode().value());
+        assertTrue(response.getBody().get("errors").toString()
+            .contains("ANTHROPIC_API_KEY is not set"));
+    }
+
+    @Test
+    void theBodyCarriesEnoughToDiagnose() {
+        ResponseEntity<Map<String, Object>> response =
+            controller(withCheck("unhealthyWithDetail")).startupz();
+
+        assertEquals(503, response.getStatusCode().value());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> checks = (Map<String, Object>) response.getBody().get("checks");
+        assertEquals(Boolean.FALSE, checks.get("api_key_present"));
+        assertTrue(response.getBody().get("errors").toString().contains("no key"));
+    }
+
+    @Test
+    void headMatchesGet() {
+        MeshHealthController passing = controller(withCheck("passes"));
+        assertEquals(passing.startupz().getStatusCode().value(),
+            passing.startupzHead().getStatusCode().value());
+        assertEquals(200, passing.startupzHead().getStatusCode().value());
+
+        MeshHealthController failing = controller(withCheck("fails"));
+        assertEquals(failing.startupz().getStatusCode().value(),
+            failing.startupzHead().getStatusCode().value());
+        assertEquals(503, failing.startupzHead().getStatusCode().value());
+    }
+
+    @Test
+    void gatewaysAreNotExempt_unlikeTheHealthCheck() {
+        // #1488 exempts api/a2a agents from readiness withdrawal by their own
+        // health check. startup_check withdraws nothing — it only stops a
+        // misconfigured gateway from coming up — so the exemption does not
+        // apply to it.
+        for (String agentType : java.util.List.of("api", "a2a")) {
+            MeshHealthController c = new MeshHealthController(
+                runtimeOf(agentType, true), null, withCheck("fails"));
+            assertEquals(503, c.startupz().getStatusCode().value(),
+                "'" + agentType + "' gateway with a broken config must not come up");
+        }
+    }
+
+    @Test
+    void doesNotConsultTheRuntime() {
+        // The mesh runtime starts late in the Spring lifecycle, and startupProbe
+        // exists to cover exactly that window. Flooring on isRunning() would
+        // fail the probe for the whole boot it is meant to be waiting through.
+        MeshRuntime runtime = mock(MeshRuntime.class);
+        when(runtime.isRunning()).thenReturn(false);
+        MeshHealthController c =
+            new MeshHealthController(runtime, null, withCheck("passes"));
+
+        assertEquals(200, c.startupz().getStatusCode().value());
+        verify(runtime, never()).isRunning();
+    }
+
+    @Test
+    void is200_whenTheLazyRuntimeProxyRaises() {
+        MeshRuntime runtime = mock(MeshRuntime.class);
+        when(runtime.getAgentSpec()).thenThrow(new IllegalStateException("bean not ready"));
+        MeshHealthController c =
+            new MeshHealthController(runtime, null, withCheck("passes"));
+
+        ResponseEntity<Map<String, Object>> response = c.startupz();
+        assertEquals(200, response.getStatusCode().value());
+        assertNull(response.getBody().get("agent"));
+    }
+
+    @Test
+    void livezStaysUnconditional() {
+        MeshHealthController c = controller(withCheck("fails"));
+        assertEquals(200, c.livez().getStatusCode().value());
+        assertEquals(200, c.livezHead().getStatusCode().value());
+    }
+
+    @Test
+    void readyIsUnchangedByAFailingStartupCheck() {
+        // Step 1 is additive: /ready keeps reflecting the health verdict only.
+        MeshHealthController c = controller(withCheck("fails"));
+        assertEquals(200, c.ready().getStatusCode().value());
+        assertEquals(200, c.health().getStatusCode().value());
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshStartupzControllerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshStartupzControllerTest.java
@@ -162,7 +162,6 @@ class MeshStartupzControllerTest {
         // exists to cover exactly that window. Flooring on isRunning() would
         // fail the probe for the whole boot it is meant to be waiting through.
         MeshRuntime runtime = mock(MeshRuntime.class);
-        when(runtime.isRunning()).thenReturn(false);
         MeshHealthController c =
             new MeshHealthController(runtime, null, withCheck("passes"));
 

--- a/src/runtime/python/_mcp_mesh/pipeline/shared/health_endpoints.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/shared/health_endpoints.py
@@ -15,6 +15,12 @@ Semantics (matching TypeScript's ``express.ts`` ``setupHealthEndpoints``):
     must not share a verdict with readiness, or a dependency outage that
     should only make the service unready restarts the pod instead.
 
+``/startupz``
+    The user's ``startup_check`` (RFC #1502). Unlike ``health_check`` this one
+    IS honoured on a gateway: it does not withdraw anything at runtime, it
+    decides whether a misconfigured gateway is allowed to come up at all, and
+    a gateway with a broken config should never come up.
+
 ``/ready``
     Whether the **mesh runtime** is up — a live Rust core handle exists and
     shutdown has not been requested — and nothing else.
@@ -30,7 +36,7 @@ For the same reason there is no health-refresh loop on these pipelines.
 
 The app is the user's, so each path is registered only if the application has
 not already defined it (``examples/python/mesh-api/main.py`` hand-rolls
-``/health`` precisely because mesh never did). The three are registered
+``/health`` precisely because mesh never did). Each is registered
 independently: an app that defines only ``/health`` still gets ``/livez`` and
 ``/ready``. The check is an explicit route walk rather than a reliance on
 Starlette's first-match-wins ordering — behaviour that depends on registration
@@ -51,6 +57,7 @@ logger = logging.getLogger(__name__)
 LIVEZ_PATH = "/livez"
 READY_PATH = "/ready"
 HEALTH_PATH = "/health"
+STARTUPZ_PATH = "/startupz"
 
 # Stamped on the handlers mesh registers so a second pipeline pass (or a
 # second discovered app object that shares a router) can tell its own
@@ -133,7 +140,7 @@ def register_health_endpoints(
     service_type: str,
     standalone: bool = False,
 ) -> dict[str, str]:
-    """Register ``/livez``, ``/ready`` and ``/health`` on a user-owned app.
+    """Register ``/livez``, ``/startupz``, ``/ready`` and ``/health`` on a user-owned app.
 
     Args:
         app: the user's FastAPI application
@@ -141,7 +148,7 @@ def register_health_endpoints(
         standalone: MCP_MESH_STANDALONE — no registry, hence no Rust handle
 
     Returns:
-        ``{path: outcome}`` for all three paths, where outcome is one of
+        ``{path: outcome}`` for every path, where outcome is one of
         ``registered`` / ``user_defined`` / ``already_registered``.
 
     Raises:
@@ -159,6 +166,18 @@ def register_health_endpoints(
             status_code=200,
             content=build_livez_response(agent_name=_agent_name()),
         )
+
+    async def startupz():
+        # RFC #1502. The one hook a gateway DOES honour: it never withdraws a
+        # running fan-out point, it only stops a misconfigured one from coming
+        # up. Runs per hit — startupProbe stops polling on first success.
+        from ...shared.startup_check_manager import build_startupz_response
+
+        body, status_code = await build_startupz_response(
+            agent_name=_agent_name(),
+            service_type=service_type,
+        )
+        return JSONResponse(status_code=status_code, content=body)
 
     async def ready():
         is_ready, state = runtime_state(standalone)
@@ -190,7 +209,12 @@ def register_health_endpoints(
             },
         )
 
-    handlers = ((LIVEZ_PATH, livez), (READY_PATH, ready), (HEALTH_PATH, health))
+    handlers = (
+        (LIVEZ_PATH, livez),
+        (STARTUPZ_PATH, startupz),
+        (READY_PATH, ready),
+        (HEALTH_PATH, health),
+    )
 
     outcomes: dict[str, str] = {}
     for path, handler in handlers:
@@ -221,7 +245,8 @@ class HealthEndpointsStep(PipelineStep):
 
     Shared by the api (``@mesh.route``) and a2a (``@mesh.a2a``) pipelines —
     both hand mesh an app they do not own, and both are deployed with the
-    agent Helm chart that probes ``/livez`` and ``/ready``.
+    agent Helm chart that probes ``/livez`` and ``/ready`` (and, once the
+    chart is repointed, ``/startupz``).
 
     Optional (``required=False``): a failure here must not stop the gateway
     from starting. It is loud instead — the alternative, aborting startup,
@@ -232,7 +257,7 @@ class HealthEndpointsStep(PipelineStep):
         super().__init__(
             name="health-endpoints",
             required=False,
-            description="Register /livez, /ready and /health on the user's FastAPI app",
+            description="Register /livez, /startupz, /ready and /health on the user's FastAPI app",
         )
         self.service_type = service_type
 

--- a/src/runtime/python/_mcp_mesh/pipeline/shared/health_endpoints.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/shared/health_endpoints.py
@@ -49,6 +49,7 @@ from typing import Any, Optional
 
 from ...shared.config_resolver import ValidationRule, get_config_value
 from ...shared.fastapi_routes import iter_app_routes
+from ...shared.startup_check_manager import STARTUPZ_PATH
 from .base_step import PipelineStep
 from .pipeline_types import PipelineResult, PipelineStatus
 
@@ -57,7 +58,9 @@ logger = logging.getLogger(__name__)
 LIVEZ_PATH = "/livez"
 READY_PATH = "/ready"
 HEALTH_PATH = "/health"
-STARTUPZ_PATH = "/startupz"
+# STARTUPZ_PATH is imported, not redeclared: the hook module owns the path it
+# is served on, and two spellings of "/startupz" is one rename away from a
+# gateway serving the endpoint on a path nothing probes.
 
 # Stamped on the handlers mesh registers so a second pipeline pass (or a
 # second discovered app object that shares a router) can tell its own

--- a/src/runtime/python/_mcp_mesh/shared/startup_check_manager.py
+++ b/src/runtime/python/_mcp_mesh/shared/startup_check_manager.py
@@ -1,0 +1,178 @@
+"""The ``startup_check`` hook and the ``/startupz`` response (RFC #1502).
+
+``health_check`` answers "can I serve *right now*?" — a transient answer, and a
+failing one only pauses the heartbeat so the registry stops selecting this agent
+until it recovers. ``startup_check`` answers the other question: "is this agent
+configured such that it can *ever* serve?" A missing API key is not going to fix
+itself, and today it looks exactly like a vendor outage — the agent sits
+unregistered, the pod runs, and nothing is loud.
+
+``startup_check`` is reported by ``/startupz``, which the agent chart's
+``startupProbe`` polls. A pod whose startup check never passes never becomes
+ready, never registers, and ends up in ``CrashLoopBackOff`` — visible.
+
+Three properties are deliberate, and each is the OPPOSITE of the corresponding
+``health_check`` rule:
+
+``A throw fails the check.``
+    ``health_check`` degrades on a throw (a buggy probe must not withdraw a
+    working provider from a mesh that may have no other one). Here the question
+    is whether a possibly-misconfigured agent should be allowed to come up at
+    all, and an indeterminate answer at boot is not a reason to let it through.
+    The cost of being wrong is also asymmetric: a false failure crash-loops one
+    pod that was never serving, a false pass silently registers a broken one.
+
+``Anything short of a clean pass fails.``
+    ``degraded``, an unrecognized return type, ``None`` — all fail. There is no
+    partial credit for "am I configured".
+
+``There is no cache.``
+    ``startupProbe`` stops polling after its first success, so the check runs a
+    handful of times at most. A TTL cache would only add a way for the endpoint
+    to answer with a verdict older than the probe that asked for it.
+
+An agent that declares no ``startup_check`` passes. Default-true is what makes
+this purely additive: every existing agent behaves exactly as it did.
+"""
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from .support_types import HealthStatus, HealthStatusType
+
+logger = logging.getLogger(__name__)
+
+STARTUPZ_PATH = "/startupz"
+
+#: Key under which ``@mesh.agent(startup_check=...)`` stores the callable.
+STARTUP_CHECK_CONFIG_KEY = "startup_check"
+
+
+def get_startup_check() -> Callable[[], Any] | None:
+    """The agent's ``startup_check``, or None when none was declared.
+
+    Resolved per call rather than captured once: the probe endpoints are
+    registered before the pipeline has finished writing the resolved agent
+    config, so reading it at request time is the only way to see a check the
+    decorator declared.
+    """
+    try:
+        from ..engine.decorator_registry import DecoratorRegistry
+
+        config = DecoratorRegistry.get_resolved_agent_config() or {}
+    except Exception as e:  # pragma: no cover - defensive
+        # Never let a config-lookup failure decide that an agent is broken:
+        # not finding a check is "no check declared", which passes.
+        logger.debug("Could not resolve agent config for startup_check: %s", e)
+        return None
+
+    check = config.get(STARTUP_CHECK_CONFIG_KEY)
+    return check if callable(check) else None
+
+
+def _parse_startup_result(raw: Any) -> tuple[bool, dict, list]:
+    """Reduce whatever the check returned to ``(passed, checks, errors)``.
+
+    The accepted shapes are ``health_check``'s, so an author writing both hooks
+    writes them the same way: a bool, a ``{status, checks, errors}`` dict, or a
+    ``HealthStatus``. What differs is the verdict mapping — only a clean
+    ``healthy``/``True`` passes (see the module docstring).
+    """
+    if isinstance(raw, bool):
+        return raw, {"startup_check": raw}, [] if raw else ["Startup check returned False"]
+
+    if isinstance(raw, dict):
+        status = str(raw.get("status", "healthy")).lower()
+        passed = status == "healthy"
+        errors = list(raw.get("errors", []))
+        if not passed and not errors:
+            errors = [f"Startup check reported '{status}'"]
+        return passed, dict(raw.get("checks", {})), errors
+
+    if isinstance(raw, HealthStatus):
+        passed = raw.status == HealthStatusType.HEALTHY
+        errors = list(raw.errors)
+        if not passed and not errors:
+            errors = [f"Startup check reported '{raw.status.value}'"]
+        return passed, dict(raw.checks), errors
+
+    type_name = type(raw).__name__
+    logger.warning(
+        "startup_check returned '%s', which is not a startup verdict — failing "
+        "the startup probe. Return a bool, a {status, checks, errors} dict, or "
+        "a HealthStatus.",
+        type_name,
+    )
+    return (
+        False,
+        {"startup_check_return_type": False},
+        [
+            f"Invalid return type: {type_name}. A startup check returns a bool, "
+            f"a {{status, checks, errors}} dict, or a HealthStatus."
+        ],
+    )
+
+
+async def run_startup_check(
+    check: Callable[[], Any] | Callable[[], Awaitable[Any]] | None,
+) -> tuple[bool, dict, list]:
+    """Run ``check`` once and report ``(passed, checks, errors)``.
+
+    Never raises. Sync and async checks are both accepted — a startup check is
+    often a bare environment-variable read, and forcing ``async def`` on it
+    would be ceremony with no payoff.
+    """
+    if check is None:
+        return True, {}, []
+
+    try:
+        result = check()
+        if inspect.isawaitable(result):
+            result = await result
+    except Exception as e:
+        # Broad on purpose. A throwing check must not take the endpoint down
+        # with it, and unlike health_check (where a throw degrades and the
+        # agent keeps heartbeating) it must not pass either — see the module
+        # docstring on why an indeterminate boot-time answer fails.
+        logger.warning("startup_check raised — failing the startup probe: %s", e)
+        return False, {"startup_check_execution": False}, [f"Startup check failed: {e}"]
+
+    return _parse_startup_result(result)
+
+
+async def build_startupz_response(
+    agent_name: str,
+    check: Callable[[], Any] | None = None,
+    **extra: Any,
+) -> tuple[dict, int]:
+    """Build the ``/startupz`` body and status code.
+
+    Mirrors ``build_ready_response``'s shape — a ``started`` boolean in place of
+    ``ready``, and ``reason``/``errors`` on failure — so an operator reads the
+    two probes the same way.
+
+    Args:
+        agent_name: name reported in the body
+        check: the check to run; resolved from the agent config when omitted
+        extra: additional body keys (e.g. ``service_type`` on a gateway)
+    """
+    if check is None:
+        check = get_startup_check()
+
+    passed, checks, errors = await run_startup_check(check)
+
+    body: dict[str, Any] = {
+        "started": passed,
+        "agent": agent_name,
+        **extra,
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+    if checks:
+        body["checks"] = checks
+    if not passed:
+        body["reason"] = "Startup check failed"
+        body["errors"] = errors
+    return body, (200 if passed else 503)

--- a/src/runtime/python/_mcp_mesh/shared/startup_check_manager.py
+++ b/src/runtime/python/_mcp_mesh/shared/startup_check_manager.py
@@ -7,9 +7,16 @@ configured such that it can *ever* serve?" A missing API key is not going to fix
 itself, and today it looks exactly like a vendor outage — the agent sits
 unregistered, the pod runs, and nothing is loud.
 
-``startup_check`` is reported by ``/startupz``, which the agent chart's
-``startupProbe`` polls. A pod whose startup check never passes never becomes
-ready, never registers, and ends up in ``CrashLoopBackOff`` — visible.
+**What ships today (RFC #1502 step 1).** ``startup_check`` is reported by
+``GET``/``HEAD`` ``/startupz``, and that is the whole effect: a failing check
+answers 503 there. Nothing else changes — the agent is not withdrawn, the
+heartbeat is untouched, ``/livez`` and ``/ready`` answer exactly as they did.
+
+The agent chart's ``startupProbe`` still points at ``/livez``, so nothing acts
+on the verdict yet. Repointing it at ``/startupz`` is step 2, and it is what
+the hook exists for: a pod whose startup check never passes then never becomes
+ready, never registers, and ends up in ``CrashLoopBackOff`` — visible. Until
+then, ``/startupz`` is a surface to build against and to scrape.
 
 Three properties are deliberate, and each is the OPPOSITE of the corresponding
 ``health_check`` rule:
@@ -27,8 +34,8 @@ Three properties are deliberate, and each is the OPPOSITE of the corresponding
     partial credit for "am I configured".
 
 ``There is no cache.``
-    ``startupProbe`` stops polling after its first success, so the check runs a
-    handful of times at most. A TTL cache would only add a way for the endpoint
+    A ``startupProbe`` stops polling after its first success, so the check runs
+    a handful of times at most. A TTL cache would only add a way for the endpoint
     to answer with a verdict older than the probe that asked for it.
 
 An agent that declares no ``startup_check`` passes. Default-true is what makes
@@ -41,6 +48,7 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import Any
 
+from .health_check_manager import _for_warning
 from .support_types import HealthStatus, HealthStatusType
 
 logger = logging.getLogger(__name__)
@@ -82,21 +90,29 @@ def _parse_startup_result(raw: Any) -> tuple[bool, dict, list]:
     ``healthy``/``True`` passes (see the module docstring).
     """
     if isinstance(raw, bool):
-        return raw, {"startup_check": raw}, [] if raw else ["Startup check returned False"]
+        return (
+            raw,
+            {"startup_check": raw},
+            [] if raw else ["Startup check returned False"],
+        )
 
     if isinstance(raw, dict):
         status = str(raw.get("status", "healthy")).lower()
         passed = status == "healthy"
         errors = list(raw.get("errors", []))
         if not passed and not errors:
-            errors = [f"Startup check reported '{status}'"]
+            errors = [f"Startup check reported '{_for_warning(status)}'"]
         return passed, dict(raw.get("checks", {})), errors
 
     if isinstance(raw, HealthStatus):
         passed = raw.status == HealthStatusType.HEALTHY
         errors = list(raw.errors)
         if not passed and not errors:
-            errors = [f"Startup check reported '{raw.status.value}'"]
+            # Not ``raw.status.value``: ``model_construct`` skips validation, so
+            # ``status`` need not be the enum, and interpolating a user value is
+            # the hazard ``_for_warning`` exists for (see health_check_manager).
+            status = getattr(raw.status, "value", raw.status)
+            errors = [f"Startup check reported '{_for_warning(status)}'"]
         return passed, dict(raw.checks), errors
 
     type_name = type(raw).__name__
@@ -132,6 +148,12 @@ async def run_startup_check(
         result = check()
         if inspect.isawaitable(result):
             result = await result
+        # Parsed INSIDE the guard, not after it. Reducing the return value
+        # touches user-controlled attributes — a lazily-computed ``status``, a
+        # dict-like config object — and a raise there is exactly as
+        # indeterminate as a raise from the check itself. Parsing outside would
+        # leave the one path this hook exists for able to 500 the endpoint.
+        return _parse_startup_result(result)
     except Exception as e:
         # Broad on purpose. A throwing check must not take the endpoint down
         # with it, and unlike health_check (where a throw degrades and the
@@ -139,8 +161,6 @@ async def run_startup_check(
         # docstring on why an indeterminate boot-time answer fails.
         logger.warning("startup_check raised — failing the startup probe: %s", e)
         return False, {"startup_check_execution": False}, [f"Startup check failed: {e}"]
-
-    return _parse_startup_result(result)
 
 
 async def build_startupz_response(

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -488,7 +488,7 @@ def _start_uvicorn_immediately(http_host: str, http_port: int):
 
             RFC #1502: the "will this ever work" verdict, as opposed to
             ``health_check``'s "can I serve right now". The check runs on every
-            hit; ``startupProbe`` stops polling once it passes, so there is
+            hit; a ``startupProbe`` stops polling once it passes, so there is
             nothing to cache.
             """
             data, status_code = await build_startupz_response(
@@ -1511,9 +1511,12 @@ def agent(
             (RFC #1502). Where ``health_check`` answers "can I serve right now"
             — a failing one pauses the heartbeat until it recovers —
             ``startup_check`` answers "is this agent configured such that it
-            can ever serve". The chart's ``startupProbe`` polls ``/startupz``,
-            so a check that never passes means the pod never becomes ready,
-            never registers, and lands in CrashLoopBackOff where it is visible.
+            can ever serve". Today (step 1) the verdict is reported by
+            ``/startupz`` and nothing else — a failing check answers 503 there,
+            and the heartbeat, ``/livez`` and ``/ready`` are all unchanged.
+            Pointing the chart's ``startupProbe`` at ``/startupz``, so that a
+            check which never passes keeps the pod from becoming ready and
+            lands it in CrashLoopBackOff where it is visible, is step 2.
             Returns a bool, a {status, checks, errors} dict, or a HealthStatus.
             Only a clean pass passes: a throw, a degraded verdict or an
             unrecognized return all fail the probe (the opposite of

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -479,6 +479,24 @@ def _start_uvicorn_immediately(http_host: str, http_port: int):
             """Kubernetes liveness probe - always returns 200 if app is running."""
             return build_livez_response(agent_name="mcp-mesh-agent")
 
+        from _mcp_mesh.shared.startup_check_manager import build_startupz_response
+
+        @app.get("/startupz")
+        @app.head("/startupz")
+        async def startupz(response: Response):
+            """Kubernetes startup probe - reports the agent's ``startup_check``.
+
+            RFC #1502: the "will this ever work" verdict, as opposed to
+            ``health_check``'s "can I serve right now". The check runs on every
+            hit; ``startupProbe`` stops polling once it passes, so there is
+            nothing to cache.
+            """
+            data, status_code = await build_startupz_response(
+                agent_name="mcp-mesh-agent"
+            )
+            response.status_code = status_code
+            return data
+
         @app.get("/immediate-status")
         def immediate_status():
             return {
@@ -1459,6 +1477,7 @@ def agent(
     heartbeat_interval: int = 5,
     health_check: Callable[[], Awaitable[Any]] | None = None,
     health_check_ttl: int = 15,
+    startup_check: Callable[[], Any] | None = None,
     auto_run: bool = True,  # Changed to True by default!
     auto_run_interval: int = 10,
     **kwargs: Any,
@@ -1488,6 +1507,19 @@ def agent(
         health_check_ttl: Cache TTL for health check results in seconds (default: 15)
             Reduces expensive health check calls by caching results
             Environment variable: MCP_MESH_HEALTH_CHECK_TTL (takes precedence)
+        startup_check: Optional sync or async function reported by ``/startupz``
+            (RFC #1502). Where ``health_check`` answers "can I serve right now"
+            — a failing one pauses the heartbeat until it recovers —
+            ``startup_check`` answers "is this agent configured such that it
+            can ever serve". The chart's ``startupProbe`` polls ``/startupz``,
+            so a check that never passes means the pod never becomes ready,
+            never registers, and lands in CrashLoopBackOff where it is visible.
+            Returns a bool, a {status, checks, errors} dict, or a HealthStatus.
+            Only a clean pass passes: a throw, a degraded verdict or an
+            unrecognized return all fail the probe (the opposite of
+            ``health_check``, which degrades rather than withdrawing — see
+            ``_mcp_mesh.shared.startup_check_manager``). Omitting it passes,
+            so this is purely additive.
         auto_run: Automatically start service and keep process alive (default: True)
             Environment variable: MCP_MESH_AUTO_RUN (takes precedence)
         auto_run_interval: Keep-alive heartbeat interval in seconds (default: 10)
@@ -1572,6 +1604,9 @@ def agent(
         if health_check_ttl < 1:
             raise ValueError("health_check_ttl must be at least 1 second")
 
+        if startup_check is not None and not callable(startup_check):
+            raise ValueError("startup_check must be a callable (sync or async)")
+
         # Separate binding host (for uvicorn server) from external host (for registry)
         from _mcp_mesh.shared.host_resolver import HostResolver
 
@@ -1645,6 +1680,7 @@ def agent(
             "heartbeat_interval": final_heartbeat_interval,
             "health_check": health_check,
             "health_check_ttl": health_check_ttl,
+            "startup_check": startup_check,
             "auto_run": final_auto_run,
             "auto_run_interval": final_auto_run_interval,
             "agent_id": agent_id,

--- a/src/runtime/python/tests/unit/test_startupz_1502.py
+++ b/src/runtime/python/tests/unit/test_startupz_1502.py
@@ -76,6 +76,11 @@ def _gateway_app(pipeline_cls=APIPipeline, app=None):
     return app
 
 
+async def _async_true():
+    """The async half of the sync/async parametrisation below."""
+    return True
+
+
 @pytest.fixture
 def runtime_up(monkeypatch):
     from _mcp_mesh.shared import simple_shutdown
@@ -142,14 +147,12 @@ class TestRunStartupCheck:
 
     @pytest.mark.parametrize(
         "check",
-        [lambda: True, pytest.param(None, id="async")],
+        [
+            pytest.param(lambda: True, id="sync"),
+            pytest.param(_async_true, id="async"),
+        ],
     )
     def test_true_passes_sync_and_async(self, check):
-        if check is None:
-
-            async def check():  # noqa: F811 - the async variant
-                return True
-
         passed, _, errors = asyncio.run(run_startup_check(check))
         assert passed is True
         assert errors == []
@@ -233,6 +236,50 @@ class TestRunStartupCheck:
         passed, _, _ = asyncio.run(run_startup_check(lambda: None))
         assert passed is False
 
+    def test_a_dict_whose_lookup_raises_fails_rather_than_propagating(self):
+        """Fail-closed covers reducing the return value, not just calling it.
+
+        A check that hands back a dict-like config object — one lazily backed
+        by a vendor client that is the very thing missing — must fail the probe
+        the same way a throwing check does, not 500 the endpoint.
+        """
+
+        class HostileDict(dict):
+            def get(self, *args, **kwargs):
+                raise RuntimeError("config not loaded")
+
+        passed, _, errors = asyncio.run(run_startup_check(lambda: HostileDict()))
+        assert passed is False
+        assert "config not loaded" in errors[0]
+
+    def test_a_health_status_with_an_unvalidated_status_fails_closed(self):
+        """``raw.status.value`` is only safe while validation has run.
+
+        ``model_construct`` bypasses it, and formatting the *value* rather than
+        the type into a message is the hazard ``health_check_manager``'s
+        ``_for_warning`` exists for.
+        """
+        from _mcp_mesh.shared.support_types import HealthStatus
+
+        raw = HealthStatus.model_construct(
+            agent_name="a", status="not-an-enum", capabilities=["c"]
+        )
+
+        passed, _, errors = asyncio.run(run_startup_check(lambda: raw))
+        assert passed is False
+        assert errors
+
+    def test_an_unrepresentable_return_type_still_fails_closed(self):
+        """The invalid-type path names the TYPE, never ``repr`` of the value."""
+
+        class Unprintable:
+            def __repr__(self):
+                raise RuntimeError("cannot repr")
+
+        passed, _, errors = asyncio.run(run_startup_check(lambda: Unprintable()))
+        assert passed is False
+        assert "Unprintable" in errors[0]
+
     def test_the_check_runs_on_every_call_there_is_no_cache(self):
         calls = []
 
@@ -299,6 +346,13 @@ class TestProviderEndpoint:
             started.wait(timeout=5)
 
         monkeypatch.setattr(uvicorn.Server, "run", fake_run)
+        # `_start_uvicorn_immediately` ends by JOINING the server thread, which
+        # here is parked in `fake_run` — without this the fixture blocks for the
+        # full 5s budget before yielding (8 tests x 5s), and the real function
+        # installs process-wide SIGINT/SIGTERM handlers on its way there.
+        monkeypatch.setattr(
+            decorators, "start_blocking_loop_with_shutdown_support", lambda thread: None
+        )
         saved = list(simple_shutdown._simple_shutdown_coordinator._uvicorn_servers)
         try:
             decorators._start_uvicorn_immediately(BIND_HOST, 0)

--- a/src/runtime/python/tests/unit/test_startupz_1502.py
+++ b/src/runtime/python/tests/unit/test_startupz_1502.py
@@ -1,0 +1,470 @@
+"""``startup_check`` and ``/startupz`` — RFC #1502, step 1.
+
+``health_check`` answers "can I serve right now" and a failing one pauses the
+heartbeat until it recovers. ``startup_check`` answers "is this agent
+configured such that it can ever serve", and the chart's ``startupProbe`` will
+poll ``/startupz`` for it, so a check that never passes means the pod never
+becomes ready and lands in CrashLoopBackOff where it is visible.
+
+Both Python sites that serve ``/livez`` are covered:
+
+* ``mesh/decorators.py`` — the ``@mesh.agent`` (MCP provider) path, whose app
+  is built by ``_start_uvicorn_immediately``;
+* ``_mcp_mesh/pipeline/shared/health_endpoints.py`` — the ``@mesh.route`` /
+  ``@mesh.a2a`` gateway path (#1491), where a user-defined path wins.
+
+The verdict rules are the OPPOSITE of ``health_check``'s and are asserted as
+such: a throw fails (it does not degrade), and anything short of a clean pass
+fails. See ``_mcp_mesh.shared.startup_check_manager`` for why.
+"""
+
+import asyncio
+import socket
+import threading
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from _mcp_mesh.pipeline.a2a_startup.a2a_pipeline import A2APipeline
+from _mcp_mesh.pipeline.api_startup.api_pipeline import APIPipeline
+from _mcp_mesh.shared.startup_check_manager import (
+    STARTUPZ_PATH,
+    build_startupz_response,
+    get_startup_check,
+    run_startup_check,
+)
+
+BIND_HOST = "127.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def declared_startup_check(monkeypatch):
+    """Install a ``startup_check`` into the resolved agent config.
+
+    Returns a setter so each test declares its own check (or none) through the
+    same path ``@mesh.agent(startup_check=...)`` uses.
+    """
+    from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+    def declare(check):
+        monkeypatch.setattr(
+            DecoratorRegistry,
+            "_cached_agent_config",
+            {
+                "agent_id": "agent-abcd1234",
+                "name": "agent",
+                "startup_check": check,
+            },
+        )
+
+    return declare
+
+
+def _gateway_app(pipeline_cls=APIPipeline, app=None):
+    app = app if app is not None else FastAPI(title="Gateway App")
+    step = next(s for s in pipeline_cls().steps if s.name == "health-endpoints")
+    result = asyncio.run(
+        step.execute({"fastapi_apps": {"app-1": {"instance": app, "title": "G"}}})
+    )
+    assert result.status.value != "failed", result.errors
+    return app
+
+
+@pytest.fixture
+def runtime_up(monkeypatch):
+    from _mcp_mesh.shared import simple_shutdown
+
+    monkeypatch.setattr(
+        simple_shutdown, "get_active_rust_agent_handles", lambda: [object()]
+    )
+    monkeypatch.setattr(simple_shutdown, "should_stop_heartbeat", lambda: False)
+
+
+# ---------------------------------------------------------------------------
+# The hook itself
+# ---------------------------------------------------------------------------
+
+
+class TestStartupCheckHook:
+    def test_mesh_agent_accepts_startup_check_next_to_health_check(self):
+        import inspect
+
+        import mesh
+
+        params = inspect.signature(mesh.agent).parameters
+        assert "startup_check" in params
+        assert params["startup_check"].default is None
+
+    def test_declared_check_reaches_the_resolved_config(self, monkeypatch):
+        import mesh
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+        def check():
+            return True
+
+        monkeypatch.setattr(DecoratorRegistry, "_cached_agent_config", None)
+
+        @mesh.agent(name="startupz-hook-agent", auto_run=False, startup_check=check)
+        class _Agent:
+            pass
+
+        assert _Agent._mesh_agent_metadata["startup_check"] is check
+
+    def test_a_non_callable_is_rejected_at_decoration(self):
+        import mesh
+
+        with pytest.raises(ValueError, match="startup_check must be a callable"):
+
+            @mesh.agent(name="bad-startup-agent", auto_run=False, startup_check="nope")
+            class _Agent:
+                pass
+
+    def test_no_check_declared_resolves_to_none(self, declared_startup_check):
+        declared_startup_check(None)
+        assert get_startup_check() is None
+
+    def test_a_non_callable_in_config_is_ignored(self, declared_startup_check):
+        declared_startup_check("not callable")
+        assert get_startup_check() is None
+
+
+class TestRunStartupCheck:
+    def test_absent_check_passes(self):
+        passed, checks, errors = asyncio.run(run_startup_check(None))
+        assert passed is True
+        assert errors == []
+
+    @pytest.mark.parametrize(
+        "check",
+        [lambda: True, pytest.param(None, id="async")],
+    )
+    def test_true_passes_sync_and_async(self, check):
+        if check is None:
+
+            async def check():  # noqa: F811 - the async variant
+                return True
+
+        passed, _, errors = asyncio.run(run_startup_check(check))
+        assert passed is True
+        assert errors == []
+
+    def test_false_fails(self):
+        passed, checks, errors = asyncio.run(run_startup_check(lambda: False))
+        assert passed is False
+        assert errors == ["Startup check returned False"]
+        assert checks == {"startup_check": False}
+
+    def test_a_throw_fails_rather_than_degrading(self):
+        """The opposite of ``health_check``, deliberately.
+
+        A throwing ``health_check`` is DEGRADED and keeps heartbeating — a
+        buggy probe must not withdraw a working provider. Here the question is
+        whether a possibly-misconfigured agent may come up at all, so an
+        indeterminate boot-time answer fails.
+        """
+
+        def boom():
+            raise RuntimeError("ANTHROPIC_API_KEY is not set")
+
+        passed, checks, errors = asyncio.run(run_startup_check(boom))
+        assert passed is False
+        assert checks == {"startup_check_execution": False}
+        assert "ANTHROPIC_API_KEY is not set" in errors[0]
+
+    def test_an_async_throw_also_fails(self):
+        async def boom():
+            raise RuntimeError("vendor returned 401")
+
+        passed, _, errors = asyncio.run(run_startup_check(boom))
+        assert passed is False
+        assert "vendor returned 401" in errors[0]
+
+    def test_dict_verdicts(self):
+        passed, _, _ = asyncio.run(run_startup_check(lambda: {"status": "healthy"}))
+        assert passed is True
+
+        passed, checks, errors = asyncio.run(
+            run_startup_check(
+                lambda: {
+                    "status": "unhealthy",
+                    "checks": {"api_key": False},
+                    "errors": ["no key"],
+                }
+            )
+        )
+        assert passed is False
+        assert checks == {"api_key": False}
+        assert errors == ["no key"]
+
+    def test_degraded_fails_there_is_no_partial_credit(self):
+        passed, _, errors = asyncio.run(run_startup_check(lambda: {"status": "degraded"}))
+        assert passed is False
+        assert errors == ["Startup check reported 'degraded'"]
+
+    def test_health_status_object(self):
+        from _mcp_mesh.shared.support_types import HealthStatus, HealthStatusType
+
+        healthy = HealthStatus(
+            agent_name="a", status=HealthStatusType.HEALTHY, capabilities=["c"]
+        )
+        passed, _, _ = asyncio.run(run_startup_check(lambda: healthy))
+        assert passed is True
+
+        unhealthy = HealthStatus(
+            agent_name="a", status=HealthStatusType.UNHEALTHY, capabilities=["c"]
+        )
+        passed, _, errors = asyncio.run(run_startup_check(lambda: unhealthy))
+        assert passed is False
+        assert errors
+
+    def test_an_unrecognized_return_type_fails(self):
+        passed, checks, errors = asyncio.run(run_startup_check(lambda: "yes"))
+        assert passed is False
+        assert checks == {"startup_check_return_type": False}
+        assert "str" in errors[0]
+
+    def test_none_return_fails(self):
+        passed, _, _ = asyncio.run(run_startup_check(lambda: None))
+        assert passed is False
+
+    def test_the_check_runs_on_every_call_there_is_no_cache(self):
+        calls = []
+
+        def check():
+            calls.append(1)
+            return True
+
+        for _ in range(3):
+            asyncio.run(run_startup_check(check))
+        assert len(calls) == 3
+
+
+class TestStartupzBody:
+    def test_pass_body(self):
+        body, status = asyncio.run(build_startupz_response("agent-x", lambda: True))
+        assert status == 200
+        assert body["started"] is True
+        assert body["agent"] == "agent-x"
+        assert "timestamp" in body
+
+    def test_failure_body_mirrors_ready(self):
+        """``/ready``'s failure shape: a boolean, a reason and errors."""
+        body, status = asyncio.run(
+            build_startupz_response(
+                "agent-x", lambda: {"status": "unhealthy", "errors": ["no key"]}
+            )
+        )
+        assert status == 503
+        assert body["started"] is False
+        assert body["reason"] == "Startup check failed"
+        assert body["errors"] == ["no key"]
+
+    def test_extra_keys_are_carried(self):
+        body, _ = asyncio.run(
+            build_startupz_response("gw", lambda: True, service_type="api")
+        )
+        assert body["service_type"] == "api"
+
+
+# ---------------------------------------------------------------------------
+# Site 1: the @mesh.agent provider path (mesh/decorators.py)
+# ---------------------------------------------------------------------------
+
+
+class TestProviderEndpoint:
+    """Exercises the app ``_start_uvicorn_immediately`` actually builds.
+
+    ``uvicorn.Server.run`` is stubbed out so no socket is served, but the
+    FastAPI app under test is the real one, with the real route registrations.
+    """
+
+    @pytest.fixture
+    def immediate_app(self, monkeypatch):
+        import uvicorn
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+        from _mcp_mesh.shared import simple_shutdown
+        from mesh import decorators
+
+        started = threading.Event()
+
+        def fake_run(self, sockets=None):
+            self.started = True
+            started.wait(timeout=5)
+
+        monkeypatch.setattr(uvicorn.Server, "run", fake_run)
+        saved = list(simple_shutdown._simple_shutdown_coordinator._uvicorn_servers)
+        try:
+            decorators._start_uvicorn_immediately(BIND_HOST, 0)
+            record = DecoratorRegistry.get_immediate_uvicorn_server()
+            assert record is not None
+            yield record["app"]
+        finally:
+            started.set()
+            DecoratorRegistry.clear_immediate_uvicorn_server()
+            simple_shutdown._simple_shutdown_coordinator._uvicorn_servers = saved
+
+    def test_startupz_is_served(self, immediate_app):
+        assert STARTUPZ_PATH in {r.path for r in immediate_app.router.routes}
+
+    def test_no_check_declared_answers_200(self, immediate_app, declared_startup_check):
+        declared_startup_check(None)
+        response = TestClient(immediate_app).get(STARTUPZ_PATH)
+        assert response.status_code == 200
+        assert response.json()["started"] is True
+
+    def test_passing_check_answers_200(self, immediate_app, declared_startup_check):
+        declared_startup_check(lambda: True)
+        assert TestClient(immediate_app).get(STARTUPZ_PATH).status_code == 200
+
+    def test_failing_check_answers_503(self, immediate_app, declared_startup_check):
+        declared_startup_check(lambda: False)
+        response = TestClient(immediate_app).get(STARTUPZ_PATH)
+        assert response.status_code == 503
+        assert response.json()["started"] is False
+
+    def test_throwing_check_answers_503_not_500(
+        self, immediate_app, declared_startup_check
+    ):
+        def boom():
+            raise RuntimeError("no key")
+
+        declared_startup_check(boom)
+        assert TestClient(immediate_app).get(STARTUPZ_PATH).status_code == 503
+
+    @pytest.mark.parametrize("check,expected", [(lambda: True, 200), (lambda: False, 503)])
+    def test_head_matches_get(
+        self, immediate_app, declared_startup_check, check, expected
+    ):
+        declared_startup_check(check)
+        client = TestClient(immediate_app)
+        assert client.head(STARTUPZ_PATH).status_code == expected
+        assert client.get(STARTUPZ_PATH).status_code == expected
+
+    def test_livez_stays_unconditional(self, immediate_app, declared_startup_check):
+        """Nothing about #1502 may make liveness consult anything."""
+
+        def boom():
+            raise RuntimeError("no key")
+
+        declared_startup_check(boom)
+        assert TestClient(immediate_app).get("/livez").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Site 2: the gateway path (pipeline/shared/health_endpoints.py)
+# ---------------------------------------------------------------------------
+
+
+class TestGatewayEndpoint:
+    @pytest.mark.parametrize("pipeline_cls", [APIPipeline, A2APipeline])
+    def test_registered_on_both_gateway_pipelines(self, pipeline_cls, runtime_up):
+        app = _gateway_app(pipeline_cls)
+        assert STARTUPZ_PATH in {r.path for r in app.router.routes}
+        assert TestClient(app).get(STARTUPZ_PATH).status_code == 200
+
+    def test_service_type_is_reported(self, runtime_up):
+        app = _gateway_app(A2APipeline)
+        assert TestClient(app).get(STARTUPZ_PATH).json()["service_type"] == "a2a"
+
+    def test_no_check_declared_answers_200(self, declared_startup_check, runtime_up):
+        declared_startup_check(None)
+        app = _gateway_app()
+        response = TestClient(app).get(STARTUPZ_PATH)
+        assert response.status_code == 200
+        assert response.json()["started"] is True
+
+    def test_passing_check_answers_200(self, declared_startup_check, runtime_up):
+        declared_startup_check(lambda: True)
+        app = _gateway_app()
+        assert TestClient(app).get(STARTUPZ_PATH).status_code == 200
+
+    def test_failing_check_answers_503(self, declared_startup_check, runtime_up):
+        declared_startup_check(lambda: False)
+        app = _gateway_app()
+        response = TestClient(app).get(STARTUPZ_PATH)
+        assert response.status_code == 503
+        assert response.json()["started"] is False
+        assert response.json()["errors"]
+
+    def test_throwing_check_answers_503_not_500(self, declared_startup_check, runtime_up):
+        async def boom():
+            raise RuntimeError("MODEL_ENDPOINT is not set")
+
+        declared_startup_check(boom)
+        app = _gateway_app()
+        response = TestClient(app).get(STARTUPZ_PATH)
+        assert response.status_code == 503
+        assert "MODEL_ENDPOINT is not set" in response.json()["errors"][0]
+
+    @pytest.mark.parametrize("check,expected", [(lambda: True, 200), (lambda: False, 503)])
+    def test_head_matches_get(self, declared_startup_check, runtime_up, check, expected):
+        declared_startup_check(check)
+        app = _gateway_app()
+        client = TestClient(app)
+        assert client.head(STARTUPZ_PATH).status_code == expected
+        assert client.get(STARTUPZ_PATH).status_code == expected
+
+    def test_a_user_defined_startupz_wins(self, declared_startup_check, runtime_up):
+        """Same per-path rule as ``/livez``/``/ready``/``/health`` (#1491)."""
+        declared_startup_check(lambda: False)
+
+        app = FastAPI(title="Hand-rolled Gateway")
+
+        @app.get(STARTUPZ_PATH)
+        async def user_startupz():
+            return {"mine": True}
+
+        _gateway_app(app=app)
+
+        response = TestClient(app).get(STARTUPZ_PATH)
+        assert response.status_code == 200
+        assert response.json() == {"mine": True}
+
+    def test_the_other_paths_are_still_registered_when_startupz_is_taken(
+        self, runtime_up
+    ):
+        app = FastAPI(title="Hand-rolled Gateway")
+
+        @app.get(STARTUPZ_PATH)
+        async def user_startupz():
+            return {"mine": True}
+
+        _gateway_app(app=app)
+
+        client = TestClient(app)
+        assert client.get("/livez").status_code == 200
+        assert client.get("/ready").status_code == 200
+        assert client.get("/health").status_code == 200
+
+    def test_registration_is_idempotent(self, runtime_up):
+        app = _gateway_app()
+        before = len(app.router.routes)
+        _gateway_app(app=app)
+        assert len(app.router.routes) == before
+
+    def test_livez_stays_unconditional(self, declared_startup_check, runtime_up):
+        declared_startup_check(lambda: False)
+        app = _gateway_app()
+        assert TestClient(app).get("/livez").status_code == 200
+
+    def test_ready_is_unchanged_by_a_failing_startup_check(
+        self, declared_startup_check, runtime_up
+    ):
+        """Step 1 is additive: ``/ready`` keeps reporting the runtime only."""
+        declared_startup_check(lambda: False)
+        app = _gateway_app()
+        assert TestClient(app).get("/ready").status_code == 200
+
+
+def test_bind_host_is_free():
+    """Guard for the provider fixture: it binds an ephemeral port."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind((BIND_HOST, 0))
+    s.close()

--- a/src/runtime/typescript/src/__tests__/startupz-route.spec.ts
+++ b/src/runtime/typescript/src/__tests__/startupz-route.spec.ts
@@ -1,0 +1,509 @@
+/**
+ * `startupCheck` and `/startupz` — RFC #1502, step 1.
+ *
+ * `healthCheck` answers "can I serve right now" and a failing one pauses the
+ * heartbeat until it recovers. `startupCheck` answers "is this agent
+ * configured such that it can ever serve", and the chart's `startupProbe` will
+ * poll `/startupz` for it, so a check that never passes means the pod never
+ * becomes ready and lands in CrashLoopBackOff where it is visible.
+ *
+ * Both TS HTTP surfaces are pinned, as `livez-route.spec.ts` does:
+ *
+ *   - the FastMCP-hosted MeshAgent (route on FastMCP's Hono app)
+ *   - MeshExpress (route on the user's Express app)
+ *
+ * The verdict rules are the OPPOSITE of `healthCheck`'s and are asserted as
+ * such: a throw fails (it does not degrade), and anything short of a clean
+ * pass fails.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { FastMCP } from "fastmcp";
+import type { Server } from "http";
+import express from "express";
+import {
+  runStartupCheck,
+  buildStartupBody,
+  startupStatusCodeFor,
+  type MeshStartupCheck,
+} from "../startup-check.js";
+import { registerStartupzRoute } from "../startupz-route.js";
+import { MeshExpress } from "../express.js";
+import { MeshAgent } from "../agent.js";
+
+describe("runStartupCheck — the verdict rules", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("an absent check passes — the default is true", async () => {
+    const verdict = await runStartupCheck(undefined, "a");
+    expect(verdict.passed).toBe(true);
+    expect(verdict.errors).toEqual([]);
+  });
+
+  it("true passes", async () => {
+    expect((await runStartupCheck(() => true, "a")).passed).toBe(true);
+  });
+
+  it("an async true passes", async () => {
+    const check: MeshStartupCheck = async () => true;
+    expect((await runStartupCheck(check, "a")).passed).toBe(true);
+  });
+
+  it("false fails", async () => {
+    const verdict = await runStartupCheck(() => false, "a");
+    expect(verdict.passed).toBe(false);
+    expect(verdict.errors).toEqual(["Startup check returned false"]);
+    expect(verdict.checks).toEqual({ startup_check: false });
+  });
+
+  it("a throw FAILS rather than degrading — the opposite of healthCheck", async () => {
+    // A throwing `healthCheck` is `degraded` and keeps the heartbeat alive: a
+    // buggy probe must not withdraw a working provider. Here the question is
+    // whether a possibly-misconfigured agent may come up at all, so an
+    // indeterminate boot-time answer fails.
+    const verdict = await runStartupCheck(() => {
+      throw new Error("ANTHROPIC_API_KEY is not set");
+    }, "a");
+    expect(verdict.passed).toBe(false);
+    expect(verdict.checks).toEqual({ startup_check_execution: false });
+    expect(verdict.errors[0]).toContain("ANTHROPIC_API_KEY is not set");
+  });
+
+  it("an async rejection also fails", async () => {
+    const check: MeshStartupCheck = async () => {
+      throw new Error("vendor returned 401");
+    };
+    const verdict = await runStartupCheck(check, "a");
+    expect(verdict.passed).toBe(false);
+    expect(verdict.errors[0]).toContain("vendor returned 401");
+  });
+
+  it("a non-Error throw is still described", async () => {
+    const verdict = await runStartupCheck(() => {
+      throw "just a string";
+    }, "a");
+    expect(verdict.passed).toBe(false);
+    expect(verdict.errors[0]).toContain("just a string");
+  });
+
+  it("a {status: healthy} object passes", async () => {
+    expect(
+      (await runStartupCheck(() => ({ status: "healthy" }), "a")).passed,
+    ).toBe(true);
+  });
+
+  it("an object with no status passes (healthy is the default)", async () => {
+    expect(
+      (await runStartupCheck(() => ({ checks: { key: true } }), "a")).passed,
+    ).toBe(true);
+  });
+
+  it("an unhealthy object fails and carries its checks and errors", async () => {
+    const verdict = await runStartupCheck(
+      () => ({
+        status: "unhealthy",
+        checks: { api_key: false },
+        errors: ["no key"],
+      }),
+      "a",
+    );
+    expect(verdict.passed).toBe(false);
+    expect(verdict.checks).toEqual({ api_key: false });
+    expect(verdict.errors).toEqual(["no key"]);
+  });
+
+  it("degraded fails — there is no partial credit for 'am I configured'", async () => {
+    const verdict = await runStartupCheck(() => ({ status: "degraded" }), "a");
+    expect(verdict.passed).toBe(false);
+    expect(verdict.errors).toEqual(["Startup check reported 'degraded'"]);
+  });
+
+  it("an unrecognized return fails", async () => {
+    const verdict = await runStartupCheck(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (() => "yes") as any,
+      "a",
+    );
+    expect(verdict.passed).toBe(false);
+    expect(verdict.checks).toEqual({ startup_check_return_type: false });
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("undefined and null fail", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((await runStartupCheck((() => undefined) as any, "a")).passed).toBe(
+      false,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((await runStartupCheck((() => null) as any, "a")).passed).toBe(false);
+  });
+
+  it("runs on every call — there is no cache", async () => {
+    const check = vi.fn(() => true);
+    await runStartupCheck(check, "a");
+    await runStartupCheck(check, "a");
+    await runStartupCheck(check, "a");
+    expect(check).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("the /startupz body", () => {
+  it("mirrors /ready's shape on success", () => {
+    const body = buildStartupBody("agent-x", {
+      passed: true,
+      checks: {},
+      errors: [],
+    });
+    expect(body.started).toBe(true);
+    expect(body.agent).toBe("agent-x");
+    expect(typeof body.timestamp).toBe("string");
+    expect(body.reason).toBeUndefined();
+  });
+
+  it("carries a reason and errors on failure", () => {
+    const verdict = { passed: false, checks: {}, errors: ["no key"] };
+    const body = buildStartupBody("agent-x", verdict);
+    expect(body.started).toBe(false);
+    expect(body.reason).toBe("Startup check failed");
+    expect(body.errors).toEqual(["no key"]);
+    expect(startupStatusCodeFor(verdict)).toBe(503);
+  });
+
+  it("200 for a passing verdict", () => {
+    expect(
+      startupStatusCodeFor({ passed: true, checks: {}, errors: [] }),
+    ).toBe(200);
+  });
+});
+
+describe("registerStartupzRoute — FastMCP/Hono surface", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function capture(check: MeshStartupCheck | undefined) {
+    let handler:
+      | ((c: unknown) => unknown | Promise<unknown>)
+      | undefined;
+    const stubServer = {
+      getApp: () => ({
+        on: (
+          _methods: string[],
+          _path: string,
+          h: (c: unknown) => unknown | Promise<unknown>,
+        ) => {
+          handler = h;
+        },
+      }),
+    } as unknown as FastMCP;
+    expect(registerStartupzRoute(stubServer, "my-agent", () => check)).toBe(
+      true,
+    );
+    expect(handler).toBeDefined();
+    return handler!;
+  }
+
+  async function call(handler: (c: unknown) => unknown | Promise<unknown>) {
+    const seen: { body?: Record<string, unknown>; status?: number } = {};
+    const json = vi.fn((body: unknown, status?: number) => {
+      seen.body = body as Record<string, unknown>;
+      seen.status = status;
+      return body;
+    });
+    await handler({ json });
+    return seen;
+  }
+
+  it("registers GET and HEAD /startupz on the Hono app", () => {
+    const onSpy = vi.fn();
+    const stubServer = {
+      getApp: () => ({ on: onSpy }),
+    } as unknown as FastMCP;
+
+    expect(registerStartupzRoute(stubServer, "my-agent", () => undefined)).toBe(
+      true,
+    );
+    expect(onSpy).toHaveBeenCalledWith(
+      ["GET", "HEAD"],
+      "/startupz",
+      expect.any(Function),
+    );
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("no check declared → 200", async () => {
+    const seen = await call(capture(undefined));
+    expect(seen.status).toBe(200);
+    expect(seen.body!.started).toBe(true);
+    expect(seen.body!.agent).toBe("my-agent");
+  });
+
+  it("a passing check → 200", async () => {
+    const seen = await call(capture(() => true));
+    expect(seen.status).toBe(200);
+  });
+
+  it("a failing check → 503", async () => {
+    const seen = await call(capture(() => false));
+    expect(seen.status).toBe(503);
+    expect(seen.body!.started).toBe(false);
+    expect(seen.body!.reason).toBe("Startup check failed");
+  });
+
+  it("a throwing check → 503, and the handler does not reject", async () => {
+    const seen = await call(
+      capture(() => {
+        throw new Error("no key");
+      }),
+    );
+    expect(seen.status).toBe(503);
+    expect((seen.body!.errors as string[])[0]).toContain("no key");
+  });
+
+  it("a throwing check SOURCE → 503 rather than an unhandled rejection", async () => {
+    let handler: ((c: unknown) => unknown | Promise<unknown>) | undefined;
+    const stubServer = {
+      getApp: () => ({
+        on: (
+          _m: string[],
+          _p: string,
+          h: (c: unknown) => unknown | Promise<unknown>,
+        ) => {
+          handler = h;
+        },
+      }),
+    } as unknown as FastMCP;
+    registerStartupzRoute(stubServer, "my-agent", () => {
+      throw new Error("config not resolved");
+    });
+    const seen = await call(handler!);
+    expect(seen.status).toBe(503);
+  });
+
+  it("logs at console.error when getApp() throws", () => {
+    const stubServer = {
+      getApp: () => {
+        throw new Error("FastMCP server not started");
+      },
+    } as unknown as FastMCP;
+
+    expect(registerStartupzRoute(stubServer, "my-agent", () => undefined)).toBe(
+      false,
+    );
+    expect(errorSpy.mock.calls[0][0] as string).toContain(
+      "/startupz route NOT registered",
+    );
+  });
+
+  it("logs at console.error when getApp() returns null", () => {
+    const stubServer = { getApp: () => null } as unknown as FastMCP;
+    expect(registerStartupzRoute(stubServer, "my-agent", () => undefined)).toBe(
+      false,
+    );
+    expect(errorSpy.mock.calls[0][0] as string).toContain("returned null");
+  });
+
+  it("logs at console.error when app.on() raises", () => {
+    const stubServer = {
+      getApp: () => ({
+        on: () => {
+          throw new Error("hono internal: route conflict");
+        },
+      }),
+    } as unknown as FastMCP;
+    expect(registerStartupzRoute(stubServer, "my-agent", () => undefined)).toBe(
+      false,
+    );
+    expect(errorSpy.mock.calls[0][0] as string).toContain(
+      "hono internal: route conflict",
+    );
+  });
+});
+
+describe("_autoStart mounts /startupz and aborts when it cannot", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const originalAutoStart = (MeshAgent.prototype as any)._autoStart;
+  const spies: ReturnType<typeof vi.spyOn>[] = [];
+
+  function stubPrototype(name: string, impl: () => unknown = () => undefined) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spies.push(vi.spyOn(MeshAgent.prototype as any, name).mockImplementation(impl));
+  }
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    stubPrototype("_autoStart", async () => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    spies.length = 0;
+  });
+
+  it("mounts GET|HEAD /startupz during startup", async () => {
+    const on = vi.fn();
+    const server = {
+      addTool: vi.fn(),
+      start: vi.fn().mockResolvedValue(undefined),
+      getApp: () => ({ on, post: vi.fn() }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const agent = new MeshAgent(server, {
+      name: "startupz-agent",
+      httpPort: 0,
+      startupCheck: () => true,
+    });
+    stubPrototype("registerLlmTools");
+    stubPrototype("registerJobsHelperTools");
+    stubPrototype("startHeartbeat", async () => undefined);
+    stubPrototype("startClaimDispatchers");
+    stubPrototype("installSignalHandlers");
+
+    await expect(originalAutoStart.call(agent)).resolves.toBeUndefined();
+    expect(on).toHaveBeenCalledWith(
+      ["GET", "HEAD"],
+      "/startupz",
+      expect.any(Function),
+    );
+  });
+
+  it("a failing startupCheck does NOT stop the agent starting", async () => {
+    // The probe reports it; the process keeps running so the kubelet can see
+    // the 503 and the operator can exec in. Crash-on-boot would erase both.
+    const on = vi.fn();
+    const server = {
+      addTool: vi.fn(),
+      start: vi.fn().mockResolvedValue(undefined),
+      getApp: () => ({ on, post: vi.fn() }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    const agent = new MeshAgent(server, {
+      name: "startupz-failing-agent",
+      httpPort: 0,
+      startupCheck: () => false,
+    });
+    stubPrototype("registerLlmTools");
+    stubPrototype("registerJobsHelperTools");
+    stubPrototype("startHeartbeat", async () => undefined);
+    stubPrototype("startClaimDispatchers");
+    stubPrototype("installSignalHandlers");
+
+    await expect(originalAutoStart.call(agent)).resolves.toBeUndefined();
+  });
+});
+
+describe("MeshExpress /startupz", () => {
+  let server: Server;
+  let base: string;
+
+  async function listen(startupCheck?: MeshStartupCheck) {
+    const app = express();
+    // Constructing MeshExpress wires the endpoints; start() is NOT called
+    // (it would register with a registry and open a heartbeat).
+    new MeshExpress(app, {
+      name: "startupz-test-api",
+      httpPort: 0,
+      startupCheck,
+    });
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, "127.0.0.1", () => resolve());
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr ? addr.port : 0;
+    base = `http://127.0.0.1:${port}`;
+  }
+
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("no check declared → 200 with started:true", async () => {
+    await listen(undefined);
+    const res = await fetch(`${base}/startupz`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.started).toBe(true);
+    expect(body.agent).toBe("startupz-test-api");
+    expect(typeof body.serviceId).toBe("string");
+    expect(typeof body.timestamp).toBe("string");
+  });
+
+  it("a passing check → 200", async () => {
+    await listen(() => true);
+    expect((await fetch(`${base}/startupz`)).status).toBe(200);
+  });
+
+  it("a failing check → 503 with a reason", async () => {
+    await listen(() => false);
+    const res = await fetch(`${base}/startupz`);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.started).toBe(false);
+    expect(body.reason).toBe("Startup check failed");
+  });
+
+  it("a throwing check → 503, not 500", async () => {
+    await listen(() => {
+      throw new Error("MODEL_ENDPOINT is not set");
+    });
+    const res = await fetch(`${base}/startupz`);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect((body.errors as string[])[0]).toContain("MODEL_ENDPOINT is not set");
+  });
+
+  it("HEAD matches GET (Express routes HEAD to the GET handler)", async () => {
+    await listen(() => false);
+    const head = await fetch(`${base}/startupz`, { method: "HEAD" });
+    const get = await fetch(`${base}/startupz`);
+    expect(head.status).toBe(503);
+    expect(get.status).toBe(head.status);
+  });
+
+  it("startupCheck is NOT ignored on a gateway, unlike healthCheck", async () => {
+    // #1476 warns that `healthCheck` is ignored on MeshExpress — withdrawing a
+    // fan-out point takes the application down. `startupCheck` withdraws
+    // nothing; it only stops a misconfigured gateway from coming up.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await listen(() => false);
+    expect((await fetch(`${base}/startupz`)).status).toBe(503);
+    expect(
+      warn.mock.calls.some((c) => String(c[0]).includes("startupCheck is IGNORED")),
+    ).toBe(false);
+  });
+
+  it("/livez stays unconditional under a failing startup check", async () => {
+    await listen(() => false);
+    expect((await fetch(`${base}/livez`)).status).toBe(200);
+  });
+
+  it("/ready is unchanged by a failing startup check (step 1 is additive)", async () => {
+    await listen(() => false);
+    // `handle` is null (start() was not called), so /ready is 503 for the
+    // reason it always was — the runtime, not the startup check.
+    const res = await fetch(`${base}/ready`);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ready).toBe(false);
+    expect(body.reason).toBeUndefined();
+  });
+});

--- a/src/runtime/typescript/src/__tests__/startupz-route.spec.ts
+++ b/src/runtime/typescript/src/__tests__/startupz-route.spec.ts
@@ -144,6 +144,25 @@ describe("runStartupCheck — the verdict rules", () => {
     expect((await runStartupCheck((() => null) as any, "a")).passed).toBe(false);
   });
 
+  it("a return value whose accessors throw fails rather than rejecting", async () => {
+    // The whole premise of this hook is fail-closed, so the reduction of the
+    // return value has to be inside the same guard as the call. A getter that
+    // raises is the reachable case: a config object backed by a Proxy, or a
+    // lazily-computed `status` that throws when the vendor client is missing.
+    const hostile = {
+      get status(): string {
+        throw new Error("config not loaded");
+      },
+    };
+    const verdict = await runStartupCheck(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (() => hostile) as any,
+      "a",
+    );
+    expect(verdict.passed).toBe(false);
+    expect(verdict.errors[0]).toContain("config not loaded");
+  });
+
   it("runs on every call — there is no cache", async () => {
     const check = vi.fn(() => true);
     await runStartupCheck(check, "a");

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -75,6 +75,7 @@ import {
 import { registerCancelRoute } from "./jobs-cancel-route.js";
 import { registerLivezRoute } from "./livez-route.js";
 import { registerHealthRoutes } from "./health-routes.js";
+import { registerStartupzRoute } from "./startupz-route.js";
 import {
   startHealthCheckLoop,
   DEFAULT_HEALTH_CHECK_TTL_SECONDS,
@@ -1997,6 +1998,37 @@ export class MeshAgent {
           `failed to register (cause logged above). Kubernetes gates Service ` +
           `endpoints on /ready, so serving without them would keep sending ` +
           `traffic to this agent after its health check reported it unhealthy.`,
+      );
+    }
+
+    // 1.7 RFC #1502: mount GET|HEAD /startupz, which reports the user's
+    // `startupCheck` — "is this agent configured such that it can EVER
+    // serve", as opposed to `healthCheck`'s "can I serve right now". A NEW
+    // URL rather than a reuse of /livez: the chart points both startupProbe
+    // and livenessProbe at /livez, and an endpoint cannot tell which probe
+    // called it, so sharing would kill a running pod every ten seconds on a
+    // failing startup check.
+    //
+    // Ordered LAST of the three probe mounts deliberately. All three fail for
+    // the same cause (a FastMCP whose Hono app cannot be reached), and the
+    // abort message an operator sees should name the route whose absence has
+    // been breaking agents the longest — /livez first, then /ready, then this.
+    //
+    // Fail-fast for the same reason as those two: once the chart's
+    // startupProbe points here, a missing route 404s every startup probe and
+    // the pod never comes up, with nothing in the events naming the cause.
+    if (
+      !registerStartupzRoute(
+        this.server,
+        this.config.name,
+        () => this.config.startupCheck,
+      )
+    ) {
+      throw new Error(
+        `agent ${this.agentId} cannot start: the /startupz startup route ` +
+          `failed to register (cause logged above). Kubernetes probes ` +
+          `/startupz for startup, so serving without it would leave this ` +
+          `agent stuck failing its startup probe.`,
       );
     }
 

--- a/src/runtime/typescript/src/config.ts
+++ b/src/runtime/typescript/src/config.ts
@@ -221,6 +221,10 @@ export function resolveConfig(config: AgentConfig): ResolvedAgentConfig {
     // SDK-side timer, not part of the registration envelope — the same
     // reason Java resolves MCP_MESH_HEALTH_CHECK_TTL in its own registry.
     healthCheckTtl: resolveHealthCheckTtlFromEnv(config.healthCheckTtl),
+    // RFC #1502: passed through unchanged. There is no env override and no
+    // TTL — startupProbe stops polling on first success, so the check runs a
+    // handful of times at most and there is nothing to cache or tune.
+    startupCheck: config.startupCheck,
   };
 }
 

--- a/src/runtime/typescript/src/express.ts
+++ b/src/runtime/typescript/src/express.ts
@@ -59,6 +59,11 @@ import {
   MAX_CONSECUTIVE_NEXT_EVENT_FAILURES,
   NEXT_EVENT_BACKOFF_CAP_MS,
 } from "./config.js";
+import {
+  buildStartupBody,
+  runStartupCheck,
+  startupStatusCodeFor,
+} from "./startup-check.js";
 import { createProxy } from "./proxy.js";
 import { RouteRegistry, type RouteMetadata } from "./route.js";
 import { initTracing, type AgentMetadata } from "./tracing.js";
@@ -235,6 +240,35 @@ export class MeshExpress {
         serviceId: this.serviceId,
         timestamp: new Date().toISOString(),
       });
+    });
+
+    // Startup endpoint (RFC #1502) — reports the user's `startupCheck`.
+    //
+    // Unlike `healthCheck` (warned about and ignored above), this hook IS
+    // honoured on a gateway. It never withdraws a running fan-out point; it
+    // only stops a misconfigured one from coming up, and a gateway with a
+    // broken config should never come up.
+    //
+    // Registered as GET only, like the three above: Express routes HEAD to a
+    // GET handler when no HEAD route exists, so HEAD answers with the same
+    // status. The check runs per hit — startupProbe stops polling on first
+    // success, so there is nothing to cache.
+    this.app.get("/startupz", (_req: Request, res: Response) => {
+      // `void` rather than an async handler: Express 4 does not handle a
+      // rejected promise from a route handler, and runStartupCheck is
+      // documented never to reject, so nothing is lost and the signature
+      // stays the same under both Express majors.
+      void runStartupCheck(this.config.startupCheck, this.config.name).then(
+        (verdict) => {
+          res
+            .status(startupStatusCodeFor(verdict))
+            .json(
+              buildStartupBody(this.config.name, verdict, {
+                serviceId: this.serviceId,
+              }),
+            );
+        },
+      );
     });
   }
 

--- a/src/runtime/typescript/src/index.ts
+++ b/src/runtime/typescript/src/index.ts
@@ -212,6 +212,16 @@ export {
   type HealthVerdict,
 } from "./health-check.js";
 
+// Startup check (RFC #1502) — reported by `/startupz`, which the chart's
+// startupProbe polls. A failing check means the pod never comes up.
+export {
+  runStartupCheck,
+  buildStartupBody,
+  startupStatusCodeFor,
+  type MeshStartupCheck,
+  type StartupVerdict,
+} from "./startup-check.js";
+
 // Service views (RFC #1280) — consumer view factory + facade types.
 export {
   serviceView,

--- a/src/runtime/typescript/src/index.ts
+++ b/src/runtime/typescript/src/index.ts
@@ -212,8 +212,9 @@ export {
   type HealthVerdict,
 } from "./health-check.js";
 
-// Startup check (RFC #1502) — reported by `/startupz`, which the chart's
-// startupProbe polls. A failing check means the pod never comes up.
+// Startup check (RFC #1502) — "can this agent EVER serve", reported by
+// `/startupz`. Step 1: the endpoint only. Pointing the chart's startupProbe at
+// it, so a failing check keeps the pod from coming up, is step 2.
 export {
   runStartupCheck,
   buildStartupBody,

--- a/src/runtime/typescript/src/startup-check.ts
+++ b/src/runtime/typescript/src/startup-check.ts
@@ -1,0 +1,174 @@
+/**
+ * The `startupCheck` hook and the verdict it produces (RFC #1502).
+ *
+ * `healthCheck` answers "can I serve *right now*?" — a transient answer, and a
+ * failing one only pauses the heartbeat so the registry stops selecting this
+ * agent until it recovers. `startupCheck` answers the other question: "is this
+ * agent configured such that it can *ever* serve?" A missing API key is not
+ * going to fix itself, and today it looks exactly like a vendor outage: the
+ * agent sits unregistered, the pod runs, and nothing is loud.
+ *
+ * `startupCheck` is reported by `/startupz`, which the agent chart's
+ * `startupProbe` polls. A pod whose startup check never passes never becomes
+ * ready, never registers, and ends up in `CrashLoopBackOff` — visible.
+ *
+ * Three properties are deliberate, and each is the OPPOSITE of the
+ * corresponding `healthCheck` rule:
+ *
+ * - **A throw fails the check.** `healthCheck` degrades on a throw (a buggy
+ *   probe must not withdraw a working provider from a mesh that may have no
+ *   other one). Here the question is whether a possibly-misconfigured agent
+ *   should be allowed to come up at all, and an indeterminate answer at boot
+ *   is not a reason to let it through. The cost of being wrong is also
+ *   asymmetric: a false failure crash-loops one pod that was never serving, a
+ *   false pass silently registers a broken one.
+ * - **Anything short of a clean pass fails.** `degraded`, an unrecognized
+ *   return, `undefined` — all fail. There is no partial credit for "am I
+ *   configured".
+ * - **There is no cache.** `startupProbe` stops polling after its first
+ *   success, so the check runs a handful of times at most. A TTL cache would
+ *   only add a way for the endpoint to answer with a verdict older than the
+ *   probe that asked for it.
+ *
+ * An agent that declares no `startupCheck` passes. Default-true is what makes
+ * this purely additive: every existing agent behaves exactly as it did.
+ *
+ * Unlike `healthCheck`, this hook is honoured on EVERY agent type, gateways
+ * included. It never withdraws a running fan-out point — it only stops a
+ * misconfigured one from coming up, and a gateway with a broken config should
+ * never come up.
+ */
+import type { MeshHealthResult } from "./health-check.js";
+
+/**
+ * A user startup check. May be sync or async — a startup check is often a
+ * bare environment-variable read, and forcing `async` on it would be ceremony
+ * with no payoff.
+ *
+ * The accepted return shapes are `healthCheck`'s, so an author writing both
+ * hooks writes them the same way. What differs is the verdict mapping: only a
+ * clean `healthy` / `true` passes.
+ */
+export type MeshStartupCheck = () =>
+  | boolean
+  | MeshHealthResult
+  | Promise<boolean | MeshHealthResult>;
+
+/** A normalized startup verdict — what `/startupz` renders. */
+export interface StartupVerdict {
+  passed: boolean;
+  checks: Record<string, unknown>;
+  errors: string[];
+}
+
+/** Render anything a `throw` can produce, including non-`Error` values. */
+function describe(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  try {
+    return String(err);
+  } catch {
+    return "<unprintable>";
+  }
+}
+
+function parse(raw: unknown): StartupVerdict {
+  if (typeof raw === "boolean") {
+    return {
+      passed: raw,
+      checks: { startup_check: raw },
+      errors: raw ? [] : ["Startup check returned false"],
+    };
+  }
+
+  if (raw !== null && typeof raw === "object") {
+    const result = raw as MeshHealthResult;
+    const status = String(result.status ?? "healthy").toLowerCase();
+    const passed = status === "healthy";
+    const errors = Array.isArray(result.errors) ? [...result.errors] : [];
+    return {
+      passed,
+      checks: result.checks ? { ...result.checks } : {},
+      errors:
+        passed || errors.length > 0
+          ? errors
+          : [`Startup check reported '${status}'`],
+    };
+  }
+
+  const typeName = raw === null ? "null" : typeof raw;
+  console.warn(
+    `[mesh-startup] startupCheck returned '${typeName}', which is not a ` +
+      `startup verdict — failing the startup probe. Return a boolean or a ` +
+      `{status, checks, errors} object.`,
+  );
+  return {
+    passed: false,
+    checks: { startup_check_return_type: false },
+    errors: [
+      `Invalid return type: ${typeName}. A startup check returns a boolean ` +
+        `or a {status, checks, errors} object.`,
+    ],
+  };
+}
+
+/**
+ * Run `check` once and report the verdict. Never rejects — a throwing check
+ * must not take the endpoint down with it, and unlike `healthCheck` it must
+ * not pass either (see the module comment).
+ */
+export async function runStartupCheck(
+  check: MeshStartupCheck | undefined,
+  agentName: string,
+): Promise<StartupVerdict> {
+  if (!check) {
+    return { passed: true, checks: {}, errors: [] };
+  }
+
+  let raw: unknown;
+  try {
+    raw = await check();
+  } catch (err) {
+    const reason = describe(err);
+    console.warn(
+      `[mesh-startup] startupCheck for agent '${agentName}' threw — failing ` +
+        `the startup probe: ${reason}`,
+    );
+    return {
+      passed: false,
+      checks: { startup_check_execution: false },
+      errors: [`Startup check failed: ${reason}`],
+    };
+  }
+  return parse(raw);
+}
+
+/**
+ * `/startupz` body. Mirrors `/ready`'s shape — a `started` boolean in place of
+ * `ready`, plus `reason`/`errors` on failure — so an operator reads the two
+ * probes the same way. Python's `build_startupz_response` emits the same keys.
+ */
+export function buildStartupBody(
+  agentName: string,
+  verdict: StartupVerdict,
+  extra: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    started: verdict.passed,
+    agent: agentName,
+    ...extra,
+    timestamp: new Date().toISOString(),
+  };
+  if (Object.keys(verdict.checks).length > 0) {
+    body.checks = verdict.checks;
+  }
+  if (!verdict.passed) {
+    body.reason = "Startup check failed";
+    body.errors = verdict.errors;
+  }
+  return body;
+}
+
+/** HTTP status for a startup verdict: 200 pass, 503 fail. */
+export function startupStatusCodeFor(verdict: StartupVerdict): 200 | 503 {
+  return verdict.passed ? 200 : 503;
+}

--- a/src/runtime/typescript/src/startup-check.ts
+++ b/src/runtime/typescript/src/startup-check.ts
@@ -8,9 +8,16 @@
  * going to fix itself, and today it looks exactly like a vendor outage: the
  * agent sits unregistered, the pod runs, and nothing is loud.
  *
- * `startupCheck` is reported by `/startupz`, which the agent chart's
- * `startupProbe` polls. A pod whose startup check never passes never becomes
- * ready, never registers, and ends up in `CrashLoopBackOff` — visible.
+ * **What ships today (RFC #1502 step 1).** `startupCheck` is reported by
+ * `GET|HEAD /startupz`, and that is the whole effect: a failing check answers
+ * 503 there. Nothing else changes — the agent is not withdrawn, the heartbeat
+ * is untouched, `/livez` and `/ready` answer exactly as they did.
+ *
+ * The agent chart's `startupProbe` still points at `/livez`, so nothing acts on
+ * the verdict yet. Repointing it at `/startupz` is step 2, and it is what the
+ * hook exists for: a pod whose startup check never passes then never becomes
+ * ready, never registers, and ends up in `CrashLoopBackOff` — visible. Until
+ * then, `/startupz` is a surface to build against and to scrape.
  *
  * Three properties are deliberate, and each is the OPPOSITE of the
  * corresponding `healthCheck` rule:
@@ -25,7 +32,7 @@
  * - **Anything short of a clean pass fails.** `degraded`, an unrecognized
  *   return, `undefined` — all fail. There is no partial credit for "am I
  *   configured".
- * - **There is no cache.** `startupProbe` stops polling after its first
+ * - **There is no cache.** A `startupProbe` stops polling after its first
  *   success, so the check runs a handful of times at most. A TTL cache would
  *   only add a way for the endpoint to answer with a verdict older than the
  *   probe that asked for it.
@@ -124,9 +131,13 @@ export async function runStartupCheck(
     return { passed: true, checks: {}, errors: [] };
   }
 
-  let raw: unknown;
   try {
-    raw = await check();
+    // `parse` is INSIDE the guard, not after it. Reducing the return value
+    // reads user-controlled properties — a getter, a Proxy, a lazily-computed
+    // `status` — and a throw there is exactly as indeterminate as a throw from
+    // the check itself. Parsing outside would leave the one path this hook
+    // exists for able to reject out of a function documented never to.
+    return parse(await check());
   } catch (err) {
     const reason = describe(err);
     console.warn(
@@ -139,7 +150,6 @@ export async function runStartupCheck(
       errors: [`Startup check failed: ${reason}`],
     };
   }
-  return parse(raw);
 }
 
 /**

--- a/src/runtime/typescript/src/startupz-route.ts
+++ b/src/runtime/typescript/src/startupz-route.ts
@@ -1,0 +1,105 @@
+/**
+ * Mount the Kubernetes startup route (`GET|HEAD /startupz`) on the agent's
+ * HTTP server (RFC #1502).
+ *
+ * Mirrors `livez-route.ts` in mechanism — the route is registered on FastMCP's
+ * underlying Hono app, which FastMCP consults before its own built-in health
+ * handling — and Python's `/startupz` in `mesh/decorators.py` in semantics.
+ *
+ * It is a NEW endpoint rather than a reuse of `/livez` because the chart points
+ * both `startupProbe` and `livenessProbe` at `/livez`, and an endpoint cannot
+ * tell which probe called it. Sharing one would mean a failing startup check
+ * kills a running pod every ten seconds.
+ *
+ * `/livez` is unchanged and stays unconditional. Nothing here may make it
+ * consult anything.
+ */
+import type { FastMCP } from "fastmcp";
+import type { MeshStartupCheck } from "./startup-check.js";
+import {
+  buildStartupBody,
+  runStartupCheck,
+  startupStatusCodeFor,
+} from "./startup-check.js";
+
+/** The configured `startupCheck`, or undefined when there is none. */
+export type StartupCheckSource = () => MeshStartupCheck | undefined;
+
+/**
+ * Register `GET|HEAD /startupz` on the FastMCP server's Hono app. Returns
+ * `true` iff the route was registered. `server.getApp()` throws before the
+ * server has started, so this must be called after `server.start()`.
+ *
+ * Each failure branch logs the CAUSE only. The consequence — that startup is
+ * aborted — is stated once, by the caller that throws (see `agent.ts`).
+ *
+ * `getCheck` is a callback rather than a value for the same reason
+ * `registerHealthRoutes` takes one: the route is mounted during startup, and
+ * reading the config lazily keeps the two in step.
+ */
+export function registerStartupzRoute(
+  server: FastMCP,
+  agentName: string,
+  getCheck: StartupCheckSource,
+): boolean {
+  let app: ReturnType<FastMCP["getApp"]> | null = null;
+  try {
+    app = server.getApp();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[mesh] /startupz route NOT registered — FastMCP.getApp() ` +
+        `unavailable: ${reason}`,
+    );
+    return false;
+  }
+  if (!app) {
+    console.error(
+      `[mesh] /startupz route NOT registered — FastMCP.getApp() returned null`,
+    );
+    return false;
+  }
+
+  try {
+    app.on(["GET", "HEAD"], "/startupz", async (c) => {
+      // Reading the check can throw if `getCheck` reaches into a
+      // half-constructed config. That is an indeterminate answer, and an
+      // indeterminate answer at boot fails — same rule as a check that
+      // throws, and the opposite of `/ready`, which falls back to "no check
+      // configured" rather than pulling a working pod out of its Service.
+      let check: MeshStartupCheck | undefined;
+      try {
+        check = getCheck();
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[mesh-startup] reading startupCheck for agent '${agentName}' ` +
+            `threw — failing the startup probe: ${reason}`,
+        );
+        return c.json(
+          {
+            started: false,
+            agent: agentName,
+            reason: "Startup check failed",
+            errors: [`Startup check could not be read: ${reason}`],
+            timestamp: new Date().toISOString(),
+          },
+          503,
+        );
+      }
+
+      const verdict = await runStartupCheck(check, agentName);
+      return c.json(
+        buildStartupBody(agentName, verdict),
+        startupStatusCodeFor(verdict),
+      );
+    });
+    return true;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[mesh] /startupz route NOT registered — app.on() raised: ${reason}`,
+    );
+    return false;
+  }
+}

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -5,6 +5,7 @@
 import { z } from "zod";
 import type { ServiceView } from "./service-view.js";
 import type { MeshHealthCheck } from "./health-check.js";
+import type { MeshStartupCheck } from "./startup-check.js";
 
 /**
  * Metadata for media-typed tool parameters.
@@ -320,6 +321,37 @@ export interface AgentConfig {
    * round trip. Env: MCP_MESH_HEALTH_CHECK_TTL. Defaults to 15.
    */
   healthCheckTtl?: number;
+  /**
+   * RFC #1502: a check that answers "is this agent configured such that it can
+   * EVER serve?", as opposed to {@link healthCheck}'s "can I serve right now".
+   *
+   * Reported by `GET|HEAD /startupz`, which the agent chart's `startupProbe`
+   * polls. A pod whose startup check never passes never becomes ready, never
+   * registers, and ends up in `CrashLoopBackOff` — which is the point: a
+   * missing API key is not going to fix itself, and without this it looks
+   * exactly like a vendor outage.
+   *
+   * The verdict rules are the OPPOSITE of {@link healthCheck}'s: a check that
+   * THROWS fails the probe (it does not degrade), and anything short of a
+   * clean pass fails. An indeterminate answer at boot is not a reason to let a
+   * possibly-misconfigured agent through, and the cost of being wrong is
+   * asymmetric — a false failure crash-loops a pod that was never serving, a
+   * false pass silently registers a broken one.
+   *
+   * Honoured on EVERY agent type, `mesh.route` and A2A included: it never
+   * withdraws a running fan-out point, it only stops a misconfigured one from
+   * coming up. Omitting it passes, so this is purely additive.
+   *
+   * Runs once per probe hit — `startupProbe` stops polling on first success,
+   * so there is nothing to cache. Keep it fast: the chart's probe
+   * `timeoutSeconds` is 5.
+   *
+   * @example
+   * ```typescript
+   * startupCheck: () => Boolean(process.env.ANTHROPIC_API_KEY)
+   * ```
+   */
+  startupCheck?: MeshStartupCheck;
 }
 
 /**
@@ -339,6 +371,8 @@ export interface ResolvedAgentConfig {
   healthCheck?: MeshHealthCheck;
   /** Issue #1476: resolved refresh period in seconds (env > config > 15). */
   healthCheckTtl: number;
+  /** RFC #1502: user startup check, or undefined when none is declared. */
+  startupCheck?: MeshStartupCheck;
 }
 
 /**

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -325,11 +325,16 @@ export interface AgentConfig {
    * RFC #1502: a check that answers "is this agent configured such that it can
    * EVER serve?", as opposed to {@link healthCheck}'s "can I serve right now".
    *
-   * Reported by `GET|HEAD /startupz`, which the agent chart's `startupProbe`
-   * polls. A pod whose startup check never passes never becomes ready, never
-   * registers, and ends up in `CrashLoopBackOff` — which is the point: a
-   * missing API key is not going to fix itself, and without this it looks
-   * exactly like a vendor outage.
+   * Today (RFC #1502 step 1) the verdict is reported by `GET|HEAD /startupz`
+   * and nothing else: a failing check answers 503 there, and the agent is not
+   * withdrawn, the heartbeat is untouched, `/livez` and `/ready` are unchanged.
+   * The agent chart's `startupProbe` still points at `/livez`.
+   *
+   * Repointing that probe at `/startupz` is step 2, and it is what the hook
+   * exists for: a pod whose startup check never passes then never becomes
+   * ready, never registers, and ends up in `CrashLoopBackOff` — a missing API
+   * key is not going to fix itself, and without this it looks exactly like a
+   * vendor outage.
    *
    * The verdict rules are the OPPOSITE of {@link healthCheck}'s: a check that
    * THROWS fails the probe (it does not degrade), and anything short of a
@@ -342,8 +347,8 @@ export interface AgentConfig {
    * withdraws a running fan-out point, it only stops a misconfigured one from
    * coming up. Omitting it passes, so this is purely additive.
    *
-   * Runs once per probe hit — `startupProbe` stops polling on first success,
-   * so there is nothing to cache. Keep it fast: the chart's probe
+   * Runs once per request — a startup probe stops polling on first success, so
+   * there is nothing to cache. Keep it fast: the chart's probe
    * `timeoutSeconds` is 5.
    *
    * @example


### PR DESCRIPTION
## Summary

**Step 1 of 4** for RFC #1502. Additive only — no existing behaviour changes.

One verdict is doing two jobs today. A missing API key and a transient vendor outage produce the *identical* outcome: check fails, heartbeat pauses, registry evicts, pod runs indefinitely. A misconfigured agent is indistinguishable from one waiting out an outage, and nothing is loud.

`startup_check` is the hook that says **"this will not fix itself."** A later step points the chart's `startupProbe` at `/startupz` so a fatal misconfiguration crash-loops visibly and never registers.

The hook exists on **every agent type** in all three runtimes and **defaults to true**, so an agent defining nothing behaves exactly as before. `/startupz` is served at every site that serves `/livez`:

| runtime | sites |
|---|---|
| Python | `@mesh.agent` (`decorators.py`) and the gateway wiring from #1494 |
| TypeScript | the FastMCP/Hono surface (`startupz-route.ts`) and MeshExpress |
| Java | one controller — it serves every agent type, so the two-path mirror does not apply |

## Review notes

**A throwing `startup_check` fails closed (503) — the opposite of `health_check`, where a throw degrades.** This is deliberate and commented at each site. A buggy probe must not withdraw a working provider from a mesh that may have no other one; but an indeterminate answer *at boot* is not a reason to admit a possibly-misconfigured agent. The costs are asymmetric: a false failure crash-loops a pod that was never serving, a false pass silently registers a broken one.

**`/livez` remains unconditional**, asserted in every runtime under a *failing* startup check. That invariant is what #1467/#1468 exist to protect, and the easiest way to lose it is a refactor that shares a handler.

Two placement details worth knowing:

- **Python resolves the check per request** from the resolved agent config, because probes are registered before that config is finalised — the same late-binding the existing `_agent_name()` uses.
- **TypeScript mounts `/startupz` last (step 1.7).** Mounting it first made it claim the `getApp()` abort message that an existing test asserts against `/livez`'s mount. The ordering is preserved deliberately, with a comment.

## Deliberately out of scope

`/ready` still reflects the verdict, the chart still points `startupProbe` at `/livez`, route/A2A still have no `health_check`, and no scaffold, man page, doc or chart file is touched. Steps 2–4.

## Found while implementing — for later steps

- **Python gateways have no declaration surface.** `@mesh.route` / `@mesh.a2a` apps carry no `@mesh.agent` decorator by convention, so the endpoint defaults to true but an author could only declare a check via `@mesh.agent(auto_run=False, startup_check=...)`, which nobody would guess. TypeScript (`MeshExpressConfig`) and Java (annotation on any bean) have no such gap. Needs resolving in step 4.
- **A pre-existing `/livez` gap, not introduced here.** `fastapiserver_setup.py` builds its own FastAPI app when no immediate-uvicorn server exists, and that app gets `/metrics` and `/metadata` but none of `/livez`, `/ready`, `/health`. `/startupz` inherits it.
- `api/mcp-mesh-agent.openapi.yaml` documents `/livez` inaccurately (as `text/plain "OK"`) and now lacks `/startupz`. Step-4 doc work.

Refs #1502

## Test plan

- [x] **Red before green**: `/startupz` returned 404 against the real `APIPipeline` health step before the change, 200 after — with the route list captured both ways
- [x] Python 1642 → **1685**; provider-path tests drive the real `_start_uvicorn_immediately` with `uvicorn.Server.run` stubbed and hit the app it actually built, not a copy
- [x] TypeScript 1360 → **1396** across 93 files; `tsc --noEmit` and `typecheck:express5` clean
- [x] Java starter 875 → **905**; full reactor `mvn -o test` BUILD SUCCESS
- [x] Per runtime: absent → 200, true → 200, false → 503, throws → 503, `HEAD` matches `GET`, user-defined path wins, and `/livez` unconditional under a failing check
- [x] `go build ./...`; `go test ./src/core/cli/... -count=1` — man goldens unmoved at 1744/519/447
- [x] Diff touches zero chart, doc, man-page, scaffold or template files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable startup checks for Java, Python, and TypeScript agents.
  * Added Kubernetes-compatible `GET` and `HEAD /startupz` health probes.
  * Startup checks support synchronous/asynchronous results, detailed diagnostics, and healthy/unhealthy status responses.
  * Agents without a configured startup check pass by default.
  * Added startup-check configuration and public APIs across supported runtimes.

* **Bug Fixes**
  * Startup-check errors and invalid results now produce clear failure responses without affecting existing `/livez`, `/ready`, and `/health` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->