### PR TITLE
example: add a Kimi (Moonshot) media LLM provider

### DIFF
--- a/examples/python/multimedia/llm_consumer.py
+++ b/examples/python/multimedia/llm_consumer.py
@@ -14,7 +14,7 @@ via a mesh tool and then describe the resulting image. The flow is:
 This tests that resource_links are correctly resolved to multimodal content
 before being sent to the LLM.
 
-Also supports multi-provider testing with Claude, OpenAI, and Gemini for
+Also supports multi-provider testing with Claude, OpenAI, Gemini, and Kimi for
 analyzing real distributed tracing screenshots via the image-tool agent.
 """
 
@@ -529,10 +529,77 @@ async def analyze_document_gemini(llm: mesh.MeshLlmAgent = None) -> str:
     return f"Gemini Analysis:\n{result}"
 
 
+# ---------------------------------------------------------------------------
+# Image analysis (chart generation) - Kimi
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["kimi", "media"]},
+    filter=[
+        {"capability": "chart_generator"},
+        {"capability": "image_generator"},
+    ],
+    max_iterations=5,
+    system_prompt=(
+        "You are an image analysis assistant. You have access to tools that "
+        "generate charts and images. When asked to analyze a topic, FIRST use "
+        "the generate_chart tool to create a chart, THEN describe what you see "
+        "in the resulting image. Be specific about colors, labels, and values."
+    ),
+)
+@mesh.tool(
+    capability="image_analyzer_kimi",
+    description="Generates a chart via media-producer then asks Kimi to describe it",
+)
+async def analyze_image_kimi(topic: str = "Sales", llm: mesh.MeshLlmAgent = None) -> str:
+    """Generate a chart on the given topic and ask Kimi to describe the image."""
+    if not llm:
+        return "Error: LLM not available"
+
+    result = await llm(
+        f"Generate a bar chart about {topic} with a few data categories, "
+        f"then describe the chart image you see in detail."
+    )
+    return f"Kimi Analysis:\n{result}"
+
+
+# ---------------------------------------------------------------------------
+# Sample PNG analysis - Kimi
+# ---------------------------------------------------------------------------
+
+
+@app.tool()
+@mesh.llm(
+    provider={"capability": "llm", "tags": ["kimi", "media"]},
+    filter=[
+        {"capability": "image_generator"},
+    ],
+    max_iterations=5,
+    system_prompt=(
+        "You are an image analysis assistant. You have access to a tool that "
+        "returns a sample PNG image. When asked, use the get_sample_image tool "
+        "to retrieve the image, then describe exactly what you see."
+    ),
+)
+@mesh.tool(
+    capability="png_analyzer_kimi",
+    description="Retrieves a sample PNG image via media-producer then asks Kimi to describe it",
+)
+async def analyze_png_kimi(llm: mesh.MeshLlmAgent = None) -> str:
+    """Retrieve a sample PNG from the media-producer and ask Kimi to describe it."""
+    if not llm:
+        return "Error: LLM not available"
+
+    result = await llm("Get the sample image and describe what you see in it.")
+    return f"Kimi Analysis:\n{result}"
+
+
 @mesh.agent(
     name="media-llm-consumer",
     version="1.0.0",
-    description="LLM consumer that generates and analyzes media from the producer, supports Claude/OpenAI/Gemini",
+    description="LLM consumer that generates and analyzes media from the producer, supports Claude/OpenAI/Gemini/Kimi",
     http_port=9203,
     enable_http=True,
     auto_run=True,

--- a/examples/python/multimedia/llm_provider_kimi.py
+++ b/examples/python/multimedia/llm_provider_kimi.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+media-llm-provider-kimi - MCP Mesh Kimi (Moonshot) LLM Provider Agent
+
+Zero-code LLM provider that exposes Kimi via mesh delegation.
+When the LLM's agentic loop calls tools that return resource_links,
+the media resolver on this provider automatically converts them to
+inline base64 images so the LLM can see and describe the actual media.
+
+Unlike the OpenAI and Gemini providers, this one points at an
+OpenAI-compatible third-party endpoint: the `base_url` and `api_key`
+overrides on @mesh.llm_provider are all it takes to route the openai/*
+model family somewhere other than OpenAI itself.
+
+Note: kimi-k2.6 and kimi-k3 are both reasoning models. With a small max_tokens
+the budget goes to reasoning and `content` comes back empty with no error
+(finish_reason=length) — which looks exactly like broken vision. A one-word
+answer cost 69 reasoning tokens on k2.6 and 18 on k3; this example sets no
+max_tokens, and if you add one leave headroom well past those figures.
+
+Model env-switchable: KIMI_MODEL=openai/kimi-k2.6 (default) or openai/kimi-k3.
+Requires MOONSHOT_API_KEY environment variable.
+"""
+
+import os
+
+import mesh
+from fastmcp import FastMCP
+
+app = FastMCP("Media LLM Provider Kimi")
+
+KIMI_MODEL = os.getenv("KIMI_MODEL", "openai/kimi-k2.6")
+
+
+@mesh.llm_provider(
+    model=KIMI_MODEL,
+    capability="llm",
+    tags=["kimi", "media"],
+    version="1.0.0",
+    api_key=os.getenv("MOONSHOT_API_KEY"),
+    base_url=os.getenv("KIMI_BASE_URL", "https://api.moonshot.ai/v1"),
+)
+def kimi_media_provider():
+    """Zero-code Kimi provider for media analysis."""
+    pass
+
+
+@mesh.agent(
+    name="media-llm-provider-kimi",
+    version="1.0.0",
+    description=f"LLM provider that resolves resource_links to inline images for Kimi ({KIMI_MODEL})",
+    http_port=9207,
+    enable_http=True,
+    auto_run=True,
+)
+class MediaLlmProviderKimi:
+    pass

