### PR TITLE
fix: stop the scroll demo feeding the dashboard's Tailwind scan

### DIFF
--- a/src/ui/__tests__/spa-css-isolation.test.ts
+++ b/src/ui/__tests__/spa-css-isolation.test.ts
@@ -1,0 +1,252 @@
+// The dashboard's stylesheet must contain nothing that exists only because of
+// the scroll demo.
+//
+// WHY THIS IS A TEST AND NOT A CODE REVIEW HABIT. Tailwind v4's automatic
+// source detection is rooted at the Vite root (src/ui) and extracts utility
+// candidates from ANY text it scans — including prose in comments. Before
+// app/spa.css the demo was contributing 79 rules and 6.2 kB to a build that
+// never renders one of them, and THREE of those rules came from ordinary
+// English words written in comments, twice in comments explaining this exact
+// hazard. Four recurrences, three of them from prose. Discipline demonstrably
+// does not hold here, so the invariant is asserted instead.
+//
+// WHAT IT ACTUALLY CHECKS, and why it is not a committed snapshot. A frozen
+// rule list would change on every legitimate dashboard edit, which trains
+// people to regenerate it without reading — and a regenerated baseline absorbs
+// the leak it was meant to catch. So the demo-only surface is recomputed from
+// source on every run: tokens that appear under demo/ and nowhere else in
+// src/ui cannot legitimately appear in the dashboard's CSS, because the
+// dashboard's build does not scan demo/. If the exclusion in app/spa.css is
+// removed or defeated by a new import path, they do.
+//
+// MOVING the exclusion is a different failure and this check cannot see it:
+// relocated into app/globals.css it still keeps the dashboard clean, while the
+// demo's own entry silently loses its classes — the regression app/spa.css was
+// written to document. The second assertion below covers that case, by holding
+// app/globals.css free of source directives entirely.
+//
+// It builds the dashboard, which no other test does — that is deliberate.
+// `npx tsc --noEmit` proves it type-checks and nothing proved it still
+// produced a correct stylesheet.
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const UI = path.resolve(__dirname, "..");
+const DEMO = path.join(UI, "demo");
+
+/** Directories that are build output or vendored, never authored sources. */
+const IGNORED = new Set(["node_modules", "dist", "dist-static", "generated", ".git", "public"]);
+const TEXT = /\.(ts|tsx|js|jsx|mjs|cjs|css|html|json|md)$/;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (IGNORED.has(e.name)) continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, out);
+    else if (TEXT.test(e.name)) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Tailwind-ish candidate tokens. This does not have to match Tailwind's
+ * extractor exactly — it only has to be a superset of the class names that
+ * could leak, so that "appears in demo/ only" is a safe over-approximation.
+ */
+function tokens(file: string): Set<string> {
+  const text = fs.readFileSync(file, "utf8");
+  const out = new Set<string>();
+  // The trailing group must be able to END on the closing bracket: an earlier
+  // version required one more character after it, so a bracketed class was
+  // never captured whole and that set came out almost empty.
+  for (const m of text.matchAll(/[a-zA-Z][a-zA-Z0-9:_./-]*(?:\[[^\]\s"'`]+\][a-zA-Z0-9:_./-]*)?/g)) {
+    out.add(m[0]);
+  }
+  return out;
+}
+
+/** Selector to bare class: strips the leading dot, any variant suffix, and
+ *  CSS escaping. (No example spelled out — see the note in the assertion.) */
+function classOf(selector: string): string | null {
+  const m = /^\.((?:\\.|[^\s.:,>+~[\]()])*(?:\\\[(?:\\.|[^\]])*\\\])?(?:\\.|[^\s.:,>+~()])*)/.exec(
+    selector.trim()
+  );
+  if (!m) return null;
+  return m[1].replace(/\\(.)/g, "$1");
+}
+
+/**
+ * Bodies of the named `@layer` blocks, brace-matched. Tailwind emits everything
+ * it GENERATES inside these; anything outside came from a stylesheet someone
+ * imported, which is not this test's business.
+ */
+function layerBlocks(css: string, names: string[]): string[] {
+  const out: string[] = [];
+  const re = new RegExp(`@layer\\s+(${names.join("|")})\\s*\\{`, "g");
+  for (const m of css.matchAll(re)) {
+    let depth = 1;
+    let i = m.index! + m[0].length;
+    const start = i;
+    while (i < css.length && depth > 0) {
+      if (css[i] === "{") depth++;
+      else if (css[i] === "}") depth--;
+      i++;
+    }
+    out.push(css.slice(start, i - 1));
+  }
+  return out;
+}
+
+describe("dashboard stylesheet isolation (#1519)", () => {
+  it("contains no utility that exists only because of demo/", () => {
+    // Build fresh: the point is to test what ships, not a stale artifact.
+    // stdio is piped so a green run stays quiet, which means a BROKEN build
+    // would otherwise surface as a bare "Command failed" with the compiler's
+    // diagnosis stranded on the error object. Put it back in the message.
+    try {
+      execFileSync("npx", ["vite", "build"], { cwd: UI, stdio: "pipe" });
+    } catch (err) {
+      const e = err as { stdout?: Buffer; stderr?: Buffer; message?: string };
+      throw new Error(
+        `the dashboard build failed, so this check never ran.\n${e.message ?? ""}\n` +
+          `--- stderr ---\n${e.stderr?.toString() ?? ""}\n` +
+          `--- stdout ---\n${e.stdout?.toString() ?? ""}`
+      );
+    }
+
+    const cssFiles = fs
+      .readdirSync(path.join(UI, "dist", "assets"))
+      .filter((f) => f.endsWith(".css"))
+      .map((f) => path.join(UI, "dist", "assets", f));
+    expect(
+      cssFiles,
+      "expected exactly one stylesheet from the dashboard build. None means the " +
+        "build emitted no CSS at all; more than one means it started splitting CSS " +
+        "per chunk, and this check would then be reading only whichever came first."
+    ).toHaveLength(1);
+    const css = fs.readFileSync(cssFiles[0], "utf8");
+
+    const demoTokens = new Set<string>();
+    for (const f of walk(DEMO)) for (const t of tokens(f)) demoTokens.add(t);
+
+    const appTokens = new Set<string>();
+    for (const f of walk(UI)) {
+      if (f.startsWith(DEMO + path.sep)) continue;
+      for (const t of tokens(f)) appTokens.add(t);
+    }
+
+    // ARBITRARY-VALUE CLASSES ONLY — the bracketed kind Tailwind generates
+    // from a literal length or colour written inside square brackets.
+    //
+    // NO CLASS NAME IS SPELLED OUT ANYWHERE IN THIS FILE, and that is not
+    // fastidiousness. This file lives under src/ui, so the dashboard build
+    // scans it: an example written here would be emitted into the very
+    // stylesheet this test guards. Worse, it would also land in the set of
+    // "app tokens" below, laundering that class out of demo-only status and
+    // blinding the check to a real leak of it. Writing four examples in this
+    // comment added four rules and hid them from the assertion in one move.
+    //
+    // A short unbracketed token is ambiguous. One of them names a visual
+    // effect that the dashboard emits as a bare utility, and NOT because any
+    // dashboard source uses it as a class: it is the tail of a dotted name
+    // inside a string literal in another test here. Tailwind's extractor
+    // splits that on the dot and takes the tail as a candidate, while this
+    // tokenizer keeps the dotted name whole — so a naive "demo token absent
+    // from app sources" set flags it as a leak when it is in the no-demo
+    // baseline. (Verified against the extractor directly, because the obvious
+    // explanation is wrong: the longer hyphenated class of the same family
+    // that the dashboard does use yields no such candidate.)
+    // Loosening to substring matching fixes that and
+    // creates the opposite problem: another of them is a prefix of a hyphenated
+    // class used all over the dashboard, so a genuine leak of its bare form —
+    // one of the four that actually happened — would stop being detected.
+    //
+    // Bracketed classes have no such ambiguity: they are long, unique, and
+    // cannot appear as a fragment of another class. They are also guaranteed
+    // to be present in any real regression, because the failure mode is the
+    // exclusion not applying AT ALL, which brings the whole demo surface with
+    // it — 79 rules, roughly a quarter of them bracketed. This is a sharp
+    // detector for a blunt failure, chosen over a blunt detector that cries
+    // wolf and gets deleted.
+    const demoOnly = new Set(
+      [...demoTokens].filter((t) => t.includes("[") && t.includes("]") && !appTokens.has(t))
+    );
+    // If this ever empties, the assertion below passes forever and means
+    // nothing. Fail loudly instead.
+    expect(
+      demoOnly.size,
+      "no demo-only arbitrary-value classes found — this check has gone vacuous"
+    ).toBeGreaterThan(10);
+
+    // ONLY inside Tailwind's own layers. Vendored stylesheets (React Flow's,
+    // which the dashboard imports) sit outside them and legitimately define
+    // classes that the demo also references but no dashboard source spells
+    // out — those are not leaks, and counting them made this fail on
+    // react-flow__viewport and friends.
+    //
+    // THE SELECTOR SCAN IS NARROWER THAN IT LOOKS, in three further ways. A
+    // rule that is the FIRST one inside a nested at-rule is preceded by `{`
+    // and never matches (about a hundred of them in the current output —
+    // mostly feature queries, where the same rule also appears unwrapped, but
+    // also the width and pointer blocks, where it does not appear anywhere
+    // else). The selector body excludes commas, so an arbitrary value
+    // containing one is never seen — one rule today. And classOf reads nothing
+    // that does not begin with a dot, so the wrapped forms Tailwind emits for
+    // some variants are skipped — around a hundred today. All three are
+    // acceptable HERE because the failure being caught is the whole demo
+    // surface arriving at once, not one rule; widening the pattern to close
+    // them would buy precision this check does not need at the price of false
+    // positives, which is how a guard gets deleted.
+    const layers = layerBlocks(css, ["utilities", "components"]);
+    // The other half of the vacuity guard, and the one that was missing: the
+    // demoOnly set above protects the SOURCE side of the comparison, nothing
+    // protected this side. If Tailwind stops emitting named layers, a minifier
+    // flattens them, or the pipeline moves to another CSS transformer, these
+    // bodies come back empty, every assertion below passes, and a completely
+    // polluted stylesheet raises no signal at all.
+    expect(
+      layers.join("").length,
+      "no @layer utilities/components content found in the built stylesheet — " +
+        "the leak scan below had nothing to read, so its result means nothing. " +
+        "Check how the build now emits generated utilities."
+    ).toBeGreaterThan(0);
+
+    const leaked: string[] = [];
+    for (const layer of layers) {
+      for (const m of layer.matchAll(/(^|[},])\s*(\.[^{},]+)\{/g)) {
+        for (const sel of m[2].split(",")) {
+          const cls = classOf(sel);
+          if (cls && demoOnly.has(cls)) leaked.push(cls);
+        }
+      }
+    }
+
+    expect(
+      [...new Set(leaked)].sort(),
+      "utilities that only exist in demo/ reached the dashboard stylesheet. " +
+        "The `@source not` exclusion in app/spa.css is not taking effect — check that " +
+        "src/main.tsx still imports app/spa.css and that nothing else pulls " +
+        "app/globals.css into the dashboard build."
+    ).toEqual([]);
+  }, 120_000);
+
+  // The design's load-bearing property, which nothing else enforces. Both
+  // builds compile app/globals.css, so a source directive placed there reaches
+  // the demo's entry too and strips it of its own classes — the check above
+  // still passes, because the dashboard itself comes out clean. Keeping this
+  // free of them is what makes "the demo bundle is unchanged BY CONSTRUCTION"
+  // true rather than something to re-verify by hand.
+  it("keeps source directives out of app/globals.css", () => {
+    const globals = fs.readFileSync(path.join(UI, "app", "globals.css"), "utf8");
+    const found = [...globals.matchAll(/^[^\n]*@source[^\n]*$/gm)].map((m) => m[0].trim());
+    expect(
+      found,
+      "app/globals.css now carries a source directive. It is the scroll demo's " +
+        "own stylesheet entry as well as the dashboard's, so this also applies to " +
+        "the demo's build and can silently strip its classes. Put dashboard-only " +
+        "directives in app/spa.css, which the demo does not import."
+    ).toEqual([]);
+  });
+});

--- a/src/ui/__tests__/spa-css-isolation.test.ts
+++ b/src/ui/__tests__/spa-css-isolation.test.ts
@@ -22,8 +22,17 @@
 // MOVING the exclusion is a different failure and this check cannot see it:
 // relocated into app/globals.css it still keeps the dashboard clean, while the
 // demo's own entry silently loses its classes — the regression app/spa.css was
-// written to document. The second assertion below covers that case, by holding
+// written to document. The third assertion below covers that case, by holding
 // app/globals.css free of source directives entirely.
+//
+// THE SAME LEAK RUNS THE OTHER WAY, and the second assertion covers it — but by
+// checking the WIRING rather than the output, for reasons set out where it sits.
+// The demo compiles its own entry, demo/entry.css, which excludes the two
+// surfaces that are dashboard-private by definition. Before that file existed
+// the demo was scanning them, and a dotted name inside a string literal in one
+// of the dashboard's unit tests was worth 225 bytes of the demo's stylesheet —
+// so "the demo is unaffected" was an assumption with a counterexample already in
+// the tree, not a property of the design.
 //
 // It builds the dashboard, which no other test does — that is deliberate.
 // `npx tsc --noEmit` proves it type-checks and nothing proved it still
@@ -35,6 +44,11 @@ import path from "node:path";
 
 const UI = path.resolve(__dirname, "..");
 const DEMO = path.join(UI, "demo");
+/** The shared theme, and the two wrappers that are the only way in to it. */
+const GLOBALS = path.join(UI, "app", "globals.css");
+const WRAPPER = path.join(DEMO, "entry.css");
+/** The surfaces demo/entry.css has to exclude. */
+const PRIVATE = [__dirname, path.join(UI, "app", "spa.css")];
 
 /** Directories that are build output or vendored, never authored sources. */
 const IGNORED = new Set(["node_modules", "dist", "dist-static", "generated", ".git", "public"]);
@@ -99,22 +113,63 @@ function layerBlocks(css: string, names: string[]): string[] {
   return out;
 }
 
+/**
+ * What a file PULLS IN, by form rather than by mention.
+ *
+ * Matching the bare text `app/globals.css` would be simpler and useless here:
+ * half the files under demo/ discuss it in prose, and one of them has to, since
+ * explaining the boundary means naming what sits on the other side of it. Only
+ * these forms actually create an import edge, and only an import edge can put a
+ * second entry into Tailwind's compilation. Covering all of them rather than
+ * the one spelling in the tree today is the point — repointing an entry at the
+ * theme via an alias, a dynamic import or a stylesheet link is the same
+ * regression as repointing it with a relative path.
+ */
+function importedPaths(file: string): string[] {
+  const text = fs.readFileSync(file, "utf8");
+  const out: string[] = [];
+  const forms = [
+    /\bimport\s+(?:[^;()]*?\bfrom\s+)?["']([^"']+)["']/g,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    /\brequire\s*\(\s*["']([^"']+)["']\s*\)/g,
+    /@import\s+(?:url\(\s*)?["']?([^"')\s;]+)/g,
+    /<link\b[^>]*\bhref\s*=\s*["']([^"']+)["']/gi,
+  ];
+  for (const re of forms) for (const m of text.matchAll(re)) out.push(m[1]);
+  return out;
+}
+
+/** Where a specifier lands, or null if it names a package rather than a file. */
+function resolveSpecifier(from: string, spec: string): string | null {
+  if (spec.startsWith("@/")) return path.join(UI, spec.slice(2));
+  if (spec.startsWith("/")) return path.join(UI, spec.slice(1));
+  if (spec.startsWith(".")) return path.resolve(path.dirname(from), spec);
+  return null;
+}
+
+/**
+ * Build fresh: the point is to test what ships, not a stale artifact.
+ *
+ * stdio is piped so a green run stays quiet, which means a BROKEN build would
+ * otherwise surface as a bare "Command failed" with the compiler's diagnosis
+ * stranded on the error object. Put it back in the message.
+ */
+function build(args: string[], what: string): void {
+  try {
+    execFileSync("npx", ["vite", "build", ...args], { cwd: UI, stdio: "pipe" });
+  } catch (err) {
+    const e = err as { stdout?: Buffer; stderr?: Buffer; message?: string };
+    throw new Error(
+      `the ${what} build failed, so this check never ran.\n${e.message ?? ""}\n` +
+        `--- stderr ---\n${e.stderr?.toString() ?? ""}\n` +
+        `--- stdout ---\n${e.stdout?.toString() ?? ""}`
+    );
+  }
+}
+
 describe("dashboard stylesheet isolation (#1519)", () => {
   it("contains no utility that exists only because of demo/", () => {
-    // Build fresh: the point is to test what ships, not a stale artifact.
-    // stdio is piped so a green run stays quiet, which means a BROKEN build
-    // would otherwise surface as a bare "Command failed" with the compiler's
-    // diagnosis stranded on the error object. Put it back in the message.
-    try {
-      execFileSync("npx", ["vite", "build"], { cwd: UI, stdio: "pipe" });
-    } catch (err) {
-      const e = err as { stdout?: Buffer; stderr?: Buffer; message?: string };
-      throw new Error(
-        `the dashboard build failed, so this check never ran.\n${e.message ?? ""}\n` +
-          `--- stderr ---\n${e.stderr?.toString() ?? ""}\n` +
-          `--- stdout ---\n${e.stdout?.toString() ?? ""}`
-      );
-    }
+    build([], "dashboard");
 
     const cssFiles = fs
       .readdirSync(path.join(UI, "dist", "assets"))
@@ -232,21 +287,95 @@ describe("dashboard stylesheet isolation (#1519)", () => {
     ).toEqual([]);
   }, 120_000);
 
-  // The design's load-bearing property, which nothing else enforces. Both
-  // builds compile app/globals.css, so a source directive placed there reaches
-  // the demo's entry too and strips it of its own classes — the check above
-  // still passes, because the dashboard itself comes out clean. Keeping this
-  // free of them is what makes "the demo bundle is unchanged BY CONSTRUCTION"
-  // true rather than something to re-verify by hand.
+  // THE MIRROR OF THE ABOVE, AND DELIBERATELY NOT AN OUTPUT CHECK. This one
+  // reads the wiring and builds nothing. That is a considered downgrade, not an
+  // omission, so the reasoning is recorded rather than left to be rediscovered.
+  //
+  // THE OUTPUT CHECK WAS WRITTEN, MEASURED AND DELETED. Its shape had to mirror
+  // the first one — recompute, on every run, the candidates that exist only in
+  // the private files, then assert none of them reached the demo's stylesheet.
+  // The dashboard direction has a large self-renewing surface to recompute from,
+  // because demo/ is full of real classes. This direction has none: both private
+  // files are disciplined about never naming a utility, so the recomputed set is
+  // made up of indexing expressions out of test code that Tailwind emits nothing
+  // for. Repointing the demo's entry back at the theme left that assertion GREEN.
+  // A check that stays green through the exact regression it names is worse than
+  // no check, and it was buying that for 1.5s of build time on every run.
+  //
+  // NOR CAN IT BE REPAIRED by loosening the tokenizer. The single rule that was
+  // in fact leaking arrived as the tail of a dotted name inside a string
+  // literal, and its bare form also occurs in a vendored stylesheet under demo/,
+  // so it is not "private-only" under any tokenizer — while a tokenizer loose
+  // enough to reach it would launder genuine leaks into the permitted set, which
+  // is the failure the first check's own notes spend a paragraph avoiding.
+  //
+  // SO THE BOUNDARY IS THE GUARANTEE HERE, and the boundary was verified once,
+  // empirically, rather than argued: with demo/entry.css in place the demo's
+  // stylesheet is byte-identical to one built with __tests__/ and app/spa.css
+  // physically removed from the tree, and the one rule that had been leaking —
+  // 225 bytes, from a string literal in a unit test — is gone. That leaves
+  // exactly one thing worth asserting on every run: that the boundary stays
+  // WIRED. Every regression available here takes that path. Nobody defeats an
+  // exclusion in place; they repoint an entry at the theme because it is one
+  // character shorter, or drop a directive that looks redundant.
+  it("keeps the scroll demo wired to its own entry", () => {
+    // Both halves of the guard, in one assertion: this is also what proves
+    // importedPaths can see an edge at all. If it silently stopped matching, the
+    // sweep below would find nothing and pass on every file in the tree.
+    expect(
+      importedPaths(WRAPPER).map((s) => resolveSpecifier(WRAPPER, s)),
+      "demo/entry.css does not import app/globals.css, so the demo has no theme " +
+        "and the check below is asserting that nothing reaches a file nothing " +
+        "imports. The wrapper exists to be the demo's one way in to the theme."
+    ).toContain(GLOBALS);
+
+    const direct = walk(DEMO)
+      .filter((f) => f !== WRAPPER)
+      .filter((f) => importedPaths(f).some((s) => resolveSpecifier(f, s) === GLOBALS))
+      .map((f) => path.relative(UI, f))
+      .sort();
+    expect(
+      direct,
+      "these files under demo/ import app/globals.css directly instead of going " +
+        "through demo/entry.css. That makes app/globals.css a second entry for " +
+        "the demo's build, and app/globals.css carries no exclusions — so the " +
+        "demo goes back to scanning the dashboard's own tests and stylesheet " +
+        "entry, which is where the 225 bytes came from. Import demo/entry.css."
+    ).toEqual([]);
+
+    // Resolved rather than compared as text, so rewriting a path in a different
+    // but equivalent spelling is not a failure and quietly dropping one is.
+    const wrapper = fs.readFileSync(WRAPPER, "utf8");
+    const excluded = [...wrapper.matchAll(/@source\s+not\s+["']([^"']+)["']/g)].map((m) =>
+      path.resolve(DEMO, m[1])
+    );
+    for (const required of PRIVATE) {
+      expect(
+        excluded,
+        `demo/entry.css no longer excludes ${path.relative(UI, required)} from the ` +
+          "demo's scan. Tailwind's source detection is rooted at the Vite root for " +
+          "both builds, so without this the demo scans a dashboard-private surface " +
+          "and emits utilities out of it that nothing in the demo renders."
+      ).toContain(required);
+    }
+  });
+
+  // The design's load-bearing property, which nothing else enforces. BOTH
+  // entries import app/globals.css, so a source directive placed there applies
+  // to both compilations at once: it cannot say anything about one of them, and
+  // an exclusion meant for the dashboard would strip the demo of its own
+  // classes. Neither check above sees that, because each build comes out clean
+  // on its own terms. Keeping this file free of directives is what makes the two
+  // wrappers independent.
   it("keeps source directives out of app/globals.css", () => {
     const globals = fs.readFileSync(path.join(UI, "app", "globals.css"), "utf8");
     const found = [...globals.matchAll(/^[^\n]*@source[^\n]*$/gm)].map((m) => m[0].trim());
     expect(
       found,
-      "app/globals.css now carries a source directive. It is the scroll demo's " +
-        "own stylesheet entry as well as the dashboard's, so this also applies to " +
-        "the demo's build and can silently strip its classes. Put dashboard-only " +
-        "directives in app/spa.css, which the demo does not import."
+      "app/globals.css now carries a source directive. It sits in the import graph " +
+        "of the scroll demo's entry as well as the dashboard's, so this also applies " +
+        "to the demo's build and can silently strip its classes. Dashboard-only " +
+        "directives belong in app/spa.css, demo-only ones in demo/entry.css."
     ).toEqual([]);
   });
 });

--- a/src/ui/app/spa.css
+++ b/src/ui/app/spa.css
@@ -1,0 +1,53 @@
+/*
+ * DASHBOARD stylesheet entry. Everything is in globals.css; this file exists
+ * only to add the exclusions that must NOT apply to the other build.
+ *
+ * THE PROBLEM. Tailwind v4's automatic source detection is rooted at the Vite
+ * root (src/ui) and extracts utility candidates from ANY text it scans —
+ * comments, prose and JSON keys included. Everything under src/ui/demo/ was
+ * therefore contributing utilities to the dashboard's stylesheet even though
+ * the dashboard never renders a single one of them: 79 rules and 6.2 kB,
+ * measured against a build with the demo directory removed from the tree.
+ * Three of those rules came from ordinary English words in comments rather
+ * than from any class anyone wrote — which is why prose discipline is not the
+ * fix and a guard is. (The three are deliberately not named here: this file is
+ * itself scanned by the demo's build, so naming a utility in it would emit
+ * that rule into the demo bundle. Same trap, opposite direction.)
+ *
+ * WHY THE EXCLUSIONS ARE HERE AND NOT IN globals.css. Tailwind v4 compiles
+ * each CSS ENTRY on its own, against the `@source` set flattened out of THAT
+ * entry's import graph. globals.css is not merely reachable from the scroll
+ * demo — it IS the demo's entry, imported straight by demo/embed.tsx and
+ * demo/static.ts. So anything added there lands in both compilations: it fixes
+ * the dashboard and simultaneously stops the demo's own entry from finding the
+ * demo's classes, which is what made an earlier attempt fail. Only the
+ * dashboard reaches globals.css through this file.
+ *
+ * A wrapper the demo does not import is the smallest thing that separates the
+ * two, and it has a property the alternatives do not: globals.css is byte-for-
+ * byte unchanged, so the demo bundle is unchanged BY CONSTRUCTION rather than
+ * by verification. The alternative designs — splitting the theme into a shared
+ * partial, or relocating the demo outside src/ui — both edit or move what the
+ * demo consumes, and would need the demo's CSS re-proven.
+ *
+ * Keep the dashboard's own sources implicit: auto-detection already covers
+ * src/, app/ and components/, and enumerating them here would be a second list
+ * to forget to update.
+ */
+@import "./globals.css";
+
+/*
+ * Paths are relative to THIS file, so the first one is src/ui/demo.
+ *
+ * The two configs are the demo's own build definitions. They live at the Vite
+ * root rather than under demo/, so the exclusion above does not reach them,
+ * and they are scanned like any other text — one of them is several hundred
+ * lines of prose about the demo's stylesheet. They belong to the demo by
+ * ownership even though they do not sit in its directory.
+ *
+ * The scroll demo is built by those two configs, each of which is its own
+ * entry with its own scan.
+ */
+@source not "../demo";
+@source not "../vite.demo.config.ts";
+@source not "../vite.static.config.ts";

--- a/src/ui/app/spa.css
+++ b/src/ui/app/spa.css
@@ -10,25 +10,35 @@
  * measured against a build with the demo directory removed from the tree.
  * Three of those rules came from ordinary English words in comments rather
  * than from any class anyone wrote — which is why prose discipline is not the
- * fix and a guard is. (The three are deliberately not named here: this file is
- * itself scanned by the demo's build, so naming a utility in it would emit
- * that rule into the demo bundle. Same trap, opposite direction.)
+ * fix and a guard is. (The three are deliberately not named here. This file is
+ * now excluded from the demo's scan too — see demo/entry.css — so a name
+ * written here no longer reaches either stylesheet, but the habit is kept:
+ * that exclusion is one edit away from being removed, and every recurrence so
+ * far arrived through prose someone was sure was safe.)
  *
  * WHY THE EXCLUSIONS ARE HERE AND NOT IN globals.css. Tailwind v4 compiles
  * each CSS ENTRY on its own, against the `@source` set flattened out of THAT
- * entry's import graph. globals.css is not merely reachable from the scroll
- * demo — it IS the demo's entry, imported straight by demo/embed.tsx and
- * demo/static.ts. So anything added there lands in both compilations: it fixes
- * the dashboard and simultaneously stops the demo's own entry from finding the
- * demo's classes, which is what made an earlier attempt fail. Only the
- * dashboard reaches globals.css through this file.
+ * entry's import graph. globals.css is reachable from BOTH entries — this one
+ * and the demo's, demo/entry.css — so anything added there lands in both
+ * compilations at once: it would fix the dashboard and simultaneously stop the
+ * demo's entry from finding the demo's own classes, which is what made an
+ * earlier attempt fail. A directive can only be scoped to one build by sitting
+ * in a file the other build's entry does not import.
  *
- * A wrapper the demo does not import is the smallest thing that separates the
- * two, and it has a property the alternatives do not: globals.css is byte-for-
- * byte unchanged, so the demo bundle is unchanged BY CONSTRUCTION rather than
- * by verification. The alternative designs — splitting the theme into a shared
- * partial, or relocating the demo outside src/ui — both edit or move what the
- * demo consumes, and would need the demo's CSS re-proven.
+ * WHAT THIS DESIGN DOES AND DOES NOT GUARANTEE. It leaves globals.css
+ * unmodified, so the demo's THEME — every variable, every @theme mapping — is
+ * untouched by anything written here. It does NOT by itself make the demo's
+ * output independent of dashboard-private files: source detection is rooted at
+ * the Vite root for both builds, so before demo/entry.css existed the demo was
+ * still scanning __tests__/ and this very file, and a string literal in one of
+ * those tests was worth 225 bytes of the demo's stylesheet. What keeps
+ * dashboard-private files out of the demo's scan is the demo's OWN boundary in
+ * demo/entry.css, not the fact that this file exists. The two are symmetric and
+ * each one only speaks for its own build.
+ *
+ * The alternative designs — splitting the theme into a shared partial, or
+ * relocating the demo outside src/ui — both edit or move what the demo
+ * consumes, and would need the demo's CSS re-proven.
  *
  * Keep the dashboard's own sources implicit: auto-detection already covers
  * src/, app/ and components/, and enumerating them here would be a second list
@@ -45,8 +55,8 @@
  * lines of prose about the demo's stylesheet. They belong to the demo by
  * ownership even though they do not sit in its directory.
  *
- * The scroll demo is built by those two configs, each of which is its own
- * entry with its own scan.
+ * The scroll demo is built by those two configs. Both compile the same entry,
+ * demo/entry.css, which carries the exclusions pointing the other way.
  */
 @source not "../demo";
 @source not "../vite.demo.config.ts";

--- a/src/ui/demo/embed.tsx
+++ b/src/ui/demo/embed.tsx
@@ -8,7 +8,9 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import "@xyflow/react/dist/style.css";
-import "../app/globals.css";
+// entry.css, not app/globals.css: same theme, plus this bundle's own source
+// boundary. See the header of that file.
+import "./entry.css";
 import "./scroll.css";
 import "./embed.css";
 

--- a/src/ui/demo/entry.css
+++ b/src/ui/demo/entry.css
@@ -1,0 +1,48 @@
+/*
+ * SCROLL-DEMO stylesheet entry, and the mirror image of app/spa.css. The theme
+ * itself lives in app/globals.css; this file exists only to carry exclusions
+ * that must NOT reach the dashboard's compilation.
+ *
+ * WHY IT EXISTS. Tailwind v4's automatic source detection is rooted at the
+ * Vite root (src/ui) and extracts utility candidates from ANY text it scans,
+ * comments and JSON keys included. Until this file was added the demo's entry
+ * was app/globals.css directly, which carries no exclusions at all, so the
+ * demo's scan covered every authored file under src/ui — including the
+ * dashboard's own unit tests and app/spa.css. That was not theoretical: a
+ * dotted name inside a string literal in one of those tests was contributing
+ * 225 bytes to a bundle that renders nothing from it, and two ordinary English
+ * words in another one added 42 more before that.
+ *
+ * WHY THE EXCLUSIONS CANNOT LIVE IN app/globals.css. Tailwind compiles each
+ * CSS ENTRY on its own, against the source set flattened out of THAT entry's
+ * import graph. Both wrappers import app/globals.css, so a directive placed
+ * there applies to both compilations at once and can say nothing about one of
+ * them alone. That is the whole reason there are two wrappers rather than one
+ * shared file: each build states its own boundary, and neither can disturb the
+ * other's.
+ *
+ * WHY THE BOUNDARY STOPS WHERE IT DOES. Only the two surfaces that are
+ * dashboard-private by definition are named below. This bundle renders
+ * meshui's real AgentNode and pulls in components/, lib/ and the rest of app/,
+ * so those must keep being scanned or the demo loses utilities it genuinely
+ * renders. Narrow on purpose: what is excluded is what this bundle can never
+ * legitimately need, not everything it happens not to use today.
+ *
+ * DO NOT NAME A UTILITY ANYWHERE IN THIS FILE, comments included. It sits
+ * under demo/, which this bundle's own scan still covers, so a name written
+ * here is emitted straight into the stylesheet it produces.
+ */
+@import "../app/globals.css";
+
+/*
+ * Paths are relative to THIS file, so these are src/ui/__tests__ and
+ * src/ui/app/spa.css.
+ *
+ * __tests__/ is the dashboard's unit tests, which assert on dashboard data and
+ * dashboard markup; this bundle imports nothing from it. app/spa.css is the
+ * dashboard's own entry, which the demo by construction never imports — it
+ * would be self-defeating for the two entries to read each other, since each
+ * one's prose is about what the other must not scan.
+ */
+@source not "../__tests__";
+@source not "../app/spa.css";

--- a/src/ui/demo/scroll.tsx
+++ b/src/ui/demo/scroll.tsx
@@ -8,7 +8,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import "@xyflow/react/dist/style.css";
-import "../app/globals.css";
+import "./entry.css";
 import "./scroll.css";
 
 import { Stage } from "./stage";

--- a/src/ui/demo/static.ts
+++ b/src/ui/demo/static.ts
@@ -3,15 +3,15 @@
 // both scoped to #mesh-scroll.
 //
 // THE STYLESHEET IS DELIBERATELY THE SAME PIPELINE as the React bundle's, down
-// to importing app/globals.css. That import is the open half of #1519 and it is
-// tempting to close it here, but changing what Tailwind scans changes which
-// utilities exist, and doing that in the same step as replacing the renderer
-// would leave any visual difference with two possible causes. The stylesheets
-// are byte-identical across the two bundles (the build asserts it), so anything
-// that looks wrong is the markup or the driver — which is the whole point of
-// having built them side by side.
+// to the same entry: demo/entry.css, which is app/globals.css plus this
+// bundle's source boundary. Keeping the two identical is what makes the
+// equivalence comparison mean anything — the stylesheets come out byte-for-byte
+// the same across the two bundles, so anything that looks wrong is the markup
+// or the driver, which is the whole point of having built them side by side.
+// Changing this import in only one of the two would give any visual difference
+// a second possible cause.
 import "@xyflow/react/dist/style.css";
-import "../app/globals.css";
+import "./entry.css";
 import "./scroll.css";
 import "./embed.css";
 

--- a/src/ui/src/main.tsx
+++ b/src/ui/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./App";
-import "../app/globals.css";
+import "../app/spa.css";
 
 const basePath = window.__MESH_BASE_PATH__ || "/";
 

--- a/src/ui/vite.demo.config.ts
+++ b/src/ui/vite.demo.config.ts
@@ -2,15 +2,15 @@
 // on purpose: nothing here is shared with it and `npm run build` never reads
 // this file.
 //
-// KNOWN, MEASURED EXCEPTION — this config does not fully separate the two
-// builds, and cannot.
+// WHY THIS FILE IS NOT SCANNED BY THE DASHBOARD BUILD.
 // Tailwind v4's automatic source detection is rooted at the Vite root
 // (src/ui), and it extracts utility candidates from ANY text it scans,
 // including prose inside comments and the keys of JSON data files. So every
-// file under src/ui/demo/ contributes utilities to the DASHBOARD's stylesheet
-// even though the dashboard never renders them.
+// file under src/ui/demo/ — and this config, which sits at the root — used to
+// contribute utilities to the DASHBOARD's stylesheet even though the dashboard
+// never renders them.
 //
-// This is not fixable by writing careful prose. An earlier draft of THIS
+// This was not fixable by writing careful prose. An earlier draft of THIS
 // comment used a word that is itself a utility name and added another rule to
 // the dashboard's stylesheet. The surface includes comments, copy documents
 // and the keys of JSON data files.
@@ -19,12 +19,16 @@
 // all". That was false and is exactly the kind of assertion that outlives the
 // thing it describes, so it is stated accurately here instead.
 //
-// Two independent fixes exist, both out of scope for this config:
-//   - relocate the demo outside src/ui (verified: a probe file in
-//     web/scroll-demo/ is NOT scanned, one in src/ui/demo/ is);
-//   - or land the prerender migration, after which the demo no longer imports
-//     app/globals.css and `@source not "../demo"` works cleanly — it does not
-//     today, because both entries share that Tailwind entry point.
+// FIXED IN app/spa.css (#1519), which the dashboard entry imports instead of
+// app/globals.css and which excludes demo/ plus this config and
+// vite.static.config.ts. The exclusions could NOT go in app/globals.css:
+// Tailwind compiles each CSS entry against its own flattened source set, and
+// app/globals.css is this bundle's entry too, so an exclusion there strips the
+// demo's own classes. __tests__/spa-css-isolation.test.ts holds both halves.
+//
+// Relocating the demo outside src/ui remains a valid alternative (verified: a
+// probe file in web/scroll-demo/ is NOT scanned, one in src/ui/demo/ is), and
+// the prerender migration would end the shared entry point altogether.
 //
 //   npx vite build --config vite.demo.config.ts
 //
@@ -89,8 +93,10 @@ export const MIN_WIDTH = 900;
  * from ANY text it scans, prose in comments included. Two ordinary English
  * words used here earlier were each a valid utility name, and emitted two
  * extra rules into the SPA's stylesheet — a build this file has nothing to
- * do with. Avoid bare utility words in files under src/ui; the durable fix
- * is one @source line in app/globals.css (see the Phase 2 notes).
+ * do with. That particular escape route is now closed: app/spa.css excludes
+ * this config from the dashboard's scan (see the header). It is still worth
+ * avoiding bare utility words anywhere under src/ui, because THIS bundle
+ * scans everything the exclusions do not cover, in the other direction.
  */
 export function scopeCss(): Plugin {
   const scoper = {

--- a/src/ui/vite.demo.config.ts
+++ b/src/ui/vite.demo.config.ts
@@ -23,8 +23,15 @@
 // app/globals.css and which excludes demo/ plus this config and
 // vite.static.config.ts. The exclusions could NOT go in app/globals.css:
 // Tailwind compiles each CSS entry against its own flattened source set, and
-// app/globals.css is this bundle's entry too, so an exclusion there strips the
-// demo's own classes. __tests__/spa-css-isolation.test.ts holds both halves.
+// app/globals.css sits in both entries' import graphs, so an exclusion there
+// applies to this bundle as well and strips the demo's own classes.
+//
+// THE SAME HAZARD RUNS THE OTHER WAY and is handled the same way. This bundle's
+// entry is demo/entry.css, which wraps app/globals.css and excludes the two
+// surfaces that are dashboard-private by definition; without it this bundle was
+// scanning the dashboard's unit tests and emitting 225 bytes it renders nothing
+// from. Neither wrapper is a guarantee about the other's output — each one only
+// states its own boundary. __tests__/spa-css-isolation.test.ts holds both.
 //
 // Relocating the demo outside src/ui remains a valid alternative (verified: a
 // probe file in web/scroll-demo/ is NOT scanned, one in src/ui/demo/ is), and
@@ -96,7 +103,7 @@ export const MIN_WIDTH = 900;
  * do with. That particular escape route is now closed: app/spa.css excludes
  * this config from the dashboard's scan (see the header). It is still worth
  * avoiding bare utility words anywhere under src/ui, because THIS bundle
- * scans everything the exclusions do not cover, in the other direction.
+ * scans everything demo/entry.css does not exclude, which is most of the tree.
  */
 export function scopeCss(): Plugin {
   const scoper = {


### PR DESCRIPTION
## Summary

Tailwind v4's automatic source detection is rooted at the **Vite root** (`src/ui`), not at the directories a build renders from. Two bundles are compiled out of this tree — the dashboard that ships inside the Go binary, and the scroll demo for the docs site — and each was scanning the other's private files, emitting rules from prose it would never render.

The fix gives **each build its own entry stylesheet** carrying its own source boundary. `app/globals.css` (the shared theme) is left byte-for-byte unchanged and carries no directives at all, because it sits in the import graph of both entries: anything placed there applies to both compilations at once and can say nothing about one of them alone. That was tried, and it broke the demo bundle.

### Direction 1 — demo → dashboard

The dashboard was scanning `src/ui/demo/`, emitting **79 rules / 6.2 kB** of dead utilities. Three of those rules came from ordinary English words in comments rather than from any class anyone wrote; two were in comments explaining this exact hazard. `app/spa.css` excludes `demo/` plus `vite.demo.config.ts` and `vite.static.config.ts` — demo-owned files that sit at the Vite root rather than under `demo/`, and were leaking a rule of their own.

### Direction 2 — dashboard → demo

The demo's entry *was* `app/globals.css`, which carries no exclusions, so its scan covered every authored file under `src/ui` including the dashboard's unit tests and `app/spa.css`. Writing the first commit of this PR demonstrated it live: two English words in a test comment emitted two rules into the demo bundle. `demo/entry.css` excludes `__tests__/` and `app/spa.css` — narrow on purpose, since the demo renders meshui's real `AgentNode` and needs `components/`, `lib/` and the rest of `app/` to keep being scanned.

This removed one real leak worth 225 bytes: a rule generated from the tail of a dotted name inside a string literal in a unit test.

## Guards

Prose discipline demonstrably does not hold here — six recurrences, three of them while writing this PR — so the invariants are asserted rather than remembered.

**Dashboard direction: an output check.** Rebuilds the dashboard and asserts no arbitrary-value utility existing only under `demo/` reaches the stylesheet. Not a committed snapshot: a frozen rule list changes on every legitimate edit, which trains people to regenerate it without reading, and a regenerated baseline absorbs the leak it was meant to catch. The demo-only surface is recomputed from source each run, with vacuity guards on both sides of the comparison.

**Demo direction: a wiring check, and that is a considered downgrade.** The mirror-image output check was written, measured and deleted. Both private files are disciplined about never naming a utility, so the set recomputed from them is indexing expressions Tailwind emits nothing for — and repointing the demo's entry back at the theme left that assertion **green**. A check that survives the exact regression it names is worse than no check, and it cost 1.5s of build time per run. It cannot be repaired by loosening the tokenizer either: the rule that was actually leaking is not private-only under any tokenizer, and a tokenizer loose enough to reach it would launder genuine leaks. So the boundary is the guarantee, verified once empirically, and what is asserted every run is that it stays **wired** — which is the path every available regression takes. Nobody defeats an exclusion in place; they repoint an entry because it is shorter, or drop a directive that looks redundant.

**Third assertion:** keeps `@source` directives out of `app/globals.css` — the failure neither of the others can see, since relocating an exclusion there leaves each build clean on its own terms while stripping the other.

No class name is spelled out anywhere in either wrapper or the test file. Doing so both emits that rule into the stylesheet under test *and* launders the class out of the recomputed set, blinding the check to a real leak of it.

## Verification

| | before | after |
|---|---|---|
| dashboard stylesheet | 77,511 B | **77,258 B** |
| demo stylesheet | 99,046 B | **98,821 B** |

- Dashboard CSS is **byte-identical** to a build with `demo/`, `vite.demo.config.ts` and `vite.static.config.ts` removed from the tree.
- Demo CSS is **byte-identical** to a build with `__tests__/` and `app/spa.css` removed from the tree.
- Both are the real bar — equivalence to a no-private-files control, not merely "differs from HEAD".
- Probes, each reverted: removing the dashboard exclusion fails with 26 leaked classes; adding an `@source` to `globals.css` fails the third assertion; repointing a demo entry via the `@/` **alias** form (a spelling not present in the tree) fails the wiring check; deleting either exclusion from `demo/entry.css` fails it.
- `npx tsc --noEmit`, full `vitest` suite (39 tests, 2.1s), `eslint` — all clean. `make docs-scroll-build` succeeds with four non-empty artifacts.

### Correction

An earlier revision of this description claimed `make docs-scroll-build` "reproduces the committed artifact with no diff." That was wrong: `docs/assets/mesh-scroll/` is gitignored (`.gitignore:303`), so there is no committed artifact and the `git status` check behind that claim was always going to come back empty. The demo's output had no baseline guarding it in any direction, which is part of why direction 2 went unnoticed. The byte-identity results above are measured against builds with the private files physically removed, not against anything committed.

Closes #1519

## Test plan

- [x] Dashboard CSS byte-identical to a no-demo control
- [x] Demo CSS byte-identical to a no-private-files control
- [x] Output check fails when the dashboard exclusion is removed
- [x] Wiring check fails on alias-form repointing and on a dropped exclusion
- [x] Third assertion fails when `globals.css` gains an `@source`
- [x] `tsc --noEmit`, `vitest`, `eslint`, `make docs-scroll-build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS isolation between the dashboard and demo experiences.
  * Prevented demo-only styles from leaking into dashboard builds.
  * Ensured dashboard-private styles do not affect demo bundles.

* **Tests**
  * Added automated checks to validate stylesheet isolation and detect leaked or missing styles during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->