### PR TITLE
feat: scaffold both health hooks, and correct the docs that outlived the design

### DIFF
--- a/api/mcp-mesh-agent.openapi.yaml
+++ b/api/mcp-mesh-agent.openapi.yaml
@@ -75,11 +75,23 @@ paths:
               schema:
                 $ref: "#/components/schemas/AgentHealthResponse"
         "503":
-          description: The health check reports degraded or unhealthy, or has not run yet
+          description: The health check reports degraded, unhealthy or unknown, or has not run yet
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/AgentHealthResponse"
+    head:
+      tags: [health]
+      summary: Agent health check (no body)
+      description: |
+        The same verdict and the same status code as `GET /health`, with no
+        response body. All three runtimes serve it.
+      operationId: headAgentHealth
+      responses:
+        "200":
+          description: The health check reports healthy
+        "503":
+          description: The health check reports degraded, unhealthy or unknown, or has not run yet
 
   /ready:
     get:
@@ -117,6 +129,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReadinessResponse"
+    head:
+      tags: [health]
+      summary: Agent readiness check (no body)
+      description: |
+        The same verdict and the same status code as `GET /ready`, with no
+        response body. All three runtimes serve it.
+      operationId: headAgentReadiness
+      responses:
+        "200":
+          description: The mesh runtime is up (or the agent is standalone)
+        "503":
+          description: The mesh runtime has not started, or is shutting down
 
   /livez:
     get:
@@ -143,6 +167,16 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/LivenessResponse"
+    head:
+      tags: [health]
+      summary: Agent liveness check (no body)
+      description: |
+        200 unconditionally, exactly as `GET /livez`, with no response body.
+        There is no 503 branch here either. All three runtimes serve it.
+      operationId: headAgentLiveness
+      responses:
+        "200":
+          description: The process is serving
 
   /startupz:
     get:
@@ -158,10 +192,10 @@ paths:
         in `CrashLoopBackOff` — where a misconfiguration is visible instead of
         looking like a vendor outage.
 
-        A NEW path rather than a reuse of `/livez`: the chart points both
-        `startupProbe` and `livenessProbe` at `/livez`, and an endpoint cannot
-        tell which probe called it, so sharing one would let a failing startup
-        check kill a running pod every ten seconds.
+        A NEW path rather than a reuse of `/livez`: an endpoint cannot tell
+        which probe called it, so a path serving both `startupProbe` and
+        `livenessProbe` would let a failing startup check kill a running pod
+        every ten seconds.
 
         The verdict rules are the OPPOSITE of `/health`'s in one respect: a check
         that RAISES fails here, where a raising health check is recorded as
@@ -184,6 +218,19 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/StartupResponse"
+    head:
+      tags: [health]
+      summary: Agent startup check (no body)
+      description: |
+        The same verdict and the same status code as `GET /startupz`, with no
+        response body — a HEAD that disagreed with the GET would be the #1488
+        bug for anyone who wired the probe to HEAD. All three runtimes serve it.
+      operationId: headAgentStartup
+      responses:
+        "200":
+          description: The startup check passed, or none is declared
+        "503":
+          description: The startup check failed, returned a non-healthy verdict, or raised
 
   /mesh/info:
     get:

--- a/api/mcp-mesh-agent.openapi.yaml
+++ b/api/mcp-mesh-agent.openapi.yaml
@@ -51,20 +51,31 @@ paths:
       tags: [health]
       summary: Agent health check
       description: |