--- a/examples/python/multimedia/media_producer.py
+++ b/examples/python/multimedia/media_producer.py
@@ -131,19 +131,24 @@ async def generate_chart(
 @app.tool()
 @mesh.tool(capability="image_generator", description="Returns a sample PNG image")
 async def get_sample_image() -> ResourceLink:
-    """Create and return a minimal valid PNG image (a small blue square)."""
-    # Minimal 2x2 PNG with blue pixels, built from raw bytes.
+    """Create and return a valid PNG image (a blue square with an orange square centered in it)."""
+    # 64x64 PNG on a blue field with a centered orange square, built from raw bytes.
+    # Large enough and distinctive enough for a vision model to describe accurately.
     # PNG structure: signature + IHDR + IDAT + IEND
     import struct
     import zlib
 
-    width, height = 2, 2
+    width, height = 64, 64
+    background = b"\x33\x66\xcc"  # #3366cc blue
+    foreground = b"\xf2\x8e\x2b"  # #f28e2b orange
+    third = width // 3  # centered square spans the middle third
     # Each row: filter byte (0 = None) + RGB pixels
     raw_rows = b""
-    for _ in range(height):
+    for y in range(height):
         raw_rows += b"\x00"  # filter byte
-        for _ in range(width):
-            raw_rows += b"\x33\x66\xcc"  # RGB blue-ish
+        for x in range(width):
+            in_center = third <= x < width - third and third <= y < height - third
+            raw_rows += foreground if in_center else background
 
     def _chunk(chunk_type: bytes, data: bytes) -> bytes:
         c = chunk_type + data
@@ -167,7 +172,7 @@ async def get_sample_image() -> ResourceLink:
         uri=uri,
         name="Sample Image",
         mime_type="image/png",
-        description="A small 2x2 blue PNG image",
+        description="A 64x64 blue PNG image with a centered orange square",
         size=len(png_bytes),
     )
 


### PR DESCRIPTION
## Summary

The multimedia examples ship providers for Claude, OpenAI and Gemini, but none pointing at an **OpenAI-compatible third-party endpoint** — the shape most non-big-3 vendors expose. Kimi demonstrates the whole pattern in a file the size of its siblings: `base_url` and `api_key` overrides on `@mesh.llm_provider` are all it takes to route the `openai/*` family somewhere other than OpenAI.

It also exercises the media resolver against a **vision-capable** third-party model rather than a hello-world, so it's a real test of `resource_link` → inline-image conversion.

Two consumer tools matching the existing per-vendor shape: generate a chart and describe it, retrieve a sample PNG and describe it.

## The caveat in the docstring

Both `kimi-k2.6` and `kimi-k3` are **reasoning** models. With a small `max_tokens` the whole budget goes to reasoning, and `content` comes back **empty** with `finish_reason=length` and **no error** — while the correct answer sits unreturned in `reasoning_content`. That looks exactly like broken vision, and it is the kind of thing that costs an afternoon.

Measured against the live API with a solid-colour test image:

| model | no `max_tokens` | `max_tokens=20` |
|---|---|---|
| `kimi-k2.6` | `'Red'` — **69** reasoning tokens of 72 | `''`, `finish_reason=length` |
| `kimi-k3` | `'Red'` — **18** reasoning tokens of 34 | `''`, `finish_reason=length` |

Both figures are quoted rather than collapsed to one: the ~4× spread is the useful signal, and the file's own `KIMI_MODEL` env var invites switching between exactly these two models. An earlier draft said "~70 tokens" without a model qualifier — a `kimi-k2.6` observation wearing a general claim.

## Review notes

**A port collision, fixed.** As written the provider sat on **9205 — already `llm_provider_gemini`**. The two could never have run together, which matters because the consumer's Gemini and Kimi tools are meant to be exercised side by side. 9206 was not free either (it belongs to `image_tool`), so this is on **9207**. All ports in the directory are now distinct.

**A local file-image server was dropped rather than shipped.** It hardcoded an absolute path to one machine, and its own docstring said to remove it after testing. Its consumer tool went with it. A repo-wide sweep across `.py/.md/.yaml/.json/.ts/.java` confirms **zero** remaining references to `file_image_provider`, `file-image-server` or the deleted tool.

**Provider lists updated to stay truthful** — the consumer's module docstring and `@mesh.agent` description both now say Kimi. No README exists in that directory and no doc anywhere mentions the OpenAI or Gemini providers either, so nothing else needed touching; a provider table for that directory would be its own change covering all four.

## What was and wasn't verified

**Verified directly against the Moonshot API:** `kimi-k2.6` and `kimi-k3` both exist on the endpoint; vision works (correctly identified the test image on both); the no-`max_tokens` path this example uses returns content normally; and the empty-content trap reproduces on both models at a small budget.

**Not verified:** the mesh delegation path end to end — the provider, consumer and media producer were not run together against a registry. The `base_url`/`api_key` override is the novel part of this example and has been exercised only at the vendor API level.

Closes #1511

## Test plan

- [x] `python3 -m py_compile` clean on both files
- [x] Moonshot `/v1/models` lists both `kimi-k2.6` and `kimi-k3`
- [x] Vision confirmed on both models with an inline base64 PNG
- [x] Empty-content-at-low-`max_tokens` reproduced on both, and the default path confirmed working
- [x] Port audit: every agent in `examples/python/multimedia/` on a distinct port
- [x] Reference sweep for the dropped server: zero hits
- [ ] End-to-end mesh run (registry + provider + consumer + media producer)
