### PR TITLE
feat!: /ready reports the mesh runtime, not the health verdict

### DIFF
--- a/docs/concepts/health-discovery.md
+++ b/docs/concepts/health-discovery.md
@@ -117,21 +117,22 @@ While the check reports `unhealthy` the agent stops heartbeating. The registry's
 
 Only an explicit unhealthy result does that. A check that raises is recorded as `degraded` and keeps heartbeating, in all three runtimes: a bug in the health check must not be able to remove a working agent from the mesh.
 
-`degraded` splits the two surfaces on all three runtimes: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider.
+`degraded` shows on the diagnostic surface only, on all three runtimes: the agent keeps heartbeating and stays in dependency resolution, and `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict.
 
-Route (`@mesh.route` / `@MeshRoute` / `mesh.route`) and A2A agents are deliberately exempt, on both surfaces: the verdict never suppresses their heartbeat and never makes their `/ready` answer 503. A gateway is a fan-out point that many requests enter through - withdrawing a provider is correct, withdrawing the gateway takes the application down, and a 503 readiness probe drops it from its Service endpoints, which takes it down harder. On Java the verdict still shows on the gateway's `/health`; Python and TypeScript never run the check on a gateway at all.
+Route (`@mesh.route` / `@MeshRoute` / `mesh.route`) and A2A agents are deliberately exempt from the heartbeat half: the verdict never suppresses their heartbeat. A gateway is a fan-out point that many requests enter through - withdrawing a provider is correct, withdrawing the gateway takes the application down. On Java the verdict still shows on the gateway's `/health`; Python and TypeScript never run the check on a gateway at all. There is no readiness half to exempt any more: `/ready` reports the mesh runtime on every agent type.
 
 ### Kubernetes Probes
 
-Every runtime serves three endpoints, and probes must not share one:
+Every runtime serves four endpoints, and probes must not share one:
 
-| Endpoint  | Probe                             | Reports                                                                                             |
-| --------- | --------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `/livez`  | `livenessProbe`, `startupProbe`   | 200 for as long as the process is serving. Consults nothing else.                                     |
-| `/ready`  | `readinessProbe`                  | Whether traffic should be routed here. Reflects your health check on all three runtimes (`health_check`, `@MeshHealthCheck`, `healthCheck`) - 200 only while it reports `healthy` - except on a route or A2A agent, where it reports only that the mesh runtime is running. |
-| `/health` | none                              | The `/ready` verdict plus `checks` and `errors`, on all three runtimes. The two part company only on a gateway: a Java gateway's `/health` still carries its check's verdict while `/ready` ignores it, and Python and TypeScript never run a gateway's check at all. |
+| Endpoint    | Probe                             | Reports                                                                                             |
+| ----------- | --------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `/startupz` | `startupProbe`                    | Your startup check (`startup_check`, `@MeshStartupCheck`, `startupCheck`). An agent that declares none passes. |
+| `/livez`    | `livenessProbe`                   | 200 for as long as the process is serving. Consults nothing else.                                     |
+| `/ready`    | `readinessProbe`                  | Whether the mesh runtime is up, on every agent type. Your health check does NOT reach it: a failing check pauses the heartbeat, which is the whole withdrawal, and a 503 here would also empty the Service that mesh traffic arrives on. |
+| `/health`   | none                              | Your health check's verdict plus `checks` and `errors`, on all three runtimes. 503 while the verdict is not healthy. This is the one endpoint the verdict moves, so it and `/ready` diverge by design. |
 
-Never point liveness or startup at `/ready` or `/health`. Both reflect a provider agent's health check on all three runtimes, so sharing a URL turns an upstream outage into a pod restart, which cannot fix the outage - and while an agent is still coming up they answer 503 (or are not mounted yet), which restart-loops a slow boot. The agent Helm chart is already wired this way; if you write your own manifests, you own this contract, and `meshctl man deployment` (`--typescript`, `--java`) has the probe stanzas to copy plus the two ways it is usually got wrong.
+Never point liveness or startup at `/ready` or `/health`. `/health` reflects your health check on all three runtimes, so sharing a URL turns an upstream outage into a pod restart, which cannot fix the outage - and while an agent is still coming up both answer 503 (or are not mounted yet), which restart-loops a slow boot. The agent Helm chart is already wired this way; if you write your own manifests, you own this contract, and `meshctl man deployment` (`--typescript`, `--java`) has the probe stanzas to copy plus the two ways it is usually got wrong.
 
 ### Health States
 

--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -311,38 +311,51 @@ agentCode:
 
 # Health probe configurations.
 #
-# Liveness and readiness MUST NOT share a URL (issue #1467). Every mesh
-# runtime serves three endpoints with three different meanings:
+# Every probe MUST have its own URL (issue #1467, RFC #1502). Each mesh
+# runtime serves four endpoints with four different meanings:
 #
-#   /livez   always 200 while the process is serving. Nothing else.
-#   /ready   should traffic be routed here? All three runtimes consult
-#            the user's health check (Python #1472, Java #1474,
-#            TypeScript #1478), so an upstream vendor outage takes the
-#            pod out of the Service. The same verdict separately stops
-#            the heartbeat, and THAT is what evicts the agent from mesh
-#            resolution — the registry never reads this probe.
-#   /health  the diagnostic view for humans and `kubectl exec` curls.
-#            No probe points at it: it carries no consequence of its own.
+#   /startupz  the agent's `startup_check` — "is this configured such
+#              that it can EVER serve". Defaults to passing, so an agent
+#              that declares none is unaffected. A check that never
+#              passes keeps the pod from becoming ready and lands it in
+#              CrashLoopBackOff, where a wrong API key is visible instead
+#              of looking like a vendor outage.
+#   /livez     always 200 while the process is serving. Nothing else.
+#   /ready     is the mesh runtime up? The user's health check does NOT
+#              reach this probe. A failing check pauses the heartbeat,
+#              the registry ages the agent out and resolution stops
+#              selecting it — that is the whole withdrawal mechanism, and
+#              the registry never reads this probe.
+#   /health    the diagnostic view for humans and `kubectl exec` curls.
+#              It DOES carry the health check's verdict, `checks` and
+#              `errors`, and answers 503 when the verdict is not healthy.
+#              No probe points at it, so that status code is free to
+#              carry information.
 #
-# When liveness also pointed at /health, an upstream outage failed the
+# Readiness is deliberately NOT wired to the health check. `agent.advertisedHost`
+# defaults to the per-agent Service DNS name and this chart ships a
+# service.yaml, so mesh traffic traverses the Service. A 503 here empties
+# the Service endpoints while the registry may still be selecting the
+# agent, and the consumer gets a connection error instead of failing over
+# to another provider. Withdrawal without readiness removal is safe; the
+# reverse is not.
+#
+# When liveness pointed at /health, an upstream outage failed the
 # LIVENESS probe and Kubernetes restarted the pod. A restart cannot fix
 # someone else's API, and it erases the only state that knew this
 # provider was failing — the agent re-registers as healthy, consumers
-# route back to it, it fails again, forever. Readiness is the probe
-# whose remedy (stop sending traffic) matches that cause.
+# route back to it, it fails again, forever.
 #
-# The same reasoning applies to the startup probe: its failure action is
-# also a container restart, so gating startup on /health meant an agent
-# that booted DURING an outage never became "started" and was killed
-# after failureThreshold × periodSeconds — reproducing the same loop on
-# a slower cadence. It gates on /livez instead; readiness still governs
-# traffic, and an agent stuck mid-boot stays visible as 0/1 READY rather
-# than flapping through CrashLoopBackOff.
+# The startup probe has the same failure action, which is why it points
+# at /startupz and not at /health or /ready: a check reached from there
+# would kill an agent that booted DURING an outage. /startupz is the one
+# check whose failure a restart-and-fix loop is the right response to,
+# and it runs once rather than every ten seconds forever.
 #
 # Do not collapse these back onto one path.
 startupProbe:
   httpGet:
-    path: /livez
+    path: /startupz
     port: http
   initialDelaySeconds: 5
   periodSeconds: 10

--- a/scripts/check_helm_render_matrix.py
+++ b/scripts/check_helm_render_matrix.py
@@ -29,15 +29,16 @@ a non-empty render cannot detect.
 
 It may also pin the container probe paths:
 
-  probe_paths={"livenessProbe": "/livez", "readinessProbe": "/ready"}
+  probe_paths={"startupProbe": "/startupz", "livenessProbe": "/livez",
+               "readinessProbe": "/ready"}
 
 Issue #1467: liveness and readiness pointing at the SAME url is the bug —
 a dependency outage that should only make an agent unready instead restarts
 the pod, which cannot fix the dependency and launders the failing agent back
 into resolution. A values default is one careless edit away from collapsing
 back, and every render stays green when it does. Declaring the paths makes
-that edit fail here. Two probes sharing a path is additionally rejected
-outright, whatever the declared paths were.
+that edit fail here. Two declared probes sharing a path is additionally
+rejected outright, whatever the declared paths were.
 
 Usage: python3 scripts/check_helm_render_matrix.py  (run from anywhere)
 Exit code 0 = every case behaved as declared.
@@ -361,16 +362,29 @@ CASES: list[Case] = [
         "the v2.4.0 agent.environment defaults verbatim",
         {"agent": {"environment": dict(V240_AGENT_ENVIRONMENT)}},
     ),
-    # --- mcp-mesh-agent: liveness and readiness are different URLs --------
-    # Issue #1467. Liveness may only fail for something a restart can fix;
-    # /ready is what an unhealthy dependency is allowed to fail. The startup
-    # probe restarts the container too, so it gates on /livez as well.
+    # --- mcp-mesh-agent: every probe is a different URL --------------------
+    # Issues #1467/#1468: liveness may only fail for something a restart can
+    # fix, so it points at /livez — the process is serving, and nothing else.
+    # A liveness probe that consults a dependency restarts the pod for an
+    # outage a restart cannot fix, then launders the still-failing agent back
+    # into resolution. That history is why liveness must never grow a
+    # dependency check.
+    #
+    # RFC #1502 split the other two apart. /ready reports whether the mesh
+    # runtime is up and never carries the user's health verdict: a dependency
+    # outage now fails NO probe: it pauses the heartbeat, the registry ages
+    # the agent out and routing moves. /startupz is the fatal-configuration
+    # check, and it gets the startup probe because that probe also restarts
+    # the container — an agent that can never serve (unusable config, missing
+    # credential) is held in CrashLoopBackOff where the cause is visible,
+    # rather than coming up and registering broken. The verdict itself is
+    # served at /health, which no probe reads.
     Case(
         "mcp-mesh-agent",
         "probes at the shipped defaults point at distinct endpoints",
         {},
         probe_paths={
-            "startupProbe": "/livez",
+            "startupProbe": "/startupz",
             "livenessProbe": "/livez",
             "readinessProbe": "/ready",
         },
@@ -451,9 +465,12 @@ def run_case(case: Case, values_file: Path) -> str | None:
 def _check_probe_paths(manifests: str, expected: dict[str, str]) -> str | None:
     """Assert every workload container's probes use the declared httpGet paths.
 
-    Also rejects two probes sharing one path regardless of what was declared —
-    the invariant behind issue #1467 is that liveness (restart) and readiness
-    (stop routing) can never be the same signal.
+    Also rejects two declared probes sharing one path regardless of what was
+    declared — the invariant behind issues #1467/#1468 and RFC #1502 is that
+    startup (restart before serving), liveness (restart) and readiness (stop
+    routing) are three different failure actions and can never be one signal.
+    Matching three distinct literals already implies this today; asserting it
+    separately is what keeps the claim true if the literals are ever edited.
     """
     containers = [
         container
@@ -484,6 +501,18 @@ def _check_probe_paths(manifests: str, expected: dict[str, str]) -> str | None:
                 f"at the same path {liveness!r} — a dependency outage would "
                 "restart the pod instead of only taking it out of rotation"
             )
+        seen: dict[str, str] = {}
+        for probe in expected:
+            path = container.get(probe, {}).get("httpGet", {}).get("path")
+            if path is None:
+                continue
+            if path in seen:
+                return (
+                    f"container {container['name']!r} probes {seen[path]} and "
+                    f"{probe} at the same path {path!r} — each probe has its "
+                    "own failure action and needs its own endpoint"
+                )
+            seen[path] = probe
     return None
 
 

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -364,15 +364,16 @@ class MyAgent:
     pass
 ```
 
-Every runtime serves three endpoints, and Kubernetes probes must not share one:
+Every runtime serves four endpoints, and Kubernetes probes must not share one:
 
-- `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
-- `/ready` - `readinessProbe`. Whether traffic should be routed here; reflects your `health_check` on a provider agent.
-- `/health` - no probe. The diagnostic view: the `/ready` signal plus `checks` and `errors`.
+- `/startupz` - `startupProbe`. Reports your `startup_check`; an agent that declares none passes.
+- `/livez` - `livenessProbe`. 200 for as long as the process is serving; consults nothing else.
+- `/ready` - `readinessProbe`. Whether the mesh runtime is up. Your `health_check` does not reach it: a failing check pauses the heartbeat and the registry stops resolving to this agent, which is the whole withdrawal, and a 503 here would also empty the Service that mesh traffic arrives on.
+- `/health` - no probe. The diagnostic view: your `health_check`'s verdict plus its `checks` and `errors`, 503 while the verdict is not healthy.
 
-Pointing liveness or startup at `/health` or `/ready` turns an upstream outage into a pod restart, which cannot fix the outage. Probe Wiring below has the manifest.
+Pointing liveness at `/health` turns an upstream outage into a pod restart, which cannot fix the outage. Probe Wiring below has the manifest.
 
-Route (`@mesh.route`) and A2A (`@mesh.a2a`) agents are the exception: they never run `health_check`, and their `/ready` reports only whether the mesh runtime is up while `/health` stays 200. A gateway is a fan-out point, and withdrawing it takes the application down. Mesh registers the three paths on the gateway's own FastAPI app, and a path your application already defines wins.
+Route (`@mesh.route`) and A2A (`@mesh.a2a`) agents never run `health_check` at all, so their `/health` stays 200. A gateway is a fan-out point, and withdrawing it takes the application down. Mesh registers the four paths on the gateway's own FastAPI app, and a path your application already defines wins.
 
 ### Probe Wiring
 
@@ -381,7 +382,7 @@ The agent chart already wires all three. If you write your own Deployment, wire 
 ```yaml
 startupProbe:
   httpGet:
-    path: /livez
+    path: /startupz
     port: 8080
   periodSeconds: 10
   failureThreshold: 30
