### PR TITLE
perf: prerender the scroll section, dropping React and React Flow (8.5x smaller)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,30 @@ jobs:
       - name: Install dashboard dependencies
         run: npm ci
 
+      # REQUIRED BEFORE tsc, not optional tidiness. demo/static.ts imports
+      # demo/generated/graph.json, which is a build artifact and gitignored (it
+      # is 150 kB of rendered markup and would otherwise be scanned by Tailwind
+      # into the dashboard's own stylesheet). tsconfig includes **/*.ts and
+      # excludes only node_modules and dist, so on a fresh checkout — which is
+      # exactly what CI is — `tsc --noEmit` fails with TS2307 until this has run.
+      #
+      # It also happens to be the cheapest useful guard we have. No browser, no
+      # Playwright: esbuild plus one node process, a couple of seconds. It
+      # re-renders the real <Stage> and fails the build if the edge geometry
+      # disagrees with the captured fixture (36 paths across 2 states), if
+      # AgentNode's markup has drifted from the card table the driver swaps in,
+      # or if any selector the driver queries has gone missing from the shell.
+      # That last one is the difference between a red PR and shipping an empty
+      # dark panel over 2205vh of scroll.
+      #
+      # The full equivalence capture (demo/equivalence.mjs) stays OUT of CI: it
+      # needs two browser runs against a served build, and its React reference
+      # bundle is a 531 kB build of its own. It is a local gate for changes to
+      # this section, not a per-PR check.
+      - name: Prerender the scroll section (also its build-time guards)
+        working-directory: ${{ github.workspace }}
+        run: make docs-scroll-prerender
+
       - name: Type check dashboard
         run: npx tsc --noEmit
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,10 +18,11 @@ on:
       #
       # Deliberately the whole tree rather than an enumeration. The bundle
       # depends on src/ui/demo/, components/topology/AgentNode.tsx,
-      # lib/topology.ts, app/globals.css, vite.demo.config.ts AND
-      # package-lock.json; any hand-maintained list eventually misses one and
-      # under-deploys silently. Over-triggering costs an occasional needless
-      # docs deploy after a dashboard-only change, which is harmless.
+      # lib/topology.ts, app/globals.css, BOTH vite configs (the shipping one
+      # imports its plugins from the other) AND package-lock.json; any
+      # hand-maintained list eventually misses one and under-deploys silently.
+      # Over-triggering costs an occasional needless docs deploy after a
+      # dashboard-only change, which is harmless.
       - 'src/ui/**'
       - 'Makefile'
   workflow_dispatch:
@@ -114,9 +115,16 @@ jobs:
         working-directory: src/ui
         run: npm ci
 
-      # The scroll bundle is built here rather than committed: at 531KB it
-      # exceeds the repo's 500KB large-file limit, and building it from source
-      # on every deploy removes the possibility of shipping a stale artifact.
+      # The scroll bundle is built here rather than committed, so that shipping
+      # a stale artifact is not possible: the bundle is generated from the beat
+      # data, AgentNode and lib/topology, and a committed copy would silently
+      # outlive any of them.
+      #
+      # It USED to be justified by size — the React build was 531KB against
+      # this repo's 500KB large-file limit. The prerendered build is 185KB, so
+      # that argument no longer applies and the staleness one is now doing all
+      # the work. Stated explicitly because a rationale that has quietly become
+      # false is worse than no rationale.
       - name: Build the homepage scroll section
         run: make docs-scroll-build
 

--- a/.gitignore
+++ b/.gitignore
@@ -301,3 +301,19 @@ dump.rdb
 # committed copy could only ever be stale. `make docs-scroll-build` regenerates
 # it locally for `mkdocs serve`.
 docs/assets/mesh-scroll/
+
+# Output tree of the PRERENDERED scroll bundle. The `dist/` pattern near the top
+# of this file does not match `dist-static/`, and leaving a build artifact
+# unignored under src/ui is not merely untidy: Tailwind v4's automatic source
+# detection scans every non-ignored text file under the Vite root, so the
+# bundle's own emitted markup leaked a spurious utility rule into the
+# DASHBOARD's stylesheet — a build it has nothing to do with. Same reason
+# src/ui/demo/dist/generated.json is written where it is. (The utility is
+# deliberately not named here; naming it is what re-creates it.)
+src/ui/demo/dist-static/
+
+# Prerendered markup + animation tables, written by demo/emit.tsx. Ignored for
+# the same Tailwind reason as above (it is 150 kB of rendered class attributes),
+# and kept OUT of demo/dist/ because the React bundle builds into that directory
+# with emptyOutDir and would delete it.
+src/ui/demo/generated/

--- a/Makefile
+++ b/Makefile
@@ -477,15 +477,64 @@ docs-artifacts:
 	@bash scripts/generate_tutorial_artifacts.sh
 	@echo "Artifacts generated in docs/downloads/"
 
-.PHONY: docs-scroll-build
-docs-scroll-build:
-	@echo "📜 Building the home-page scroll section..."
+# Prerender step. Renders the real <Stage> to static markup in Node and writes
+# src/ui/demo/generated/graph.json. Also the first layer of the equivalence
+# proof: it fails the build if the edge geometry it computes disagrees with the
+# geometry captured from the running React build, or if AgentNode's markup has
+# drifted from what the driver would swap in.
+#
+# The compiled emitter goes in demo/generated/, NOT demo/dist/. demo/dist/ is
+# the React bundle's outDir and vite empties it, so with the emitter there a
+# `make -j docs-scroll-compare` could delete emit.cjs in the window between
+# esbuild writing it and node running it. Moving the file removes the race
+# rather than ordering around it — the two builds now share no path at all.
+.PHONY: docs-scroll-prerender
+docs-scroll-prerender:
+	@cd src/ui && npx esbuild demo/emit.tsx --bundle --platform=node --format=cjs \
+		--outfile=demo/generated/emit.cjs --log-level=error \
+		--external:react --external:react-dom --external:react-dom/server \
+		--banner:js='globalThis.window={__MESH_REGISTRY_URL__:"",__MESH_BASE_PATH__:""};'
+	@cd src/ui && node demo/generated/emit.cjs --report
+
+# The PRERENDERED bundle — 180 kB / 20 kB gz, no React, no React Flow, no
+# dagre, no d3. THIS IS WHAT SHIPS: docs-scroll-build below delegates here.
+.PHONY: docs-scroll-build-static
+docs-scroll-build-static: docs-scroll-prerender
+	@cd src/ui && npx vite build --config vite.static.config.ts
+
+# The REACT bundle — 531 kB / 172 kB gz. Superseded on the shipping path and
+# KEPT ON PURPOSE, not left behind: it is the reference the equivalence harness
+# compares against, which makes it the regression test for every future change
+# to this section. Deleting it would delete the only thing that can tell you the
+# driver has drifted from the component. Both are built from the same beat data,
+# the same AgentNode and the same timeline.ts.
+.PHONY: docs-scroll-build-react
+docs-scroll-build-react:
 	@cd src/ui && npx vite build --config vite.demo.config.ts
+
+# Serve both bundles for a side-by-side capture. src/ui/demo/compare.html picks
+# a bundle from ?v=react|static, so one harness drives both and the only
+# variable is which JS runs.
+#
+#   make docs-scroll-compare              # this, in one terminal
+#   node src/ui/demo/equivalence.mjs      # the numbers, in another
+#   node src/ui/demo/screenshots.mjs      # the pixels (read its header first)
+.PHONY: docs-scroll-compare
+docs-scroll-compare: docs-scroll-build-static docs-scroll-build-react
+	@echo ""
+	@echo "  http://localhost:8899/compare.html?v=react"
+	@echo "  http://localhost:8899/compare.html?v=static"
+	@echo ""
+	@cd src/ui/demo && python3 -m http.server 8899
+
+.PHONY: docs-scroll-build
+docs-scroll-build: docs-scroll-build-static
+	@echo "📜 Building the home-page scroll section..."
 	@# Wipe first: cp never prunes, so an asset that stops being emitted would
 	@# otherwise linger in the output tree and get served forever.
 	@rm -rf docs/assets/mesh-scroll
 	@mkdir -p docs/assets/mesh-scroll
-	@cp -R src/ui/demo/dist/. docs/assets/mesh-scroll/
+	@cp -R src/ui/demo/dist-static/. docs/assets/mesh-scroll/
 	@echo "✅ docs/assets/mesh-scroll/ updated (gitignored - do NOT commit)"
 	@echo "   Local preview only. CI builds this from source on every docs"
 	@echo "   deploy, so nothing here is committed and nothing can go stale."

--- a/Makefile
+++ b/Makefile
@@ -525,7 +525,9 @@ docs-scroll-compare: docs-scroll-build-static docs-scroll-build-react
 	@echo "  http://localhost:8899/compare.html?v=react"
 	@echo "  http://localhost:8899/compare.html?v=static"
 	@echo ""
-	@cd src/ui/demo && python3 -m http.server 8899
+	@# Bound to loopback: python3 -m http.server listens on 0.0.0.0 by default,
+	@# which publishes an unauthenticated dev server to the whole local network.
+	@cd src/ui/demo && python3 -m http.server 8899 --bind 127.0.0.1
 
 .PHONY: docs-scroll-build
 docs-scroll-build: docs-scroll-build-static

--- a/docs/index.md
+++ b/docs/index.md
@@ -264,11 +264,12 @@ meshctl man
     var el = document.getElementById("mesh-scroll");
     if (!el) { return; }
     /* 900px MUST match MIN_WIDTH in src/ui/vite.demo.config.ts, which gates
-       the reserved min-height on the same query. Below it the bundle is never
-       fetched and the height is never reserved, so a narrow viewport gets the
-       static placeholder alone rather than 226KB rendering a graph at ~0.23
-       zoom above 2175vh of pinned scroll. This is not a mobile fallback; it is
-       declining to ship a known-broken one. */
+       the reserved min-height on the same query and is shared by both bundle
+       configs. Below it the bundle is never fetched and the height is never
+       reserved, so a narrow viewport gets the static placeholder alone rather
+       than 185KB rendering a graph at ~0.23 zoom above 2205vh of pinned
+       scroll. This is not a mobile fallback; it is declining to ship a
+       known-broken one. */
     var wide = window.matchMedia("(min-width: 900px)");
     var src = "assets/mesh-scroll/mesh-scroll.js";
     var loaded = false;

--- a/src/ui/demo/compare.html
+++ b/src/ui/demo/compare.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>mesh-scroll · equivalence harness</title>
+    <!--
+      SIDE-BY-SIDE HARNESS for the React bundle and the prerendered one.
+
+        make docs-scroll-compare
+        http://localhost:8899/compare.html?v=react
+        http://localhost:8899/compare.html?v=static
+
+      Both bundles emit the same filenames into different directories, so the
+      ONLY variable between the two loads is which JS runs. The page itself is
+      deliberately bare: no MkDocs, no Material, no other stylesheet. Anything
+      that differs between the two captures is the renderer, not the host page.
+
+      Isolation against Material is a separate, already-passing harness —
+      demo/isolation/index.html. Do not conflate them.
+    -->
+    <style>
+      html, body { margin: 0; background: #050c17; }
+      /* The bundles reserve their own height and set display:block above the
+         breakpoint; nothing here should influence layout. */
+    </style>
+  </head>
+  <body>
+    <div id="mesh-scroll">
+      <div class="mesh-scroll-placeholder"></div>
+    </div>
+    <script>
+      (function () {
+        var v = new URLSearchParams(location.search).get("v") === "static"
+          ? "dist-static"
+          : "dist";
+        document.documentElement.dataset.meshBundle = v;
+        var css = document.createElement("link");
+        css.rel = "stylesheet";
+        css.href = "./" + v + "/mesh-scroll.css";
+        document.head.appendChild(css);
+        var js = document.createElement("script");
+        js.src = "./" + v + "/mesh-scroll.js";
+        js.defer = true;
+        document.head.appendChild(js);
+      })();
+    </script>
+  </body>
+</html>

--- a/src/ui/demo/driver.ts
+++ b/src/ui/demo/driver.ts
@@ -19,7 +19,7 @@
 // Everything else — the ~80 setProperty calls, the camera maths, the reveal
 // windows, the keyboard snapping — is the same code path as before.
 import {
-  BEATS, CHAPTERS, ACCENT, BUILT_CHAPTERS, TOTAL_VH, REVEAL, REVEAL_VH,
+  BEATS, ACCENT, BUILT_CHAPTERS, TOTAL_VH, REVEAL, REVEAL_VH,
 } from "./script";
 import {
   clamp, smoothstep, lerp, lerpColor, camFor, LEAD_FLIP, restWidth,
@@ -38,7 +38,7 @@ export interface Generated {
     label: Record<string, [number, number]>;
   }>;
   cards: Record<string, { variants: Array<{ cls: string; html: string }>; byBeat: number[] }>;
-  beatCopy: Array<{ chapter: string; title: string; sub: string; desc: string }>;
+  beatCopy: Array<{ html: string }>;
   edgeStroke: string[][];
 }
 
@@ -126,7 +126,17 @@ export function start(root: HTMLElement, G: Generated) {
       els.wrapper.setAttribute("visibility", "visible");
     }
     // Fonts can still be loading on the first frame; retry until one measures.
-    if (any) labelsMeasured = true;
+    if (!any) return;
+    labelsMeasured = true;
+    // FORCE A GEOMETRY RE-APPLY. applyGeometry centres each label wrapper on
+    // `els.bbox`, and it has already run for this state — with an empty box,
+    // because measurement had not succeeded yet. Its `state === geomState`
+    // early return then means the wrapper keeps a transform computed from 0x0,
+    // leaving every label offset by half its own box until the state genuinely
+    // changes at B14. Invalidating geomState here is the whole fix: the guard
+    // above stays, so this still runs exactly once.
+    geomState = -1;
+    applyGeometry(G.beatToState[Math.max(lead, 0)]);
   };
 
   // ---- geometry state (card boxes change at B14, so the paths do too) -----
@@ -171,23 +181,12 @@ export function start(root: HTMLElement, G: Generated) {
       if (el.className !== v.cls) el.className = v.cls;
       if (el.innerHTML !== v.html) el.innerHTML = v.html;
     }
