### PR TITLE
docs: the tutorial wired liveness and readiness to /health

### DIFF
--- a/docs/tutorial/day-10-whats-next.md
+++ b/docs/tutorial/day-10-whats-next.md
@@ -179,10 +179,21 @@ agent:
 
 ### Health probes
 
-Mesh agents expose health endpoints automatically (`/health`). The Helm
-chart wires liveness and readiness probes to this endpoint -- no
-configuration needed. If an agent becomes unhealthy, Kubernetes restarts it
-and the registry removes it from the topology within one heartbeat cycle.
+Mesh agents serve four health endpoints automatically, and every probe gets
+its own -- the Helm chart wires `startupProbe` to `/startupz`,
+`livenessProbe` to `/livez`, and `readinessProbe` to `/ready`, with no
+configuration needed. Nothing probes `/health`: that one is the diagnostic
+view you curl, the only endpoint your health check's verdict moves.
+
+An unhealthy agent is not restarted. Its heartbeat pauses, the registry ages
+it out, and dependency resolution stops selecting it -- the pod keeps running
+and rejoins the topology on its own once the check passes again. That split
+is deliberate: restarting a pod cannot fix the upstream API that made the
+agent unhealthy, and it erases the state that knew.
+
+Full details: [Health and discovery](../concepts/health-discovery.md). Run
+`meshctl man deployment` for the probe stanzas to copy if you write your own
+manifests.
 
 ### Secrets management
 

--- a/src/core/cli/man/content/tutorial.md
+++ b/src/core/cli/man/content/tutorial.md
@@ -1901,8 +1901,13 @@ agent:
 
 ### Health probes
 
-Mesh agents expose health endpoints automatically (`/health`). The Helm
-chart wires liveness and readiness probes.
+The Helm chart gives every probe its own endpoint: `startupProbe` to
+`/startupz`, `livenessProbe` to `/livez`, `readinessProbe` to `/ready`.
+Nothing probes `/health` -- it is the diagnostic view.
+
+An unhealthy agent is not restarted. Its heartbeat pauses, the registry ages
+it out, and resolution stops selecting it; the pod keeps running and rejoins
+once the check passes. See `meshctl man deployment`.
 
 ### Secrets management
 

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -345,8 +345,17 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // that fails the boot. As ever they move nothing here — these constants sample
 // the default variant alone, so a review of those files cannot lean on this
 // test.
+// Issue #1509: +7 / +0 / +0, all of it in `tutorial.md`'s "Health probes"
+// section, which predates #1468 and said the chart wires liveness and
+// readiness to `/health`. It had one span, `/health`, and now has eight: the
+// three probes with the endpoint each is actually wired to, `/health` as the
+// one nothing probes, and `meshctl man deployment` for the stanzas. The
+// replacement for the restart claim — heartbeat pause, age-out, no restart —
+// is plain prose and adds none. Prose throughout, so the list goldens hold.
+// The `docs/tutorial/day-10-whats-next.md` twin carries the same correction at
+// tutorial length and is not sampled here.
 const (
-	wantInlineCodeSpans = 1762
+	wantInlineCodeSpans = 1769
 	wantListCodeSpans   = 522
 	wantMarkupListLines = 448
 )


### PR DESCRIPTION
## Summary

The tutorial said the Helm chart wires liveness and readiness to `/health`, and that *"If an agent becomes unhealthy, Kubernetes restarts it."*

Both wrong since **3.5.1**. #1468 split the probes — startup and liveness to `/livez`, readiness to `/ready`, and **nothing probes `/health`**, which is the diagnostic view. RFC #1502 then moved startup again, to `/startupz`.

**The restart claim is the sharper error.** It teaches exactly the failure #1467/#1468 exist to remove, on the page most likely to be copied verbatim into a Deployment. An unhealthy agent is *not* restarted: its heartbeat pauses, the registry ages it out, resolution stops selecting it, and the pod keeps running and rejoins on its own once the check passes. A restart cannot fix the upstream API, and it erases the state that knew the agent was failing.

Missed by two earlier doc passes (#1501 and RFC #1502) because this page lives under `tutorial/` rather than `deployment*`/`health*`.

## Review notes

**Both twins corrected, and their size difference kept.** `docs/tutorial/day-10-whats-next.md` gets the wiring, the mechanism, and one sentence of *why*, plus pointers to `health-discovery.md` and `meshctl man deployment`. The `tutorial.md` man topic keeps its terser three-and-three with a bare `See` line. Neither grows into the probe-wiring contract that already lives in `deployment*.md` — this is day-10 "what's next", not a reference page.

Wiring was read from `helm/mcp-mesh-agent/values.yaml:356-381` rather than from the issue text.

**The sweep found nothing else repeating either claim**, and three near-misses worth recording as *not* stale:

- `day-09-kubernetes.md:468` / `tutorial.md:1777` have a comparison row "Health probes | Docker health checks | k8s liveness/readiness" — generic, makes no endpoint claim.
- `day-09` curls `/health` twice against the gateway. Correct usage of the diagnostic view, and it matches the hand-written handler in `examples/tutorial/trip-planner/day-09/python/gateway/main.py:13` — a path the app defines itself, which Python leaves alone.
- `docs/downloads/tutorial-complete.{txt,html}` contain the old paragraph verbatim, but `docs/downloads/` is gitignored and regenerated by the docs workflow, so they pick the fix up on next deploy.

Closes #1509

## Test plan

- [x] `go build ./...`; `go test ./src/core/cli/... -count=1` — all five packages
- [x] Golden 1762 → **1769** (+7/+0/+0), predicted span by span before measuring: the section held one span and now holds eight, the restart replacement is plain prose, and nothing added is a list line
- [x] Rendered `meshctl man tutorial` and read the section as terminal output rather than source
- [x] Diff touches exactly the two docs plus the golden constant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Kubernetes health probes, distinguishing startup, liveness, and readiness checks from the diagnostic health endpoint.
  * Documented that unhealthy agents pause heartbeats and are removed from dependency resolution without pod restarts, then rejoin after recovery.
  * Added links to health, discovery, and deployment probe examples.
* **Tests**
  * Updated inline-code documentation corpus expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->