### PR TITLE
fix: colour topology edges by what they call, not who calls

### DIFF
--- a/src/ui/__tests__/topology-edges.test.tsx
+++ b/src/ui/__tests__/topology-edges.test.tsx
@@ -398,6 +398,42 @@ describe("replicas collapsing into one edge", () => {
       expect(edges[0].style?.strokeDasharray).toBe("5 5");
     }
   });
+
+  it("unavailable beats unresolved when replicas disagree, in either order", () => {
+    // The remaining order-dependence, between the two cases above: both
+    // contributions are degraded, so neither the worst-of merge nor the job
+    // escalation fires and the map kept whichever arrived first. One order
+    // alone cannot see it — it passes for the builder that has no rule at all.
+    //
+    // The unresolved contribution carries a provider id, which a registry does
+    // not currently emit (see the note in addEdge): without one the edge loop
+    // drops the dep and there is nothing to merge. The precedence is a property
+    // of the merge, and is asserted as one.
+    const disagreeing = (unavailableFirst: boolean): Agent[] => {
+      const left = provider("prov-22222222", "prov", [cap("reports")]);
+      const right = provider("prov-33333333", "prov", [cap("reports")]);
+      const brokenCaller = consumer("caller-11111111", "caller", [
+        dep("reports", left.id, "unavailable"),
+      ]);
+      const pendingCaller = consumer("caller-44444444", "caller", [
+        dep("reports", right.id, "unresolved"),
+      ]);
+      return unavailableFirst
+        ? [brokenCaller, pendingCaller, left, right]
+        : [pendingCaller, brokenCaller, left, right];
+    };
+
+    for (const unavailableFirst of [true, false]) {
+      const { edges } = buildGraphFromAgents(disagreeing(unavailableFirst));
+      expect(edges).toHaveLength(1);
+      expect(edges[0].style?.stroke).toBe(EDGE_COLORS.unavailable);
+      // The dash has to go with the colour: half a merge leaves a red edge
+      // still drawn dashed, which is the grey row's styling under the red row's
+      // colour and describes neither state.
+      expect(edges[0].style).toHaveProperty("strokeDasharray", undefined);
+      expect(edges[0].animated).toBe(false);
+    }
+  });
 });
 
 describe("edges nothing can be drawn to", () => {

--- a/src/ui/__tests__/topology-edges.test.tsx
+++ b/src/ui/__tests__/topology-edges.test.tsx
@@ -1,0 +1,569 @@
+// Edge construction and edge COLOUR in buildGraphFromAgents.
+//
+// None of this was covered when issue #1521 was found: the only topology test
+// was buildIdToNodeKey, so the builder colouring a dependency edge by the
+// CALLER's agent_type — while the legend described the target — was something
+// no test in this suite could see, for as long as it existed.
+//
+// The rule these tests hold: an edge's colour describes WHAT IS BEING CALLED.
+// The provider's matching capability decides `dep` colour; nothing reads the
+// consumer's type.
+//
+// The last block renders the legend. Everything before it compares modules and
+// builder output with each other, which is half the palette contract — the
+// half that cannot see a swatch written back to a literal colour.
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Agent, Capability, DependencyResolution } from "../lib/types";
+import { buildGraphFromAgents } from "../lib/topology";
+import { EDGE_COLORS, EDGE_HEAT_COLORS, EDGE_LEGEND } from "../lib/edge-palette";
+import { EdgeLegend } from "../components/topology/EdgeLegend";
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "svc-00000000",
+    name: "svc",
+    agent_type: "mcp_agent",
+    status: "healthy",
+    endpoint: "http://svc:8080",
+    total_dependencies: 0,
+    dependencies_resolved: 0,
+    capabilities: [],
+    ...overrides,
+  };
+}
+
+const cap = (name: string, task?: boolean): Capability => ({
+  function_name: `fn_${name}`,
+  name,
+  version: "1.0.0",
+  ...(task === undefined ? {} : { task }),
+});
+
+const dep = (
+  capability: string,
+  provider: string,
+  status: DependencyResolution["status"] = "available"
+): DependencyResolution => ({
+  function_name: "consume",
+  capability,
+  status,
+  provider_agent_id: provider,
+});
+
+/** Every edge's stroke, keyed by edge id. */
+function strokes(agents: Agent[]): Record<string, string> {
+  const { edges } = buildGraphFromAgents(agents);
+  return Object.fromEntries(edges.map((e) => [e.id, e.style?.stroke as string]));
+}
+
+/** The one edge in a two-agent fixture. */
+function onlyEdge(agents: Agent[]) {
+  const { edges } = buildGraphFromAgents(agents);
+  expect(edges).toHaveLength(1);
+  return edges[0];
+}
+
+const provider = (id: string, name: string, caps: Capability[]) =>
+  makeAgent({ id, name, capabilities: caps });
+
+const consumer = (
+  id: string,
+  name: string,
+  deps: DependencyResolution[],
+  overrides: Partial<Agent> = {}
+) =>
+  makeAgent({
+    id,
+    name,
+    dependency_resolutions: deps,
+    total_dependencies: deps.length,
+    dependencies_resolved: deps.filter((d) => d.status === "available").length,
+    ...overrides,
+  });
+
+describe("dep edge colour is decided by the provider", () => {
+  it("an ordinary capability is a plain dependency", () => {
+    const edge = onlyEdge([
+      consumer("caller-11111111", "caller", [dep("reports", "prov-22222222")]),
+      provider("prov-22222222", "prov", [cap("reports")]),
+    ]);
+    expect(edge.style?.stroke).toBe(EDGE_COLORS.dependency);
+    expect(edge.animated).toBe(true);
+  });
+
+  it("a task=true capability is a job", () => {
+    const edge = onlyEdge([
+      consumer("caller-11111111", "caller", [dep("reports", "prov-22222222")]),
+      provider("prov-22222222", "prov", [cap("reports", true)]),
+    ]);
+    expect(edge.style?.stroke).toBe(EDGE_COLORS.job);
+  });
+
+  it("matches on the resolved capability, not merely on the provider owning some task", () => {
+    // The provider is a MeshJob producer, but NOT for the capability this edge
+    // resolved. Colouring by "the provider has a task somewhere" would repaint
+    // every other edge into that agent.
+    const edge = onlyEdge([
+      consumer("caller-11111111", "caller", [dep("reports", "prov-22222222")]),
+      provider("prov-22222222", "prov", [cap("reports"), cap("bulk_export", true)]),
+    ]);
+    expect(edge.style?.stroke).toBe(EDGE_COLORS.dependency);
+  });
+
+  it("matches the resolved FUNCTION when one capability name is on two functions", () => {
+    // A capability name is not unique within an agent: two functions can
+    // declare the same name and be told apart by tags, and only one of them
+    // need be a job. The resolution says which function won, in `mcp_tool`,
+    // and that is the only field that can answer this.
+    const twoFunctions = makeAgent({
+      id: "prov-22222222",
+      name: "prov",
+      capabilities: [
+        { function_name: "run_now", name: "reports", version: "1.0.0" },
+        { function_name: "run_overnight", name: "reports", version: "1.0.0", task: true },
+      ],
+    });
+
+    const toTheJob = onlyEdge([
+      consumer("caller-11111111", "caller", [
+        { ...dep("reports", "prov-22222222"), mcp_tool: "run_overnight" },
+      ]),
+      twoFunctions,
+    ]);
+    expect(toTheJob.style?.stroke).toBe(EDGE_COLORS.job);
+
+    const toTheOther = onlyEdge([
+      consumer("caller-11111111", "caller", [
+        { ...dep("reports", "prov-22222222"), mcp_tool: "run_now" },
+      ]),
+      twoFunctions,
+    ]);
+    expect(toTheOther.style?.stroke).toBe(EDGE_COLORS.dependency);
+  });
+
+  it("falls back to the capability name when the wire carries no mcp_tool", () => {
+    // Registries predating that field, and any resolution that simply lacks
+    // it. Ambiguous where a name is shared, which is the best available answer
+    // rather than a choice — and strictly better than drawing nothing.
+    const edge = onlyEdge([
+      consumer("caller-11111111", "caller", [dep("reports", "prov-22222222")]),
+      provider("prov-22222222", "prov", [cap("reports", true)]),
+    ]);
+    expect(edge.style?.stroke).toBe(EDGE_COLORS.job);
+  });
+
+  it("an mcp_tool naming no known function is not a job", () => {
+    // Skew between the resolution and the snapshot's capability list. The
+    // precise key missed, and a silent fall back to the name would paint an
+    // edge whose provenance nothing in the payload supports.
+    const edge = onlyEdge([
+      consumer("caller-11111111", "caller", [
+        { ...dep("reports", "prov-22222222"), mcp_tool: "renamed_since" },
+      ]),
+      provider("prov-22222222", "prov", [cap("reports", true)]),
+    ]);
+    expect(edge.style?.stroke).toBe(EDGE_COLORS.dependency);
+  });
+
+  it("a duplicated agent id is LAST WINS, including when the last declares no job", () => {
+    // Two records for one id should not reach the UI at all. If they do, the
+    // later one describes the agent — so a capability that has stopped being a
+    // task stops colouring its edge, rather than the earlier copy holding the
+    // colour indefinitely.
+    const wasAJob = makeAgent({ id: "prov-22222222", name: "prov", capabilities: [cap("reports", true)] });
+    const isNot = makeAgent({ id: "prov-22222222", name: "prov", capabilities: [cap("reports")] });
+    const caller = consumer("caller-11111111", "caller", [dep("reports", "prov-22222222")]);
+
+    const { edges: nowPlain } = buildGraphFromAgents([caller, wasAJob, isNot]);
+    expect(nowPlain[0].style?.stroke).toBe(EDGE_COLORS.dependency);
+
+    const { edges: nowJob } = buildGraphFromAgents([caller, isNot, wasAJob]);
+    expect(nowJob[0].style?.stroke).toBe(EDGE_COLORS.job);
+  });
+
+  it("task=false and an absent task flag are both ordinary (older registries)", () => {
+    const explicit = onlyEdge([
+      consumer("caller-11111111", "caller", [dep("reports", "prov-22222222")]),
+      provider("prov-22222222", "prov", [cap("reports", false)]),
+    ]);
+    expect(explicit.style?.stroke).toBe(EDGE_COLORS.dependency);
+
+    const absent = onlyEdge([
+      consumer("caller-11111111", "caller", [dep("reports", "prov-22222222")]),
+      provider("prov-22222222", "prov", [cap("reports")]),
+    ]);
+    expect(absent.style?.stroke).toBe(EDGE_COLORS.dependency);
+  });
+});
+
+describe("the caller's agent_type does not colour anything (issue #1521)", () => {
+  // Every member of the union, so a type the builder has never seen cannot be
+  // the one that still colours an edge.
+  const cases: Array<Agent["agent_type"]> = [
+    "mcp_agent",
+    "mesh_tool",
+    "decorator_agent",
+    "api",
+    "a2a",
+  ];
+
+  it.each(cases)("a %s caller into an ordinary provider draws a plain dependency", (type) => {
+    const edge = onlyEdge([
+      consumer("caller-11111111", "caller", [dep("reports", "prov-22222222")], {
+        agent_type: type,
+      }),
+      provider("prov-22222222", "prov", [cap("reports")]),
+    ]);
+    expect(edge.style?.stroke).toBe(EDGE_COLORS.dependency);
+  });
+
+  it("an @mesh.route gateway no longer draws pink — the same edge as any other caller", () => {
+    const gatewayEdge = onlyEdge([
+      // A route agent publishes no capability of its own, which is exactly why
+      // it can never BE a provider and why the pink branch was unreachable.
+      consumer("gateway-11111111", "gateway", [dep("trip_planning", "planner-22222222")], {
+        agent_type: "api",
+        capabilities: [],
+      }),
+      provider("planner-22222222", "planner", [cap("trip_planning")]),
+    ]);
+    const mcpEdge = onlyEdge([
+      consumer("plain-11111111", "plain", [dep("trip_planning", "planner-22222222")]),
+      provider("planner-22222222", "planner", [cap("trip_planning")]),
+    ]);
+    // Named, not merely compared: two edges with no stroke at all would be
+    // equal to each other and unequal to the job colour, so the comparison on
+    // its own passes for a builder that has stopped styling anything.
+    expect(gatewayEdge.style?.stroke).toBe(EDGE_COLORS.dependency);
+    expect(gatewayEdge.style?.stroke).toBe(mcpEdge.style?.stroke);
+    expect(gatewayEdge.style?.stroke).not.toBe(EDGE_COLORS.job);
+  });
+
+  it("an api caller into a job provider IS a job edge — the provider still decides", () => {
+    const edge = onlyEdge([
+      consumer("gateway-11111111", "gateway", [dep("bulk_export", "prov-22222222")], {
+        agent_type: "api",
+      }),
+      provider("prov-22222222", "prov", [cap("bulk_export", true)]),
+    ]);
+    expect(edge.style?.stroke).toBe(EDGE_COLORS.job);
+  });
+});
+
+describe("unavailable and unresolved are unchanged", () => {
+  it("unavailable is red and not animated", () => {
+    const edge = onlyEdge([
+      consumer("caller-11111111", "caller", [dep("reports", "prov-22222222", "unavailable")]),
+      provider("prov-22222222", "prov", [cap("reports")]),
+    ]);
+    expect(edge.style?.stroke).toBe(EDGE_COLORS.unavailable);
+    // The style has to BE there for its dash to be meaningfully absent: an edge
+    // with no style at all satisfies the undefined check while being drawn by
+    // React Flow's defaults.
+    expect(edge.style).toBeDefined();
+    expect(edge.style).toHaveProperty("strokeDasharray", undefined);
+    expect(edge.animated).toBe(false);
+  });
+
+  it("unresolved is grey and dashed", () => {
+    const edge = onlyEdge([
+      consumer("caller-11111111", "caller", [dep("reports", "prov-22222222", "unresolved")]),
+      provider("prov-22222222", "prov", [cap("reports")]),
+    ]);
+    expect(edge.style?.stroke).toBe(EDGE_COLORS.unresolved);
+    expect(edge.style?.strokeDasharray).toBe("5 5");
+  });
+
+  it("status wins over the job colour — a broken job edge is still red", () => {
+    const edge = onlyEdge([
+      consumer("caller-11111111", "caller", [dep("reports", "prov-22222222", "unavailable")]),
+      provider("prov-22222222", "prov", [cap("reports", true)]),
+    ]);
+    expect(edge.style?.stroke).toBe(EDGE_COLORS.unavailable);
+  });
+
+  it("llm tool and llm provider edges keep their own colours", () => {
+    const agents: Agent[] = [
+      makeAgent({
+        id: "planner-11111111",
+        name: "planner",
+        llm_tool_resolutions: [
+          {
+            function_name: "plan",
+            filter_capability: "reports",
+            status: "available",
+            provider_agent_id: "prov-22222222",
+          },
+          {
+            function_name: "plan",
+            filter_capability: "missing",
+            status: "unresolved",
+            provider_agent_id: "prov-22222222",
+          },
+        ],
+        llm_provider_resolutions: [
+          {
+            function_name: "plan",
+            required_capability: "llm",
+            status: "available",
+            provider_agent_id: "model-33333333",
+          },
+          {
+            function_name: "plan",
+            required_capability: "llm2",
+            status: "unavailable",
+            provider_agent_id: "model-33333333",
+          },
+        ],
+      }),
+      // task=true on the provider must NOT leak into llm/prov edges: those are
+      // not dependency resolutions and are never job invocations.
+      provider("prov-22222222", "prov", [cap("reports", true)]),
+      provider("model-33333333", "model", [cap("llm", true)]),
+    ];
+    const s = strokes(agents);
+    expect(s["llm|planner-11111111|prov-22222222|llm:reports"]).toBe(EDGE_COLORS.llmTool);
+    expect(s["llm|planner-11111111|prov-22222222|llm:missing"]).toBe(EDGE_COLORS.unavailable);
+    expect(s["prov|planner-11111111|model-33333333|provider:llm"]).toBe(EDGE_COLORS.llmProvider);
+    expect(s["prov|planner-11111111|model-33333333|provider:llm2"]).toBe(EDGE_COLORS.unavailable);
+  });
+});
+
+describe("replicas collapsing into one edge", () => {
+  // Two provider replicas under one name, so the target collapses to
+  // `group:prov`, and two consumer replicas resolving one to each. Both
+  // contributions land on the SAME edge key, which is where a colour
+  // disagreement can now exist at all.
+  const mixedGroup = (jobFirst: boolean): Agent[] => {
+    const jobbing = provider("prov-22222222", "prov", [cap("reports", true)]);
+    const plain = provider("prov-33333333", "prov", [cap("reports")]);
+    const providers = jobFirst ? [jobbing, plain] : [plain, jobbing];
+    return [
+      consumer("caller-11111111", "caller", [dep("reports", providers[0].id)]),
+      consumer("caller-44444444", "caller", [dep("reports", providers[1].id)]),
+      ...providers,
+    ];
+  };
+
+  it("collapses to a single edge between the two group nodes", () => {
+    const { nodes, edges } = buildGraphFromAgents(mixedGroup(true));
+    expect(nodes.map((n) => n.id).sort()).toEqual(["group:caller", "group:prov"]);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].id).toBe("dep|group:caller|group:prov|reports");
+  });
+
+  it("draws the job colour when ANY replica behind it is a job, in either order", () => {
+    for (const jobFirst of [true, false]) {
+      const { edges } = buildGraphFromAgents(mixedGroup(jobFirst));
+      expect(edges[0].style?.stroke).toBe(EDGE_COLORS.job);
+    }
+  });
+
+  it("stays a plain dependency when no replica is a job", () => {
+    const agents: Agent[] = [
+      consumer("caller-11111111", "caller", [dep("reports", "prov-22222222")]),
+      consumer("caller-44444444", "caller", [dep("reports", "prov-33333333")]),
+      provider("prov-22222222", "prov", [cap("reports")]),
+      provider("prov-33333333", "prov", [cap("reports")]),
+    ];
+    const { edges } = buildGraphFromAgents(agents);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].style?.stroke).toBe(EDGE_COLORS.dependency);
+  });
+
+  it("a degraded replica still wins over a healthy job one, in either order", () => {
+    // Both orders, and the reason is the job branch rather than the worst-of
+    // rule it is checking: that branch reaches for the job colour only while
+    // the edge it would overwrite is healthy. Drop that conjunct as
+    // redundant-looking and the degraded contribution seen FIRST is repainted
+    // as a job by the healthy one arriving second — a broken edge drawn as a
+    // working MeshJob. Fixing one order cannot see it.
+    const degradedFirst = (jobFirst: boolean): Agent[] => {
+      const jobbing = provider("prov-22222222", "prov", [cap("reports", true)]);
+      const plain = provider("prov-33333333", "prov", [cap("reports")]);
+      const jobCaller = consumer("caller-11111111", "caller", [dep("reports", jobbing.id)]);
+      const brokenCaller = consumer("caller-44444444", "caller", [
+        dep("reports", plain.id, "unresolved"),
+      ]);
+      return jobFirst
+        ? [jobCaller, brokenCaller, jobbing, plain]
+        : [brokenCaller, jobCaller, jobbing, plain];
+    };
+
+    for (const jobFirst of [true, false]) {
+      const { edges } = buildGraphFromAgents(degradedFirst(jobFirst));
+      expect(edges).toHaveLength(1);
+      expect(edges[0].style?.stroke).toBe(EDGE_COLORS.unresolved);
+      expect(edges[0].style?.strokeDasharray).toBe("5 5");
+    }
+  });
+});
+
+describe("edges nothing can be drawn to", () => {
+  it("skips a resolution whose provider is not in the snapshot", () => {
+    const { edges } = buildGraphFromAgents([
+      consumer("caller-11111111", "caller", [dep("reports", "gone-99999999")]),
+    ]);
+    expect(edges).toEqual([]);
+  });
+
+  it("skips a resolution carrying no provider id", () => {
+    const { edges } = buildGraphFromAgents([
+      consumer("caller-11111111", "caller", [
+        { function_name: "consume", capability: "reports", status: "unresolved" },
+      ]),
+    ]);
+    expect(edges).toEqual([]);
+  });
+});
+
+// The duplication this issue was half about: the legend carried its own copy of
+// the six hexes, so it went on advertising a colour the builder had stopped
+// emitting. Both directions are asserted, against a fixture that exercises
+// every branch — a new stroke with no legend row fails, and so does a legend
+// row for a stroke nothing can produce.
+describe("the legend and the builder cannot drift apart", () => {
+  /** One fixture reaching every colour the builder is able to emit. */
+  const everyBranch: Agent[] = [
+    makeAgent({
+      id: "caller-11111111",
+      name: "caller",
+      dependency_resolutions: [
+        dep("reports", "prov-22222222"),
+        dep("bulk_export", "prov-22222222"),
+        dep("broken", "prov-22222222", "unavailable"),
+        dep("pending", "prov-22222222", "unresolved"),
+      ],
+      llm_tool_resolutions: [
+        {
+          function_name: "plan",
+          filter_capability: "reports",
+          status: "available",
+          provider_agent_id: "prov-22222222",
+        },
+      ],
+      llm_provider_resolutions: [
+        {
+          function_name: "plan",
+          required_capability: "llm",
+          status: "available",
+          provider_agent_id: "model-33333333",
+        },
+      ],
+    }),
+    provider("prov-22222222", "prov", [
+      cap("reports"),
+      cap("bulk_export", true),
+      cap("broken"),
+      cap("pending"),
+    ]),
+    provider("model-33333333", "model", [cap("llm")]),
+  ];
+
+  const emitted = () =>
+    new Set(buildGraphFromAgents(everyBranch).edges.map((e) => e.style?.stroke as string));
+
+  it("every colour the BUILDER emits has a legend row", () => {
+    // Scoped to the builder on purpose, and it is not the whole screen: the
+    // traffic-heat scale in TopologyGraph.tsx paints over these strokes, and
+    // one of its three values has no legend row and no way to acquire one from
+    // this palette. The next assertion states that rather than leaving this one
+    // to be read as a claim about what is rendered.
+    const legend = new Set<string>(EDGE_LEGEND.map((e) => EDGE_COLORS[e.key]));
+    expect([...emitted()].filter((c) => !legend.has(c))).toEqual([]);
+  });
+
+  it("the heat scale is outside the legend contract, deliberately and knowingly", () => {
+    // Heat is a second axis (see lib/edge-palette.ts) and is NOT expected to
+    // have rows. Pinned so that its absence stays a recorded decision rather
+    // than something the suite silently overlooks: `elevated` is a seventh
+    // colour a reader of the graph has no key for, which is a question about
+    // the override, tracked on its own.
+    const legend = new Set<string>(EDGE_LEGEND.map((e) => EDGE_COLORS[e.key]));
+    expect(legend.has(EDGE_HEAT_COLORS.elevated)).toBe(false);
+    // The other two collide with palette entries by taste, not by meaning, so
+    // no assertion is made about them either way.
+    expect(Object.values(EDGE_COLORS)).not.toContain(EDGE_HEAT_COLORS.elevated);
+  });
+
+  it("every legend row names a colour the builder can emit", () => {
+    const drawn = emitted();
+    expect(EDGE_LEGEND.filter((e) => !drawn.has(EDGE_COLORS[e.key])).map((e) => e.label)).toEqual(
+      []
+    );
+  });
+
+  it("the palette has no entry the legend does not show", () => {
+    expect(EDGE_LEGEND.map((e) => e.key).sort()).toEqual(Object.keys(EDGE_COLORS).sort());
+  });
+
+  it("only the dependency-unresolved edge is drawn dashed-and-grey", () => {
+    // What the "Unresolved dependency" row claims. llm/prov edges render their
+    // unresolved state red, which is why the red row's label has to cover it.
+    const dashedGrey = buildGraphFromAgents(everyBranch).edges.filter(
+      (e) => e.style?.stroke === EDGE_COLORS.unresolved
+    );
+    expect(dashedGrey.map((e) => e.id)).toEqual(["dep|caller-11111111|prov-22222222|pending"]);
+    expect(dashedGrey[0].style?.strokeDasharray).toBe("5 5");
+  });
+});
+
+// Everything above this line is data: two modules and a builder, compared with
+// each other. None of it renders anything, so none of it can see the half of
+// the contract that reaches a person — the swatches. Restating a colour there
+// as a literal is the precise regression lib/edge-palette.ts was written to
+// prevent, and until this block existed it passed the whole suite.
+describe("the legend a person actually sees", () => {
+  /** What the DOM gives back for a colour written as a hex. */
+  const asRendered = (hex: string) => {
+    const n = parseInt(hex.slice(1), 16);
+    return `rgb(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255})`;
+  };
+
+  const swatchFor = (key: string) => screen.getByTestId(`edge-legend-swatch-${key}`);
+
+  it("renders one row per legend entry, labels and all", () => {
+    render(<EdgeLegend />);
+    for (const entry of EDGE_LEGEND) {
+      expect(swatchFor(entry.key)).toBeInTheDocument();
+      expect(screen.getByText(entry.label)).toBeInTheDocument();
+    }
+  });
+
+  it("paints every swatch the colour the builder strokes that edge with", () => {
+    render(<EdgeLegend />);
+    for (const entry of EDGE_LEGEND) {
+      const swatch = swatchFor(entry.key);
+      const painted = entry.dashed
+        ? swatch.style.borderColor
+        : swatch.style.backgroundColor;
+      expect(painted).toBe(asRendered(EDGE_COLORS[entry.key]));
+    }
+  });
+
+  it("carries no colour of its own — every swatch reads it from the palette", () => {
+    render(<EdgeLegend />);
+    // A hex named anywhere in the markup other than in an element's own style
+    // is a colour that has stopped being derived: written into the component,
+    // it can drift from the stroke the builder emits, which is how the two came
+    // apart the first time (issue #1521).
+    //
+    // Read off document.body rather than the render result's own root, whose
+    // name is a utility candidate: Tailwind extracts from any text under
+    // src/ui, this file included, and that one word is worth 282 bytes of
+    // rules the dashboard never uses. See __tests__/spa-css-isolation.test.ts.
+    for (const el of document.body.querySelectorAll("*")) {
+      expect(el.className).not.toMatch(/#[0-9a-fA-F]{3,8}/);
+    }
+    for (const entry of EDGE_LEGEND) {
+      const swatch = swatchFor(entry.key);
+      const painted = entry.dashed
+        ? swatch.style.borderColor
+        : swatch.style.backgroundColor;
+      // Empty means the colour arrived some other way — a literal class, most
+      // likely — and the assertion above it would then be comparing nothing.
+      expect(painted).not.toBe("");
+    }
+  });
+});

--- a/src/ui/components/topology/EdgeLegend.tsx
+++ b/src/ui/components/topology/EdgeLegend.tsx
@@ -1,0 +1,45 @@
+import { EDGE_COLORS, EDGE_LEGEND } from "@/lib/edge-palette";
+
+/**
+ * The topology's edge key, rendered from lib/edge-palette.ts — the same module
+ * lib/topology.ts strokes the edges from, so the key and the graph cannot
+ * disagree about a colour again (issue #1521).
+ *
+ * Its own component rather than markup inside TopologyGraph so that
+ * `__tests__/topology-edges.test.tsx` can render it: the swatches are the half
+ * of the palette contract that data-level assertions cannot see, and reverting
+ * one to a literal colour is exactly the regression this module exists to
+ * prevent.
+ *
+ * Each colour arrives as an element style. That is forced, not stylistic: an
+ * arbitrary-value class is a literal string the stylesheet generator has to
+ * find by scanning source text, so a value read from a module could never
+ * produce one.
+ */
+export function EdgeLegend() {
+  return (
+    <div className="absolute top-4 left-4 z-10 rounded-lg border border-border bg-card/90 backdrop-blur-sm px-3 py-2.5 shadow-lg">
+      <p className="text-[10px] font-medium text-muted-foreground mb-1.5 uppercase tracking-wider">Edges</p>
+      <div className="space-y-1">
+        {EDGE_LEGEND.map((entry) => (
+          <div key={entry.key} className="flex items-center gap-2">
+            <div
+              data-testid={`edge-legend-swatch-${entry.key}`}
+              className={
+                entry.dashed
+                  ? "w-5 h-0.5 border-t border-dashed"
+                  : "w-5 h-0.5 rounded"
+              }
+              style={
+                entry.dashed
+                  ? { borderColor: EDGE_COLORS[entry.key] }
+                  : { backgroundColor: EDGE_COLORS[entry.key] }
+              }
+            />
+            <span className="text-[10px] text-muted-foreground">{entry.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/topology/TopologyGraph.tsx
+++ b/src/ui/components/topology/TopologyGraph.tsx
@@ -13,9 +13,11 @@ import {
 import "@xyflow/react/dist/style.css";
 import { Agent, EdgeStat } from "@/lib/types";
 import { buildGraphFromAgents, buildIdToNodeKey, computeStructureHash } from "@/lib/topology";
+import { EDGE_HEAT_COLORS } from "@/lib/edge-palette";
 import { extractAgentName, formatDuration } from "@/lib/api";
 import { useMesh } from "@/lib/mesh-context";
 import { AgentNode } from "./AgentNode";
+import { EdgeLegend } from "./EdgeLegend";
 import { TopologySidebar, type SidebarSelection } from "./TopologySidebar";
 
 const nodeTypes = { agentNode: AgentNode };
@@ -67,10 +69,13 @@ function getForwardNeighborIds(
   return ids;
 }
 
+// Traffic heat, NOT edge kind. The scale is its own axis and its own constant
+// (lib/edge-palette.ts) for the reasons written there; two of its three values
+// coinciding with palette entries is not a duplication to collapse.
 function getEdgeHeatColor(errorRate: number): string {
-  if (errorRate === 0) return "#22c55e";
-  if (errorRate < 10) return "#eab308";
-  return "#ef4444";
+  if (errorRate === 0) return EDGE_HEAT_COLORS.clean;
+  if (errorRate < 10) return EDGE_HEAT_COLORS.elevated;
+  return EDGE_HEAT_COLORS.failing;
 }
 
 function computeStrokeWidth(callCount: number, maxCount: number): number {
@@ -301,36 +306,7 @@ export function TopologyGraph({ agents }: TopologyGraphProps) {
         />
       </ReactFlow>
 
-      {/* Legend */}
-      <div className="absolute top-4 left-4 z-10 rounded-lg border border-border bg-card/90 backdrop-blur-sm px-3 py-2.5 shadow-lg">
-        <p className="text-[10px] font-medium text-muted-foreground mb-1.5 uppercase tracking-wider">Edges</p>
-        <div className="space-y-1">
-          <div className="flex items-center gap-2">
-            <div className="w-5 h-0.5 bg-[#22c55e] rounded" />
-            <span className="text-[10px] text-muted-foreground">Dependency</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-5 h-0.5 bg-[#ec4899] rounded" />
-            <span className="text-[10px] text-muted-foreground">API dependency</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-5 h-0.5 bg-[#22d3ee] rounded" />
-            <span className="text-[10px] text-muted-foreground">LLM tool</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-5 h-0.5 bg-[#a855f7] rounded" />
-            <span className="text-[10px] text-muted-foreground">LLM provider</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-5 h-0.5 bg-[#ef4444] rounded" />
-            <span className="text-[10px] text-muted-foreground">Unavailable</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="w-5 h-0.5 border-t border-dashed border-[#6b7280]" />
-            <span className="text-[10px] text-muted-foreground">Unresolved</span>
-          </div>
-        </div>
-      </div>
+      <EdgeLegend />
 
       <TopologySidebar selection={sidebarSelection} onClose={onPaneClick} />
     </div>

--- a/src/ui/demo/emit.tsx
+++ b/src/ui/demo/emit.tsx
@@ -21,6 +21,7 @@ import { ReactFlowProvider } from "@xyflow/react";
 
 import { AgentNode } from "@/components/topology/AgentNode";
 import { buildGraphFromAgents } from "@/lib/topology";
+import { EDGE_COLORS } from "@/lib/edge-palette";
 import {
   Stage, setSsrGeometry, HANDLE_OFFSET, type SsrBox,
   RevealTitle, RevealSub, PhaseCopy, CtaCopy,
@@ -565,11 +566,17 @@ const partial = renderPartial();
 }
 fs.writeFileSync(partialPath, partial);
 
-/** Per-beat edge stroke, so the driver never needs the graph builder. */
+/**
+ * Per-beat edge stroke, so the driver never needs the graph builder. An edge
+ * absent from a beat falls back to the builder's own unresolved stroke, read
+ * from the palette rather than restated.
+ */
 const edgeStroke = BEATS.map((b) => {
   const g = buildGraphFromAgents(buildWorld(b.world));
-  const m = new Map(g.edges.map((e) => [e.id, (e.style?.stroke as string) ?? "#6b7280"]));
-  return EDGE_IDS.map((id) => m.get(id) ?? "#6b7280");
+  const m = new Map(
+    g.edges.map((e) => [e.id, (e.style?.stroke as string) ?? EDGE_COLORS.unresolved])
+  );
+  return EDGE_IDS.map((id) => m.get(id) ?? EDGE_COLORS.unresolved);
 });
 
 const out = {

--- a/src/ui/demo/script.ts
+++ b/src/ui/demo/script.ts
@@ -227,7 +227,11 @@ export function buildWorld(cfg: WorldConfig): Agent[] {
   const openai = base(OPENAI, "llm", "chat", ["openai", "gpt"], "OpenAI GPT");
 
   // The REST entry point: provides nothing, depends on trip_planning.
-  // agent_type "api" makes topology.ts colour its outgoing edge pink.
+  // agent_type "api" is what it IS, and it no longer decides how its edge is
+  // drawn: an edge is coloured by what is being called, so this one is an
+  // ordinary dependency on the planner (issue #1521). The pink in this piece is
+  // now the job colour, on planner -> budget-analyst in the final beat, where
+  // that capability is a `task` producer.
   const gateway = base(GATEWAY, null, "handle_request", [], "REST entry point");
   gateway.agent_type = "api";
   gateway.dependency_resolutions = [dep("handle_request", "trip_planning", PLANNER, "plan_trip")];

--- a/src/ui/demo/stage.tsx
+++ b/src/ui/demo/stage.tsx
@@ -25,6 +25,7 @@ import {
 } from "@xyflow/react";
 
 import { buildGraphFromAgents } from "@/lib/topology";
+import { EDGE_COLORS } from "@/lib/edge-palette";
 import { AgentNode } from "@/components/topology/AgentNode";
 import {
   BEATS,
@@ -76,7 +77,7 @@ const BUILT = BEATS.map((b) => {
   return {
     nodeData: new Map(g.nodes.map((n) => [n.id, n.data])),
     edgeStroke: new Map(
-      g.edges.map((e) => [e.id, (e.style?.stroke as string) ?? "#6b7280"])
+      g.edges.map((e) => [e.id, (e.style?.stroke as string) ?? EDGE_COLORS.unresolved])
     ),
   };
 });
@@ -91,8 +92,10 @@ for (const built of BUILT) {
 }
 const dataFor = (id: string, lead: number) =>
   BUILT[lead].nodeData.get(id) ?? FALLBACK_DATA.get(id)!;
+// An edge missing from this beat is drawn as the builder draws an unresolved
+// one, read from the palette rather than restated here.
 const strokeFor = (id: string, beat: number) =>
-  BUILT[beat].edgeStroke.get(id) ?? "#6b7280";
+  BUILT[beat].edgeStroke.get(id) ?? EDGE_COLORS.unresolved;
 const nodeVar = (i: number) => `--n${i}`;
 const edgeVar = (i: number) => `--e${i}`;
 

--- a/src/ui/lib/edge-palette.ts
+++ b/src/ui/lib/edge-palette.ts
@@ -1,0 +1,90 @@
+// THE topology edge colours. One definition, two consumers: lib/topology.ts
+// strokes the edges from it, and the legend in components/topology/EdgeLegend.tsx
+// renders its swatches from it. They used to carry separate copies of the same
+// six hexes, which is how the legend came to describe a colour the builder no
+// longer emitted (issue #1521).
+//
+// The traffic-heat scale at the foot of this file is a second, deliberately
+// separate axis. Read its note before merging anything into `EDGE_COLORS`.
+//
+// The legend swatches read these values as INLINE STYLES. That is not a
+// stylistic choice: the swatches were arbitrary-value classes, which are literal
+// strings the stylesheet generator has to find by scanning source text, so a
+// value read from this file could never produce one.
+
+/**
+ * An edge's colour describes WHAT IS BEING CALLED, never who is calling
+ * (issue #1521). `dependency` vs `job` is decided by the provider's matching
+ * capability; the caller's agent_type is not consulted anywhere.
+ */
+export const EDGE_COLORS = {
+  /** Resolved dependency on an ordinary capability. */
+  dependency: "#22c55e",
+  /** Resolved dependency whose provider declared the capability `task=true`. */
+  job: "#ec4899",
+  /** Resolved `@mesh.llm(filter=...)` tool. */
+  llmTool: "#22d3ee",
+  /** Resolved `@mesh.llm(provider=...)` model provider. */
+  llmProvider: "#a855f7",
+  /**
+   * A dependency whose provider is unavailable — and, on LLM tool/provider
+   * edges, the unresolved case too: those two kinds have never drawn the grey
+   * below. Hence the legend wording.
+   */
+  unavailable: "#ef4444",
+  /** A declared dependency nothing satisfies yet. `dep` edges only. */
+  unresolved: "#6b7280",
+} as const;
+
+export type EdgeColorKey = keyof typeof EDGE_COLORS;
+
+export interface EdgeLegendEntry {
+  key: EdgeColorKey;
+  label: string;
+  /** Drawn as a dashed rule rather than a solid one, as the edge itself is. */
+  dashed?: boolean;
+}
+
+/**
+ * The legend, in render order — every colour the builder can emit, and nothing
+ * else. `__tests__/topology-edges.test.tsx` asserts that both ways round, so a
+ * new stroke without a row here (or a row for a stroke that is no longer
+ * reachable, which is what #1521 was) fails the suite.
+ */
+export const EDGE_LEGEND: EdgeLegendEntry[] = [
+  { key: "dependency", label: "Dependency" },
+  { key: "job", label: "MeshJob" },
+  { key: "llmTool", label: "LLM tool" },
+  { key: "llmProvider", label: "LLM provider" },
+  { key: "unavailable", label: "Unavailable — or LLM unresolved" },
+  { key: "unresolved", label: "Unresolved dependency", dashed: true },
+];
+
+/**
+ * The traffic-heat scale. A SEPARATE AXIS from `EDGE_COLORS`, kept apart on
+ * purpose — do not fold the two together on the grounds that they share two
+ * values.
+ *
+ * `EDGE_COLORS` answers WHAT AN EDGE IS, which is a fact about the topology and
+ * changes when the mesh is rewired. These answer HOW IT IS GOING, which is a
+ * fact about the last window of calls and changes while nothing is rewired at
+ * all. That `clean` and `failing` happen to hold the same two hexes as
+ * `dependency` and `unavailable` is a coincidence of taste, not a shared
+ * meaning: if the dependency stroke were ever restyled, a healthy edge under
+ * traffic should not move with it, and a single constant would drag it along.
+ *
+ * These have no legend row — `elevated` in particular is a colour the legend
+ * cannot explain — because they are painted OVER the palette above by
+ * `mergeEdgeStatsIntoEdges` in components/topology/TopologyGraph.tsx. That the
+ * heat scale overrides edge kind at all is a known and separate question; the
+ * legend contract asserted in `__tests__/topology-edges.test.tsx` is therefore
+ * scoped to the builder, and says so.
+ */
+export const EDGE_HEAT_COLORS = {
+  /** No errors observed on this edge. */
+  clean: "#22c55e",
+  /** Errors, but under the threshold that counts as failing. */
+  elevated: "#eab308",
+  /** Failing often enough to be the first thing you should look at. */
+  failing: "#ef4444",
+} as const;

--- a/src/ui/lib/topology.ts
+++ b/src/ui/lib/topology.ts
@@ -1,7 +1,8 @@
 import dagre from "dagre";
 import { type Node, type Edge } from "@xyflow/react";
-import { Agent } from "./types";
+import { Agent, DependencyResolution } from "./types";
 import { groupKeyOf, aggregateStatus } from "./agent-group";
+import { EDGE_COLORS } from "./edge-palette";
 
 // Returns the canonical grouping key for an agent — the declared `agent.name`
 // (falling back to the full id when empty). Replica bucketing keys off this
@@ -101,9 +102,73 @@ export function computeStructureHash(agents: Agent[]): string {
   return nodeKeys.join(",") + "|" + uniqueEdgePairs.join(",");
 }
 
+// Per-agent index of the capabilities declared `task=true` — the MeshJob
+// producers. Keyed by the FULL agent id (not the node key) because a dependency
+// resolution names the exact provider instance it resolved to, which may be one
+// replica of a collapsed group.
+//
+// Built from the same `agents` array the edge loop walks, so a provider that is
+// not in the snapshot simply has no entry and its edge is coloured as an
+// ordinary dependency. That is also the pre-registry-support case: `task` is
+// absent on older registries, and absent must mean "not a job".
+interface TaskIndexEntry {
+  /**
+   * `capability.function_name` — the precise key. A resolution's `mcp_tool` is
+   * written from the winning capability's function name (registry:
+   * resolver.go picks `cap.FunctionName`, ent_service.go emits it as
+   * `mcp_tool`), so the two are the same column and match exactly.
+   */
+  functions: Set<string>;
+  /**
+   * `capability.name`. Only consulted when a resolution carries no `mcp_tool`,
+   * which is every resolution from a registry predating that field. Ambiguous
+   * by nature: one capability name may be declared on two functions of the
+   * same agent, distinguished by tags, and only one of them may be a job.
+   */
+  names: Set<string>;
+}
+
+function buildTaskCapabilityIndex(agents: Agent[]): Map<string, TaskIndexEntry> {
+  const index = new Map<string, TaskIndexEntry>();
+  for (const agent of agents) {
+    const entry: TaskIndexEntry = { functions: new Set(), names: new Set() };
+    for (const cap of agent.capabilities ?? []) {
+      if (cap.task === true) {
+        entry.functions.add(cap.function_name);
+        entry.names.add(cap.name);
+      }
+    }
+    // Written unconditionally, so a duplicated agent id is LAST WINS rather
+    // than last-non-empty-wins. A snapshot should never carry an id twice, but
+    // if it does, the later record is the one that describes the agent — the
+    // same rule every other id-keyed map in this file follows. Skipping empty
+    // entries would let a stale earlier copy keep colouring edges as jobs after
+    // the capability stopped being one.
+    index.set(agent.id, entry);
+  }
+  return index;
+}
+
+// Whether a resolved dependency landed on a `task=true` capability, i.e. is a
+// MeshJob invocation rather than an ordinary call.
+function resolvesToJob(
+  index: Map<string, TaskIndexEntry>,
+  providerAgentId: string,
+  dep: DependencyResolution
+): boolean {
+  const entry = index.get(providerAgentId);
+  if (!entry) return false;
+  // `mcp_tool` names the exact function the dependency resolved to, so when it
+  // is on the wire it decides on its own — falling back to the capability name
+  // here would re-admit the ambiguity it exists to settle.
+  if (dep.mcp_tool) return entry.functions.has(dep.mcp_tool);
+  return entry.names.has(dep.capability);
+}
+
 export function buildGraphFromAgents(agents: Agent[]): { nodes: Node[]; edges: Edge[] } {
   const buckets = bucketAgents(agents);
   const idMap = buildIdToNodeKeyFromBuckets(buckets);
+  const taskCapabilities = buildTaskCapabilityIndex(agents);
 
   // Build nodes: one per group (collapsed) or single agent.
   const nodes: Node[] = [];
@@ -164,20 +229,45 @@ export function buildGraphFromAgents(agents: Agent[]): { nodes: Node[]; edges: E
       base.animated === true && !base.style?.strokeDasharray;
     if (existingHealthy && !incomingHealthy) {
       edgeMap.set(key, { ...existing, animated: base.animated, style: base.style });
+      return;
+    }
+    // Two healthy contributions can now disagree on COLOUR, which they never
+    // could while colour was a property of the caller: the caller is the same
+    // agent for both, but the providers are two replicas that may disagree
+    // about whether the resolved capability is a task — a half-rolled-out
+    // change, or a mixed-version group. The merge above compares animation and
+    // dashes only, so first-seen would have won by snapshot order.
+    //
+    // The job colour escalates, matching the worst-of rule's direction: a
+    // collapsed edge is drawn as a job when ANY replica behind it is one,
+    // because calling into that group can land on the long-running instance.
+    // Order-independent by construction.
+    if (
+      existingHealthy &&
+      incomingHealthy &&
+      base.style?.stroke === EDGE_COLORS.job &&
+      existing.style?.stroke !== EDGE_COLORS.job
+    ) {
+      edgeMap.set(key, { ...existing, style: base.style });
     }
   }
 
   for (const agent of agents) {
     const src = idMap.get(agent.id);
     if (!src || !validNodeKeys.has(src)) continue;
-    const isApi = agent.agent_type === "api";
 
     for (const dep of agent.dependency_resolutions ?? []) {
       if (!dep.provider_agent_id) continue;
       const dst = idMap.get(dep.provider_agent_id);
       if (!dst || !validNodeKeys.has(dst)) continue;
 
-      const availableColor = isApi ? "#ec4899" : "#22c55e";
+      // Coloured by WHAT IS BEING CALLED (issue #1521): the provider's matching
+      // capability decides, not the caller. A `task=true` capability is a
+      // MeshJob invocation rather than an ordinary call, and that is a property
+      // of the callee alone.
+      const availableColor = resolvesToJob(taskCapabilities, dep.provider_agent_id, dep)
+        ? EDGE_COLORS.job
+        : EDGE_COLORS.dependency;
       const label = dep.capability;
       addEdge("dep", src, dst, label, {
         id: `dep|${src}|${dst}|${label}`,
@@ -187,7 +277,12 @@ export function buildGraphFromAgents(agents: Agent[]): { nodes: Node[]; edges: E
         animated: dep.status === "available",
         data: { originalLabel: label },
         style: {
-          stroke: dep.status === "available" ? availableColor : dep.status === "unavailable" ? "#ef4444" : "#6b7280",
+          stroke:
+            dep.status === "available"
+              ? availableColor
+              : dep.status === "unavailable"
+                ? EDGE_COLORS.unavailable
+                : EDGE_COLORS.unresolved,
           strokeDasharray: dep.status === "unresolved" ? "5 5" : undefined,
         },
       });
@@ -198,6 +293,13 @@ export function buildGraphFromAgents(agents: Agent[]): { nodes: Node[]; edges: E
       const dst = idMap.get(llm.provider_agent_id);
       if (!dst || !validNodeKeys.has(dst)) continue;
 
+      // The job colour is scoped to dependency edges ON PURPOSE. An
+      // `@mesh.llm(filter=...)` tool can resolve onto a `task=true` capability,
+      // and this edge stays the LLM-tool colour when it does: the edge kind is
+      // what the reader is being told here — a model reaching for a tool — and
+      // that is a different fact from how the callee runs. The kind is decided
+      // before the callee is consulted, so no `task` lookup happens on this
+      // path at all.
       const label = `llm:${llm.filter_capability}`;
       addEdge("llm", src, dst, label, {
         id: `llm|${src}|${dst}|${label}`,
@@ -207,7 +309,7 @@ export function buildGraphFromAgents(agents: Agent[]): { nodes: Node[]; edges: E
         animated: llm.status === "available",
         data: { originalLabel: label },
         style: {
-          stroke: llm.status === "available" ? "#22d3ee" : "#ef4444",
+          stroke: llm.status === "available" ? EDGE_COLORS.llmTool : EDGE_COLORS.unavailable,
           strokeDasharray: llm.status !== "available" ? "5 5" : undefined,
         },
       });
@@ -227,7 +329,7 @@ export function buildGraphFromAgents(agents: Agent[]): { nodes: Node[]; edges: E
         animated: prov.status === "available",
         data: { originalLabel: label },
         style: {
-          stroke: prov.status === "available" ? "#a855f7" : "#ef4444",
+          stroke: prov.status === "available" ? EDGE_COLORS.llmProvider : EDGE_COLORS.unavailable,
           strokeDasharray: prov.status !== "available" ? "5 5" : undefined,
         },
       });

--- a/src/ui/lib/topology.ts
+++ b/src/ui/lib/topology.ts
@@ -231,6 +231,38 @@ export function buildGraphFromAgents(agents: Agent[]): { nodes: Node[]; edges: E
       edgeMap.set(key, { ...existing, animated: base.animated, style: base.style });
       return;
     }
+    // Two DEGRADED contributions can disagree too, and the worst-of rule above
+    // cannot separate them: it compares animation and dashes to decide which is
+    // degraded, and both of these are. One replica's dependency landed on a
+    // provider that is no longer healthy; another's matched nothing at all. The
+    // gap sits exactly between the two cases that ARE order-independent — the
+    // healthy-vs-degraded merge above and the job escalation below — so first
+    // seen would win by snapshot order, and the same mesh could draw this edge
+    // either way from one poll to the next as the agents array is reordered.
+    //
+    // UNAVAILABLE WINS, in the same direction as both neighbouring rules: it is
+    // this palette's broader degraded signal, the one llm and prov edges stroke
+    // for BOTH of their degraded states, which is what the legend row saying
+    // "Unavailable — or LLM unresolved" describes. The other style is the narrow
+    // claim that nothing satisfies the dependency yet, asserted for dep edges
+    // alone, and it should only be shown when that is true of every replica
+    // behind a collapsed edge — one replica having matched a provider is
+    // evidence that something does satisfy it.
+    //
+    // Not reachable from a registry snapshot as things stand: a resolution is
+    // only given a provider_agent_id when it resolves (ent_service.go writes the
+    // id and "available" together, or neither), and the one transition that
+    // keeps that id afterwards sets "unavailable"
+    // (UpdateDependencyStatusOnAgentOffline). The edge loop skips a dep with no
+    // provider id, so the pair cannot meet here today. Written as a rule anyway
+    // — it is an invariant of a different process, this file cannot enforce it,
+    // and nothing here would notice it being relaxed.
+    const existingUnresolved = existing.style?.stroke === EDGE_COLORS.unresolved;
+    const incomingUnavailable = base.style?.stroke === EDGE_COLORS.unavailable;
+    if (!existingHealthy && !incomingHealthy && existingUnresolved && incomingUnavailable) {
+      edgeMap.set(key, { ...existing, animated: base.animated, style: base.style });
+      return;
+    }
     // Two healthy contributions can now disagree on COLOUR, which they never
     // could while colour was a property of the caller: the caller is the same
     // agent for both, but the providers are two replicas that may disagree


### PR DESCRIPTION
## Summary

A dependency edge took its colour from the **caller's** `agent_type` — an edge out of an `api`-typed agent was drawn pink and labelled "API dependency" — while the legend reads as though the colour describes what is being called. Both readings were defensible, which is why this sat open: it needed a semantic decision, not a patch.

**Colour now describes the provider.** The decision and its consequences are recorded on the issue.

## What follows from it

**The pink branch is unreachable, not merely wrong.** `api` agents cannot hold a capability row — their route tool specs carry `capability=""` (`rust_api_heartbeat.py:133-136`) and the registry refuses to persist one without a name (`ent_service.go:570-574`) — so they are never a resolution target. The legend entry is removed rather than relabelled.

**There is no A2A colour, and not for the same reason.** `a2a` is *additive*, so unlike `api` those agents genuinely can be providers (`status_hooks.go:130-132`). But A2A calls never go through dependency resolution — there are three resolution arrays and none is A2A — so there is no A2A edge to draw. An a2a agent appearing as a provider is providing an ordinary mesh capability, and that is an ordinary green edge.

**A MeshJob colour is added**, reusing the hex the API branch vacates. No backend change: `task` is already on the wire per-capability (`types.ts:48-50`), so a dependency edge whose resolved provider capability is a task is a job invocation. Reading that needs the same provider lookup provider-colouring needs, so both land on one change. Amber was the obvious alternative and sits too close to traffic heat's `#eab308` to distinguish on a thin stroke.

## Two things the review caught that were not obvious

**Matching on the capability name alone was wrong.** `mcp_tool` is on the resolution and is written from the *winning* capability's function name (`resolver.go:508` → `ent_service.go:1846`) — the same column the snapshot's `function_name` comes from. Matching on the name would mis-colour a capability name declared on two functions where only one is a job. Now matches `mcp_tool`, with the name as fallback only when the wire lacks it.

**Replica collapse became able to disagree.** Colour used to be a property of the caller, so contributions merging into one edge could not conflict. Under the new rule the *providers* are different replicas that may disagree about `task`. The job colour escalates — same direction as the existing worst-of rule, and order-independent — while a degraded replica still beats a healthy job one. The original test for that ran the one contribution order that cannot break; both orders are now covered, and dropping the guard's `existingHealthy` conjunct fails only the new loop.

## The palette

The six hexes were duplicated between the builder and the legend. They now have one home. The traffic-heat scale gets its own named home beside them rather than being folded in — heat says *how an edge is going*, the palette says *what it is*, and sharing a constant would mean restyling a dependency silently restyles a healthy edge under traffic.

The legend swatches were Tailwind arbitrary-value classes, which are load-bearing strings for the scanner, so sharing goes through inline styles. Removing them shrank the dashboard stylesheet by 252 B and the demo's by 330 B.

## Tests

Edge construction and colour had **no coverage of any kind** — the only topology test covered node-key grouping. There are 33 now.

The one worth calling out: the pure-data drift assertions compared the legend table, the palette and the builder, and could not see a hardcoded swatch reappearing in the component — which is exactly half of what this issue is about. The legend was extracted so it can be rendered in a test that fails on any hex literal in a class. Verified by mutation: reintroducing `bg-[#22c55e]` fails it.

## Homepage animation

The gateway edge goes green and the planner→budget-analyst edge turns pink in the final frame, where that capability already carried `task` — so the new colour appears in the story with **no world data changed and no fixture moved**. `geometry.json` and `copy.generated.html` are untouched, verified after a full rebuild.

| | before | after |
|---|---|---|
| dashboard CSS | 77,536 B | 77,284 B (−252) |
| demo CSS | 99,129 B | 98,799 B (−330) |
| demo JS | 193,813 B | 193,813 B |
| edges changed colour | — | 2 of 18 |

Both reductions are exactly the six arbitrary-value rules removed; nothing was added.

## Filed separately, not fixed here

Traffic heat overrides these colours entirely — `TopologyGraph.tsx` replaces the stroke for any edge carrying stats, unconditionally, with no toggle, and the legend does not mention it. On a mesh with traffic the palette this PR fixes is largely invisible, and the heat scale emits a seventh colour with no legend row. That is a distinct semantic question. The builder-side assertion here is scoped honestly to the builder and says so.

Closes #1521

## Test plan

- [x] Provider-typed colouring, job detection, api-caller edge no longer pink
- [x] `mcp_tool` matching, including two functions sharing one capability name
- [x] Replica collapse in both contribution orders; degraded still wins
- [x] Legend renders from the palette; mutation-tested against a hardcoded swatch
- [x] Demo fixtures untouched after a full rebuild
- [x] `npm test` (91), `tsc --noEmit`, `eslint`, `go build ./...`, `make docs-scroll-build`, `mkdocs build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clear topology edge legend covering dependencies, jobs, LLM tools/providers, unavailable connections, and unresolved edges.
  * Improved edge coloring to reflect provider capabilities, task-producing connections, replica status, and dependency state.
  * Added traffic-based edge colors for healthy, elevated, and failing activity.

* **Bug Fixes**
  * Standardized unresolved-edge coloring across topology views and demos.
  * Improved consistency between displayed edge colors, legend swatches, and topology behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->