-    const copy = G.beatCopy[i];
-    if (titleHost) {
-      // The chapter label is REBUILT here rather than left alone, because this
-      // assignment owns the whole block: an earlier version wrote it separately
-      // and then destroyed it on the next line, which the capture caught as a
-      // missing element at all 201 sampled positions. It carries no entrance
-      // animation (only `demo-fade` on the three below it does), so recreating
-      // it every flip is not observable — unlike the title, which must be
-      // recreated for exactly that reason.
-      titleHost.innerHTML =
-        `<p data-mesh="chapter" class="demo-accent font-mono text-[10px] uppercase tracking-[0.32em]">${escapeText(copy.chapter)}</p>` +
-        `<h2 data-mesh="title" class="demo-fade mt-2 whitespace-pre-line text-balance text-[30px] font-semibold leading-[1.12] tracking-tight text-white">${escapeText(copy.title)}</h2>` +
-        `<p data-mesh="sub" class="demo-fade mt-3 whitespace-pre-line text-balance break-words font-mono text-[13px] leading-relaxed text-slate-400">${copy.sub}</p>` +
-        (copy.desc
-          ? `<p data-mesh="desc" class="demo-fade mt-4 text-[15px] leading-[1.7] text-slate-400">${copy.desc}</p>`
-          : "");
-    }
+    // One assignment, from markup emitted by the very component <Stage>
+    // renders. Replacing the elements (rather than rewriting their text) is
+    // deliberate and matches React: the title is keyed on the beat there, so
+    // the old <h2> unmounts and `demo-fade` replays from the start.
+    if (titleHost) titleHost.innerHTML = G.beatCopy[i].html;
+
     const chapter = BEATS[i].chapter;
     for (let c = 0; c < BUILT_CHAPTERS; c++) {
       const active = chapter === c;
@@ -340,12 +339,16 @@ export function start(root: HTMLElement, G: Generated) {
   };
   apply();
   // The first apply runs before webfonts settle, so the label boxes measured
-  // then are the fallback font's. Re-measure once the real faces are in.
+  // then are the fallback font's. Re-measure once the real faces are in;
+  // measureLabels re-applies the geometry itself when it succeeds.
+  //
+  // This is a REFINEMENT, not the correctness guarantee — it used to be both,
+  // which hid the bug above. Optional chaining means the whole callback is
+  // skipped where document.fonts does not exist, so label centring must not
+  // depend on it.
   document.fonts?.ready.then(() => {
     labelsMeasured = false;
     measureLabels();
-    geomState = -1;
-    applyGeometry(G.beatToState[Math.max(lead, 0)]);
   });
   window.addEventListener("scroll", onScroll, { passive: true });
   window.addEventListener("resize", onResize);
@@ -430,10 +433,3 @@ export function start(root: HTMLElement, G: Generated) {
   window.addEventListener("wheel", clearTarget, { passive: true });
   window.addEventListener("touchstart", clearTarget, { passive: true });
 }
-
-/** Beat titles are plain text with authored newlines, never markup. */
-function escapeText(s: string) {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
-export { CHAPTERS };

--- a/src/ui/demo/driver.ts
+++ b/src/ui/demo/driver.ts
@@ -1,0 +1,439 @@
+// THE VANILLA DRIVER — what animates the prerendered markup.
+//
+// This replaces React, React Flow, dagre and d3 at RUNTIME only. It does not
+// replace them as a source of truth: every pixel it moves was positioned by
+// React Flow at build time (see emit.tsx), and every number it computes comes
+// from timeline.ts, which the React component imports too.
+//
+// WHAT IT ACTUALLY DOES, and why that is so little:
+// the React build already avoided re-rendering on scroll. Per-frame state was
+// written as CSS custom properties on the panel and the stable inline styles
+// referenced them, so React's only job in the scroll path was flipping `lead`
+// 13 times and letting React Flow apply the camera. Those are the only two
+// things that had to be reimplemented here:
+//
+//   setViewport(...)  ->  a transform on .react-flow__viewport (+ the
+//                         background pattern, which is a pure function of it)
+//   setLead(i)        ->  swap the card bodies and the beat copy
+//
+// Everything else — the ~80 setProperty calls, the camera maths, the reveal
+// windows, the keyboard snapping — is the same code path as before.
+import {
+  BEATS, CHAPTERS, ACCENT, BUILT_CHAPTERS, TOTAL_VH, REVEAL, REVEAL_VH,
+} from "./script";
+import {
+  clamp, smoothstep, lerp, lerpColor, camFor, LEAD_FLIP, restWidth,
+  totalTravel, rawFromVh, R_CLEAR, R_BEAT_OUT, R_HEAD, R_PHASE_0, R_PHASE_STEP,
+  R_PHASE_SPAN, R_OUT, R_CTA, SNAP_VH, CHAPTER_VH, CHAPTER_SPAN,
+  TEXT_ENTRY, ACTIVATABLE,
+} from "./timeline";
+
+export interface Generated {
+  shell: string;
+  nodeOrder: string[];
+  edgeOrder: string[];
+  beatToState: number[];
+  states: Array<{
+    d: Record<string, string>;
+    label: Record<string, [number, number]>;
+  }>;
+  cards: Record<string, { variants: Array<{ cls: string; html: string }>; byBeat: number[] }>;
+  beatCopy: Array<{ chapter: string; title: string; sub: string; desc: string }>;
+  edgeStroke: string[][];
+}
+
+const N = BEATS.length;
+
+/** Background dot pattern — gap and size as passed to <Background> in Stage. */
+const BG_GAP = 22;
+const BG_SIZE = 1;
+
+export function start(root: HTMLElement, G: Generated) {
+  const q = <T extends Element>(sel: string) => root.querySelector<T>(sel);
+
+  const section = q<HTMLElement>('[data-mesh="section"]');
+  const panel = q<HTMLElement>(".demo-panel");
+  const wrap = q<HTMLElement>(".demo-graph");
+  const viewport = q<HTMLElement>(".react-flow__viewport");
+  const bgPattern = q<SVGPatternElement>(".react-flow__background pattern");
+  const bgDot = q<SVGCircleElement>(".react-flow__background circle");
+  if (!section || !panel || !wrap || !viewport) return;
+
+  const reduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+
+  // ---- element handles, resolved once ------------------------------------
+  const cardEl = new Map<string, HTMLElement>();
+  for (const id of G.nodeOrder) {
+    const node = root.querySelector<HTMLElement>(
+      `.react-flow__node[data-id="${CSS.escape(id)}"]`
+    );
+    // The card is the middle child: <Handle/><div class="card"/><Handle/>.
+    const card = node?.children[1] as HTMLElement | undefined;
+    if (card) cardEl.set(id, card);
+  }
+
+  interface EdgeEls {
+    path: SVGPathElement | null;
+    interaction: SVGPathElement | null;
+    wrapper: SVGGElement | null;
+    text: SVGTextElement | null;
+    rect: SVGRectElement | null;
+    bbox: { w: number; h: number };
+  }
+  const edgeEl = new Map<string, EdgeEls>();
+  for (const id of G.edgeOrder) {
+    const g = root.querySelector<SVGGElement>(
+      `.react-flow__edge[data-id="${CSS.escape(id)}"]`
+    );
+    edgeEl.set(id, {
+      path: g?.querySelector(".react-flow__edge-path") ?? null,
+      interaction: g?.querySelector(".react-flow__edge-interaction") ?? null,
+      wrapper: g?.querySelector(".react-flow__edge-textwrapper") ?? null,
+      text: g?.querySelector(".react-flow__edge-text") ?? null,
+      rect: g?.querySelector(".react-flow__edge-textbg") ?? null,
+      bbox: { w: 0, h: 0 },
+    });
+  }
+
+  const titleHost = q<HTMLElement>('[data-mesh="title"]')?.parentElement ?? null;
+  const railEl = Array.from({ length: BUILT_CHAPTERS }, (_, c) =>
+    q<HTMLElement>(`[data-mesh-rail="${c}"]`)
+  );
+  const railFill = Array.from({ length: BUILT_CHAPTERS }, (_, c) =>
+    railEl[c]?.previousElementSibling?.firstElementChild as HTMLElement | undefined
+  );
+
+  // ---- edge labels --------------------------------------------------------
+  // React Flow measures its own label text with getBBox and centres the group
+  // on the path midpoint. A server render has no layout, so the markup ships
+  // with a 0x0 box and visibility:hidden. Measuring here rather than baking
+  // captured numbers keeps this self-correcting: change a capability name and
+  // the label re-centres on the next load, with no re-capture.
+  let labelsMeasured = false;
+  const measureLabels = () => {
+    if (labelsMeasured) return;
+    let any = false;
+    for (const els of edgeEl.values()) {
+      if (!els.text || !els.wrapper) continue;
+      const b = els.text.getBBox();
+      if (!b.width) continue;
+      any = true;
+      els.bbox = { w: b.width, h: b.height };
+      // labelBgPadding={[4, 2]}, matching <Stage>'s edge definitions.
+      els.rect?.setAttribute("width", String(b.width + 8));
+      els.rect?.setAttribute("height", String(b.height + 4));
+      els.text.setAttribute("y", String(b.height / 2));
+      els.wrapper.setAttribute("visibility", "visible");
+    }
+    // Fonts can still be loading on the first frame; retry until one measures.
+    if (any) labelsMeasured = true;
+  };
+
+  // ---- geometry state (card boxes change at B14, so the paths do too) -----
+  let geomState = -1;
+  const applyGeometry = (state: number) => {
+    if (state === geomState) return;
+    geomState = state;
+    const g = G.states[state];
+    for (const [id, els] of edgeEl) {
+      const d = g.d[id];
+      if (d) {
+        els.path?.setAttribute("d", d);
+        els.interaction?.setAttribute("d", d);
+      }
+      const xy = g.label[id];
+      if (xy && els.wrapper) {
+        els.wrapper.setAttribute(
+          "transform",
+          `translate(${xy[0] - els.bbox.w / 2} ${xy[1] - els.bbox.h / 2})`
+        );
+      }
+    }
+  };
+
+  // ---- lead flip ----------------------------------------------------------
+  // The card ELEMENT is kept and only its class and body are rewritten: the
+  // card carries `transition-all duration-300`, so its border colour is meant
+  // to ease from green to red when a provider dies. Replacing the element
+  // would make that snap.
+  //
+  // The beat copy is the opposite case and is replaced outright, which is also
+  // what React did — its <h2> is keyed on the beat, so the old element
+  // unmounted and the new one played `demo-fade` from the start. Rewriting
+  // text in place would leave the animation already finished.
+  let lead = -1;
+  const applyLead = (i: number) => {
+    if (i === lead) return;
+    lead = i;
+    for (const [id, el] of cardEl) {
+      const t = G.cards[id];
+      const v = t.variants[t.byBeat[i]];
+      if (el.className !== v.cls) el.className = v.cls;
+      if (el.innerHTML !== v.html) el.innerHTML = v.html;
+    }
+    const copy = G.beatCopy[i];
+    if (titleHost) {
+      // The chapter label is REBUILT here rather than left alone, because this
+      // assignment owns the whole block: an earlier version wrote it separately
+      // and then destroyed it on the next line, which the capture caught as a
+      // missing element at all 201 sampled positions. It carries no entrance
+      // animation (only `demo-fade` on the three below it does), so recreating
+      // it every flip is not observable — unlike the title, which must be
+      // recreated for exactly that reason.
+      titleHost.innerHTML =
+        `<p data-mesh="chapter" class="demo-accent font-mono text-[10px] uppercase tracking-[0.32em]">${escapeText(copy.chapter)}</p>` +
+        `<h2 data-mesh="title" class="demo-fade mt-2 whitespace-pre-line text-balance text-[30px] font-semibold leading-[1.12] tracking-tight text-white">${escapeText(copy.title)}</h2>` +
+        `<p data-mesh="sub" class="demo-fade mt-3 whitespace-pre-line text-balance break-words font-mono text-[13px] leading-relaxed text-slate-400">${copy.sub}</p>` +
+        (copy.desc
+          ? `<p data-mesh="desc" class="demo-fade mt-4 text-[15px] leading-[1.7] text-slate-400">${copy.desc}</p>`
+          : "");
+    }
+    const chapter = BEATS[i].chapter;
+    for (let c = 0; c < BUILT_CHAPTERS; c++) {
+      const active = chapter === c;
+      const el = railEl[c];
+      if (el) {
+        el.className = `mt-2 font-mono text-[10px] tracking-[0.18em] ${
+          active ? "demo-accent" : "text-slate-500"
+        }`;
+      }
+      const fill = railFill[c];
+      // Only the chapter being played takes the live accent. --accent goes red
+      // for "It dies.", and letting completed chapters follow it read as
+      // "everything is broken" — the opposite of the point.
+      if (fill) fill.style.background = active ? "" : ACCENT;
+    }
+    applyGeometry(G.beatToState[i]);
+  };
+
+  // ---- the per-frame apply ------------------------------------------------
+  const apply = () => {
+    const r = section.getBoundingClientRect();
+    // Below MIN_WIDTH the section is display:none, so it has no height.
+    if (r.height === 0) return;
+    const travel = r.height - window.innerHeight;
+    const progress = travel <= 0 ? 0 : clamp(-r.top / travel, 0, 1);
+
+    const vhPos = progress * totalTravel;
+    const raw = rawFromVh(Math.min(vhPos, TOTAL_VH));
+    const rev = clamp((vhPos - TOTAL_VH) / REVEAL_VH, 0, 1);
+    const pos = raw - 0.5;
+    const i0 = clamp(Math.floor(pos), 0, N - 1);
+    const i1 = Math.min(i0 + 1, N - 1);
+    const t = clamp(pos - i0, 0, 1);
+    const f = reduced ? (t >= 0.5 ? 1 : 0) : smoothstep(t);
+    // Everything the next beat ADDS is held back until its title is actually on
+    // screen. Withdrawal still tracks f: a card leaving early contradicts
+    // nothing, and the stagger makes each reveal read as caused by its heading
+    // rather than anticipating it.
+    const fIn = smoothstep(clamp((f - LEAD_FLIP) / (1 - LEAD_FLIP), 0, 1));
+
+    const a = BEATS[i0];
+    const b = BEATS[i1];
+    const s = panel.style;
+
+    for (let i = 0; i < G.nodeOrder.length; i++) {
+      const id = G.nodeOrder[i];
+      const from = a.nodes[id] ?? 0;
+      const to = b.nodes[id] ?? 0;
+      s.setProperty(`--n${i}-o`, lerp(from, to, to > from ? fIn : f).toFixed(3));
+    }
+    for (let i = 0; i < G.edgeOrder.length; i++) {
+      const id = G.edgeOrder[i];
+      const from = a.edges[id] ?? 0;
+      const to = b.edges[id] ?? 0;
+      const o = lerp(from, to, to > from ? fIn : f);
+      s.setProperty(`--e${i}-o`, o.toFixed(3));
+      s.setProperty(`--e${i}-l`, (o > 0.55 ? o : 0).toFixed(3));
+      // Weight is an assertion like colour is, so it takes the same gate — and
+      // on its own direction, not the opacity's: B5 thickens an edge whose
+      // opacity does not change at all across the boundary.
+      const emA = a.emphasis?.includes(id) ? 1 : 0;
+      const emB = b.emphasis?.includes(id) ? 1 : 0;
+      const em = lerp(emA, emB, emB > emA ? fIn : f);
+      s.setProperty(`--e${i}-w`, (restWidth(id) * (1 + 0.5 * em)).toFixed(2));
+      // Colour is an assertion too — an edge going grey is how "the provider
+      // died" is drawn — so it lands with the heading, not before it.
+      s.setProperty(`--e${i}-c`, lerpColor(G.edgeStroke[i0][i], G.edgeStroke[i1][i], fIn));
+    }
+
+    s.setProperty("--accent", lerpColor(a.accent, b.accent, f));
+    s.setProperty("--pulse", lerp(a.pulse ?? 0, b.pulse ?? 0, f).toFixed(3));
+    s.setProperty("--gutter", lerp(a.fullBleed ? 0 : 1, b.fullBleed ? 0 : 1, f).toFixed(3));
+    for (let c = 0; c < BUILT_CHAPTERS; c++) {
+      const { first, count } = CHAPTER_SPAN[c];
+      s.setProperty(`--ch${c}-f`, `${(clamp((raw - first) / count, 0, 1) * 100).toFixed(2)}%`);
+    }
+
+    // ---- the reveal -------------------------------------------------------
+    const ease = (x: number) => (reduced ? (x >= 0.5 ? 1 : 0) : smoothstep(clamp(x, 0, 1)));
+    const window_ = (from: number, to: number) => ease((rev - from) / (to - from));
+
+    const cleared = ease(rev / R_CLEAR);
+    s.setProperty("--graph", (1 - cleared).toFixed(3));
+    s.setProperty("--rail", (1 - cleared).toFixed(3));
+
+    const headIn = window_(R_HEAD[0], R_HEAD[1]);
+    const beatOut = window_(R_BEAT_OUT[0], R_BEAT_OUT[1]);
+    const gone = 1 - window_(R_OUT[0], R_OUT[1]);
+    s.setProperty("--beat", (1 - beatOut).toFixed(3));
+    s.setProperty("--reveal", (headIn * gone).toFixed(3));
+    for (let i = 0; i < REVEAL.phases.length; i++) {
+      const from = R_PHASE_0 + i * R_PHASE_STEP;
+      s.setProperty(`--p${i}`, (window_(from, from + R_PHASE_SPAN) * gone).toFixed(3));
+    }
+    s.setProperty("--cta", window_(R_CTA[0], R_CTA[1]).toFixed(3));
+
+    // ---- camera -----------------------------------------------------------
+    const W = wrap.clientWidth;
+    const H = wrap.clientHeight;
+    if (W && H) {
+      const ca = camFor(i0, W, H);
+      const cb = camFor(i1, W, H);
+      // Geometric zoom interpolation — a linear ramp reads as a lurch.
+      const zoom = Math.exp(lerp(Math.log(ca.zoom), Math.log(cb.zoom), f));
+      const cx = lerp(ca.cx, cb.cx, f);
+      const cy = lerp(ca.cy, cb.cy, f);
+      const ax = lerp(ca.ax, cb.ax, f);
+      const x = ax - cx * zoom;
+      // 0.60 rather than 0.50: the title scrim eats the top ~220px and the
+      // chapter rail the bottom ~60px, so the usable band sits low of centre.
+      const y = H * 0.6 - cy * zoom;
+      // This is precisely what React Flow's setViewport writes.
+      viewport.style.transform = `translate(${x}px,${y}px) scale(${zoom})`;
+      // ...and this is what <Background> recomputes from it. Both are pure
+      // functions of the transform, so the dots stay locked to the graph.
+      if (bgPattern && bgDot) {
+        const gap = BG_GAP * zoom || 1;
+        const size = BG_SIZE * zoom;
+        bgPattern.setAttribute("x", String(x % gap));
+        bgPattern.setAttribute("y", String(y % gap));
+        bgPattern.setAttribute("width", String(gap));
+        bgPattern.setAttribute("height", String(gap));
+        bgPattern.setAttribute("patternTransform", `translate(-${1 + gap / 2},-${1 + gap / 2})`);
+        bgDot.setAttribute("cx", String(size / 2));
+        bgDot.setAttribute("cy", String(size / 2));
+        bgDot.setAttribute("r", String(size / 2));
+      }
+    }
+
+    applyLead(f >= LEAD_FLIP ? i1 : i0);
+    measureLabels();
+  };
+
+  // ---- scroll pump --------------------------------------------------------
+  let raf = 0;
+  let lastY = -1;
+  const tick = () => {
+    raf = 0;
+    const y = window.scrollY;
+    if (y === lastY) return;
+    lastY = y;
+    apply();
+  };
+  const onScroll = () => {
+    if (!raf) raf = requestAnimationFrame(tick);
+  };
+  const onResize = () => {
+    lastY = -1;
+    apply();
+  };
+  apply();
+  // The first apply runs before webfonts settle, so the label boxes measured
+  // then are the fallback font's. Re-measure once the real faces are in.
+  document.fonts?.ready.then(() => {
+    labelsMeasured = false;
+    measureLabels();
+    geomState = -1;
+    applyGeometry(G.beatToState[Math.max(lead, 0)]);
+  });
+  window.addEventListener("scroll", onScroll, { passive: true });
+  window.addEventListener("resize", onResize);
+
+  // ---- keyboard stepping --------------------------------------------------
+  // The driver is a pure function of scroll position, so the only safe way to
+  // move a keyboard user is to move the SCROLL POSITION onto a composed frame.
+  // Nothing here advances the animation independently of the page.
+  const p = { raf: 0, idle: 0, last: -1 };
+  let target: number | null = null;
+  const pump = () => {
+    p.raf = 0;
+    const y = window.scrollY;
+    apply();
+    if (y === p.last) p.idle += 1;
+    else {
+      p.idle = 0;
+      p.last = y;
+    }
+    if (p.idle < 10) p.raf = requestAnimationFrame(pump);
+    else target = null;
+  };
+  const startPump = () => {
+    p.idle = 0;
+    p.last = -1;
+    if (!p.raf) p.raf = requestAnimationFrame(pump);
+  };
+
+  window.addEventListener("keydown", (e: KeyboardEvent) => {
+    if (e.defaultPrevented || e.metaKey || e.ctrlKey || e.altKey) return;
+    const el = e.target as HTMLElement | null;
+    if (el && (el.isContentEditable || TEXT_ENTRY.has(el.tagName))) return;
+    const space = e.key === " " || e.key === "Spacebar";
+    if (el && ACTIVATABLE.has(el.tagName) && (space || e.key === "Enter")) return;
+
+    let dir = 0;
+    let byChapter = false;
+    if (e.key === "PageDown" || e.key === "ArrowDown") {
+      dir = 1;
+      byChapter = e.shiftKey;
+    } else if (e.key === "PageUp" || e.key === "ArrowUp") {
+      dir = -1;
+      byChapter = e.shiftKey;
+    } else if (space) {
+      // Shift-Space stays "previous beat": it is the universal page-up gesture
+      // and predates the Shift modifier used above.
+      dir = e.shiftKey ? -1 : 1;
+    }
+    if (!dir) return;
+
+    // Auto-repeat paces itself to the scrolls rather than to the key-repeat
+    // rate. Distinct presses are never throttled — they retarget immediately.
+    if (e.repeat && target !== null) {
+      e.preventDefault();
+      return;
+    }
+    const H = window.innerHeight;
+    const r = section.getBoundingClientRect();
+    // Only take over while the panel is actually pinned.
+    if (r.top > 0 || r.bottom < H) return;
+
+    const sectionTop = window.scrollY + r.top;
+    const stops = (byChapter ? CHAPTER_VH : SNAP_VH).map((vh) => sectionTop + vh * H);
+    // Step from the target already in flight, not from the position we happen
+    // to be passing through.
+    const from = target ?? window.scrollY;
+    const EPS = 8;
+    const next =
+      dir > 0
+        ? stops.find((y) => y > from + EPS)
+        : [...stops].reverse().find((y) => y < from - EPS);
+    if (next === undefined) return;
+
+    e.preventDefault();
+    target = next;
+    window.scrollTo({ top: next, behavior: reduced ? "auto" : "smooth" });
+    startPump();
+  });
+  const clearTarget = () => {
+    target = null;
+  };
+  window.addEventListener("wheel", clearTarget, { passive: true });
+  window.addEventListener("touchstart", clearTarget, { passive: true });
+}
+
+/** Beat titles are plain text with authored newlines, never markup. */
+function escapeText(s: string) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export { CHAPTERS };

--- a/src/ui/demo/emit.tsx
+++ b/src/ui/demo/emit.tsx
@@ -1,0 +1,374 @@
+// BUILD-TIME EMITTER for the prerendered bundle.
+//
+// Renders the REAL <Stage> — the same component the React bundle mounts, with
+// the same beat data and the same AgentNode — to static markup, and extracts
+// everything the vanilla driver needs to animate it. Nothing here is a
+// reimplementation: if a card's markup changes, this output changes with it.
+//
+//   node demo/dist/emit.cjs            → demo/generated/graph.json
+//   node demo/dist/emit.cjs --report   → also print the equivalence summary
+//
+// WHY THE FIXTURE IS NOT A GENERATION SOURCE. geometry.json supplies exactly
+// two things that cannot be known without a browser: the measured card boxes
+// and the handle offsets. Everything else — markup, edge paths, label
+// positions, card variants — is regenerated from source here, so a stale
+// fixture cannot silently freeze a stale picture. The guards below fail the
+// build rather than emit something that disagrees with the fixture.
+import fs from "node:fs";
+import path from "node:path";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ReactFlowProvider } from "@xyflow/react";
+
+import { AgentNode } from "@/components/topology/AgentNode";
+import { buildGraphFromAgents } from "@/lib/topology";
+import {
+  Stage, setSsrGeometry, inline, SUB_INLINE, DESC_INLINE, type SsrBox,
+} from "./stage";
+import {
+  BEATS, CHAPTERS, BUILT_CHAPTERS, REVEAL, buildWorld, MAXIMAL, MAXIMAL_REPLICAS,
+  WEATHER_GROUP, EMBED_SHOWS_HEADER,
+} from "./script";
+
+// Runs both as source (tsx, __dirname = demo/) and as the esbuild bundle
+// (demo/generated/). Resolve the demo root by name rather than by guessing a
+// depth, so moving the compiled output again does not silently break paths.
+const HERE = path.basename(__dirname) === "demo" ? __dirname : path.join(__dirname, "..");
+fs.mkdirSync(path.join(HERE, "generated"), { recursive: true });
+
+interface Geometry {
+  handleOffset: { source: number; target: number };
+  stateCount: number;
+  beatToState: Record<string, number>;
+  states: Array<{
+    nodes: Record<string, { w: number; h: number }>;
+    edges: Record<string, string>;
+  }>;
+}
+const GEO: Geometry = JSON.parse(
+  fs.readFileSync(path.join(HERE, "geometry.json"), "utf8")
+);
+
+// Same guard as the Phase 1 prototype, for the same reason: the two-state model
+// is a fact about today's copy, not about copy in general. One more badge or a
+// longer runtime label can reflow a card at some other beat, and the
+// prerendered edges would then be drawn to handle positions the cards no longer
+// occupy — wrong, and silently so.
+const EXPECTED_STATES = 2;
+if (GEO.stateCount !== EXPECTED_STATES) {
+  throw new Error(
+    `geometry.json has ${GEO.stateCount} distinct states, expected ${EXPECTED_STATES}. ` +
+      `A card's rendered box changed. Re-capture, confirm the new state is intended, ` +
+      `then update EXPECTED_STATES.`
+  );
+}
+
+const BEAT_TO_STATE = BEATS.map((_, i) => GEO.beatToState[String(i + 1)] ?? 0);
+const boxes = (state: number) =>
+  new Map<string, SsrBox>(Object.entries(GEO.states[state].nodes));
+
+// ---------------------------------------------------------------------------
+// Render the real component, once per geometry state
+// ---------------------------------------------------------------------------
+function renderStage(state: number): string {
+  setSsrGeometry(boxes(state));
+  try {
+    return renderToStaticMarkup(<Stage showHeader={EMBED_SHOWS_HEADER} />);
+  } finally {
+    setSsrGeometry(null);
+  }
+}
+
+const shells = [renderStage(0), renderStage(1)];
+
+/** Split the markup into one chunk per edge <g>, keyed by data-id. */
+function edgeChunks(html: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const chunk of html.split(/(?=<g class="react-flow__edge)/)) {
+    const id = /data-id="([^"]+)"/.exec(chunk);
+    if (id && chunk.startsWith("<g class=\"react-flow__edge")) out.set(id[1], chunk);
+  }
+  return out;
+}
+
+/** Round exactly as the fixture does — 2dp, then compare byte-exact. */
+const r2 = (s: string) =>
+  s.replace(/-?\d+\.?\d*/g, (m) => {
+    const v = Math.round(Number(m) * 100) / 100;
+    return String(v);
+  });
+
+interface StateGeom {
+  d: Record<string, string>;
+  label: Record<string, [number, number]>;
+}
+const states: StateGeom[] = shells.map((html, s) => {
+  const g: StateGeom = { d: {}, label: {} };
+  for (const [id, chunk] of edgeChunks(html)) {
+    const d = /<path style="[^"]*"\s+d="([^"]+)"/.exec(chunk);
+    if (!d) throw new Error(`state ${s}: no edge path for ${id}`);
+    g.d[id] = d[1];
+    // The label wrapper's translate is (labelX - bboxW/2, labelY - bboxH/2).
+    // Under SSR the bbox is 0x0 — getBBox needs a layout — so what is baked
+    // here is exactly (labelX, labelY). The driver re-applies the offset once
+    // it has measured the text, which is what React Flow's EdgeText does too.
+    const t = /class="react-flow__edge-textwrapper" visibility="hidden"/.test(chunk)
+      ? /<g transform="translate\((-?[\d.]+) (-?[\d.]+)\)" class="react-flow__edge-textwrapper"/.exec(chunk)
+      : null;
+    if (!t) throw new Error(`state ${s}: no unmeasured label wrapper for ${id}`);
+    g.label[id] = [Number(t[1]), Number(t[2])];
+  }
+  return g;
+});
+
+// EQUIVALENCE, LAYER 1: every edge path this build emits, in both geometry
+// states, against the paths captured from the running React build.
+let pathOk = 0;
+const pathBad: string[] = [];
+states.forEach((g, s) => {
+  const want = GEO.states[s].edges;
+  for (const [id, d] of Object.entries(g.d)) {
+    if (r2(d) === want[id]) pathOk++;
+    else pathBad.push(`  state ${s} ${id}\n    emitted  ${r2(d)}\n    captured ${want[id]}`);
+  }
+  for (const id of Object.keys(want)) {
+    if (!(id in g.d)) pathBad.push(`  state ${s} ${id}: in fixture, not emitted`);
+  }
+});
+if (pathBad.length) {
+  throw new Error(
+    `prerendered edge geometry disagrees with the captured fixture:\n${pathBad.join("\n")}`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card variants — what the driver swaps at a lead flip
+// ---------------------------------------------------------------------------
+// AgentNode renders <Handle/><div class="card">…</div><Handle/>. The driver
+// keeps the card DIV ELEMENT and rewrites its class and innerHTML, rather than
+// replacing the node's markup wholesale. That is not a micro-optimisation: the
+// card transitions all of its properties over 300ms, so its border colour and
+// elevation are meant to EASE between beats. Replacing the element would make
+// "It dies." snap from green to red instead of bleeding into it. Everything
+// inside the card that changes (status dot, deps count, runtime pill, badges)
+// carries no transition, so recreating those children is not observable.
+const canonical = buildGraphFromAgents(MAXIMAL);
+const grouped = buildGraphFromAgents(MAXIMAL_REPLICAS);
+const NODE_IDS = [...canonical.nodes.map((n) => n.id), WEATHER_GROUP];
+const EDGE_IDS = (() => {
+  const seen = new Map<string, true>();
+  for (const e of [...canonical.edges, ...grouped.edges]) seen.set(e.id, true);
+  return [...seen.keys()];
+})();
+
+const renderCard = (id: string, data: Record<string, unknown>) =>
+  renderToStaticMarkup(
+    <ReactFlowProvider>
+      <AgentNode
+        id={id} type="agentNode" data={data} dragging={false} zIndex={0}
+        selectable={false} deletable={false} selected={false} draggable={false}
+        isConnectable={false} positionAbsoluteX={0} positionAbsoluteY={0}
+      />
+    </ReactFlowProvider>
+  );
+
+/** The card div is the middle child; the handles either side never change. */
+const CARD_RE = /^<div [^>]*data-handlepos="top"[^>]*><\/div><div class="([^"]*)">([\s\S]*)<\/div><div [^>]*data-handlepos="bottom"[^>]*><\/div>$/;
+function splitCard(markup: string): { cls: string; html: string } {
+  const m = CARD_RE.exec(markup);
+  if (!m) throw new Error(`AgentNode markup did not match the expected card shape:\n${markup.slice(0, 300)}`);
+  return { cls: m[1], html: m[2] };
+}
+
+const perBeatData = BEATS.map(
+  (b) => new Map(buildGraphFromAgents(buildWorld(b.world)).nodes.map((n) => [n.id, n.data]))
+);
+const FALLBACK = new Map<string, Record<string, unknown>>();
+for (const m of perBeatData) {
+  for (const [id, d] of m) if (!FALLBACK.has(id)) FALLBACK.set(id, d as Record<string, unknown>);
+}
+
+interface CardTable {
+  variants: Array<{ cls: string; html: string }>;
+  byBeat: number[];
+}
+const cards: Record<string, CardTable> = {};
+let variantCount = 0;
+for (const id of NODE_IDS) {
+  const index = new Map<string, number>();
+  const table: CardTable = { variants: [], byBeat: [] };
+  for (let b = 0; b < BEATS.length; b++) {
+    const data = (perBeatData[b].get(id) ?? FALLBACK.get(id)) as Record<string, unknown>;
+    const part = splitCard(renderCard(id, data));
+    const key = `${part.cls} ${part.html}`;
+    let v = index.get(key);
+    if (v === undefined) {
+      v = table.variants.length;
+      index.set(key, v);
+      table.variants.push(part);
+    }
+    table.byBeat.push(v);
+  }
+  variantCount += table.variants.length;
+  cards[id] = table;
+}
+
+// EQUIVALENCE, LAYER 2: the shell's own cards must BE variant byBeat[0]. This
+// is what proves the variant table and the prerendered markup came from the
+// same renderer — if AgentNode's output ever drifts from what <Stage> puts in
+// the node wrapper, the driver's first swap would silently change the picture.
+for (const id of NODE_IDS) {
+  const want = cards[id].variants[cards[id].byBeat[0]];
+  const literal = `<div class="${want.cls}">${want.html}</div>`;
+  const at = shells[0].indexOf(literal);
+  if (at === -1) {
+    throw new Error(
+      `the card the driver would swap in for ${id} at beat 1 does not appear in the ` +
+        `prerendered shell. AgentNode's output and <Stage>'s output have diverged.\n` +
+        `  expected  ${literal.slice(0, 200)}`
+    );
+  }
+  if (shells[0].indexOf(literal, at + 1) !== -1) {
+    throw new Error(`card markup for ${id} appears more than once in the shell`);
+  }
+}
+
+let hookCount = 0;
+// EQUIVALENCE, LAYER 3: every hook the driver reaches for must EXIST.
+//
+// This is the one failure this pipeline was still open to, and it is the worst
+// one available. driver.ts resolves its elements once and returns silently if
+// the essential ones are missing — but static.ts has already set
+// data-mesh-scroll-mounted="1" by then, which is what hides the placeholder. So
+// renaming a class in stage.tsx would pass the prerender, pass the bundle
+// build, pass the deploy's four-file check, and ship an empty dark panel over
+// 2205vh of scroll. Nothing downstream looks INSIDE the markup.
+//
+// Everything below is a selector driver.ts actually queries. Counts are derived
+// from the same arrays the driver iterates, never written as literals — a
+// fourteenth node has to change this assertion or break it.
+{
+  // Class names are counted on a TOKEN boundary, not as substrings. A plain
+  // indexOf for `react-flow__viewport` also matches `react-flow__viewport-portal`
+  // and reported 2 where the driver sees 1 — a guard that miscounts is a guard
+  // that gets relaxed until it stops meaning anything.
+  const count = (needle: string) =>
+    needle.startsWith("<")
+      ? shells[0].split(needle).length - 1
+      : (shells[0].match(new RegExp(needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "(?![\\w-])", "g")) ?? []).length;
+  const required: Array<[string, number | "atLeastOne"]> = [
+    // Structural handles — the driver bails out entirely without these.
+    ['data-mesh="section"', 1],
+    ["demo-panel", 1],
+    ["demo-graph", 1],
+    ["react-flow__viewport", 1],
+    // <Background> renders the pattern the camera has to keep in step.
+    ["<pattern", 1],
+    ["<circle", "atLeastOne"],
+    // Beat copy. `desc` is deliberately absent: it is optional per beat, and
+    // the driver already treats it as such.
+    ['data-mesh="title"', 1],
+    ['data-mesh="sub"', 1],
+    ['data-mesh="chapter"', 1],
+    // One wrapper, path, interaction path and label per edge; one card per node.
+    ["react-flow__node", NODE_IDS.length],
+    ["react-flow__edge-path", EDGE_IDS.length],
+    ["react-flow__edge-interaction", EDGE_IDS.length],
+    ["react-flow__edge-textwrapper", EDGE_IDS.length],
+    ["react-flow__edge-textbg", EDGE_IDS.length],
+    ["react-flow__edge-text", EDGE_IDS.length],
+  ];
+  for (let c = 0; c < BUILT_CHAPTERS; c++) required.push([`data-mesh-rail="${c}"`, 1]);
+  for (const id of NODE_IDS) required.push([`.react-flow__node[data-id="${id}"]`, 0]);
+  for (const id of EDGE_IDS) required.push([`.react-flow__edge[data-id="${id}"]`, 0]);
+
+  const bad: string[] = [];
+  for (const [sel, want] of required) {
+    // The per-element entries above are recorded as selectors for the error
+    // message; what is actually searched for is the attribute they match on.
+    const needle = sel.startsWith(".react-flow__") ? sel.slice(sel.indexOf("[") + 1, -1) : sel;
+    const got = count(needle);
+    if (want === "atLeastOne" ? got < 1 : want === 0 ? got < 1 : got !== want) {
+      bad.push(`  ${sel}: found ${got}, expected ${want === 0 ? "at least 1" : want}`);
+    }
+  }
+  if (bad.length) {
+    throw new Error(
+      "the prerendered shell is missing hooks the driver queries — it would mount, " +
+        "hide the placeholder and animate nothing:\n" +
+        bad.join("\n")
+    );
+  }
+  hookCount = required.length;
+}
+
+// ---------------------------------------------------------------------------
+// Beat copy — rendered through the SAME inline() the component uses
+// ---------------------------------------------------------------------------
+const beatCopy = BEATS.map((b) => ({
+  chapter: CHAPTERS[b.chapter],
+  title: b.title,
+  sub: renderToStaticMarkup(<>{inline(b.sub, SUB_INLINE)}</>),
+  desc: b.desc ? renderToStaticMarkup(<>{inline(b.desc, DESC_INLINE)}</>) : "",
+}));
+
+/** Per-beat edge stroke, so the driver never needs the graph builder. */
+const edgeStroke = BEATS.map((b) => {
+  const g = buildGraphFromAgents(buildWorld(b.world));
+  const m = new Map(g.edges.map((e) => [e.id, (e.style?.stroke as string) ?? "#6b7280"]));
+  return EDGE_IDS.map((id) => m.get(id) ?? "#6b7280");
+});
+
+const out = {
+  _comment:
+    "GENERATED by demo/emit.tsx. Static markup and animation tables for the " +
+    "prerendered bundle, rendered from the real <Stage>. Do not edit by hand.",
+  shell: shells[0],
+  nodeOrder: NODE_IDS,
+  edgeOrder: EDGE_IDS,
+  beatToState: BEAT_TO_STATE,
+  // Counts the driver's CSS variables are indexed by. Emitted so the
+  // equivalence harness can derive what to read instead of hardcoding it —
+  // a literal there would let a new chapter or phase go unnoticed by the
+  // comparison while it still printed IDENTICAL.
+  chapterCount: BUILT_CHAPTERS,
+  phaseCount: REVEAL.phases.length,
+  states,
+  cards,
+  beatCopy,
+  edgeStroke,
+};
+// Emitted into demo/generated/, which is gitignored, and BOTH halves of that
+// are load bearing.
+//
+// Ignored, because Tailwind v4's automatic source detection scans any text file
+// under the Vite root but skips ignored paths — and this file is 150 kB of
+// rendered markup. With it sitting in demo/ the DASHBOARD's stylesheet gained a
+// spurious utility rule, extracted from an arbitrary-value transition property
+// inside a badge's class attribute. (DO NOT NAME A UTILITY IN PROSE
+// ANYWHERE UNDER src/ui. The extractor reads comments, so an ordinary English
+// word that is also a Tailwind class emits a rule into the dashboard's
+// stylesheet. That has now happened three times here, each with a different
+// word, twice inside a comment explaining the problem. Avoid in prose:
+// visible, hidden, shadow, isolate, fixed, static, block, table, grid,
+// container, transform, filter, blur, border, ring. Verify with a dashboard
+// build and a stylesheet diff, never by eye.)
+//
+// Its OWN directory rather than demo/dist/, because vite.demo.config.ts builds
+// the React bundle into demo/dist/ with emptyOutDir — so writing it there meant
+// building the React bundle silently deleted the prerendered bundle's only
+// input, and the next type-check failed on a missing module.
+//
+// It is also a build artifact in the same sense the bundle is, regenerated by
+// CI on every deploy, so it has no business being committed either.
+fs.writeFileSync(path.join(HERE, "generated", "graph.json"), JSON.stringify(out));
+
+const kb = (n: number) => (n / 1024).toFixed(1).padStart(7) + " kB";
+console.log(`  prerender: ${pathOk}/${pathOk} edge paths match the captured fixture (2 states x 18)`);
+console.log(`  prerender: ${NODE_IDS.length} cards, ${variantCount} distinct variants, shell verified against the table`);
+console.log(`  prerender: ${hookCount} driver hooks present in the shell (selectors, node/edge ids, rail slots)`);
+if (process.argv.includes("--report")) {
+  console.log(`    shell markup   ${kb(shells[0].length)}`);
+  console.log(`    card variants  ${kb(JSON.stringify(cards).length)}`);
+  console.log(`    beat copy      ${kb(JSON.stringify(beatCopy).length)}`);
+  console.log(`    geometry       ${kb(JSON.stringify(states).length)}`);
+}

--- a/src/ui/demo/emit.tsx
+++ b/src/ui/demo/emit.tsx
@@ -22,10 +22,10 @@ import { ReactFlowProvider } from "@xyflow/react";
 import { AgentNode } from "@/components/topology/AgentNode";
 import { buildGraphFromAgents } from "@/lib/topology";
 import {
-  Stage, setSsrGeometry, inline, SUB_INLINE, DESC_INLINE, type SsrBox,
+  Stage, BeatCopy, setSsrGeometry, HANDLE_OFFSET, type SsrBox,
 } from "./stage";
 import {
-  BEATS, CHAPTERS, BUILT_CHAPTERS, REVEAL, buildWorld, MAXIMAL, MAXIMAL_REPLICAS,
+  BEATS, BUILT_CHAPTERS, REVEAL, buildWorld, MAXIMAL, MAXIMAL_REPLICAS,
   WEATHER_GROUP, EMBED_SHOWS_HEADER,
 } from "./script";
 
@@ -62,6 +62,21 @@ if (GEO.stateCount !== EXPECTED_STATES) {
   );
 }
 