-        Returns agent health status and basic information.
+        The diagnostic view of the agent's `health_check` verdict. NOT probed by
+        Kubernetes: nothing acts on this status code, which is exactly why it is
+        free to carry the verdict (RFC #1502).
 
-        🤖 AI NOTE: This is AGENT health, not registry health.
-        Used by Kubernetes health checks and external monitoring.
+        200 only while the verdict is `healthy`; `degraded`, `unhealthy` and the
+        pre-first-check `starting` all answer 503. A `degraded` agent still
+        heartbeats and stays in dependency resolution, so 503 here does NOT mean
+        the agent has been withdrawn — a paused heartbeat does, and that is not
+        visible from a status code.
+
+        Also served on HEAD, with the same status code and no body.
+
+        🤖 AI NOTE: This is AGENT health, not registry health. Do NOT wire it to
+        a livenessProbe or a startupProbe: the failure action of both is a
+        restart, and a restart cannot fix the upstream outage this reports.
       operationId: getAgentHealth
       responses:
         "200":
-          description: Agent is healthy
+          description: The health check reports healthy
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/AgentHealthResponse"
         "503":
-          description: Agent is unhealthy
+          description: The health check reports degraded or unhealthy, or has not run yet
           content:
             application/json:
               schema:
@@ -75,39 +86,104 @@ paths:
       tags: [health]
       summary: Agent readiness check
       description: |
-        Returns agent readiness status for Kubernetes readiness probes.
+        Whether the MESH RUNTIME is up, and nothing else, on every agent type
+        (RFC #1502). The user's `health_check` verdict deliberately does NOT
+        reach this endpoint.
 
-        🤖 AI NOTE: Kubernetes-specific readiness endpoint.
+        A failing check pauses the heartbeat, the registry ages the agent out
+        and resolution stops selecting it; that is the whole withdrawal and it
+        needs no help from readiness. Adding a 503 here is strictly worse:
+        `agent.advertisedHost` defaults to the per-agent Service DNS name, so
+        mesh traffic traverses the Service, and dropping the pod from its
+        Service endpoints while the registry may still be selecting it turns a
+        consumer's failover into a connection error.
+
+        Also served on HEAD, with the same status code and no body.
+
+        🤖 AI NOTE: Kubernetes-specific readiness endpoint. The body carries
+        `runtime` — one of `up`, `starting`, `shutting_down`, `standalone` — and
+        a `reason` when it is not ready.
       operationId: getAgentReadiness
       responses:
         "200":
-          description: Agent is ready
+          description: The mesh runtime is up (or the agent is standalone)
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReadinessResponse"
         "503":
-          description: Agent is not ready
+          description: The mesh runtime has not started, or is shutting down
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReadinessResponse"
 
   /livez:
     get:
       tags: [health]
       summary: Agent liveness check
       description: |
-        Returns agent liveness status for Kubernetes liveness probes.
+        200 UNCONDITIONALLY for as long as the process is serving. Consults
+        nothing — not the health check, not the mesh runtime state (issues
+        #1467/#1468).
 
-        🤖 AI NOTE: Kubernetes-specific liveness endpoint.
+        Reaching this handler at all is the proof, and a container restart is
+        the only remedy a livenessProbe can offer, so anything this endpoint
+        could consult is something a restart cannot fix. There is no 503 branch.
+
+        Also served on HEAD, with an empty body.
+
+        🤖 AI NOTE: Kubernetes-specific liveness endpoint. Returns JSON, not
+        text/plain.
       operationId: getAgentLiveness
       responses:
         "200":
-          description: Agent is alive
+          description: The process is serving
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-                example: "OK"
+                $ref: "#/components/schemas/LivenessResponse"
+
+  /startupz:
+    get:
+      tags: [health]
+      summary: Agent startup check
+      description: |
+        The agent's `startup_check` verdict (RFC #1502): "is this agent
+        configured such that it can EVER serve?", as opposed to `/health`'s "can
+        I serve right now".
+
+        Wired to the chart's `startupProbe`, so a check that never passes keeps
+        the pod from ever becoming ready, keeps it from registering, and lands it
+        in `CrashLoopBackOff` — where a misconfiguration is visible instead of
+        looking like a vendor outage.
+
+        A NEW path rather than a reuse of `/livez`: the chart points both
+        `startupProbe` and `livenessProbe` at `/livez`, and an endpoint cannot
+        tell which probe called it, so sharing one would let a failing startup
+        check kill a running pod every ten seconds.
+
+        The verdict rules are the OPPOSITE of `/health`'s in one respect: a check
+        that RAISES fails here, where a raising health check is recorded as
+        `degraded` and keeps the agent heartbeating. An agent that declares no
+        `startup_check` passes.
+
+        The check runs on every hit and is never cached — a `startupProbe` stops
+        polling after its first success. Also served on HEAD.
+      operationId: getAgentStartup
+      responses:
+        "200":
+          description: The startup check passed, or none is declared
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StartupResponse"
         "503":
-          description: Agent is not alive
+          description: The startup check failed, returned a non-healthy verdict, or raised
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StartupResponse"
 
   /mesh/info:
     get:
@@ -219,69 +295,166 @@ paths:
 components:
   schemas:
     # Agent Health Schemas
+    #
+    # `checks` and `errors` on the two hook-driven schemas are whatever the
+    # user's check returned, verbatim. They are user data, not a mesh vocabulary:
+    # a scaffolded LLM provider reports `{"anthropic_api_key_present": true}`,
+    # and nothing in mesh reads either field — they exist so an operator running
+    # `curl` can see WHY the verdict is what it is.
     AgentHealthResponse:
       type: object
-      required: [status, agent_id, timestamp, transport]
+      # Only `status` is guaranteed. Before the first health-check refresh the
+      # body is the two-key placeholder `{status: starting, message: ...}`, which
+      # is why nothing else can be required here.
+      required: [status]
       properties:
         status:
           type: string
-          enum: [healthy, degraded, unhealthy]
-          description: Overall agent health status
-        agent_id:
+          enum: [healthy, degraded, unhealthy, unknown, starting]
+          description: |
+            The health check's verdict. `starting` is the placeholder served
+            before the first refresh has run; `unknown` is what a check that
+            returned an unrecognized type is recorded as. Only `healthy` answers
+            200.
+        agent:
           type: string
           example: "hello-world"
-          description: Agent identifier
+          description: Agent name. Absent from the pre-first-check placeholder.
+        checks:
+          type: object
+          additionalProperties: true
+          example: { anthropic_api_key_present: true, anthropic_api_reachable: true }
+          description: The `checks` map the user's health check returned.
+        errors:
+          type: array
+          items:
+            type: string
+          example: ["Anthropic API returned status: 529"]
+          description: The `errors` list the user's health check returned.
+        message:
+          type: string
+          example: "Agent is starting"
+          description: Present only on the pre-first-check `starting` placeholder.
+        service_type:
+          type: string
+          enum: [api, a2a]
+          description: |
+            Route (`api`) and A2A gateways only — they serve these endpoints
+            from the gateway pipeline, which stamps the type. Absent on an
+            `@mesh.agent` provider.
+        runtime:
+          type: string
+          enum: [up, starting, shutting_down, standalone]
+          description: Gateway responses only; see ReadinessResponse.runtime.
+        mesh_ready:
+          type: boolean
+          description: Gateway responses only; the boolean form of `runtime`.
         timestamp:
           type: string
           format: date-time
           example: "2024-01-20T10:30:45Z"
-          description: Current timestamp
-        transport:
-          type: array
-          items:
-            type: string
-          example: ["stdio", "http"]
-          description: Available transport methods
-        version:
-          type: string
-          example: "1.0.0"
-          description: Agent version
-        uptime_seconds:
-          type: integer
-          minimum: 0
-          example: 3600
-          description: Agent uptime in seconds
-        mcp_server_status:
-          type: string
-          enum: [connected, disconnected, error]
-          example: "connected"
-          description: MCP server connection status
+          description: When the verdict was recorded.
 
     ReadinessResponse:
       type: object
-      required: [ready, timestamp]
+      required: [ready, agent, runtime, timestamp]
       properties:
         ready:
           type: boolean
           example: true
-          description: Whether agent is ready to serve requests
+          description: |
+            Whether the MESH RUNTIME is up — NOT whether the user's health check
+            passes (RFC #1502).
+        agent:
+          type: string
+          example: "hello-world"
+        runtime:
+          type: string
+          enum: [up, starting, shutting_down, standalone]
+          example: "up"
+          description: |
+            `up` once a live Rust core handle exists; `starting` before that;
+            `shutting_down` once shutdown has been requested; `standalone` when
+            `MCP_MESH_STANDALONE` is set, which never starts a core at all and so
+            is ready as soon as the process serves.
+        reason:
+          type: string
+          example: "Mesh runtime has not started yet"
+          description: Present only when `ready` is false.
+        mcp_wrappers:
+          type: integer
+          minimum: 0
+          example: 1
+          description: "@mesh.agent providers only: how many MCP wrappers are mounted."
+        service_type:
+          type: string
+          enum: [api, a2a]
+          description: Route and A2A gateways only.
         timestamp:
           type: string
           format: date-time
           example: "2024-01-20T10:30:45Z"
+
+    LivenessResponse:
+      type: object
+      required: [alive, agent, timestamp]
+      properties:
+        alive:
+          type: boolean
+          enum: [true]
+          example: true
+          description: |
+            Always true. `/livez` has no failure branch — see the endpoint
+            description.
+        agent:
+          type: string
+          example: "hello-world"
+        timestamp:
+          type: string
+          format: date-time
+          example: "2024-01-20T10:30:45Z"
+
+    StartupResponse:
+      type: object
+      required: [started, agent, timestamp]
+      properties:
+        started:
+          type: boolean
+          example: true
+          description: |
+            The `startup_check` verdict. True when the check passed or none is
+            declared.
+        agent:
+          type: string
+          example: "hello-world"
         checks:
           type: object
-          additionalProperties:
-            type: object
-            properties:
-              status:
-                type: string
-                enum: [pass, fail]
-              message:
-                type: string
-          example:
-            mcp_server: { status: "pass", message: "Connected" }
-            registry: { status: "pass", message: "Registered" }
+          additionalProperties: true
+          example: { anthropic_api_key_present: true }
+          description: |
+            The `checks` map the user's startup check returned. Omitted when
+            empty. A check that returned a bare boolean is reported as
+            `{"startup_check": <bool>}`.
+        reason:
+          type: string
+          enum: ["Startup check failed"]
+          description: Present only when `started` is false.
+        errors:
+          type: array
+          items:
+            type: string
+          example: ["ANTHROPIC_API_KEY not set"]
+          description: |
+            Present only when `started` is false. Served to anyone who can reach
+            the pod, so name the setting that is missing, never its value.
+        service_type:
+          type: string
+          enum: [api, a2a]
+          description: Route and A2A gateways only.
+        timestamp:
+          type: string
+          format: date-time
+          example: "2024-01-20T10:30:45Z"
 
     # Agent Mesh Schemas
     AgentMeshInfo:

--- a/cmd/meshctl/templates/java/a2a-consumer/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/a2a-consumer/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -1,6 +1,9 @@
 package {{ .JavaPackage }};
 
 import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthCheck;
+import io.mcpmesh.MeshStartupCheck;
 import io.mcpmesh.MeshTool;
 import io.mcpmesh.a2a.A2AClient;
 import io.mcpmesh.a2a.A2AConsumer;
@@ -38,6 +41,74 @@ public class {{ .NamePascal }}Application {
 
     public static void main(String[] args) {
         SpringApplication.run({{ .NamePascal }}Application.class, args);
+    }
+
+    // ===== HEALTH AND STARTUP CHECKS =====
+    //
+    // Two hooks, two questions, two different consequences. Both default to
+    // passing, so deleting either one leaves this bridge behaving exactly as
+    // it does today.
+    //
+    //   @MeshHealthCheck   "Can I serve RIGHT NOW?" Re-runs every ttlSeconds.
+    //                      While it reports UNHEALTHY the bridge stops
+    //                      heartbeating: the registry ages it out and
+    //                      dependency resolution stops selecting it. The JVM
+    //                      keeps running and keeps serving, and the registry
+    //                      restores it the moment the check passes again - no
+    //                      restart, no redeploy. Override it for anything
+    //                      TRANSIENT: the A2A producer at {{ .A2AURL }}
+    //                      being down is the obvious one here.
+    //
+    //   @MeshStartupCheck  "Can I EVER serve?" Read by the Kubernetes
+    //                      startupProbe, on /startupz. A pod whose startup
+    //                      check fails never becomes ready, never registers,
+    //                      and lands in CrashLoopBackOff - which is the point:
+    //                      a misconfiguration is loud instead of looking like
+    //                      an outage. A startupProbe stops polling once it
+    //                      passes, so a credential revoked later falls to the
+    //                      health check. Override it for anything a restart
+    //                      CANNOT fix{{ if .AuthBearer }}: {{ .AuthEnvVar }} not being set is exactly that{{ else }}: a missing token, an unreadable config file{{ end }}.
+    //
+    // Choosing the wrong hook is the trap this split exists to remove. A
+    // missing token reported by the health check leaves the pod Running and
+    // silently unregistered, indistinguishable from a producer outage; a
+    // producer outage reported by the startup check crash-loops a pod whose
+    // configuration was fine - and on Java each of those restarts is a fresh
+    // JVM and a fresh Spring context.
+    //
+    // They also disagree about exceptions, deliberately. A health check that
+    // throws is recorded as DEGRADED and keeps heartbeating - a buggy probe
+    // must not withdraw a working bridge from a mesh that may have no other
+    // one. A startup check that throws FAILS: at boot an indeterminate answer
+    // is not a reason to admit a possibly-misconfigured agent.
+
+    /** Can this bridge serve right now? */
+    @MeshHealthCheck(ttlSeconds = 30)
+    public MeshHealth healthCheck() {
+        // TODO: probe the producer this bridge fronts - its agent card at
+        // {{ .A2AURL }}/.well-known/agent.json is a cheap, metadata-only
+        // request. Return MeshHealth.unhealthy(...) to be withdrawn from the
+        // mesh until the producer is back.
+        return MeshHealth.healthy();
+    }
+
+    /** Is this bridge configured such that it can ever serve? */
+    @MeshStartupCheck
+    public boolean startupCheck() {
+{{- if .AuthBearer }}
+        // The producer needs a bearer token, and a pod that does not have one
+        // is never going to acquire it: failing here is the whole point of the
+        // hook.
+        String token = System.getenv({{ toJSON .AuthEnvVar }});
+        return token != null && !token.isBlank();
+{{- else }}
+        // TODO: assert the configuration this bridge cannot run without - the
+        // producer URL, a token, a mounted secret. Return false (or a
+        // MeshHealth that is not HEALTHY) and the pod never comes up. Name what
+        // is missing in the message, never its value: the body is served to
+        // anyone who can reach the pod.
+        return true;
+{{- end }}
     }
 {{ range .Skills }}
     @MeshTool(

--- a/cmd/meshctl/templates/java/api/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/api/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -1,5 +1,8 @@
 package {{ .JavaPackage }};
 
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthCheck;
+import io.mcpmesh.MeshStartupCheck;
 import io.mcpmesh.spring.web.MeshDependency;
 import io.mcpmesh.spring.web.MeshInject;
 import io.mcpmesh.spring.web.MeshRoute;
@@ -43,6 +46,67 @@ public class {{ .NamePascal }}Application {
 
     public static void main(String[] args) {
         SpringApplication.run({{ .NamePascal }}Application.class, args);
+    }
+
+    // ===== HEALTH AND STARTUP CHECKS =====
+    //
+    // Both hooks work on a gateway in Java: the starter scans every Spring bean
+    // for them and the mesh health controller serves every agent type, so
+    // nothing here is agent-type specific. Both default to passing, so deleting
+    // either one leaves this gateway behaving exactly as it does today.
+    //
+    //   @MeshHealthCheck   "Can I serve RIGHT NOW?" Re-runs every ttlSeconds.
+    //                      While it reports UNHEALTHY the gateway stops
+    //                      heartbeating and the registry withdraws it from
+    //                      DISCOVERY. It does not go dark: the heartbeat is
+    //                      registry traffic only, so Tomcat keeps listening,
+    //                      the dependencies already resolved are retained, and
+    //                      /ready stays 200 - the pod keeps its Service
+    //                      endpoints and keeps taking ingress. Override it for
+    //                      anything TRANSIENT.
+    //
+    //   @MeshStartupCheck  "Can I EVER serve?" Read by the Kubernetes
+    //                      startupProbe, on /startupz. A pod whose startup
+    //                      check fails never becomes ready, never registers,
+    //                      and lands in CrashLoopBackOff - which is what you
+    //                      want from a gateway with a broken config, and it is
+    //                      also what plain Spring gives you by failing the boot
+    //                      outright. Override it for anything a restart CANNOT
+    //                      fix: a missing credential, an unreadable config.
+    //
+    // Choosing the wrong hook is the trap this split exists to remove. A
+    // missing credential reported by the health check leaves the pod Running
+    // and silently unregistered, indistinguishable from an outage; an upstream
+    // outage reported by the startup check crash-loops a pod whose
+    // configuration was fine all along - and on Java each of those restarts is
+    // a fresh JVM and a fresh Spring context.
+    //
+    // They also disagree about exceptions, deliberately. A health check that
+    // throws is recorded as DEGRADED and keeps heartbeating - a buggy probe
+    // must not withdraw a working gateway. A startup check that throws FAILS:
+    // at boot an indeterminate answer is not a reason to admit a
+    // possibly-misconfigured agent.
+
+    /** Can this gateway serve right now? */
+    @MeshHealthCheck(ttlSeconds = 30)
+    public MeshHealth healthCheck() {
+        // TODO: probe what this gateway needs in order to answer a request -
+        // a datasource, an upstream API of its own. Do NOT report an unresolved
+        // mesh capability here: mesh already knows, and a handler answering 503
+        // for the one route that needed it is more precise than withdrawing the
+        // whole gateway from discovery.
+        return MeshHealth.healthy();
+    }
+
+    /** Is this gateway configured such that it can ever serve? */
+    @MeshStartupCheck
+    public boolean startupCheck() {
+        // TODO: assert the configuration this gateway cannot run without - an
+        // env var, a mounted secret. Return false (or a MeshHealth that is not
+        // HEALTHY) and the pod never comes up. Name what is missing in the
+        // message, never its value: the body is served to anyone who can reach
+        // the pod.
+        return true;
     }
 }
 
@@ -98,12 +162,10 @@ class ApiController {
     //     return ResponseEntity.ok(response);
     // }
 
-    @GetMapping("/health")
-    public ResponseEntity<Map<String, Object>> health() {
-        return ResponseEntity.ok(Map.of(
-            "status", "healthy",
-            "service", "{{ .Name }}",
-            "timestamp", LocalDateTime.now().toString()
-        ));
-    }
+    // There is deliberately no @GetMapping("/health") here. The mesh starter
+    // mounts its own controller for /startupz, /livez, /ready and /health on
+    // every agent type, gateways included, so a second mapping for any of those
+    // four paths is an Ambiguous mapping and the application does not start at
+    // all. /health carries the @MeshHealthCheck verdict declared above; add
+    // your own diagnostics on a path of your own if you want more.
 }

--- a/cmd/meshctl/templates/java/basic/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/basic/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -1,6 +1,9 @@
 package {{ .JavaPackage }};
 
 import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthCheck;
+import io.mcpmesh.MeshStartupCheck;
 import io.mcpmesh.MeshTool;
 import io.mcpmesh.types.McpMeshTool;
 import io.mcpmesh.Param;
@@ -33,6 +36,66 @@ public class {{ .NamePascal }}Application {
     public static void main(String[] args) {
         log.info("Starting {{ .NamePascal }} Agent...");
         SpringApplication.run({{ .NamePascal }}Application.class, args);
+    }
+
+    // ===== HEALTH AND STARTUP CHECKS =====
+    //
+    // Two hooks, two questions, two different consequences. Both default to
+    // passing, so deleting either one leaves this agent behaving exactly as it
+    // does today.
+    //
+    //   @MeshHealthCheck   "Can I serve RIGHT NOW?" Re-runs every ttlSeconds.
+    //                      While it reports UNHEALTHY the agent stops
+    //                      heartbeating: the registry ages it out and
+    //                      dependency resolution stops selecting it. The JVM
+    //                      keeps running and keeps serving, and the registry
+    //                      restores the agent the moment the check passes
+    //                      again - no restart, no redeploy. Override it for
+    //                      anything TRANSIENT: a database that may come back,
+    //                      a vendor API having an outage.
+    //
+    //   @MeshStartupCheck  "Can I EVER serve?" Read by the Kubernetes
+    //                      startupProbe, on /startupz. A pod whose startup
+    //                      check fails never becomes ready, never registers,
+    //                      and lands in CrashLoopBackOff - which is the point:
+    //                      a misconfiguration is loud instead of looking like
+    //                      an outage. A startupProbe stops polling once it
+    //                      passes, so a credential revoked later falls to the
+    //                      health check. Override it for anything a restart
+    //                      CANNOT fix: a missing API key, an unreadable
+    //                      config file.
+    //
+    // Choosing the wrong hook is the trap this split exists to remove. A
+    // missing API key reported by the health check leaves the pod Running and
+    // silently unregistered, indistinguishable from an outage; a vendor outage
+    // reported by the startup check crash-loops a pod whose configuration was
+    // fine all along - and on Java each of those restarts is a fresh JVM and a
+    // fresh Spring context.
+    //
+    // They also disagree about exceptions, deliberately. A health check that
+    // throws is recorded as DEGRADED and keeps heartbeating - a buggy probe
+    // must not withdraw a working agent from a mesh that may have no other
+    // one. A startup check that throws FAILS: at boot an indeterminate answer
+    // is not a reason to admit a possibly-misconfigured agent.
+
+    /** Can this agent serve right now? */
+    @MeshHealthCheck(ttlSeconds = 30)
+    public MeshHealth healthCheck() {
+        // TODO: probe whatever this agent needs in order to answer a call - a
+        // datasource, a downstream API. Return MeshHealth.unhealthy(...) to be
+        // withdrawn from the mesh until it recovers.
+        return MeshHealth.healthy();
+    }
+
+    /** Is this agent configured such that it can ever serve? */
+    @MeshStartupCheck
+    public boolean startupCheck() {
+        // TODO: assert the configuration this agent cannot run without - an
+        // env var, a mounted secret, a readable file. Return false (or a
+        // MeshHealth that is not HEALTHY) and the pod never comes up. Name what
+        // is missing in the message, never its value: the body is served to
+        // anyone who can reach the pod.
+        return true;
     }
 
     /**

--- a/cmd/meshctl/templates/java/llm-agent/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -2,7 +2,10 @@ package {{ .JavaPackage }};
 
 {{ if .ToolFilter }}import io.mcpmesh.FilterMode;
 {{ end }}import io.mcpmesh.MeshAgent;
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthCheck;
 import io.mcpmesh.MeshLlm;
+import io.mcpmesh.MeshStartupCheck;
 import io.mcpmesh.MeshTool;
 import io.mcpmesh.Param;
 import io.mcpmesh.Selector;
@@ -34,6 +37,71 @@ public class {{ .NamePascal }}Application {
     public static void main(String[] args) {
         log.info("Starting {{ .NamePascal }} Agent...");
         SpringApplication.run({{ .NamePascal }}Application.class, args);
+    }
+
+    // ===== HEALTH AND STARTUP CHECKS =====
+    //
+    // Two hooks, two questions, two different consequences. Both default to
+    // passing, so deleting either one leaves this agent behaving exactly as it
+    // does today.
+    //
+    //   @MeshHealthCheck   "Can I serve RIGHT NOW?" Re-runs every ttlSeconds.
+    //                      While it reports UNHEALTHY the agent stops
+    //                      heartbeating: the registry ages it out and
+    //                      dependency resolution stops selecting it. The JVM
+    //                      keeps running and keeps serving, and the registry
+    //                      restores the agent the moment the check passes
+    //                      again - no restart, no redeploy. Override it for
+    //                      anything TRANSIENT: a database that may come back,
+    //                      a vendor API having an outage.
+    //
+    //   @MeshStartupCheck  "Can I EVER serve?" Read by the Kubernetes
+    //                      startupProbe, on /startupz. A pod whose startup
+    //                      check fails never becomes ready, never registers,
+    //                      and lands in CrashLoopBackOff - which is the point:
+    //                      a misconfiguration is loud instead of looking like
+    //                      an outage. A startupProbe stops polling once it
+    //                      passes, so a credential revoked later falls to the
+    //                      health check. Override it for anything a restart
+    //                      CANNOT fix: a missing API key, an unreadable
+    //                      config file.
+    //
+    // Choosing the wrong hook is the trap this split exists to remove. A
+    // missing API key reported by the health check leaves the pod Running and
+    // silently unregistered, indistinguishable from an outage; a vendor outage
+    // reported by the startup check crash-loops a pod whose configuration was
+    // fine all along - and on Java each of those restarts is a fresh JVM and a
+    // fresh Spring context.
+    //
+    // They also disagree about exceptions, deliberately. A health check that
+    // throws is recorded as DEGRADED and keeps heartbeating - a buggy probe
+    // must not withdraw a working agent from a mesh that may have no other
+    // one. A startup check that throws FAILS: at boot an indeterminate answer
+    // is not a reason to admit a possibly-misconfigured agent.
+    //
+    // Neither one belongs on the LLM provider this agent resolves through. The
+    // provider holds the vendor credential and probes the vendor itself; this
+    // agent has no key to check and no vendor to reach, and a provider that
+    // goes unhealthy is withdrawn by mesh without help from here.
+
+    /** Can this agent serve right now? */
+    @MeshHealthCheck(ttlSeconds = 30)
+    public MeshHealth healthCheck() {
+        // TODO: probe whatever this agent needs in order to answer a call - a
+        // datasource, a downstream API. Return MeshHealth.unhealthy(...) to be
+        // withdrawn from the mesh until it recovers.
+        return MeshHealth.healthy();
+    }
+
+    /** Is this agent configured such that it can ever serve? */
+    @MeshStartupCheck
+    public boolean startupCheck() {
+        // TODO: assert the configuration this agent cannot run without - an
+        // env var, a mounted secret, a readable prompt template. Return false
+        // (or a MeshHealth that is not HEALTHY) and the pod never comes up.
+        // Name what is missing in the message, never its value: the body is
+        // served to anyone who can reach the pod.
+        return true;
     }
 
     // ===== CONTEXT =====

--- a/cmd/meshctl/templates/java/llm-provider/README.md.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/README.md.tmpl
@@ -40,6 +40,45 @@ The provider will start on port {{ .Port }} and register with the mesh.
 3. LLM requests are routed through the mesh to this provider
 4. This provider forwards requests to the LLM API via Spring AI
 
+## Health and Startup Checks
+
+Two annotated methods on the application class, answering two different
+questions:
+
+- `@MeshHealthCheck` - "can I serve **right now**". Re-runs every 30s. While it
+  returns UNHEALTHY the agent stops heartbeating and the registry withdraws it,
+  so consumers fail over to another provider; the JVM keeps running and the
+  registry restores it the moment the check passes again.
+- `@MeshStartupCheck` - "can I **ever** serve". Read by the Kubernetes
+  `startupProbe`, on `/startupz`. A pod whose startup check fails never becomes
+  ready, never registers, and lands in `CrashLoopBackOff`, where a
+  misconfiguration is visible instead of looking like an outage.
+{{ if probeVendor (default "anthropic/claude-sonnet-5" .Model) }}
+The generated startup check reads the API key locally first, then asks the
+vendor whether it is accepted. The two answers are not treated alike:
+
+| The vendor... | Startup | Because |
+|---|---|---|
+| has no key to read | **fails** | a key that is not set will not set itself |
+| rejects the key | **fails** | no restart mints a valid one |
+| answers 5xx or rate-limits | passes | an outage, not a misconfiguration |
+| does not answer at all | passes | same - the health check withdraws the agent meanwhile |
+
+Crash-looping on an outage would restart a pod whose configuration was fine -
+each restart a fresh JVM and a fresh Spring context - and would make
+`CrashLoopBackOff` stop meaning "your configuration is wrong".
+{{ else }}
+Both are skeletons for this model: they always pass, so a pod with no
+credentials at all comes up and fails every call, and an upstream outage never
+withdraws this agent. Implement them against the endpoint this model is actually
+served from. In the startup check, fail only on a rejected credential - a 5xx, a
+rate limit or an unreachable endpoint is an outage and belongs in the health
+check.
+{{ end }}
+Both are served from the mesh starter's own controller, alongside `/livez` and
+`/ready`. Those four paths are taken: a `@GetMapping` of your own for any of
+them is an ambiguous mapping and the application does not start.
+
 ## License
 
 MIT

--- a/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -4,6 +4,7 @@ import io.mcpmesh.MeshAgent;
 import io.mcpmesh.MeshHealth;
 import io.mcpmesh.MeshHealthCheck;
 import io.mcpmesh.MeshLlmProvider;
+import io.mcpmesh.MeshStartupCheck;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -64,11 +65,44 @@ public class {{ .NamePascal }}Application {
     // No implementation needed - @MeshLlmProvider handles everything!
     // Resource links (images, PDFs) in tool results are automatically resolved.
 
-    // ===== HEALTH CHECK =====
+    // ===== HEALTH AND STARTUP CHECKS =====
     //
-    // Runs every ttlSeconds. While it returns unhealthy the agent stops
-    // heartbeating, the registry withdraws it, and consumers fail over to
-    // another provider — automatically restored when the check passes again.
+    // Two hooks, two questions, two different consequences.
+    //
+    //   @MeshHealthCheck   "Can I serve RIGHT NOW?" Re-runs every ttlSeconds.
+    //                      While it returns UNHEALTHY this provider stops
+    //                      heartbeating: the registry ages it out, dependency
+    //                      resolution stops selecting it, and consumers fail
+    //                      over to another provider. The JVM keeps running and
+    //                      the registry restores it the moment the check
+    //                      passes again — no restart, no redeploy. This is the
+    //                      hook for a vendor OUTAGE, which is transient by
+    //                      definition.
+    //
+    //   @MeshStartupCheck  "Can I EVER serve?" Read by the Kubernetes
+    //                      startupProbe, on /startupz. A pod whose startup
+    //                      check fails never becomes ready, never registers,
+    //                      and lands in CrashLoopBackOff — which is the point:
+    //                      a missing or rejected API key is loud instead of
+    //                      looking like an outage. A startupProbe stops polling
+    //                      once it passes, so a key revoked later falls to the
+    //                      health check. This is the hook for a
+    //                      MISCONFIGURATION, which no restart is going to fix.
+    //
+    // The two checks below probe the same endpoint and read the verdict
+    // differently, and that difference is the whole design. A rejected
+    // credential fails startup; a 5xx, a rate limit or an unreachable vendor
+    // PASSES startup and is left to the health check. Mapping an outage onto
+    // the startup check would crash-loop a correctly configured pod for as long
+    // as the vendor is down — each restart a fresh JVM and a fresh Spring
+    // context — and, worse, would make CrashLoopBackOff stop meaning "your
+    // configuration is wrong", which is the signal this hook exists to produce.
+    //
+    // They also disagree about exceptions, deliberately. A health check that
+    // throws is recorded as DEGRADED and keeps heartbeating — a buggy probe
+    // must not withdraw a working provider from a mesh that may have no other
+    // one. A startup check that throws FAILS: at boot an indeterminate answer
+    // is not a reason to admit a possibly-misconfigured agent.
 {{ if eq $probeVendor "anthropic" }}
     private static final HttpClient HTTP = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(5))
@@ -302,4 +336,230 @@ public class {{ .NamePascal }}Application {
         return MeshHealth.healthy().withCheck("provider_configured", true);
     }
 {{ end }}
+{{- if eq $probeVendor "anthropic" }}
+
+    /**
+     * Startup check for {{ .Name }}.
+     *
+     * Answers "is this provider configured such that it can EVER serve?" — the
+     * question a restart cannot change the answer to.
+     */
+    @MeshStartupCheck
+    public MeshHealth startupCheck() {
+        // Local first: a missing key costs nothing to detect and never fixes
+        // itself, so it needs no network call to be certain about.
+        String apiKey = System.getenv("ANTHROPIC_API_KEY");
+        if (apiKey == null || apiKey.isBlank()) {
+            return MeshHealth.unhealthy("ANTHROPIC_API_KEY not set")
+                .withCheck("anthropic_api_key_present", false);
+        }
+
+        // A WRONG key can only be detected by asking the vendor. A network call
+        // on the startup path is acceptable because a startupProbe stops
+        // polling once it passes — this runs a handful of times, not every ten
+        // seconds forever.
+        int status;
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://api.anthropic.com/v1/models"))
+                .header("anthropic-version", "2023-06-01")
+                .header("x-api-key", apiKey)
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build();
+            status = HTTP.send(request, HttpResponse.BodyHandlers.discarding()).statusCode();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            // The probe was cut short, which concluded nothing about the
+            // credential. Startup PASSES, for the same reason as below.
+            return MeshHealth.healthy()
+                .withCheck("anthropic_api_key_present", true)
+                .withCheck("anthropic_api_reachable", false);
+        } catch (Exception e) {
+            // The vendor could not be reached at all (DNS, connect, timeout,
+            // TLS). An outage, not a misconfiguration: startup PASSES and the
+            // health check withdraws this agent for as long as it lasts.
+            // Failing here would crash-loop a correctly configured pod, and
+            // would dilute CrashLoopBackOff from "your configuration is wrong"
+            // into "something somewhere is unwell".
+            return MeshHealth.healthy()
+                .withCheck("anthropic_api_key_present", true)
+                .withCheck("anthropic_api_reachable", false);
+        }
+
+        if (status == 401 || status == 403) {
+            // The vendor answered and REJECTED the credential. Fatal: no
+            // restart mints a valid key, so fail startup and make it visible.
+            return MeshHealth.unhealthy("Anthropic rejected ANTHROPIC_API_KEY")
+                .withCheck("anthropic_api_key_present", true)
+                .withCheck("anthropic_api_key_valid", false);
+        }
+
+        // The vendor answered with something that is not a rejection — a 200, a
+        // 5xx, a rate limit. The credential is not what is wrong, so startup
+        // PASSES and anything transient is the health check's to report.
+        return MeshHealth.healthy()
+            .withCheck("anthropic_api_key_present", true)
+            .withCheck("anthropic_api_key_valid", status == 200);
+    }
+{{- else if eq $probeVendor "openai" }}
+
+    /**
+     * Startup check for {{ .Name }}.
+     *
+     * Answers "is this provider configured such that it can EVER serve?" — the
+     * question a restart cannot change the answer to.
+     */
+    @MeshStartupCheck
+    public MeshHealth startupCheck() {
+        // Local first: a missing key costs nothing to detect and never fixes
+        // itself, so it needs no network call to be certain about.
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        if (apiKey == null || apiKey.isBlank()) {
+            return MeshHealth.unhealthy("OPENAI_API_KEY not set")
+                .withCheck("openai_api_key_present", false);
+        }
+
+        // A WRONG key can only be detected by asking the vendor. A network call
+        // on the startup path is acceptable because a startupProbe stops
+        // polling once it passes — this runs a handful of times, not every ten
+        // seconds forever.
+        int status;
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://api.openai.com/v1/models"))
+                .header("Authorization", "Bearer " + apiKey)
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build();
+            status = HTTP.send(request, HttpResponse.BodyHandlers.discarding()).statusCode();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            // The probe was cut short, which concluded nothing about the
+            // credential. Startup PASSES, for the same reason as below.
+            return MeshHealth.healthy()
+                .withCheck("openai_api_key_present", true)
+                .withCheck("openai_api_reachable", false);
+        } catch (Exception e) {
+            // The vendor could not be reached at all (DNS, connect, timeout,
+            // TLS). An outage, not a misconfiguration: startup PASSES and the
+            // health check withdraws this agent for as long as it lasts.
+            // Failing here would crash-loop a correctly configured pod, and
+            // would dilute CrashLoopBackOff from "your configuration is wrong"
+            // into "something somewhere is unwell".
+            return MeshHealth.healthy()
+                .withCheck("openai_api_key_present", true)
+                .withCheck("openai_api_reachable", false);
+        }
+
+        if (status == 401 || status == 403) {
+            // The vendor answered and REJECTED the credential. Fatal: no
+            // restart mints a valid key, so fail startup and make it visible.
+            return MeshHealth.unhealthy("OpenAI rejected OPENAI_API_KEY")
+                .withCheck("openai_api_key_present", true)
+                .withCheck("openai_api_key_valid", false);
+        }
+
+        // The vendor answered with something that is not a rejection — a 200, a
+        // 5xx, a rate limit. The credential is not what is wrong, so startup
+        // PASSES and anything transient is the health check's to report.
+        return MeshHealth.healthy()
+            .withCheck("openai_api_key_present", true)
+            .withCheck("openai_api_key_valid", status == 200);
+    }
+{{- else if eq $probeVendor "gemini" }}
+
+    /**
+     * Startup check for {{ .Name }}.
+     *
+     * Answers "is this provider configured such that it can EVER serve?" — the
+     * question a restart cannot change the answer to.
+     */
+    @MeshStartupCheck
+    public MeshHealth startupCheck() {
+        // Local first: a missing key costs nothing to detect and never fixes
+        // itself, so it needs no network call to be certain about.
+        String apiKey = System.getenv("GOOGLE_API_KEY");
+        if (apiKey == null || apiKey.isBlank()) {
+            return MeshHealth.unhealthy("GOOGLE_API_KEY not set")
+                .withCheck("google_api_key_present", false);
+        }
+
+        // A WRONG key can only be detected by asking the vendor. A network call
+        // on the startup path is acceptable because a startupProbe stops
+        // polling once it passes — this runs a handful of times, not every ten
+        // seconds forever.
+        int status;
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(
+                    "https://generativelanguage.googleapis.com/v1beta/models?key=" + apiKey))
+                .timeout(Duration.ofSeconds(5))
+                .GET()
+                .build();
+            status = HTTP.send(request, HttpResponse.BodyHandlers.discarding()).statusCode();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            // The probe was cut short, which concluded nothing about the
+            // credential. Startup PASSES, for the same reason as below.
+            return MeshHealth.healthy()
+                .withCheck("google_api_key_present", true)
+                .withCheck("gemini_api_reachable", false);
+        } catch (Exception e) {
+            // The vendor could not be reached at all (DNS, connect, timeout,
+            // TLS). An outage, not a misconfiguration: startup PASSES and the
+            // health check withdraws this agent for as long as it lasts.
+            // Failing here would crash-loop a correctly configured pod, and
+            // would dilute CrashLoopBackOff from "your configuration is wrong"
+            // into "something somewhere is unwell".
+            return MeshHealth.healthy()
+                .withCheck("google_api_key_present", true)
+                .withCheck("gemini_api_reachable", false);
+        }
+
+        // 400, not 401: Gemini answers a bad API key with INVALID_ARGUMENT
+        // rather than an auth status, which is why this branch is wider than
+        // the other two vendors'. It is the same pair the health check reads.
+        if (status == 400 || status == 403) {
+            // The vendor answered and REJECTED the credential. Fatal: no
+            // restart mints a valid key, so fail startup and make it visible.
+            return MeshHealth.unhealthy("Google rejected GOOGLE_API_KEY")
+                .withCheck("google_api_key_present", true)
+                .withCheck("google_api_key_valid", false);
+        }
+
+        // The vendor answered with something that is not a rejection — a 200, a
+        // 5xx, a rate limit. The credential is not what is wrong, so startup
+        // PASSES and anything transient is the health check's to report.
+        return MeshHealth.healthy()
+            .withCheck("google_api_key_present", true)
+            .withCheck("google_api_key_valid", status == 200);
+    }
+{{- else }}
+
+    /**
+     * Startup check for {{ .Name }}.
+     *
+     * NOT IMPLEMENTED — a skeleton that always passes, so a {{ $model }} pod
+     * with no credentials at all still comes up, registers, and fails every
+     * call it is given.
+     *
+     * Replace it with the local checks this deployment cannot run without: the
+     * credential your gateway authenticates with (an AWS role, ADC / Workload
+     * Identity, your proxy's token), a required endpoint URL. Return false and
+     * the pod never becomes ready, never registers, and lands in
+     * CrashLoopBackOff with the reason in its logs.
+     *
+     * Keep it local if you can. If you do call your gateway from here, branch
+     * on the answer: a REJECTED credential is fatal and must fail, but a 5xx, a
+     * rate limit, a timeout or an unreachable endpoint must PASS — those are
+     * outages, and crash-looping on one restarts a pod whose configuration was
+     * fine. Report those from the health check instead, which withdraws the
+     * agent while they last and restores it afterwards.
+     */
+    @MeshStartupCheck
+    public boolean startupCheck() {
+        return true;
+    }
+{{- end }}
 }

--- a/cmd/meshctl/templates/python/a2a-consumer/main.py.tmpl
+++ b/cmd/meshctl/templates/python/a2a-consumer/main.py.tmpl
@@ -35,6 +35,66 @@ from fastmcp import FastMCP
 
 app = FastMCP("{{ toPascalCase .Name }} Bridge")
 
+
+# ===== HEALTH AND STARTUP CHECKS =====
+#
+# Two hooks, two questions, two different consequences. Both default to
+# passing, so deleting either one leaves this bridge behaving exactly as it
+# does today.
+#
+#   health_check   "Can I serve RIGHT NOW?" Re-runs every health_check_ttl
+#                  seconds. While it reports unhealthy the bridge stops
+#                  heartbeating: the registry ages it out and dependency
+#                  resolution stops selecting it. The process keeps running
+#                  and keeps serving, and the registry restores it the moment
+#                  the check passes again - no restart, no redeploy. Override
+#                  it for anything TRANSIENT: the A2A producer at
+#                  {{ .A2AURL }} being down is the obvious one here.
+#
+#   startup_check  "Can I EVER serve?" Read by the Kubernetes startupProbe,
+#                  on /startupz. A pod whose startup check fails never becomes
+#                  ready, never registers, and lands in CrashLoopBackOff -
+#                  which is the point: a misconfiguration is loud instead of
+#                  looking like an outage. A startupProbe stops polling once
+#                  it passes, so a credential revoked later falls to
+#                  health_check. Override it for anything a restart CANNOT
+#                  fix{{ if .AuthBearer }}: {{ .AuthEnvVar }} not being set is exactly that{{ else }}: a missing token, an unreadable config file{{ end }}.
+#
+# Choosing the wrong hook is the trap this split exists to remove. A missing
+# token reported by health_check leaves the pod Running and silently
+# unregistered, indistinguishable from a producer outage; a producer outage
+# reported by startup_check crash-loops a pod whose configuration was fine.
+#
+# They also disagree about exceptions, deliberately. A health_check that
+# raises is recorded as degraded and keeps heartbeating - a buggy probe must
+# not withdraw a working bridge from a mesh that may have no other one. A
+# startup_check that raises FAILS: at boot an indeterminate answer is not a
+# reason to admit a possibly-misconfigured agent.
+
+
+async def health_check() -> dict:
+    """Can this bridge serve right now?"""
+    # TODO: probe the producer this bridge fronts - its agent card at
+    # {{ .A2AURL }}/.well-known/agent.json is a cheap, metadata-only
+    # request. Return {"status": "unhealthy", ...} (or plain False) to be
+    # withdrawn from the mesh until the producer is back.
+    return {"status": "healthy", "checks": {}, "errors": []}
+
+
+def startup_check() -> bool:
+    """Is this bridge configured such that it can ever serve?"""
+{{- if .AuthBearer }}
+    # The producer needs a bearer token, and a pod that does not have one is
+    # never going to acquire it: failing here is the whole point of the hook.
+    return bool(os.getenv({{ toJSON .AuthEnvVar }}))
+{{- else }}
+    # TODO: assert the configuration this bridge cannot run without - the
+    # producer URL, a token, a mounted secret. Return False (or
+    # {"status": "unhealthy", ...}) and the pod never comes up. Sync is fine
+    # here; an async def is accepted too.
+    return True
+{{- end }}
+
 {{ range .Skills }}
 
 @app.tool()
@@ -65,6 +125,9 @@ async def {{ .FunctionName }}(_a2a: mesh.A2AClient = None) -> dict:
     version="1.0.0",{{ if .Description }}
     description={{ toJSON .Description }},{{ end }}
     http_port=HTTP_PORT,
+    health_check=health_check,
+    health_check_ttl=30,
+    startup_check=startup_check,
 )
 class {{ toPascalCase .Name }}:
     """A2A consumer bridge agent."""

--- a/cmd/meshctl/templates/python/a2a-consumer/main.py.tmpl
+++ b/cmd/meshctl/templates/python/a2a-consumer/main.py.tmpl
@@ -86,7 +86,9 @@ def startup_check() -> bool:
 {{- if .AuthBearer }}
     # The producer needs a bearer token, and a pod that does not have one is
     # never going to acquire it: failing here is the whole point of the hook.
-    return bool(os.getenv({{ toJSON .AuthEnvVar }}))
+    # Stripped before the test: a credential pasted with a trailing newline,
+    # or a Secret key whose value is blank, is not a token.
+    return bool(os.getenv({{ toJSON .AuthEnvVar }}, "").strip())
 {{- else }}
     # TODO: assert the configuration this bridge cannot run without - the
     # producer URL, a token, a mounted secret. Return False (or

--- a/cmd/meshctl/templates/python/api/main.py.tmpl
+++ b/cmd/meshctl/templates/python/api/main.py.tmpl
@@ -5,6 +5,9 @@
 {{ if .Description }}{{ .Description }}{{ else }}An HTTP API gateway that consumes mesh capabilities via @mesh.route.{{ end }}
 """
 
+import os
+import sys
+
 import mesh
 from fastapi import FastAPI, HTTPException, Request
 from mesh.types import McpMeshTool
@@ -16,7 +19,39 @@ app = FastAPI(
 )
 
 
+# ===== STARTUP VALIDATION =====
+#
+# There is no health_check or startup_check hook to declare here, and that is
+# a design decision rather than a gap (issue #1506).
+#
+# This gateway is an ordinary FastAPI application that happens to consume mesh
+# capabilities. What mesh gives it is dependency injection - @mesh.route
+# resolves capabilities and hands them to your handlers - not ownership of the
+# application's lifecycle. Both hooks are arguments to @mesh.agent, and
+# @mesh.agent cannot share a process with @mesh.route: the runtime rejects the
+# combination at startup ("Mixed mode not supported"), because each family owns
+# the HTTP server and the heartbeat, and they cannot both.
+#
+# Startup validation is a solved problem here, and the solution is strictly
+# more flexible than a hook would be: check the configuration at boot and exit
+# non-zero. Kubernetes gives you CrashLoopBackOff with the cause in the logs,
+# with no mesh involvement at all.
+REQUIRED_SETTINGS = []  # e.g. ["DATABASE_URL", "UPSTREAM_TOKEN"]
+
+_missing = [name for name in REQUIRED_SETTINGS if not os.getenv(name)]
+if _missing:
+    # Exit non-zero BEFORE serving. A gateway that comes up misconfigured takes
+    # ingress it cannot answer; one that never comes up is visible immediately.
+    print(f"{{ .Name }}: not configured: {', '.join(_missing)} not set", file=sys.stderr)
+    raise SystemExit(1)
+
+
 # ===== HEALTH CHECK =====
+#
+# Mesh registers /livez, /startupz, /ready and /health on this app for the
+# Kubernetes probes the agent Helm chart wires. A path your application already
+# defines wins - including this one, so the endpoint below is what /health
+# answers with and mesh does not add its own.
 
 @app.get("/health")
 async def health():

--- a/cmd/meshctl/templates/python/api/main.py.tmpl
+++ b/cmd/meshctl/templates/python/api/main.py.tmpl
@@ -38,7 +38,7 @@ app = FastAPI(
 # with no mesh involvement at all.
 REQUIRED_SETTINGS = []  # e.g. ["DATABASE_URL", "UPSTREAM_TOKEN"]
 
-_missing = [name for name in REQUIRED_SETTINGS if not os.getenv(name)]
+_missing = [name for name in REQUIRED_SETTINGS if not os.getenv(name, "").strip()]
 if _missing:
     # Exit non-zero BEFORE serving. A gateway that comes up misconfigured takes
     # ingress it cannot answer; one that never comes up is visible immediately.

--- a/cmd/meshctl/templates/python/basic/main.py.tmpl
+++ b/cmd/meshctl/templates/python/basic/main.py.tmpl
@@ -14,6 +14,59 @@ from fastmcp import FastMCP
 app = FastMCP("{{ toPascalCase .Name }} Service")
 
 
+# ===== HEALTH AND STARTUP CHECKS =====
+#
+# Two hooks, two questions, two different consequences. Both default to
+# passing, so deleting either one leaves this agent behaving exactly as it
+# does today.
+#
+#   health_check   "Can I serve RIGHT NOW?" Re-runs every health_check_ttl
+#                  seconds. While it reports unhealthy the agent stops
+#                  heartbeating: the registry ages it out and dependency
+#                  resolution stops selecting it. The process keeps running
+#                  and keeps serving, and the registry restores the agent the
+#                  moment the check passes again - no restart, no redeploy.
+#                  Override it for anything TRANSIENT: a database that may
+#                  come back, a vendor API having an outage.
+#
+#   startup_check  "Can I EVER serve?" Read by the Kubernetes startupProbe,
+#                  on /startupz. A pod whose startup check fails never becomes
+#                  ready, never registers, and lands in CrashLoopBackOff -
+#                  which is the point: a misconfiguration is loud instead of
+#                  looking like an outage. A startupProbe stops polling once
+#                  it passes, so a credential revoked later falls to
+#                  health_check. Override it for anything a restart CANNOT
+#                  fix: a missing API key, an unreadable config file.
+#
+# Choosing the wrong hook is the trap this split exists to remove. A missing
+# API key reported by health_check leaves the pod Running and silently
+# unregistered, indistinguishable from an outage; a vendor outage reported by
+# startup_check crash-loops a pod whose configuration was fine all along.
+#
+# They also disagree about exceptions, deliberately. A health_check that
+# raises is recorded as degraded and keeps heartbeating - a buggy probe must
+# not withdraw a working agent from a mesh that may have no other one. A
+# startup_check that raises FAILS: at boot an indeterminate answer is not a
+# reason to admit a possibly-misconfigured agent.
+
+
+async def health_check() -> dict:
+    """Can this agent serve right now?"""
+    # TODO: probe whatever this agent needs in order to answer a call - a
+    # database handle, a downstream API. Return {"status": "unhealthy", ...}
+    # (or plain False) to be withdrawn from the mesh until it recovers.
+    return {"status": "healthy", "checks": {}, "errors": []}
+
+
+def startup_check() -> bool:
+    """Is this agent configured such that it can ever serve?"""
+    # TODO: assert the configuration this agent cannot run without - an env
+    # var, a mounted secret, a readable file. Return False (or
+    # {"status": "unhealthy", ...}) and the pod never comes up. Sync is fine
+    # here; an async def is accepted too.
+    return True
+
+
 # ===== TOOLS =====
 
 @app.tool()
@@ -105,6 +158,9 @@ async def {{ .ToolName | default "hello" }}() -> str:
     http_port={{ .Port }},
     enable_http=True,
     auto_run=True,
+    health_check=health_check,
+    health_check_ttl=30,
+    startup_check=startup_check,
 )
 class {{ toAgentClassName .Name }}:
     """

--- a/cmd/meshctl/templates/python/llm-agent/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/main.py.tmpl
@@ -17,6 +17,64 @@ app = FastMCP("{{ toPascalCase .Name }} Service")
 # System prompt is loaded from: prompts/{{ .Name }}.jinja2
 # Customize the prompt file to change the LLM behavior.
 
+# ===== HEALTH AND STARTUP CHECKS =====
+#
+# Two hooks, two questions, two different consequences. Both default to
+# passing, so deleting either one leaves this agent behaving exactly as it
+# does today.
+#
+#   health_check   "Can I serve RIGHT NOW?" Re-runs every health_check_ttl
+#                  seconds. While it reports unhealthy the agent stops
+#                  heartbeating: the registry ages it out and dependency
+#                  resolution stops selecting it. The process keeps running
+#                  and keeps serving, and the registry restores the agent the
+#                  moment the check passes again - no restart, no redeploy.
+#                  Override it for anything TRANSIENT: a database that may
+#                  come back, a vendor API having an outage.
+#
+#   startup_check  "Can I EVER serve?" Read by the Kubernetes startupProbe,
+#                  on /startupz. A pod whose startup check fails never becomes
+#                  ready, never registers, and lands in CrashLoopBackOff -
+#                  which is the point: a misconfiguration is loud instead of
+#                  looking like an outage. A startupProbe stops polling once
+#                  it passes, so a credential revoked later falls to
+#                  health_check. Override it for anything a restart CANNOT
+#                  fix: a missing API key, an unreadable config file.
+#
+# Choosing the wrong hook is the trap this split exists to remove. A missing
+# API key reported by health_check leaves the pod Running and silently
+# unregistered, indistinguishable from an outage; a vendor outage reported by
+# startup_check crash-loops a pod whose configuration was fine all along.
+#
+# They also disagree about exceptions, deliberately. A health_check that
+# raises is recorded as degraded and keeps heartbeating - a buggy probe must
+# not withdraw a working agent from a mesh that may have no other one. A
+# startup_check that raises FAILS: at boot an indeterminate answer is not a
+# reason to admit a possibly-misconfigured agent.
+#
+# Neither one belongs on the LLM provider this agent resolves through. The
+# provider holds the vendor credential and probes the vendor itself; this
+# agent has no key to check and no vendor to reach, and a provider that goes
+# unhealthy is withdrawn by mesh without help from here.
+
+
+async def health_check() -> dict:
+    """Can this agent serve right now?"""
+    # TODO: probe whatever this agent needs in order to answer a call - a
+    # database handle, a downstream API. Return {"status": "unhealthy", ...}
+    # (or plain False) to be withdrawn from the mesh until it recovers.
+    return {"status": "healthy", "checks": {}, "errors": []}
+
+
+def startup_check() -> bool:
+    """Is this agent configured such that it can ever serve?"""
+    # TODO: assert the configuration this agent cannot run without - an env
+    # var, a mounted secret, a readable prompt file. Return False (or
+    # {"status": "unhealthy", ...}) and the pod never comes up. Sync is fine
+    # here; an async def is accepted too.
+    return True
+
+
 # ===== CONTEXT MODEL =====
 
 class {{ toPascalCase .Name }}Context(BaseModel):
@@ -86,6 +144,9 @@ def {{ toSnakeCase .Name }}(
     http_port={{ .Port }},
     enable_http=True,
     auto_run=True,
+    health_check=health_check,
+    health_check_ttl=30,
+    startup_check=startup_check,
 )
 class {{ toAgentClassName .Name }}:
     """

--- a/cmd/meshctl/templates/python/llm-provider/README.md.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/README.md.tmpl
@@ -119,7 +119,39 @@ The provider includes a health check that validates:
   from, or this agent cannot withdraw itself when that endpoint is down.
 {{ end }}
 
-Health status is cached for 30 seconds.
+Health status is cached for 30 seconds. It answers "can I serve **right now**":
+while it reports unhealthy the agent stops heartbeating and the registry
+withdraws it from resolution, so consumers fail over to another provider. The
+pod keeps running and is restored automatically when the check passes again.
+
+## Startup Check
+
+`startup_check()` answers the other question — "can I **ever** serve" — and it
+is read by the Kubernetes `startupProbe`, on `/startupz`. A pod whose startup
+check fails never becomes ready, never registers, and lands in
+`CrashLoopBackOff`, where a misconfiguration is visible instead of looking like
+an outage.
+{{ if .ProbeVendor }}
+The generated check reads the API key locally first, then asks the vendor
+whether it is accepted. The two answers are not treated alike:
+
+| The vendor... | Startup | Because |
+|---|---|---|
+| has no key to read | **fails** | a key that is not set will not set itself |
+| rejects the key | **fails** | no restart mints a valid one |
+| answers 5xx or rate-limits | passes | an outage, not a misconfiguration |
+| does not answer at all | passes | same - the health check withdraws the agent meanwhile |
+
+Crash-looping on an outage would restart a pod whose configuration was fine, and
+would make `CrashLoopBackOff` stop meaning "your configuration is wrong".
+{{ else }}
+It is a skeleton that always passes, so a {{ .Model }} pod with no credentials
+at all still comes up and fails every call. Replace it with the local checks
+this deployment cannot run without - the credential your gateway authenticates
+with, a required endpoint URL. If you call your gateway from it, fail only on a
+rejected credential: a 5xx, a rate limit or an unreachable endpoint is an outage
+and belongs in the health check.
+{{ end }}
 
 ## License
 

--- a/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
@@ -68,7 +68,7 @@ async def health_check() -> dict:
     status = "healthy"
 
     # Check API Key presence
-    api_key = os.getenv("ANTHROPIC_API_KEY")
+    api_key = (os.getenv("ANTHROPIC_API_KEY") or "").strip()
     if api_key:
         checks["anthropic_api_key_present"] = True
     else:
@@ -133,7 +133,7 @@ async def health_check() -> dict:
     status = "healthy"
 
     # Check API Key presence
-    api_key = os.getenv("OPENAI_API_KEY")
+    api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
     if api_key:
         checks["openai_api_key_present"] = True
     else:
@@ -195,7 +195,7 @@ async def health_check() -> dict:
     status = "healthy"
 
     # Check API Key presence
-    api_key = os.getenv("GOOGLE_API_KEY")
+    api_key = (os.getenv("GOOGLE_API_KEY") or "").strip()
     if api_key:
         checks["google_api_key_present"] = True
     else:
@@ -287,7 +287,7 @@ async def startup_check() -> dict:
     """
     # Local first: a missing key costs nothing to detect and never fixes
     # itself, so it needs no network call to be certain about.
-    api_key = os.getenv("ANTHROPIC_API_KEY")
+    api_key = (os.getenv("ANTHROPIC_API_KEY") or "").strip()
     if not api_key:
         return {
             "status": "unhealthy",
@@ -348,7 +348,7 @@ async def startup_check() -> dict:
     """
     # Local first: a missing key costs nothing to detect and never fixes
     # itself, so it needs no network call to be certain about.
-    api_key = os.getenv("OPENAI_API_KEY")
+    api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
     if not api_key:
         return {
             "status": "unhealthy",
@@ -406,7 +406,7 @@ async def startup_check() -> dict:
     """
     # Local first: a missing key costs nothing to detect and never fixes
     # itself, so it needs no network call to be certain about.
-    api_key = os.getenv("GOOGLE_API_KEY")
+    api_key = (os.getenv("GOOGLE_API_KEY") or "").strip()
     if not api_key:
         return {
             "status": "unhealthy",

--- a/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
@@ -16,7 +16,41 @@ from fastmcp import FastMCP
 app = FastMCP("{{ toPascalCase .Name }}")
 
 
-# ===== HEALTH CHECK =====
+# ===== HEALTH AND STARTUP CHECKS =====
+#
+# Two hooks, two questions, two different consequences.
+#
+#   health_check   "Can I serve RIGHT NOW?" Re-runs every health_check_ttl
+#                  seconds. While it reports unhealthy this provider stops
+#                  heartbeating: the registry ages it out, dependency
+#                  resolution stops selecting it, and consumers fail over to
+#                  another provider. The process keeps running and the
+#                  registry restores it the moment the check passes again -
+#                  no restart, no redeploy. This is the hook for a vendor
+#                  OUTAGE, which is transient by definition.
+#
+#   startup_check  "Can I EVER serve?" Read by the Kubernetes startupProbe,
+#                  on /startupz. A pod whose startup check fails never becomes
+#                  ready, never registers, and lands in CrashLoopBackOff -
+#                  which is the point: a missing or rejected API key is loud
+#                  instead of looking like an outage. A startupProbe stops
+#                  polling once it passes, so a key revoked later falls to
+#                  health_check. This is the hook for a MISCONFIGURATION,
+#                  which no restart is going to fix.
+#
+# The two checks below probe the same endpoint and read the verdict
+# differently, and that difference is the whole design. A rejected credential
+# fails startup; a 5xx, a rate limit or an unreachable vendor PASSES startup
+# and is left to health_check. Mapping an outage onto startup_check would
+# crash-loop a correctly configured pod for as long as the vendor is down -
+# and, worse, would make CrashLoopBackOff stop meaning "your configuration is
+# wrong", which is the signal this hook exists to produce.
+#
+# They also disagree about exceptions, deliberately. A health_check that
+# raises is recorded as degraded and keeps heartbeating - a buggy probe must
+# not withdraw a working provider from a mesh that may have no other one. A
+# startup_check that raises FAILS: at boot an indeterminate answer is not a
+# reason to admit a possibly-misconfigured agent.
 {{ if eq .ProbeVendor "anthropic" }}
 async def health_check() -> dict:
     """
@@ -240,6 +274,212 @@ async def health_check() -> dict:
         "errors": [],
     }
 {{ end }}
+{{ if eq .ProbeVendor "anthropic" }}
+async def startup_check() -> dict:
+    """
+    Startup check for {{ .Name }}.
+
+    Answers "is this provider configured such that it can EVER serve?" - the
+    question a restart cannot change the answer to.
+
+    Returns:
+        dict: Startup verdict with checks and errors
+    """
+    # Local first: a missing key costs nothing to detect and never fixes
+    # itself, so it needs no network call to be certain about.
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        return {
+            "status": "unhealthy",
+            "checks": {"anthropic_api_key_present": False},
+            "errors": ["ANTHROPIC_API_KEY not set"],
+        }
+
+    # A WRONG key can only be detected by asking the vendor. A network call on
+    # the startup path is acceptable because a startupProbe stops polling once
+    # it passes - this runs a handful of times, not every ten seconds forever.
+    checks = {"anthropic_api_key_present": True}
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(
+                "https://api.anthropic.com/v1/models",
+                headers={
+                    "anthropic-version": "2023-06-01",
+                    "x-api-key": api_key,
+                },
+            )
+    except Exception:
+        # The vendor could not be reached at all (DNS, connect, timeout, TLS).
+        # An outage, not a misconfiguration: startup PASSES and health_check
+        # withdraws this agent for as long as it lasts. Failing here would
+        # crash-loop a correctly configured pod, and would dilute
+        # CrashLoopBackOff from "your configuration is wrong" into "something
+        # somewhere is unwell".
+        checks["anthropic_api_reachable"] = False
+        return {"status": "healthy", "checks": checks, "errors": []}
+
+    if response.status_code in (401, 403):
+        # The vendor answered and REJECTED the credential. Fatal: no restart
+        # mints a valid key, so fail startup and make the mistake visible.
+        checks["anthropic_api_key_valid"] = False
+        return {
+            "status": "unhealthy",
+            "checks": checks,
+            "errors": ["Anthropic rejected ANTHROPIC_API_KEY"],
+        }
+
+    # The vendor answered with something that is not a rejection - a 200, a
+    # 5xx, a rate limit. The credential is not what is wrong, so startup
+    # PASSES and anything transient is health_check's to report.
+    checks["anthropic_api_key_valid"] = response.status_code == 200
+    return {"status": "healthy", "checks": checks, "errors": []}
+{{ else if eq .ProbeVendor "openai" }}
+async def startup_check() -> dict:
+    """
+    Startup check for {{ .Name }}.
+
+    Answers "is this provider configured such that it can EVER serve?" - the
+    question a restart cannot change the answer to.
+
+    Returns:
+        dict: Startup verdict with checks and errors
+    """
+    # Local first: a missing key costs nothing to detect and never fixes
+    # itself, so it needs no network call to be certain about.
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return {
+            "status": "unhealthy",
+            "checks": {"openai_api_key_present": False},
+            "errors": ["OPENAI_API_KEY not set"],
+        }
+
+    # A WRONG key can only be detected by asking the vendor. A network call on
+    # the startup path is acceptable because a startupProbe stops polling once
+    # it passes - this runs a handful of times, not every ten seconds forever.
+    checks = {"openai_api_key_present": True}
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(
+                "https://api.openai.com/v1/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+    except Exception:
+        # The vendor could not be reached at all (DNS, connect, timeout, TLS).
+        # An outage, not a misconfiguration: startup PASSES and health_check
+        # withdraws this agent for as long as it lasts. Failing here would
+        # crash-loop a correctly configured pod, and would dilute
+        # CrashLoopBackOff from "your configuration is wrong" into "something
+        # somewhere is unwell".
+        checks["openai_api_reachable"] = False
+        return {"status": "healthy", "checks": checks, "errors": []}
+
+    if response.status_code in (401, 403):
+        # The vendor answered and REJECTED the credential. Fatal: no restart
+        # mints a valid key, so fail startup and make the mistake visible.
+        checks["openai_api_key_valid"] = False
+        return {
+            "status": "unhealthy",
+            "checks": checks,
+            "errors": ["OpenAI rejected OPENAI_API_KEY"],
+        }
+
+    # The vendor answered with something that is not a rejection - a 200, a
+    # 5xx, a rate limit. The credential is not what is wrong, so startup
+    # PASSES and anything transient is health_check's to report.
+    checks["openai_api_key_valid"] = response.status_code == 200
+    return {"status": "healthy", "checks": checks, "errors": []}
+{{ else if eq .ProbeVendor "gemini" }}
+async def startup_check() -> dict:
+    """
+    Startup check for {{ .Name }}.
+
+    Answers "is this provider configured such that it can EVER serve?" - the
+    question a restart cannot change the answer to.
+
+    Returns:
+        dict: Startup verdict with checks and errors
+    """
+    # Local first: a missing key costs nothing to detect and never fixes
+    # itself, so it needs no network call to be certain about.
+    api_key = os.getenv("GOOGLE_API_KEY")
+    if not api_key:
+        return {
+            "status": "unhealthy",
+            "checks": {"google_api_key_present": False},
+            "errors": ["GOOGLE_API_KEY not set"],
+        }
+
+    # A WRONG key can only be detected by asking the vendor. A network call on
+    # the startup path is acceptable because a startupProbe stops polling once
+    # it passes - this runs a handful of times, not every ten seconds forever.
+    checks = {"google_api_key_present": True}
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(
+                f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}",
+            )
+    except Exception:
+        # The vendor could not be reached at all (DNS, connect, timeout, TLS).
+        # An outage, not a misconfiguration: startup PASSES and health_check
+        # withdraws this agent for as long as it lasts. Failing here would
+        # crash-loop a correctly configured pod, and would dilute
+        # CrashLoopBackOff from "your configuration is wrong" into "something
+        # somewhere is unwell".
+        checks["gemini_api_reachable"] = False
+        return {"status": "healthy", "checks": checks, "errors": []}
+
+    # 400, not 401: Gemini answers a bad API key with INVALID_ARGUMENT rather
+    # than an auth status, which is why this branch is wider than the other
+    # two vendors'. It is the same pair the health check above reads.
+    if response.status_code in (400, 403):
+        # The vendor answered and REJECTED the credential. Fatal: no restart
+        # mints a valid key, so fail startup and make the mistake visible.
+        checks["google_api_key_valid"] = False
+        return {
+            "status": "unhealthy",
+            "checks": checks,
+            "errors": ["Google rejected GOOGLE_API_KEY"],
+        }
+
+    # The vendor answered with something that is not a rejection - a 200, a
+    # 5xx, a rate limit. The credential is not what is wrong, so startup
+    # PASSES and anything transient is health_check's to report.
+    checks["google_api_key_valid"] = response.status_code == 200
+    return {"status": "healthy", "checks": checks, "errors": []}
+{{ else }}
+async def startup_check() -> bool:
+    """
+    Startup check for {{ .Name }}.
+
+    NOT IMPLEMENTED - a skeleton that always passes, so a {{ .Model }} pod
+    with no credentials at all still comes up, registers, and fails every
+    call it is given.
+
+    Replace it with the local checks this deployment cannot run without: the
+    credential your gateway authenticates with (an AWS role, ADC / Workload
+    Identity, your proxy's token), a required endpoint URL. Return False and
+    the pod never becomes ready, never registers, and lands in
+    CrashLoopBackOff with the reason in its logs.
+
+    Keep it local if you can. If you do call your gateway from here, branch on
+    the answer: a REJECTED credential is fatal and must fail, but a 5xx, a
+    rate limit, a timeout or an unreachable endpoint must PASS - those are
+    outages, and crash-looping on one restarts a pod whose configuration was
+    fine. Report those from the health check instead, which withdraws the
+    agent while they last and restores it afterwards.
+
+    Returns:
+        bool: True to start, False to refuse
+    """
+    return True
+{{ end }}
 
 
 # ===== LLM PROVIDER =====
@@ -279,6 +519,7 @@ def {{ toSnakeCase .Name }}():
     auto_run=True,
     health_check=health_check,
     health_check_ttl=30,
+    startup_check=startup_check,
 )
 class {{ toAgentClassName .Name }}:
     """

--- a/cmd/meshctl/templates/typescript/a2a-consumer/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/a2a-consumer/src/index.ts.tmpl
@@ -13,7 +13,12 @@
  * and skill IDs below before running.
 {{ else }} * Generated from: {{ .A2AURL }}/.well-known/agent.json
 {{ end }} */
-import { FastMCP, mesh, type A2AClient } from "@mcpmesh/sdk";
+import {
+  FastMCP,
+  mesh,
+  type A2AClient,
+  type MeshHealthResult,
+} from "@mcpmesh/sdk";
 import { z } from "zod";
 
 function parsePort(raw: string | undefined, fallback: number): number {
@@ -31,10 +36,72 @@ const server = new FastMCP({
   version: "1.0.0",
 });
 
+// ===== HEALTH AND STARTUP CHECKS =====
+//
+// Two hooks, two questions, two different consequences. Both default to
+// passing, so deleting either one leaves this bridge behaving exactly as it
+// does today.
+//
+//   healthCheck   "Can I serve RIGHT NOW?" Re-runs every healthCheckTtl
+//                 seconds. While it reports "unhealthy" the bridge stops
+//                 heartbeating: the registry ages it out and dependency
+//                 resolution stops selecting it. The process keeps running
+//                 and keeps serving, and the registry restores it the moment
+//                 the check passes again - no restart, no redeploy. Override
+//                 it for anything TRANSIENT: the A2A producer at
+//                 {{ .A2AURL }} being down is the obvious one here.
+//
+//   startupCheck  "Can I EVER serve?" Read by the Kubernetes startupProbe,
+//                 on /startupz. A pod whose startup check fails never becomes
+//                 ready, never registers, and lands in CrashLoopBackOff -
+//                 which is the point: a misconfiguration is loud instead of
+//                 looking like an outage. A startupProbe stops polling once
+//                 it passes, so a credential revoked later falls to
+//                 healthCheck. Override it for anything a restart CANNOT
+//                 fix{{ if .AuthBearer }}: {{ .AuthEnvVar }} not being set is exactly that{{ else }}: a missing token, an unreadable config file{{ end }}.
+//
+// Choosing the wrong hook is the trap this split exists to remove. A missing
+// token reported by healthCheck leaves the pod Running and silently
+// unregistered, indistinguishable from a producer outage; a producer outage
+// reported by startupCheck crash-loops a pod whose configuration was fine.
+//
+// They also disagree about exceptions, deliberately. A healthCheck that
+// throws is recorded as "degraded" and keeps heartbeating - a buggy probe
+// must not withdraw a working bridge from a mesh that may have no other one.
+// A startupCheck that throws FAILS: at boot an indeterminate answer is not a
+// reason to admit a possibly-misconfigured agent.
+
+/** Can this bridge serve right now? */
+async function healthCheck(): Promise<MeshHealthResult> {
+  // TODO: probe the producer this bridge fronts - its agent card at
+  // {{ .A2AURL }}/.well-known/agent.json is a cheap, metadata-only
+  // request. Return { status: "unhealthy", ... } (or plain false) to be
+  // withdrawn from the mesh until the producer is back.
+  return { status: "healthy", checks: {}, errors: [] };
+}
+
+/** Is this bridge configured such that it can ever serve? */
+function startupCheck(): boolean {
+{{- if .AuthBearer }}
+  // The producer needs a bearer token, and a pod that does not have one is
+  // never going to acquire it: failing here is the whole point of the hook.
+  return Boolean(process.env[{{ toJSON .AuthEnvVar }}]);
+{{- else }}
+  // TODO: assert the configuration this bridge cannot run without - the
+  // producer URL, a token, a mounted secret. Return false (or
+  // { status: "unhealthy", ... }) and the pod never comes up. Sync is fine
+  // here; a promise is accepted too.
+  return true;
+{{- end }}
+}
+
 const agent = mesh(server, {
   name: {{ toJSON .Name }},
   httpPort: HTTP_PORT,{{ if .Description }}
   description: {{ toJSON .Description }},{{ end }}
+  healthCheck,
+  healthCheckTtl: 30,
+  startupCheck,
 });
 
 {{ range .Skills }}

--- a/cmd/meshctl/templates/typescript/a2a-consumer/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/a2a-consumer/src/index.ts.tmpl
@@ -85,7 +85,9 @@ function startupCheck(): boolean {
 {{- if .AuthBearer }}
   // The producer needs a bearer token, and a pod that does not have one is
   // never going to acquire it: failing here is the whole point of the hook.
-  return Boolean(process.env[{{ toJSON .AuthEnvVar }}]);
+  // Trimmed before the test: a credential pasted with a trailing newline, or
+  // a Secret key whose value is blank, is not a token.
+  return Boolean(process.env[{{ toJSON .AuthEnvVar }}]?.trim());
 {{- else }}
   // TODO: assert the configuration this bridge cannot run without - the
   // producer URL, a token, a mounted secret. Return false (or

--- a/cmd/meshctl/templates/typescript/api/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/api/src/index.ts.tmpl
@@ -32,7 +32,7 @@ const PORT = process.env.PORT || {{ .Port }};
 // with no mesh involvement at all.
 const REQUIRED_SETTINGS: string[] = []; // e.g. ["DATABASE_URL", "UPSTREAM_TOKEN"]
 
-const missing = REQUIRED_SETTINGS.filter((name) => !process.env[name]);
+const missing = REQUIRED_SETTINGS.filter((name) => !process.env[name]?.trim());
 if (missing.length > 0) {
   // Exit non-zero BEFORE listening. A gateway that comes up misconfigured
   // takes ingress it cannot answer; one that never comes up is visible

--- a/cmd/meshctl/templates/typescript/api/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/api/src/index.ts.tmpl
@@ -12,12 +12,76 @@ app.use(express.json());
 
 const PORT = process.env.PORT || {{ .Port }};
 
+// ===== STARTUP VALIDATION =====
+//
+// There is no healthCheck or startupCheck hook to declare here, and that is a
+// design decision rather than a gap (issue #1506).
+//
+// This gateway is an ordinary Express application that happens to consume mesh
+// capabilities. What mesh gives it is dependency injection - mesh.route()
+// resolves capabilities and hands them to your handlers - not ownership of the
+// application's lifecycle. Both hooks live on a mesh agent's config object,
+// and this app has none: meshExpress() is the only TypeScript surface that
+// carries them, and wrapping this app in it as well would start a second mesh
+// agent from one process, since mesh.route() already auto-starts the API
+// runtime that registers this one.
+//
+// Startup validation is a solved problem here, and the solution is strictly
+// more flexible than a hook would be: check the configuration at boot and exit
+// non-zero. Kubernetes gives you CrashLoopBackOff with the cause in the logs,
+// with no mesh involvement at all.
+const REQUIRED_SETTINGS: string[] = []; // e.g. ["DATABASE_URL", "UPSTREAM_TOKEN"]
+
+const missing = REQUIRED_SETTINGS.filter((name) => !process.env[name]);
+if (missing.length > 0) {
+  // Exit non-zero BEFORE listening. A gateway that comes up misconfigured
+  // takes ingress it cannot answer; one that never comes up is visible
+  // immediately.
+  console.error(`{{ .Name }}: not configured: ${missing.join(", ")} not set`);
+  process.exit(1);
+}
+
+// ===== KUBERNETES PROBE ENDPOINTS =====
+//
+// These are yours, not mesh's. A mesh.route() gateway keeps its own Express
+// server and mesh never touches it, so nothing mounts the paths the agent Helm
+// chart probes - they are defined here so this scaffold is deployable as
+// generated. Each answers the question its own probe asks, and no two share a
+// URL: a probe whose failure action is a restart must never be able to see a
+// dependency outage, which a restart cannot fix.
+
+// startupProbe. Nothing here can fail yet - the configuration was validated
+// above, and a gateway that got this far is started. Add checks that a restart
+// CANNOT fix, and let the process exit rather than answering 503 forever.
+app.get("/startupz", (_req: Request, res: Response) => {
+  res.json({ started: true, service: "{{ .Name }}" });
+});
+
+// livenessProbe. 200 for as long as this process serves, consulting nothing:
+// reaching this handler is itself the proof, and a restart is the only remedy
+// it can offer.
+app.get("/livez", (_req: Request, res: Response) => {
+  res.json({ alive: true, service: "{{ .Name }}" });
+});
+
+// readinessProbe. 200 while this gateway should take ingress. Do NOT wire an
+// upstream capability's availability in here: mesh traffic and your ingress
+// both arrive through the Service, and a 503 empties its endpoints, so an
+// unresolved dependency would take the gateway off the network instead of
+// letting a handler answer 503 for the one route that needed it.
+app.get("/ready", (_req: Request, res: Response) => {
+  res.json({ ready: true, service: "{{ .Name }}" });
+});
+
 // ===== HEALTH & INFO ENDPOINTS =====
 
 app.get("/", (req: Request, res: Response) => {
   res.json({
     service: "{{ .Name }}",
     endpoints: [
+      "GET  /startupz   - startupProbe",
+      "GET  /livez      - livenessProbe",
+      "GET  /ready      - readinessProbe",
       "GET  /health     - Health check",
       "GET  /api/hello  - Call hello capability",
     ],

--- a/cmd/meshctl/templates/typescript/basic/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/src/index.ts.tmpl
@@ -5,7 +5,15 @@
  * {{ if .Description }}{{ .Description }}{{ else }}A MCP Mesh agent generated using meshctl scaffold.{{ end }}
  */
 
-import { FastMCP, mesh, McpMeshTool, uploadMedia, mediaResult, mediaParam } from "@mcpmesh/sdk";
+import {
+  FastMCP,
+  mesh,
+  McpMeshTool,
+  uploadMedia,
+  mediaResult,
+  mediaParam,
+  type MeshHealthResult,
+} from "@mcpmesh/sdk";
 import { z } from "zod";
 
 // FastMCP server instance
@@ -14,10 +22,65 @@ const server = new FastMCP({
   version: "1.0.0",
 });
 
+// ===== HEALTH AND STARTUP CHECKS =====
+//
+// Two hooks, two questions, two different consequences. Both default to
+// passing, so deleting either one leaves this agent behaving exactly as it
+// does today.
+//
+//   healthCheck   "Can I serve RIGHT NOW?" Re-runs every healthCheckTtl
+//                 seconds. While it reports "unhealthy" the agent stops
+//                 heartbeating: the registry ages it out and dependency
+//                 resolution stops selecting it. The process keeps running
+//                 and keeps serving, and the registry restores the agent the
+//                 moment the check passes again - no restart, no redeploy.
+//                 Override it for anything TRANSIENT: a database that may
+//                 come back, a vendor API having an outage.
+//
+//   startupCheck  "Can I EVER serve?" Read by the Kubernetes startupProbe,
+//                 on /startupz. A pod whose startup check fails never becomes
+//                 ready, never registers, and lands in CrashLoopBackOff -
+//                 which is the point: a misconfiguration is loud instead of
+//                 looking like an outage. A startupProbe stops polling once
+//                 it passes, so a credential revoked later falls to
+//                 healthCheck. Override it for anything a restart CANNOT
+//                 fix: a missing API key, an unreadable config file.
+//
+// Choosing the wrong hook is the trap this split exists to remove. A missing
+// API key reported by healthCheck leaves the pod Running and silently
+// unregistered, indistinguishable from an outage; a vendor outage reported by
+// startupCheck crash-loops a pod whose configuration was fine all along.
+//
+// They also disagree about exceptions, deliberately. A healthCheck that
+// throws is recorded as "degraded" and keeps heartbeating - a buggy probe
+// must not withdraw a working agent from a mesh that may have no other one. A
+// startupCheck that throws FAILS: at boot an indeterminate answer is not a
+// reason to admit a possibly-misconfigured agent.
+
+/** Can this agent serve right now? */
+async function healthCheck(): Promise<MeshHealthResult> {
+  // TODO: probe whatever this agent needs in order to answer a call - a
+  // database handle, a downstream API. Return { status: "unhealthy", ... }
+  // (or plain false) to be withdrawn from the mesh until it recovers.
+  return { status: "healthy", checks: {}, errors: [] };
+}
+
+/** Is this agent configured such that it can ever serve? */
+function startupCheck(): boolean {
+  // TODO: assert the configuration this agent cannot run without - an env
+  // var, a mounted secret, a readable file. Return false (or
+  // { status: "unhealthy", ... }) and the pod never comes up. Sync is fine
+  // here; a promise is accepted too.
+  return true;
+}
+
 // Wrap with MCP Mesh
 const agent = mesh(server, {
   name: "{{ .Name }}",
   httpPort: {{ .Port }},
+  healthCheck,
+  healthCheckTtl: 30,
+  startupCheck,
 });
 
 // ===== TOOLS =====

--- a/cmd/meshctl/templates/typescript/llm-agent/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/src/index.ts.tmpl
@@ -5,7 +5,7 @@
  * {{ if .Description }}{{ .Description }}{{ else }}A MCP Mesh LLM agent generated using meshctl scaffold.{{ end }}
  */
 
-import { FastMCP, mesh } from "@mcpmesh/sdk";
+import { FastMCP, mesh, type MeshHealthResult } from "@mcpmesh/sdk";
 import { z } from "zod";
 
 // FastMCP server instance
@@ -13,6 +13,63 @@ const server = new FastMCP({
   name: "{{ toPascalCase .Name }} Service",
   version: "1.0.0",
 });
+
+// ===== HEALTH AND STARTUP CHECKS =====
+//
+// Two hooks, two questions, two different consequences. Both default to
+// passing, so deleting either one leaves this agent behaving exactly as it
+// does today.
+//
+//   healthCheck   "Can I serve RIGHT NOW?" Re-runs every healthCheckTtl
+//                 seconds. While it reports "unhealthy" the agent stops
+//                 heartbeating: the registry ages it out and dependency
+//                 resolution stops selecting it. The process keeps running
+//                 and keeps serving, and the registry restores the agent the
+//                 moment the check passes again - no restart, no redeploy.
+//                 Override it for anything TRANSIENT: a database that may
+//                 come back, a vendor API having an outage.
+//
+//   startupCheck  "Can I EVER serve?" Read by the Kubernetes startupProbe,
+//                 on /startupz. A pod whose startup check fails never becomes
+//                 ready, never registers, and lands in CrashLoopBackOff -
+//                 which is the point: a misconfiguration is loud instead of
+//                 looking like an outage. A startupProbe stops polling once
+//                 it passes, so a credential revoked later falls to
+//                 healthCheck. Override it for anything a restart CANNOT
+//                 fix: a missing API key, an unreadable config file.
+//
+// Choosing the wrong hook is the trap this split exists to remove. A missing
+// API key reported by healthCheck leaves the pod Running and silently
+// unregistered, indistinguishable from an outage; a vendor outage reported by
+// startupCheck crash-loops a pod whose configuration was fine all along.
+//
+// They also disagree about exceptions, deliberately. A healthCheck that
+// throws is recorded as "degraded" and keeps heartbeating - a buggy probe
+// must not withdraw a working agent from a mesh that may have no other one. A
+// startupCheck that throws FAILS: at boot an indeterminate answer is not a
+// reason to admit a possibly-misconfigured agent.
+//
+// Neither one belongs on the LLM provider this agent resolves through. The
+// provider holds the vendor credential and probes the vendor itself; this
+// agent has no key to check and no vendor to reach, and a provider that goes
+// unhealthy is withdrawn by mesh without help from here.
+
+/** Can this agent serve right now? */
+async function healthCheck(): Promise<MeshHealthResult> {
+  // TODO: probe whatever this agent needs in order to answer a call - a
+  // database handle, a downstream API. Return { status: "unhealthy", ... }
+  // (or plain false) to be withdrawn from the mesh until it recovers.
+  return { status: "healthy", checks: {}, errors: [] };
+}
+
+/** Is this agent configured such that it can ever serve? */
+function startupCheck(): boolean {
+  // TODO: assert the configuration this agent cannot run without - an env
+  // var, a mounted secret, a readable prompt file. Return false (or
+  // { status: "unhealthy", ... }) and the pod never comes up. Sync is fine
+  // here; a promise is accepted too.
+  return true;
+}
 
 // ===== CONTEXT SCHEMA =====
 
@@ -94,6 +151,9 @@ const agent = mesh(server, {
   version: "1.0.0",
   description: "{{ if .Description }}{{ .Description }}{{ else }}MCP Mesh LLM agent{{ end }}",
   httpPort: {{ .Port }},
+  healthCheck,
+  healthCheckTtl: 30,
+  startupCheck,
 });
 
 // No explicit start needed - auto-starts via process.nextTick()!

--- a/cmd/meshctl/templates/typescript/llm-provider/README.md.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/README.md.tmpl
@@ -24,6 +24,39 @@ This provider uses `mesh.llmProvider()` which:
 - Provides health checks for API connectivity
 - Handles rate limiting and error recovery
 
+## Health and Startup Checks
+
+Two hooks in `src/index.ts`, answering two different questions:
+
+- `healthCheck()` - "can I serve **right now**". Re-runs every 30s. While it
+  reports unhealthy the agent stops heartbeating and the registry withdraws it,
+  so consumers fail over to another provider; the pod keeps running and is
+  restored the moment the check passes again.
+- `startupCheck()` - "can I **ever** serve". Read by the Kubernetes
+  `startupProbe`, on `/startupz`. A pod whose startup check fails never becomes
+  ready, never registers, and lands in `CrashLoopBackOff`, where a
+  misconfiguration is visible instead of looking like an outage.
+{{ if .ProbeVendor }}
+The generated `startupCheck()` reads the API key locally first, then asks the
+vendor whether it is accepted. The two answers are not treated alike:
+
+| The vendor... | Startup | Because |
+|---|---|---|
+| has no key to read | **fails** | a key that is not set will not set itself |
+| rejects the key | **fails** | no restart mints a valid one |
+| answers 5xx or rate-limits | passes | an outage, not a misconfiguration |
+| does not answer at all | passes | same - `healthCheck` withdraws the agent meanwhile |
+
+Crash-looping on an outage would restart a pod whose configuration was fine, and
+would make `CrashLoopBackOff` stop meaning "your configuration is wrong".
+{{ else }}
+Both are skeletons for {{ .Model }}: they always pass, so a pod with no
+credentials at all comes up and fails every call, and a {{ .Model }} outage
+never withdraws this agent. Implement them against the endpoint this model is
+actually served from. In `startupCheck()`, fail only on a rejected credential -
+a 5xx, a rate limit or an unreachable endpoint is an outage and belongs in
+`healthCheck()`.
+{{ end }}
 ## Using This Provider
 
 Other agents can use this provider via `mesh.llm()`:

--- a/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
@@ -78,7 +78,7 @@ function describeError(err: unknown): string {
  * Uses /v1/models - metadata only, no tokens consumed.
  */
 async function healthCheck(): Promise<MeshHealthResult> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const apiKey = process.env.ANTHROPIC_API_KEY?.trim();
   if (!apiKey) {
     return {
       status: "unhealthy",
@@ -141,7 +141,7 @@ async function healthCheck(): Promise<MeshHealthResult> {
  * Uses /v1/models - metadata only, no tokens consumed.
  */
 async function healthCheck(): Promise<MeshHealthResult> {
-  const apiKey = process.env.OPENAI_API_KEY;
+  const apiKey = process.env.OPENAI_API_KEY?.trim();
   if (!apiKey) {
     return {
       status: "unhealthy",
@@ -201,7 +201,7 @@ async function healthCheck(): Promise<MeshHealthResult> {
  * Uses /v1beta/models - metadata only, no tokens consumed.
  */
 async function healthCheck(): Promise<MeshHealthResult> {
-  const apiKey = process.env.GOOGLE_API_KEY;
+  const apiKey = process.env.GOOGLE_API_KEY?.trim();
   if (!apiKey) {
     return {
       status: "unhealthy",
@@ -267,7 +267,7 @@ async function healthCheck(): Promise<MeshHealthResult> {
  *
  * A sketch of the shape:
  *
- *   const apiKey = process.env.MY_VENDOR_API_KEY;
+ *   const apiKey = process.env.MY_VENDOR_API_KEY?.trim();
  *   if (!apiKey) {
  *     return { status: "unhealthy", errors: ["MY_VENDOR_API_KEY not set"] };
  *   }
@@ -310,7 +310,7 @@ async function healthCheck(): Promise<MeshHealthResult> {
 async function startupCheck(): Promise<MeshHealthResult> {
   // Local first: a missing key costs nothing to detect and never fixes
   // itself, so it needs no network call to be certain about.
-  const apiKey = process.env.ANTHROPIC_API_KEY;
+  const apiKey = process.env.ANTHROPIC_API_KEY?.trim();
   if (!apiKey) {
     return {
       status: "unhealthy",
@@ -371,7 +371,7 @@ async function startupCheck(): Promise<MeshHealthResult> {
 async function startupCheck(): Promise<MeshHealthResult> {
   // Local first: a missing key costs nothing to detect and never fixes
   // itself, so it needs no network call to be certain about.
-  const apiKey = process.env.OPENAI_API_KEY;
+  const apiKey = process.env.OPENAI_API_KEY?.trim();
   if (!apiKey) {
     return {
       status: "unhealthy",
@@ -429,7 +429,7 @@ async function startupCheck(): Promise<MeshHealthResult> {
 async function startupCheck(): Promise<MeshHealthResult> {
   // Local first: a missing key costs nothing to detect and never fixes
   // itself, so it needs no network call to be certain about.
-  const apiKey = process.env.GOOGLE_API_KEY;
+  const apiKey = process.env.GOOGLE_API_KEY?.trim();
   if (!apiKey) {
     return {
       status: "unhealthy",

--- a/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
@@ -15,11 +15,41 @@ const server = new FastMCP({
   version: "1.0.0",
 });
 
-// ===== HEALTH CHECK =====
+// ===== HEALTH AND STARTUP CHECKS =====
 //
-// Runs every healthCheckTtl seconds. While it returns "unhealthy" the agent
-// stops heartbeating, the registry withdraws it, and consumers fail over to
-// another provider — automatically restored when the check passes again.
+// Two hooks, two questions, two different consequences.
+//
+//   healthCheck   "Can I serve RIGHT NOW?" Re-runs every healthCheckTtl
+//                 seconds. While it returns "unhealthy" this provider stops
+//                 heartbeating: the registry ages it out, dependency
+//                 resolution stops selecting it, and consumers fail over to
+//                 another provider. The process keeps running and the
+//                 registry restores it the moment the check passes again -
+//                 no restart, no redeploy. This is the hook for a vendor
+//                 OUTAGE, which is transient by definition.
+//
+//   startupCheck  "Can I EVER serve?" Read by the Kubernetes startupProbe,
+//                 on /startupz. A pod whose startup check fails never becomes
+//                 ready, never registers, and lands in CrashLoopBackOff -
+//                 which is the point: a missing or rejected API key is loud
+//                 instead of looking like an outage. A startupProbe stops
+//                 polling once it passes, so a key revoked later falls to
+//                 healthCheck. This is the hook for a MISCONFIGURATION,
+//                 which no restart is going to fix.
+//
+// The two checks below probe the same endpoint and read the verdict
+// differently, and that difference is the whole design. A rejected credential
+// fails startup; a 5xx, a rate limit or an unreachable vendor PASSES startup
+// and is left to healthCheck. Mapping an outage onto startupCheck would
+// crash-loop a correctly configured pod for as long as the vendor is down -
+// and, worse, would make CrashLoopBackOff stop meaning "your configuration is
+// wrong", which is the signal this hook exists to produce.
+//
+// They also disagree about exceptions, deliberately. A healthCheck that
+// throws is recorded as "degraded" and keeps heartbeating - a buggy probe
+// must not withdraw a working provider from a mesh that may have no other
+// one. A startupCheck that throws FAILS: at boot an indeterminate answer is
+// not a reason to admit a possibly-misconfigured agent.
 {{ if .ProbeVendor }}
 /**
  * Ceiling for one probe. `AbortSignal.timeout` rejects with a
@@ -269,6 +299,212 @@ async function healthCheck(): Promise<MeshHealthResult> {
   return { status: "healthy", checks: { provider_configured: true }, errors: [] };
 }
 {{- end }}
+{{- if eq .ProbeVendor "anthropic" }}
+
+/**
+ * Startup check for {{ .Name }}.
+ *
+ * Answers "is this provider configured such that it can EVER serve?" - the
+ * question a restart cannot change the answer to.
+ */
+async function startupCheck(): Promise<MeshHealthResult> {
+  // Local first: a missing key costs nothing to detect and never fixes
+  // itself, so it needs no network call to be certain about.
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return {
+      status: "unhealthy",
+      checks: { anthropic_api_key_present: false },
+      errors: ["ANTHROPIC_API_KEY not set"],
+    };
+  }
+
+  // A WRONG key can only be detected by asking the vendor. A network call on
+  // the startup path is acceptable because a startupProbe stops polling once
+  // it passes - this runs a handful of times, not every ten seconds forever.
+  const checks: Record<string, boolean> = { anthropic_api_key_present: true };
+  let response: Response;
+  try {
+    response = await fetch("https://api.anthropic.com/v1/models", {
+      headers: {
+        "anthropic-version": "2023-06-01",
+        "x-api-key": apiKey,
+      },
+      signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+    });
+  } catch {
+    // The vendor could not be reached at all (DNS, connect, timeout, TLS).
+    // An outage, not a misconfiguration: startup PASSES and healthCheck
+    // withdraws this agent for as long as it lasts. Failing here would
+    // crash-loop a correctly configured pod, and would dilute
+    // CrashLoopBackOff from "your configuration is wrong" into "something
+    // somewhere is unwell".
+    checks.anthropic_api_reachable = false;
+    return { status: "healthy", checks, errors: [] };
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    // The vendor answered and REJECTED the credential. Fatal: no restart
+    // mints a valid key, so fail startup and make the mistake visible.
+    checks.anthropic_api_key_valid = false;
+    return {
+      status: "unhealthy",
+      checks,
+      errors: ["Anthropic rejected ANTHROPIC_API_KEY"],
+    };
+  }
+
+  // The vendor answered with something that is not a rejection - a 200, a
+  // 5xx, a rate limit. The credential is not what is wrong, so startup
+  // PASSES and anything transient is healthCheck's to report.
+  checks.anthropic_api_key_valid = response.status === 200;
+  return { status: "healthy", checks, errors: [] };
+}
+{{- else if eq .ProbeVendor "openai" }}
+
+/**
+ * Startup check for {{ .Name }}.
+ *
+ * Answers "is this provider configured such that it can EVER serve?" - the
+ * question a restart cannot change the answer to.
+ */
+async function startupCheck(): Promise<MeshHealthResult> {
+  // Local first: a missing key costs nothing to detect and never fixes
+  // itself, so it needs no network call to be certain about.
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return {
+      status: "unhealthy",
+      checks: { openai_api_key_present: false },
+      errors: ["OPENAI_API_KEY not set"],
+    };
+  }
+
+  // A WRONG key can only be detected by asking the vendor. A network call on
+  // the startup path is acceptable because a startupProbe stops polling once
+  // it passes - this runs a handful of times, not every ten seconds forever.
+  const checks: Record<string, boolean> = { openai_api_key_present: true };
+  let response: Response;
+  try {
+    response = await fetch("https://api.openai.com/v1/models", {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+    });
+  } catch {
+    // The vendor could not be reached at all (DNS, connect, timeout, TLS).
+    // An outage, not a misconfiguration: startup PASSES and healthCheck
+    // withdraws this agent for as long as it lasts. Failing here would
+    // crash-loop a correctly configured pod, and would dilute
+    // CrashLoopBackOff from "your configuration is wrong" into "something
+    // somewhere is unwell".
+    checks.openai_api_reachable = false;
+    return { status: "healthy", checks, errors: [] };
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    // The vendor answered and REJECTED the credential. Fatal: no restart
+    // mints a valid key, so fail startup and make the mistake visible.
+    checks.openai_api_key_valid = false;
+    return {
+      status: "unhealthy",
+      checks,
+      errors: ["OpenAI rejected OPENAI_API_KEY"],
+    };
+  }
+
+  // The vendor answered with something that is not a rejection - a 200, a
+  // 5xx, a rate limit. The credential is not what is wrong, so startup
+  // PASSES and anything transient is healthCheck's to report.
+  checks.openai_api_key_valid = response.status === 200;
+  return { status: "healthy", checks, errors: [] };
+}
+{{- else if eq .ProbeVendor "gemini" }}
+
+/**
+ * Startup check for {{ .Name }}.
+ *
+ * Answers "is this provider configured such that it can EVER serve?" - the
+ * question a restart cannot change the answer to.
+ */
+async function startupCheck(): Promise<MeshHealthResult> {
+  // Local first: a missing key costs nothing to detect and never fixes
+  // itself, so it needs no network call to be certain about.
+  const apiKey = process.env.GOOGLE_API_KEY;
+  if (!apiKey) {
+    return {
+      status: "unhealthy",
+      checks: { google_api_key_present: false },
+      errors: ["GOOGLE_API_KEY not set"],
+    };
+  }
+
+  // A WRONG key can only be detected by asking the vendor. A network call on
+  // the startup path is acceptable because a startupProbe stops polling once
+  // it passes - this runs a handful of times, not every ten seconds forever.
+  const checks: Record<string, boolean> = { google_api_key_present: true };
+  let response: Response;
+  try {
+    response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`,
+      { signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS) },
+    );
+  } catch {
+    // The vendor could not be reached at all (DNS, connect, timeout, TLS).
+    // An outage, not a misconfiguration: startup PASSES and healthCheck
+    // withdraws this agent for as long as it lasts. Failing here would
+    // crash-loop a correctly configured pod, and would dilute
+    // CrashLoopBackOff from "your configuration is wrong" into "something
+    // somewhere is unwell".
+    checks.gemini_api_reachable = false;
+    return { status: "healthy", checks, errors: [] };
+  }
+
+  // 400, not 401: Gemini answers a bad API key with INVALID_ARGUMENT rather
+  // than an auth status, which is why this branch is wider than the other
+  // two vendors'. It is the same pair the health check above reads.
+  if (response.status === 400 || response.status === 403) {
+    // The vendor answered and REJECTED the credential. Fatal: no restart
+    // mints a valid key, so fail startup and make the mistake visible.
+    checks.google_api_key_valid = false;
+    return {
+      status: "unhealthy",
+      checks,
+      errors: ["Google rejected GOOGLE_API_KEY"],
+    };
+  }
+
+  // The vendor answered with something that is not a rejection - a 200, a
+  // 5xx, a rate limit. The credential is not what is wrong, so startup
+  // PASSES and anything transient is healthCheck's to report.
+  checks.google_api_key_valid = response.status === 200;
+  return { status: "healthy", checks, errors: [] };
+}
+{{- else }}
+
+/**
+ * Startup check for {{ .Name }}.
+ *
+ * NOT IMPLEMENTED - a skeleton that always passes, so a {{ .Model }} pod with
+ * no credentials at all still comes up, registers, and fails every call it is
+ * given.
+ *
+ * Replace it with the local checks this deployment cannot run without: the
+ * credential your gateway authenticates with (an AWS role, ADC / Workload
+ * Identity, your proxy's token), a required endpoint URL. Return false and the
+ * pod never becomes ready, never registers, and lands in CrashLoopBackOff with
+ * the reason in its logs.
+ *
+ * Keep it local if you can. If you do call your gateway from here, branch on
+ * the answer: a REJECTED credential is fatal and must fail, but a 5xx, a rate
+ * limit, a timeout or an unreachable endpoint must PASS - those are outages,
+ * and crash-looping on one restarts a pod whose configuration was fine. Report
+ * those from the health check instead, which withdraws the agent while they
+ * last and restores it afterwards.
+ */
+function startupCheck(): boolean {
+  return true;
+}
+{{- end }}
 
 /**
  * LLM Provider agent that exposes {{ .Model }} via mesh.
@@ -288,6 +524,7 @@ const agent = mesh(server, {
   // costs the registry staleness window once heartbeats stop, and recovery
   // needs a passing check plus the heartbeat resume and re-register round trip.
   healthCheckTtl: 30,
+  startupCheck,
 });
 
 // ===== LLM PROVIDER =====

--- a/docs/concepts/health-discovery.md
+++ b/docs/concepts/health-discovery.md
@@ -123,11 +123,13 @@ Route (`@mesh.route` / `@MeshRoute` / `mesh.route`) and A2A agents are no longer
 
 So a withdrawn gateway is not a gateway that went down. Suppressing the heartbeat stops registry traffic only: the HTTP server keeps serving, already-resolved dependencies stay wired, and `/ready` reports the mesh runtime rather than the verdict on every agent type - so the pod keeps its Service endpoints and keeps taking ingress. It stops being discovered, it does not go dark.
 
-Declaring one differs by runtime. Java takes a `@MeshHealthCheck` bean on a gateway exactly as on a provider, and TypeScript a `healthCheck` in the `meshExpress` config (a bare `mesh.route()` gateway has no config object to put one in). Python has no declaration surface yet: `health_check` is an `@mesh.agent` argument, and that decorator cannot share a process with `@mesh.route` or `@mesh.a2a` - the runtime honours a gateway's check, the decorators cannot yet carry one.
+Declaring one differs by runtime, and where you cannot, that is the design rather than a gap waiting to be closed (issue #1506). Java takes a `@MeshHealthCheck` bean on a gateway exactly as on a provider. TypeScript takes a `healthCheck` in the `meshExpress` config; a bare `mesh.route()` gateway has no config object to put one in, and adding `meshExpress` alongside it would register a second agent from the one process. Python has no declaration surface at all: `health_check` is an `@mesh.agent` argument, and that decorator cannot share a process with `@mesh.route` or `@mesh.a2a` - the runtime rejects the combination at startup, because each family owns the HTTP server and the heartbeat.
+
+What mesh offers a gateway is dependency injection, not lifecycle management. A route or A2A agent is an ordinary FastAPI, Express or Spring application that happens to consume mesh capabilities, so its own startup and liveness stay yours, handled with the tools that framework already gives you: validate the configuration at boot and exit non-zero, and Kubernetes gives you `CrashLoopBackOff` with the cause in the logs and no mesh involvement at all. Mesh manages the mesh-facing parts - discovery, injection, and the withdrawal a failing check performs when one does reach it.
 
 ### Kubernetes Probes
 
-Every runtime serves four endpoints, and probes must not share one:
+Every runtime serves four endpoints on an MCP agent, and probes must not share one:
 
 | Endpoint    | Probe                             | Reports                                                                                             |
 | ----------- | --------------------------------- | --------------------------------------------------------------------------------------------------- |
@@ -135,6 +137,8 @@ Every runtime serves four endpoints, and probes must not share one:
 | `/livez`    | `livenessProbe`                   | 200 for as long as the process is serving. Consults nothing else.                                     |
 | `/ready`    | `readinessProbe`                  | Whether the mesh runtime is up, on every agent type. Your health check does NOT reach it: a failing check pauses the heartbeat, which is the whole withdrawal, and a 503 here would also empty the Service that mesh traffic arrives on. |
 | `/health`   | none                              | Your health check's verdict plus `checks` and `errors`, on all three runtimes. 503 while the verdict is not healthy. This is the one endpoint the verdict moves, so it and `/ready` diverge by design. |
+
+On a gateway the four are yours as much as mesh's. Python registers all four on the FastAPI app you hand it, leaving alone any path you defined yourself, and Java serves them from one controller whatever the agent type - so on Java a second `@GetMapping` for any of the four is an ambiguous mapping and the application does not start. TypeScript mounts them from `meshExpress`; a bare `mesh.route()` app keeps its own Express server untouched, so define them there yourself or the chart's probes 404.
 
 Never point liveness or startup at `/ready` or `/health`. `/health` reflects your health check on all three runtimes, so sharing a URL turns an upstream outage into a pod restart, which cannot fix the outage - and while an agent is still coming up both answer 503 (or are not mounted yet), which restart-loops a slow boot. The agent Helm chart is already wired this way; if you write your own manifests, you own this contract, and `meshctl man deployment` (`--typescript`, `--java`) has the probe stanzas to copy plus the two ways it is usually got wrong.
 

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -375,11 +375,11 @@ Pointing liveness at `/health` turns an upstream outage into a pod restart, whic
 
 Route (`@mesh.route`) and A2A (`@mesh.a2a`) agents run `health_check` on the same timer, and a failing one pauses their heartbeat too. A withdrawn gateway keeps serving the ingress it already had - `/ready` stays 200, so the pod keeps its Service endpoints - and stops being discovered. Mesh registers the four paths on the gateway's own FastAPI app, and a path your application already defines wins.
 
-Declaring either hook is another matter: `startup_check` and `health_check` are `@mesh.agent` arguments, and that decorator cannot share a process with `@mesh.route` or `@mesh.a2a` (issue #1506), so the examples above apply to `@mesh.agent` agents only. `meshctl man health` has the detail.
+Declaring either hook is another matter, and issue #1506 closes that as by design: `startup_check` and `health_check` are `@mesh.agent` arguments, and that decorator cannot share a process with `@mesh.route` or `@mesh.a2a`, so the examples above apply to `@mesh.agent` agents only. Mesh gives a gateway dependency injection, not lifecycle management - it is an ordinary FastAPI application, so validate its configuration at import time and exit non-zero, which Kubernetes reports as `CrashLoopBackOff` exactly as a failing `startup_check` would. `meshctl man health` has the detail.
 
 ### Probe Wiring
 
-The agent chart already wires all three. If you write your own Deployment, wire them the same way - the paths are the whole contract:
+The agent chart already wires all three probes. If you write your own Deployment, wire them the same way - the paths are the whole contract:
 
 ```yaml
 startupProbe:

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -295,11 +295,11 @@ public MeshHealth healthCheck() {
 
 While the check returns unhealthy the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider - restored automatically when the check passes, with no restart. Returning `boolean` works too: `true` is healthy, `false` unhealthy. A check that throws is recorded as `degraded` and keeps heartbeating, so a bug in the check cannot take a working agent out of the mesh. `MCP_MESH_HEALTH_CHECK_TTL` overrides `ttlSeconds`.
 
-Route-only (`api`) and A2A agents are no exception: their check pauses the heartbeat too, so the registry stops advertising the gateway. It keeps serving the ingress it already had - `/ready` reports the mesh runtime on every agent type, so the pod keeps its Service endpoints.
+Route-only (`api`) and A2A agents are no exception: their check pauses the heartbeat too, so the registry stops advertising the gateway. It keeps serving the ingress it already had - `/ready` reports the mesh runtime on every agent type, so the pod keeps its Service endpoints. Both hooks are declared the same way there, on any Spring bean, and the starter serves the four paths below from one controller whatever the agent type - so a `@GetMapping` of your own for any of them is an ambiguous mapping and the application does not start.
 
 ### Probe Wiring
 
-The agent chart already wires all three. If you write your own Deployment, wire them the same way - the paths are the whole contract:
+The agent chart already wires all three probes. If you write your own Deployment, wire them the same way - the paths are the whole contract:
 
 ```yaml
 startupProbe:

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -260,9 +260,11 @@ While the check returns unhealthy the agent stops heartbeating, the registry wit
 
 Route (`mesh.route`) and A2A agents are no exception: a `healthCheck` declared in the `meshExpress` config pauses the heartbeat too, so the registry stops advertising the gateway. It keeps serving the ingress it already had - `/ready` reports the mesh runtime on every agent type, so the pod keeps its Service endpoints.
 
+A bare `mesh.route()` app has no config object for either hook, and mesh leaves its Express server alone, so it also serves none of the four paths below. That is the design, not a gap: mesh gives a gateway dependency injection, not lifecycle management. Define the probe endpoints yourself - `meshctl scaffold api --lang typescript` generates them - and validate the configuration at boot with `process.exit(1)` in place of a `startupCheck`.
+
 ### Probe Wiring
 
-The agent chart already wires all three. If you write your own Deployment, wire them the same way - the paths are the whole contract:
+The agent chart already wires all three probes. If you write your own Deployment, wire them the same way - the paths are the whole contract:
 
 ```yaml
 startupProbe:

--- a/src/core/cli/man/content/health.md
+++ b/src/core/cli/man/content/health.md
@@ -158,9 +158,9 @@ A check that **raises** is recorded as `degraded`, not unhealthy, and keeps hear
 
 `@mesh.route` and `@mesh.a2a` agents run the check on the same timer as a provider, and a failing one pauses their heartbeat too, so the registry ages the gateway out and stops advertising it. That is the whole effect: the heartbeat is registry traffic, so a withdrawn gateway keeps serving its own routes, keeps the dependencies it already resolved, and still answers 200 on `/ready` - it stays in its Service endpoints and keeps taking ingress. It stops being discovered; it does not go dark.
 
-Declaring one on a gateway is another matter: `health_check` is an argument to `@mesh.agent`, which cannot share a process with `@mesh.route` or `@mesh.a2a`. The runtime honours a gateway's check; the decorators have no way to carry one yet.
+Declaring one on a gateway is another matter, and issue #1506 closes that as by design: `health_check` is an argument to `@mesh.agent`, and that decorator cannot share a process with `@mesh.route` or `@mesh.a2a` - the runtime rejects the combination at startup. Mesh gives a gateway dependency injection, not lifecycle management. It is an ordinary FastAPI application, so its startup and liveness stay yours to handle the way FastAPI already lets you: validate the configuration at import time and exit non-zero, which Kubernetes reports as `CrashLoopBackOff` with the cause in the logs.
 
-They still serve the same probe endpoints, on your own FastAPI app: `/livez` answers 200 for as long as the process serves, `/ready` reports only whether the mesh runtime is running, and `/health` carries the verdict. If your app already defines one of those paths, yours is left alone and the others are still added.
+They still serve the same four probe endpoints, on your own FastAPI app: `/startupz` reports the startup check (a gateway declares none, so it passes), `/livez` answers 200 for as long as the process serves, `/ready` reports only whether the mesh runtime is running, and `/health` carries the verdict. If your app already defines one of those paths, yours is left alone and the others are still added.
 
 ## Graceful Failure
 

--- a/src/core/cli/man/content/health_java.md
+++ b/src/core/cli/man/content/health_java.md
@@ -68,7 +68,9 @@ A check that **throws** is recorded as `degraded`, not unhealthy, and keeps hear
 
 A route-only (`api`) or A2A agent runs the check exactly as a provider does, and a failing one **pauses its heartbeat** too, so the registry stops advertising the gateway. Nothing else changes for it: the heartbeat is registry traffic, so the servlet container keeps serving, the dependencies it already resolved stay wired, and `/ready` still answers 200 - the pod keeps its Service endpoints and keeps taking ingress. A withdrawn gateway stops being discovered; it does not go dark.
 
-Declare it the same way you would on a provider: one `@MeshHealthCheck` method on any Spring bean. No agent type is a carve-out any more, on any endpoint or on the heartbeat.
+Declare it the same way you would on a provider: one `@MeshHealthCheck` method on any Spring bean. No agent type is a carve-out any more, on any endpoint or on the heartbeat. `@MeshStartupCheck` works on a gateway too, and it is the one that matters more there - a gateway with a broken config should never come up.
+
+The starter mounts `/startupz`, `/livez`, `/ready` and `/health` from one controller on every agent type, so those four paths are taken. A `@GetMapping` of your own for any of them is an ambiguous mapping and the application fails to start; put your own diagnostics on a path of your own.
 
 ## Checking Dependency Health
 

--- a/src/core/cli/man/content/health_typescript.md
+++ b/src/core/cli/man/content/health_typescript.md
@@ -89,7 +89,7 @@ const meshApp = meshExpress(app, {
 });
 ```
 
-`mesh.route()` on its own auto-initializes a gateway with no config object, so there is nowhere to declare a check on that path - use `meshExpress` when you want one.
+`mesh.route()` on its own auto-initializes a gateway with no config object, so there is nowhere to declare a check on that path - use `meshExpress` when you want one, and use it INSTEAD of `mesh.route()`, not alongside it: `mesh.route()` starts the API runtime itself, so a process doing both registers two agents. That is not a gap awaiting a fix (issue #1506, for the equivalent on Python). Mesh gives a gateway dependency injection, not lifecycle management: a `mesh.route()` app is an ordinary Express application, so validate its configuration at boot and `process.exit(1)`, and Kubernetes reports `CrashLoopBackOff` with the cause in the logs.
 
 ## Registry Health Monitor
 
@@ -196,7 +196,7 @@ TypeScript agents automatically expose four endpoints, and Kubernetes probes mus
 // { ready: true, agent: "my-agent", runtime: "up", mcp_wrappers: 1, timestamp: "..." }
 ```
 
-A `mesh.route` or A2A agent serves the same URLs, and its `/health` carries the same verdict.
+A gateway wrapped in `meshExpress` serves the same four URLs, and its `/health` carries the same verdict. A bare `mesh.route()` app does not: mesh never touches the Express server there, so nothing mounts the four and the chart's probes 404 until you define them yourself. `meshctl scaffold api --lang typescript` generates them.
 
 ## Graceful Shutdown
 

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -320,8 +320,33 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // only (+1) and `meshctl man health` carries the detail (+1). Python-only, so
 // the `_java` and `_typescript` deployment pages do not get it — and they are
 // not sampled here anyway.
+// RFC #1502 step 4 follow-up: +4 / +0 / +0, split evenly between `health.md`
+// and `deployment.md`. Both said Python "cannot yet" carry a gateway hook.
+// Issue #1506 closed that as BY DESIGN, so "yet" promised a fix that is not
+// coming, and both pages are rewritten to state the design instead: mesh gives
+// a gateway dependency injection, not lifecycle management, so its startup
+// validation is its own — check the configuration at boot and exit non-zero.
+//
+// `health.md`: two paragraphs, +1 each. The declaration paragraph swaps its
+// four spans one-for-one and gains `CrashLoopBackOff`, the thing a gateway gets
+// instead of the hook. The endpoint paragraph went from three endpoints to
+// four — step 1 added `/startupz` and this page never counted it — which is the
+// other +1.
+//
+// `deployment.md`: one paragraph, +2. It keeps all seven of its spans (the
+// `#1506` citation stays; a closed issue carrying the rationale is a fine
+// reference) and gains `CrashLoopBackOff` plus the second `startup_check` that
+// names what it stands in for.
+//
+// Prose in both cases, so the two list goldens hold. The `_java` and
+// `_typescript` variants of both pages gained the same design statement, plus
+// two facts neither had: a bare `mesh.route()` app serves none of the four
+// paths, and a Java `@GetMapping` for any of the four is an ambiguous mapping
+// that fails the boot. As ever they move nothing here — these constants sample
+// the default variant alone, so a review of those files cannot lean on this
+// test.
 const (
-	wantInlineCodeSpans = 1758
+	wantInlineCodeSpans = 1762
 	wantListCodeSpans   = 522
 	wantMarkupListLines = 448
 )

--- a/src/core/cli/scaffold/startup_check_template_test.go
+++ b/src/core/cli/scaffold/startup_check_template_test.go
@@ -1,0 +1,502 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// RFC #1502 step 4: every scaffold ships BOTH hooks, and an llm-provider ships
+// real ones.
+//
+// `health_check` answers "can I serve right now" and a failing one pauses the
+// heartbeat; `startup_check` answers "can I ever serve" and a failing one keeps
+// the pod from ever becoming ready. Two hooks that both take a "is this agent
+// OK" verdict and do opposite things with it are exactly the pair a scaffold
+// gets wrong by hand-copying, and the failure is silent in both directions: a
+// missing hook is a template that simply says nothing, and an outage mapped
+// onto the startup check crash-loops a correctly configured pod for as long as
+// a vendor is down.
+//
+// So the guards here are mechanical rather than illustrative:
+//
+//  1. every template that CAN declare the hooks declares BOTH, wires BOTH, and
+//     carries the comment that tells the two apart;
+//  2. the two templates that CANNOT (issue #1506, closed as by design) declare
+//     NEITHER, and say why;
+//  3. the generated llm-provider `startup_check` maps a rejected credential to
+//     FAIL and a vendor outage — a 5xx, a timeout, an unreachable host — to
+//     PASS, for three vendors in three runtimes.
+//
+// (3) is the one that regresses invisibly. The probe body is hand-duplicated
+// nine times, the two verdicts differ by one word, and a template that failed
+// startup on a 5xx would look completely reasonable in review while turning
+// every vendor outage into a CrashLoopBackOff — which is also how the signal
+// this hook exists to produce ("your configuration is wrong") stops meaning
+// anything.
+
+// The comment markers are identical across the three runtimes on purpose: they
+// are what makes this guard a matrix rather than fifteen hand-written cases.
+const (
+	// The two questions the hooks answer, verbatim from the scaffold comment.
+	// A scaffold that declares both hooks and explains neither has shipped the
+	// code and dropped the deliverable.
+	nowQuestionMarker  = `"Can I serve RIGHT NOW?"`
+	everQuestionMarker = `"Can I EVER serve?"`
+
+	// Branch openers in the generated `startup_check`.
+	missingKeyMarker  = "a missing key costs nothing to detect"
+	rejectedMarker    = "The vendor answered and REJECTED the credential"
+	notARejectMarker  = "that is not a rejection"
+	unreachableMarker = "could not be reached at all"
+)
+
+// One runtime's spelling of the two hooks.
+type hookRuntime struct {
+	language string
+	// Entry file, relative to the generated agent directory. Java's carries
+	// the agent name, so it is a func rather than a constant.
+	entry func(name string) string
+	// Proof the hook is DECLARED.
+	declaresHealth  string
+	declaresStartup string
+	// Proof the hook is HANDED TO the agent. A correct check nothing calls
+	// withdraws nothing and admits everything.
+	wiresHealth  string
+	wiresStartup string
+	// The verdict literals a `startup_check` branch can produce.
+	startupPass string
+	startupFail string
+}
+
+// javaEntryFor mirrors the scaffolder's Java layout: package
+// com.example.<name with separators stripped>, class <NamePascal>Application.
+func javaEntryFor(name string) string {
+	flat := strings.NewReplacer("-", "", "_", "").Replace(strings.ToLower(name))
+	pascal := ""
+	for _, part := range strings.FieldsFunc(name, func(r rune) bool { return r == '-' || r == '_' }) {
+		pascal += strings.ToUpper(part[:1]) + part[1:]
+	}
+	return filepath.Join("src", "main", "java", "com", "example", flat, pascal+"Application.java")
+}
+
+var hookRuntimes = []hookRuntime{
+	{
+		language:        "python",
+		entry:           func(string) string { return "main.py" },
+		declaresHealth:  "def health_check(",
+		declaresStartup: "def startup_check(",
+		wiresHealth:     "health_check=health_check",
+		wiresStartup:    "startup_check=startup_check",
+		startupPass:     `"status": "healthy"`,
+		startupFail:     `"status": "unhealthy"`,
+	},
+	{
+		language:        "typescript",
+		entry:           func(string) string { return filepath.Join("src", "index.ts") },
+		declaresHealth:  "function healthCheck(",
+		declaresStartup: "function startupCheck(",
+		wiresHealth:     "\n  healthCheck,",
+		wiresStartup:    "\n  startupCheck,",
+		startupPass:     `status: "healthy"`,
+		startupFail:     `status: "unhealthy"`,
+	},
+	{
+		language: "java",
+		entry:    javaEntryFor,
+		// Java has no separate declaration site: the annotation IS the
+		// declaration and the wiring, since the starter scans beans for it.
+		declaresHealth:  "@MeshHealthCheck(ttlSeconds =",
+		declaresStartup: "@MeshStartupCheck",
+		wiresHealth:     "@MeshHealthCheck(ttlSeconds =",
+		wiresStartup:    "@MeshStartupCheck",
+		startupPass:     "MeshHealth.healthy()",
+		startupFail:     "MeshHealth.unhealthy(",
+	},
+}
+
+// renderTemplateEntry scaffolds `template` in `language` and returns one
+// generated file. Defaults come from NewScaffoldContext so the render matches
+// what `meshctl scaffold` actually produces.
+func renderTemplateEntry(t *testing.T, language, template, name, file string) string {
+	t.Helper()
+	ctx := NewScaffoldContext()
+	ctx.Name = name
+	ctx.Description = "hook probe"
+	ctx.Language = language
+	ctx.OutputDir = t.TempDir()
+	ctx.Port = 9500
+	ctx.Template = template
+	ctx.TemplateDir = templatesRoot(t)
+	ctx.AgentType = ""
+	ctx.ProviderTags = []string{"llm", "+claude"}
+	if template == "llm-provider" {
+		ctx.Model = "anthropic/claude-sonnet-5"
+	}
+	require.NoError(t, NewStaticProvider().Execute(ctx))
+
+	path := filepath.Join(ctx.OutputDir, ctx.Name, file)
+	content, err := os.ReadFile(path)
+	require.NoError(t, err, "rendered file %s", path)
+	return string(content)
+}
+
+// The templates whose agent surface can carry both hooks. `api` is absent from
+// every language, for two different reasons — see the exemption guard below.
+var hookBearingTemplates = []string{"basic", "llm-agent", "llm-provider", "a2a-consumer"}
+
+func TestScaffold_EveryHookBearingTemplateDeclaresAndWiresBothHooks(t *testing.T) {
+	for _, rt := range hookRuntimes {
+		for _, template := range hookBearingTemplates {
+			t.Run(rt.language+" "+template, func(t *testing.T) {
+				name := "hook-probe"
+				content := renderTemplateEntry(t, rt.language, template, name, rt.entry(name))
+
+				require.Contains(t, content, rt.declaresHealth,
+					"%s/%s declares no health check: the agent cannot say "+
+						"\"I am not available\" and mesh keeps routing to it "+
+						"through an outage", rt.language, template)
+				require.Contains(t, content, rt.declaresStartup,
+					"%s/%s declares no startup check: a misconfigured pod "+
+						"comes up, registers, and fails every call it is given "+
+						"— indistinguishable from a vendor outage, which is the "+
+						"confusion RFC #1502 exists to remove",
+					rt.language, template)
+
+				require.Contains(t, content, rt.wiresHealth,
+					"%s/%s declares a health check the agent is never given, "+
+						"so nothing ever runs it", rt.language, template)
+				require.Contains(t, content, rt.wiresStartup,
+					"%s/%s declares a startup check the agent is never given, "+
+						"so /startupz answers 200 whatever it would have said",
+					rt.language, template)
+			})
+		}
+	}
+}
+
+// The code is half the deliverable. Two hooks that both take an "is this agent
+// OK" verdict and do opposite things with it are useless — worse than useless,
+// since one of the two mistakes crash-loops a working pod — unless the file
+// says which is which.
+func TestScaffold_HookBearingTemplatesExplainBothQuestions(t *testing.T) {
+	for _, rt := range hookRuntimes {
+		for _, template := range hookBearingTemplates {
+			t.Run(rt.language+" "+template, func(t *testing.T) {
+				name := "hook-probe"
+				content := renderTemplateEntry(t, rt.language, template, name, rt.entry(name))
+
+				require.Contains(t, content, nowQuestionMarker,
+					"the scaffold must say what the health check is FOR: "+
+						"without it the hook reads as a second startup check")
+				require.Contains(t, content, everQuestionMarker,
+					"the scaffold must say what the startup check is FOR: "+
+						"without it the hook reads as a second health check, "+
+						"and a vendor outage put in it crash-loops a pod whose "+
+						"configuration was fine")
+
+				// Naming the consequence is what makes the distinction
+				// actionable — "override this one" is advice, "the pod lands in
+				// CrashLoopBackOff" is a reason.
+				require.Contains(t, content, "CrashLoopBackOff",
+					"the startup check's consequence is the whole reason to "+
+						"choose it over the health check")
+				require.Contains(t, content, "heartbeat",
+					"the health check's consequence — a paused heartbeat and "+
+						"withdrawal from discovery, not a restart — is the "+
+						"whole reason to choose it over the startup check")
+			})
+		}
+	}
+}
+
+// Issue #1506, closed as BY DESIGN. Neither the Python nor the TypeScript `api`
+// template can carry a hook, for two different structural reasons, and neither
+// is waiting on a fix:
+//
+//   - Python: both hooks are `@mesh.agent` arguments, and `@mesh.agent` cannot
+//     share a process with `@mesh.route` — the runtime rejects the combination
+//     at startup ("Mixed mode not supported"), because each family owns the
+//     HTTP server and the heartbeat;
+//   - TypeScript: the hooks live on a mesh agent's config object, and a bare
+//     `mesh.route()` app has none. `meshExpress()` carries them, but calling it
+//     as well would register a SECOND agent from one process, since
+//     `mesh.route()` already auto-starts the API runtime.
+//
+// Emitting a hook here anyway would be worse than emitting nothing: it would
+// look declared, read as active, and do nothing at all. So the assertion is
+// that the hook is ABSENT and the reason is PRESENT.
+//
+// Java's `api` template is deliberately not in this list — the starter scans
+// every Spring bean for both annotations and serves the probes from one
+// controller whatever the agent type, so a Java gateway carries both hooks and
+// is covered by the matrix above.
+var hookExemptAPITemplates = []string{"python", "typescript"}
+
+func TestScaffold_APITemplatesThatCannotCarryHooksEmitNoneAndSayWhy(t *testing.T) {
+	for _, language := range hookExemptAPITemplates {
+		t.Run(language, func(t *testing.T) {
+			var rt hookRuntime
+			for _, candidate := range hookRuntimes {
+				if candidate.language == language {
+					rt = candidate
+				}
+			}
+			require.NotEmpty(t, rt.language, "no runtime spelling for %s", language)
+
+			name := "hook-probe"
+			content := renderTemplateEntry(t, language, "api", name, rt.entry(name))
+
+			require.NotContains(t, content, rt.declaresHealth,
+				"%s/api cannot carry a health check: a declared one is dead "+
+					"code that reads as active", language)
+			require.NotContains(t, content, rt.declaresStartup,
+				"%s/api cannot carry a startup check: a declared one is dead "+
+					"code that reads as active", language)
+			require.NotContains(t, content, rt.wiresStartup,
+				"%s/api has nothing to wire a startup check into", language)
+
+			require.Contains(t, content, "#1506",
+				"the absence needs its citation, or the next reader adds the "+
+					"hook back and it silently does nothing")
+			require.Contains(t, content, "design decision rather than a gap",
+				"#1506 is closed as BY DESIGN: wording that reads as \"not "+
+					"yet\" promises a fix that is not coming")
+			// Stating the gap without the replacement leaves the operator with
+			// nothing. The replacement is not advice, it is generated code: a
+			// gateway validates its own configuration at boot and exits, which
+			// is what its framework already does and is strictly more flexible
+			// than a hook.
+			exitCall := map[string]string{
+				"python":     "raise SystemExit(1)",
+				"typescript": "process.exit(1)",
+			}[language]
+			require.Contains(t, content, "non-zero",
+				"the comment must name what a gateway does INSTEAD of the hook")
+			require.Contains(t, content, exitCall,
+				"the replacement must be generated code, not a suggestion: a "+
+					"gateway that comes up misconfigured takes ingress it "+
+					"cannot answer")
+		})
+	}
+}
+
+// The generated `startup_check` must distinguish a credential the vendor
+// REJECTED from a vendor that is merely unwell. Three branches, three runtimes,
+// three vendors, and the whole design is in which verdict each one produces.
+var startupBranches = []struct {
+	name   string
+	marker string
+	// "pass" or "fail".
+	want string
+	why  string
+}{
+	{
+		name:   "missing key fails",
+		marker: missingKeyMarker,
+		want:   "fail",
+		why: "a key that is not set is never going to set itself: this is the " +
+			"case the hook exists for, and passing it puts a provider on the " +
+			"mesh that fails every call it is given",
+	},
+	{
+		name:   "rejected credential fails",
+		marker: rejectedMarker,
+		want:   "fail",
+		why: "the vendor answered and refused the key. No restart mints a valid " +
+			"one, so the pod must crash-loop where an operator can see it " +
+			"rather than register and fail every call",
+	},
+	{
+		name:   "vendor answered non-200 passes",
+		marker: notARejectMarker,
+		want:   "pass",
+		why: "a 5xx or a rate limit is the vendor's problem, not this agent's " +
+			"configuration. Failing startup on it crash-loops a correctly " +
+			"configured pod for as long as the outage lasts, and dilutes " +
+			"CrashLoopBackOff from \"your configuration is wrong\" into noise. " +
+			"The health check is what withdraws the agent meanwhile",
+	},
+	{
+		name:   "unreachable vendor passes",
+		marker: unreachableMarker,
+		want:   "pass",
+		why: "DNS, connect, timeout and TLS all mean the vendor did not answer, " +
+			"which says nothing about the credential. Same reasoning as the " +
+			"non-200 branch — and this is the branch a naive implementation " +
+			"gets wrong, because the health check reports the identical " +
+			"condition as UNHEALTHY",
+	},
+}
+
+// firstVerdictAfter reports which verdict a branch produces: the FIRST of the
+// two literals to appear after marker.
+//
+// Deliberately not a window between two end markers. The branch boundary in
+// each runtime is a different token (`except`, `catch`, a closing brace), and a
+// window that lost its end marker would silently widen until it matched some
+// other branch's verdict and passed for the wrong reason. "What does this
+// comment return" has one answer and needs no boundary.
+func firstVerdictAfter(t *testing.T, content, marker, pass, fail string) string {
+	t.Helper()
+	start := strings.Index(content, marker)
+	require.GreaterOrEqual(t, start, 0,
+		"branch marker %q not found in the rendered startup check — the "+
+			"comment moved, and with it this guard's only anchor", marker)
+
+	rest := content[start+len(marker):]
+	passAt := strings.Index(rest, pass)
+	failAt := strings.Index(rest, fail)
+	require.False(t, passAt < 0 && failAt < 0,
+		"no verdict follows %q: the branch reports nothing", marker)
+
+	if failAt < 0 || (passAt >= 0 && passAt < failAt) {
+		return "pass"
+	}
+	return "fail"
+}
+
+// startupCheckOf isolates the generated `startup_check` from the `health_check`
+// above it. The two probe the same endpoint and read the answer differently, so
+// an assertion that could see both would be satisfied by the wrong one.
+func startupCheckOf(t *testing.T, content, language string) string {
+	t.Helper()
+	var anchor string
+	switch language {
+	case "python":
+		anchor = "async def startup_check("
+	case "typescript":
+		anchor = "async function startupCheck("
+	default:
+		anchor = "public MeshHealth startupCheck("
+	}
+	at := strings.Index(content, anchor)
+	require.GreaterOrEqual(t, at, 0,
+		"no startup check found in the rendered %s provider (%q)", language, anchor)
+	return content[at:]
+}
+
+func TestLlmProviderTemplates_StartupCheckVerdictPerBranch(t *testing.T) {
+	for _, rt := range hookRuntimes {
+		for _, vendor := range probeVendors {
+			for _, branch := range startupBranches {
+				t.Run(rt.language+" "+vendor.name+" "+branch.name, func(t *testing.T) {
+					content := renderProvider(t, rt.language, vendor.model, rt.entry("verdict-probe"))
+					startup := startupCheckOf(t, content, rt.language)
+
+					got := firstVerdictAfter(t, startup, branch.marker, rt.startupPass, rt.startupFail)
+					require.Equal(t, branch.want, got, branch.why)
+				})
+			}
+		}
+	}
+}
+
+// The health check and the startup check must DISAGREE about a vendor that is
+// not answering. That is the entire point of splitting them, and it is also the
+// single easiest thing to get wrong by copying one probe into the other: both
+// bodies call the same endpoint, and "unreachable" is a plausible failure in
+// either.
+func TestLlmProviderTemplates_TheTwoChecksDisagreeOnAnOutage(t *testing.T) {
+	for _, rt := range hookRuntimes {
+		for _, vendor := range probeVendors {
+			t.Run(rt.language+" "+vendor.name, func(t *testing.T) {
+				content := renderProvider(t, rt.language, vendor.model, rt.entry("verdict-probe"))
+				startup := startupCheckOf(t, content, rt.language)
+
+				require.Equal(t, "pass",
+					firstVerdictAfter(t, startup, unreachableMarker, rt.startupPass, rt.startupFail),
+					"the startup check must PASS an unreachable vendor")
+
+				// The health check's own verdict on the same condition is
+				// pinned by TestLlmProviderTemplates_TransportFailureIsUnhealthy;
+				// asserted again here so the DISAGREEMENT is a single failing
+				// test rather than two passing ones in different files.
+				health := content[:strings.Index(content, startup)]
+				require.Contains(t, health, transportMarker,
+					"the health check lost its transport-failure branch")
+				require.NotContains(t, health, unreachableMarker,
+					"the two probes must not share a branch comment: an "+
+						"assertion anchored on it would stop being able to "+
+						"tell which check it is reading")
+			})
+		}
+	}
+}
+
+// A gateway-prefixed model has no probeable direct vendor API, so its startup
+// check is a skeleton — and the skeleton must not name a vendor credential the
+// deployment never sets. A startup check gated on one would fail forever, and
+// unlike the health-check version of this bug (#1479, a provider withdrawn from
+// the registry) this one keeps the pod from ever coming up at all.
+func TestLlmProviderTemplates_GatewayModelGetsSkeletonStartupCheck(t *testing.T) {
+	for _, rt := range hookRuntimes {
+		for _, gw := range gatewayModels {
+			t.Run(rt.language+" "+gw.name, func(t *testing.T) {
+				content := renderProvider(t, rt.language, gw.model, rt.entry("verdict-probe"))
+
+				require.Contains(t, content, rt.declaresStartup,
+					"even with nothing to probe, the hook must be present so "+
+						"the operator has somewhere to put their own check")
+				require.NotContains(t, content, missingKeyMarker,
+					"%s has no vendor key to look for: the real probe leaked "+
+						"into the gateway branch", gw.model)
+				require.NotContains(t, content, gw.bannedKey,
+					"a startup check gated on %s never passes for %s, so the "+
+						"pod never becomes ready — a permanent outage from a "+
+						"credential nothing reads", gw.bannedKey, gw.model)
+			})
+		}
+	}
+}
+
+// A bearer-authenticated A2A bridge knows exactly what it cannot run without,
+// so its generated startup check is real rather than a TODO. This branch is
+// only reachable when the producer's card advertises bearer auth, which the
+// static render never sets, so the data is supplied directly.
+func TestA2AConsumerTemplates_BearerAuthGetsARealStartupCheck(t *testing.T) {
+	wantEnvRead := map[string]string{
+		"python":     `os.getenv("A2A_TEST_TOKEN")`,
+		"typescript": `process.env["A2A_TEST_TOKEN"]`,
+		"java":       `System.getenv("A2A_TEST_TOKEN")`,
+	}
+
+	for _, rt := range hookRuntimes {
+		t.Run(rt.language, func(t *testing.T) {
+			name := "hook-probe"
+			ctx := NewScaffoldContext()
+			ctx.Name = name
+			ctx.Language = rt.language
+			ctx.Template = "a2a-consumer"
+			ctx.Port = 9500
+			ctx.JavaPackage = "com.example.hookprobe"
+
+			data := TemplateDataFromContext(ctx)
+			data["A2AURL"] = "https://producer.example/agents/x"
+			data["AuthBearer"] = true
+			data["AuthEnvVar"] = "A2A_TEST_TOKEN"
+			data["Offline"] = false
+			data["Skills"] = []map[string]interface{}{}
+
+			outDir := t.TempDir()
+			srcDir := filepath.Join(templatesRoot(t), rt.language, "a2a-consumer")
+			require.NoError(t, NewTemplateRenderer().RenderDirectory(srcDir, outDir, data))
+
+			raw, err := os.ReadFile(filepath.Join(outDir, rt.entry(name)))
+			require.NoError(t, err)
+			content := string(raw)
+
+			startupAt := strings.Index(content, rt.declaresStartup)
+			require.GreaterOrEqual(t, startupAt, 0, "no startup check declared")
+
+			require.Contains(t, content[startupAt:], wantEnvRead[rt.language],
+				"a bridge whose producer requires a bearer token must FAIL "+
+					"startup without one: that token is not going to appear "+
+					"while the pod runs, and a bridge without it fails every "+
+					"call it is given")
+		})
+	}
+}

--- a/src/core/cli/scaffold/startup_check_template_test.go
+++ b/src/core/cli/scaffold/startup_check_template_test.go
@@ -458,9 +458,14 @@ func TestLlmProviderTemplates_GatewayModelGetsSkeletonStartupCheck(t *testing.T)
 // only reachable when the producer's card advertises bearer auth, which the
 // static render never sets, so the data is supplied directly.
 func TestA2AConsumerTemplates_BearerAuthGetsARealStartupCheck(t *testing.T) {
+	// Each spelling includes the blank-strip: a token pasted with a trailing
+	// newline, or a Secret key whose value is empty, must not satisfy the
+	// check. Java has always read it this way (`isBlank`); Python and
+	// TypeScript applied bare truthiness to the raw value until they were
+	// brought in line.
 	wantEnvRead := map[string]string{
-		"python":     `os.getenv("A2A_TEST_TOKEN")`,
-		"typescript": `process.env["A2A_TEST_TOKEN"]`,
+		"python":     `os.getenv("A2A_TEST_TOKEN", "").strip()`,
+		"typescript": `process.env["A2A_TEST_TOKEN"]?.trim()`,
 		"java":       `System.getenv("A2A_TEST_TOKEN")`,
 	}
 

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshStartupCheck.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshStartupCheck.java
@@ -16,18 +16,14 @@ import java.lang.annotation.Target;
  * exactly like a vendor outage — the agent sits unregistered, the pod runs, and
  * nothing is loud.
  *
- * <h2>What ships today (RFC #1502 step 1)</h2>
+ * <h2>What it is wired to</h2>
  *
- * <p>The verdict is served from {@code GET}/{@code HEAD} {@code /startupz}, and
- * that is the whole effect: a failing check answers 503 there. Nothing else
- * changes — the agent is not withdrawn, the heartbeat is untouched, and
- * {@code /livez} and {@code /ready} answer exactly as they did.
- *
- * <p>The agent Helm chart's {@code startupProbe} still points at {@code /livez},
- * so nothing acts on the verdict yet. Repointing it at {@code /startupz} is
- * step 2, and it is what this hook exists for: a pod whose startup check never
- * passes then never becomes ready, never registers, and ends up in
- * {@code CrashLoopBackOff} — which is the point.
+ * <p>The verdict is served from {@code GET}/{@code HEAD} {@code /startupz},
+ * which the agent Helm chart's {@code startupProbe} asks for. So a pod whose
+ * startup check never passes never becomes ready, never registers, and ends up
+ * in {@code CrashLoopBackOff} — which is the point: the misconfiguration is
+ * visible. {@code /livez} still answers 200 unconditionally and {@code /ready}
+ * still reports the mesh runtime; neither consults this hook.
  *
  * <p>The message on a failing verdict is served to any caller who can reach the
  * pod, so name the setting that is missing without including its value:

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
@@ -269,10 +269,10 @@ public class MeshHealthController {
      * looking like a vendor outage. {@code /livez}, {@code /ready} and the
      * heartbeat are unaffected by it.
      *
-     * <p>A NEW endpoint rather than a reuse of {@code /livez}: the chart points
-     * both {@code startupProbe} and {@code livenessProbe} at {@code /livez}, and
-     * an endpoint cannot tell which probe called it, so sharing one would let a
-     * failing startup check kill a running pod every ten seconds.
+     * <p>A NEW endpoint rather than a reuse of {@code /livez}: an endpoint
+     * cannot tell which probe called it, so a path serving both
+     * {@code startupProbe} and {@code livenessProbe} would let a failing startup
+     * check kill a running pod every ten seconds.
      *
      * <p>The check runs on every hit. A {@code startupProbe} stops polling after
      * its first success, so there is nothing to cache.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java
@@ -262,13 +262,12 @@ public class MeshHealthController {
      * Kubernetes startup probe (RFC #1502).
      *
      * <p>Reports whether this agent is configured well enough to serve at all,
-     * as opposed to {@code /ready}'s "should traffic reach me now". Step 1 of
-     * RFC #1502 is this endpoint and nothing else: a failing check answers 503
-     * here, and {@code /livez}, {@code /ready} and the heartbeat are unchanged.
-     * Pointing the chart's {@code startupProbe} at it — after which a check
-     * that never passes keeps the pod from ever becoming ready and lands it in
+     * as opposed to {@code /ready}'s "should traffic reach me now". The chart's
+     * {@code startupProbe} asks for this path, so a check that never passes
+     * keeps the pod from ever becoming ready and lands it in
      * {@code CrashLoopBackOff}, where a misconfiguration is visible instead of
-     * looking like a vendor outage — is step 2.
+     * looking like a vendor outage. {@code /livez}, {@code /ready} and the
+     * heartbeat are unaffected by it.
      *
      * <p>A NEW endpoint rather than a reuse of {@code /livez}: the chart points
      * both {@code startupProbe} and {@code livenessProbe} at {@code /livez}, and

--- a/src/runtime/python/_mcp_mesh/pipeline/shared/health_endpoints.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/shared/health_endpoints.py
@@ -4,9 +4,10 @@
 ``_start_uvicorn_immediately`` because mesh owns the server it starts. A
 ``@mesh.route`` (api) or ``@mesh.a2a`` (a2a) gateway owns its own FastAPI app
 and its own uvicorn, so nothing registered those paths — and the agent Helm
-chart points ``startupProbe``/``livenessProbe`` at ``/livez`` and
-``readinessProbe`` at ``/ready`` (#1468). A Python gateway therefore 404'd
-every probe and the kubelet restart-looped a perfectly working process.
+chart points ``livenessProbe`` at ``/livez``, ``readinessProbe`` at ``/ready``
+(#1468) and ``startupProbe`` at ``/startupz`` (RFC #1502). A Python gateway
+therefore 404'd every probe and the kubelet restart-looped a perfectly working
+process.
 
 Semantics (matching TypeScript's ``express.ts`` ``setupHealthEndpoints``):
 
@@ -244,8 +245,7 @@ class HealthEndpointsStep(PipelineStep):
 
     Shared by the api (``@mesh.route``) and a2a (``@mesh.a2a``) pipelines —
     both hand mesh an app they do not own, and both are deployed with the
-    agent Helm chart that probes ``/livez`` and ``/ready`` (and, once the
-    chart is repointed, ``/startupz``).
+    agent Helm chart that probes ``/livez``, ``/ready`` and ``/startupz``.
 
     Optional (``required=False``): a failure here must not stop the gateway
     from starting. It is loud instead — the alternative, aborting startup,

--- a/src/runtime/python/_mcp_mesh/shared/startup_check_manager.py
+++ b/src/runtime/python/_mcp_mesh/shared/startup_check_manager.py
@@ -4,19 +4,15 @@
 failing one only pauses the heartbeat so the registry stops selecting this agent
 until it recovers. ``startup_check`` answers the other question: "is this agent
 configured such that it can *ever* serve?" A missing API key is not going to fix
-itself, and today it looks exactly like a vendor outage — the agent sits
-unregistered, the pod runs, and nothing is loud.
+itself, and without this hook it looks exactly like a vendor outage — the agent
+sits unregistered, the pod runs, and nothing is loud.
 
-**What ships today (RFC #1502 step 1).** ``startup_check`` is reported by
-``GET``/``HEAD`` ``/startupz``, and that is the whole effect: a failing check
-answers 503 there. Nothing else changes — the agent is not withdrawn, the
-heartbeat is untouched, ``/livez`` and ``/ready`` answer exactly as they did.
-
-The agent chart's ``startupProbe`` still points at ``/livez``, so nothing acts
-on the verdict yet. Repointing it at ``/startupz`` is step 2, and it is what
-the hook exists for: a pod whose startup check never passes then never becomes
-ready, never registers, and ends up in ``CrashLoopBackOff`` — visible. Until
-then, ``/startupz`` is a surface to build against and to scrape.
+The verdict is reported by ``GET``/``HEAD`` ``/startupz``, which the agent
+chart's ``startupProbe`` asks for. So a pod whose startup check never passes
+never becomes ready, never registers, and ends up in ``CrashLoopBackOff`` —
+which is the point: the misconfiguration is visible. ``/livez`` still answers
+200 unconditionally and ``/ready`` still reports the mesh runtime; neither
+consults this hook.
 
 Three properties are deliberate, and each is the OPPOSITE of the corresponding
 ``health_check`` rule:

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -1518,12 +1518,11 @@ def agent(
             (RFC #1502). Where ``health_check`` answers "can I serve right now"
             — a failing one pauses the heartbeat until it recovers —
             ``startup_check`` answers "is this agent configured such that it
-            can ever serve". Today (step 1) the verdict is reported by
-            ``/startupz`` and nothing else — a failing check answers 503 there,
-            and the heartbeat, ``/livez`` and ``/ready`` are all unchanged.
-            Pointing the chart's ``startupProbe`` at ``/startupz``, so that a
-            check which never passes keeps the pod from becoming ready and
-            lands it in CrashLoopBackOff where it is visible, is step 2.
+            can ever serve". The verdict is reported by ``/startupz``, which
+            the chart's ``startupProbe`` asks for, so a check that never passes
+            keeps the pod from ever becoming ready and lands it in
+            CrashLoopBackOff where it is visible. The heartbeat, ``/livez`` and
+            ``/ready`` never consult it.
             Returns a bool, a {status, checks, errors} dict, or a HealthStatus.
             Only a clean pass passes: a throw, a degraded verdict or an
             unrecognized return all fail the probe (the opposite of

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -2010,19 +2010,18 @@ export class MeshAgent {
     // 1.7 RFC #1502: mount GET|HEAD /startupz, which reports the user's
     // `startupCheck` — "is this agent configured such that it can EVER
     // serve", as opposed to `healthCheck`'s "can I serve right now". A NEW
-    // URL rather than a reuse of /livez: the chart points both startupProbe
-    // and livenessProbe at /livez, and an endpoint cannot tell which probe
-    // called it, so sharing would kill a running pod every ten seconds on a
-    // failing startup check.
+    // URL rather than a reuse of /livez: an endpoint cannot tell which probe
+    // called it, so a path serving both startupProbe and livenessProbe would
+    // kill a running pod every ten seconds on a failing startup check.
     //
     // Ordered LAST of the three probe mounts deliberately. All three fail for
     // the same cause (a FastMCP whose Hono app cannot be reached), and the
     // abort message an operator sees should name the route whose absence has
     // been breaking agents the longest — /livez first, then /ready, then this.
     //
-    // Fail-fast for the same reason as those two: once the chart's
-    // startupProbe points here, a missing route 404s every startup probe and
-    // the pod never comes up, with nothing in the events naming the cause.
+    // Fail-fast for the same reason as those two: the chart's startupProbe
+    // points here, so a missing route 404s every startup probe and the pod
+    // never comes up, with nothing in the events naming the cause.
     if (
       !registerStartupzRoute(
         this.server,

--- a/src/runtime/typescript/src/index.ts
+++ b/src/runtime/typescript/src/index.ts
@@ -213,8 +213,8 @@ export {
 } from "./health-check.js";
 
 // Startup check (RFC #1502) — "can this agent EVER serve", reported by
-// `/startupz`. Step 1: the endpoint only. Pointing the chart's startupProbe at
-// it, so a failing check keeps the pod from coming up, is step 2.
+// `/startupz`, which the chart's startupProbe asks for: a failing check keeps
+// the pod from ever coming up.
 export {
   runStartupCheck,
   buildStartupBody,

--- a/src/runtime/typescript/src/startup-check.ts
+++ b/src/runtime/typescript/src/startup-check.ts
@@ -5,19 +5,15 @@
  * failing one only pauses the heartbeat so the registry stops selecting this
  * agent until it recovers. `startupCheck` answers the other question: "is this
  * agent configured such that it can *ever* serve?" A missing API key is not
- * going to fix itself, and today it looks exactly like a vendor outage: the
- * agent sits unregistered, the pod runs, and nothing is loud.
+ * going to fix itself, and without this hook it looks exactly like a vendor
+ * outage: the agent sits unregistered, the pod runs, and nothing is loud.
  *
- * **What ships today (RFC #1502 step 1).** `startupCheck` is reported by
- * `GET|HEAD /startupz`, and that is the whole effect: a failing check answers
- * 503 there. Nothing else changes — the agent is not withdrawn, the heartbeat
- * is untouched, `/livez` and `/ready` answer exactly as they did.
- *
- * The agent chart's `startupProbe` still points at `/livez`, so nothing acts on
- * the verdict yet. Repointing it at `/startupz` is step 2, and it is what the
- * hook exists for: a pod whose startup check never passes then never becomes
- * ready, never registers, and ends up in `CrashLoopBackOff` — visible. Until
- * then, `/startupz` is a surface to build against and to scrape.
+ * The verdict is reported by `GET|HEAD /startupz`, which the agent chart's
+ * `startupProbe` asks for. So a pod whose startup check never passes never
+ * becomes ready, never registers, and ends up in `CrashLoopBackOff` — which is
+ * the point: the misconfiguration is visible. `/livez` still answers 200
+ * unconditionally and `/ready` still reports the mesh runtime; neither consults
+ * this hook.
  *
  * Three properties are deliberate, and each is the OPPOSITE of the
  * corresponding `healthCheck` rule:

--- a/src/runtime/typescript/src/startupz-route.ts
+++ b/src/runtime/typescript/src/startupz-route.ts
@@ -6,10 +6,10 @@
  * underlying Hono app, which FastMCP consults before its own built-in health
  * handling — and Python's `/startupz` in `mesh/decorators.py` in semantics.
  *
- * It is a NEW endpoint rather than a reuse of `/livez` because the chart points
- * both `startupProbe` and `livenessProbe` at `/livez`, and an endpoint cannot
- * tell which probe called it. Sharing one would mean a failing startup check
- * kills a running pod every ten seconds.
+ * It is a NEW endpoint rather than a reuse of `/livez` because an endpoint
+ * cannot tell which probe called it. A path serving both `startupProbe` and
+ * `livenessProbe` would mean a failing startup check kills a running pod every
+ * ten seconds.
  *
  * `/livez` is unchanged and stays unconditional. Nothing here may make it
  * consult anything.

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -327,16 +327,12 @@ export interface AgentConfig {
    * RFC #1502: a check that answers "is this agent configured such that it can
    * EVER serve?", as opposed to {@link healthCheck}'s "can I serve right now".
    *
-   * Today (RFC #1502 step 1) the verdict is reported by `GET|HEAD /startupz`
-   * and nothing else: a failing check answers 503 there, and the agent is not
-   * withdrawn, the heartbeat is untouched, `/livez` and `/ready` are unchanged.
-   * The agent chart's `startupProbe` still points at `/livez`.
-   *
-   * Repointing that probe at `/startupz` is step 2, and it is what the hook
-   * exists for: a pod whose startup check never passes then never becomes
-   * ready, never registers, and ends up in `CrashLoopBackOff` — a missing API
-   * key is not going to fix itself, and without this it looks exactly like a
-   * vendor outage.
+   * The verdict is reported by `GET|HEAD /startupz`, which the agent chart's
+   * `startupProbe` asks for, so a pod whose startup check never passes never
+   * becomes ready, never registers, and ends up in `CrashLoopBackOff` — a
+   * missing API key is not going to fix itself, and without this it looks
+   * exactly like a vendor outage. The heartbeat, `/livez` and `/ready` never
+   * consult it.
    *
    * The verdict rules are the OPPOSITE of {@link healthCheck}'s: a check that
    * THROWS fails the probe (it does not degrade), and anything short of a


### PR DESCRIPTION
## Summary

**Step 4 of 4** — the last of RFC #1502.

Every scaffolded agent now carries `health_check` and `startup_check` with default-true implementations and a comment explaining the difference between **"cannot serve right now"** and **"cannot ever serve"**. The comment is as much the deliverable as the code: that distinction took a long design conversation to settle, and a bare stub teaches none of it.

The big-3 `llm-provider` templates get real implementations — missing key fails locally with no network, a rejected credential fails, any other answered status passes to `health_check`, and an unreachable vendor passes. Gateway-prefixed models get a skeleton naming no vendor credential.

## Two pre-existing bugs, found by rendering and booting rather than compiling

**The Java `api` scaffold did not boot at all.** Its generated `ApiController` declared `@GetMapping("/health")`, colliding with `MeshHealthController`:

```
Ambiguous mapping. Cannot map 'meshHealthController' method
```

Removed, with a comment naming all four taken paths, and verified booting after. **The same collision exists in three checked-in Java examples** — filed separately.

**The TypeScript `api` scaffold 404'd every probe its own `helm-values.yaml` wires**, because a bare `mesh.route()` app mounts no probe endpoints — only `agent.ts` and `express.ts` do. The template now generates them. The underlying runtime gap is the TypeScript equivalent of #1494 and remains for hand-written apps; filed separately.

Neither would have surfaced from a type-check or a template-text assertion.

## Review notes

**Two `api` exemptions, for different reasons.** Python's cannot carry hooks — `@mesh.agent` cannot share a process with `@mesh.route` (#1506, closed as by design). TypeScript's cannot for a *structural* reason found while implementing: hooks live on a mesh agent config object, `mesh.route()` has none, and `meshExpress()` cannot be added alongside because `route.ts` auto-starts `ApiRuntime` and the process would register twice. **Java's `api` is not exempt** — `MeshAutoConfiguration` mounts the controller and both post-processors unconditionally, verified by booting one. Both exempt templates generate real boot-time config validation exiting non-zero, which is what #1506 argues a gateway should do anyway.

**`a2a-consumer` is not a gateway** — it is an `@mesh.agent` process whose tools carry `@mesh.a2a_consumer`, so it takes both hooks. Where the producer card advertises bearer auth, the generated `startup_check` is real rather than a TODO.

**Documentation that outlived the design:**

- **"yet"** — `health-discovery.md` and `health.md` said Python has no declaration surface *yet*. With #1506 closed by design, that promised a fix that is not coming.
- `health.md` said a Python gateway serves **three** probe endpoints; step 1 made it four.
- `health_typescript.md` claimed a `mesh.route` agent serves the same URLs — disproved by grepping every importer of the route modules.
- **Seven shipped API docstrings** still said "the chart's `startupProbe` still points at `/livez`", which step 2 falsified.

**OpenAPI** was wrong in four places: `/livez` documented as `text/plain "OK"` with a 503 branch when it is JSON with no 503; `/startupz` missing; `/ready`'s body reshaped in step 2, and its old `checks` map never existed at all; `/health` documenting two fields the runtime never emits and requiring a `status` that is absent before the first refresh. Regenerating confirms the agent spec drives no Go codegen — only the registry spec does, so the pre-commit hook fires on a path glob rather than real drift.

Closes #1502

## Test plan

- [x] **89 scaffold guard cases, each proven red**: dropping a hook, mapping a vendor outage to the wrong verdict, adding a hook to an exempt template, and removing the explanatory comment all fail
- [x] All 3 languages × 5 templates rendered; Python `py_compile`, Java `mvn compile` 8/8, TypeScript `tsc --noEmit` — the one `TS2769` on `api-typescript` reproduces identically on HEAD and is pre-existing
- [x] `llm-provider` rendered for each big-3 vendor plus a `bedrock/…` gateway model, verdict mapping confirmed per branch
- [x] Java `api` scaffold **booted**: `/startupz` returned `{"started":true,...}` and `/health` carried the `@MeshHealthCheck` verdict
- [x] `go build ./...`; `go test ./src/core/cli/... -count=1` — all five packages
- [x] Golden 1758 → **1762** (+4/+0/+0), predicted per file before measuring
- [x] TS vitest 79, Python pytest 99, Java `mvn test` on sdk + starter — no failures
- [x] OpenAPI validated with `openapi_spec_validator`; `make generate` produces no drift


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distinct health, readiness, liveness, and startup probes, including the new `/startupz` endpoint.
  * Generated Python, TypeScript, and Java projects now include health and startup-check hooks.
  * Supported LLM providers validate credentials during startup while treating transient service outages as health conditions.
* **Documentation**
  * Clarified Kubernetes probe behavior, endpoint usage, lifecycle handling, and configuration requirements across supported runtimes.
* **Bug Fixes**
  * Invalid startup configuration now prevents services from becoming ready or registering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->