@@ -401,12 +402,12 @@ readinessProbe:
   failureThreshold: 3
 ```
 
-Never point `livenessProbe` or `startupProbe` at `/ready` or `/health`. Both reflect a provider agent's `health_check`, and the failure action of both probes is a container restart:
+Never point `livenessProbe` or `startupProbe` at `/health` or `/ready`. The failure action of both probes is a container restart, and a restart cannot fix what either endpoint reports:
 
 - `livenessProbe: /health` - a dependency outage answers 503, the default `failureThreshold` of three kills the pod, and the replacement finds the same dependency still down. The pod restarts for as long as the outage lasts.
-- `startupProbe: /ready` - fires only during an outage, when the check is already failing at boot. The probe never succeeds, so the pod CrashLoops instead of starting and reporting unready - precisely when you want the agent up and withdrawn rather than dead.
+- `startupProbe: /ready` - readiness reports the mesh runtime, not whether this agent has finished starting, and it goes down again on every shutdown. `/startupz` is the endpoint whose failure a restart is the right response to.
 
-Nothing probes `/health`. It is the diagnostic view: curl it from `kubectl exec` to see the `checks` and `errors` behind an unready pod.
+Nothing probes `/health`. It is the diagnostic view: curl it from `kubectl exec` to see the `checks` and `errors` behind a `health_check` that has withdrawn an agent.
 
 ### Resource Limits
 

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -271,13 +271,14 @@ The Helm chart sets `MCP_MESH_HTTP_PORT=8080` which overrides `@MeshAgent(port =
 
 Spring Actuator is not a starter dependency, and mesh contributes nothing to it. If your application adds Actuator itself, `/actuator/health` aggregates every registered indicator - datasource, disk, mail - so it is not a substitute for `/ready`: gating mesh traffic on it gates on conditions the agent's author never intended to affect routing.
 
-The starter serves the three mesh endpoints, and Kubernetes probes must not share one:
+The starter serves the four mesh endpoints, and Kubernetes probes must not share one:
 
-- `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
-- `/ready` - `readinessProbe`. Whether traffic should be routed here; reflects your `@MeshHealthCheck` on top of the mesh runtime state, except on a route-only (`api`) or A2A agent, where only the runtime state counts.
-- `/health` - no probe. The `/ready` signal plus the `checks` and `errors` your check returned - except on a route-only (`api`) or A2A agent, where `/ready` ignores the check but `/health` still reports its verdict.
+- `/startupz` - `startupProbe`. Reports your `@MeshStartupCheck`; an agent that declares none passes.
+- `/livez` - `livenessProbe`. 200 for as long as the process is serving; consults nothing else.
+- `/ready` - `readinessProbe`. Whether the mesh runtime is up, on every agent type. Your `@MeshHealthCheck` does not reach it: a failing check pauses the heartbeat and the registry stops resolving to this agent, which is the whole withdrawal, and a 503 here would also empty the Service that mesh traffic arrives on.
+- `/health` - no probe. Your check's verdict plus the `checks` and `errors` it returned, 503 while the verdict is not healthy.
 
-Both `/health` and `/ready` answer 503 until the mesh runtime is up, so pointing liveness or startup at either restarts pods that are merely still booting. Probe Wiring below has the manifest.
+Both `/health` and `/ready` answer 503 until the mesh runtime is up - it starts late in the Spring lifecycle - so pointing liveness at either restarts pods that are merely still booting. Probe Wiring below has the manifest.
 
 Annotate one no-argument method with `@MeshHealthCheck` to say what "ready" means for this agent:
 
@@ -294,7 +295,7 @@ public MeshHealth healthCheck() {
 
 While the check returns unhealthy the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider - restored automatically when the check passes, with no restart. Returning `boolean` works too: `true` is healthy, `false` unhealthy. A check that throws is recorded as `degraded` and keeps heartbeating, so a bug in the check cannot take a working agent out of the mesh. `MCP_MESH_HEALTH_CHECK_TTL` overrides `ttlSeconds`.
 
-Route-only (`api`) and A2A agents are the exception: their check feeds `/health` only - it never suppresses the heartbeat and never makes `/ready` answer 503. A gateway is a fan-out point, and taking it out of rotation takes the application down.
+Route-only (`api`) and A2A agents are the exception on the heartbeat: their check feeds `/health` only and never suppresses it. A gateway is a fan-out point, and taking it out of rotation takes the application down. `/ready` was already exempt on those types and is now exempt on every type.
 
 ### Probe Wiring
 
@@ -303,7 +304,7 @@ The agent chart already wires all three. If you write your own Deployment, wire 
 ```yaml
 startupProbe:
   httpGet:
-    path: /livez
+    path: /startupz
     port: 8080
   periodSeconds: 10
   failureThreshold: 30
@@ -326,11 +327,11 @@ readinessProbe:
 Never point `livenessProbe` or `startupProbe` at `/ready` or `/health`. The failure action of both probes is a container restart, and a restart cannot fix what either endpoint reports:
 
 - `livenessProbe: /health` - a dependency outage answers 503, the default `failureThreshold` of three kills the pod, and the replacement finds the same dependency still down.
-- `startupProbe: /ready` - the mesh runtime starts late in the Spring lifecycle, so this gates "started" on something that is not up yet, and during an outage `@MeshHealthCheck` keeps it failing. The probe never succeeds and the pod CrashLoops instead of starting and reporting unready - precisely when you want the agent up and withdrawn rather than dead.
+- `startupProbe: /ready` - readiness reports the mesh runtime, not whether this agent has finished starting, and it goes down again on every shutdown. `/startupz` is the endpoint whose failure a restart is the right response to, and unlike `/ready` it is not gated on a runtime that starts late in the Spring lifecycle.
 
 `/actuator/health` is not an option either, for the reason above: a liveness probe pointed there restarts the pod for whatever an unrelated indicator reports.
 
-Nothing probes `/health`. It is the diagnostic view: curl it from `kubectl exec` to see the `checks` and `errors` behind an unready pod.
+Nothing probes `/health`. It is the diagnostic view: curl it from `kubectl exec` to see the `checks` and `errors` behind a `@MeshHealthCheck` that has withdrawn an agent.
 
 ### Graceful Shutdown
 

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -224,13 +224,14 @@ TypeScript agents automatically expose health endpoints:
 // Returns: { status: "healthy", agent: "my-agent", checks: {}, errors: [], timestamp: "..." }
 ```
 
-There are three of them, and Kubernetes probes must not share one:
+There are four of them, and Kubernetes probes must not share one:
 
-- `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
-- `/ready` - `readinessProbe`. Whether traffic should be routed here; reflects your `healthCheck`, answering 200 only while it reports `healthy`. An agent with no `healthCheck` - or one whose first run has not finished - is healthy, so it is unaffected.
-- `/health` - no probe. The same verdict as `/ready`, plus the `checks` and `errors` your check returned.
+- `/startupz` - `startupProbe`. Reports your `startupCheck`; an agent that declares none passes.
+- `/livez` - `livenessProbe`. 200 for as long as the process is serving; consults nothing else.
+- `/ready` - `readinessProbe`. Whether the mesh runtime is up. Your `healthCheck` does not reach it: a failing check pauses the heartbeat and the registry stops resolving to this agent, which is the whole withdrawal, and a 503 here would also empty the Service that mesh traffic arrives on.
+- `/health` - no probe. Your `healthCheck`'s verdict plus the `checks` and `errors` it returned, answering 200 only while it reports `healthy`. An agent with no `healthCheck` - or one whose first run has not finished - is healthy, so it is unaffected.
 
-Both answer 503 while the check reports `degraded` or `unhealthy`, so pointing liveness or startup at either turns a vendor outage into a pod restart, which cannot fix it. Probe Wiring below has the manifest.
+`/health` answers 503 while the check reports `degraded` or `unhealthy`, so pointing liveness at it turns a vendor outage into a pod restart, which cannot fix it. Probe Wiring below has the manifest.
 
 Pass a `healthCheck` to `mesh()` to say what "able to serve" means for this agent:
 
@@ -257,7 +258,7 @@ const agent = mesh(server, {
 
 While the check returns unhealthy the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider - restored automatically when the check passes, with no restart. Returning `boolean` works too: `true` is healthy, `false` unhealthy. A check that throws is recorded as `degraded` and keeps heartbeating, so a bug in the check cannot take a working agent out of the mesh. `MCP_MESH_HEALTH_CHECK_TTL` overrides `healthCheckTtl` (default 15s).
 
-Route (`mesh.route`) and A2A agents are the exception: they ignore `healthCheck` entirely, and their `/ready` reports only whether the mesh runtime is up. A gateway is a fan-out point, and withdrawing it takes the application down.
+Route (`mesh.route`) and A2A agents are the exception: they ignore `healthCheck` entirely, so their `/health` is a fixed `healthy`. A gateway is a fan-out point, and withdrawing it takes the application down. Their `/ready` reports the mesh runtime, which is what every agent type's now reports.
 
 ### Probe Wiring
 
@@ -266,7 +267,7 @@ The agent chart already wires all three. If you write your own Deployment, wire 
 ```yaml
 startupProbe:
   httpGet:
-    path: /livez
+    path: /startupz
     port: 8080
   periodSeconds: 10
   failureThreshold: 30
@@ -286,12 +287,12 @@ readinessProbe:
   failureThreshold: 3
 ```
 
-Never point `livenessProbe` or `startupProbe` at `/ready` or `/health`. Both reflect a provider agent's `healthCheck`, and the failure action of both probes is a container restart:
+Never point `livenessProbe` or `startupProbe` at `/health` or `/ready`. The failure action of both probes is a container restart, and a restart cannot fix what either endpoint reports:
 
 - `livenessProbe: /health` - a vendor outage answers 503, the default `failureThreshold` of three kills the pod, and the replacement finds the vendor still down. This is the one to check first on an upgraded agent: before 3.5.2 `/health` was a fixed 200 that consulted nothing, so a manifest wired this way survived by accident and stops surviving as soon as a declared `healthCheck` reports anything but `healthy`.
-- `startupProbe: /ready` - fires only during an outage, when the check is already failing at boot. The probe never succeeds, so the pod CrashLoops instead of starting and reporting unready - precisely when you want the agent up and withdrawn rather than dead.
+- `startupProbe: /ready` - readiness reports the mesh runtime, not whether this agent has finished starting, and it goes down again on every shutdown. `/startupz` is the endpoint whose failure a restart is the right response to.
 
-Nothing probes `/health`. It is the diagnostic view: curl it from `kubectl exec` to see the `checks` and `errors` behind an unready pod.
+Nothing probes `/health`. It is the diagnostic view: curl it from `kubectl exec` to see the `checks` and `errors` behind a `healthCheck` that has withdrawn an agent.
 
 ### Graceful Shutdown
 

--- a/src/core/cli/man/content/health.md
+++ b/src/core/cli/man/content/health.md
@@ -146,13 +146,13 @@ While the check reports unhealthy the agent **stops heartbeating**. The registry
 
 The check that runs during startup is deliberately exempt: it seeds `/health` but is never reported to the core, so an agent registers and becomes visible first. The first refresh, one TTL later, is the earliest a check can withdraw it.
 
-The verdict also drives the probe endpoints: `/ready` and `/health` answer 200 only while the check reports `healthy`, and `/health` carries the `checks` and `errors` it returned. `/livez` never consults it - a restart cannot fix a vendor outage.
+The verdict drives `/health`, which answers 200 only while the check reports `healthy` and carries the `checks` and `errors` it returned. It does not drive `/ready`, which reports whether the mesh runtime is up: pausing the heartbeat already withdraws the agent, and a 503 on `/ready` would additionally empty the Service that mesh traffic arrives on. `/livez` never consults it either - a restart cannot fix a vendor outage.
 
 ### Only an Explicit Unhealthy Withdraws the Agent
 
 A check that **raises** is recorded as `degraded`, not unhealthy, and keeps heartbeating. So is one that returns something other than a dict, a `bool` or a `HealthStatus`. A bug in a health check must not be able to remove a working agent from the mesh. Return `False` or `{"status": "unhealthy"}` to actually withdraw.
 
-`degraded` splits the two surfaces on purpose: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider.
+`degraded` shows on the diagnostic surface only: the agent keeps heartbeating and stays in dependency resolution, and `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict; readiness reports the mesh runtime and nothing else.
 
 ### Route and A2A Agents
 

--- a/src/core/cli/man/content/health_java.md
+++ b/src/core/cli/man/content/health_java.md
@@ -56,17 +56,17 @@ One check per agent, on any Spring bean. Return `MeshHealth` for full detail, or
 
 While the check reports unhealthy the agent **stops heartbeating**. The registry marks it unhealthy after the staleness window, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent through the `410 Gone` re-register path - no restart. The TTL is the cadence, not the end-to-end latency: it only bounds how long until the next check runs. Withdrawal costs that plus the registry's staleness window once heartbeats stop, and recovery costs it plus the heartbeat resume and re-register round trip.
 
-The verdict also drives the probe endpoints: `/ready` answers 503 while unhealthy, and `/health` carries the `checks` and `errors` the method returned. `/livez` never consults it - a restart cannot fix a vendor outage. On a route (`api`) or A2A agent `/ready` is exempt too - see below.
+The verdict drives `/health`, which answers 503 while unhealthy and carries the `checks` and `errors` the method returned. It does not drive `/ready`, which reports whether the mesh runtime is up, on every agent type: pausing the heartbeat already withdraws the agent, and a 503 on `/ready` would additionally empty the Kubernetes Service that mesh traffic arrives on. `/livez` never consults it either - a restart cannot fix a vendor outage.
 
 ### Only an Explicit Unhealthy Withdraws the Agent
 
 A check that **throws** is recorded as `degraded`, not unhealthy, and keeps heartbeating. A bug in a health check must not be able to remove a working agent from the mesh. Return `false` or `MeshHealth.unhealthy(...)` to actually withdraw.
 
-`degraded` splits the two surfaces on purpose, the same way it does on Python: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider.
+`degraded` shows on the diagnostic surface only, the same way it does on Python: the agent keeps heartbeating and stays in dependency resolution, and `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict; readiness reports the mesh runtime and nothing else.
 
 ### Route and A2A Agents
 
-On a route-only (`api`) or A2A agent the check feeds `/health` only. It **never** suppresses the heartbeat and **never** affects `/ready`, which reports whether the mesh runtime is up and nothing else. A gateway is a fan-out point that many requests enter through: withdrawing a provider is correct, withdrawing the gateway takes the application down - and a 503 on `/ready` drops it from its Kubernetes Service endpoints, which takes it down harder. `/health` is where you see what a gateway's check reports. This matches Python, whose API and A2A pipelines have no health-refresh loop at all.
+On a route-only (`api`) or A2A agent the check feeds `/health` only: it **never** suppresses the heartbeat. A gateway is a fan-out point that many requests enter through, so withdrawing a provider is correct while withdrawing the gateway takes the application down. `/health` is where you see what a gateway's check reports. This matches Python, whose API and A2A pipelines have no health-refresh loop at all. `/ready` needs no carve-out any more - it reports the mesh runtime on every agent type.
 
 ## Checking Dependency Health
 

--- a/src/core/cli/man/content/health_typescript.md
+++ b/src/core/cli/man/content/health_typescript.md
@@ -66,7 +66,7 @@ const agent = mesh(server, {
 
 One check per agent. Return `{ status, checks, errors }` for full detail, or a `boolean` for the terse form (`true` healthy, `false` unhealthy). `healthCheckTtl` is how often it re-runs (default 15); `MCP_MESH_HEALTH_CHECK_TTL` overrides it.
 
-The verdict also drives the probe endpoints: `/ready` and `/health` answer 200 only while the check reports `healthy`, and `/health` carries the `checks` and `errors` it returned. `/livez` never consults it - a restart cannot fix a vendor outage. On a `mesh.route` or A2A agent the check is ignored entirely - see below.
+The verdict drives `/health`, which answers 200 only while the check reports `healthy` and carries the `checks` and `errors` it returned. It does not drive `/ready`, which reports whether the mesh runtime is up: pausing the heartbeat already withdraws the agent, and a 503 on `/ready` would additionally empty the Service that mesh traffic arrives on. `/livez` never consults it either - a restart cannot fix a vendor outage. On a `mesh.route` or A2A agent the check is ignored entirely - see below.
 
 ### What a Failing Check Does
 
@@ -74,7 +74,7 @@ While the check reports unhealthy the agent **stops heartbeating**. The registry
 
 Report `unhealthy` only for conditions the mesh should route around: the upstream this agent needs is genuinely not serving. A check that **throws**, or that could not reach a conclusion, is recorded as `degraded` and keeps heartbeating - a broken probe says nothing about the upstream, and withdrawing a working agent over one is the worse failure.
 
-`degraded` splits the two surfaces on purpose, the same way it does on Python and Java: the agent keeps heartbeating and stays in dependency resolution, but `/ready` and `/health` answer 503. Readiness is a load-balancer decision about new external traffic; the heartbeat is a statement about whether this is still a valid mesh provider.
+`degraded` shows on the diagnostic surface only, the same way it does on Python and Java: the agent keeps heartbeating and stays in dependency resolution, and `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict; readiness reports the mesh runtime and nothing else.
 
 `mesh.route` and A2A agents ignore `healthCheck`. They are fan-out points, so withdrawing one takes down every path that enters through it - declare the check on the agents behind the gateway instead.
 
@@ -168,21 +168,22 @@ agent.addTool({
 
 ## Health Endpoints
 
-TypeScript agents automatically expose three endpoints, and Kubernetes probes must not share one:
+TypeScript agents automatically expose four endpoints, and Kubernetes probes must not share one:
 
-- `/livez` - `livenessProbe` and `startupProbe`. 200 for as long as the process is serving; consults nothing else.
-- `/ready` - `readinessProbe`. 200 only while your `healthCheck` reports `healthy`; 503 on `degraded` or `unhealthy`. An agent with no `healthCheck` is healthy.
-- `/health` - no probe. The same verdict, plus the `checks` and `errors` the check returned.
+- `/startupz` - `startupProbe`. Reports your `startupCheck`; an agent that declares none passes.
+- `/livez` - `livenessProbe`. 200 for as long as the process is serving; consults nothing else.
+- `/ready` - `readinessProbe`. 200 once the mesh runtime is up; 503 before that and while shutting down. Your `healthCheck` does not reach it.
+- `/health` - no probe. The check's verdict plus the `checks` and `errors` it returned; 200 only while it reports `healthy`. An agent with no `healthCheck` is healthy.
 
 ```typescript
 // GET /health
 // { status: "healthy", agent: "my-agent", checks: { vendor_api_reachable: true }, errors: [], timestamp: "..." }
 
 // GET /ready
-// { ready: true, agent: "my-agent", status: "healthy", mcp_wrappers: 1, timestamp: "..." }
+// { ready: true, agent: "my-agent", runtime: "up", mcp_wrappers: 1, timestamp: "..." }
 ```
 
-A `mesh.route` or A2A agent serves the same three URLs, but its `/ready` reports only whether the mesh runtime is up and its `/health` is a fixed `healthy` - the `healthCheck` is ignored there.
+A `mesh.route` or A2A agent serves the same URLs, and its `/health` is a fixed `healthy` - the `healthCheck` is ignored there.
 
 ## Graceful Shutdown
 

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -270,10 +270,36 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // carve-out paragraph follows the endpoint list: the exception 5
 // (`@mesh.route`, `@mesh.a2a`, `health_check`, `/ready`, `/health`) = 5. It is
 // prose, not a bullet, so the two list goldens hold.
+// RFC #1502 step 2 follow-up: +2 / +3 / +1, split between `deployment.md`
+// (+1 / +3 / +1) and `health.md` (+1 / +0 / +0). `/ready` stopped reflecting
+// the health verdict on every agent type and the chart repointed
+// `startupProbe` from `/livez` to `/startupz`, so both pages described
+// behaviour the runtimes no longer have.
+//
+// `deployment.md`: the endpoint list goes from three bullets to four — the new
+// `/startupz` bullet is 3 spans (`/startupz`, `startupProbe`, `startup_check`)
+// and the `/livez` bullet loses `startupProbe`, which is the whole +2 on the
+// list goldens and the +1 markup list line. The rewritten `/ready` and
+// `/health` bullets swap spans one-for-one. In prose, the two "never point
+// liveness at" sentences shed `/ready` and `health_check` and the closing
+// diagnostic sentence gains `health_check` back, netting 0; the `startupProbe:
+// /ready` bullet gains `/startupz`, which is the remaining +1 on both the
+// inline and list goldens. The stanza's `path:` change is fenced, so it
+// contributes nothing.
+//
+// `health.md`: the two sentences that said a failing check 503s `/ready` are
+// rewritten to say it 503s `/health` alone. Both swap spans one-for-one except
+// the `degraded` sentence, which gains one `/health` explaining why the
+// diagnostic endpoint is free to carry a status code — the single inline span.
+// Prose throughout, so its list goldens hold.
+//
+// The `_java` and `_typescript` variants of both pages were rewritten the same
+// way and, as ever, move nothing here: these constants sample the default
+// variant alone, so a review of those files cannot lean on this test.
 const (
-	wantInlineCodeSpans = 1744
-	wantListCodeSpans   = 519
-	wantMarkupListLines = 447
+	wantInlineCodeSpans = 1746
+	wantListCodeSpans   = 522
+	wantMarkupListLines = 448
 )
 
 // assertCorpusSize replaces the t.Logf these tests used to end on.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAgentTypes.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshAgentTypes.java
@@ -8,14 +8,19 @@ import java.util.Set;
 /**
  * The "is this agent a gateway" rule, in ONE place (issue #1488).
  *
- * <p>Two mechanisms act on a failing {@link io.mcpmesh.MeshHealthCheck} — the
- * heartbeat in {@link MeshHealthCheckScheduler} and the readiness probe in
- * {@link MeshHealthController} — and both must exempt the same agent types. When
- * only the scheduler knew the rule, a gateway with a failing check kept
- * heartbeating (correct) but answered 503 on {@code /ready}, so Kubernetes
- * dropped it from its Service endpoints: the same outcome the exemption exists
- * to prevent, reached by another route. Two copies of the rule is how that
- * happens, so there is one.
+ * <p>It now has a single consumer: the heartbeat in
+ * {@link MeshHealthCheckScheduler}. {@link MeshHealthController} was the second
+ * — a gateway with a failing check kept heartbeating (correct) but answered 503
+ * on {@code /ready}, so Kubernetes dropped it from its Service endpoints, the
+ * same outcome the exemption exists to prevent reached by another route. RFC
+ * #1502 closed that route for every agent type rather than for gateways alone:
+ * readiness reports the mesh runtime and never the verdict, so the controller
+ * has no rule to ask about.
+ *
+ * <p>This stays a shared type rather than folding back into the scheduler
+ * because the exemption is a property of the agent type, not of the heartbeat,
+ * and the next mechanism that needs it must find the rule rather than write a
+ * second copy.
  */
 final class MeshAgentTypes {
 
@@ -39,10 +44,6 @@ final class MeshAgentTypes {
 
     static boolean isGateway(String agentType) {
         return GATEWAY_TYPES.contains(agentType);
-    }
-
-    static boolean isGateway(MeshRuntime runtime) {
-        return isGateway(agentTypeOf(runtime));
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
@@ -21,9 +21,9 @@ import java.util.Map;
  *
  * <p>Unlike Python and TypeScript, which serve their provider and gateway
  * probes from two different places, Java serves every agent type from this one
- * controller — the starter mounts it whatever the agent is. Where the other two
- * runtimes have to keep two sites in step, the per-agent-type rules here are
- * expressed as branches ({@link #readyStatus}) instead.
+ * controller — the starter mounts it whatever the agent is. Since RFC #1502
+ * every endpoint here answers the same way for every agent type, so there is
+ * nothing left for the other two runtimes to keep in step with either.
  *
  * <p>Liveness and readiness are deliberately DIFFERENT endpoints (issue #1467).
  * When both probes share a URL, anything that makes an agent unready also makes
@@ -32,18 +32,33 @@ import java.util.Map;
  * 200 unconditionally, while {@code /ready} reports whether the agent should be
  * receiving traffic.
  *
- * <p>Since issue #1474 {@code /ready} also reflects the user's
- * {@link io.mcpmesh.MeshHealthCheck}, and {@code /health} carries its
- * {@code checks} and {@code errors} so an operator can see WHICH probe failed.
- * The runtime state remains the floor: an agent whose mesh runtime is not up is
- * not ready regardless of what the user's check says.
+ * <p>{@code /ready} reports whether the mesh runtime is up, on every agent type
+ * (RFC #1502). The user's {@link io.mcpmesh.MeshHealthCheck} does NOT reach it.
+ * A failing check already withdraws the agent by pausing the heartbeat — the
+ * registry ages it out and resolution stops selecting it — and answering 503
+ * here as well is not defence in depth but a regression: mesh traffic traverses
+ * the Kubernetes Service, so emptying the Service endpoints while the registry
+ * may still be selecting the agent turns a consumer's failover into a
+ * connection error.
  *
- * <p>On a gateway ({@link MeshAgentTypes#isGateway}) the verdict does NOT reach
- * {@code /ready} (issue #1488): readiness there reports only whether the mesh
- * runtime is up, exactly as Python's {@code build_ready_response} and
- * TypeScript's {@code express.ts} do. The verdict still shows on {@code /health}
- * — nothing probes it, so it costs nothing and it is where an operator can see
- * what a gateway's check reports.
+ * <p>Readiness is not unconditional either. {@link io.mcpmesh.MeshStartupCheck}
+ * defaults to passing, so {@code /startupz} answers 200 before the mesh runtime
+ * has started in the Spring lifecycle; without the runtime floor a pod could go
+ * Ready with no runtime behind it. The floor is also the only probe that can
+ * notice a runtime that dies while the JVM lives, since {@code /livez} consults
+ * nothing.
+ *
+ * <p>This subsumes #1488's gateway carve-out: readiness now reports the runtime
+ * on a gateway and on a provider alike, so there is no longer a branch to take.
+ * {@link MeshAgentTypes} still carries the rule for the heartbeat
+ * ({@link MeshHealthCheckScheduler}), which is where the route/A2A exemption
+ * actually lives.
+ *
+ * <p>{@code /health} is unchanged: it carries the verdict, its {@code checks}
+ * and its {@code errors}, and answers 503 when the verdict is not healthy.
+ * Nothing probes it, so its status code is free to carry information — which
+ * means {@code /ready} and {@code /health} now diverge on every agent type, by
+ * design.
  */
 @Controller
 public class MeshHealthController {
@@ -87,25 +102,19 @@ public class MeshHealthController {
     }
 
     /**
-     * The readiness verdict: the effective status, except on a gateway, where
-     * the user's check is ignored and only the runtime floor applies.
+     * The readiness verdict: the mesh runtime state, and nothing else (RFC
+     * #1502).
      *
-     * <p>A route ({@code api}) or A2A agent is exempt from withdrawal by its own
-     * check — {@link MeshAgentTypes} carries that rule for both this controller
-     * and {@link MeshHealthCheckScheduler}. Answering 503 here would evade the
-     * exemption: the chart's readiness probe points at {@code /ready}, so a 503
-     * drops the gateway from its Kubernetes Service endpoints, which takes the
-     * application down harder than withdrawing it from dependency resolution
-     * would have. The runtime floor still applies — a gateway whose mesh runtime
-     * is not up genuinely cannot serve.
+     * <p>Takes no {@link MeshHealth} argument on purpose. A parameter the method
+     * ignores is an invitation to start consulting it again, and the whole point
+     * of this change is that the user's check has no path to the readiness
+     * probe. See the class comment for why 503-ing readiness on a failing check
+     * makes an outage worse rather than safer.
      */
-    private MeshHealthStatus readyStatus(MeshHealth latest) {
-        if (MeshAgentTypes.isGateway(runtime)) {
-            return runtime != null && runtime.isRunning()
-                ? MeshHealthStatus.HEALTHY
-                : MeshHealthStatus.UNHEALTHY;
-        }
-        return effectiveStatus(latest);
+    private MeshHealthStatus readyStatus() {
+        return runtime != null && runtime.isRunning()
+            ? MeshHealthStatus.HEALTHY
+            : MeshHealthStatus.UNHEALTHY;
     }
 
     /**
@@ -126,18 +135,16 @@ public class MeshHealthController {
     }
 
     /**
-     * Whether the probes answer 200. Only {@link MeshHealthStatus#HEALTHY}
-     * does — exactly Python's {@code build_health_response} /
-     * {@code build_ready_response}, which are {@code 200 if status ==
-     * "healthy" else 503}.
+     * Whether a status maps to 200. Only {@link MeshHealthStatus#HEALTHY} does —
+     * exactly Python's {@code build_health_response}, which is {@code 200 if
+     * status == "healthy" else 503}.
      *
-     * <p>So {@code degraded} answers 503 here while the agent keeps
-     * heartbeating and stays in dependency resolution. That asymmetry is
-     * Python's and is deliberate on both sides: readiness is a load-balancer
-     * decision about NEW external traffic, while the heartbeat is a statement
-     * about whether this agent is still a valid provider for the mesh. An
-     * impaired agent can honestly answer "stop adding load" without also
-     * withdrawing itself from a mesh that may have no other provider.
+     * <p>So {@code degraded} answers 503 on {@code /health} while the agent
+     * keeps heartbeating and stays in dependency resolution. Nothing probes
+     * {@code /health}, so its status code is free to carry the verdict. The
+     * probe the kubelet actually reads is {@code /ready}, and the only statuses
+     * that reach this from there are the two {@link #readyStatus} produces from
+     * the runtime state.
      */
     private static boolean serving(MeshHealthStatus status) {
         return status == MeshHealthStatus.HEALTHY;
@@ -170,29 +177,21 @@ public class MeshHealthController {
     /**
      * Kubernetes readiness probe.
      *
-     * <p>Reports whether traffic should be routed here: the mesh runtime is up
-     * AND the user's {@link io.mcpmesh.MeshHealthCheck} (if any) is not
-     * reporting unhealthy — except on a gateway, where only the runtime counts
-     * (see {@link #readyStatus}). It does NOT restart anything — see the class
-     * comment on why this is a separate endpoint from {@code /livez}.
+     * <p>Reports whether the mesh runtime is up, and nothing else (see
+     * {@link #readyStatus}). It does NOT restart anything — see the class
+     * comment on why this is a separate endpoint from {@code /livez}, and on why
+     * the user's health check reaches {@code /health} but not this.
      */
     @GetMapping("/ready")
     public ResponseEntity<Map<String, Object>> ready() {
-        boolean running = runtime != null && runtime.isRunning();
-        MeshHealth latest = healthOf(latestResult());
-        MeshHealthStatus status = readyStatus(latest);
+        MeshHealthStatus status = readyStatus();
         boolean ready = serving(status);
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("ready", ready);
         body.put("status", status.wireValue());
         if (!ready) {
-            body.put("reason", running
-                ? "service is " + status.wireValue()
-                : "mesh runtime is not running");
-            if (latest != null && !latest.errors().isEmpty()) {
-                body.put("errors", latest.errors());
-            }
+            body.put("reason", "mesh runtime is not running");
         }
         return ResponseEntity.status(ready ? 200 : 503).body(body);
     }
@@ -201,8 +200,7 @@ public class MeshHealthController {
     public ResponseEntity<Void> readyHead() {
         // Same verdict as GET — a HEAD probe that disagreed with the GET would
         // be the #1488 bug again for anyone who configured HEAD.
-        return ResponseEntity.status(
-            serving(readyStatus(healthOf(latestResult()))) ? 200 : 503).build();
+        return ResponseEntity.status(serving(readyStatus()) ? 200 : 503).build();
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthControllerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthControllerTest.java
@@ -9,12 +9,21 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
- * Unit tests for the probe endpoints (issue #1467).
+ * Unit tests for the probe endpoints (issue #1467, RFC #1502).
  *
- * <p>The invariant under test: liveness and readiness are DIFFERENT signals.
- * {@code /ready} follows {@code runtime.isRunning()} so an agent whose runtime
- * is down is taken out of rotation; {@code /livez} answers 200 regardless, so
- * the same condition never causes a pod restart.
+ * <p>Two invariants, and they are separate:
+ *
+ * <ul>
+ *   <li>liveness and readiness are DIFFERENT signals. {@code /ready} follows
+ *       {@code runtime.isRunning()} so an agent whose runtime is down is taken
+ *       out of rotation; {@code /livez} answers 200 regardless, so the same
+ *       condition never causes a pod restart (#1467).
+ *   <li>readiness and the health VERDICT are different signals too. The
+ *       runtime state is all {@code /ready} reports, on every agent type; a
+ *       failing {@link io.mcpmesh.MeshHealthCheck} withdraws the agent by
+ *       pausing the heartbeat and never touches this probe (RFC #1502). It
+ *       still drives {@code /health}, which nothing probes.
+ * </ul>
  */
 class MeshHealthControllerTest {
 
@@ -147,44 +156,50 @@ class MeshHealthControllerTest {
     }
 
     @Test
-    void ready_is503_whenTheUserHealthCheckIsUnhealthy() {
+    void ready_is200_whenTheUserHealthCheckIsUnhealthy() {
+        // RFC #1502. The heartbeat pause is the whole withdrawal mechanism; a
+        // 503 here would ALSO empty the Kubernetes Service the mesh routes
+        // through, so a consumer calling the withdrawn agent before the
+        // registry sweeps gets a connection error instead of a failover.
         MeshHealthController controller = new MeshHealthController(runtimeWith(true),
             withVerdict(io.mcpmesh.MeshHealth.unhealthy("anthropic API unreachable")));
 
         ResponseEntity<Map<String, Object>> response = controller.ready();
 
-        assertEquals(503, response.getStatusCode().value());
-        assertEquals(Boolean.FALSE, response.getBody().get("ready"));
-        assertEquals("unhealthy", response.getBody().get("status"));
-        assertEquals("service is unhealthy", response.getBody().get("reason"));
-        assertEquals(java.util.List.of("anthropic API unreachable"),
-            response.getBody().get("errors"));
-        assertEquals(503, controller.readyHead().getStatusCode().value());
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(Boolean.TRUE, response.getBody().get("ready"));
+        assertFalse(response.getBody().containsKey("reason"));
+        assertFalse(response.getBody().containsKey("errors"),
+            "/ready must not carry the health check's errors — it did not consult it");
+        assertEquals(200, controller.readyHead().getStatusCode().value());
+
+        // ...and the verdict is still visible where an operator looks for it.
+        assertEquals(503, controller.health().getStatusCode().value());
+        assertEquals("unhealthy", controller.health().getBody().get("status"));
     }
 
     @Test
-    void ready_is503_whenTheUserHealthCheckIsDegraded() {
-        // Python parity: build_ready_response / build_health_response are
-        // `200 if status == "healthy" else 503`. Degraded therefore leaves the
-        // load balancer while STILL heartbeating and staying in dependency
-        // resolution — readiness is about new external traffic, the heartbeat
-        // is about whether this is still a valid mesh provider.
+    void ready_is200_whenTheUserHealthCheckIsDegraded() {
         MeshHealthController controller = new MeshHealthController(runtimeWith(true),
             withVerdict(io.mcpmesh.MeshHealth.degraded("elevated latency")));
 
-        ResponseEntity<Map<String, Object>> response = controller.ready();
+        assertEquals(200, controller.ready().getStatusCode().value());
+        assertEquals(200, controller.readyHead().getStatusCode().value());
 
-        assertEquals(503, response.getStatusCode().value());
-        assertEquals(Boolean.FALSE, response.getBody().get("ready"));
-        assertEquals("degraded", response.getBody().get("status"));
-        assertEquals("service is degraded", response.getBody().get("reason"));
+        // /health is unchanged: Python parity, `200 if status == "healthy"
+        // else 503`. Nothing probes it, so the status code is free to carry
+        // the verdict.
         assertEquals(503, controller.health().getStatusCode().value());
+        assertEquals("degraded", controller.health().getBody().get("status"));
     }
 
     @Test
     void ready_is503_whenTheRuntimeIsDownEvenIfTheCheckSaysHealthy() {
-        // The runtime state is the FLOOR: a vendor probe says nothing about
-        // whether this agent is registered and reachable.
+        // The runtime state is all readiness reports, and it is not vestigial:
+        // MeshStartupCheck defaults to passing, so /startupz answers 200 before
+        // the mesh runtime has started in the Spring lifecycle. Without this a
+        // pod would go Ready with no runtime behind it, and /livez — which
+        // consults nothing — would never notice a runtime that died either.
         MeshHealthController controller = new MeshHealthController(runtimeWith(false),
             withVerdict(io.mcpmesh.MeshHealth.healthy()));
 
@@ -224,7 +239,13 @@ class MeshHealthControllerTest {
         assertFalse(controller.health().getBody().containsKey("checks"));
     }
 
-    // ---- gateways are never taken out of Service endpoints (issue #1488) ----
+    // ---- no agent type is taken out of Service endpoints by its own check ----
+    //
+    // These started as the #1488 gateway carve-out. RFC #1502 generalised it:
+    // the rule is the same for every agent type now, so the pairs below assert
+    // the SAME behaviour for gateways and providers. They are kept apart
+    // because a future change that reintroduces a per-type branch has to fail
+    // one of them, and which one it fails names the direction of the mistake.
 
     @Test
     void gateway_ready_is200_whenTheUserHealthCheckIsUnhealthy() {
@@ -298,9 +319,11 @@ class MeshHealthControllerTest {
     }
 
     @Test
-    void nonGateway_ready_is503_whenTheUserHealthCheckIsUnhealthy() {
-        // Guards against over-correcting: an mcp agent is a provider, and
-        // withdrawing ONE provider is exactly what the mechanism is for.
+    void nonGateway_ready_is200_whenTheUserHealthCheckIsUnhealthy() {
+        // A provider withdraws by GOING QUIET, not by leaving its Service. The
+        // registry ages it out on the missing heartbeat and resolution stops
+        // selecting it; the pod keeps its endpoint so an in-flight consumer
+        // gets an answer rather than a refused connection.
         for (String agentType : java.util.List.of("mcp", "mcp_agent")) {
             MeshHealthController controller = new MeshHealthController(
                 runtimeOf(agentType, true),
@@ -308,23 +331,32 @@ class MeshHealthControllerTest {
 
             ResponseEntity<Map<String, Object>> response = controller.ready();
 
-            assertEquals(503, response.getStatusCode().value(),
-                "'" + agentType + "' agent must still leave rotation");
-            assertEquals(Boolean.FALSE, response.getBody().get("ready"));
-            assertEquals("service is unhealthy", response.getBody().get("reason"));
-            assertEquals(503, controller.readyHead().getStatusCode().value());
+            assertEquals(200, response.getStatusCode().value(),
+                "'" + agentType + "' agent must stay in Service endpoints");
+            assertEquals(Boolean.TRUE, response.getBody().get("ready"));
+            assertEquals(200, controller.readyHead().getStatusCode().value());
+            assertEquals(503, controller.health().getStatusCode().value(),
+                "'" + agentType + "' agent's /health must still carry the verdict");
         }
     }
 
     @Test
-    void livez_is200_evenWhenTheUserHealthCheckIsUnhealthy() {
-        // The #1467 invariant, extended: a vendor outage must never restart the
-        // pod — a restart cannot fix the vendor and erases the evidence.
+    void everyProbeIsUnmovedByAnUnhealthyCheckExceptHealth() {
+        // The #1467 invariant, extended by RFC #1502: a vendor outage must move
+        // exactly ONE endpoint. Asserted together so a change that quietly
+        // rewires any of the four has to edit this line.
         MeshHealthController controller = new MeshHealthController(runtimeWith(true),
             withVerdict(io.mcpmesh.MeshHealth.unhealthy("vendor down")));
 
-        assertEquals(200, controller.livez().getStatusCode().value());
+        assertEquals(200, controller.livez().getStatusCode().value(),
+            "a restart cannot fix the vendor and erases the evidence");
         assertEquals(200, controller.livezHead().getStatusCode().value());
-        assertEquals(503, controller.ready().getStatusCode().value());
+        assertEquals(200, controller.ready().getStatusCode().value(),
+            "the heartbeat pause withdraws the agent; readiness must not also "
+                + "empty the Service the mesh routes through");
+        assertEquals(200, controller.startupz().getStatusCode().value(),
+            "startup answers the 'will this ever work' question, not this one");
+        assertEquals(503, controller.health().getStatusCode().value(),
+            "the diagnostic view is where the verdict shows");
     }
 }

--- a/src/runtime/python/_mcp_mesh/pipeline/shared/health_endpoints.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/shared/health_endpoints.py
@@ -23,7 +23,10 @@ Semantics (matching TypeScript's ``express.ts`` ``setupHealthEndpoints``):
 
 ``/ready``
     Whether the **mesh runtime** is up — a live Rust core handle exists and
-    shutdown has not been requested — and nothing else.
+    shutdown has not been requested — and nothing else. Since RFC #1502 that
+    is the rule on every agent type, not a gateway carve-out —
+    ``health_check_manager.runtime_state``, imported below, is what a
+    provider's ``build_ready_response`` answers from too.
 
 ``/health``
     The diagnostic view. Always 200; no probe points at it.
@@ -49,6 +52,7 @@ from typing import Any, Optional
 
 from ...shared.config_resolver import ValidationRule, get_config_value
 from ...shared.fastapi_routes import iter_app_routes
+from ...shared.health_check_manager import NOT_READY_REASON, runtime_state
 from ...shared.startup_check_manager import STARTUPZ_PATH
 from .base_step import PipelineStep
 from .pipeline_types import PipelineResult, PipelineStatus
@@ -93,35 +97,6 @@ def _agent_name(default: str = "mcp-mesh-gateway") -> str:
         return config.get("name") or config.get("agent_id") or default
     except Exception:  # pragma: no cover - defensive, name is cosmetic
         return default
-
-
-def runtime_state(standalone: bool = False) -> tuple[bool, str]:
-    """Report whether the mesh runtime is up, and in what state.
-
-    ``standalone`` mode never starts a Rust core (registry communication is
-    switched off by configuration), so the gateway is ready as soon as it
-    serves — the absence of a handle is the configured outcome, not a
-    startup that has not finished.
-    """
-    if standalone:
-        return True, "standalone"
-
-    from ...shared.simple_shutdown import (
-        get_active_rust_agent_handles,
-        should_stop_heartbeat,
-    )
-
-    if should_stop_heartbeat():
-        return False, "shutting_down"
-    if get_active_rust_agent_handles():
-        return True, "up"
-    return False, "starting"
-
-
-_NOT_READY_REASON = {
-    "starting": "Mesh runtime has not started yet",
-    "shutting_down": "Mesh runtime is shutting down",
-}
 
 
 def _find_route(app: Any, path: str) -> Optional[Any]:
@@ -192,7 +167,7 @@ def register_health_endpoints(
             "timestamp": _now(),
         }
         if not is_ready:
-            body["reason"] = _NOT_READY_REASON.get(state, f"Mesh runtime is {state}")
+            body["reason"] = NOT_READY_REASON.get(state, f"Mesh runtime is {state}")
         return JSONResponse(status_code=200 if is_ready else 503, content=body)
 
     async def health():

--- a/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
+++ b/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
@@ -469,6 +469,65 @@ def get_cache_stats() -> dict[str, Any]:
 # =============================================================================
 
 
+def _standalone_from_env() -> bool:
+    """Whether MCP_MESH_STANDALONE switches registry communication off.
+
+    Never raises: this feeds a probe response, and a config-resolution error
+    must not turn ``/ready`` into a 500. An unreadable value is treated as
+    "not standalone", which is the mode every deployed agent runs in.
+    """
+    try:
+        from .config_resolver import ValidationRule, get_config_value
+
+        return bool(
+            get_config_value(
+                "MCP_MESH_STANDALONE",
+                default=False,
+                rule=ValidationRule.TRUTHY_RULE,
+            )
+        )
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
+def runtime_state(standalone: bool | None = None) -> tuple[bool, str]:
+    """Report whether the mesh runtime is up, and in what state.
+
+    This is the ONE definition of "the runtime is up" for every Python probe
+    — the provider endpoints in ``mesh/decorators.py`` and the gateway
+    endpoints in ``pipeline/shared/health_endpoints.py`` both answer
+    ``/ready`` from it. Two copies of the rule is how a gateway and a
+    provider end up disagreeing about what readiness means.
+
+    ``standalone`` mode never starts a Rust core (registry communication is
+    switched off by configuration), so the agent is ready as soon as it
+    serves — the absence of a handle is the configured outcome, not a
+    startup that has not finished. ``None`` reads the environment; the
+    gateway pipeline passes the value it already resolved.
+    """
+    if standalone is None:
+        standalone = _standalone_from_env()
+    if standalone:
+        return True, "standalone"
+
+    from .simple_shutdown import (
+        get_active_rust_agent_handles,
+        should_stop_heartbeat,
+    )
+
+    if should_stop_heartbeat():
+        return False, "shutting_down"
+    if get_active_rust_agent_handles():
+        return True, "up"
+    return False, "starting"
+
+
+NOT_READY_REASON = {
+    "starting": "Mesh runtime has not started yet",
+    "shutting_down": "Mesh runtime is shutting down",
+}
+
+
 def build_health_response(
     agent_name: str,
     health_status: HealthStatus | None = None,
@@ -510,37 +569,35 @@ def build_ready_response(
     """
     Build /ready endpoint response with appropriate HTTP status code.
 
+    Reports whether the **mesh runtime** is up, and nothing else (RFC #1502).
+    The user's ``health_check`` is deliberately NOT consulted here — this is
+    the same rule the gateway pipelines have always applied, now applied to
+    every agent type.
+
+    A failing check pauses the heartbeat, the registry ages the agent out and
+    resolution stops selecting it; that is the whole withdrawal mechanism and
+    it needs no help from the readiness probe. Adding readiness on top is
+    strictly worse: ``agent.advertisedHost`` defaults to the per-agent
+    Service DNS name, so mesh traffic traverses the Service. A 503 here drops
+    the pod from its Service endpoints while the registry may still be
+    selecting it, and a consumer gets a connection error instead of failing
+    over. The verdict still shows on ``/health``, which nothing probes.
+
     Returns:
         Tuple of (response_dict, http_status_code)
     """
-    stored = get_health_check_result()
+    is_ready, state = runtime_state()
 
-    if stored:
-        status = stored.get("status", "starting")
-        if status == "healthy":
-            return {
-                "ready": True,
-                "agent": agent_name,
-                "status": status,
-                "mcp_wrappers": mcp_wrappers_count,
-                "timestamp": datetime.now(UTC).isoformat(),
-            }, 200
-        else:
-            return {
-                "ready": False,
-                "agent": agent_name,
-                "status": status,
-                "reason": f"Service is {status}",
-                "errors": stored.get("errors", []),
-            }, 503
-    else:
-        # No health check configured - assume ready
-        return {
-            "ready": True,
-            "agent": agent_name,
-            "mcp_wrappers": mcp_wrappers_count,
-            "timestamp": datetime.now(UTC).isoformat(),
-        }, 200
+    response: dict[str, Any] = {
+        "ready": is_ready,
+        "agent": agent_name,
+        "runtime": state,
+        "mcp_wrappers": mcp_wrappers_count,
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+    if not is_ready:
+        response["reason"] = NOT_READY_REASON.get(state, f"Mesh runtime is {state}")
+    return response, 200 if is_ready else 503
 
 
 def build_livez_response(agent_name: str) -> dict:

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -468,7 +468,14 @@ def _start_uvicorn_immediately(http_host: str, http_port: int):
         @app.get("/ready")
         @app.head("/ready")
         async def ready(response: Response):
-            """Kubernetes readiness probe - service ready to serve traffic."""
+            """Kubernetes readiness probe.
+
+            RFC #1502: reports whether the mesh runtime is up, NOT the user's
+            ``health_check`` verdict. A failing check withdraws the agent by
+            pausing the heartbeat; adding a 503 here would additionally drop
+            the pod from its Service endpoints, which is where mesh traffic
+            arrives. See ``build_ready_response``.
+            """
             data, status_code = build_ready_response(agent_name="mcp-mesh-agent")
             response.status_code = status_code
             return data

--- a/src/runtime/python/tests/unit/test_gateway_health_endpoints_1491.py
+++ b/src/runtime/python/tests/unit/test_gateway_health_endpoints_1491.py
@@ -93,8 +93,8 @@ def declared_health_check(monkeypatch):
 
     Both of the things a health check produces: the callable itself (which must
     never be invoked from these endpoints) and the stored ``unhealthy`` verdict
-    that ``build_health_response`` / ``build_ready_response`` would turn into a
-    503. Neither may reach a gateway probe.
+    that ``build_health_response`` would turn into a 503. Neither may reach a
+    gateway probe.
     """
     from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
     from _mcp_mesh.shared import health_check_manager
@@ -366,8 +366,9 @@ class TestReady:
         self, api_app, runtime_up, declared_health_check
     ):
         """#1473/#1488: a gateway is a fan-out point — its own check must not
-        withdraw it. A stored ``unhealthy`` verdict would 503 through
-        ``build_ready_response``; this endpoint must not consult it."""
+        withdraw it. Since RFC #1502 no agent type's ``/ready`` consults the
+        verdict, but a stored ``unhealthy`` result must still not reach this
+        endpoint by any other route."""
         response = TestClient(api_app).get("/ready")
         assert response.status_code == 200
         assert response.json()["ready"] is True

--- a/src/runtime/python/tests/unit/test_ready_runtime_state_1502.py
+++ b/src/runtime/python/tests/unit/test_ready_runtime_state_1502.py
@@ -1,0 +1,225 @@
+"""``/ready`` reports the mesh runtime, never the health verdict — RFC #1502.
+
+Step 2 of the RFC. Until this landed, a Python ``@mesh.agent`` provider's
+``/ready`` answered 503 whenever the stored ``health_check`` result was
+anything but ``healthy``, while its gateway pipelines (#1491) already reported
+runtime state alone. Providers now adopt the gateway's rule, so the two agree.
+
+WHY THE VERDICT MUST NOT DRIVE READINESS
+
+``agent.advertisedHost`` defaults to the per-agent Service DNS name and the
+chart ships a ``service.yaml``, so mesh traffic traverses the Service. A
+failing check already withdraws the agent by pausing the heartbeat — the
+registry ages it out and resolution stops selecting it. Answering 503 here as
+well drops the pod from its Service endpoints, and during the window where the
+registry has not swept yet a consumer gets a connection error instead of a
+failover. Readiness removal without heartbeat suppression is strictly worse
+than either alone.
+
+WHY IT IS NOT UNCONDITIONAL EITHER
+
+``startup_check`` defaults to true, so ``/startupz`` answers 200 before the
+runtime is up: an unconditional ``/ready`` would let a pod go Ready with no
+mesh runtime behind it. The runtime floor keeps that window closed and still
+removes every verdict-driven readiness transition.
+
+``/health`` is deliberately NOT part of this: it keeps answering 503 for a
+non-healthy verdict. Nothing probes it, so the status code is free to carry
+information, and it is where an operator sees what the check reports.
+"""
+
+import pytest
+
+from _mcp_mesh.shared import health_check_manager, simple_shutdown
+from _mcp_mesh.shared.health_check_manager import (
+    build_health_response,
+    build_livez_response,
+    build_ready_response,
+)
+
+# ``runtime_state`` is imported inside the one test that needs it, not here:
+# a module-level import of a name this change introduces would make the whole
+# file red on an ImportError against the pre-change tree, and an ImportError
+# proves nothing about what ``/ready`` answered.
+
+
+@pytest.fixture(autouse=True)
+def _clean_stored_result():
+    """No stored verdict leaks between tests (the store is module global)."""
+    health_check_manager.clear_health_check_result()
+    yield
+    health_check_manager.clear_health_check_result()
+
+
+@pytest.fixture
+def runtime_up(monkeypatch):
+    """A live Rust core handle exists — the mesh runtime is up."""
+    monkeypatch.setattr(
+        simple_shutdown, "get_active_rust_agent_handles", lambda: [object()]
+    )
+    monkeypatch.setattr(simple_shutdown, "should_stop_heartbeat", lambda: False)
+
+
+@pytest.fixture
+def runtime_starting(monkeypatch):
+    """No handle yet — start_agent() has not returned."""
+    monkeypatch.setattr(simple_shutdown, "get_active_rust_agent_handles", list)
+    monkeypatch.setattr(simple_shutdown, "should_stop_heartbeat", lambda: False)
+
+
+@pytest.fixture
+def runtime_shutting_down(monkeypatch):
+    """Shutdown requested — the handle may still exist for a moment."""
+    monkeypatch.setattr(
+        simple_shutdown, "get_active_rust_agent_handles", lambda: [object()]
+    )
+    monkeypatch.setattr(simple_shutdown, "should_stop_heartbeat", lambda: True)
+
+
+def _store(status: str, **extra):
+    health_check_manager.store_health_check_result(
+        {"status": status, "agent": "provider", **extra}
+    )
+
+
+# ---------------------------------------------------------------------------
+# The change: a non-healthy verdict no longer makes a provider unready
+# ---------------------------------------------------------------------------
+
+
+class TestVerdictDoesNotDriveReadiness:
+    @pytest.mark.parametrize("status", ["unhealthy", "degraded", "unknown"])
+    def test_ready_stays_200_for_every_non_healthy_verdict(self, runtime_up, status):
+        _store(status, errors=["simulated vendor outage"])
+
+        body, code = build_ready_response(agent_name="provider")
+
+        assert code == 200
+        assert body["ready"] is True
+
+    def test_ready_carries_the_runtime_state_not_the_verdict(self, runtime_up):
+        """The body reports what the endpoint actually consulted.
+
+        A ``status`` key echoing the health verdict would invite exactly the
+        misreading this change exists to remove — ``status: unhealthy`` beside
+        a 200 reads as a contradiction rather than as two separate facts.
+        """
+        _store("unhealthy", errors=["vendor 503"])
+
+        body, _ = build_ready_response(agent_name="provider")
+
+        assert body["runtime"] == "up"
+        assert "status" not in body
+        assert "errors" not in body
+
+    def test_a_healthy_verdict_is_200_as_before(self, runtime_up):
+        _store("healthy")
+
+        body, code = build_ready_response(agent_name="provider")
+
+        assert code == 200
+        assert body["ready"] is True
+
+    def test_no_stored_result_at_all_is_200(self, runtime_up):
+        """An agent with no ``health_check`` is unaffected, as it always was."""
+        body, code = build_ready_response(agent_name="provider")
+
+        assert code == 200
+        assert body["ready"] is True
+        assert body["agent"] == "provider"
+        assert body["mcp_wrappers"] == 0
+
+    def test_ready_never_reads_the_stored_result(self, runtime_up, monkeypatch):
+        """Not just "the verdict does not change the answer" — it is not read.
+
+        A builder that still consulted the store and happened to map every
+        verdict to 200 would pass the assertions above and reintroduce the
+        coupling the moment someone re-added a branch.
+        """
+
+        def exploding_getter():
+            raise AssertionError("/ready must not consult the health verdict")
+
+        monkeypatch.setattr(
+            health_check_manager, "get_health_check_result", exploding_getter
+        )
+
+        assert build_ready_response(agent_name="provider")[1] == 200
+
+
+# ---------------------------------------------------------------------------
+# The floor: the runtime state still decides
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeStateIsTheFloor:
+    def test_no_handle_yet_is_503_even_with_a_healthy_verdict(self, runtime_starting):
+        _store("healthy")
+
+        body, code = build_ready_response(agent_name="provider")
+
+        assert code == 503
+        assert body["ready"] is False
+        assert body["runtime"] == "starting"
+        assert body["reason"] == "Mesh runtime has not started yet"
+
+    def test_shutting_down_is_503(self, runtime_shutting_down):
+        _store("healthy")
+
+        body, code = build_ready_response(agent_name="provider")
+
+        assert code == 503
+        assert body["runtime"] == "shutting_down"
+        assert body["reason"] == "Mesh runtime is shutting down"
+
+    def test_standalone_is_ready_without_any_handle(
+        self, runtime_starting, monkeypatch
+    ):
+        """Standalone never starts a Rust core; that is configuration, not a
+        startup that has not finished."""
+        monkeypatch.setenv("MCP_MESH_STANDALONE", "true")
+
+        body, code = build_ready_response(agent_name="provider")
+
+        assert code == 200
+        assert body["runtime"] == "standalone"
+
+    def test_runtime_state_is_one_definition_shared_with_the_gateway(self):
+        """The gateway pipeline must resolve the SAME function.
+
+        Two copies of "the runtime is up" is how a gateway and a provider end
+        up disagreeing about what readiness means.
+        """
+        from _mcp_mesh.pipeline.shared import health_endpoints
+        from _mcp_mesh.shared.health_check_manager import runtime_state
+
+        assert health_endpoints.runtime_state is runtime_state
+
+
+# ---------------------------------------------------------------------------
+# What did NOT change
+# ---------------------------------------------------------------------------
+
+
+class TestOtherEndpointsAreUnchanged:
+    @pytest.mark.parametrize("status", ["unhealthy", "degraded"])
+    def test_health_still_answers_503_for_a_non_healthy_verdict(self, status):
+        """``/health`` is the diagnostic view and nothing probes it, so the
+        status code is free to carry the verdict. It must keep doing so —
+        ``/ready`` and ``/health`` now diverge, deliberately."""
+        _store(status, errors=["vendor 503"])
+
+        body, code = build_health_response(agent_name="provider")
+
+        assert code == 503
+        assert body["status"] == status
+
+    def test_health_is_200_when_healthy(self):
+        _store("healthy")
+
+        assert build_health_response(agent_name="provider")[1] == 200
+
+    def test_livez_consults_nothing(self, runtime_starting):
+        _store("unhealthy")
+
+        assert build_livez_response(agent_name="provider")["alive"] is True

--- a/src/runtime/typescript/src/__tests__/health-routes.spec.ts
+++ b/src/runtime/typescript/src/__tests__/health-routes.spec.ts
@@ -1,20 +1,26 @@
 /**
- * Mesh-aware `/ready` and `/health` tests (issue #1478).
+ * Mesh-aware `/ready` and `/health` tests (issue #1478, RFC #1502).
  *
- * The agent chart gates Service endpoints on `/ready` (#1468). Before this
- * change both URLs were FastMCP's built-ins — `/ready` a hardcoded 200 in
- * stateless mode, `/health` the literal string `✓ Ok` — so a TypeScript
- * provider whose health check had withdrawn it from the mesh kept receiving
- * direct Service traffic, and `/health` told an operator nothing.
+ * Before #1478 both URLs were FastMCP's built-ins — `/ready` a hardcoded
+ * 200 in stateless mode, `/health` the literal string `✓ Ok` — so an
+ * operator who curled `/health` learned nothing about the agent.
  *
- * Three properties are pinned here, and the third is the one most likely to
- * regress silently:
+ * RFC #1502 step 2 then split what the two report, and that split is the
+ * subject of most of this file:
  *
- *   1. a non-healthy verdict answers 503 on BOTH endpoints, with detail;
- *   2. a healthy verdict answers 200;
- *   3. an agent with NO `healthCheck` configured is unaffected — it must
- *      keep answering ready/healthy exactly as it did before. Only a
- *      configured check may make these endpoints report not-ready.
+ *   - `/ready` reports the MESH RUNTIME STATE and nothing else. A failing
+ *     or throwing `healthCheck` must not move it. A failing check already
+ *     withdraws the agent by pausing the heartbeat; a 503 here would
+ *     additionally empty the Kubernetes Service the mesh routes through,
+ *     turning a failover into a connection error.
+ *   - `/health` still answers 503 for a non-healthy verdict. Nothing
+ *     probes it, so its status code is free to carry information.
+ *
+ * The runtime floor is not decoration: `startupCheck` defaults to passing,
+ * so `/startupz` answers 200 before `startAgent()` has returned, and an
+ * unconditional `/ready` would put a pod in the Service with no mesh
+ * runtime behind it. It is also the only probe that can notice a runtime
+ * that dies while the process lives, since `/livez` consults nothing.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { FastMCP } from "fastmcp";
@@ -22,8 +28,10 @@ import {
   registerHealthRoutes,
   buildHealthBody,
   buildReadyBody,
+  readyStatusCodeFor,
   statusCodeFor,
 } from "../health-routes.js";
+import type { RuntimeState } from "../health-routes.js";
 import type { HealthVerdict } from "../health-check.js";
 import { MeshAgent } from "../agent.js";
 
@@ -97,6 +105,16 @@ const healthy: HealthVerdict = {
   errors: [],
 };
 
+/** `registerHealthRoutes` with the runtime up, which is the normal case. */
+function register(
+  server: FastMCP,
+  agentName: string,
+  getVerdict: () => HealthVerdict | null,
+  getRuntimeState: () => RuntimeState = () => "up",
+): boolean {
+  return registerHealthRoutes(server, agentName, getVerdict, getRuntimeState);
+}
+
 describe("registerHealthRoutes — registration", () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
@@ -109,7 +127,7 @@ describe("registerHealthRoutes — registration", () => {
 
   it("registers GET and HEAD for both /ready and /health", () => {
     const { server, routes } = stubServer();
-    expect(registerHealthRoutes(server, "my-agent", () => null)).toBe(true);
+    expect(register(server, "my-agent", () => null)).toBe(true);
 
     expect(routes.map((r) => r.path).sort()).toEqual(["/health", "/ready"]);
     for (const route of routes) {
@@ -125,7 +143,7 @@ describe("registerHealthRoutes — registration", () => {
       },
     } as unknown as FastMCP;
 
-    expect(registerHealthRoutes(server, "my-agent", () => null)).toBe(false);
+    expect(register(server, "my-agent", () => null)).toBe(false);
     expect(errorSpy).toHaveBeenCalledOnce();
     const msg = errorSpy.mock.calls[0][0] as string;
     expect(msg).toContain("/ready and /health routes NOT registered");
@@ -135,7 +153,7 @@ describe("registerHealthRoutes — registration", () => {
   it("logs at console.error when getApp() returns null", () => {
     const server = { getApp: () => null } as unknown as FastMCP;
 
-    expect(registerHealthRoutes(server, "my-agent", () => null)).toBe(false);
+    expect(register(server, "my-agent", () => null)).toBe(false);
     expect(errorSpy.mock.calls[0][0] as string).toContain("returned null");
   });
 
@@ -148,30 +166,148 @@ describe("registerHealthRoutes — registration", () => {
       }),
     } as unknown as FastMCP;
 
-    expect(registerHealthRoutes(server, "my-agent", () => null)).toBe(false);
+    expect(register(server, "my-agent", () => null)).toBe(false);
     expect(errorSpy.mock.calls[0][0] as string).toContain(
       "hono internal: route conflict",
     );
   });
 });
 
-describe("the verdict drives both endpoints", () => {
-  it("an unhealthy verdict answers 503 on /ready with the reason and errors", () => {
+// ---------------------------------------------------------------------------
+// RFC #1502: /ready is the mesh runtime, and only the mesh runtime
+// ---------------------------------------------------------------------------
+
+describe("/ready reports the mesh runtime state, not the verdict", () => {
+  // THE assertion of this change. Before it, an unhealthy verdict answered
+  // 503 here — which emptied the Service endpoints the mesh itself routes
+  // through, so a consumer calling the withdrawn provider got a connection
+  // error instead of failing over to another one.
+  it.each([
+    ["unhealthy", unhealthy],
+    ["degraded", degraded],
+  ])("stays 200 through a %s verdict while the runtime is up", (_name, verdict) => {
     const { server, routes } = stubServer();
-    registerHealthRoutes(server, "provider-a", () => unhealthy);
+    register(server, "provider-a", () => verdict, () => "up");
+
+    const { body, status } = dispatch(routes, "/ready", "GET");
+    expect(status).toBe(200);
+    expect(body.ready).toBe(true);
+    expect(body.reason).toBeUndefined();
+  });
+
+  it("stays 200 when the verdict source throws", () => {
+    const { server, routes } = stubServer();
+    register(
+      server,
+      "provider-a",
+      () => {
+        throw new Error("verdict source exploded");
+      },
+      () => "up",
+    );
+
+    expect(dispatch(routes, "/ready", "GET").status).toBe(200);
+  });
+
+  // Not merely "the verdict does not change the answer" — it is never read.
+  // A handler that still consulted it and happened to map every verdict to
+  // 200 would pass the cases above and reintroduce the coupling the moment
+  // someone re-added a branch.
+  it("never reads the verdict source at all", () => {
+    const { server, routes } = stubServer();
+    const source = vi.fn(() => unhealthy);
+    register(server, "provider-a", source, () => "up");
+
+    dispatch(routes, "/ready", "GET");
+    expect(source).not.toHaveBeenCalled();
+  });
+
+  it("carries the runtime state and no verdict fields", () => {
+    const { server, routes } = stubServer();
+    register(server, "provider-a", () => unhealthy, () => "up");
+
+    const { body } = dispatch(routes, "/ready", "GET");
+    expect(body.runtime).toBe("up");
+    expect(body.agent).toBe("provider-a");
+    expect(body.mcp_wrappers).toBe(1);
+    expect(body.status).toBeUndefined();
+    expect(body.errors).toBeUndefined();
+  });
+
+  // The floor. `startupCheck` defaults to passing, so /startupz answers 200
+  // before startAgent() returns; without this a pod would enter its Service
+  // with no mesh runtime behind it.
+  it("answers 503 while the runtime is still starting, healthy verdict or not", () => {
+    const { server, routes } = stubServer();
+    register(server, "provider-a", () => healthy, () => "starting");
 
     const { body, status } = dispatch(routes, "/ready", "GET");
     expect(status).toBe(503);
     expect(body.ready).toBe(false);
-    expect(body.agent).toBe("provider-a");
-    expect(body.status).toBe("unhealthy");
-    expect(body.reason).toBe("Service is unhealthy");
-    expect(body.errors).toEqual(["vendor returned 503"]);
+    expect(body.runtime).toBe("starting");
+    expect(body.reason).toBe("Mesh runtime has not started yet");
   });
 
-  it("an unhealthy verdict answers 503 on /health carrying checks and errors", () => {
+  it("answers 503 while shutting down", () => {
     const { server, routes } = stubServer();
-    registerHealthRoutes(server, "provider-a", () => unhealthy);
+    register(server, "provider-a", () => healthy, () => "shutting_down");
+
+    const { body, status } = dispatch(routes, "/ready", "GET");
+    expect(status).toBe(503);
+    expect(body.runtime).toBe("shutting_down");
+    expect(body.reason).toBe("Mesh runtime is shutting down");
+  });
+
+  // The state is re-read per request, not captured at registration: the
+  // routes are mounted BEFORE startAgent() runs, so a handler that cached
+  // the boot value would answer 503 forever.
+  it("reads the runtime state per request rather than caching it", () => {
+    const { server, routes } = stubServer();
+    let state: RuntimeState = "starting";
+    register(server, "provider-a", () => null, () => state);
+
+    expect(dispatch(routes, "/ready", "GET").status).toBe(503);
+    state = "up";
+    expect(dispatch(routes, "/ready", "GET").status).toBe(200);
+    state = "shutting_down";
+    expect(dispatch(routes, "/ready", "GET").status).toBe(503);
+  });
+
+  // A probe that cannot answer is not evidence the runtime is up, and a 500
+  // is not an answer a kubelet can act on.
+  it("reports not ready when the runtime-state source throws", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { server, routes } = stubServer();
+    register(server, "provider-a", () => null, () => {
+      throw new Error("handle read exploded");
+    });
+
+    const { body, status } = dispatch(routes, "/ready", "GET");
+    expect(status).toBe(503);
+    expect(body.runtime).toBe("starting");
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("HEAD answers the same status as GET", () => {
+    const { server, routes } = stubServer();
+    register(server, "provider-a", () => unhealthy, () => "up");
+    expect(dispatch(routes, "/ready", "HEAD").status).toBe(200);
+
+    const { server: down, routes: downRoutes } = stubServer();
+    register(down, "provider-a", () => healthy, () => "starting");
+    expect(dispatch(downRoutes, "/ready", "HEAD").status).toBe(503);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /health is unchanged: it still carries the verdict, including in its code
+// ---------------------------------------------------------------------------
+
+describe("/health still reports the verdict", () => {
+  it("an unhealthy verdict answers 503 carrying checks and errors", () => {
+    const { server, routes } = stubServer();
+    register(server, "provider-a", () => unhealthy);
 
     const { body, status } = dispatch(routes, "/health", "GET");
     expect(status).toBe(503);
@@ -183,25 +319,18 @@ describe("the verdict drives both endpoints", () => {
   });
 
   // Python's `200 if status == "healthy" else 503` and Java's `serving()`
-  // both answer 503 for degraded. The heartbeat keeps running (degraded
-  // never withdraws), but a load balancer is told to stop adding load.
-  it("a degraded verdict answers 503 on both endpoints", () => {
+  // both answer 503 for degraded on this endpoint too.
+  it("a degraded verdict answers 503", () => {
     const { server, routes } = stubServer();
-    registerHealthRoutes(server, "provider-a", () => degraded);
+    register(server, "provider-a", () => degraded);
 
-    expect(dispatch(routes, "/ready", "GET").status).toBe(503);
     expect(dispatch(routes, "/health", "GET").status).toBe(503);
     expect(dispatch(routes, "/health", "GET").body.status).toBe("degraded");
   });
 
-  it("a healthy verdict answers 200 on both endpoints", () => {
+  it("a healthy verdict answers 200", () => {
     const { server, routes } = stubServer();
-    registerHealthRoutes(server, "provider-a", () => healthy);
-
-    const ready = dispatch(routes, "/ready", "GET");
-    expect(ready.status).toBe(200);
-    expect(ready.body.ready).toBe(true);
-    expect(ready.body.reason).toBeUndefined();
+    register(server, "provider-a", () => healthy);
 
     const health = dispatch(routes, "/health", "GET");
     expect(health.status).toBe(200);
@@ -209,21 +338,11 @@ describe("the verdict drives both endpoints", () => {
     expect(health.body.checks).toEqual({ vendor_api_reachable: true });
   });
 
-  // THE compatibility guarantee. Making these endpoints mesh-aware must not
-  // change what an agent WITHOUT a health check answers — every existing
-  // TypeScript agent is in that category, and a regression here would make
-  // the whole fleet unready on upgrade.
-  it("no healthCheck configured (null verdict) answers exactly as before: 200", () => {
+  // THE compatibility guarantee. Making this endpoint mesh-aware must not
+  // change what an agent WITHOUT a health check answers.
+  it("no healthCheck configured (null verdict) answers 200", () => {
     const { server, routes } = stubServer();
-    registerHealthRoutes(server, "plain-agent", () => null);
-
-    const ready = dispatch(routes, "/ready", "GET");
-    expect(ready.status).toBe(200);
-    expect(ready.body.ready).toBe(true);
-    expect(ready.body.status).toBe("healthy");
-    expect(ready.body.agent).toBe("plain-agent");
-    expect(ready.body.mcp_wrappers).toBe(1);
-    expect(ready.body.reason).toBeUndefined();
+    register(server, "plain-agent", () => null);
 
     const health = dispatch(routes, "/health", "GET");
     expect(health.status).toBe(200);
@@ -232,32 +351,16 @@ describe("the verdict drives both endpoints", () => {
     expect(health.body.errors).toEqual([]);
   });
 
-  it("HEAD answers the same status as GET on both endpoints", () => {
-    const { server, routes } = stubServer();
-    registerHealthRoutes(server, "provider-a", () => unhealthy);
-
-    expect(dispatch(routes, "/ready", "HEAD").status).toBe(503);
-    expect(dispatch(routes, "/health", "HEAD").status).toBe(503);
-
-    const { server: ok, routes: okRoutes } = stubServer();
-    registerHealthRoutes(ok, "provider-a", () => null);
-    expect(dispatch(okRoutes, "/ready", "HEAD").status).toBe(200);
-    expect(dispatch(okRoutes, "/health", "HEAD").status).toBe(200);
-  });
-
-  // The verdict is re-read per request, not captured at registration: the
-  // loop rewrites it every TTL and a route that cached the boot value would
-  // answer 200 forever.
-  it("reads the verdict per request rather than caching it", () => {
+  it("the verdict is re-read per request rather than cached", () => {
     const { server, routes } = stubServer();
     let current: HealthVerdict | null = null;
-    registerHealthRoutes(server, "provider-a", () => current);
+    register(server, "provider-a", () => current);
 
-    expect(dispatch(routes, "/ready", "GET").status).toBe(200);
+    expect(dispatch(routes, "/health", "GET").status).toBe(200);
     current = unhealthy;
-    expect(dispatch(routes, "/ready", "GET").status).toBe(503);
+    expect(dispatch(routes, "/health", "GET").status).toBe(503);
     current = healthy;
-    expect(dispatch(routes, "/ready", "GET").status).toBe(200);
+    expect(dispatch(routes, "/health", "GET").status).toBe(200);
   });
 
   // One snapshot per request. Reading the source twice could mix two
@@ -265,24 +368,30 @@ describe("the verdict drives both endpoints", () => {
   it("takes one verdict snapshot per request", () => {
     const { server, routes } = stubServer();
     const source = vi.fn(() => unhealthy);
-    registerHealthRoutes(server, "provider-a", source);
+    register(server, "provider-a", source);
 
     dispatch(routes, "/health", "GET");
     expect(source).toHaveBeenCalledOnce();
   });
 
-  // A probe that cannot answer is not evidence the agent is broken, and a
-  // 500 here would pull a working pod out of the Service.
+  // A diagnostic endpoint that 500s tells an operator less than one that
+  // says "no verdict".
   it("a throwing verdict source answers as if no check were configured", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { server, routes } = stubServer();
-    registerHealthRoutes(server, "provider-a", () => {
+    register(server, "provider-a", () => {
       throw new Error("verdict source exploded");
     });
 
-    expect(dispatch(routes, "/ready", "GET").status).toBe(200);
+    expect(dispatch(routes, "/health", "GET").status).toBe(200);
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+
+  it("HEAD answers the same status as GET", () => {
+    const { server, routes } = stubServer();
+    register(server, "provider-a", () => unhealthy);
+    expect(dispatch(routes, "/health", "HEAD").status).toBe(503);
   });
 });
 
@@ -297,14 +406,20 @@ describe("body builders match the Python contract", () => {
     ]);
   });
 
-  it("/ready carries ready, agent, status, mcp_wrappers and timestamp", () => {
-    expect(Object.keys(buildReadyBody("a", healthy)).sort()).toEqual([
+  it("/ready carries ready, agent, runtime, mcp_wrappers and timestamp", () => {
+    expect(Object.keys(buildReadyBody("a", "up")).sort()).toEqual([
       "agent",
       "mcp_wrappers",
       "ready",
-      "status",
+      "runtime",
       "timestamp",
     ]);
+  });
+
+  it("readyStatusCodeFor is 200 only once the runtime is up", () => {
+    expect(readyStatusCodeFor("up")).toBe(200);
+    expect(readyStatusCodeFor("starting")).toBe(503);
+    expect(readyStatusCodeFor("shutting_down")).toBe(503);
   });
 
   it("statusCodeFor is 200 only for healthy", () => {
@@ -315,11 +430,58 @@ describe("body builders match the Python contract", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// The runtime-state source the agent actually passes
+// ---------------------------------------------------------------------------
+
+describe("MeshAgent.getRuntimeState", () => {
+  function agentWithHandle(handle: unknown, shutdownRequested = false): MeshAgent {
+    const server = {
+      addTool: vi.fn(),
+      start: vi.fn().mockResolvedValue(undefined),
+      getApp: () => ({ on: vi.fn(), post: vi.fn() }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const agent = new MeshAgent(server, { name: "state-test", httpPort: 0 }) as any;
+    agent.handle = handle;
+    agent.shutdownRequested = shutdownRequested;
+    return agent as MeshAgent;
+  }
+
+  beforeEach(() => {
+    // The constructor schedules _autoStart, whose rejection handler calls
+    // process.exit(1) — existing convention in this file.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.spyOn(MeshAgent.prototype as any, "_autoStart").mockImplementation(
+      async () => undefined,
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is 'starting' before startAgent() returns a handle", () => {
+    expect(agentWithHandle(null).getRuntimeState()).toBe("starting");
+  });
+
+  it("is 'up' once a handle exists", () => {
+    expect(agentWithHandle({}).getRuntimeState()).toBe("up");
+  });
+
+  // Checked BEFORE the handle: shutdown() nulls the handle only after the
+  // napi teardown returns, and a pod being drained is not "starting".
+  it("is 'shutting_down' from the moment shutdown is requested", () => {
+    expect(agentWithHandle({}, true).getRuntimeState()).toBe("shutting_down");
+  });
+});
+
 describe("_autoStart aborts when /ready and /health cannot be registered", () => {
   // Same fail-loud posture as /livez: an unregistered route here does NOT
   // fall back to something harmless — FastMCP's built-in answers a
-  // hardcoded 200, so the agent would serve while lying about readiness,
-  // which is the bug #1478 fixes. Silence would ship the regression.
+  // hardcoded 200, so the pod would enter its Service before the mesh
+  // runtime exists, which is the boot window the runtime floor closes.
   //
   // The auto-scheduled `_autoStart` tick from the constructor is stubbed
   // out (existing convention) — its rejection handler calls

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -75,6 +75,7 @@ import {
 import { registerCancelRoute } from "./jobs-cancel-route.js";
 import { registerLivezRoute } from "./livez-route.js";
 import { registerHealthRoutes } from "./health-routes.js";
+import type { RuntimeState } from "./health-routes.js";
 import { registerStartupzRoute } from "./startupz-route.js";
 import {
   startHealthCheckLoop,
@@ -1968,12 +1969,15 @@ export class MeshAgent {
     }
 
     // 1.6 Issue #1478: take over GET|HEAD /ready and /health from FastMCP's
-    // built-ins so both reflect the user health check's verdict, matching
-    // Python (#1472) and Java (#1474). Before this, `/ready` answered a
-    // hardcoded 200 and `/health` the literal string `✓ Ok`, so a TS
-    // provider whose vendor was down kept receiving direct Service traffic
-    // that mesh consumers had already routed away from, and `kubectl exec
-    // curl /health` told an operator nothing.
+    // built-ins, matching Python (#1472) and Java (#1474). Before this,
+    // `/ready` answered a hardcoded 200 and `/health` the literal string
+    // `✓ Ok`, so `kubectl exec curl /health` told an operator nothing.
+    //
+    // /ready reports the MESH RUNTIME STATE and /health the user health
+    // check's verdict (RFC #1502) — the two diverge, deliberately. See the
+    // module comment in health-routes.ts for why a failing check must not
+    // 503 readiness: mesh traffic traverses the Service, so emptying the
+    // Service endpoints turns a failover into a connection error.
     //
     // Owning /ready also removes a latent trap: FastMCP's built-in returns
     // 503 when `totalSessions === 0` in STATEFUL mode, and mesh escapes it
@@ -1982,22 +1986,24 @@ export class MeshAgent {
     // otherwise have made every TypeScript agent unready in Kubernetes
     // until its first session.
     //
-    // Fail-fast for the same reason as /livez, one step up: the agent chart
-    // gates Service endpoints on /ready (#1468). An unregistered route here
-    // is not a silent fallback to the built-in — the built-in is the wrong
-    // answer (always-200), so the agent would serve traffic while lying
-    // about its readiness, which is precisely the bug this fixes. Throwing
-    // makes the cause visible instead of shipping the regression.
+    // Fail-fast for the same reason as /livez: the agent chart gates
+    // Service endpoints on /ready (#1468), and the built-in it would fall
+    // back to is hardcoded 200 — so the pod would go Ready before the mesh
+    // runtime exists, which is the boot window the runtime floor closes.
+    // Throwing makes the cause visible instead of shipping the regression.
     if (
-      !registerHealthRoutes(this.server, this.config.name, () =>
-        this.getHealthVerdict(),
+      !registerHealthRoutes(
+        this.server,
+        this.config.name,
+        () => this.getHealthVerdict(),
+        () => this.getRuntimeState(),
       )
     ) {
       throw new Error(
         `agent ${this.agentId} cannot start: the /ready and /health routes ` +
           `failed to register (cause logged above). Kubernetes gates Service ` +
-          `endpoints on /ready, so serving without them would keep sending ` +
-          `traffic to this agent after its health check reported it unhealthy.`,
+          `endpoints on /ready, so serving without them would put this agent ` +
+          `in the Service before its mesh runtime is up.`,
       );
     }
 
@@ -2136,12 +2142,29 @@ export class MeshAgent {
    * Issue #1476: the latest health verdict, or null before the first run
    * completes (or when no `healthCheck` is configured).
    *
-   * Read per request by the `/ready` and `/health` routes (#1478); null
-   * is answered as healthy there, so an agent with no `healthCheck` is
-   * unaffected by those endpoints becoming mesh-aware.
+   * Read per request by the `/health` route (#1478); null is answered as
+   * healthy there, so an agent with no `healthCheck` is unaffected by that
+   * endpoint becoming mesh-aware. `/ready` does NOT read this — RFC #1502
+   * put it on the mesh runtime state instead (`getRuntimeState`).
    */
   getHealthVerdict(): HealthVerdict | null {
     return this.healthLoop?.latest() ?? null;
+  }
+
+  /**
+   * RFC #1502: whether the mesh runtime is up, for `/ready`.
+   *
+   * `up` once `startAgent()` has handed back a napi handle, `starting`
+   * before that, `shutting_down` from the moment shutdown is requested —
+   * checked first, because `shutdown()` nulls the handle only after the
+   * napi teardown returns and a pod being drained is not "starting".
+   *
+   * The same floor `express.ts` has always applied to a gateway
+   * (`this.handle !== null`) and Python's `runtime_state`.
+   */
+  getRuntimeState(): RuntimeState {
+    if (this.shutdownRequested) return "shutting_down";
+    return this.handle !== null ? "up" : "starting";
   }
 
   /**

--- a/src/runtime/typescript/src/health-routes.ts
+++ b/src/runtime/typescript/src/health-routes.ts
@@ -4,12 +4,34 @@
  *
  * Until this landed both URLs were FastMCP's own built-ins: `/ready`
  * answered a hardcoded 200 in stateless mode and `/health` returned the
- * literal `text/plain` string `✓ Ok`. A TypeScript provider whose vendor
- * was down therefore kept receiving direct Kubernetes Service traffic
- * long after mesh consumers had failed over (#1468 made `/ready` gate
- * Service endpoints), and an operator who curled `/health` learned
- * nothing. Python (#1472) and Java (#1474) both answer 503 with detail;
- * this is the TypeScript half of that contract.
+ * literal `text/plain` string `✓ Ok`, so an operator who curled `/health`
+ * learned nothing about the agent. Python (#1472) and Java (#1474) both
+ * carry the verdict with detail; this is the TypeScript half of that
+ * contract.
+ *
+ * ## What each endpoint reports (RFC #1502)
+ *
+ * `/ready` reports whether the **mesh runtime** is up, and nothing else.
+ * `/health` reports the user's `healthCheck` verdict — 200 only while it
+ * is `healthy` — and nothing probes it. The two therefore DIVERGE on
+ * every agent type, deliberately.
+ *
+ * A failing check already withdraws the agent by pausing the heartbeat:
+ * the registry ages it out and resolution stops selecting it. Adding
+ * readiness on top is strictly worse rather than defence in depth,
+ * because mesh traffic traverses the Kubernetes Service — `advertisedHost`
+ * defaults to the per-agent Service DNS name. A 503 here empties the
+ * Service endpoints while the registry may still be selecting the agent,
+ * and the consumer gets a connection error instead of failing over.
+ *
+ * Readiness is not unconditional either. `startupCheck` defaults to
+ * passing, so `/startupz` answers 200 before the runtime is up; without
+ * the runtime floor a pod could go Ready with no mesh runtime behind it.
+ * The floor is also the only probe that notices a runtime that dies while
+ * the process lives, since `/livez` consults nothing.
+ *
+ * This matches `express.ts`, whose gateway `/ready` has always been
+ * `this.handle !== null`, and Python's `runtime_state`.
  *
  * ## Why registering here shadows FastMCP
  *
@@ -28,28 +50,15 @@
  * agent unready in Kubernetes until the first session arrived. Owning
  * the route removes the dependency on that flag entirely.
  *
- * ## An agent with no health check is unaffected
+ * ## An agent with no health check is unaffected on /health
  *
  * A null verdict means "no `healthCheck` configured, or the seed run has
- * not finished yet" and is treated as HEALTHY. Only a configured check
- * that reports a non-healthy verdict can make an agent unready.
- *
- * This MATCHES the other two runtimes; it is not a divergence from them:
- *
- *   - Java's `MeshHealthController.effectiveStatus` returns `HEALTHY`
- *     outright when `latest` is null and the runtime is running;
- *   - Python reaches the same answer one step earlier. Its startup seed
- *     stores a default result for an agent with no `health_check` at all
- *     (`{"status": "healthy", ...}` in `fastapiserver_setup.py`), so
- *     `build_ready_response` / `build_health_response` see a stored
- *     healthy status and answer 200. Its no-stored-result branch is
- *     `# No health check configured - assume ready` → 200 as well.
- *
- * Python's `"starting"` 503 in `build_health_response` is NOT the
- * check-less case: it is the window before the seed has stored anything,
- * i.e. an agent that is genuinely still starting. Do not read it as a
- * runtime disagreement and "fix" this branch to match it — that would
- * make every check-less agent, on every runtime, unready.
+ * not finished yet" and is treated as HEALTHY, so `/health` answers 200.
+ * Only a configured check that reports a non-healthy verdict can make it
+ * 503. Java's `MeshHealthController.effectiveStatus` returns `HEALTHY`
+ * outright when `latest` is null and the runtime is running, and Python's
+ * startup seed stores a default healthy result for an agent with no
+ * `health_check` at all.
  *
  * `/livez` is unchanged and stays in `livez-route.ts` — liveness must
  * never consult the verdict, or a vendor outage becomes a pod restart.
@@ -61,17 +70,33 @@ import type { HealthVerdict } from "./health-check.js";
 export type HealthVerdictSource = () => HealthVerdict | null;
 
 /**
- * Only `healthy` answers 200 — the same rule as Python's
- * `build_health_response` / `build_ready_response` (`200 if status ==
- * "healthy" else 503`) and Java's `MeshHealthController.serving`.
+ * Whether the mesh runtime is up, and in what state.
  *
- * So `degraded` answers 503 here while the agent keeps heartbeating and
- * stays in dependency resolution. That asymmetry is deliberate on all
- * three runtimes: readiness is a load-balancer decision about NEW
- * external traffic, while the heartbeat states whether this agent is
- * still a valid provider for the mesh. An impaired agent can honestly
- * say "stop adding load" without withdrawing itself from a mesh that may
- * have no other provider.
+ * `up` once `startAgent()` has returned a napi handle; `shutting_down`
+ * once shutdown has been requested; `starting` before either. The same
+ * three states Python's `runtime_state` reports, minus `standalone` —
+ * TypeScript has no standalone mode, `_autoStart` always calls
+ * `startAgent`.
+ */
+export type RuntimeState = "up" | "starting" | "shutting_down";
+
+/** Reads the runtime state at request time (see `snapshot` below). */
+export type RuntimeStateSource = () => RuntimeState;
+
+const NOT_READY_REASON: Record<string, string> = {
+  starting: "Mesh runtime has not started yet",
+  shutting_down: "Mesh runtime is shutting down",
+};
+
+/**
+ * Only `healthy` answers 200 on `/health` — the same rule as Python's
+ * `build_health_response` (`200 if status == "healthy" else 503`) and
+ * Java's `MeshHealthController.serving`.
+ *
+ * So `degraded` answers 503 there while the agent keeps heartbeating and
+ * stays in dependency resolution. Nothing probes `/health`, so the status
+ * code is free to carry the verdict; `/ready`, which the kubelet does
+ * read, is governed by the runtime state alone.
  */
 function serving(status: string): boolean {
   return status === "healthy";
@@ -104,14 +129,13 @@ export function buildHealthBody(
 }
 
 /**
- * `/ready` body — Python's `build_ready_response` keys.
+ * `/ready` body — Python's `build_ready_response` keys: `{ready, agent,
+ * runtime, mcp_wrappers, timestamp}`, plus `reason` when not ready.
  *
- * Python varies them per branch: `{ready, agent, status, mcp_wrappers,
- * timestamp}` when ready, `{ready, agent, status, reason, errors}` when
- * not (no `timestamp`), and no `status` at all in its no-stored-result
- * branch. This emits the common keys unconditionally and adds
- * `reason`/`errors` when not ready — again a superset, so nothing a
- * Python-shaped reader looks for is missing.
+ * There is deliberately no `status` key carrying the health verdict. It
+ * used to be here, and beside a 200 it now reads as a contradiction
+ * rather than as two separate facts — exactly the conflation RFC #1502
+ * exists to undo. The verdict is on `/health`.
  *
  * `mcp_wrappers` counts the MCP servers this agent fronts. A TypeScript
  * agent wraps exactly one FastMCP server, so the honest constant is 1.
@@ -123,25 +147,28 @@ export function buildHealthBody(
  */
 export function buildReadyBody(
   agentName: string,
-  verdict: HealthVerdict | null,
+  state: RuntimeState,
 ): Record<string, unknown> {
-  const status = verdict ? verdict.status : "healthy";
-  const ready = serving(status);
+  const ready = state === "up";
   const body: Record<string, unknown> = {
     ready,
     agent: agentName,
-    status,
+    runtime: state,
     mcp_wrappers: 1,
     timestamp: new Date().toISOString(),
   };
   if (!ready) {
-    body.reason = `Service is ${status}`;
-    body.errors = verdict ? verdict.errors : [];
+    body.reason = NOT_READY_REASON[state] ?? `Mesh runtime is ${state}`;
   }
   return body;
 }
 
-/** HTTP status for a verdict: 200 healthy, 503 otherwise. */
+/** HTTP status for `/ready`: 200 once the mesh runtime is up. */
+export function readyStatusCodeFor(state: RuntimeState): 200 | 503 {
+  return state === "up" ? 200 : 503;
+}
+
+/** HTTP status for `/health`: 200 healthy, 503 otherwise. */
 export function statusCodeFor(verdict: HealthVerdict | null): 200 | 503 {
   return serving(verdict ? verdict.status : "healthy") ? 200 : 503;
 }
@@ -155,14 +182,17 @@ export function statusCodeFor(verdict: HealthVerdict | null): 200 | 503 {
  * Each failure branch logs the CAUSE only. The consequence is stated
  * once, by the caller that throws (see `agent.ts`).
  *
- * `getVerdict` is a callback rather than a value because the routes are
- * mounted during startup, before the health-check loop has produced (or
- * even been started with) anything.
+ * `getVerdict` and `getRuntimeState` are callbacks rather than values
+ * because the routes are mounted during startup — before the health-check
+ * loop has produced anything, and before `startAgent()` has returned a
+ * handle. A `/ready` that captured either at registration would answer the
+ * boot value forever.
  */
 export function registerHealthRoutes(
   server: FastMCP,
   agentName: string,
   getVerdict: HealthVerdictSource,
+  getRuntimeState: RuntimeStateSource,
 ): boolean {
   let app: ReturnType<FastMCP["getApp"]> | null = null;
   try {
@@ -189,10 +219,9 @@ export function registerHealthRoutes(
   // and whose `errors` came from the next, or a 200 status line over an
   // unhealthy body. Java's `latestResult()` exists for the same reason.
   //
-  // A verdict source that THROWS must not take the endpoint down with
-  // it: a probe that cannot answer is not evidence the agent is broken,
-  // and a 500 here would fail the readiness probe and pull a working pod
-  // out of the Service. Falling back to null answers exactly as an agent
+  // A verdict source that THROWS must not take `/health` down with it: a
+  // diagnostic endpoint that 500s tells an operator less than one that
+  // says "no verdict". Falling back to null answers exactly as an agent
   // with no health check does.
   const snapshot = (): HealthVerdict | null => {
     try {
@@ -207,10 +236,30 @@ export function registerHealthRoutes(
     }
   };
 
+  // Same containment as `snapshot`, for the same reason: a runtime-state
+  // source that throws must not 500 the readiness probe. `starting` is the
+  // conservative answer — it 503s, which is what an agent whose state
+  // cannot be determined should report to a load balancer, and unlike the
+  // verdict path there is no "as if unconfigured" reading that is safe.
+  const runtimeSnapshot = (): RuntimeState => {
+    try {
+      return getRuntimeState();
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[mesh-health] reading the mesh runtime state for agent ` +
+          `'${agentName}' threw — reporting not ready: ${reason}`,
+      );
+      return "starting";
+    }
+  };
+
   try {
     app.on(["GET", "HEAD"], "/ready", (c) => {
-      const verdict = snapshot();
-      return c.json(buildReadyBody(agentName, verdict), statusCodeFor(verdict));
+      // RFC #1502: the mesh runtime, NOT the health verdict. See the module
+      // comment for why adding the verdict here is worse than leaving it out.
+      const state = runtimeSnapshot();
+      return c.json(buildReadyBody(agentName, state), readyStatusCodeFor(state));
     });
     app.on(["GET", "HEAD"], "/health", (c) => {
       const verdict = snapshot();

--- a/src/runtime/typescript/src/startupz-route.ts
+++ b/src/runtime/typescript/src/startupz-route.ts
@@ -34,8 +34,8 @@ export type StartupCheckSource = () => MeshStartupCheck | undefined;
  * aborted — is stated once, by the caller that throws (see `agent.ts`).
  *
  * `getCheck` is a callback rather than a value for the same reason
- * `registerHealthRoutes` takes one: the route is mounted during startup, and
- * reading the config lazily keeps the two in step.
+ * `registerHealthRoutes` takes callbacks: the route is mounted during startup,
+ * and reading the config lazily keeps the two in step.
  */
 export function registerStartupzRoute(
   server: FastMCP,

--- a/tests/integration/suites/uc41_health_check_withdrawal/tc03_typescript_withdraw_failover_recover/test.yaml
+++ b/tests/integration/suites/uc41_health_check_withdrawal/tc03_typescript_withdraw_failover_recover/test.yaml
@@ -26,17 +26,24 @@
 #
 # THE VERDICT IS READ FROM /health, NOT FROM THE LOG
 #
-# Since #1478 TypeScript's `/ready` and `/health` are mesh-owned routes that
-# reflect the user health check's verdict, exactly as Python's and Java's do.
-# That is what is asserted here, and it is strictly stronger than the log line
-# it replaced: a runtime that printed `[mesh-health] ... reports UNHEALTHY`
-# while serving a 200 `/ready` would still be shipping the #1478 bug — direct
-# Kubernetes Service traffic keeps arriving at a provider mesh consumers have
-# already abandoned — and the log grep could not see it.
+# Since #1478 TypeScript's `/health` is a mesh-owned route that reflects the
+# user health check's verdict, exactly as Python's and Java's do. That is what
+# is asserted here, and it is strictly stronger than the log line it replaced:
+# a runtime that printed `[mesh-health] ... reports UNHEALTHY` while serving a
+# healthy `/health` body would still be shipping the #1478 bug, and the log
+# grep could not see it.
 #
-# `/ready` is checked by STATUS CODE rather than body text because that is the
-# only thing the kubelet reads: #1468 made the agent chart gate Service
-# endpoints on it, so a 200 here is the outage this test exists to catch.
+# /ready IS ASSERTED TOO, AND IT MUST STAY 200 (RFC #1502)
+#
+# Readiness reports the mesh runtime, not the verdict, on every agent type.
+# The assertion below is not a relaxation of the one it replaces — it is the
+# opposite claim, and it is the one that matters operationally. #1468 made the
+# agent chart gate Service endpoints on `/ready`, and mesh traffic traverses
+# that Service (`advertisedHost` defaults to the per-agent Service DNS name).
+# A 503 during withdrawal empties the endpoints while the registry may still be
+# selecting the agent, so a consumer gets a connection error instead of the
+# failover this test then goes on to verify. Checked by STATUS CODE, because
+# that is the only thing the kubelet reads.
 #
 # The rest of the design (file-toggled flag, poll-for-the-condition rather
 # than fixed waits, provider B as the control) is documented in tc01.
@@ -245,16 +252,21 @@ test:
   # The verdict, read from provider A's own endpoints (#1478) — see the header.
   #
   # `/ready` is captured as a bare status code: `curl -o /dev/null -w` prints
-  # nothing else, so the assertion below matches an exact `READY_HTTP_CODE: 503`
+  # nothing else, so the assertion below matches an exact `READY_HTTP_CODE: 200`
   # rather than a substring that a body could satisfy by accident. `--max-time`
   # on both so a hung server fails the step instead of the whole run.
-  - name: "Phase B: A's own /health and /ready must report the unhealthy verdict, not a crash"
+  - name: "Phase B: A's /health must report the unhealthy verdict while /ready stays 200"
     handler: shell
     workdir: /workspace
     command: |
       echo "HEALTH_BODY: $(curl -s --max-time 5 http://localhost:3421/health || echo 'HEALTH_UNREACHABLE')"
       echo "READY_HTTP_CODE: $(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:3421/ready || echo 'READY_UNREACHABLE')"
-      echo "READY_BODY: $(curl -s --max-time 5 http://localhost:3421/ready || echo 'READY_UNREACHABLE')"
+      READY_BODY=$(curl -s --max-time 5 http://localhost:3421/ready || echo 'READY_UNREACHABLE')
+      echo "READY_BODY: $READY_BODY"
+      # Derived as its own token so the assertion never has to match raw JSON
+      # punctuation through the expression parser. MISSING covers both an
+      # absent key and an unparseable body.
+      echo "READY_FLAG: $(printf '%s' "$READY_BODY" | jq -r '.ready // "MISSING"' 2>/dev/null || echo MISSING)"
     capture: provider_a_health_during_outage
 
   - name: "Phase B: poll until the consumer fails over to provider B"
@@ -399,14 +411,18 @@ assertions:
   - expr: "${captured.provider_a_health_during_outage} not contains 'HEALTH_UNREACHABLE'"
     message: "WITHDRAWAL: provider A's HTTP server must still answer /health while withdrawn — withdrawn is not dead"
 
-  # The Kubernetes half, and the reason #1478 was a bug rather than a cosmetic
-  # gap: #1468 gates Service endpoints on /ready, so a provider that keeps
-  # answering 200 here goes on receiving direct traffic that mesh consumers
-  # have already routed away from.
-  - expr: "${captured.provider_a_health_during_outage} contains 'READY_HTTP_CODE: 503'"
-    message: "WITHDRAWAL: /ready must answer 503 while the health check reports unhealthy — a 200 keeps the pod in the Service and sends direct traffic to a provider the mesh has abandoned"
+  # The Kubernetes half (RFC #1502). Withdrawal is going quiet, not leaving the
+  # Service: #1468 gates Service endpoints on /ready, and mesh traffic arrives
+  # through that Service, so a 503 here would empty the endpoints while the
+  # registry may still be selecting A — turning the failover asserted below
+  # into a connection error. Asserted positively, and with a captured body, so
+  # a runtime that stopped serving /ready altogether cannot satisfy it.
+  - expr: "${captured.provider_a_health_during_outage} contains 'READY_HTTP_CODE: 200'"
+    message: "WITHDRAWAL: /ready must stay 200 while the health check reports unhealthy — readiness reports the mesh runtime, and a 503 would empty the Service endpoints the mesh itself routes through"
+  - expr: "${captured.provider_a_health_during_outage} contains 'READY_FLAG: true'"
+    message: "WITHDRAWAL: /ready's body must say ready — a 200 over a not-ready body would mean the status line and the body disagree"
   - expr: "${captured.provider_a_health_during_outage} not contains 'READY_UNREACHABLE'"
-    message: "WITHDRAWAL: provider A must still answer /ready while withdrawn — an unreachable endpoint is a different failure from an honest 503"
+    message: "WITHDRAWAL: provider A must still answer /ready while withdrawn — an unreachable endpoint is a different failure from an honest answer"
 
   - expr: "${captured.fault_trace} not contains 'FAIL_TICKS: 0'"
     message: "WITHDRAWAL: the health check must have been invoked at least once while the flag said fail"

--- a/tests/integration/suites/uc41_health_check_withdrawal/tc04_typescript_throwing_check_degrades/test.yaml
+++ b/tests/integration/suites/uc41_health_check_withdrawal/tc04_typescript_throwing_check_degrades/test.yaml
@@ -31,6 +31,8 @@
 #
 # Since #1478 TS `/health` reflects the verdict, exactly as Python's and
 # Java's do, so (2) is read from the endpoint rather than from a log line.
+# `/ready` does NOT reflect it (RFC #1502) and is asserted to stay 200
+# alongside, which is a claim about the split rather than an omission.
 # The core-transition grep stays alongside it: `/health` is what the runtime
 # BELIEVES, and `Health status changed: Healthy -> Degraded` is what actually
 # crossed the napi boundary and became the core's state. A runtime that
@@ -238,11 +240,12 @@ test:
   # Non-vacuity, part 2a: the runtime saw the throw and classified it as
   # degraded, read from the agent's own endpoint (#1478).
   #
-  # /ready is captured as a bare status code alongside it. `degraded` answers
-  # 503 there on all three runtimes — deliberately: readiness is a load
-  # balancer's "stop adding load", while the heartbeat below keeps running so
-  # the mesh can still resolve an impaired provider that may be the only one.
-  - name: "A's /health must report degraded, carrying the thrown message"
+  # /ready is captured as a bare status code alongside it, and it must be 200
+  # (RFC #1502). A `degraded` verdict is precisely the case where 503-ing
+  # readiness would be worst: the agent keeps heartbeating and the mesh keeps
+  # resolving to it — it may be the only provider — so emptying its Service
+  # endpoints would break the very calls the registry is still directing there.
+  - name: "A's /health must report degraded while /ready stays 200"
     handler: shell
     workdir: /workspace
     command: |
@@ -359,8 +362,8 @@ assertions:
     message: "CLASSIFICATION: /health must carry the thrown error's own message, proving the runtime caught THIS throw"
   - expr: "${captured.provider_a_health} not contains 'HEALTH_UNREACHABLE'"
     message: "CLASSIFICATION: provider A's HTTP server must still answer /health while its check is throwing"
-  - expr: "${captured.provider_a_health} contains 'READY_HTTP_CODE: 503'"
-    message: "CLASSIFICATION: /ready must answer 503 for a degraded agent — a load balancer is told to stop adding load even though the mesh keeps resolving it"
+  - expr: "${captured.provider_a_health} contains 'READY_HTTP_CODE: 200'"
+    message: "CLASSIFICATION: /ready must stay 200 for a degraded agent — the mesh keeps resolving it, so dropping it from its Service endpoints would break the calls the registry is still directing there"
   - expr: "${captured.degrade_log} not contains 'CORE_DEGRADE_TRANSITIONS: 0'"
     message: "CLASSIFICATION: the degraded verdict must reach the mesh core (Health status changed: Healthy -> Degraded) — otherwise the runtime only printed the word and published something else"
   - expr: "${captured.degrade_log} contains 'UNHEALTHY_LOG_LINES: 0'"


### PR DESCRIPTION
## Summary

**Step 2 of 4** for RFC #1502 — the step that turns the hook on.

`/ready` reports **whether the mesh runtime is up**, never the user's health verdict, on every agent type. The chart's `startupProbe` moves from `/livez` to `/startupz`.

## ⚠️ Breaking

- **`/ready` no longer diverts Service traffic during a dependency outage** on any runtime. That is the point — mesh withdrawal already stopped the traffic that matters, and readiness flapping only produced Deployment-level churn.
- **The Python and TypeScript `/ready` bodies drop `status`/`errors`** in favour of `runtime`.
- **Chart and image move together**: `startupProbe` now asks for `/startupz`, which only a 3.5.3+ image serves.

## Why not "200 unconditionally", as the RFC said

Two things would have broken. `startup_check` defaults to true, so `/startupz` answers 200 *before* the runtime is up — a pod could be marked Ready with no runtime, taking Service traffic it cannot serve. And Java's `isRunning()` floor is the only probe that catches a runtime dying while the process lives, since `/livez` is unconditional too.

Runtime-state readiness keeps both properties and still removes the verdict-driven churn, which was the actual goal.

**Gateways already behaved this way**, so this is providers adopting the gateway rule rather than readiness ceasing to mean anything.

## Review notes

**Java's `isGateway` branch collapses entirely.** #1489 carved gateways out of verdict-based readiness; once *every* type uses runtime state, that carve-out is subsumed by the general rule. `readyStatus()` now takes no `MeshHealth` argument at all — a parameter it ignored would invite re-consulting it. The now-dead `isGateway(MeshRuntime)` overload is removed; `MeshAgentTypes` stays, because the heartbeat exemption still uses it.

**`/health` is deliberately unchanged** — still the diagnostic view, still 503s a non-healthy verdict. So `/ready` and `/health` now diverge on every agent type rather than only on a Java gateway. Intended, and the docs say so.

Two placement details: Python's `runtime_state` moved **down** into `health_check_manager` rather than the gateway path importing up from `pipeline`, which would invert layering — a test pins that both sites resolve the same function object. TypeScript checks shutdown **before** the handle, because `shutdown()` nulls the handle only after napi teardown.

**Docs are in this PR rather than deferred to step 4.** Shipping a `/ready` semantic change while every page describing `/ready` stays wrong is exactly what #1487 did, and cleaning that up took three PRs. Each runtime's behaviour was read from source rather than ported between sibling pages — Java's `/health` genuinely 503s until `isRunning()`, TypeScript's gateway `/health` is a fixed `healthy`, so the three pages legitimately differ.

**Integration assertions inverted, not deleted.** uc41 `tc03`/`tc04` now assert `/ready` stays **200** with a derived `READY_FLAG: true` through a vendor outage, while `/health` reports unhealthy. A runtime that stopped serving `/ready` satisfies neither.

Known gap for step 4: `health.md:161` says a Python gateway serves "all three probe endpoints" — that became wrong in **step 1** when gateways gained `/startupz`, not from this change.

Refs #1502

## Test plan

- [x] **Red before green** in both runtimes: Python 9 failed on `assert 503 == 200`; TypeScript 14 failed, including "never reads the verdict source" catching a spy called once
- [x] Per runtime: `/ready` 200 while the runtime is up regardless of verdict, 503 when it is down, unchanged by a failing or throwing check; `/health` still 503s; `/livez` still unconditional
- [x] Python suite green; TypeScript **1410** across 93 files; both typechecks; Java `mvn -o test` BUILD SUCCESS
- [x] `go build ./...`, `go test ./src/core/cli/... -count=1`; goldens 1744/519/447 → **1746/522/448**, predicted per file before measuring — a one-span discrepancy on the first pass was traced to its cause rather than absorbed
- [x] `helm template`: `startupProbe → /startupz`, liveness and readiness unchanged, every other field byte-identical
- [x] `tsuite src-tests` **12/12** (whole suite, image rebuilt), `uc41` **6/6**
- [x] Additionally `tc25/26/27` — unit tests monkeypatch the handle and could not catch a provider left permanently 503; these assert an exact 200 from live agents on all three runtimes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distinct startup, liveness, readiness, and diagnostic health endpoints.
  * Readiness now reflects mesh runtime availability rather than custom health-check results.
  * Diagnostic health responses clearly report healthy, degraded, and unhealthy states.
  * Startup probes now use `/startupz`, while liveness and readiness use `/livez` and `/ready`.

* **Bug Fixes**
  * Health-check failures no longer incorrectly mark running services unready.
  * Explicitly unhealthy checks can withdraw providers, while degraded checks remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->