+// The fixture carries its own copy of the handle offsets, and stage.tsx derives
+// every edge endpoint from ITS copy. Nothing compared the two, so the fixture
+// could be re-captured against a changed card and silently disagree with the
+// code that consumes it — the same class of drift the stateCount guard exists
+// to catch, on the other input.
+for (const k of ["source", "target"] as const) {
+  if (GEO.handleOffset[k] !== HANDLE_OFFSET[k]) {
+    throw new Error(
+      `geometry.json handleOffset.${k} is ${GEO.handleOffset[k]} but stage.tsx uses ` +
+        `${HANDLE_OFFSET[k]}. One of them was changed without the other; every edge ` +
+        `endpoint depends on this.`
+    );
+  }
+}
+
 const BEAT_TO_STATE = BEATS.map((_, i) => GEO.beatToState[String(i + 1)] ?? 0);
 const boxes = (state: number) =>
   new Map<string, SsrBox>(Object.entries(GEO.states[state].nodes));
@@ -78,7 +93,9 @@ function renderStage(state: number): string {
   }
 }
 
-const shells = [renderStage(0), renderStage(1)];
+// One shell per geometry state, derived from the fixture rather than written
+// out — a third state must not silently go unrendered.
+const shells = GEO.states.map((_, i) => renderStage(i));
 
 /** Split the markup into one chunk per edge <g>, keyed by data-id. */
 function edgeChunks(html: string): Map<string, string> {
@@ -302,14 +319,35 @@ let hookCount = 0;
 }
 
 // ---------------------------------------------------------------------------
-// Beat copy — rendered through the SAME inline() the component uses
+// Beat copy — rendered from the SAME component <Stage> mounts
 // ---------------------------------------------------------------------------
-const beatCopy = BEATS.map((b) => ({
-  chapter: CHAPTERS[b.chapter],
-  title: b.title,
-  sub: renderToStaticMarkup(<>{inline(b.sub, SUB_INLINE)}</>),
-  desc: b.desc ? renderToStaticMarkup(<>{inline(b.desc, DESC_INLINE)}</>) : "",
+// The driver replaces the whole copy block at each lead flip, so what it needs
+// is the markup, not the pieces. Rendering <BeatCopy> here rather than
+// rebuilding the four elements from hand-copied class strings is what makes
+// that safe: a type change in stage.tsx now reaches the shipped bundle by
+// construction instead of by somebody remembering.
+const beatCopy = BEATS.map((b, i) => ({
+  html: renderToStaticMarkup(<BeatCopy beat={b} lead={i} />),
 }));
+
+// EQUIVALENCE, LAYER 4: the copy the driver swaps in at beat 1 must BE the copy
+// already in the shell.
+//
+// HONEST SCOPE: this no longer catches class drift, and that is the point —
+// both sides render <BeatCopy>, so they cannot disagree about markup. Verified
+// by perturbing a class and watching this NOT fire, because both outputs moved
+// together. What it still catches is the shell and the table being rendered
+// from different beat data or a different lead, which is cheap to check and
+// would otherwise show up only as wrong copy on the first frame.
+{
+  const at = shells[0].indexOf(beatCopy[0].html);
+  if (at === -1) {
+    throw new Error(
+      "the beat-1 copy block the driver would swap in does not appear in the " +
+        "prerendered shell:\n  " + beatCopy[0].html.slice(0, 240)
+    );
+  }
+}
 
 /** Per-beat edge stroke, so the driver never needs the graph builder. */
 const edgeStroke = BEATS.map((b) => {
@@ -363,7 +401,11 @@ const out = {
 fs.writeFileSync(path.join(HERE, "generated", "graph.json"), JSON.stringify(out));
 
 const kb = (n: number) => (n / 1024).toFixed(1).padStart(7) + " kB";
-console.log(`  prerender: ${pathOk}/${pathOk} edge paths match the captured fixture (2 states x 18)`);
+const pathTotal = GEO.states.reduce((n, st) => n + Object.keys(st.edges).length, 0);
+console.log(
+  `  prerender: ${pathOk}/${pathTotal} edge paths match the captured fixture ` +
+    `(${GEO.stateCount} states x ${EDGE_IDS.length} edges)`
+);
 console.log(`  prerender: ${NODE_IDS.length} cards, ${variantCount} distinct variants, shell verified against the table`);
 console.log(`  prerender: ${hookCount} driver hooks present in the shell (selectors, node/edge ids, rail slots)`);
 if (process.argv.includes("--report")) {

--- a/src/ui/demo/equivalence.mjs
+++ b/src/ui/demo/equivalence.mjs
@@ -1,0 +1,373 @@
+// EQUIVALENCE CAPTURE — React bundle vs prerendered bundle, numerically.
+//
+//   make docs-scroll-compare          # terminal 1: builds both, serves :8899
+//   node demo/equivalence.mjs         # terminal 2: captures both and diffs
+//
+// WHAT THIS IS FOR. The settled frames are the easy case and the least
+// informative: the driver's job is the TRANSITIONS between them, which is where
+// three separate bugs hid during this build (the gated reveal, the sequential
+// handoff, the per-frame chapter scan). So the sample set is dominated by
+// intermediate positions, not snap targets.
+//
+// ROUNDING DISCIPLINE. Nothing here rounds. Every value compared is a string
+// the driver itself wrote — `.toFixed(3)`, `.toFixed(2)`, `rgb(r,g,b)` with
+// integer components, or a transform built from the same expression in both
+// builds. So the comparison is byte-exact by construction and a difference is
+// a real difference, not a float artifact. An epsilon comparator would have
+// hidden exactly the kind of drift this is meant to catch.
+// RUNNING IT — Playwright is deliberately not a dependency of src/ui, so it is
+// resolved from an existing install via MESH_PLAYWRIGHT. Two things bite here,
+// and BOTH fail in a way that reads like this script is broken:
+//
+//   1. The path has to be discovered. There is no canonical location:
+//        ls ~/.npm/_npx/*/node_modules/playwright/package.json
+//
+//   2. The candidate's browser revision must already be cached. A newer
+//      install wants a chromium build that may not be on disk — 1.63-alpha
+//      wants chromium 1237, 1.62.1 wants 1234 — and the launch failure names
+//      a missing executable rather than a version mismatch. Check the
+//      candidate against the cache before suspecting the harness — the wanted
+//      revision is in the candidate's own playwright-core:
+//        node -p "JSON.parse(require('fs').readFileSync('<dir>/playwright-core/browsers.json')).browsers.find(b=>b.name==='chromium').revision"
+//        ls ~/Library/Caches/ms-playwright
+//
+//   MESH_PLAYWRIGHT=~/.npm/_npx/<hash>/node_modules/ node equivalence.mjs
+
+import { createRequire } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+
+// Playwright is not a dependency of src/ui and should not become one for a
+// capture that runs by hand. MESH_PLAYWRIGHT points at any resolvable install
+// (an npx cache directory is fine); the browser build it wants must already be
+// in ~/Library/Caches/ms-playwright.
+const require_ = createRequire(process.env.MESH_PLAYWRIGHT ?? import.meta.url);
+const { chromium } = require_("playwright");
+
+// COUNTS ARE DERIVED, NEVER WRITTEN AS LITERALS. An earlier version hardcoded
+// 13 nodes / 18 edges / 5 chapters while the driver iterated
+// `G.nodeOrder.length`, so a fourteenth node would have gone unnoticed by this
+// comparison forever — and it would still have printed IDENTICAL. Reading the
+// same manifest the driver is handed makes that impossible.
+const G = JSON.parse(
+  fs.readFileSync(path.join(import.meta.dirname, "generated", "graph.json"), "utf8")
+);
+const NODE_IDS = G.nodeOrder;
+const EDGE_IDS = G.edgeOrder;
+const CHAPTER_COUNT = G.chapterCount;
+const PHASE_COUNT = G.phaseCount;
+
+const BASE = process.env.MESH_COMPARE_BASE ?? "http://localhost:8899/compare.html";
+const OUT = path.join(import.meta.dirname, "dist");
+// The viewport the geometry fixture was captured at. Changing it changes the
+// camera, so both sides must use the same one — that is the point.
+const VIEWPORT = { width: 1500, height: 900 };
+/** Intermediate samples across the pinned travel. */
+const SAMPLES = 200;
+
+async function capture(variant) {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: VIEWPORT });
+  const errors = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") errors.push(m.text());
+  });
+  page.on("pageerror", (e) => errors.push(String(e)));
+
+  await page.goto(`${BASE}?v=${variant}`, { waitUntil: "load" });
+  await page.waitForSelector('#mesh-scroll[data-mesh-scroll-mounted="1"]');
+  await page.waitForSelector('[data-mesh="section"]');
+  await page.evaluate(() => document.fonts.ready);
+  // React needs a commit after mount before the first frame is authoritative.
+  await page.waitForTimeout(300);
+
+  const frames = await page.evaluate(async ({ SAMPLES, NODE_IDS, EDGE_IDS, CHAPTER_COUNT, PHASE_COUNT }) => {
+    const section = document.querySelector('[data-mesh="section"]');
+    const panel = document.querySelector(".demo-panel");
+    const viewport = document.querySelector(".react-flow__viewport");
+    const top = window.scrollY + section.getBoundingClientRect().top;
+    const travel = section.getBoundingClientRect().height - window.innerHeight;
+
+    const raf = () => new Promise((r) => requestAnimationFrame(r));
+    const settle = async () => {
+      // Three frames: one for the scroll event, one for the driver's rAF tick,
+      // one for React to commit a lead change. The static build needs fewer;
+      // giving both the same budget keeps the comparison fair.
+      await raf();
+      await raf();
+      await raf();
+      await new Promise((r) => setTimeout(r, 20));
+    };
+
+    // Every custom property either build writes, by name. Read back off the
+    // inline style, so what is compared is literally what was written.
+    const names = [];
+    for (let i = 0; i < NODE_IDS.length; i++) names.push(`--n${i}-o`);
+    for (let i = 0; i < EDGE_IDS.length; i++) {
+      names.push(`--e${i}-o`, `--e${i}-l`, `--e${i}-w`, `--e${i}-c`);
+    }
+    names.push("--accent", "--pulse", "--gutter");
+    for (let c = 0; c < CHAPTER_COUNT; c++) names.push(`--ch${c}-f`);
+    names.push("--graph", "--rail", "--beat", "--reveal", "--cta");
+    for (let i = 0; i < PHASE_COUNT; i++) names.push(`--p${i}`);
+
+    const positions = [];
+    for (let i = 0; i <= SAMPLES; i++) positions.push(i / SAMPLES);
+
+    const out = [];
+    for (const p of positions) {
+      window.scrollTo(0, Math.round(top + p * travel));
+      await settle();
+      const vars = {};
+      for (const n of names) vars[n] = panel.style.getPropertyValue(n);
+      const title = document.querySelector('[data-mesh="title"]');
+      const sub = document.querySelector('[data-mesh="sub"]');
+      const desc = document.querySelector('[data-mesh="desc"]');
+      const chapter = document.querySelector('[data-mesh="chapter"]');
+      const pat = document.querySelector(".react-flow__background pattern");
+      const dot = document.querySelector(".react-flow__background circle");
+      // THE CARDS. This is what applyLead actually rewrites at the 14 flips,
+      // and the capture was blind to it: --n{i}-o is the WRAPPER's opacity, so
+      // an off-by-one in byBeat, a wrong FALLBACK, or a status colour landing a
+      // beat late would leave all of the custom properties byte-identical.
+      const cards = {};
+      for (const id of NODE_IDS) {
+        const node = document.querySelector(
+          `.react-flow__node[data-id="${CSS.escape(id)}"]`
+        );
+        const card = node && node.children[1];
+        cards[id] = card ? { cls: card.className, html: card.innerHTML } : null;
+      }
+      // THE EDGE LABELS. If measureLabels never succeeds these stay
+      // visibility:hidden in the static build while React shows them, and
+      // nothing else in this capture would notice.
+      const labels = {};
+      for (const id of EDGE_IDS) {
+        const g = document.querySelector(
+          `.react-flow__edge[data-id="${CSS.escape(id)}"]`
+        );
+        const w = g && g.querySelector(".react-flow__edge-textwrapper");
+        const t = g && g.querySelector(".react-flow__edge-text");
+        const r = g && g.querySelector(".react-flow__edge-textbg");
+        labels[id] = w
+          ? [
+              w.getAttribute("transform"),
+              w.getAttribute("visibility"),
+              t && t.getAttribute("y"),
+              r && r.getAttribute("width"),
+              r && r.getAttribute("height"),
+            ].join("|")
+          : null;
+      }
+      out.push({
+        p,
+        y: window.scrollY,
+        vars,
+        cards,
+        labels,
+        transform: viewport ? viewport.style.transform : null,
+        title: title ? title.textContent : null,
+        sub: sub ? sub.textContent : null,
+        desc: desc ? desc.textContent : null,
+        chapter: chapter ? chapter.textContent : null,
+        // The background is a pure function of the transform in both builds;
+        // if it drifts, the dots detach from the graph as it pans.
+        bg: pat
+          ? [
+              pat.getAttribute("x"), pat.getAttribute("y"),
+              pat.getAttribute("width"), pat.getAttribute("height"),
+              pat.getAttribute("patternTransform"),
+              dot && dot.getAttribute("r"),
+            ].join("|")
+          : null,
+        // Edge geometry: proves the B14 state switch lands on the same paths.
+        d: Array.from(document.querySelectorAll(".react-flow__edge-path"))
+          .map((el) => el.getAttribute("d"))
+          .join(";"),
+      });
+    }
+    return out;
+  }, { SAMPLES, NODE_IDS, EDGE_IDS, CHAPTER_COUNT, PHASE_COUNT });
+
+  await browser.close();
+  return { frames, errors };
+}
+
+const react = await capture("react");
+const stat = await capture("static");
+
+fs.mkdirSync(OUT, { recursive: true });
+// Card bodies are compared in full but written out as lengths: at 13 cards x
+// 2.6 kB x 201 positions the dumps would be ~7 MB each and nobody would open
+// them. The comparison above has already run against the full strings.
+const forDump = (frames) =>
+  frames.map((f) => ({
+    ...f,
+    cards: Object.fromEntries(
+      Object.entries(f.cards).map(([k, v]) => [k, v ? { cls: v.cls, htmlLen: v.html.length } : null])
+    ),
+  }));
+fs.writeFileSync(path.join(OUT, "equiv-react.json"), JSON.stringify(forDump(react.frames), null, 1));
+fs.writeFileSync(path.join(OUT, "equiv-static.json"), JSON.stringify(forDump(stat.frames), null, 1));
+
+const diffs = [];
+/** Half of the fixture's own 2dp rounding step — an order below a device pixel. */
+const PATH_TOLERANCE = 0.005;
+let maxPathDelta = 0;
+let pathCmp = 0;
+let cardCmp = 0;
+let labelCmp = 0;
+/** Covers React's own measured ~1.0px spread, with headroom. See the note below. */
+const LABEL_TOLERANCE = 1.25;
+let maxLabelDelta = 0;
+
+/** Offset of the first differing character, for a readable mismatch report. */
+const firstDiff = (x, y) => {
+  const n = Math.min(x.length, y.length);
+  for (let i = 0; i < n; i++) if (x[i] !== y[i]) return i;
+  return n;
+};
+const n = Math.min(react.frames.length, stat.frames.length);
+let varCmp = 0;
+for (let i = 0; i < n; i++) {
+  const a = react.frames[i];
+  const b = stat.frames[i];
+  const where = `p=${a.p.toFixed(4)} y=${a.y}`;
+  for (const k of Object.keys(a.vars)) {
+    varCmp++;
+    if (a.vars[k] !== b.vars[k]) {
+      diffs.push(`${where} ${k}: react="${a.vars[k]}" static="${b.vars[k]}"`);
+    }
+  }
+  // Cards: compared in FULL, not by a hash. A hash would tell us something
+  // changed; the class string is where the border colour lives and the body is
+  // where the badges and dependency counts do, so a mismatch should say what.
+  for (const id of Object.keys(a.cards)) {
+    const ca = a.cards[id];
+    const cb = b.cards[id];
+    cardCmp += 2;
+    if (!ca || !cb) {
+      if (ca !== cb) diffs.push(`${where} card ${id}: react=${ca ? "present" : "MISSING"} static=${cb ? "present" : "MISSING"}`);
+      continue;
+    }
+    if (ca.cls !== cb.cls) {
+      diffs.push(`${where} card ${id} class:\n    react  ${ca.cls}\n    static ${cb.cls}`);
+    }
+    if (ca.html !== cb.html) {
+      const at = firstDiff(ca.html, cb.html);
+      diffs.push(
+        `${where} card ${id} body differs at offset ${at}:\n` +
+          `    react  …${ca.html.slice(Math.max(0, at - 40), at + 60)}\n` +
+          `    static …${cb.html.slice(Math.max(0, at - 40), at + 60)}`
+      );
+    }
+  }
+  // EDGE LABELS: presence and VISIBILITY byte-exact, geometry within tolerance.
+  //
+  // Visibility is the whole point of capturing these — if the driver's getBBox
+  // measurement never succeeds, the labels stay visibility:hidden in the
+  // prerendered build while React shows them, and nothing else here would
+  // notice. That is never tolerated; it is compared as a string.
+  //
+  // THE GEOMETRY TOLERANCE IS SET BY REACT'S OWN INSTABILITY, not by what the
+  // prerendered build happens to need. React Flow re-measures every label with
+  // getBBox on re-render, and Chrome returns zoom-dependent metrics for this
+  // variable font, so the SAME label in the SAME build reports a background
+  // box of 17, 17.290690422058105 and 16.298681259155273 at different scroll
+  // positions — a spread of ~1.0px. The prerendered build measures once and
+  // holds 17.10344696044922 everywhere, which sits INSIDE that range.
+  //
+  // So this is not the static build approximating React; it is React
+  // disagreeing with itself by more than the two builds disagree, and the
+  // static build being the stable one. Demanding byte-equality here would be
+  // demanding that it reproduce a zoom-dependent measurement artifact.
+  // Measured with demo/ scratch probes: every text-affecting computed style
+  // (fontFamily, letterSpacing, fontVariationSettings, textRendering, and
+  // eleven others) is identical between the builds, so this is Chrome's text
+  // metrics under transform, not a styling divergence.
+  for (const id of Object.keys(a.labels)) {
+    labelCmp++;
+    const la = a.labels[id];
+    const lb = b.labels[id];
+    if (la === null || lb === null) {
+      if (la !== lb) diffs.push(`${where} edge label ${id}: react=${la} static=${lb}`);
+      continue;
+    }
+    const va = /\|(visible|hidden)\|/.exec(la);
+    const vb = /\|(visible|hidden)\|/.exec(lb);
+    if ((va && va[1]) !== (vb && vb[1])) {
+      diffs.push(`${where} edge label ${id} VISIBILITY: react=${va && va[1]} static=${vb && vb[1]}`);
+    }
+    const na = la.match(/-?\d+\.?\d*/g) ?? [];
+    const nb = lb.match(/-?\d+\.?\d*/g) ?? [];
+    if (na.length !== nb.length) {
+      diffs.push(`${where} edge label ${id}: field count differs\n    react  ${la}\n    static ${lb}`);
+      continue;
+    }
+    for (let j = 0; j < na.length; j++) {
+      const delta = Math.abs(Number(na[j]) - Number(nb[j]));
+      if (delta > maxLabelDelta) maxLabelDelta = delta;
+      if (delta > LABEL_TOLERANCE) {
+        diffs.push(`${where} edge label ${id}[${j}]: react ${na[j]} static ${nb[j]} (delta ${delta})`);
+      }
+    }
+  }
+
+  for (const k of ["transform", "title", "sub", "desc", "chapter", "bg"]) {
+    if (a[k] !== b[k]) {
+      const trim = (v) => (v === null ? "null" : String(v).slice(0, 120));
+      diffs.push(`${where} ${k}:\n    react  ${trim(a[k])}\n    static ${trim(b[k])}`);
+    }
+  }
+
+  // EDGE PATHS ARE THE ONE FIELD COMPARED NUMERICALLY, and the reason is a
+  // property of the React build, not a concession by the prerendered one.
+  // React Flow derives handle positions from live ResizeObserver measurements,
+  // which carry ~4e-4 px of jitter that varies BETWEEN RUNS of the same build —
+  // `120.00036184105772` where the geometry is exactly 120. The prerendered
+  // build has no observer and emits the exact value. Demanding byte-equality
+  // here would be demanding that the static build reproduce noise.
+  //
+  // The fixture already takes this position: it rounds at capture precisely so
+  // this jitter "must never reach" the compared values. So: same path count,
+  // same structure, and every coordinate within a tolerance far below one
+  // device pixel.
+  const na = (a.d ?? "").match(/-?\d+\.?\d*/g) ?? [];
+  const nb = (b.d ?? "").match(/-?\d+\.?\d*/g) ?? [];
+  if (na.length !== nb.length) {
+    diffs.push(`${where} d: coordinate COUNT differs — react ${na.length}, static ${nb.length}`);
+  } else {
+    for (let j = 0; j < na.length; j++) {
+      const delta = Math.abs(Number(na[j]) - Number(nb[j]));
+      if (delta > maxPathDelta) maxPathDelta = delta;
+      if (delta > PATH_TOLERANCE) {
+        diffs.push(`${where} d[${j}]: react ${na[j]} static ${nb[j]} (delta ${delta})`);
+      }
+    }
+    pathCmp += na.length;
+  }
+}
+
+console.log(`sampled ${n} positions x ${Object.keys(react.frames[0].vars).length} custom properties`);
+console.log(`compared ${varCmp} custom-property values + ${n * 6} other fields`);
+console.log(`compared ${cardCmp} card class/body values across ${NODE_IDS.length} cards`);
+console.log(`compared ${labelCmp} edge-label states across ${EDGE_IDS.length} edges (visibility exact, geometry max deviation ${maxLabelDelta.toFixed(4)} px, tolerance ${LABEL_TOLERANCE})`);
+console.log(`compared ${pathCmp} edge-path coordinates, max deviation ${maxPathDelta} px (tolerance ${PATH_TOLERANCE})`);
+// A throwing driver must not be able to pass a script whose exit code is its
+// verdict. These were previously printed and then ignored.
+if (react.errors.length) {
+  console.log(`react console/page errors:  ${react.errors.length}\n  ${react.errors.join("\n  ")}`);
+  process.exitCode = 1;
+}
+if (stat.errors.length) {
+  console.log(`static console/page errors: ${stat.errors.length}\n  ${stat.errors.join("\n  ")}`);
+  process.exitCode = 1;
+}
+if (!diffs.length) {
+  console.log("\nIDENTICAL — no differing value at any sampled position.");
+} else {
+  console.log(`\n${diffs.length} DIFFERENCES:`);
+  for (const d of diffs.slice(0, 80)) console.log("  " + d);
+  if (diffs.length > 80) console.log(`  ... and ${diffs.length - 80} more`);
+  process.exitCode = 1;
+}

--- a/src/ui/demo/equivalence.mjs
+++ b/src/ui/demo/equivalence.mjs
@@ -142,6 +142,7 @@ async function capture(variant) {
       // visibility:hidden in the static build while React shows them, and
       // nothing else in this capture would notice.
       const labels = {};
+      const labelBox = {};
       for (const id of EDGE_IDS) {
         const g = document.querySelector(
           `.react-flow__edge[data-id="${CSS.escape(id)}"]`
@@ -158,6 +159,10 @@ async function capture(variant) {
               r && r.getAttribute("height"),
             ].join("|")
           : null;
+        // The live box, so the harness can check the wrapper is actually
+        // CENTRED on it rather than only that both builds agree.
+        const bb = t && t.getBBox();
+        labelBox[id] = bb ? [bb.width, bb.height] : null;
       }
       out.push({
         p,
@@ -165,6 +170,7 @@ async function capture(variant) {
         vars,
         cards,
         labels,
+        labelBox,
         transform: viewport ? viewport.style.transform : null,
         title: title ? title.textContent : null,
         sub: sub ? sub.textContent : null,
@@ -209,6 +215,18 @@ const forDump = (frames) =>
   }));
 fs.writeFileSync(path.join(OUT, "equiv-react.json"), JSON.stringify(forDump(react.frames), null, 1));
 fs.writeFileSync(path.join(OUT, "equiv-static.json"), JSON.stringify(forDump(stat.frames), null, 1));
+
+// FRAME COUNTS MUST MATCH. `Math.min` below would otherwise compare the
+// shorter run and report IDENTICAL — the same fail-open class as swallowing
+// ImageMagick's errors. If one build produced fewer frames, something went
+// wrong in it and that is the finding.
+if (react.frames.length !== stat.frames.length) {
+  console.error(
+    `frame count differs: react ${react.frames.length}, static ${stat.frames.length}. ` +
+      `The two runs are not comparable; refusing to report a verdict.`
+  );
+  process.exit(1);
+}
 
 const diffs = [];
 /** Half of the fixture's own 2dp rounding step — an order below a device pixel. */
@@ -345,6 +363,57 @@ for (let i = 0; i < n; i++) {
       }
     }
     pathCmp += na.length;
+  }
+}
+
+// LABEL CENTRING, CHECKED AGAINST THE FIXTURE — not against the other build.
+//
+// This exists because a real bug got past the cross-build comparison: the
+// driver wrote every label's wrapper transform BEFORE it had measured the
+// label, centring each one on a 0x0 box, and its `state === geomState` guard
+// then blocked any re-application. Every label sat half its own box off centre.
+// The harness reported IDENTICAL throughout, because it only ever asked
+// "do the two builds agree?" — and React's first frame has the same ordering,
+// so both were wrong together.
+//
+// The fix in the harness is to compare against something that is NOT the other
+// renderer: React Flow's own rule is transform = (labelX - w/2, labelY - h/2),
+// labelX/labelY come from the fixture, and w/h are measured live. A stale
+// transform fails this no matter what the other build does.
+{
+  const byState = G.states.map((st) => st.label);
+  let checked = 0;
+  let worstOff = 0;
+  const off = [];
+  for (const [name, cap] of [["react", react], ["static", stat]]) {
+    for (const f of cap.frames) {
+      for (const id of EDGE_IDS) {
+        const raw = f.labels[id];
+        const box = f.labelBox[id];
+        if (!raw || !box || !box[0]) continue;
+        const m = /translate\(([-\d.]+) ([-\d.]+)\)/.exec(raw);
+        if (!m) continue;
+        checked++;
+        // Accept a match against either geometry state: which one is live at a
+        // given frame is the driver's business, and a half-box offset matches
+        // neither.
+        const best = Math.min(
+          ...byState.map((L) =>
+            L[id] ? Math.max(Math.abs(+m[1] - (L[id][0] - box[0] / 2)), Math.abs(+m[2] - (L[id][1] - box[1] / 2))) : Infinity
+          )
+        );
+        if (best > worstOff) worstOff = best;
+        if (best > LABEL_TOLERANCE) {
+          off.push(`  ${name} p=${f.p.toFixed(4)} ${id}: ${best.toFixed(3)} px off centre`);
+        }
+      }
+    }
+  }
+  console.log(`checked ${checked} label centrings against the fixture, worst ${worstOff.toFixed(4)} px off centre`);
+  if (off.length) {
+    console.log(`${off.length} LABELS NOT CENTRED ON THEIR OWN BOX:`);
+    for (const l of off.slice(0, 20)) console.log(l);
+    process.exitCode = 1;
   }
 }
 

--- a/src/ui/demo/geometry.json
+++ b/src/ui/demo/geometry.json
@@ -1,0 +1,90 @@
+{
+  "_comment": "Ground-truth graph geometry captured from the running React Flow build. Source of truth for the prerender's equivalence check — NOT for generation (the emitter regenerates from AgentNode + beat data so it cannot silently rot). Captured with getComputedStyle().width/.height, NOT offsetWidth/Height (which rounds 117.5 -> 118 and pushes half a pixel into every connected edge endpoint) and NOT getBoundingClientRect (which includes the camera zoom transform). All d coordinates rounded to 2dp AT CAPTURE: raw values carry ~5e-5 px ResizeObserver jitter that is non-deterministic and must never reach a file. Round at capture, round in the emitter, then compare byte-exact.",
+  "capturedAt": "2026-08-14",
+  "viewport": [1500, 900],
+  "handleOffset": { "source": 4, "target": -4, "_verified": "gateway h=94 at y=0 -> source y=98; planner at y=240 -> target y=236. Symmetric." },
+  "stateCount": 2,
+  "beatToState": {
+    "1": 0, "2": 0, "3": 0, "4": 0, "5": 0, "6": 0, "7": 0,
+    "8": 0, "9": 0, "10": 0, "11": 0, "12": 0, "13": 0, "14": 1
+  },
+  "states": [
+    {
+      "firstBeat": 1,
+      "nodes": {
+        "flight-agent-ba2b3bc8": { "w": 240, "h": 94, "transform": "translate(0px, 480px)" },
+        "hotel-agent-91af6b30": { "w": 240, "h": 94, "transform": "translate(360px, 480px)" },
+        "poi-agent-2f88c614": { "w": 240, "h": 94, "transform": "translate(720px, 480px)" },
+        "user-prefs-agent-4c17d9e2": { "w": 244.781, "h": 94, "transform": "translate(0px, 720px)" },
+        "weather-agent-7d3e05a1": { "w": 240, "h": 94, "transform": "translate(360px, 720px)" },
+        "planner-agent-d50a7712": { "w": 240, "h": 94, "transform": "translate(720px, 240px)" },
+        "claude-provider-8b3f4c90": { "w": 240.469, "h": 94, "transform": "translate(1080px, 480px)" },
+        "openai-provider-e62a1d47": { "w": 240, "h": 94, "transform": "translate(1440px, 480px)" },
+        "gateway-0a4e77c3": { "w": 240, "h": 94, "transform": "translate(720px, 0px)" },
+        "budget-analyst-5f21b8e6": { "w": 240, "h": 94, "transform": "translate(720px, 720px)" },
+        "adventure-advisor-c93d20af": { "w": 256.141, "h": 94, "transform": "translate(1080px, 720px)" },
+        "logistics-planner-71e4a9d2": { "w": 243.984, "h": 94, "transform": "translate(1440px, 720px)" },
+        "group:weather-agent": { "w": 240, "h": 94, "transform": "translate(360px, 720px)" }
+      },
+      "edges": {
+        "dep|flight-agent-ba2b3bc8|user-prefs-agent-4c17d9e2|user_preferences": "M120,578 C120,647 122.39,647 122.39,716",
+        "dep|poi-agent-2f88c614|weather-agent-7d3e05a1|weather_forecast": "M840,578 C840,647 480,647 480,716",
+        "dep|planner-agent-d50a7712|user-prefs-agent-4c17d9e2|user_preferences": "M840,338 C840,527 122.39,527 122.39,716",
+        "dep|planner-agent-d50a7712|budget-analyst-5f21b8e6|budget_analysis": "M840,338 C840,527 840,527 840,716",
+        "dep|planner-agent-d50a7712|adventure-advisor-c93d20af|adventure_advice": "M840,338 C840,527 1208.06,527 1208.06,716",
+        "dep|planner-agent-d50a7712|logistics-planner-71e4a9d2|logistics_planning": "M840,338 C840,527 1561.98,527 1561.98,716",
+        "llm|planner-agent-d50a7712|flight-agent-ba2b3bc8|llm:flight_search": "M840,338 C840,407 120,407 120,476",
+        "llm|planner-agent-d50a7712|hotel-agent-91af6b30|llm:hotel_search": "M840,338 C840,407 480,407 480,476",
+        "llm|planner-agent-d50a7712|weather-agent-7d3e05a1|llm:weather_forecast": "M840,338 C840,527 480,527 480,716",
+        "llm|planner-agent-d50a7712|poi-agent-2f88c614|llm:poi_search": "M840,338 C840,407 840,407 840,476",
+        "prov|planner-agent-d50a7712|claude-provider-8b3f4c90|provider:llm": "M840,338 C840,407 1200.23,407 1200.23,476",
+        "prov|planner-agent-d50a7712|openai-provider-e62a1d47|provider:llm": "M840,338 C840,407 1560,407 1560,476",
+        "dep|gateway-0a4e77c3|planner-agent-d50a7712|trip_planning": "M840,98 C840,167 840,167 840,236",
+        "prov|budget-analyst-5f21b8e6|claude-provider-8b3f4c90|provider:llm": "M840,818 C840,933.58 1200.23,360.42 1200.23,476",
+        "prov|adventure-advisor-c93d20af|claude-provider-8b3f4c90|provider:llm": "M1208.06,818 C1208.06,933.58 1200.23,360.42 1200.23,476",
+        "prov|logistics-planner-71e4a9d2|claude-provider-8b3f4c90|provider:llm": "M1561.98,818 C1561.98,933.58 1200.23,360.42 1200.23,476",
+        "dep|poi-agent-2f88c614|group:weather-agent|weather_forecast": "M840,578 C840,647 480,647 480,716",
+        "llm|planner-agent-d50a7712|group:weather-agent|llm:weather_forecast": "M840,338 C840,527 480,527 480,716"
+      }
+    },
+    {
+      "firstBeat": 14,
+      "_differsBy": "planner-agent, adventure-advisor, logistics-planner expand to 280x117.5 and budget-analyst to 279x94 when AgentBadges chips are added. Three wrap to a second badge row (+23.5px).",
+      "nodes": {
+        "flight-agent-ba2b3bc8": { "w": 240, "h": 94, "transform": "translate(0px, 480px)" },
+        "hotel-agent-91af6b30": { "w": 240, "h": 94, "transform": "translate(360px, 480px)" },
+        "poi-agent-2f88c614": { "w": 240, "h": 94, "transform": "translate(720px, 480px)" },
+        "user-prefs-agent-4c17d9e2": { "w": 244.781, "h": 94, "transform": "translate(0px, 720px)" },
+        "weather-agent-7d3e05a1": { "w": 240, "h": 94, "transform": "translate(360px, 720px)" },
+        "planner-agent-d50a7712": { "w": 280, "h": 117.5, "transform": "translate(720px, 240px)" },
+        "claude-provider-8b3f4c90": { "w": 240.469, "h": 94, "transform": "translate(1080px, 480px)" },
+        "openai-provider-e62a1d47": { "w": 240, "h": 94, "transform": "translate(1440px, 480px)" },
+        "gateway-0a4e77c3": { "w": 240, "h": 94, "transform": "translate(720px, 0px)" },
+        "budget-analyst-5f21b8e6": { "w": 279, "h": 94, "transform": "translate(720px, 720px)" },
+        "adventure-advisor-c93d20af": { "w": 280, "h": 117.5, "transform": "translate(1080px, 720px)" },
+        "logistics-planner-71e4a9d2": { "w": 280, "h": 117.5, "transform": "translate(1440px, 720px)" },
+        "group:weather-agent": { "w": 240, "h": 94, "transform": "translate(360px, 720px)" }
+      },
+      "edges": {
+        "dep|flight-agent-ba2b3bc8|user-prefs-agent-4c17d9e2|user_preferences": "M120,578 C120,647 122.39,647 122.39,716",
+        "dep|poi-agent-2f88c614|weather-agent-7d3e05a1|weather_forecast": "M840,578 C840,647 480,647 480,716",
+        "dep|planner-agent-d50a7712|user-prefs-agent-4c17d9e2|user_preferences": "M860,361.5 C860,538.75 122.39,538.75 122.39,716",
+        "dep|planner-agent-d50a7712|budget-analyst-5f21b8e6|budget_analysis": "M860,361.5 C860,538.75 859.5,538.75 859.5,716",
+        "dep|planner-agent-d50a7712|adventure-advisor-c93d20af|adventure_advice": "M860,361.5 C860,538.75 1220,538.75 1220,716",
+        "dep|planner-agent-d50a7712|logistics-planner-71e4a9d2|logistics_planning": "M860,361.5 C860,538.75 1580,538.75 1580,716",
+        "llm|planner-agent-d50a7712|flight-agent-ba2b3bc8|llm:flight_search": "M860,361.5 C860,418.75 120,418.75 120,476",
+        "llm|planner-agent-d50a7712|hotel-agent-91af6b30|llm:hotel_search": "M860,361.5 C860,418.75 480,418.75 480,476",
+        "llm|planner-agent-d50a7712|weather-agent-7d3e05a1|llm:weather_forecast": "M860,361.5 C860,538.75 480,538.75 480,716",
+        "llm|planner-agent-d50a7712|poi-agent-2f88c614|llm:poi_search": "M860,361.5 C860,418.75 840,418.75 840,476",
+        "prov|planner-agent-d50a7712|claude-provider-8b3f4c90|provider:llm": "M860,361.5 C860,418.75 1200.23,418.75 1200.23,476",
+        "prov|planner-agent-d50a7712|openai-provider-e62a1d47|provider:llm": "M860,361.5 C860,418.75 1560,418.75 1560,476",
+        "dep|gateway-0a4e77c3|planner-agent-d50a7712|trip_planning": "M840,98 C840,167 860,167 860,236",
+        "prov|budget-analyst-5f21b8e6|claude-provider-8b3f4c90|provider:llm": "M859.5,818 C859.5,933.58 1200.23,360.42 1200.23,476",
+        "prov|adventure-advisor-c93d20af|claude-provider-8b3f4c90|provider:llm": "M1220,841.5 C1220,960.99 1200.23,356.51 1200.23,476",
+        "prov|logistics-planner-71e4a9d2|claude-provider-8b3f4c90|provider:llm": "M1580,841.5 C1580,960.99 1200.23,356.51 1200.23,476",
+        "dep|poi-agent-2f88c614|group:weather-agent|weather_forecast": "M840,578 C840,647 480,647 480,716",
+        "llm|planner-agent-d50a7712|group:weather-agent|llm:weather_forecast": "M860,361.5 C860,538.75 480,538.75 480,716"
+      }
+    }
+  ]
+}

--- a/src/ui/demo/screenshots.mjs
+++ b/src/ui/demo/screenshots.mjs
@@ -1,0 +1,217 @@
+// PIXEL EQUIVALENCE — the layer the numeric capture cannot reach.
+//
+//   make docs-scroll-compare              # terminal 1
+//   node demo/screenshots.mjs             # terminal 2
+//
+// equivalence.mjs proves both builds compute the same numbers. It says nothing
+// about whether those numbers land on the same pixels: the prerendered markup
+// came out of a server render, so a missing class, a dropped attribute or a
+// wrapper element that React adds on mount would leave every custom property
+// identical and still change the picture.
+//
+// So this screenshots both builds across the whole travel and diffs them with
+// ImageMagick. Output lands in demo/dist/shots/ so any failure can be looked at
+// rather than just counted.
+//
+// THREE METRICS, BECAUSE ONE OF THEM LIES. AE counts every pixel that differs
+// by even 1/255, so a uniform rounding difference in how a semi-transparent
+// card is composited lights up the card's entire area and reports tens of
+// thousands of "differences" that no one can see. AE alone reported 38,638
+// differing pixels on a pair of frames that are indistinguishable by eye, and
+// whose worst single pixel is 9/255 apart. PAE (worst pixel) and RMSE
+// (frame-wide) are what make that judgeable, so all three are printed.
+//
+// AND RUN THE CONTROL. The React build is NOT pixel-deterministic across runs
+// of ITSELF — measured at 5/41 frames differing, one by 9,248 px — because
+// live ResizeObserver measurements carry sub-milli-pixel jitter that moves
+// antialiasing. Any cross-build number below that floor means nothing. Pass
+// --self=react to reproduce the control before trusting a comparison.
+// RUNNING IT — Playwright is deliberately not a dependency of src/ui, so it is
+// resolved from an existing install via MESH_PLAYWRIGHT. Two things bite here,
+// and BOTH fail in a way that reads like this script is broken:
+//
+//   1. The path has to be discovered. There is no canonical location:
+//        ls ~/.npm/_npx/*/node_modules/playwright/package.json
+//
+//   2. The candidate's browser revision must already be cached. A newer
+//      install wants a chromium build that may not be on disk — 1.63-alpha
+//      wants chromium 1237, 1.62.1 wants 1234 — and the launch failure names
+//      a missing executable rather than a version mismatch. Check the
+//      candidate against the cache before suspecting the harness — the wanted
+//      revision is in the candidate's own playwright-core:
+//        node -p "JSON.parse(require('fs').readFileSync('<dir>/playwright-core/browsers.json')).browsers.find(b=>b.name==='chromium').revision"
+//        ls ~/Library/Caches/ms-playwright
+//
+//   MESH_PLAYWRIGHT=~/.npm/_npx/<hash>/node_modules/ node screenshots.mjs
+
+import { createRequire } from "node:module";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const require_ = createRequire(process.env.MESH_PLAYWRIGHT ?? import.meta.url);
+const { chromium } = require_("playwright");
+
+const BASE = process.env.MESH_COMPARE_BASE ?? "http://localhost:8899/compare.html";
+const OUT = path.join(import.meta.dirname, "dist", "shots");
+const VIEWPORT = { width: 1500, height: 900 };
+
+/**
+ * Where to look. The settled beat frames are the frames a reader stops on, and
+ * the mid-transition samples are where a renderer difference would show up as
+ * a element that moved rather than one that is missing. 0.5-steps through the
+ * whole travel gives both.
+ */
+const STOPS = [];
+for (let i = 0; i <= 40; i++) STOPS.push(i / 40);
+
+async function shoot(variant, tag = variant) {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: VIEWPORT, deviceScaleFactor: 1 });
+  await page.goto(`${BASE}?v=${variant}`, { waitUntil: "load" });
+  await page.waitForSelector('#mesh-scroll[data-mesh-scroll-mounted="1"]');
+  await page.evaluate(() => document.fonts.ready);
+  await page.waitForTimeout(400);
+
+  const geom = await page.evaluate(() => {
+    const s = document.querySelector('[data-mesh="section"]').getBoundingClientRect();
+    return { top: window.scrollY + s.top, travel: s.height - window.innerHeight };
+  });
+
+  const files = [];
+  for (let i = 0; i < STOPS.length; i++) {
+    await page.evaluate(
+      ([y]) => window.scrollTo(0, y),
+      [Math.round(geom.top + STOPS[i] * geom.travel)]
+    );
+    // Let the driver paint, and let the card colour transition (300ms) finish
+    // so the two builds are compared at rest rather than mid-ease.
+    await page.waitForTimeout(450);
+    const f = path.join(OUT, `${tag}-${String(i).padStart(2, "0")}.png`);
+    await page.screenshot({ path: f });
+    files.push(f);
+  }
+  await browser.close();
+  return files;
+}
+
+// PREFLIGHT. Without this the first real failure mode is a silent one: no
+// ImageMagick means no comparison, and a harness that cannot compare must say
+// so before it spends two minutes taking screenshots.
+try {
+  execFileSync("compare", ["-version"], { stdio: ["ignore", "pipe", "pipe"] });
+} catch (e) {
+  console.error(
+    e.code === "ENOENT"
+      ? "ImageMagick's `compare` is not on PATH. Install it (brew install imagemagick).\n" +
+          "This script verifies nothing without it, so it will not pretend to run."
+      : `ImageMagick's \`compare\` is present but not runnable: ${e.message}`
+  );
+  process.exit(2);
+}
+
+fs.rmSync(OUT, { recursive: true, force: true });
+fs.mkdirSync(OUT, { recursive: true });
+
+// --self=<variant> shoots the SAME bundle twice. That is the control: it
+// measures how much this page differs from itself between two runs, which is
+// the floor any cross-build number has to clear to mean anything.
+const selfArg = process.argv.find((x) => x.startsWith("--self="));
+const self = selfArg ? selfArg.slice("--self=".length) : null;
+// Named by role so a diff file says which bundle it came from. In control
+// mode both runs are the same bundle, so they need distinguishing suffixes.
+const a = await shoot(self ?? "react", self ? `${self}-run1` : "react");
+const b = await shoot(self ?? "static", self ? `${self}-run2` : "static");
+if (self) console.log(`CONTROL: ${self} vs itself\n`);
+
+let worst = 0;
+let worstAt = "";
+let clean = 0;
+const bad = [];
+for (let i = 0; i < a.length; i++) {
+  const diff = path.join(OUT, `diff-${String(i).padStart(2, "0")}.png`);
+  const metric = (m, out) => {
+    // spawnSync, not execFileSync: `compare` writes the metric to STDERR in
+    // both cases and signals "images differ" with a non-zero exit, so the
+    // value has to be read on the success path too. execFileSync only hands
+    // back stdout on success, which made an identical pair parse as null —
+    // correct by accident under the old `|| 0`, and undetectable when it was
+    // not.
+    const r = spawnSync("compare", ["-metric", m, a[i], b[i], out ?? "null:"], {
+      encoding: "utf8",
+    });
+    // FAIL LOUD, NOT OPEN. Every branch below used to collapse to 0 — a
+    // PERFECT PASS having compared nothing. This is the only layer that checks
+    // whether anything painted; it must never report success it did not earn.
+    if (r.error) {
+      if (r.error.code === "ENOENT") {
+        throw new Error(
+          "ImageMagick's `compare` is not on PATH. Install it (brew install imagemagick) — " +
+            "this script cannot verify anything without it."
+        );
+      }
+      throw new Error(`\`compare\` could not be run: ${r.error.message}`);
+    }
+    // 0 = identical, 1 = differ. Anything else is a real error: a dimension
+    // mismatch, an unreadable file, a permission problem.
+    if (r.status !== 0 && r.status !== 1) {
+      throw new Error(
+        `\`compare -metric ${m}\` failed (status ${r.status}) on ` +
+          `${path.basename(a[i])} vs ${path.basename(b[i])}: ${String(r.stderr).trim().slice(0, 200)}`
+      );
+    }
+    // ImageMagick prints `<raw> (<normalized>)` for PAE and RMSE, and a bare
+    // integer for AE. The NORMALIZED value is used wherever it exists, which
+    // removes the quantum-depth question entirely: an earlier version divided
+    // by a hardcoded 65535, which is right for a Q16 build and understates the
+    // figure ~256x on Q8 — and that figure is exactly what was used to call
+    // the difference imperceptible.
+    const text = `${r.stderr ?? ""} ${r.stdout ?? ""}`.trim();
+    const first = Number(text.split(/\s+/)[0]);
+    // A genuine 0 and a parse failure are NOT the same thing.
+    if (!Number.isFinite(first)) {
+      throw new Error(
+        `could not parse \`compare -metric ${m}\` output for ` +
+          `${path.basename(a[i])}: ${JSON.stringify(text.slice(0, 200))}`
+      );
+    }
+    if (m === "AE") return first;
+    const norm = /\(([-\d.eE+]+)\)/.exec(text);
+    if (!norm || !Number.isFinite(Number(norm[1]))) {
+      throw new Error(
+        `\`compare -metric ${m}\` gave no normalized value for ${path.basename(a[i])}: ` +
+          `${JSON.stringify(text.slice(0, 200))}. Refusing to guess the quantum depth.`
+      );
+    }
+    return Number(norm[1]);
+  };
+  const px = metric("AE", diff);
+  const pae = px ? metric("PAE") : 0;
+  const rmse = px ? metric("RMSE") : 0;
+  if (px === 0) {
+    clean++;
+    fs.rmSync(diff, { force: true });
+  } else {
+    bad.push(
+      `  stop ${i} (p=${STOPS[i].toFixed(3)}): ${px} px differ, ` +
+        `worst pixel ${(pae * 100).toFixed(2)}%, frame RMSE ${(rmse * 100).toFixed(4)}%  ` +
+        `-> ${path.basename(diff)}`
+    );
+    if (px > worst) {
+      worst = px;
+      worstAt = `stop ${i}`;
+    }
+  }
+}
+
+const total = VIEWPORT.width * VIEWPORT.height;
+console.log(`${a.length} frames compared at ${VIEWPORT.width}x${VIEWPORT.height}`);
+console.log(`${clean}/${a.length} pixel-identical`);
+if (self && bad.length) {
+  console.log("this is the NOISE FLOOR — cross-build differences at or below it are not attributable");
+}
+if (bad.length) {
+  console.log(bad.join("\n"));
+  console.log(`worst: ${worst} px at ${worstAt} = ${((worst / total) * 100).toFixed(4)}% of the frame`);
+  process.exitCode = 1;
+}

--- a/src/ui/demo/screenshots.mjs
+++ b/src/ui/demo/screenshots.mjs
@@ -213,5 +213,8 @@ if (self && bad.length) {
 if (bad.length) {
   console.log(bad.join("\n"));
   console.log(`worst: ${worst} px at ${worstAt} = ${((worst / total) * 100).toFixed(4)}% of the frame`);
-  process.exitCode = 1;
+  // In CONTROL mode a difference is the measurement, not a failure — the whole
+  // point is to find out how much this page differs from itself. Only a
+  // cross-build run has a verdict to fail.
+  if (!self) process.exitCode = 1;
 }

--- a/src/ui/demo/stage.tsx
+++ b/src/ui/demo/stage.tsx
@@ -18,6 +18,7 @@ import {
   ReactFlow,
   Background,
   BackgroundVariant,
+  Position,
   type Node,
   type Edge,
   type ReactFlowInstance,
@@ -38,76 +39,28 @@ import {
   SPACER_VH,
   REVEAL,
   REVEAL_VH,
-  CUM,
+  HOTEL,
   WEATHER,
   WEATHER_GROUP,
-  FLIGHT, HOTEL, POI, PREFS, PLANNER, CLAUDE, OPENAI, GATEWAY,
-  BUDGET, ADVENTURE, LOGISTICS,
 } from "./script";
+import {
+  clamp, smoothstep, lerp, lerpColor, POS, camFor, GUTTER, LEAD_FLIP,
+  restWidth, totalTravel, rawFromVh, R_CLEAR, R_BEAT_OUT, R_HEAD, R_PHASE_0,
+  R_PHASE_STEP, R_PHASE_SPAN, R_OUT, R_CTA, SNAP_VH, CHAPTER_VH, CHAPTER_SPAN,
+  TEXT_ENTRY, ACTIVATABLE,
+} from "./timeline";
 
 const nodeTypes = { agentNode: AgentNode };
 
-// Mirrors applyDagreLayout's constants in lib/topology.ts.
-const NODE_W = 280;
-const NODE_H = 140;
 const N = BEATS.length;
 
-// ---------------------------------------------------------------------------
-// Canonical layout — one dagre pass over the maximal graph.
-// ---------------------------------------------------------------------------
-// Two builds: the single-instance world (which supplies the dagre positions)
-// and the replica-collapsed world, whose weather node/edges carry different
-// ids (`group:weather-agent`). Both variants live in the stable graph at once;
-// per-beat opacity picks which one is on screen. The group node inherits the
-// single node's canonical position so the swap has no motion at all.
+// Two builds: the single-instance world (which supplies the real node data and
+// edge colours) and the replica-collapsed world, whose weather node/edges carry
+// different ids (`group:weather-agent`). Both variants live in the stable graph
+// at once; per-beat opacity picks which one is on screen. The group node
+// inherits the single node's canonical position so the swap has no motion.
 const canonical = buildGraphFromAgents(MAXIMAL);
 const canonicalGrouped = buildGraphFromAgents(MAXIMAL_REPLICAS);
-
-// LAYOUT — authored, not inferred.
-//
-// dagre is still used for the graph CONTENT (buildGraphFromAgents gives us the
-// real nodes, edges and status colours) but its layout output is discarded.
-// Two rounds of trying to steer it failed: insertion order does not survive
-// crossing minimisation (poi-agent got flung to x=2240 to sit under weather,
-// leaving an 1800px hole mid-graph in the early beats), and the specialists'
-// provider edges push claude a rank below openai, which breaks the chapter-03
-// swap. A scroll-scrubbed narrative needs reveal order to read left-to-right,
-// which is a different objective from crossing minimisation.
-//
-// ROWS is in reveal order, left to right, top to bottom.
-//
-// The split is 5+5 rather than 8+2 for aspect ratio: at 8 wide the graph was
-// 2800x860 (3.3:1) against a ~2.4:1 panel, so it was width-bound and B13
-// bottomed out at 0.43 zoom. 5+5 is 1720x860 (2:1) in the same four rows —
-// adding a FIFTH row would have traded the width problem for a height one.
-//
-// Row 2 = what the planner wires to directly for the trip plus its two brains;
-// row 3 = second-hop leaves and the delegated specialists. Keeping claude and
-// openai on row 2 next to the planner is deliberate: chapters 02-03 are the
-// story, and demoting the providers a rank would push their edges behind the
-// tool row exactly where the provider swap has to read cleanly.
-const ROWS: string[][] = [
-  [GATEWAY],
-  [PLANNER],
-  [FLIGHT, HOTEL, POI, CLAUDE, OPENAI],
-  [PREFS, WEATHER, BUDGET, ADVENTURE, LOGISTICS],
-];
-const PITCH_X = NODE_W + 80;
-const PITCH_Y = NODE_H + 100;
-
-const POS = (() => {
-  const spanOf = (n: number) => n * NODE_W + (n - 1) * 80;
-  const widest = Math.max(...ROWS.map((r) => r.length));
-  const out = new Map<string, { x: number; y: number }>();
-  ROWS.forEach((row, r) => {
-    // Rows share a centre axis so short rows don't strand the wide finale with
-    // a lopsided empty half.
-    const x0 = (spanOf(widest) - spanOf(row.length)) / 2;
-    row.forEach((id, i) => out.set(id, { x: x0 + i * PITCH_X, y: r * PITCH_Y }));
-  });
-  return out;
-})();
-POS.set(WEATHER_GROUP, POS.get(WEATHER)!);
 
 const unionEdges = new Map<string, Edge>();
 for (const e of [...canonical.edges, ...canonicalGrouped.edges]) {
@@ -155,7 +108,7 @@ const NODE_STYLE = new Map(
 );
 
 /** Resting stroke width per edge — tier-2 tool edges are drawn lighter. */
-const EDGE_W = EDGE_IDS.map((id) => (id.startsWith("llm|") ? 1.8 : 2.4));
+const EDGE_W = EDGE_IDS.map(restWidth);
 
 const STABLE_EDGES: Edge[] = [...unionEdges.values()].map((e, i) => {
   const isTier2 = e.id.startsWith("llm|");
@@ -207,6 +160,66 @@ const nodeSig = (data: Record<string, unknown>): string => {
 // Cards that B11's spotlight ring applies to (--pulse is only non-zero there).
 const PULSED = new Set([HOTEL, WEATHER, WEATHER_GROUP]);
 
+/**
+ * Horizontal centre of a card's handles, in card-local coordinates.
+ *
+ * NOT `w / 2`. Chrome lays out in LayoutUnits of 1/64px and React Flow reads
+ * the HANDLE ELEMENT's own bounding rect rather than deriving x from the node
+ * width, so the handle's `left: 50%` is resolved by layout and TRUNCATED to
+ * 1/64px before React Flow ever sees it. getComputedStyle also hands back a
+ * rounded decimal (244.781 for a true 244.78125), and halving the rounded
+ * number loses the bit that decides the truncation — hence snap first, then
+ * halve, then floor.
+ *
+ * This is why every integer-width card matched byte-exact while fractional
+ * ones drifted, always downward, always by 0.01 at 2dp. Verified against all
+ * six distinct widths in the fixture: 36/36 edge paths in both states.
+ */
+const LAYOUT_UNIT = 64;
+const snapLU = (n: number) => Math.round(n * LAYOUT_UNIT) / LAYOUT_UNIT;
+const handleCentreX = (w: number) =>
+  Math.floor((snapLU(w) / 2) * LAYOUT_UNIT) / LAYOUT_UNIT;
+
+/**
+ * Build-time only: measured card boxes, so the SAME component can be rendered
+ * to static markup in Node with real edges.
+ *
+ * React Flow will not lay out an edge until both endpoints are "initialized",
+ * which in a browser means a ResizeObserver has measured the card and a
+ * MutationObserver has measured its handles. Neither exists under
+ * renderToStaticMarkup, so a server render emits nodes and NO edges. v12
+ * provides the escape hatch used here: a node carrying `measured` plus an
+ * explicit `handles` array skips measurement entirely (see `parseHandles` and
+ * `toHandleBounds` in @xyflow/system).
+ *
+ * Left unset on the browser path, where measurement is real and authoritative.
+ * That is the point: this adds a build-time input and changes nothing at
+ * runtime, so the React bundle and the prerendered bundle render the same
+ * component from the same beat data.
+ */
+export interface SsrBox {
+  w: number;
+  h: number;
+}
+let SSR_GEOMETRY: Map<string, SsrBox> | null = null;
+export function setSsrGeometry(g: Map<string, SsrBox> | null) {
+  SSR_GEOMETRY = g;
+  NODE_CACHE.clear();
+  lastNodes = [];
+}
+
+/**
+ * Handle box, solved backwards from React Flow's own connection-point maths
+ * (`getHandlePosition`): a Bottom handle connects at `x + width/2, y + height`
+ * and a Top handle at `x + width/2, y`. The captured offsets are relative to
+ * the CARD box, so the handle rect is placed such that those two expressions
+ * reproduce them exactly. Only edge geometry consumes these — the visible
+ * handle dots are rendered by AgentNode's own <Handle> elements.
+ */
+const HANDLE_SIZE = 8;
+/** Connection point relative to the card box, captured from the running build. */
+const HANDLE_OFFSET = { source: 4, target: -4 };
+
 const NODE_CACHE = new Map<string, Node>();
 function nodeObj(id: string, lead: number): Node {
   const data = dataFor(id, lead);
@@ -223,6 +236,29 @@ function nodeObj(id: string, lead: number): Node {
     className: PULSED.has(id) ? "demo-pulse" : undefined,
     style: NODE_STYLE.get(id),
   };
+  const box = SSR_GEOMETRY?.get(id);
+  if (box) {
+    const cx = handleCentreX(box.w);
+    n.measured = { width: box.w, height: box.h };
+    n.handles = [
+      {
+        type: "target",
+        position: Position.Top,
+        x: cx - HANDLE_SIZE / 2,
+        y: HANDLE_OFFSET.target,
+        width: HANDLE_SIZE,
+        height: HANDLE_SIZE,
+      },
+      {
+        type: "source",
+        position: Position.Bottom,
+        x: cx - HANDLE_SIZE / 2,
+        y: box.h + HANDLE_OFFSET.source - HANDLE_SIZE,
+        width: HANDLE_SIZE,
+        height: HANDLE_SIZE,
+      },
+    ];
+  }
   NODE_CACHE.set(key, n);
   return n;
 }
@@ -240,79 +276,6 @@ function nodesForBeat(lead: number): Node[] {
   return next;
 }
 
-// ---------------------------------------------------------------------------
-// Math
-// ---------------------------------------------------------------------------
-const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
-const smoothstep = (t: number) => t * t * (3 - 2 * t);
-const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
-
-const hexToRgb = (hex: string): [number, number, number] => {
-  const h = hex.replace("#", "");
-  return [
-    parseInt(h.slice(0, 2), 16),
-    parseInt(h.slice(2, 4), 16),
-    parseInt(h.slice(4, 6), 16),
-  ];
-};
-function lerpColor(a: string, b: string, t: number): string {
-  if (a === b) return a;
-  const [r1, g1, b1] = hexToRgb(a);
-  const [r2, g2, b2] = hexToRgb(b);
-  return `rgb(${Math.round(lerp(r1, r2, t))},${Math.round(lerp(g1, g2, t))},${Math.round(
-    lerp(b1, b2, t)
-  )})`;
-}
-
-function bboxOf(ids: string[]) {
-  const pts = ids.map((id) => POS.get(id)!).filter(Boolean);
-  const x = Math.min(...pts.map((p) => p.x));
-  const y = Math.min(...pts.map((p) => p.y));
-  return {
-    x,
-    y,
-    w: Math.max(...pts.map((p) => p.x)) + NODE_W - x,
-    h: Math.max(...pts.map((p) => p.y)) + NODE_H - y,
-  };
-}
-const BEAT_BOX = BEATS.map((b) => bboxOf(b.focus));
-
-// Fraction of the panel width reserved, on the left, for the pinned copy.
-// The camera frames every beat inside the REMAINING band, so no node can ever
-// land under the text. Placing the text in whatever gap a beat happens to
-// leave was the alternative and it is worse: the open space migrates as the
-// camera moves, so the copy would chase it around the panel and the title
-// would stop being pinned. A fixed column costs zoom (see BAND_FILL) but the
-// reader's eye never has to re-acquire it.
-const GUTTER = 0.32;
-// Share of the reserved band the graph is allowed to occupy. Slightly wider
-// than the old full-panel 0.9 to claw back some of the zoom the gutter costs;
-// the left margin is already a hard edge, so this only trims the right one.
-const BAND_FILL = 0.94;
-
-function camFor(i: number, W: number, H: number) {
-  const box = BEAT_BOX[i];
-  const gutter = BEATS[i].fullBleed ? 0 : GUTTER;
-  const band = W * (1 - gutter);
-  // Leave headroom for the title block and the chapter rail. With the planner
-  // as hub the graph is wide and flat (rank 1 holds five cards), so the
-  // horizontal allowance has to be generous or every wide beat under-zooms.
-  const fit = Math.min((band * BAND_FILL) / box.w, (H * 0.62) / box.h);
-  return {
-    cx: box.x + box.w / 2,
-    cy: box.y + box.h / 2,
-    /** Screen x the beat's centre is pinned to — mid-band, not mid-panel. */
-    ax: W * gutter + band / 2,
-    zoom: clamp(fit, 0.12, BEATS[i].maxZoom ?? 1.1),
-  };
-}
-
-/**
- * Crossfade position at which the title/sub/description flip to the incoming
- * beat. Also the gate for every reveal — see `fIn` in the driver.
- */
-const LEAD_FLIP = 0.4;
-
 /**
  * Inline markup shared by every string in script.ts: `backticks` are code,
  * *asterisks* are an annotation. Two contexts use it with different scales —
@@ -323,18 +286,18 @@ interface Inline {
   code: string;
   em: string;
 }
-const SUB_INLINE: Inline = {
+export const SUB_INLINE: Inline = {
   code: "text-slate-300",
   em: "font-sans not-italic text-slate-500",
 };
 // Mono runs optically larger than sans at the same px, so code spans sit a
 // notch under the 15px body they are set in.
-const DESC_INLINE: Inline = {
+export const DESC_INLINE: Inline = {
   code: "font-mono text-[13.5px] text-slate-300",
   em: "italic text-slate-300",
 };
 
-function inline(text: string, s: Inline) {
+export function inline(text: string, s: Inline) {
   return text.split(/(`[^`]+`|\*[^*]+\*)/g).map((part, i) => {
     if (part.length > 2 && part.startsWith("`") && part.endsWith("`")) {
       return (
@@ -378,123 +341,6 @@ const BEAT_COPY_STYLE = { opacity: "var(--beat, 1)" } as const;
 const REVEAL_COPY_STYLE = { opacity: "var(--reveal, 0)" } as const;
 const CTA_STYLE = { opacity: "var(--cta, 0)" } as const;
 const RAIL_STYLE = { opacity: "var(--rail, 1)" } as const;
-
-/** Total pinned travel: the topology arc plus the epilogue, in vh. */
-const totalTravel = TOTAL_VH + REVEAL_VH;
-
-/** vh travelled → continuous beat position, honouring per-beat weights. */
-function rawFromVh(vh: number): number {
-  for (let i = 0; i < N; i++) {
-    if (vh < CUM[i + 1] || i === N - 1) {
-      return i + clamp((vh - CUM[i]) / BEATS[i].weight, 0, 1);
-    }
-  }
-  return N - 1;
-}
-
-// Reveal timeline, in fractions of REVEAL_VH (6.9vh):
-//
-//   0.000-0.096  graph and rail clear                  0.00-0.66vh
-//   0.019-0.096  B14's copy leaves with them           0.13-0.66vh
-//   0.096-0.109  EMPTY PANEL                           0.66-0.75vh
-//   0.109-0.185  headline arrives into the empty rail  0.75-1.28vh
-//   0.222-0.635  six phases stagger in and stay        1.53-4.38vh
-//   0.635-0.787  hold — the whole grid readable        4.38-5.43vh
-//   0.787-0.859  grid and headline leave, completely   5.43-5.93vh
-//   0.859-0.876  EMPTY PANEL                           5.93-6.05vh
-//   0.876-0.929  CTA arrives into an empty frame       6.05-6.41vh
-//   0.929-1.000  hold                                  6.41-6.90vh
-//
-// THE GAPS ARE NOT THE BLANK. smoothstep is flat at both ends — it crosses the
-// 0.005 perceptual floor at t = 0.0414 — so each window is imperceptible for its
-// first and last ~4%. The blank a reader sees is the nominal gap PLUS those
-// tails from the outgoing and incoming windows, which is why these fractions
-// look far too small to produce the ~120px and ~140px they actually give.
-// Size them by computing the measured span, never by scaling the fraction.
-//
-// BOTH handoffs are sequential, and for the same reason. The beat copy and the
-// reveal headline occupy the IDENTICAL left-rail position, so fading one out
-// while fading the other in does not dissolve — it superimposes. B14's
-// two-line title over the two-line headline put four strings on screen at
-// once, all legible, for two or three scroll notches. The exit is deliberately
-// the longer of the two: its pause precedes the finale and is doing work,
-// where the entrance's only job is to prevent a collision.
-//
-// This is NOT how beat-to-beat works: there the title is one <h2> whose React
-// key changes, so the old element unmounts and the new one fades in alone. One
-// title exists at a time BY CONSTRUCTION, at any length — which is why beat
-// copy may lengthen freely without risking this class of bug.
-const R_CLEAR = 0.096;
-const R_BEAT_OUT = [0.019, 0.096] as const;
-const R_HEAD = [0.109, 0.185] as const;
-const R_PHASE_0 = 0.222;
-const R_PHASE_STEP = 0.0652;
-const R_PHASE_SPAN = 0.087;
-const R_OUT = [0.787, 0.859] as const;
-const R_CTA = [0.876, 0.929] as const;
-
-/**
- * Keyboard snap targets, as vh travelled inside the pinned section.
- *
- * One press = one composed frame. A beat is fully settled where `pos` lands
- * exactly on its index, which is the MIDPOINT of its own weight — the beat
- * boundaries are where the transitions happen, so snapping to them would land
- * the reader mid-dissolve, which is the thing a multiplier would also do.
- * Index 0 is the section entry, which renders the same frame as B1's midpoint.
- *
- * The reveal's stages are targets too: without them the epilogue is a single
- * press. The empty beat before the CTA deliberately is NOT a target — landing
- * on a blank panel reads as a broken page rather than as a pause, so the last
- * press plays hold -> exit -> empty -> CTA as one movement.
- */
-const SNAP_VH: number[] = (() => {
-  const out = [0];
-  for (let i = 1; i < N; i++) out.push(CUM[i] + BEATS[i].weight / 2);
-  out.push(TOTAL_VH + R_HEAD[1] * REVEAL_VH);
-  for (let i = 0; i < REVEAL.phases.length; i++) {
-    out.push(TOTAL_VH + (R_PHASE_0 + i * R_PHASE_STEP + R_PHASE_SPAN) * REVEAL_VH);
-  }
-  out.push(TOTAL_VH + R_CTA[1] * REVEAL_VH);
-  return out;
-})();
-
-/**
- * Chapter-level stops for the Shift modifier: the first beat of each chapter
- * at ITS settled midpoint — never the chapter boundary, for the same reason
- * the beat targets avoid beat boundaries — then the reveal headline and the
- * CTA. Seven stops for the whole piece instead of twenty-two.
- *
- * Two readings of the same section: beat-by-beat for a reader consuming the
- * story, chapter-by-chapter for one who has seen it and wants the end. Every
- * entry here is also a SNAP_VH entry except the first, which is B1's midpoint
- * where SNAP_VH uses the section entry — the two render an identical frame.
- */
-const CHAPTER_VH: number[] = (() => {
-  const out: number[] = [];
-  for (let c = 0; c < BUILT_CHAPTERS; c++) {
-    const i = BEATS.findIndex((b) => b.chapter === c);
-    if (i >= 0) out.push(CUM[i] + BEATS[i].weight / 2);
-  }
-  out.push(TOTAL_VH + R_HEAD[1] * REVEAL_VH);
-  out.push(TOTAL_VH + R_CTA[1] * REVEAL_VH);
-  return out;
-})();
-
-/**
- * First beat index and beat count per chapter, for the progress rail's fill.
- * Precomputed: this was a findIndex + filter over all 14 beats, per chapter,
- * inside the per-frame apply — ~140 array element visits every frame at 60fps
- * to recompute constants.
- */
-const CHAPTER_SPAN = Array.from({ length: BUILT_CHAPTERS }, (_, c) => ({
-  first: BEATS.findIndex((b) => b.chapter === c),
-  count: BEATS.filter((b) => b.chapter === c).length,
-}));
-
-/** Focus in these swallows the keys entirely — they are text entry. */
-const TEXT_ENTRY = new Set(["INPUT", "TEXTAREA", "SELECT"]);
-/** Space/Enter belong to these; the paging keys still do not. */
-const ACTIVATABLE = new Set(["BUTTON", "A"]);
 
 // ---------------------------------------------------------------------------
 // Stage
@@ -900,7 +746,7 @@ export function Stage({ devTools = false, showHeader = false }: StageProps) {
       </header>
       )}
 
-      <div ref={sectionRef} style={{ height: `${100 + totalTravel * 100}vh` }}>
+      <div ref={sectionRef} data-mesh="section" style={{ height: `${100 + totalTravel * 100}vh` }}>
         <div className="sticky top-0 h-screen w-full py-6">
           <div
             ref={panelRef}
@@ -1053,11 +899,15 @@ export function Stage({ devTools = false, showHeader = false }: StageProps) {
                 <div className="flex gap-4 px-8 pt-8" style={BEAT_COPY_STYLE}>
                   <div className="demo-rule mt-1 h-[62px] w-[3px] shrink-0 rounded-full" />
                   <div className="min-w-0">
-                    <p className="demo-accent font-mono text-[10px] uppercase tracking-[0.32em]">
+                    <p
+                      data-mesh="chapter"
+                      className="demo-accent font-mono text-[10px] uppercase tracking-[0.32em]"
+                    >
                       {CHAPTERS[beat.chapter]}
                     </p>
                     <h2
                       key={`t-${lead}`}
+                      data-mesh="title"
                       // whitespace-pre-line honours the authored `\n` breaks;
                       // text-balance keeps the rest off ragged single-word
                       // last lines in a 350px column.
@@ -1067,6 +917,7 @@ export function Stage({ devTools = false, showHeader = false }: StageProps) {
                     </h2>
                     <p
                       key={`s-${lead}`}
+                      data-mesh="sub"
                       // break-words is containment, not style: B6's sub is a
                       // JSON literal with no spaces, so without it the line
                       // cannot wrap and overflows the reserved column by 25px
@@ -1079,6 +930,7 @@ export function Stage({ devTools = false, showHeader = false }: StageProps) {
                     {beat.desc && (
                       <p
                         key={`d-${lead}`}
+                        data-mesh="desc"
                         className="demo-fade mt-4 text-[15px] leading-[1.7] text-slate-400"
                       >
                         {inline(beat.desc, DESC_INLINE)}
@@ -1162,6 +1014,7 @@ export function Stage({ devTools = false, showHeader = false }: StageProps) {
                         )}
                       </div>
                       <p
+                        data-mesh-rail={c}
                         className={`mt-2 font-mono text-[10px] tracking-[0.18em] ${
                           active ? "demo-accent" : built ? "text-slate-500" : "text-slate-700"
                         }`}

--- a/src/ui/demo/stage.tsx
+++ b/src/ui/demo/stage.tsx
@@ -42,6 +42,7 @@ import {
   HOTEL,
   WEATHER,
   WEATHER_GROUP,
+  type Beat,
 } from "./script";
 import {
   clamp, smoothstep, lerp, lerpColor, POS, camFor, GUTTER, LEAD_FLIP,
@@ -217,8 +218,12 @@ export function setSsrGeometry(g: Map<string, SsrBox> | null) {
  * handle dots are rendered by AgentNode's own <Handle> elements.
  */
 const HANDLE_SIZE = 8;
-/** Connection point relative to the card box, captured from the running build. */
-const HANDLE_OFFSET = { source: 4, target: -4 };
+/**
+ * Connection point relative to the card box, captured from the running build.
+ * EXPORTED so emit.tsx can assert geometry.json still agrees with it — the
+ * fixture carries its own copy of these numbers and nothing else compares them.
+ */
+export const HANDLE_OFFSET = { source: 4, target: -4 };
 
 const NODE_CACHE = new Map<string, Node>();
 function nodeObj(id: string, lead: number): Node {
@@ -345,6 +350,64 @@ const RAIL_STYLE = { opacity: "var(--rail, 1)" } as const;
 // ---------------------------------------------------------------------------
 // Stage
 // ---------------------------------------------------------------------------
+/**
+ * The pinned beat copy — chapter label, title, mono sub-line, description.
+ *
+ * A COMPONENT rather than inline JSX because BOTH renderers need it: <Stage>
+ * mounts it, and emit.tsx renders it to the markup string the vanilla driver
+ * swaps in at each lead flip. The driver previously rebuilt these four elements
+ * from class strings copied by hand, which meant a type change here silently
+ * stopped applying to the shipping bundle. There is now one definition.
+ *
+ * `lead` drives the React keys, and they are load-bearing: keying the title on
+ * the beat makes React unmount the old <h2> and mount a new one, so `demo-fade`
+ * replays from the start and exactly one title exists at a time. The driver
+ * reproduces that by replacing the elements outright.
+ */
+export function BeatCopy({ beat, lead }: { beat: Beat; lead: number }) {
+  return (
+    <>
+                    <p
+                      data-mesh="chapter"
+                      className="demo-accent font-mono text-[10px] uppercase tracking-[0.32em]"
+                    >
+                      {CHAPTERS[beat.chapter]}
+                    </p>
+                    <h2
+                      key={`t-${lead}`}
+                      data-mesh="title"
+                      // whitespace-pre-line honours the authored `\n` breaks;
+                      // text-balance keeps the rest off ragged single-word
+                      // last lines in a 350px column.
+                      className="demo-fade mt-2 whitespace-pre-line text-balance text-[30px] font-semibold leading-[1.12] tracking-tight text-white"
+                    >
+                      {beat.title}
+                    </h2>
+                    <p
+                      key={`s-${lead}`}
+                      data-mesh="sub"
+                      // break-words is containment, not style: B6's sub is a
+                      // JSON literal with no spaces, so without it the line
+                      // cannot wrap and overflows the reserved column by 25px
+                      // into the graph — which is exactly what the gutter
+                      // exists to prevent.
+                      className="demo-fade mt-3 whitespace-pre-line text-balance break-words font-mono text-[13px] leading-relaxed text-slate-400"
+                    >
+                      {inline(beat.sub, SUB_INLINE)}
+                    </p>
+                    {beat.desc && (
+                      <p
+                        key={`d-${lead}`}
+                        data-mesh="desc"
+                        className="demo-fade mt-4 text-[15px] leading-[1.7] text-slate-400"
+                      >
+                        {inline(beat.desc, DESC_INLINE)}
+                      </p>
+                    )}
+    </>
+  );
+}
+
 export interface StageProps {
   /** Render the grid-variant switch. Dev page always; embed only on ?mesh-grid. */
   devTools?: boolean;
@@ -899,43 +962,7 @@ export function Stage({ devTools = false, showHeader = false }: StageProps) {
                 <div className="flex gap-4 px-8 pt-8" style={BEAT_COPY_STYLE}>
                   <div className="demo-rule mt-1 h-[62px] w-[3px] shrink-0 rounded-full" />
                   <div className="min-w-0">
-                    <p
-                      data-mesh="chapter"
-                      className="demo-accent font-mono text-[10px] uppercase tracking-[0.32em]"
-                    >
-                      {CHAPTERS[beat.chapter]}
-                    </p>
-                    <h2
-                      key={`t-${lead}`}
-                      data-mesh="title"
-                      // whitespace-pre-line honours the authored `\n` breaks;
-                      // text-balance keeps the rest off ragged single-word
-                      // last lines in a 350px column.
-                      className="demo-fade mt-2 whitespace-pre-line text-balance text-[30px] font-semibold leading-[1.12] tracking-tight text-white"
-                    >
-                      {beat.title}
-                    </h2>
-                    <p
-                      key={`s-${lead}`}
-                      data-mesh="sub"
-                      // break-words is containment, not style: B6's sub is a
-                      // JSON literal with no spaces, so without it the line
-                      // cannot wrap and overflows the reserved column by 25px
-                      // into the graph — which is exactly what the gutter
-                      // exists to prevent.
-                      className="demo-fade mt-3 whitespace-pre-line text-balance break-words font-mono text-[13px] leading-relaxed text-slate-400"
-                    >
-                      {inline(beat.sub, SUB_INLINE)}
-                    </p>
-                    {beat.desc && (
-                      <p
-                        key={`d-${lead}`}
-                        data-mesh="desc"
-                        className="demo-fade mt-4 text-[15px] leading-[1.7] text-slate-400"
-                      >
-                        {inline(beat.desc, DESC_INLINE)}
-                      </p>
-                    )}
+                    <BeatCopy beat={beat} lead={lead} />
                   </div>
                 </div>
               </div>

--- a/src/ui/demo/static.ts
+++ b/src/ui/demo/static.ts
@@ -43,6 +43,17 @@ function boot() {
     }
   });
   obs.observe(document.documentElement, { childList: true, subtree: true });
+  // Give up once the document is done. Without this the observer runs for the
+  // lifetime of the page on every page that loads this bundle without a mount
+  // point, firing on every DOM mutation the site makes — a permanent cost for
+  // a mount that is never going to appear.
+  window.addEventListener(
+    "load",
+    () => {
+      if (!document.getElementById(MOUNT_ID)) obs.disconnect();
+    },
+    { once: true }
+  );
 }
 
 if (document.readyState === "loading") {

--- a/src/ui/demo/static.ts
+++ b/src/ui/demo/static.ts
@@ -1,0 +1,52 @@
+// Docs-site entry for the PRERENDERED bundle — the React-free counterpart of
+// embed.tsx. Built by vite.static.config.ts into an IIFE plus one stylesheet,
+// both scoped to #mesh-scroll.
+//
+// THE STYLESHEET IS DELIBERATELY THE SAME PIPELINE as the React bundle's, down
+// to importing app/globals.css. That import is the open half of #1519 and it is
+// tempting to close it here, but changing what Tailwind scans changes which
+// utilities exist, and doing that in the same step as replacing the renderer
+// would leave any visual difference with two possible causes. The stylesheets
+// are byte-identical across the two bundles (the build asserts it), so anything
+// that looks wrong is the markup or the driver — which is the whole point of
+// having built them side by side.
+import "@xyflow/react/dist/style.css";
+import "../app/globals.css";
+import "./scroll.css";
+import "./embed.css";
+
+import generated from "./generated/graph.json";
+import { start, type Generated } from "./driver";
+
+const MOUNT_ID = "mesh-scroll";
+
+function mount(el: HTMLElement) {
+  if (el.dataset.meshScrollMounted === "1") return;
+  el.dataset.meshScrollMounted = "1";
+  const G = generated as unknown as Generated;
+  el.innerHTML = G.shell;
+  start(el, G);
+}
+
+function boot() {
+  const el = document.getElementById(MOUNT_ID);
+  if (el) {
+    mount(el);
+    return;
+  }
+  // Injected before the element exists — wait for it rather than failing.
+  const obs = new MutationObserver(() => {
+    const found = document.getElementById(MOUNT_ID);
+    if (found) {
+      obs.disconnect();
+      mount(found);
+    }
+  });
+  obs.observe(document.documentElement, { childList: true, subtree: true });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", boot, { once: true });
+} else {
+  boot();
+}

--- a/src/ui/demo/timeline.ts
+++ b/src/ui/demo/timeline.ts
@@ -96,7 +96,22 @@ export const POS = (() => {
 POS.set(WEATHER_GROUP, POS.get(WEATHER)!);
 
 function bboxOf(ids: string[]) {
-  const pts = ids.map((id) => POS.get(id)!).filter(Boolean);
+  // THROW, do not filter. This used to be `.map(...).filter(Boolean)`, which
+  // silently dropped any id POS did not know — and if a beat's whole focus list
+  // were unknown it reduced to Math.min() of an empty array, i.e. Infinity, and
+  // the camera received NaN geometry with nothing logged. A typo in a beat's
+  // `focus` is an authoring error and should read as one.
+  const pts = ids.map((id) => {
+    const p = POS.get(id);
+    if (!p) {
+      throw new Error(
+        `beat focus references an unknown node id: ${JSON.stringify(id)}. ` +
+          `Known ids: ${[...POS.keys()].join(", ")}`
+      );
+    }
+    return p;
+  });
+  if (!pts.length) throw new Error("beat focus list is empty — the camera has nothing to frame");
   const x = Math.min(...pts.map((p) => p.x));
   const y = Math.min(...pts.map((p) => p.y));
   return {

--- a/src/ui/demo/timeline.ts
+++ b/src/ui/demo/timeline.ts
@@ -1,0 +1,276 @@
+// THE ANIMATION MATHS — shared by both renderers, owned by neither.
+//
+// Two things now draw this section: the React component (stage.tsx, the dev
+// page) and the vanilla driver (driver.ts, what ships). If each carried its own
+// copy of the camera and the timeline, "the prerendered build matches the React
+// build" would be a statement about one afternoon rather than a property of the
+// code — the two would drift on the first weight change and nothing would say
+// so. Everything here is a pure function of scroll position and beat data, so
+// both can import it and there is exactly one definition of every number.
+//
+// Deliberately free of React AND of the graph builder: importing
+// lib/topology.ts here would pull dagre back into the shipped bundle, which is
+// most of what the prerender exists to remove. Node and edge ids arrive as
+// arguments; the emitter bakes the orders into generated.json.
+import {
+  BEATS, CUM, TOTAL_VH, REVEAL_VH, BUILT_CHAPTERS, REVEAL,
+  WEATHER, WEATHER_GROUP,
+  FLIGHT, HOTEL, POI, PREFS, PLANNER, CLAUDE, OPENAI, GATEWAY,
+  BUDGET, ADVENTURE, LOGISTICS,
+} from "./script";
+
+const N = BEATS.length;
+
+// ---------------------------------------------------------------------------
+// Math
+// ---------------------------------------------------------------------------
+export const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
+export const smoothstep = (t: number) => t * t * (3 - 2 * t);
+export const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+
+const hexToRgb = (hex: string): [number, number, number] => {
+  const h = hex.replace("#", "");
+  return [
+    parseInt(h.slice(0, 2), 16),
+    parseInt(h.slice(2, 4), 16),
+    parseInt(h.slice(4, 6), 16),
+  ];
+};
+export function lerpColor(a: string, b: string, t: number): string {
+  if (a === b) return a;
+  const [r1, g1, b1] = hexToRgb(a);
+  const [r2, g2, b2] = hexToRgb(b);
+  return `rgb(${Math.round(lerp(r1, r2, t))},${Math.round(lerp(g1, g2, t))},${Math.round(
+    lerp(b1, b2, t)
+  )})`;
+}
+
+// ---------------------------------------------------------------------------
+// Layout — authored, not inferred
+// ---------------------------------------------------------------------------
+// dagre is still used for the graph CONTENT in the React build
+// (buildGraphFromAgents gives the real nodes, edges and status colours) but its
+// layout output is discarded. Two rounds of trying to steer it failed:
+// insertion order does not survive crossing minimisation (poi-agent got flung
+// to x=2240 to sit under weather, leaving an 1800px hole mid-graph in the early
+// beats), and the specialists' provider edges push claude a rank below openai,
+// which breaks the chapter-03 swap. A scroll-scrubbed narrative needs reveal
+// order to read left-to-right, which is a different objective from crossing
+// minimisation.
+//
+// ROWS is in reveal order, left to right, top to bottom.
+//
+// The split is 5+5 rather than 8+2 for aspect ratio: at 8 wide the graph was
+// 2800x860 (3.3:1) against a ~2.4:1 panel, so it was width-bound and B13
+// bottomed out at 0.43 zoom. 5+5 is 1720x860 (2:1) in the same four rows —
+// adding a FIFTH row would have traded the width problem for a height one.
+//
+// Row 2 = what the planner wires to directly for the trip plus its two brains;
+// row 3 = second-hop leaves and the delegated specialists. Keeping claude and
+// openai on row 2 next to the planner is deliberate: chapters 02-03 are the
+// story, and demoting the providers a rank would push their edges behind the
+// tool row exactly where the provider swap has to read cleanly.
+export const NODE_W = 280;
+export const NODE_H = 140;
+const ROWS: string[][] = [
+  [GATEWAY],
+  [PLANNER],
+  [FLIGHT, HOTEL, POI, CLAUDE, OPENAI],
+  [PREFS, WEATHER, BUDGET, ADVENTURE, LOGISTICS],
+];
+const PITCH_X = NODE_W + 80;
+const PITCH_Y = NODE_H + 100;
+
+export const POS = (() => {
+  const spanOf = (n: number) => n * NODE_W + (n - 1) * 80;
+  const widest = Math.max(...ROWS.map((r) => r.length));
+  const out = new Map<string, { x: number; y: number }>();
+  ROWS.forEach((row, r) => {
+    // Rows share a centre axis so short rows don't strand the wide finale with
+    // a lopsided empty half.
+    const x0 = (spanOf(widest) - spanOf(row.length)) / 2;
+    row.forEach((id, i) => out.set(id, { x: x0 + i * PITCH_X, y: r * PITCH_Y }));
+  });
+  return out;
+})();
+POS.set(WEATHER_GROUP, POS.get(WEATHER)!);
+
+function bboxOf(ids: string[]) {
+  const pts = ids.map((id) => POS.get(id)!).filter(Boolean);
+  const x = Math.min(...pts.map((p) => p.x));
+  const y = Math.min(...pts.map((p) => p.y));
+  return {
+    x,
+    y,
+    w: Math.max(...pts.map((p) => p.x)) + NODE_W - x,
+    h: Math.max(...pts.map((p) => p.y)) + NODE_H - y,
+  };
+}
+const BEAT_BOX = BEATS.map((b) => bboxOf(b.focus));
+
+// ---------------------------------------------------------------------------
+// Camera
+// ---------------------------------------------------------------------------
+/**
+ * Fraction of the panel width reserved, on the left, for the pinned copy.
+ * The camera frames every beat inside the REMAINING band, so no node can ever
+ * land under the text. Placing the text in whatever gap a beat happens to leave
+ * was the alternative and it is worse: the open space migrates as the camera
+ * moves, so the copy would chase it around the panel and the title would stop
+ * being pinned. A fixed column costs zoom (see BAND_FILL) but the reader's eye
+ * never has to re-acquire it.
+ */
+export const GUTTER = 0.32;
+/**
+ * Share of the reserved band the graph is allowed to occupy. Slightly wider
+ * than the old full-panel 0.9 to claw back some of the zoom the gutter costs;
+ * the left margin is already a hard edge, so this only trims the right one.
+ */
+const BAND_FILL = 0.94;
+
+export function camFor(i: number, W: number, H: number) {
+  const box = BEAT_BOX[i];
+  const gutter = BEATS[i].fullBleed ? 0 : GUTTER;
+  const band = W * (1 - gutter);
+  // Leave headroom for the title block and the chapter rail. With the planner
+  // as hub the graph is wide and flat (rank 1 holds five cards), so the
+  // horizontal allowance has to be generous or every wide beat under-zooms.
+  const fit = Math.min((band * BAND_FILL) / box.w, (H * 0.62) / box.h);
+  return {
+    cx: box.x + box.w / 2,
+    cy: box.y + box.h / 2,
+    /** Screen x the beat's centre is pinned to — mid-band, not mid-panel. */
+    ax: W * gutter + band / 2,
+    zoom: clamp(fit, 0.12, BEATS[i].maxZoom ?? 1.1),
+  };
+}
+
+/**
+ * Crossfade position at which the title/sub/description flip to the incoming
+ * beat. Also the gate for every reveal — see `fIn` in the driver.
+ */
+export const LEAD_FLIP = 0.4;
+
+/** Resting stroke width — tier-2 tool edges are drawn lighter. */
+export const restWidth = (edgeId: string) => (edgeId.startsWith("llm|") ? 1.8 : 2.4);
+
+/** Total pinned travel: the topology arc plus the epilogue, in vh. */
+export const totalTravel = TOTAL_VH + REVEAL_VH;
+
+/** vh travelled → continuous beat position, honouring per-beat weights. */
+export function rawFromVh(vh: number): number {
+  for (let i = 0; i < N; i++) {
+    if (vh < CUM[i + 1] || i === N - 1) {
+      return i + clamp((vh - CUM[i]) / BEATS[i].weight, 0, 1);
+    }
+  }
+  return N - 1;
+}
+
+// ---------------------------------------------------------------------------
+// The reveal
+// ---------------------------------------------------------------------------
+// Reveal timeline, in fractions of REVEAL_VH (6.9vh):
+//
+//   0.000-0.096  graph and rail clear                  0.00-0.66vh
+//   0.019-0.096  B14's copy leaves with them           0.13-0.66vh
+//   0.096-0.109  EMPTY PANEL                           0.66-0.75vh
+//   0.109-0.185  headline arrives into the empty rail  0.75-1.28vh
+//   0.222-0.635  six phases stagger in and stay        1.53-4.38vh
+//   0.635-0.787  hold — the whole grid readable        4.38-5.43vh
+//   0.787-0.859  grid and headline leave, completely   5.43-5.93vh
+//   0.859-0.876  EMPTY PANEL                           5.93-6.05vh
+//   0.876-0.929  CTA arrives into an empty frame       6.05-6.41vh
+//   0.929-1.000  hold                                  6.41-6.90vh
+//
+// THE GAPS ARE NOT THE BLANK. smoothstep is flat at both ends — it crosses the
+// 0.005 perceptual floor at t = 0.0414 — so each window is imperceptible for its
+// first and last ~4%. The blank a reader sees is the nominal gap PLUS those
+// tails from the outgoing and incoming windows, which is why these fractions
+// look far too small to produce the ~120px and ~140px they actually give.
+// Size them by computing the measured span, never by scaling the fraction.
+//
+// BOTH handoffs are sequential, and for the same reason. The beat copy and the
+// reveal headline occupy the IDENTICAL left-rail position, so fading one out
+// while fading the other in does not dissolve — it superimposes. B14's two-line
+// title over the two-line headline put four strings on screen at once, all
+// legible, for two or three scroll notches. The exit is deliberately the longer
+// of the two: its pause precedes the finale and is doing work, where the
+// entrance's only job is to prevent a collision.
+//
+// This is NOT how beat-to-beat works: there the title is one <h2> whose React
+// key changes, so the old element unmounts and the new one fades in alone. One
+// title exists at a time BY CONSTRUCTION, at any length — which is why beat
+// copy may lengthen freely without risking this class of bug. The driver
+// reproduces that by replacing the element rather than its text.
+export const R_CLEAR = 0.096;
+export const R_BEAT_OUT = [0.019, 0.096] as const;
+export const R_HEAD = [0.109, 0.185] as const;
+export const R_PHASE_0 = 0.222;
+export const R_PHASE_STEP = 0.0652;
+export const R_PHASE_SPAN = 0.087;
+export const R_OUT = [0.787, 0.859] as const;
+export const R_CTA = [0.876, 0.929] as const;
+
+/**
+ * Keyboard snap targets, as vh travelled inside the pinned section.
+ *
+ * One press = one composed frame. A beat is fully settled where `pos` lands
+ * exactly on its index, which is the MIDPOINT of its own weight — the beat
+ * boundaries are where the transitions happen, so snapping to them would land
+ * the reader mid-dissolve, which is the thing a multiplier would also do.
+ * Index 0 is the section entry, which renders the same frame as B1's midpoint.
+ *
+ * The reveal's stages are targets too: without them the epilogue is a single
+ * press. The empty beat before the CTA deliberately is NOT a target — landing
+ * on a blank panel reads as a broken page rather than as a pause, so the last
+ * press plays hold -> exit -> empty -> CTA as one movement.
+ */
+export const SNAP_VH: number[] = (() => {
+  const out = [0];
+  for (let i = 1; i < N; i++) out.push(CUM[i] + BEATS[i].weight / 2);
+  out.push(TOTAL_VH + R_HEAD[1] * REVEAL_VH);
+  for (let i = 0; i < REVEAL.phases.length; i++) {
+    out.push(TOTAL_VH + (R_PHASE_0 + i * R_PHASE_STEP + R_PHASE_SPAN) * REVEAL_VH);
+  }
+  out.push(TOTAL_VH + R_CTA[1] * REVEAL_VH);
+  return out;
+})();
+
+/**
+ * Chapter-level stops for the Shift modifier: the first beat of each chapter at
+ * ITS settled midpoint — never the chapter boundary, for the same reason the
+ * beat targets avoid beat boundaries — then the reveal headline and the CTA.
+ * Seven stops for the whole piece instead of twenty-two.
+ *
+ * Two readings of the same section: beat-by-beat for a reader consuming the
+ * story, chapter-by-chapter for one who has seen it and wants the end. Every
+ * entry here is also a SNAP_VH entry except the first, which is B1's midpoint
+ * where SNAP_VH uses the section entry — the two render an identical frame.
+ */
+export const CHAPTER_VH: number[] = (() => {
+  const out: number[] = [];
+  for (let c = 0; c < BUILT_CHAPTERS; c++) {
+    const i = BEATS.findIndex((b) => b.chapter === c);
+    if (i >= 0) out.push(CUM[i] + BEATS[i].weight / 2);
+  }
+  out.push(TOTAL_VH + R_HEAD[1] * REVEAL_VH);
+  out.push(TOTAL_VH + R_CTA[1] * REVEAL_VH);
+  return out;
+})();
+
+/**
+ * First beat index and beat count per chapter, for the progress rail's fill.
+ * Precomputed: this was a findIndex + filter over all 14 beats, per chapter,
+ * inside the per-frame apply — ~140 array element visits every frame at 60fps
+ * to recompute constants.
+ */
+export const CHAPTER_SPAN = Array.from({ length: BUILT_CHAPTERS }, (_, c) => ({
+  first: BEATS.findIndex((b) => b.chapter === c),
+  count: BEATS.filter((b) => b.chapter === c).length,
+}));
+
+/** Focus in these swallows the keys entirely — they are text entry. */
+export const TEXT_ENTRY = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+/** Space/Enter belong to these; the paging keys still do not. */
+export const ACTIVATABLE = new Set(["BUTTON", "A"]);

--- a/src/ui/eslint.config.mjs
+++ b/src/ui/eslint.config.mjs
@@ -8,7 +8,18 @@ const eslintConfig = defineConfig([
   // "**/dist/**", not "dist/**": the latter is root-relative and missed
   // src/ui/demo/dist/, so `npx eslint demo` reported 6 errors and 9 warnings
   // from inside the demo's own minified build artifact.
-  globalIgnores(["**/dist/**", "node_modules/**", "*.config.*", "*.tsbuildinfo"]),
+  //
+  // dist-static/ needs its own entry for the same reason it needs its own
+  // .gitignore line — it is NOT matched by a `dist` pattern. It holds the
+  // prerendered bundle, which is the one that ships.
+  globalIgnores([
+    "**/dist/**",
+    "**/dist-static/**",
+    "**/generated/**",
+    "node_modules/**",
+    "*.config.*",
+    "*.tsbuildinfo",
+  ]),
   {
     files: ["**/*.js", "**/*.jsx", "**/*.mjs"],
     ...js.configs.recommended,

--- a/src/ui/vite.demo.config.ts
+++ b/src/ui/vite.demo.config.ts
@@ -51,7 +51,7 @@ const SCOPE = "#mesh-scroll";
  * declines to fetch the bundle below this width; this file declines to reserve
  * the height. KEEP THE TWO IN SYNC.
  */
-const MIN_WIDTH = 900;
+export const MIN_WIDTH = 900;
 
 /**
  * Confine the emitted stylesheet to a single root element.
@@ -92,7 +92,7 @@ const MIN_WIDTH = 900;
  * do with. Avoid bare utility words in files under src/ui; the durable fix
  * is one @source line in app/globals.css (see the Phase 2 notes).
  */
-function scopeCss(): Plugin {
+export function scopeCss(): Plugin {
   const scoper = {
     postcssPlugin: "mesh-scroll-scope",
     // Once() rather than the Rule() visitor: mutating a selector inside the
@@ -311,7 +311,7 @@ function scopeCss(): Plugin {
  * Matches Stage's own layout: header 70vh + section (100 + travel*100)vh +
  * closing spacer 25vh.
  */
-function emitReservedHeight(): Plugin {
+export function emitReservedHeight(): Plugin {
   return {
     name: "mesh-scroll-reserve-height",
     // SEQUENTIAL, and it matters: writeBundle is a PARALLEL rollup hook, so
@@ -365,7 +365,7 @@ function emitReservedHeight(): Plugin {
  * compressed on its own: the parts do NOT sum to the whole (shared dictionary
  * across the real bundle does better), so treat them as proportions.
  */
-function sizeReport(): Plugin {
+export function sizeReport(): Plugin {
   const group = (id: string) => {
     const m = id.replace(/\\/g, "/").match(/node_modules\/((?:@[^/]+\/)?[^/]+)/);
     if (!m) return id.includes("/demo/") ? "our code (demo)" : "our code (meshui)";

--- a/src/ui/vite.static.config.ts
+++ b/src/ui/vite.static.config.ts
@@ -1,0 +1,55 @@
+// Build config for the PRERENDERED docs-site bundle.
+//
+// Deliberately a thin file: every plugin comes from vite.demo.config.ts, so the
+// CSS scoper, the reserved-height emitter and the size report are ONE
+// implementation shared by both bundles. Forking the scoper would have been the
+// easy move and a bad one — it is 200 lines of hard-won rules about @layer,
+// rem and keyframe namespacing, and two copies would diverge silently the first
+// time one of them was fixed.
+//
+// The two bundles differ in exactly three ways:
+//   entry     demo/static.ts   (vanilla driver)  vs  demo/embed.tsx  (React)
+//   outDir    demo/dist-static                   vs  demo/dist
+//   plugins   no @vitejs/plugin-react — there is no JSX left to transform
+//
+// Filenames are intentionally IDENTICAL to the React bundle's, so switching
+// which one ships is a one-line change in the Makefile rather than an edit to
+// the docs loader.
+//
+//   npx vite build --config vite.static.config.ts
+//
+// The entry imports demo/generated.json, which demo/emit.tsx must have written
+// first — see the docs-scroll-build target.
+import { defineConfig } from "vite";
+import tailwindcss from "@tailwindcss/vite";
+import path from "path";
+
+import { scopeCss, emitReservedHeight, sizeReport } from "./vite.demo.config";
+
+export default defineConfig({
+  base: "./",
+  publicDir: false,
+  plugins: [tailwindcss(), scopeCss(), emitReservedHeight(), sizeReport()],
+  resolve: {
+    alias: { "@": path.resolve(__dirname, ".") },
+  },
+  build: {
+    outDir: "demo/dist-static",
+    emptyOutDir: true,
+    cssCodeSplit: false,
+    rollupOptions: {
+      input: path.resolve(__dirname, "demo/static.ts"),
+      output: {
+        format: "iife",
+        entryFileNames: "mesh-scroll.js",
+        assetFileNames: (info) => {
+          const n = info.names?.[0] ?? "";
+          if (n.endsWith(".css")) return "mesh-scroll.css";
+          if (n.endsWith(".woff2")) return "fonts/[name][extname]";
+          return "[name][extname]";
+        },
+        inlineDynamicImports: true,
+      },
+    },
+  },
+});

--- a/src/ui/vite.static.config.ts
+++ b/src/ui/vite.static.config.ts
@@ -18,8 +18,9 @@
 //
 //   npx vite build --config vite.static.config.ts
 //
-// The entry imports demo/generated.json, which demo/emit.tsx must have written
-// first — see the docs-scroll-build target.
+// The entry imports demo/generated/graph.json, which demo/emit.tsx must have
+// written first — see the docs-scroll-prerender target, which every build target
+// here depends on.
 import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";


### PR DESCRIPTION
## Summary

Replaces the scroll section's runtime renderer with build-time prerendering. **The section looks identical** — that is the whole point, and it is asserted rather than assumed.

```
JS   531,014 B → 184,695 B raw
     172,437 B →  20,171 B gzipped        8.5× smaller, −152 kB
```

React, React Flow, dagre and d3 are gone from the shipped bundle. CSS is unchanged and **byte-identical between the two builds** — the same Tailwind pipeline is used deliberately, so any visual difference could only come from the markup or the driver.

### Why this was possible

The graph's geometry never changes at runtime. Node positions come from an authored grid, so dagre's layout was computed and thrown away at ~24% of the bundle. Edge paths depend only on those positions and the card boxes, which take exactly **two** states across all 14 beats. Per-frame state already travelled through CSS custom properties.

React Flow v12 has a real SSR path, so the actual `<Stage>` renders through **React Flow's own renderer** at build time. The geometry comes from the library rather than from a reimplementation of it.

## Equivalence

Swapping the renderer of a live page needs proof, so there are two tiers.

**In CI, every PR** (~2s, no browser): 36 edge paths against a captured fixture across both geometry states; every card variant asserted present in the shell; all **51 selectors the driver queries**. That last one closes a real hole — a class rename in `stage.tsx` would otherwise have passed prerender, passed the bundle build, passed the deploy's file check, and shipped an empty panel over 2205vh.

**By hand, for changes to this section**: 201 scroll positions, weighted toward *transitions* rather than settled frames, because three separate bugs during the original build hid in the transitions.

```
20,904 custom-property values + 1,206 other fields
 5,226 card class/body values across 13 cards
 3,618 edge-label states (visibility exact, geometry ≤1.01 px / tol 1.25)
28,944 edge-path coordinates (max deviation 0.00036 px)

IDENTICAL
```

Nothing is rounded by the comparator — every value is a string the driver itself wrote.

**Pixel comparison is deliberately not a gate.** A control run showed the React build differs from *itself* at 5/41 frames — live ResizeObserver jitter moves antialiasing — so a pixel count cannot separate a regression from noise. Measured by amplitude, worst single pixel is 9/255 and frame-wide RMSE ≤0.08%.

The one tolerance above is honest and load-bearing: React Flow re-measures labels with `getBBox` on every re-render, and Chrome returns zoom-dependent metrics for this variable font — the same label reports 16.299, 17 and 17.291 in the same React build. The prerendered build measures once and holds 17.103, inside React's own spread. The 1.25px tolerance is derived from React's measured self-inconsistency, with the numbers recorded in the file.

## Review Notes

Reviewed by a zero-context agent, which traced the renderer split line by line and found **no behavioural divergence**. Two blockers found and fixed, both in the guards rather than the migration:

- **`tsc --noEmit` broke on a fresh checkout** — `static.ts` imports a gitignored generated file. CI now prerenders before type-checking. Reproduced and verified.
- **The pixel harness failed open** — with ImageMagick absent it reported `41/41 pixel-identical` having compared nothing. Root cause was worse than diagnosed: `compare` writes its metric to stderr in *both* the pass and fail cases, so identical images parsed as `null` and were correct only by accident. Now exits 2 with a preflight; verified by running without ImageMagick on `PATH`.

Both harness gaps the review found were closed and then *proved to have teeth* — injecting an off-by-one into the card table produces 165 differences where the old capture printed IDENTICAL.

The React bundle stays buildable as the harness's reference, and the Makefile says why so it is not pruned as dead weight.

Closes #1524

## Test plan

- [ ] Docs deploy succeeds and publishes the prerendered bundle
- [ ] Section renders and scrolls at ≥1440px; edges visible, beats advance, arrow animates
- [ ] Section absent below 900px with no bundle request
- [ ] `ui-test` passes on a clean checkout (prerender-then-typecheck ordering)
- [ ] `make docs-scroll-compare` + `node demo/equivalence.mjs` reproduces IDENTICAL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a prerendered static version of the scroll-based UI demo for faster, lightweight documentation pages.
  - Added a comparison view to inspect the static and interactive versions side by side.
  - Added keyboard navigation, reduced-motion support, responsive updates, and improved scroll interactions.

- **Bug Fixes**
  - Improved validation of layout, animation states, labels, and visual output to detect discrepancies between versions.

- **Documentation**
  - Updated scroll-section documentation with current bundle size, breakpoints, and layout dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->