### PR TITLE
feat: key traffic stats by callee function, not just agent pair

### DIFF
--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -63,7 +63,7 @@ export TEMPO_URL=http://localhost:3200
 | `MCP_MESH_TRACE_RETENTION` | `24h` | Redis `mesh:trace` stream retention (`0` disables trimming). Honoured by both the registry and meshui, so trimming survives either being down |
 | `MCP_MESH_TRACE_STREAM_MAXLEN` | `100000` | Producer-side `XADD MAXLEN ~` ceiling on `mesh:trace`, applied by every agent runtime. Bounds the stream even with no consumer alive (`0` disables) |
 | `MCP_MESH_TELEMETRY_AGGREGATE_RETENTION` | `24h` | Age-out window for the in-memory per-agent / per-model / per-edge dashboard aggregates (`0` disables age pruning) |
-| `MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES` | `10000` | Hard key ceiling per aggregate map, evicting least-recently-seen first (`0` disables the ceiling) |
+| `MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES` | `10000` | Hard key ceiling per aggregate map, evicting least-recently-seen first (`0` disables the ceiling). An edge key costs ~2.1 KB, so the default admits ~20 MB of edge aggregates |
 
 See the [environment variables reference](environment-variables.md) for the full list.
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -500,7 +500,8 @@ export MCP_MESH_TRACE_STREAM_MAXLEN=100000
 # stats). Keyed by name, so they grow with agent/model name cardinality rather
 # than trace volume. A key not written to within the retention window ages out;
 # the max-entries ceiling is a backstop for name churn, evicting the
-# least-recently-seen key first. "0" disables the respective bound.
+# least-recently-seen key first. "0" disables the respective bound. An edge key
+# costs ~2.1 KB, so the default ceiling admits ~20 MB of edge aggregates.
 export MCP_MESH_TELEMETRY_AGGREGATE_RETENTION=24h
 export MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES=10000
 

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -367,7 +367,8 @@ export MCP_MESH_TRACE_STREAM_MAXLEN=100000
 
 # In-memory dashboard aggregates (per-agent, per-model, per-edge). Keyed by
 # name, so bounded by age first and by a key ceiling as a backstop against
-# name churn (0 disables the respective bound)
+# name churn (0 disables the respective bound). An edge key costs ~2.1 KB, so
+# the default ceiling admits ~20 MB of edge aggregates
 export MCP_MESH_TELEMETRY_AGGREGATE_RETENTION=24h
 export MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES=10000
 

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -103,7 +103,7 @@ Default credentials: `admin` / `admin`
 | `MCP_MESH_TRACE_RETENTION`             | Redis trace stream retention (`0` = no trimming) | `24h` |
 | `MCP_MESH_TRACE_STREAM_MAXLEN`         | Producer-side `XADD MAXLEN ~` ceiling on `mesh:trace` (`0` = no cap) | `100000` |
 | `MCP_MESH_TELEMETRY_AGGREGATE_RETENTION` | Age-out window for in-memory dashboard aggregates (`0` = no age pruning) | `24h` |
-| `MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES` | Key ceiling per aggregate map, LRU eviction (`0` = no ceiling) | `10000` |
+| `MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES` | Key ceiling per aggregate map, LRU eviction (`0` = no ceiling). An edge key costs ~2.1 KB, so the default admits ~20 MB of edge aggregates | `10000` |
 
 ## Troubleshooting
 

--- a/src/core/registry/tracing/accumulator.go
+++ b/src/core/registry/tracing/accumulator.go
@@ -134,6 +134,11 @@ type edgeAccum struct {
 	// The histogram holds a ROLLING WINDOW of recent samples, as the reservoir
 	// did; Total/Max/Min are exact and lifetime, as they were. See
 	// latency_histogram.go.
+	//
+	// The aggregate of this per-key cost is what bounds the map, not this
+	// number: see the ceiling arithmetic on AggregateBounds in aggregates.go,
+	// which is where an operator tuning
+	// MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES ends up.
 	Latency  latencyHistogram
 	TotalMs  int64
 	MaxMs    int64

--- a/src/core/registry/tracing/accumulator.go
+++ b/src/core/registry/tracing/accumulator.go
@@ -54,10 +54,11 @@ type TraceAccumulator struct {
 	// Active (in-progress) traces keyed by trace ID
 	activeTraces map[string]*activeTrace
 
-	// Per-edge stats keyed by "source -> target". Bounded by edgeBounds:
-	// each entry carries a LastSeen stamp so idle edges age out, and the
-	// number of keys is capped as a backstop against name churn (#1424).
-	edgeStats  map[string]*edgeAccum
+	// Per-edge stats keyed by (source, target, function) — see edgeKey.
+	// Bounded by edgeBounds: each entry carries a LastSeen stamp so idle edges
+	// age out, and the number of keys is capped as a backstop against name
+	// churn (#1424).
+	edgeStats  map[edgeKey]*edgeAccum
 	edgeBounds AggregateBounds
 
 	// Total number of finalized traces (never resets)
@@ -92,17 +93,52 @@ type activeTrace struct {
 	HasError  bool
 }
 
-const maxEdgeLatencies = 10000
+// edgeKey identifies one traffic row: the calls from Source into Target that
+// landed on one particular function of Target.
+//
+// A STRUCT, not a delimited string (#1531). The previous key was
+// `source + " -> " + target`, which the read side had to take apart again by
+// scanning for the first " -> " — a parse that is wrong for any agent name
+// containing that sequence, and that would only get more fragile with a third
+// field appended. Nothing here needs a parse: the map key already holds the
+// three values separately.
+type edgeKey struct {
+	Source string
+	Target string
+	// Function is the CALLEE's span operation, i.e. the provider's own function
+	// name — the caller's proxy span is not what edges are attributed from. For
+	// an MCP tool it is character-for-character the `function_name` the registry
+	// stores for that capability (Python `func.__name__`, TypeScript `def.name`,
+	// Java `method.getName()`; no normalisation on either path), which is what
+	// lets the UI join a stat to the exact topology edge that produced it.
+	//
+	// EMPTY when the span carried no operation. A span with no operation can
+	// only come from a malformed event — every runtime names its span after the
+	// function it is running — and it is recorded rather than dropped so the
+	// call still counts towards the traffic totals. It simply joins to no
+	// topology edge, which is the honest outcome: the call happened, but nothing
+	// in the payload says what was called.
+	Function string
+}
 
 type edgeAccum struct {
-	CallCount   int
-	ErrorCount  int
-	Latencies   []int64
-	latencyHead int // ring buffer write position (used once Latencies reaches cap)
-	TotalMs     int64
-	MaxMs       int64
-	MinMs       int64
-	LastSeen    time.Time // last observation, drives age-based pruning
+	CallCount  int
+	ErrorCount int
+	// Latency percentiles come from a fixed-bucket histogram rather than a
+	// reservoir of raw samples, so per-key memory no longer scales with
+	// traffic — a flat ~2 KB per key instead of anywhere from nothing to 80 KB.
+	// The floor is therefore HIGHER than the reservoir's for a key that saw one
+	// call, which is the trade: bounded and predictable rather than cheap until
+	// it is not, on a key that is now per function and so far more numerous.
+	//
+	// The histogram holds a ROLLING WINDOW of recent samples, as the reservoir
+	// did; Total/Max/Min are exact and lifetime, as they were. See
+	// latency_histogram.go.
+	Latency  latencyHistogram
+	TotalMs  int64
+	MaxMs    int64
+	MinMs    int64
+	LastSeen time.Time // last observation, drives age-based pruning
 }
 
 // NewTraceAccumulator creates a new accumulator with the given ring buffer
@@ -122,7 +158,7 @@ func NewTraceAccumulatorWithBounds(ringSize int, logger *log.Logger, bounds Aggr
 		recentTraces: make([]RecentTraceSummary, ringSize),
 		ringSize:     ringSize,
 		activeTraces: make(map[string]*activeTrace),
-		edgeStats:    make(map[string]*edgeAccum),
+		edgeStats:    make(map[edgeKey]*edgeAccum),
 		edgeBounds:   bounds,
 		liveClients:  make(map[chan *LiveTraceEvent]struct{}),
 		dirtyTraces:  make(map[string]bool),
@@ -196,9 +232,20 @@ func (ta *TraceAccumulator) ProcessTraceEvent(event *TraceEvent) error {
 	return nil
 }
 
-// recordEdge records a cross-agent edge observation.
-func (ta *TraceAccumulator) recordEdge(source, target string, durationMs int64, success *bool) {
-	key := source + " -> " + target
+// recordEdge records a cross-agent edge observation. `function` is the callee's
+// span operation; see edgeKey.Function for what an empty one means.
+func (ta *TraceAccumulator) recordEdge(source, target, function string, durationMs int64, success *bool) {
+	// An edge with an unnamed end names no edge at all and has never been
+	// reported. Refused HERE rather than filtered at read time so it does not
+	// occupy a slot under the key ceiling: an unnamed key kept in the map would
+	// evict a real, displayable edge to hold a row nothing can ever show. (An
+	// empty FUNCTION is different — a partial observation, and kept. See
+	// edgeKey.Function.)
+	if source == "" || target == "" {
+		return
+	}
+
+	key := edgeKey{Source: source, Target: target, Function: function}
 	ea, exists := ta.edgeStats[key]
 	if !exists {
 		ea = &edgeAccum{
@@ -208,12 +255,7 @@ func (ta *TraceAccumulator) recordEdge(source, target string, durationMs int64, 
 	}
 	ea.CallCount++
 	ea.TotalMs += durationMs
-	if len(ea.Latencies) < maxEdgeLatencies {
-		ea.Latencies = append(ea.Latencies, durationMs)
-	} else {
-		ea.Latencies[ea.latencyHead] = durationMs
-		ea.latencyHead = (ea.latencyHead + 1) % maxEdgeLatencies
-	}
+	ea.Latency.Record(durationMs)
 	if durationMs > ea.MaxMs {
 		ea.MaxMs = durationMs
 	}
@@ -228,7 +270,12 @@ func (ta *TraceAccumulator) recordEdge(source, target string, durationMs int64, 
 	// Hard key ceiling. Age pruning (pruneEdgeStats) is the primary bound;
 	// this only trips when new edge names appear faster than the retention
 	// window retires them, and it evicts least-recently-seen first.
-	if evicted := EnforceMaxEntries(ta.edgeStats, edgeLastSeen, ta.edgeBounds.MaxEntries); evicted > 0 && ta.logger != nil {
+	//
+	// The finer key raises cardinality by the number of distinct provider
+	// functions called across each pair, so the ceiling is reached sooner than
+	// it used to be on the same mesh. It is still names, not volume: one key
+	// per (caller, provider, tool) actually in use.
+	if evicted := EnforceMaxEntries(ta.edgeStats, edgeLastSeen, ta.edgeBounds.MaxEntries, edgeKeyLess); evicted > 0 && ta.logger != nil {
 		ta.logger.Printf("TraceAccumulator: edge-stat key cap (%d) reached, evicted %d least-recently-seen edges "+
 			"(raise MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES or shorten MCP_MESH_TELEMETRY_AGGREGATE_RETENTION)",
 			ta.edgeBounds.MaxEntries, evicted)
@@ -238,6 +285,18 @@ func (ta *TraceAccumulator) recordEdge(source, target string, durationMs int64, 
 // edgeLastSeen adapts edgeAccum to the PruneOlderThan/EnforceMaxEntries
 // accessor signature.
 func edgeLastSeen(ea *edgeAccum) time.Time { return ea.LastSeen }
+
+// edgeKeyLess is EnforceMaxEntries' deterministic tiebreak for edge keys,
+// ordering on the three fields in turn.
+func edgeKeyLess(a, b edgeKey) bool {
+	if a.Source != b.Source {
+		return a.Source < b.Source
+	}
+	if a.Target != b.Target {
+		return a.Target < b.Target
+	}
+	return a.Function < b.Function
+}
 
 // pruneEdgeStats removes edge entries not observed within the retention
 // window. Mirrors SpanCorrelator.pruneExpiredCompletedTraces: age-based, with
@@ -427,41 +486,31 @@ func (ta *TraceAccumulator) GetRecentTraces(limit int) []RecentTraceSummary {
 	return result
 }
 
-// GetEdgeStats computes EdgeStats from the accumulated edge data.
+// GetEdgeStats computes EdgeStats from the accumulated edge data. Returns EVERY
+// edge; truncation belongs to the caller (SelectEdgeStats), because the two
+// consumers of these rows want different budgets.
 func (ta *TraceAccumulator) GetEdgeStats() []EdgeStats {
 	ta.mu.RLock()
 	defer ta.mu.RUnlock()
 
 	edges := make([]EdgeStats, 0, len(ta.edgeStats))
 	for key, ea := range ta.edgeStats {
-		// Parse "source -> target"
-		var source, target string
-		for i := 0; i+3 < len(key); i++ {
-			if key[i:i+4] == " -> " {
-				source = key[:i]
-				target = key[i+4:]
-				break
-			}
-		}
-		if source == "" || target == "" {
-			continue
-		}
-
+		// No read-time filter for unnamed agents: recordEdge refuses to create
+		// such a key in the first place, so one cannot be here. Dropping them on
+		// the way in matters because a row skipped here would still be holding a
+		// slot under the key ceiling, evicting a real edge to keep a row nothing
+		// will ever display.
 		avgLatency := float64(ea.TotalMs) / float64(ea.CallCount)
 		errorRate := 100.0 * float64(ea.ErrorCount) / float64(ea.CallCount)
 
-		// P99 calculation
-		sorted := make([]int64, len(ea.Latencies))
-		copy(sorted, ea.Latencies)
-		sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
-		p99Index := int(math.Ceil(float64(len(sorted))*0.99)) - 1
-		if p99Index < 0 {
-			p99Index = 0
+		// P99 is a bucket estimate over a rolling window of recent calls, and it
+		// never understates what is inside that window (latency_histogram.go).
+		// Clamped to the exactly-tracked lifetime max so it can never claim a latency
+		// larger than one that was actually observed.
+		p99 := ea.Latency.Quantile(0.99)
+		if p99 > ea.MaxMs {
+			p99 = ea.MaxMs
 		}
-		if p99Index >= len(sorted) {
-			p99Index = len(sorted) - 1
-		}
-		p99Latency := float64(sorted[p99Index])
 
 		minMs := ea.MinMs
 		if minMs == math.MaxInt64 {
@@ -469,21 +518,23 @@ func (ta *TraceAccumulator) GetEdgeStats() []EdgeStats {
 		}
 
 		edges = append(edges, EdgeStats{
-			Source:       source,
-			Target:       target,
-			CallCount:    ea.CallCount,
-			ErrorCount:   ea.ErrorCount,
-			ErrorRate:    errorRate,
-			AvgLatencyMs: avgLatency,
-			P99LatencyMs: p99Latency,
-			MaxLatencyMs: ea.MaxMs,
-			MinLatencyMs: minMs,
+			Source:         key.Source,
+			Target:         key.Target,
+			TargetFunction: key.Function,
+			CallCount:      ea.CallCount,
+			ErrorCount:     ea.ErrorCount,
+			ErrorRate:      errorRate,
+			AvgLatencyMs:   avgLatency,
+			P99LatencyMs:   float64(p99),
+			MaxLatencyMs:   ea.MaxMs,
+			MinLatencyMs:   minMs,
 		})
 	}
 
-	sort.Slice(edges, func(i, j int) bool {
-		return edges[i].CallCount > edges[j].CallCount
-	})
+	// Busiest first, then a total order on the key — see SortEdgeStats. This
+	// returns EVERY edge; truncation is the caller's, through SelectEdgeStats,
+	// because the right budget differs per consumer.
+	SortEdgeStats(edges)
 
 	return edges
 }
@@ -606,14 +657,16 @@ func (ta *TraceAccumulator) finalizeReadyTraces() {
 		if at.RootSeen != nil && now.Sub(*at.RootSeen) >= traceGracePeriod {
 			// Grace period elapsed — finalize this trace
 
-			// Detect cross-agent edges from all spans
+			// Detect cross-agent edges from all spans. The edge is attributed
+			// from the CALLEE's span, so s.Operation is the provider's own
+			// function name — see edgeKey.Function.
 			for _, s := range at.Spans {
 				if s.ParentSpan == nil || s.DurationMS == nil {
 					continue
 				}
 				parentAgent, ok := at.SpanAgent[*s.ParentSpan]
 				if ok && parentAgent != s.AgentName {
-					ta.recordEdge(parentAgent, s.AgentName, *s.DurationMS, s.Success)
+					ta.recordEdge(parentAgent, s.AgentName, s.Operation, *s.DurationMS, s.Success)
 				}
 			}
 
@@ -665,7 +718,7 @@ func (ta *TraceAccumulator) FinalizeAllActive() {
 			}
 			parentAgent, ok := at.SpanAgent[*s.ParentSpan]
 			if ok && parentAgent != s.AgentName {
-				ta.recordEdge(parentAgent, s.AgentName, *s.DurationMS, s.Success)
+				ta.recordEdge(parentAgent, s.AgentName, s.Operation, *s.DurationMS, s.Success)
 			}
 		}
 

--- a/src/core/registry/tracing/accumulator_bounds_test.go
+++ b/src/core/registry/tracing/accumulator_bounds_test.go
@@ -10,11 +10,18 @@ import (
 
 // feedEdgeTrace drives one two-agent trace through the accumulator's real
 // entry points (ProcessTraceEvent + FinalizeAllActive), producing exactly one
-// "source -> target" edge key. This is the live path — no direct map writes.
+// edge key. This is the live path — no direct map writes.
 func feedEdgeTrace(ta *TraceAccumulator, traceID, source, target string) {
 	_ = ta.ProcessTraceEvent(makeEndEvent(traceID, "root-"+traceID, "", source, 10, true))
 	_ = ta.ProcessTraceEvent(makeEndEvent(traceID, "child-"+traceID, "root-"+traceID, target, 5, true))
 	ta.FinalizeAllActive()
+}
+
+// edgeKeyFor names the key feedEdgeTrace produces. makeEndEvent stamps every
+// span's operation as "test_op", and the callee's operation is the key's
+// function component (#1531).
+func edgeKeyFor(source, target string) edgeKey {
+	return edgeKey{Source: source, Target: target, Function: "test_op"}
 }
 
 // TestEdgeStatsUnboundedWithoutBounds is the "before" half of the #1424
@@ -79,7 +86,7 @@ func TestEdgeStatsAgePrune(t *testing.T) {
 
 	// Age the retired edge past the window; leave the live one fresh.
 	ta.mu.Lock()
-	ta.edgeStats["retired-agent -> backend"].LastSeen = time.Now().Add(-2 * time.Hour)
+	ta.edgeStats[edgeKeyFor("retired-agent", "backend")].LastSeen = time.Now().Add(-2 * time.Hour)
 	ta.mu.Unlock()
 
 	ta.pruneEdgeStats()
@@ -88,8 +95,8 @@ func TestEdgeStatsAgePrune(t *testing.T) {
 		t.Fatalf("edge keys = %d after prune, want 1", got)
 	}
 	ta.mu.RLock()
-	_, liveOK := ta.edgeStats["live-agent -> backend"]
-	_, deadOK := ta.edgeStats["retired-agent -> backend"]
+	_, liveOK := ta.edgeStats[edgeKeyFor("live-agent", "backend")]
+	_, deadOK := ta.edgeStats[edgeKeyFor("retired-agent", "backend")]
 	ta.mu.RUnlock()
 	if !liveOK {
 		t.Error("still-active edge was pruned")
@@ -107,7 +114,7 @@ func TestEdgeStatsAgePruneDisabled(t *testing.T) {
 
 	feedEdgeTrace(ta, "t1", "ancient", "backend")
 	ta.mu.Lock()
-	ta.edgeStats["ancient -> backend"].LastSeen = time.Now().Add(-1000 * time.Hour)
+	ta.edgeStats[edgeKeyFor("ancient", "backend")].LastSeen = time.Now().Add(-1000 * time.Hour)
 	ta.mu.Unlock()
 
 	ta.pruneEdgeStats()
@@ -134,14 +141,15 @@ func TestEdgeStatsDefaultPathUnchanged(t *testing.T) {
 		feedEdgeTrace(unbounded, id, src, dst)
 	}
 
-	// Compare as a keyed set: GetEdgeStats sorts by CallCount with an
-	// unstable sort, so equal-count edges have never had a deterministic
-	// order. The invariant that matters is that every edge and every number
-	// is identical.
+	// Compare as a keyed set rather than as a list: the invariant that matters
+	// is that every edge and every number is identical, not the order they
+	// arrive in. (GetEdgeStats does now impose a total order — see the
+	// truncation argument there — but this test predates it and should keep
+	// asserting the weaker, more durable property.)
 	index := func(edges []EdgeStats) map[string]EdgeStats {
 		m := make(map[string]EdgeStats, len(edges))
 		for _, e := range edges {
-			m[e.Source+" -> "+e.Target] = e
+			m[e.Source+" -> "+e.Target+" -> "+e.TargetFunction] = e
 		}
 		return m
 	}

--- a/src/core/registry/tracing/accumulator_edgekey_test.go
+++ b/src/core/registry/tracing/accumulator_edgekey_test.go
@@ -1,0 +1,338 @@
+package tracing
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Edge stats keyed by (source, target, function) — issue #1531. Before this,
+// every call between one pair of agents landed in one bucket, so a pair that
+// exchanged three different tools reported one averaged number three times over
+// and the topology graph stamped it onto all three edges.
+
+// makeCalleeSpan is makeEndEvent with the operation spelled out: the operation
+// is now part of the key, so a test that cannot set it cannot see the change.
+func makeCalleeSpan(traceID, spanID, parent, agent, operation string, durationMs int64, success bool) *TraceEvent {
+	e := makeEndEvent(traceID, spanID, parent, agent, durationMs, success)
+	e.Operation = operation
+	return e
+}
+
+// feedCall drives one caller->callee trace where the callee's span names the
+// provider function it ran. That span is the one the edge is attributed from.
+func feedCall(ta *TraceAccumulator, traceID, caller, callee, calleeOp string, durationMs int64, success bool) {
+	_ = ta.ProcessTraceEvent(makeCalleeSpan(traceID, "root-"+traceID, "", caller, "caller_entrypoint", 1, true))
+	_ = ta.ProcessTraceEvent(makeCalleeSpan(traceID, "child-"+traceID, "root-"+traceID, callee, calleeOp, durationMs, success))
+	ta.FinalizeAllActive()
+}
+
+// statFor finds the single row for one (source, target, function).
+func statFor(t *testing.T, edges []EdgeStats, source, target, fn string) EdgeStats {
+	t.Helper()
+	var found []EdgeStats
+	for _, e := range edges {
+		if e.Source == source && e.Target == target && e.TargetFunction == fn {
+			found = append(found, e)
+		}
+	}
+	if len(found) == 0 {
+		t.Fatalf("no edge stat for %s -> %s (%s); got %+v", source, target, fn, edges)
+	}
+	if len(found) > 1 {
+		t.Fatalf("%d rows for %s -> %s (%s), want exactly 1", len(found), source, target, fn)
+	}
+	return found[0]
+}
+
+// TestEdgeStatsSplitByProviderFunction is the bug itself: one pair, three tools
+// with very different latencies. Before the finer key all three read the same
+// average; now each carries its own numbers.
+func TestEdgeStatsSplitByProviderFunction(t *testing.T) {
+	ta := newTestAccumulator(t, 64)
+
+	// A fast tool, a slow one, and a very slow one — 100 calls each.
+	for i := 0; i < 100; i++ {
+		feedCall(ta, fmt.Sprintf("fast%03d", i), "caller", "provider", "lookup", 2, true)
+		feedCall(ta, fmt.Sprintf("slow%03d", i), "caller", "provider", "summarise", 400, true)
+		feedCall(ta, fmt.Sprintf("job%03d", i), "caller", "provider", "bulk_export", 9000, true)
+	}
+
+	edges := ta.GetEdgeStats()
+	if len(edges) != 3 {
+		t.Fatalf("got %d edge rows, want 3 (one per called function): %+v", len(edges), edges)
+	}
+
+	lookup := statFor(t, edges, "caller", "provider", "lookup")
+	summarise := statFor(t, edges, "caller", "provider", "summarise")
+	bulk := statFor(t, edges, "caller", "provider", "bulk_export")
+
+	if lookup.AvgLatencyMs != 2 || summarise.AvgLatencyMs != 400 || bulk.AvgLatencyMs != 9000 {
+		t.Fatalf("averages bled across functions: lookup=%v summarise=%v bulk=%v",
+			lookup.AvgLatencyMs, summarise.AvgLatencyMs, bulk.AvgLatencyMs)
+	}
+	// The pair-level average these used to share, spelled out so the assertion
+	// above is visibly about the thing that was wrong.
+	const pairAverage = (2.0 + 400.0 + 9000.0) / 3.0
+	for _, e := range edges {
+		if e.AvgLatencyMs == pairAverage {
+			t.Fatalf("%s still reports the pair-level average %v", e.TargetFunction, pairAverage)
+		}
+		if e.CallCount != 100 {
+			t.Fatalf("%s call count = %d, want 100", e.TargetFunction, e.CallCount)
+		}
+	}
+}
+
+// TestEdgeStatsErrorsStayWithTheirFunction: a failing tool must not colour the
+// healthy tools between the same two agents. This is what drives the graph's
+// heat colour, so the leak was visible as red edges that were never failing.
+func TestEdgeStatsErrorsStayWithTheirFunction(t *testing.T) {
+	ta := newTestAccumulator(t, 64)
+
+	for i := 0; i < 10; i++ {
+		feedCall(ta, fmt.Sprintf("ok%02d", i), "caller", "provider", "healthy_tool", 5, true)
+		feedCall(ta, fmt.Sprintf("bad%02d", i), "caller", "provider", "broken_tool", 5, false)
+	}
+
+	edges := ta.GetEdgeStats()
+	healthy := statFor(t, edges, "caller", "provider", "healthy_tool")
+	broken := statFor(t, edges, "caller", "provider", "broken_tool")
+
+	if healthy.ErrorCount != 0 || healthy.ErrorRate != 0 {
+		t.Fatalf("healthy tool inherited errors: count=%d rate=%v", healthy.ErrorCount, healthy.ErrorRate)
+	}
+	if broken.ErrorCount != 10 || broken.ErrorRate != 100 {
+		t.Fatalf("broken tool: count=%d rate=%v, want 10 / 100", broken.ErrorCount, broken.ErrorRate)
+	}
+}
+
+// TestEdgeStatsDifferentPairsSameFunctionStaySeparate: the function is the
+// THIRD component, not a replacement for either of the first two. Two agents
+// happening to publish a tool of the same name must not merge.
+func TestEdgeStatsDifferentPairsSameFunctionStaySeparate(t *testing.T) {
+	ta := newTestAccumulator(t, 64)
+
+	feedCall(ta, "t1", "caller-a", "provider-x", "search", 10, true)
+	feedCall(ta, "t2", "caller-b", "provider-x", "search", 20, true)
+	feedCall(ta, "t3", "caller-a", "provider-y", "search", 30, true)
+
+	edges := ta.GetEdgeStats()
+	if len(edges) != 3 {
+		t.Fatalf("got %d rows, want 3: %+v", len(edges), edges)
+	}
+	if got := statFor(t, edges, "caller-a", "provider-x", "search").AvgLatencyMs; got != 10 {
+		t.Fatalf("caller-a -> provider-x avg = %v, want 10", got)
+	}
+	if got := statFor(t, edges, "caller-b", "provider-x", "search").AvgLatencyMs; got != 20 {
+		t.Fatalf("caller-b -> provider-x avg = %v, want 20", got)
+	}
+	if got := statFor(t, edges, "caller-a", "provider-y", "search").AvgLatencyMs; got != 30 {
+		t.Fatalf("caller-a -> provider-y avg = %v, want 30", got)
+	}
+}
+
+// TestEdgeStatsKeyIsNotAParsedString is the reason the key is a struct. The old
+// key was `source + " -> " + target`, taken apart again on the read side by
+// scanning for the FIRST " -> ": an agent named with that sequence in it split
+// in the wrong place and reported traffic for two agents that do not exist.
+func TestEdgeStatsKeyIsNotAParsedString(t *testing.T) {
+	const hostile = "weird -> name"
+	ta := newTestAccumulator(t, 16)
+	feedCall(ta, "t1", hostile, "backend", "handle", 7, true)
+
+	edges := ta.GetEdgeStats()
+	if len(edges) != 1 {
+		t.Fatalf("got %d rows, want 1: %+v", len(edges), edges)
+	}
+	if edges[0].Source != hostile || edges[0].Target != "backend" {
+		t.Fatalf("names came apart: source=%q target=%q, want %q -> %q",
+			edges[0].Source, edges[0].Target, hostile, "backend")
+	}
+	if strings.Contains(edges[0].Target, "->") {
+		t.Fatalf("target %q still carries a fragment of the source", edges[0].Target)
+	}
+}
+
+// TestEdgeStatsEmptyOperationIsRecordedNotDropped pins the deliberate choice for
+// a span carrying no operation: keep the call, under an empty function.
+//
+// Dropping it would be the quiet option and the wrong one — the call really did
+// happen, and losing it makes the traffic totals disagree with the traces they
+// were computed from. Recorded, it is a row that joins to no topology edge,
+// which is exactly what the payload supports: something was called, and nothing
+// says what.
+func TestEdgeStatsEmptyOperationIsRecordedNotDropped(t *testing.T) {
+	ta := newTestAccumulator(t, 16)
+
+	feedCall(ta, "t1", "caller", "provider", "", 42, true)
+	feedCall(ta, "t2", "caller", "provider", "named_tool", 8, true)
+
+	edges := ta.GetEdgeStats()
+	if len(edges) != 2 {
+		t.Fatalf("got %d rows, want 2 (the unnamed call must not be folded into the named one): %+v",
+			len(edges), edges)
+	}
+	unnamed := statFor(t, edges, "caller", "provider", "")
+	if unnamed.CallCount != 1 || unnamed.AvgLatencyMs != 42 {
+		t.Fatalf("unnamed row: count=%d avg=%v, want 1 / 42", unnamed.CallCount, unnamed.AvgLatencyMs)
+	}
+	named := statFor(t, edges, "caller", "provider", "named_tool")
+	if named.CallCount != 1 || named.AvgLatencyMs != 8 {
+		t.Fatalf("named row: count=%d avg=%v, want 1 / 8", named.CallCount, named.AvgLatencyMs)
+	}
+}
+
+// TestEdgeStatsMissingAgentNameNeverEntersTheMap is the other half of that
+// decision: a row with no source or no target names no edge at all. An empty
+// FUNCTION is a partial observation; an empty AGENT is not an observation.
+//
+// Refused on the way IN, not filtered on the way out. A read-time filter left
+// the key sitting in the map holding a slot under the key ceiling, so an
+// undisplayable row could evict a real edge.
+func TestEdgeStatsMissingAgentNameNeverEntersTheMap(t *testing.T) {
+	ta := newTestAccumulator(t, 16)
+	ta.mu.Lock()
+	ta.recordEdge("", "provider", "tool", 5, nil)
+	ta.recordEdge("caller", "", "tool", 5, nil)
+	ta.recordEdge("", "", "tool", 5, nil)
+	ta.recordEdge("caller", "provider", "tool", 5, nil)
+	ta.mu.Unlock()
+
+	if got := ta.EdgeStatCount(); got != 1 {
+		t.Fatalf("edge map holds %d keys, want 1 — an unnamed edge is occupying a "+
+			"slot under the key ceiling", got)
+	}
+
+	edges := ta.GetEdgeStats()
+	if len(edges) != 1 {
+		t.Fatalf("got %d rows, want 1: %+v", len(edges), edges)
+	}
+	if edges[0].Source != "caller" || edges[0].Target != "provider" {
+		t.Fatalf("wrong row survived: %+v", edges[0])
+	}
+}
+
+// TestEdgeStatsEvictionUnderTheFinerKey: the key ceiling still holds when the
+// cardinality comes from FUNCTIONS rather than agent names. One pair calling
+// thousands of distinct tools is the shape the finer key introduces, and it must
+// be bounded the same way name churn is.
+func TestEdgeStatsEvictionUnderTheFinerKey(t *testing.T) {
+	const cap = 40
+	ta := NewTraceAccumulatorWithBounds(16, log.New(io.Discard, "", 0),
+		AggregateBounds{Retention: 24 * time.Hour, MaxEntries: cap})
+
+	const tools = 1000
+	for i := 0; i < tools; i++ {
+		feedCall(ta, fmt.Sprintf("t%04d", i), "caller", "provider", fmt.Sprintf("tool_%04d", i), 5, true)
+		if got := ta.EdgeStatCount(); got > cap {
+			t.Fatalf("after tool %d: edge keys = %d exceeds cap %d", i, got, cap)
+		}
+	}
+	if got := ta.EdgeStatCount(); got == 0 {
+		t.Fatal("edge map emptied entirely under function churn")
+	}
+
+	// The survivors are the most recently seen, so the newest tool is present
+	// and the oldest is gone: eviction is least-recently-seen, not arbitrary.
+	edges := ta.GetEdgeStats()
+	seen := make(map[string]bool, len(edges))
+	for _, e := range edges {
+		seen[e.TargetFunction] = true
+	}
+	if !seen[fmt.Sprintf("tool_%04d", tools-1)] {
+		t.Error("the most recent function was evicted")
+	}
+	if seen["tool_0000"] {
+		t.Error("the oldest function survived a full cap turnover")
+	}
+}
+
+// TestEdgeStatsAgePruneUnderTheFinerKey: one function of a pair going quiet ages
+// out on its own while the pair's other function keeps reporting. Under the
+// pair-level key there was nothing finer than the pair to age out.
+func TestEdgeStatsAgePruneUnderTheFinerKey(t *testing.T) {
+	ta := NewTraceAccumulatorWithBounds(16, log.New(io.Discard, "", 0),
+		AggregateBounds{Retention: time.Hour, MaxEntries: 1000})
+
+	feedCall(ta, "t1", "caller", "provider", "retired_tool", 5, true)
+	feedCall(ta, "t2", "caller", "provider", "live_tool", 5, true)
+
+	ta.mu.Lock()
+	ta.edgeStats[edgeKey{Source: "caller", Target: "provider", Function: "retired_tool"}].
+		LastSeen = time.Now().Add(-2 * time.Hour)
+	ta.mu.Unlock()
+
+	ta.pruneEdgeStats()
+
+	edges := ta.GetEdgeStats()
+	if len(edges) != 1 {
+		t.Fatalf("got %d rows after prune, want 1: %+v", len(edges), edges)
+	}
+	if edges[0].TargetFunction != "live_tool" {
+		t.Fatalf("survivor is %q, want live_tool", edges[0].TargetFunction)
+	}
+}
+
+// TestEdgeStatsOrderIsTotal: rows are truncated to a limit by every caller, so
+// equal-traffic rows — now the common case — must not swap places between polls.
+func TestEdgeStatsOrderIsTotal(t *testing.T) {
+	build := func(reversed bool) []EdgeStats {
+		ta := newTestAccumulator(t, 64)
+		names := []string{"alpha", "beta", "gamma", "delta", "epsilon"}
+		for i := range names {
+			j := i
+			if reversed {
+				j = len(names) - 1 - i
+			}
+			feedCall(ta, fmt.Sprintf("t%02d%v", i, reversed), "caller", "provider", names[j], 5, true)
+		}
+		return ta.GetEdgeStats()
+	}
+
+	forward, backward := build(false), build(true)
+	if len(forward) != 5 || len(backward) != 5 {
+		t.Fatalf("expected 5 rows each, got %d and %d", len(forward), len(backward))
+	}
+	for i := range forward {
+		if forward[i].TargetFunction != backward[i].TargetFunction {
+			t.Fatalf("row %d differs by insertion order: %q vs %q",
+				i, forward[i].TargetFunction, backward[i].TargetFunction)
+		}
+	}
+	// And that order is by name, since every row here has the same call count.
+	want := []string{"alpha", "beta", "delta", "epsilon", "gamma"}
+	for i, w := range want {
+		if forward[i].TargetFunction != w {
+			t.Fatalf("row %d = %q, want %q", i, forward[i].TargetFunction, w)
+		}
+	}
+}
+
+// TestEdgeStatsP99StaysWithinTheObservedMax: the percentile is a bucket estimate
+// now, and GetEdgeStats clamps it. A dashboard reporting a P99 above a latency
+// no call ever took would be reporting the bucket layout, not the mesh.
+func TestEdgeStatsP99StaysWithinTheObservedMax(t *testing.T) {
+	ta := newTestAccumulator(t, 256)
+	for i := 0; i < 500; i++ {
+		// Values just above an octave boundary, where the bucket's upper bound
+		// sits furthest above anything actually observed.
+		feedCall(ta, fmt.Sprintf("t%03d", i), "caller", "provider", "tool", 1025, true)
+	}
+	e := statFor(t, ta.GetEdgeStats(), "caller", "provider", "tool")
+	if e.MaxLatencyMs != 1025 || e.MinLatencyMs != 1025 {
+		t.Fatalf("min/max must stay exact: min=%d max=%d", e.MinLatencyMs, e.MaxLatencyMs)
+	}
+	if e.AvgLatencyMs != 1025 {
+		t.Fatalf("avg must stay exact: %v", e.AvgLatencyMs)
+	}
+	if e.P99LatencyMs > float64(e.MaxLatencyMs) {
+		t.Fatalf("P99 %v exceeds the observed max %d", e.P99LatencyMs, e.MaxLatencyMs)
+	}
+	if e.P99LatencyMs < float64(e.MinLatencyMs) {
+		t.Fatalf("P99 %v is below the observed min %d", e.P99LatencyMs, e.MinLatencyMs)
+	}
+}

--- a/src/core/registry/tracing/aggregates.go
+++ b/src/core/registry/tracing/aggregates.go
@@ -20,6 +20,21 @@ import (
 // case (name churn faster than the retention window can absorb); it evicts
 // least-recently-seen first, so it only ever degrades into LRU once age
 // pruning has already failed to keep up.
+//
+// WHAT THE CEILING COSTS. MaxEntries is a key count, so the memory it admits
+// depends on the map. The expensive one is the edge map, whose value carries a
+// fixed-size latency histogram: 1,992 bytes per edgeAccum plus a 48-byte
+// edgeKey, the agent and function names it retains, and the map's own overhead
+// — call it ~2.1 KB an entry. At the 10,000 default that is a steady-state
+// ceiling of roughly 20 MB for the edge map, reached only by a mesh with that
+// many live (caller, provider, function) triples; the per-agent and per-model
+// maps hold counters only and are negligible beside it. An operator raising
+// MaxEntries is buying edge rows at ~2.1 KB each.
+//
+// The default is NOT lowered to compensate for per-function edge keys (#1531)
+// multiplying the row count: 20 MB is a fair ceiling for a process whose job is
+// telemetry, and lowering it would silently start evicting live edges in meshes
+// that fit today. If it should move, it should move on its own evidence.
 const (
 	defaultAggregateRetention  = 24 * time.Hour
 	defaultAggregateMaxEntries = 10000
@@ -66,6 +81,9 @@ func DefaultAggregateBounds() AggregateBounds {
 //   - positive: use it
 //   - "0": key ceiling disabled — logged as a removed bound
 //   - negative / unparseable: warn and fall back to the default
+//
+// See the bounds comment above for what a key costs before changing this: an
+// edge entry is ~2.1 KB, so the default admits ~20 MB of edge aggregates.
 //
 // Uses the stdlib log package because it runs at package init, before any
 // manager (and therefore any manager logger) exists.

--- a/src/core/registry/tracing/aggregates.go
+++ b/src/core/registry/tracing/aggregates.go
@@ -121,7 +121,10 @@ func LoadAggregateBoundsFromEnv() AggregateBounds {
 //
 // Exported so the UI package's MetricsProcessor can share the accumulator's
 // pruning semantics rather than reimplementing them.
-func PruneOlderThan[V any](m map[string]V, lastSeen func(V) time.Time, cutoff time.Time) int {
+//
+// The key is any comparable type: agent and model aggregates are keyed by name,
+// edge stats by a (source, target, function) struct (#1531).
+func PruneOlderThan[K comparable, V any](m map[K]V, lastSeen func(V) time.Time, cutoff time.Time) int {
 	removed := 0
 	for k, v := range m {
 		if lastSeen(v).Before(cutoff) {
@@ -132,6 +135,15 @@ func PruneOlderThan[V any](m map[string]V, lastSeen func(V) time.Time, cutoff ti
 	return removed
 }
 
+// KeyLess orders two map keys. It is only ever consulted to break a tie between
+// entries sharing a lastSeen timestamp, so it needs to be deterministic, not
+// meaningful. StringKeyLess covers the name-keyed maps; a struct-keyed map
+// supplies its own (see edgeKeyLess).
+type KeyLess[K comparable] func(a, b K) bool
+
+// StringKeyLess is the KeyLess for name-keyed aggregate maps.
+func StringKeyLess(a, b string) bool { return a < b }
+
 // EnforceMaxEntries drops the least-recently-seen entries when m exceeds max,
 // returning the number evicted. max <= 0 disables the ceiling.
 //
@@ -139,7 +151,7 @@ func PruneOlderThan[V any](m map[string]V, lastSeen func(V) time.Time, cutoff ti
 // (always at least one entry) so the O(n log n) sort is amortised over many
 // subsequent inserts instead of being paid on every insert past the cap. The
 // post-condition callers rely on is len(m) <= max.
-func EnforceMaxEntries[V any](m map[string]V, lastSeen func(V) time.Time, max int) int {
+func EnforceMaxEntries[K comparable, V any](m map[K]V, lastSeen func(V) time.Time, max int, keyLess KeyLess[K]) int {
 	if max <= 0 || len(m) <= max {
 		return 0
 	}
@@ -156,7 +168,7 @@ func EnforceMaxEntries[V any](m map[string]V, lastSeen func(V) time.Time, max in
 	}
 
 	type entry struct {
-		key  string
+		key  K
 		seen time.Time
 	}
 	entries := make([]entry, 0, len(m))
@@ -167,7 +179,7 @@ func EnforceMaxEntries[V any](m map[string]V, lastSeen func(V) time.Time, max in
 		if entries[i].seen.Equal(entries[j].seen) {
 			// Stable tiebreak so eviction is deterministic when many keys
 			// share a timestamp (common in tests and in bursty churn).
-			return entries[i].key < entries[j].key
+			return keyLess(entries[i].key, entries[j].key)
 		}
 		return entries[i].seen.Before(entries[j].seen)
 	})

--- a/src/core/registry/tracing/aggregates_test.go
+++ b/src/core/registry/tracing/aggregates_test.go
@@ -102,7 +102,7 @@ func TestEnforceMaxEntriesBoundsGrowth(t *testing.T) {
 	maxSeen := 0
 	for i := 0; i < 5000; i++ {
 		m[fmt.Sprintf("key-%05d", i)] = &stamped{seen: base.Add(time.Duration(i) * time.Millisecond)}
-		EnforceMaxEntries(m, stampedSeen, cap)
+		EnforceMaxEntries(m, stampedSeen, cap, StringKeyLess)
 		if len(m) > maxSeen {
 			maxSeen = len(m)
 		}
@@ -131,7 +131,7 @@ func TestEnforceMaxEntriesDisabled(t *testing.T) {
 	m := make(map[string]*stamped)
 	for i := 0; i < 1000; i++ {
 		m[fmt.Sprintf("k%d", i)] = &stamped{seen: time.Now()}
-		if n := EnforceMaxEntries(m, stampedSeen, 0); n != 0 {
+		if n := EnforceMaxEntries(m, stampedSeen, 0, StringKeyLess); n != 0 {
 			t.Fatalf("cap of 0 evicted %d entries; it must be a no-op", n)
 		}
 	}
@@ -148,7 +148,7 @@ func TestEnforceMaxEntriesTinyCap(t *testing.T) {
 		base := time.Now()
 		for i := 0; i < 50; i++ {
 			m[fmt.Sprintf("k%02d", i)] = &stamped{seen: base.Add(time.Duration(i) * time.Millisecond)}
-			EnforceMaxEntries(m, stampedSeen, cap)
+			EnforceMaxEntries(m, stampedSeen, cap, StringKeyLess)
 			if len(m) > cap {
 				t.Fatalf("cap=%d: len(m) = %d after insert %d", cap, len(m), i)
 			}

--- a/src/core/registry/tracing/edge_selection.go
+++ b/src/core/registry/tracing/edge_selection.go
@@ -1,0 +1,95 @@
+package tracing
+
+import "sort"
+
+// SortEdgeStats orders a computed edge-stat list: busiest first, then a total
+// order on the key.
+//
+// The tiebreak is not decoration. Callers TRUNCATE this list to a limit, and one
+// row per (source, target, function) makes equal call counts the common case
+// rather than a rarity — without a deterministic order the same unchanged mesh
+// would drop a different row from the bottom of the dashboard on every 5s poll.
+func SortEdgeStats(edges []EdgeStats) {
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].CallCount != edges[j].CallCount {
+			return edges[i].CallCount > edges[j].CallCount
+		}
+		if edges[i].Source != edges[j].Source {
+			return edges[i].Source < edges[j].Source
+		}
+		if edges[i].Target != edges[j].Target {
+			return edges[i].Target < edges[j].Target
+		}
+		return edges[i].TargetFunction < edges[j].TargetFunction
+	})
+}
+
+// SelectEdgeStats truncates a SortEdgeStats-ordered list to at most `limit`
+// rows, choosing them FAIRLY ACROSS AGENT PAIRS rather than taking the head.
+// limit <= 0 means no limit.
+//
+// WHY NOT THE HEAD. The row limits on these endpoints were chosen when one row
+// meant one agent pair, so taking the busiest `limit` rows dropped the quietest
+// PAIRS — a proportionate thing to do. Since #1531 a row is one (caller,
+// provider, function), so a single pair exchanging 25 tools can occupy every
+// slot on its own and every other pair falls out of the payload entirely. The
+// topology graph reads the same payload and leaves an unmatched edge in its
+// structural style, so the failure is silent: most of the mesh simply stops
+// reporting traffic, with no error and no empty state.
+//
+// WHAT FAIR MEANS HERE. One pass per rank: every pair contributes its busiest
+// remaining function, then every pair its second-busiest, and so on until the
+// budget runs out. So a pair is only starved once EVERY pair has a row, and the
+// row a pair keeps is its busiest — the number a reader would want if they are
+// only getting one. Pairs are visited in the order they first appear in the
+// sorted input, so when the budget is smaller than the number of pairs the
+// busiest pairs are the ones served, which is the old behaviour at the point
+// where the old behaviour was still reasonable.
+//
+// This bounds the damage; it does not remove it. A consumer that needs a row for
+// every edge it draws needs a budget large enough for them — see
+// edgeStatsStreamLimit in the ui package, which is why the graph's feed and the
+// tables' feed no longer share one number.
+func SelectEdgeStats(edges []EdgeStats, limit int) []EdgeStats {
+	if limit <= 0 || len(edges) <= limit {
+		return edges
+	}
+
+	type pair struct{ source, target string }
+	byPair := make(map[pair][]EdgeStats, limit)
+	// Pair visit order = first appearance in the sorted input, which is a total
+	// order, so the selection is a pure function of the input.
+	order := make([]pair, 0, limit)
+	for _, e := range edges {
+		p := pair{e.Source, e.Target}
+		if _, seen := byPair[p]; !seen {
+			order = append(order, p)
+		}
+		byPair[p] = append(byPair[p], e)
+	}
+
+	kept := make([]EdgeStats, 0, limit)
+	for rank := 0; len(kept) < limit; rank++ {
+		progressed := false
+		for _, p := range order {
+			rows := byPair[p]
+			if rank >= len(rows) {
+				continue
+			}
+			progressed = true
+			kept = append(kept, rows[rank])
+			if len(kept) == limit {
+				break
+			}
+		}
+		if !progressed {
+			// Every pair is exhausted, which cannot happen while len(edges) >
+			// limit, but a loop with no unconditional exit does not get to
+			// depend on that.
+			break
+		}
+	}
+
+	SortEdgeStats(kept)
+	return kept
+}

--- a/src/core/registry/tracing/edge_selection.go
+++ b/src/core/registry/tracing/edge_selection.go
@@ -41,10 +41,16 @@ func SortEdgeStats(edges []EdgeStats) {
 // remaining function, then every pair its second-busiest, and so on until the
 // budget runs out. So a pair is only starved once EVERY pair has a row, and the
 // row a pair keeps is its busiest — the number a reader would want if they are
-// only getting one. Pairs are visited in the order they first appear in the
-// sorted input, so when the budget is smaller than the number of pairs the
-// busiest pairs are the ones served, which is the old behaviour at the point
-// where the old behaviour was still reasonable.
+// only getting one.
+//
+// PAIR ORDER IS BY THE PAIR'S TOTAL, summed over all its functions, which
+// decides who is served when the budget is smaller than the number of pairs.
+// That total is what the old pair-level row reported, so this degrades into the
+// old ranking at the point where the old ranking was still the reasonable
+// answer. Ranking pairs by their busiest SINGLE function instead — which is
+// what their first appearance in the call-count-sorted input gives — would put
+// a pair with one 1,000-call tool ahead of a pair with ten 500-call ones, and
+// the old payload ranked the second pair five times higher.
 //
 // This bounds the damage; it does not remove it. A consumer that needs a row for
 // every edge it draws needs a budget large enough for them — see
@@ -56,28 +62,47 @@ func SelectEdgeStats(edges []EdgeStats, limit int) []EdgeStats {
 	}
 
 	type pair struct{ source, target string }
-	byPair := make(map[pair][]EdgeStats, limit)
-	// Pair visit order = first appearance in the sorted input, which is a total
-	// order, so the selection is a pure function of the input.
-	order := make([]pair, 0, limit)
+	type pairRows struct {
+		key   pair
+		total int
+		// rows in input order, i.e. busiest function first (SortEdgeStats).
+		rows []EdgeStats
+	}
+	byPair := make(map[pair]*pairRows, limit)
+	order := make([]*pairRows, 0, limit)
 	for _, e := range edges {
 		p := pair{e.Source, e.Target}
-		if _, seen := byPair[p]; !seen {
-			order = append(order, p)
+		pr, seen := byPair[p]
+		if !seen {
+			pr = &pairRows{key: p}
+			byPair[p] = pr
+			order = append(order, pr)
 		}
-		byPair[p] = append(byPair[p], e)
+		pr.total += e.CallCount
+		pr.rows = append(pr.rows, e)
 	}
+
+	// Busiest pair first, then a total order on the pair, so the selection is a
+	// pure function of the input rather than of map iteration order.
+	sort.Slice(order, func(i, j int) bool {
+		if order[i].total != order[j].total {
+			return order[i].total > order[j].total
+		}
+		if order[i].key.source != order[j].key.source {
+			return order[i].key.source < order[j].key.source
+		}
+		return order[i].key.target < order[j].key.target
+	})
 
 	kept := make([]EdgeStats, 0, limit)
 	for rank := 0; len(kept) < limit; rank++ {
 		progressed := false
-		for _, p := range order {
-			rows := byPair[p]
-			if rank >= len(rows) {
+		for _, pr := range order {
+			if rank >= len(pr.rows) {
 				continue
 			}
 			progressed = true
-			kept = append(kept, rows[rank])
+			kept = append(kept, pr.rows[rank])
 			if len(kept) == limit {
 				break
 			}

--- a/src/core/registry/tracing/edge_selection_test.go
+++ b/src/core/registry/tracing/edge_selection_test.go
@@ -1,0 +1,209 @@
+package tracing
+
+import (
+	"fmt"
+	"testing"
+)
+
+// The row budget on the edge-stat endpoints was a PER-PAIR budget when a row
+// meant an agent pair. Per-function rows (#1531) turned it into a per-function
+// budget, and a plain head-truncation of a call-count ranking then lets one busy
+// pair take every slot. SelectEdgeStats is what stops that.
+
+// pairsIn returns the distinct "source -> target" pairs present in a row set.
+func pairsIn(edges []EdgeStats) map[string]int {
+	pairs := make(map[string]int)
+	for _, e := range edges {
+		pairs[e.Source+" -> "+e.Target]++
+	}
+	return pairs
+}
+
+// TestSelectEdgeStatsDoesNotStarveOtherPairs is the failure the change exists to
+// prevent, built as the reviewer described it: one chatty pair with more tools
+// than the entire budget, plus a handful of ordinary pairs. Under a head
+// truncation the chatty pair takes all 20 slots and every other pair disappears
+// from the payload — and because the topology graph leaves an unmatched edge in
+// its structural style, it disappears SILENTLY.
+func TestSelectEdgeStatsDoesNotStarveOtherPairs(t *testing.T) {
+	ta := newTestAccumulator(t, 512)
+
+	// One pair exchanging 25 tools, each busier than anything else in the mesh.
+	const chattyTools = 25
+	for tool := 0; tool < chattyTools; tool++ {
+		for call := 0; call < 50; call++ {
+			feedCall(ta, fmt.Sprintf("chat-%02d-%03d", tool, call),
+				"chatty-caller", "chatty-provider", fmt.Sprintf("tool_%02d", tool), 5, true)
+		}
+	}
+
+	// Six ordinary pairs, one call each — the quiet majority of a real mesh.
+	quiet := []struct{ src, dst string }{
+		{"web", "auth"},
+		{"web", "billing"},
+		{"worker", "storage"},
+		{"worker", "search"},
+		{"scheduler", "worker"},
+		{"api", "web"},
+	}
+	for i, p := range quiet {
+		feedCall(ta, fmt.Sprintf("quiet-%d", i), p.src, p.dst, "handle", 5, true)
+	}
+
+	all := ta.GetEdgeStats()
+	if got := len(all); got != chattyTools+len(quiet) {
+		t.Fatalf("accumulator holds %d rows, want %d", got, chattyTools+len(quiet))
+	}
+
+	// The old behaviour, spelled out so the contrast is in the test rather than
+	// only in the commit message.
+	head := all[:20]
+	if got := len(pairsIn(head)); got != 1 {
+		t.Fatalf("precondition failed: a head truncation should show only the chatty "+
+			"pair, showed %d pairs", got)
+	}
+
+	selected := SelectEdgeStats(all, 20)
+	if got := len(selected); got != 20 {
+		t.Fatalf("selected %d rows, want the full budget of 20", got)
+	}
+
+	pairs := pairsIn(selected)
+	for _, p := range quiet {
+		if pairs[p.src+" -> "+p.dst] == 0 {
+			t.Errorf("pair %s -> %s was starved out of the payload entirely", p.src, p.dst)
+		}
+	}
+	if pairs["chatty-caller -> chatty-provider"] == 0 {
+		t.Error("the busiest pair lost its row, which is the opposite failure")
+	}
+	if got := len(pairs); got != 1+len(quiet) {
+		t.Fatalf("payload covers %d pairs, want all %d", got, 1+len(quiet))
+	}
+}
+
+// TestSelectEdgeStatsKeepsEachPairsBusiestFunction: the one row a starved pair
+// keeps must be the row worth keeping.
+func TestSelectEdgeStatsKeepsEachPairsBusiestFunction(t *testing.T) {
+	ta := newTestAccumulator(t, 256)
+
+	for _, pair := range []string{"a", "b", "c"} {
+		for tool, calls := range map[string]int{"quiet_tool": 1, "busy_tool": 40, "middling_tool": 10} {
+			for i := 0; i < calls; i++ {
+				feedCall(ta, fmt.Sprintf("%s-%s-%03d", pair, tool, i),
+					pair+"-caller", pair+"-provider", tool, 5, true)
+			}
+		}
+	}
+
+	selected := SelectEdgeStats(ta.GetEdgeStats(), 3)
+	if len(selected) != 3 {
+		t.Fatalf("selected %d rows, want 3", len(selected))
+	}
+	for _, e := range selected {
+		if e.TargetFunction != "busy_tool" {
+			t.Errorf("%s -> %s kept %q, want its busiest function", e.Source, e.Target, e.TargetFunction)
+		}
+	}
+	if got := len(pairsIn(selected)); got != 3 {
+		t.Fatalf("selection covers %d pairs, want 3", got)
+	}
+}
+
+// TestSelectEdgeStatsIsDeterministic: the selection is polled every 5s, so the
+// same unchanged mesh must produce the same rows every time, whatever order the
+// map iteration handed them over in.
+func TestSelectEdgeStatsIsDeterministic(t *testing.T) {
+	build := func(reversed bool) []EdgeStats {
+		ta := newTestAccumulator(t, 512)
+		pairs := []string{"alpha", "beta", "gamma", "delta"}
+		tools := []string{"one", "two", "three", "four", "five"}
+		for pi := range pairs {
+			for ti := range tools {
+				p, tl := pi, ti
+				if reversed {
+					p, tl = len(pairs)-1-pi, len(tools)-1-ti
+				}
+				for i := 0; i < 3; i++ {
+					feedCall(ta, fmt.Sprintf("t-%v-%d-%d-%d", reversed, p, tl, i),
+						pairs[p]+"-caller", pairs[p]+"-provider", tools[tl], 5, true)
+				}
+			}
+		}
+		return SelectEdgeStats(ta.GetEdgeStats(), 9)
+	}
+
+	forward, backward := build(false), build(true)
+	if len(forward) != 9 || len(backward) != 9 {
+		t.Fatalf("selected %d and %d rows, want 9 each", len(forward), len(backward))
+	}
+	for i := range forward {
+		if forward[i] != backward[i] {
+			t.Fatalf("row %d differs by insertion order: %+v vs %+v", i, forward[i], backward[i])
+		}
+	}
+}
+
+// TestSelectEdgeStatsBudgetSmallerThanPairCount: when even one row per pair does
+// not fit, the pairs served are the busiest ones — the old ranking, at the point
+// where the old ranking was still the reasonable answer.
+func TestSelectEdgeStatsBudgetSmallerThanPairCount(t *testing.T) {
+	edges := []EdgeStats{
+		{Source: "a", Target: "z", TargetFunction: "one", CallCount: 100},
+		{Source: "a", Target: "z", TargetFunction: "two", CallCount: 90},
+		{Source: "b", Target: "z", TargetFunction: "one", CallCount: 80},
+		{Source: "c", Target: "z", TargetFunction: "one", CallCount: 70},
+		{Source: "d", Target: "z", TargetFunction: "one", CallCount: 60},
+	}
+	SortEdgeStats(edges)
+
+	selected := SelectEdgeStats(edges, 2)
+	if len(selected) != 2 {
+		t.Fatalf("selected %d rows, want 2", len(selected))
+	}
+	pairs := pairsIn(selected)
+	if pairs["a -> z"] != 1 || pairs["b -> z"] != 1 {
+		t.Fatalf("want one row each for the two busiest pairs, got %v", pairs)
+	}
+}
+
+// TestSelectEdgeStatsNoLimitAndUnderBudget: the identity cases, including the
+// limit <= 0 that means "everything" throughout this package.
+func TestSelectEdgeStatsNoLimitAndUnderBudget(t *testing.T) {
+	edges := []EdgeStats{
+		{Source: "a", Target: "b", TargetFunction: "x", CallCount: 2},
+		{Source: "a", Target: "b", TargetFunction: "y", CallCount: 1},
+	}
+	if got := SelectEdgeStats(edges, 0); len(got) != 2 {
+		t.Fatalf("limit 0 returned %d rows, want all 2", len(got))
+	}
+	if got := SelectEdgeStats(edges, -1); len(got) != 2 {
+		t.Fatalf("limit -1 returned %d rows, want all 2", len(got))
+	}
+	if got := SelectEdgeStats(edges, 5); len(got) != 2 {
+		t.Fatalf("over-budget limit returned %d rows, want all 2", len(got))
+	}
+	if got := SelectEdgeStats(nil, 5); len(got) != 0 {
+		t.Fatalf("nil returned %d rows", len(got))
+	}
+}
+
+// TestSelectEdgeStatsOutputStaysSorted: callers render the result directly, so
+// the selection must not leave rows in round-robin order.
+func TestSelectEdgeStatsOutputStaysSorted(t *testing.T) {
+	edges := []EdgeStats{
+		{Source: "a", Target: "z", TargetFunction: "one", CallCount: 100},
+		{Source: "b", Target: "z", TargetFunction: "one", CallCount: 90},
+		{Source: "a", Target: "z", TargetFunction: "two", CallCount: 80},
+		{Source: "b", Target: "z", TargetFunction: "two", CallCount: 70},
+	}
+	SortEdgeStats(edges)
+
+	selected := SelectEdgeStats(edges, 3)
+	for i := 1; i < len(selected); i++ {
+		if selected[i-1].CallCount < selected[i].CallCount {
+			t.Fatalf("row %d (%d calls) precedes a busier row (%d calls)",
+				i-1, selected[i-1].CallCount, selected[i].CallCount)
+		}
+	}
+}

--- a/src/core/registry/tracing/edge_selection_test.go
+++ b/src/core/registry/tracing/edge_selection_test.go
@@ -145,8 +145,9 @@ func TestSelectEdgeStatsIsDeterministic(t *testing.T) {
 }
 
 // TestSelectEdgeStatsBudgetSmallerThanPairCount: when even one row per pair does
-// not fit, the pairs served are the busiest ones — the old ranking, at the point
-// where the old ranking was still the reasonable answer.
+// not fit, the pairs served are the ones carrying the most traffic in total —
+// the old ranking, at the point where the old ranking was still the reasonable
+// answer.
 func TestSelectEdgeStatsBudgetSmallerThanPairCount(t *testing.T) {
 	edges := []EdgeStats{
 		{Source: "a", Target: "z", TargetFunction: "one", CallCount: 100},
@@ -164,6 +165,36 @@ func TestSelectEdgeStatsBudgetSmallerThanPairCount(t *testing.T) {
 	pairs := pairsIn(selected)
 	if pairs["a -> z"] != 1 || pairs["b -> z"] != 1 {
 		t.Fatalf("want one row each for the two busiest pairs, got %v", pairs)
+	}
+}
+
+// TestSelectEdgeStatsRanksPairsByTheirTotal: the two candidate rankings differ
+// exactly here. `spread` carries five times the traffic of `spiky` but spreads
+// it over ten tools, so its busiest single row is the smaller of the two — and
+// its first appearance in the call-count-sorted input is therefore later. A
+// visit order taken from that first appearance serves `spiky`; the pair total,
+// which is the number the old pair-level row reported, serves `spread`.
+func TestSelectEdgeStatsRanksPairsByTheirTotal(t *testing.T) {
+	edges := []EdgeStats{
+		{Source: "spiky", Target: "z", TargetFunction: "one", CallCount: 1000},
+	}
+	for i := 0; i < 10; i++ {
+		edges = append(edges, EdgeStats{
+			Source: "spread", Target: "z", TargetFunction: fmt.Sprintf("tool_%02d", i), CallCount: 500,
+		})
+	}
+	SortEdgeStats(edges)
+	if edges[0].Source != "spiky" {
+		t.Fatalf("precondition failed: the head row should be the spiky pair's, was %q", edges[0].Source)
+	}
+
+	selected := SelectEdgeStats(edges, 1)
+	if len(selected) != 1 {
+		t.Fatalf("selected %d rows, want 1", len(selected))
+	}
+	if selected[0].Source != "spread" {
+		t.Errorf("the single slot went to %q (%d calls in its busiest row); want the pair "+
+			"carrying the most traffic overall", selected[0].Source, selected[0].CallCount)
 	}
 }
 

--- a/src/core/registry/tracing/latency_histogram.go
+++ b/src/core/registry/tracing/latency_histogram.go
@@ -1,0 +1,192 @@
+package tracing
+
+import (
+	"math"
+	"math/bits"
+)
+
+// latencyHistogram is a fixed-size, log-linear histogram over integer
+// millisecond latencies, held over a rolling window of recent samples. It
+// replaces the per-key reservoir of raw samples that existed only to sort a P99
+// at read time (#1531): a reservoir costs memory proportional to TRAFFIC, and
+// once edge stats are keyed per provider function there are many more keys to
+// pay it on. A histogram costs the same 1,928 bytes whether a key saw one call
+// or a billion.
+//
+// BUCKET LAYOUT — the range that matters here runs from a sub-millisecond
+// in-cluster hop to a multi-second LLM turn to a multi-hour MeshJob, five or
+// more orders of magnitude. Linear buckets cannot serve both ends: fine enough
+// for the fast hop and there are millions of them; coarse enough for the job
+// and every fast edge lands in bucket zero. So the layout is log-LINEAR, the
+// HdrHistogram shape:
+//
+//   - [0, 16) ms: one bucket per millisecond. Exact — these values are integers,
+//     so the bucket IS the value.
+//   - >= 16 ms: each power-of-two octave is cut into 8 equal sub-buckets, so a
+//     bucket is 1/8 of its octave wide. Its members are between 1 and 2 octave
+//     bases, so a bucket spans between 1/16 and 1/8 of the values it holds.
+//
+// WORST-CASE ERROR: a bucket at octave o spans 2^(o-3) and its members are at
+// least 2^o, so reporting a bucket's UPPER bound overstates a value by at most
+// 1/8 = 12.5%, and never understates it. The error is deliberately one-sided —
+// a latency dashboard that rounds the wrong way tells you the mesh is faster
+// than it is. Below 16 ms the error is exactly zero. GetEdgeStats then clamps
+// the estimate to the exactly-tracked MaxMs, so the reported P99 can never
+// exceed a latency that was actually observed.
+//
+// THE WINDOW is the second half of the design and is not a memory measure. The
+// reservoir this replaced held the last 10,000 samples, so a latency spike aged
+// out of the percentile once 10,000 calls had happened since. A single
+// accumulating histogram would NOT: an edge stat key is refreshed on every call,
+// so a busy edge's key never ages out and nothing would ever reset it — one bad
+// afternoon would sit in that edge's P99 for the life of the process. A P99 that
+// cannot recover is a P99 nobody trusts. So the histogram keeps two generations
+// and rotates (see histRotateSamples), which restores the old window rather than
+// inventing a new one.
+//
+// min/max/avg stay EXACT and are LIFETIME, as they always were — they are not
+// read from here at all, since a running min, max and sum need no samples
+// retained. So the P99 alone is both an estimate and windowed, and the pairing
+// of a lifetime average with a recent percentile is the same pairing the
+// reservoir produced.
+//
+// Note the accumulator's per-agent and per-model aggregates (the UI's
+// MetricsProcessor) do NOT move to this: they hold counters and token sums
+// only, never a latency sample, so there is nothing there to bound.
+const (
+	// histSubBucketBits is log2 of the sub-buckets per octave. 3 => 8
+	// sub-buckets => 12.5% worst-case bucket width.
+	histSubBucketBits = 3
+
+	// histSubBucketCount is the sub-buckets per octave (8).
+	histSubBucketCount = 1 << histSubBucketBits
+
+	// histLinearLimit is the exclusive top of the exact, one-bucket-per-ms
+	// region (16). Above it the octave scale takes over, seamlessly: the first
+	// octave bucket starts at exactly this value.
+	histLinearLimit = histSubBucketCount << 1
+
+	// histMaxValueMs is the largest latency the layout addresses: 2^32-1 ms,
+	// just under 50 days. Anything longer is clamped into the final bucket.
+	// Nothing is lost by that — MaxMs records the true value exactly.
+	histMaxValueMs = int64(1)<<32 - 1
+
+	// histBucketCount is histIndex(histMaxValueMs)+1. Asserted by
+	// TestHistogramBucketCountCoversRange rather than left as a claim.
+	histBucketCount = 240
+
+	// histRotateSamples is how many observations one generation holds before the
+	// histogram rotates. Deliberately the reservoir's old capacity: the window a
+	// quantile is computed over is then between histRotateSamples and twice it,
+	// which brackets the exactly-10,000 window the reservoir gave. Counted in
+	// SAMPLES rather than in wall time for the same reason — a count window is
+	// what the old behaviour was, and it needs no clock on the accumulator's
+	// hottest path.
+	//
+	// A quiet edge never rotates and its P99 covers everything it ever saw. That
+	// is also unchanged: the old ring buffer never wrapped below 10,000 samples
+	// either.
+	histRotateSamples = 10000
+)
+
+// histGeneration is one window's counters. uint32 is sufficient BY
+// CONSTRUCTION, not by estimate: Record rotates the moment count reaches
+// histRotateSamples, so no field here can exceed that constant.
+type histGeneration struct {
+	buckets [histBucketCount]uint32
+	count   uint32
+}
+
+// latencyHistogram counts observations per bucket over a rolling two-generation
+// window. The zero value is ready to use and allocates nothing beyond itself
+// (two 960-byte counter arrays plus two counts = 1,928 bytes — byte for byte
+// what a single non-windowed uint64-counter version would have cost).
+type latencyHistogram struct {
+	current  histGeneration
+	previous histGeneration
+}
+
+// histIndex maps a latency in milliseconds to its bucket.
+//
+// Values <= 0 (including the sub-millisecond calls that the wire format has
+// already truncated to 0 — duration_ms is an integer everywhere upstream) land
+// in bucket 0. Values above histMaxValueMs are clamped into the last bucket.
+func histIndex(ms int64) int {
+	if ms <= 0 {
+		return 0
+	}
+	if ms > histMaxValueMs {
+		ms = histMaxValueMs
+	}
+	if ms < histLinearLimit {
+		return int(ms)
+	}
+	// 2^octave <= ms < 2^(octave+1), so octave >= 4 and shift >= 1.
+	octave := bits.Len64(uint64(ms)) - 1
+	shift := octave - histSubBucketBits
+	sub := int(ms >> shift) // in [8, 16) by construction
+	return (shift+1)*histSubBucketCount + (sub - histSubBucketCount)
+}
+
+// histUpperBound returns the largest millisecond value that lands in bucket i.
+// In the linear region that is the value itself.
+func histUpperBound(i int) int64 {
+	if i < histLinearLimit {
+		return int64(i)
+	}
+	shift := i/histSubBucketCount - 1
+	sub := int64(i%histSubBucketCount + histSubBucketCount)
+	return (sub << shift) + (int64(1) << shift) - 1
+}
+
+// Record adds one observation, rotating the window first when the current
+// generation is full. The rotation is a 964-byte struct copy paid once per
+// histRotateSamples observations.
+func (h *latencyHistogram) Record(ms int64) {
+	if h.current.count >= histRotateSamples {
+		h.previous = h.current
+		h.current = histGeneration{}
+	}
+	h.current.buckets[histIndex(ms)]++
+	h.current.count++
+}
+
+// Count returns the number of observations inside the current window, which is
+// not the total ever recorded once the histogram has rotated. The accumulator's
+// exact CallCount is the lifetime number.
+func (h *latencyHistogram) Count() uint64 {
+	return uint64(h.current.count) + uint64(h.previous.count)
+}
+
+// Quantile returns the q-th percentile OF THE WINDOW as the UPPER bound of the
+// bucket holding it (see the error discussion above), or 0 when nothing has been
+// recorded.
+//
+// The rank is ceil(q*N), 1-based, the same rank formula the sorted-slice
+// implementation this replaced used. Over a population that fits entirely in the
+// exact sub-16 ms region and has not yet rotated, that makes the answer
+// identical to the old one; the estimate and the window are what differ
+// elsewhere.
+func (h *latencyHistogram) Quantile(q float64) int64 {
+	count := h.Count()
+	if count == 0 {
+		return 0
+	}
+	rank := uint64(math.Ceil(float64(count) * q))
+	if rank < 1 {
+		rank = 1
+	}
+	if rank > count {
+		rank = count
+	}
+
+	var cumulative uint64
+	for i := 0; i < histBucketCount; i++ {
+		cumulative += uint64(h.current.buckets[i]) + uint64(h.previous.buckets[i])
+		if cumulative >= rank {
+			return histUpperBound(i)
+		}
+	}
+	// Unreachable: cumulative reaches count, and rank <= count.
+	return histUpperBound(histBucketCount - 1)
+}

--- a/src/core/registry/tracing/latency_histogram_test.go
+++ b/src/core/registry/tracing/latency_histogram_test.go
@@ -1,0 +1,314 @@
+package tracing
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+	"testing"
+	"unsafe"
+)
+
+// TestHistogramBucketCountCoversRange pins the constant that the whole layout
+// depends on. histBucketCount is derived by hand from the index formula, so it
+// is the one number here nothing else would catch: too small and Record writes
+// out of range (a panic, on the hottest path in the accumulator); too large and
+// every key silently pays for buckets no value can reach.
+func TestHistogramBucketCountCoversRange(t *testing.T) {
+	if got := histIndex(histMaxValueMs); got != histBucketCount-1 {
+		t.Fatalf("histIndex(max) = %d, want %d — histBucketCount is wrong", got, histBucketCount-1)
+	}
+	// Anything beyond the addressable range clamps into that same last bucket
+	// rather than escaping the array.
+	if got := histIndex(math.MaxInt64); got != histBucketCount-1 {
+		t.Fatalf("histIndex(MaxInt64) = %d, want %d", got, histBucketCount-1)
+	}
+	if got := histIndex(-5); got != 0 {
+		t.Fatalf("histIndex(-5) = %d, want 0", got)
+	}
+}
+
+// TestHistogramIndexIsMonotonicAndContiguous walks the whole addressable range
+// and holds the two properties the bucket search relies on: indices never go
+// backwards as the value grows, and every value lands at or below its bucket's
+// stated upper bound (so Quantile's answer is never an understatement).
+func TestHistogramIndexIsMonotonicAndContiguous(t *testing.T) {
+	prev := -1
+	check := func(v int64) {
+		i := histIndex(v)
+		if i < prev {
+			t.Fatalf("histIndex(%d) = %d went backwards from %d", v, i, prev)
+		}
+		if i < 0 || i >= histBucketCount {
+			t.Fatalf("histIndex(%d) = %d out of range", v, i)
+		}
+		if ub := histUpperBound(i); v > ub {
+			t.Fatalf("histIndex(%d) = %d whose upper bound %d is BELOW the value", v, i, ub)
+		}
+		prev = i
+	}
+
+	// Exhaustive across the exact region and the first few octaves, then every
+	// octave boundary and its neighbours the rest of the way up.
+	for v := int64(0); v < 4096; v++ {
+		check(v)
+	}
+	for shift := uint(12); shift < 32; shift++ {
+		base := int64(1) << shift
+		for _, v := range []int64{base - 1, base, base + 1, base + base/2, 2*base - 1} {
+			if v <= histMaxValueMs {
+				check(v)
+			}
+		}
+	}
+}
+
+// TestHistogramExactBelowLinearLimit: under 16 ms every bucket holds exactly one
+// integer, so there is no estimate at all down there — the region most edges in
+// a healthy mesh live in.
+func TestHistogramExactBelowLinearLimit(t *testing.T) {
+	for v := int64(0); v < histLinearLimit; v++ {
+		var h latencyHistogram
+		h.Record(v)
+		if got := h.Quantile(0.99); got != v {
+			t.Fatalf("single sample %d ms: P99 = %d, want it exact", v, got)
+		}
+	}
+}
+
+// TestHistogramWorstCaseRelativeError is the accuracy bound the design claims:
+// the reported value never understates, and overstates by at most 12.5%.
+func TestHistogramWorstCaseRelativeError(t *testing.T) {
+	var worst float64
+	for i := 0; i < histBucketCount; i++ {
+		ub := histUpperBound(i)
+		if ub > histMaxValueMs {
+			t.Fatalf("bucket %d upper bound %d exceeds the addressable max", i, ub)
+		}
+		// The smallest value in this bucket is one past the previous bucket's
+		// top, and it is the value the upper bound overstates the most.
+		var lo int64
+		if i == 0 {
+			lo = 0
+		} else {
+			lo = histUpperBound(i-1) + 1
+		}
+		if lo == 0 {
+			continue
+		}
+		if histIndex(lo) != i {
+			t.Fatalf("bucket %d: lowest value %d indexes to %d instead", i, lo, histIndex(lo))
+		}
+		if rel := float64(ub-lo) / float64(lo); rel > worst {
+			worst = rel
+		}
+	}
+	const bound = 1.0 / float64(histSubBucketCount) // 12.5%
+	if worst > bound+1e-12 {
+		t.Fatalf("worst-case relative error %.4f exceeds the stated bound %.4f", worst, bound)
+	}
+	if worst < bound/2 {
+		t.Fatalf("worst-case error %.4f is far below the stated %.4f — the doc comment "+
+			"is claiming a looser bound than the layout delivers, which is its own bug", worst, bound)
+	}
+}
+
+// TestHistogramQuantileTracksExactP99 compares the estimate against the sorted
+// exact answer the reservoir used to compute, over distributions shaped like
+// real traffic: a fast body with a slow tail. The estimate must bracket the
+// truth from above, within the bound.
+func TestHistogramQuantileTracksExactP99(t *testing.T) {
+	cases := []struct {
+		name string
+		gen  func(i int) int64
+		n    int
+	}{
+		{"sub-millisecond body, all zero", func(int) int64 { return 0 }, 1000},
+		{"tight around 3ms", func(i int) int64 { return int64(2 + i%3) }, 1000},
+		{"fast body with a 2s tail", func(i int) int64 {
+			if i%100 == 0 {
+				return 2000 + int64(i%37)
+			}
+			return int64(1 + i%9)
+		}, 5000},
+		{"multi-second spread", func(i int) int64 { return int64(500 + i*7) }, 3000},
+		{"single sample", func(int) int64 { return 12345 }, 1},
+		{"two samples", func(i int) int64 { return int64(1 + i*4000) }, 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var h latencyHistogram
+			exact := make([]int64, 0, tc.n)
+			for i := 0; i < tc.n; i++ {
+				v := tc.gen(i)
+				h.Record(v)
+				exact = append(exact, v)
+			}
+			sort.Slice(exact, func(a, b int) bool { return exact[a] < exact[b] })
+			idx := int(math.Ceil(float64(len(exact))*0.99)) - 1
+			if idx < 0 {
+				idx = 0
+			}
+			want := exact[idx]
+
+			got := h.Quantile(0.99)
+			if got < want {
+				t.Fatalf("P99 estimate %d UNDERSTATES the true %d", got, want)
+			}
+			if want > 0 {
+				rel := float64(got-want) / float64(want)
+				if rel > 1.0/float64(histSubBucketCount)+1e-12 {
+					t.Fatalf("P99 estimate %d overstates the true %d by %.3f%%", got, want, rel*100)
+				}
+			} else if got != 0 {
+				t.Fatalf("P99 estimate %d for an all-zero sample, want 0", got)
+			}
+		})
+	}
+}
+
+// TestHistogramQuantileRandomised is the same contract under randomised input,
+// so the accuracy claim does not rest on hand-picked shapes.
+func TestHistogramQuantileRandomised(t *testing.T) {
+	rng := rand.New(rand.NewSource(1531))
+	for round := 0; round < 200; round++ {
+		var h latencyHistogram
+		n := 1 + rng.Intn(400)
+		exact := make([]int64, 0, n)
+		for i := 0; i < n; i++ {
+			// Log-uniform over 0..~1 hour, which is the shape the layout is for.
+			v := int64(math.Pow(2, rng.Float64()*22))
+			h.Record(v)
+			exact = append(exact, v)
+		}
+		sort.Slice(exact, func(a, b int) bool { return exact[a] < exact[b] })
+		idx := int(math.Ceil(float64(n)*0.99)) - 1
+		if idx < 0 {
+			idx = 0
+		}
+		want := exact[idx]
+		got := h.Quantile(0.99)
+		if got < want {
+			t.Fatalf("round %d: P99 estimate %d understates the true %d", round, got, want)
+		}
+		if want > 0 {
+			if rel := float64(got-want) / float64(want); rel > 1.0/float64(histSubBucketCount)+1e-12 {
+				t.Fatalf("round %d: P99 estimate %d overstates the true %d by %.3f%%", round, got, want, rel*100)
+			}
+		}
+	}
+}
+
+// TestHistogramMemoryIsIndependentOfTraffic is half the point of the change: the
+// reservoir it replaced grew to 10,000 int64 per key. Nothing here grows, and
+// the rolling window does not grow it either — two fixed generations, whatever
+// the traffic.
+func TestHistogramMemoryIsIndependentOfTraffic(t *testing.T) {
+	var quiet, busy latencyHistogram
+	quiet.Record(5)
+	for i := 0; i < 200000; i++ {
+		busy.Record(int64(i % 5000))
+	}
+	if unsafe.Sizeof(quiet) != unsafe.Sizeof(busy) {
+		t.Fatalf("histogram grew with traffic: %d vs %d bytes",
+			unsafe.Sizeof(quiet), unsafe.Sizeof(busy))
+	}
+	// The window is bounded by two generations, so the sample population a
+	// quantile is computed over never exceeds twice the rotation size no matter
+	// how many calls the edge saw.
+	if got := busy.Count(); got > 2*histRotateSamples {
+		t.Fatalf("window holds %d samples, want at most %d", got, 2*histRotateSamples)
+	}
+	if got := busy.Count(); got < histRotateSamples {
+		t.Fatalf("window holds %d samples, want at least %d", got, histRotateSamples)
+	}
+}
+
+// TestHistogramCountersCannotOverflow: the generation counters are uint32, which
+// is only safe because Record rotates AT histRotateSamples. Pinned so that
+// raising that constant past 2^32 without widening the counters fails here
+// rather than silently wrapping a bucket in production.
+func TestHistogramCountersCannotOverflow(t *testing.T) {
+	if histRotateSamples > math.MaxUint32 {
+		t.Fatalf("histRotateSamples %d exceeds the uint32 generation counters", histRotateSamples)
+	}
+	var h latencyHistogram
+	// Every sample into one bucket is the worst case for a bucket counter.
+	for i := 0; i < histRotateSamples*3; i++ {
+		h.Record(7)
+	}
+	if h.current.count > histRotateSamples || h.previous.count > histRotateSamples {
+		t.Fatalf("generation counts %d/%d exceed the rotation size %d",
+			h.current.count, h.previous.count, histRotateSamples)
+	}
+	if h.current.buckets[7] > histRotateSamples || h.previous.buckets[7] > histRotateSamples {
+		t.Fatalf("bucket counts %d/%d exceed the rotation size %d",
+			h.current.buckets[7], h.previous.buckets[7], histRotateSamples)
+	}
+}
+
+// TestHistogramSpikeAgesOutOfTheWindow is the behaviour the window exists for,
+// and the one a single accumulating histogram would have lost: after an incident
+// and enough subsequent healthy traffic, the P99 comes back down.
+//
+// The old reservoir did this because it held the last 10,000 samples. An edge
+// stat key is refreshed on every call, so a busy edge's key never ages out and
+// nothing else would ever clear it.
+func TestHistogramSpikeAgesOutOfTheWindow(t *testing.T) {
+	var h latencyHistogram
+
+	// The incident: a full generation of 5-second calls.
+	for i := 0; i < histRotateSamples; i++ {
+		h.Record(5000)
+	}
+	if got := h.Quantile(0.99); got < 5000 {
+		t.Fatalf("during the incident P99 = %d, want >= 5000", got)
+	}
+
+	// Recovery, still inside the two-generation window: the spike is in the
+	// PREVIOUS generation and must still count. This is the half that says the
+	// window is a window and not a reset.
+	for i := 0; i < histRotateSamples/2; i++ {
+		h.Record(3)
+	}
+	if got := h.Quantile(0.99); got < 5000 {
+		t.Fatalf("one generation after the incident P99 = %d, want the spike still "+
+			"inside the window (>= 5000)", got)
+	}
+
+	// Two full generations of healthy traffic later, the incident has left the
+	// window entirely.
+	for i := 0; i < 2*histRotateSamples; i++ {
+		h.Record(3)
+	}
+	if got := h.Quantile(0.99); got != 3 {
+		t.Fatalf("after the spike aged out P99 = %d, want 3 — a P99 that never "+
+			"recovers is the regression this window prevents", got)
+	}
+}
+
+// TestHistogramWindowIsAtLeastTheOldReservoir: the rotation size is what makes
+// the window comparable to the reservoir it replaced, so a quantile is never
+// computed over a SMALLER recent population than the old code used.
+func TestHistogramWindowIsAtLeastTheOldReservoir(t *testing.T) {
+	var h latencyHistogram
+	for i := 1; i <= 4*histRotateSamples; i++ {
+		h.Record(int64(i % 11))
+		if got := h.Count(); got < uint64(min(i, histRotateSamples)) {
+			t.Fatalf("after %d samples the window holds only %d", i, got)
+		}
+	}
+}
+
+// TestHistogramEmptyIsZero: a histogram nobody wrote to reports 0 rather than
+// reaching into an empty slice, which is what the sorted-reservoir version had
+// to guard against with index clamping.
+func TestHistogramEmptyIsZero(t *testing.T) {
+	var h latencyHistogram
+	if got := h.Quantile(0.99); got != 0 {
+		t.Fatalf("empty histogram P99 = %d, want 0", got)
+	}
+	if h.Count() != 0 {
+		t.Fatalf("empty histogram count = %d, want 0", h.Count())
+	}
+}

--- a/src/core/registry/tracing/manager.go
+++ b/src/core/registry/tracing/manager.go
@@ -620,14 +620,33 @@ type RecentTraceSummary struct {
 	Agents        []string  `json:"agents"`
 }
 
-// EdgeStats represents aggregated call stats for a dependency edge
+// EdgeStats represents aggregated call stats for one dependency edge — one row
+// per (source, target, target function), not one per agent pair (#1531).
 type EdgeStats struct {
-	Source       string  `json:"source"`
-	Target       string  `json:"target"`
-	CallCount    int     `json:"call_count"`
-	ErrorCount   int     `json:"error_count"`
-	ErrorRate    float64 `json:"error_rate"`
-	AvgLatencyMs float64 `json:"avg_latency_ms"`
+	Source string `json:"source"`
+	Target string `json:"target"`
+	// TargetFunction is the function ON THE TARGET that these calls landed on.
+	//
+	// Named for the target on purpose. The nearby `function_name` on a
+	// DependencyResolution is the CONSUMER's function — the one that declared
+	// the dependency — and calling this one `function_name` too would put two
+	// unrelated meanings behind one word on the same screen. The resolution
+	// calls the provider's function `mcp_tool`, which is the field the UI joins
+	// this to; that name is not reused here because a span's operation is not
+	// always an MCP tool.
+	//
+	// Empty when the callee's span carried no operation (see edgeKey.Function).
+	TargetFunction string  `json:"target_function"`
+	CallCount      int     `json:"call_count"`
+	ErrorCount     int     `json:"error_count"`
+	ErrorRate      float64 `json:"error_rate"`
+	AvgLatencyMs   float64 `json:"avg_latency_ms"`
+	// P99LatencyMs is measured over a ROLLING WINDOW of recent calls, while
+	// Avg/Max/Min are lifetime figures for the key. That split is not new — the
+	// reservoir this replaced held the last 10,000 samples and the other three
+	// were always running totals — but it is the one number here whose meaning
+	// is not "since the key first appeared", so it is worth saying out loud.
+	// See latency_histogram.go for the window and for the bucket estimate.
 	P99LatencyMs float64 `json:"p99_latency_ms"`
 	MaxLatencyMs int64   `json:"max_latency_ms"`
 	MinLatencyMs int64   `json:"min_latency_ms"`
@@ -702,11 +721,9 @@ func (tm *TracingManager) GetEdgeStats(limit int) ([]EdgeStats, error) {
 
 	// Prefer accumulator (fast, in-memory)
 	if tm.accumulator != nil {
-		edges := tm.accumulator.GetEdgeStats()
-		if limit > 0 && limit < len(edges) {
-			edges = edges[:limit]
-		}
-		return edges, nil
+		// Fair across agent pairs rather than a plain head-truncation — see
+		// SelectEdgeStats for why a ranked head starves the topology graph.
+		return SelectEdgeStats(tm.accumulator.GetEdgeStats(), limit), nil
 	}
 
 	if !tm.streamThroughMode || tm.tempoClient == nil {
@@ -719,12 +736,14 @@ func (tm *TracingManager) GetEdgeStats(limit int) ([]EdgeStats, error) {
 		return nil, fmt.Errorf("failed to search traces for edge stats: %w", err)
 	}
 
-	// edgeKey -> list of observations
+	// edgeKey -> list of observations. Keyed the same three ways as the
+	// accumulator (#1531) so both sources of edge stats produce the same row
+	// shape and the dashboard's function column is populated either way.
 	type edgeObs struct {
 		durationMs int64
 		success    bool
 	}
-	edgeData := make(map[string][]edgeObs)
+	edgeData := make(map[edgeKey][]edgeObs)
 
 	for _, r := range results {
 		trace, err := tm.tempoClient.GetTrace(r.TraceID)
@@ -752,7 +771,7 @@ func (tm *TracingManager) GetEdgeStats(limit int) ([]EdgeStats, error) {
 				continue
 			}
 
-			key := parentAgent + " -> " + childAgent
+			key := edgeKey{Source: parentAgent, Target: childAgent, Function: span.Operation}
 			dur := int64(0)
 			if span.DurationMS != nil {
 				dur = *span.DurationMS
@@ -768,11 +787,6 @@ func (tm *TracingManager) GetEdgeStats(limit int) ([]EdgeStats, error) {
 	// Aggregate per edge
 	edges := make([]EdgeStats, 0, len(edgeData))
 	for key, observations := range edgeData {
-		parts := strings.SplitN(key, " -> ", 2)
-		if len(parts) != 2 {
-			continue
-		}
-
 		callCount := len(observations)
 		errorCount := 0
 		var totalLatency int64
@@ -811,24 +825,28 @@ func (tm *TracingManager) GetEdgeStats(limit int) ([]EdgeStats, error) {
 		p99Latency := float64(latencies[p99Index])
 
 		edges = append(edges, EdgeStats{
-			Source:       parts[0],
-			Target:       parts[1],
-			CallCount:    callCount,
-			ErrorCount:   errorCount,
-			ErrorRate:    errorRate,
-			AvgLatencyMs: avgLatency,
-			P99LatencyMs: p99Latency,
-			MaxLatencyMs: maxLatency,
-			MinLatencyMs: minLatency,
+			Source:         key.Source,
+			Target:         key.Target,
+			TargetFunction: key.Function,
+			CallCount:      callCount,
+			ErrorCount:     errorCount,
+			ErrorRate:      errorRate,
+			AvgLatencyMs:   avgLatency,
+			P99LatencyMs:   p99Latency,
+			MaxLatencyMs:   maxLatency,
+			MinLatencyMs:   minLatency,
 		})
 	}
 
-	// Sort edges by call count descending for consistent ordering
-	sort.Slice(edges, func(i, j int) bool {
-		return edges[i].CallCount > edges[j].CallCount
-	})
+	// Busiest first, then a total order on the key — see SortEdgeStats.
+	SortEdgeStats(edges)
 
-	return edges, nil
+	// Then the SAME budget the accumulator path applies. This path never
+	// truncated at all: `limit` reached it only as the number of TRACES to
+	// search, and one trace can contribute many edges, so a caller asking for 20
+	// rows could be handed hundreds. That was survivable while a row meant a
+	// pair; per-function rows multiply it.
+	return SelectEdgeStats(edges, limit), nil
 }
 
 // GetAccumulator returns the trace accumulator (may be nil if tracing is

--- a/src/core/ui/metrics_processor.go
+++ b/src/core/ui/metrics_processor.go
@@ -177,12 +177,12 @@ func (mp *MetricsProcessor) enforceBoundsLocked(now time.Time) {
 		}
 	}
 
-	if n := tracing.EnforceMaxEntries(mp.agentMetrics, agentLastSeen, mp.bounds.MaxEntries); n > 0 {
+	if n := tracing.EnforceMaxEntries(mp.agentMetrics, agentLastSeen, mp.bounds.MaxEntries, tracing.StringKeyLess); n > 0 {
 		log.Printf("[UI-METRICS] Agent aggregate key cap (%d) reached, evicted %d least-recently-seen agents "+
 			"(raise MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES or shorten MCP_MESH_TELEMETRY_AGGREGATE_RETENTION)",
 			mp.bounds.MaxEntries, n)
 	}
-	if n := tracing.EnforceMaxEntries(mp.modelMetrics, modelLastSeen, mp.bounds.MaxEntries); n > 0 {
+	if n := tracing.EnforceMaxEntries(mp.modelMetrics, modelLastSeen, mp.bounds.MaxEntries, tracing.StringKeyLess); n > 0 {
 		log.Printf("[UI-METRICS] Model aggregate key cap (%d) reached, evicted %d least-recently-seen models "+
 			"(raise MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES or shorten MCP_MESH_TELEMETRY_AGGREGATE_RETENTION)",
 			mp.bounds.MaxEntries, n)

--- a/src/core/ui/trace_handlers.go
+++ b/src/core/ui/trace_handlers.go
@@ -48,7 +48,13 @@ func (s *Server) handleRecentTraces(c *gin.Context) {
 	})
 }
 
-// handleEdgeStats returns aggregated edge statistics from recent traces
+// handleEdgeStats returns aggregated edge statistics from recent traces.
+//
+// `limit` counts ROWS, and a row is one (source, target, target function) since
+// #1531 — so the same number covers fewer agent pairs than it used to. What it
+// no longer does is drop the quietest pairs first: rows past the budget are
+// dropped fairly across pairs (tracing.SelectEdgeStats), so a caller asking for
+// 20 still sees every pair it would have seen, just fewer of each pair's tools.
 func (s *Server) handleEdgeStats(c *gin.Context) {
 	if s.tracingManager == nil {
 		c.JSON(200, map[string]interface{}{

--- a/src/core/ui/trace_handlers.go
+++ b/src/core/ui/trace_handlers.go
@@ -51,10 +51,15 @@ func (s *Server) handleRecentTraces(c *gin.Context) {
 // handleEdgeStats returns aggregated edge statistics from recent traces.
 //
 // `limit` counts ROWS, and a row is one (source, target, target function) since
-// #1531 — so the same number covers fewer agent pairs than it used to. What it
-// no longer does is drop the quietest pairs first: rows past the budget are
-// dropped fairly across pairs (tracing.SelectEdgeStats), so a caller asking for
-// 20 still sees every pair it would have seen, just fewer of each pair's tools.
+// #1531 — so the same number covers fewer agent pairs than it used to. Rows past
+// the budget are dropped fairly across pairs (tracing.SelectEdgeStats), which
+// guarantees this much and no more: while there are at most `limit` pairs, every
+// pair appears, and a caller asking for 20 sees fewer of each pair's tools
+// rather than losing pairs. Past that the budget cannot cover the mesh at all —
+// 50 pairs on a budget of 20 leaves 30 pairs with nothing, and the 20 served are
+// the ones carrying the most traffic. That ceiling is why the topology graph,
+// which needs a row for every edge it draws, streams on a budget of its own
+// (edgeStatsStreamLimit) instead of reading this endpoint.
 func (s *Server) handleEdgeStats(c *gin.Context) {
 	if s.tracingManager == nil {
 		c.JSON(200, map[string]interface{}{

--- a/src/core/ui/trace_poller.go
+++ b/src/core/ui/trace_poller.go
@@ -9,6 +9,28 @@ import (
 	"mcp-mesh/src/core/registry/tracing"
 )
 
+// edgeStatsStreamLimit is the row budget for the streamed `edge_stats` event.
+//
+// It is deliberately NOT the 20 the tables' endpoints default to, because the
+// stream has a consumer the endpoints do not: the topology graph, whose only
+// source of traffic this event is. The graph needs a row for every edge it
+// DRAWS, and one edge is one (consumer, provider, function) since #1531 — so a
+// budget sized for a readable table starves it. An unmatched edge keeps its
+// structural style, which means the starvation is silent: the graph just stops
+// reporting traffic for most of the mesh.
+//
+// A table wants a ranked top-N; a graph wants coverage. One number cannot be
+// both, so the stream gets its own, sized for the drawn edges of a substantial
+// mesh (100 agents each calling 5 tools of 1 other agent is 500) rather than
+// for a screenful. At roughly 200 bytes of JSON a row that is ~100 KB per
+// publish, against the full agent snapshot the same dashboard already fetches.
+// Rows past the budget are dropped fairly across agent pairs, not by rank —
+// see tracing.SelectEdgeStats.
+//
+// The dashboard's own traffic widget takes its top rows from this same event
+// (TrafficTable), which is what keeps the wider budget off the screen.
+const edgeStatsStreamLimit = 500
+
 // TracePoller polls the TracingManager for recent trace data and publishes
 // summary events via the UI EventHub.
 type TracePoller struct {
@@ -141,7 +163,7 @@ func (p *TracePoller) poll() {
 	}
 
 	// Fetch edge stats (reads from accumulator when available)
-	edges, edgeErr := p.tracingManager.GetEdgeStats(20)
+	edges, edgeErr := p.tracingManager.GetEdgeStats(edgeStatsStreamLimit)
 	if edgeErr != nil {
 		log.Printf("[ui] Trace poller: failed to get edge stats: %v", edgeErr)
 	} else {

--- a/src/core/ui/trace_poller_test.go
+++ b/src/core/ui/trace_poller_test.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"testing"
+	"time"
+
+	"mcp-mesh/src/core/registry/tracing"
+)
+
+// The streamed `edge_stats` event is the topology graph's ONLY source of
+// traffic, and it is also what the dashboard's traffic widget reads. Those two
+// want different things from one payload — a graph wants a row for every edge it
+// draws, a widget wants a screenful — which is why the stream has a budget of
+// its own rather than the tables' 20.
+
+// TestEdgeStatsStreamBudgetIsNotTableSized pins the relationship rather than the
+// number: whatever edgeStatsStreamLimit is set to, it has to be far above what a
+// table asks for, or the graph is back to being served by a ranking that can
+// starve it.
+func TestEdgeStatsStreamBudgetIsNotTableSized(t *testing.T) {
+	const tableCap = 100 // the ceiling handleTraffic/handleEdgeStats clamp to
+	if edgeStatsStreamLimit <= tableCap {
+		t.Fatalf("edgeStatsStreamLimit = %d, which is within the tables' ceiling of %d — "+
+			"the graph's feed is sized for a table again", edgeStatsStreamLimit, tableCap)
+	}
+}
+
+// TestEdgeStatsStreamBudgetCoversAMeshOfDrawnEdges builds the starvation case at
+// the budget the poller actually publishes with: one pair exchanging more tools
+// than a table budget would hold, plus many other pairs. Every pair has to reach
+// the payload, because an edge with no row keeps its structural style and the
+// loss is invisible on screen.
+func TestEdgeStatsStreamBudgetCoversAMeshOfDrawnEdges(t *testing.T) {
+	acc := tracing.NewTraceAccumulator(64, log.New(io.Discard, "", 0))
+
+	seq := 0
+	call := func(source, target, calleeOp string) {
+		seq++
+		id := fmt.Sprintf("t%05d", seq)
+		root := fmt.Sprintf("r%05d", seq)
+		for _, e := range makeCall(id, root, source, target, time.Now(), true) {
+			if e.ParentSpan != nil {
+				e.Operation = calleeOp
+			}
+			_ = acc.ProcessTraceEvent(e)
+		}
+	}
+
+	// The chatty pair: 40 tools, each busier than anything else.
+	for tool := 0; tool < 40; tool++ {
+		for i := 0; i < 5; i++ {
+			call("chatty-caller", "chatty-provider", fmt.Sprintf("tool_%02d", tool))
+		}
+	}
+	// 60 quiet pairs with 2 tools each — 120 more rows, past any table budget.
+	for p := 0; p < 60; p++ {
+		for _, tool := range []string{"read", "write"} {
+			call(fmt.Sprintf("caller-%02d", p), fmt.Sprintf("provider-%02d", p), tool)
+		}
+	}
+	acc.FinalizeAllActive()
+
+	published := tracing.SelectEdgeStats(acc.GetEdgeStats(), edgeStatsStreamLimit)
+
+	pairs := make(map[string]int)
+	for _, e := range published {
+		pairs[e.Source+" -> "+e.Target]++
+	}
+	if got := len(pairs); got != 61 {
+		t.Fatalf("published payload covers %d pairs, want all 61", got)
+	}
+	// And not merely present: every drawn edge of every pair has its own row, so
+	// nothing on the graph is left guessing.
+	if len(published) != 40+120 {
+		t.Fatalf("published %d rows, want one per drawn edge (%d)", len(published), 40+120)
+	}
+
+	// Contrast: the table budget could not have done this.
+	tableSized := tracing.SelectEdgeStats(acc.GetEdgeStats(), 20)
+	if len(tableSized) != 20 {
+		t.Fatalf("table-sized selection returned %d rows, want 20", len(tableSized))
+	}
+}

--- a/src/core/ui/traffic_handler.go
+++ b/src/core/ui/traffic_handler.go
@@ -89,10 +89,9 @@ func replayWindow(events []*tracing.TraceEvent, limit int) (edges []tracing.Edge
 	// Flush all in-flight traces synchronously so edges + totals are complete.
 	acc.FinalizeAllActive()
 
-	edges = acc.GetEdgeStats()
-	if limit > 0 && limit < len(edges) {
-		edges = edges[:limit]
-	}
+	// Same fair-across-pairs truncation the live path applies, for the same
+	// reason: the head of a per-function ranking can be one busy pair.
+	edges = tracing.SelectEdgeStats(acc.GetEdgeStats(), limit)
 	agents = mp.GetAgentMetrics()
 	models = mp.GetModelMetrics()
 	totalCalls = acc.GetTotalFinalized()
@@ -103,6 +102,11 @@ func replayWindow(events []*tracing.TraceEvent, limit int) (edges []tracing.Edge
 // handleTraffic returns windowed traffic aggregates for the Traffic-page time
 // filter. window=all (default) serves the live all-time aggregates unchanged;
 // window=1h/1d re-aggregate over a bounded XRANGE of the Redis trace stream.
+//
+// This endpoint feeds a TABLE, so a screenful-sized budget is the right budget
+// and the 20/100 below are unchanged. The topology graph does NOT read it — its
+// rows arrive over SSE, on a budget of its own (edgeStatsStreamLimit), because a
+// graph needs a row per edge it draws and a table does not.
 func (s *Server) handleTraffic(c *gin.Context) {
 	limit := 20
 	if l := c.Query("limit"); l != "" {

--- a/src/core/ui/traffic_handler_test.go
+++ b/src/core/ui/traffic_handler_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -111,6 +112,93 @@ func TestReplayWindowExcludesOlderEvents(t *testing.T) {
 	if calls1h >= callsAll || len(edges1h) >= len(edgesAll) || len(agents1h) >= len(agentsAll) {
 		t.Fatalf("1h aggregate did not narrow vs all-time: calls %d/%d edges %d/%d agents %d/%d",
 			calls1h, callsAll, len(edges1h), len(edgesAll), len(agents1h), len(agentsAll))
+	}
+}
+
+// TestReplayWindowKeysEdgesPerFunction: the windowed (1h/1d) path re-aggregates
+// through a throwaway TraceAccumulator fed by the same ProcessTraceEvent the
+// live consumer uses, so it inherits the per-function edge key (#1531) with no
+// windowing-specific code. Asserted rather than assumed — the two paths reading
+// the same field is the whole reason the Traffic page can offer a time filter
+// over the finer rows.
+func TestReplayWindowKeysEdgesPerFunction(t *testing.T) {
+	now := time.Now()
+	var events []*tracing.TraceEvent
+
+	withOp := func(traceID, rootID, source, target, calleeOp string) {
+		spans := makeCall(traceID, rootID, source, target, now, true)
+		spans[1].Operation = calleeOp
+		events = append(events, spans...)
+	}
+
+	withOp("t1", "r1", "agentA", "agentB", "lookup")
+	withOp("t2", "r2", "agentA", "agentB", "lookup")
+	withOp("t3", "r3", "agentA", "agentB", "summarise")
+
+	edges, _, _, _, _ := replayWindow(events, 20)
+	if len(edges) != 2 {
+		t.Fatalf("replayed edges = %d, want 2 (one per called function): %+v", len(edges), edges)
+	}
+
+	byFunction := make(map[string]tracing.EdgeStats, len(edges))
+	for _, e := range edges {
+		if e.Source != "agentA" || e.Target != "agentB" {
+			t.Fatalf("unexpected pair %s -> %s", e.Source, e.Target)
+		}
+		byFunction[e.TargetFunction] = e
+	}
+	if got := byFunction["lookup"].CallCount; got != 2 {
+		t.Fatalf("lookup call count = %d, want 2", got)
+	}
+	if got := byFunction["summarise"].CallCount; got != 1 {
+		t.Fatalf("summarise call count = %d, want 1", got)
+	}
+}
+
+// TestReplayWindowTruncatesFairlyAcrossPairs: the windowed path truncates too,
+// and it must starve the same way the live path does — which is to say, not by
+// dropping whole pairs. Same shape as the accumulator's own starvation test: one
+// chatty pair with more tools than the budget, plus quiet pairs.
+func TestReplayWindowTruncatesFairlyAcrossPairs(t *testing.T) {
+	now := time.Now()
+	var events []*tracing.TraceEvent
+	seq := 0
+
+	call := func(source, target, calleeOp string) {
+		seq++
+		id := "t" + strconv.Itoa(seq)
+		spans := makeCall(id, "r"+strconv.Itoa(seq), source, target, now, true)
+		spans[1].Operation = calleeOp
+		events = append(events, spans...)
+	}
+
+	const budget = 5
+	for tool := 0; tool < budget*2; tool++ {
+		for i := 0; i < 10; i++ {
+			call("chatty-caller", "chatty-provider", "tool_"+strconv.Itoa(tool))
+		}
+	}
+	quiet := [][2]string{{"web", "auth"}, {"worker", "storage"}, {"api", "web"}}
+	for _, p := range quiet {
+		call(p[0], p[1], "handle")
+	}
+
+	edges, _, _, _, _ := replayWindow(events, budget)
+	if len(edges) != budget {
+		t.Fatalf("replayed %d rows, want the full budget of %d", len(edges), budget)
+	}
+
+	pairs := make(map[string]bool, len(edges))
+	for _, e := range edges {
+		pairs[e.Source+" -> "+e.Target] = true
+	}
+	for _, p := range quiet {
+		if !pairs[p[0]+" -> "+p[1]] {
+			t.Errorf("windowed payload starved out %s -> %s", p[0], p[1])
+		}
+	}
+	if !pairs["chatty-caller -> chatty-provider"] {
+		t.Error("windowed payload dropped the busiest pair")
 	}
 }
 

--- a/src/ui/__tests__/traffic-per-function.test.tsx
+++ b/src/ui/__tests__/traffic-per-function.test.tsx
@@ -1,0 +1,427 @@
+// Traffic attributed per CALLED FUNCTION rather than per agent pair (#1531).
+//
+// The bug this covers: edge stats were keyed by (source, target) alone, so a
+// pair exchanging a regular tool, an LLM-filtered tool and a MeshJob drew three
+// correctly-coloured edges and gave all three the same latency, the same heat
+// colour and the same stroke width — the average across all of it. Two of those
+// three numbers described traffic that edge never carried.
+//
+// Both surfaces are asserted: the graph merge (which joins a stat row to the
+// edge that produced it) and the Traffic table (which now shows the rows).
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import type { Edge } from "@xyflow/react";
+import type { Agent, EdgeStat, TrafficResponse } from "../lib/types";
+import { buildGraphFromAgents } from "../lib/topology";
+import { mergeEdgeStatsIntoEdges } from "../components/topology/TopologyGraph";
+import { TrafficTable } from "../components/dashboard/TrafficTable";
+import { EDGE_COLORS, EDGE_HEAT_COLORS } from "../lib/edge-palette";
+
+// The dashboard's TrafficTable reads its rows straight off the SSE feed through
+// useMesh(); stub the context so it can be rendered without a live provider.
+const mockEdgeStats: EdgeStat[] = [];
+vi.mock("../lib/mesh-context", () => ({
+  useMesh: () => ({ edgeStats: mockEdgeStats, traceActivity: {}, setPaused: () => {} }),
+}));
+
+function makeStat(overrides: Partial<EdgeStat> & Pick<EdgeStat, "source" | "target" | "target_function">): EdgeStat {
+  return {
+    call_count: 10,
+    error_count: 0,
+    error_rate: 0,
+    avg_latency_ms: 5,
+    p99_latency_ms: 9,
+    max_latency_ms: 12,
+    min_latency_ms: 1,
+    ...overrides,
+  };
+}
+
+function makeEdge(overrides: Partial<Edge> = {}): Edge {
+  return {
+    id: "dep|caller-11111111|prov-22222222|reports",
+    source: "caller-11111111",
+    target: "prov-22222222",
+    label: "reports",
+    animated: true,
+    data: { originalLabel: "reports", targetFunctions: ["run_report"] },
+    style: { stroke: EDGE_COLORS.dependency },
+    ...overrides,
+  };
+}
+
+describe("the graph joins a stat to the edge that produced it", () => {
+  it("gives two edges of one pair their OWN numbers", () => {
+    const fast = makeEdge({
+      id: "fast",
+      label: "lookup",
+      data: { originalLabel: "lookup", targetFunctions: ["lookup"] },
+    });
+    const slow = makeEdge({
+      id: "slow",
+      label: "summary",
+      data: { originalLabel: "summary", targetFunctions: ["summarise"] },
+    });
+
+    const merged = mergeEdgeStatsIntoEdges([fast, slow], [
+      makeStat({ source: "caller", target: "prov", target_function: "lookup", avg_latency_ms: 4, call_count: 100 }),
+      makeStat({ source: "caller", target: "prov", target_function: "summarise", avg_latency_ms: 1500, call_count: 10 }),
+    ]);
+
+    // The label carries the latency, formatted; assert on the milliseconds
+    // rather than on formatDuration's exact rendering.
+    expect(merged[0].label).toContain("lookup");
+    expect(String(merged[0].label)).toMatch(/4/);
+    expect(String(merged[1].label)).toMatch(/1\.5|1500/);
+    expect(String(merged[0].label)).not.toBe(String(merged[1].label));
+
+    // Stroke width is relative to the busiest FUNCTION, so the 100-call edge is
+    // drawn heavier than the 10-call one between the very same two agents —
+    // impossible when one number covered both.
+    expect(Number(merged[0].style?.strokeWidth)).toBeGreaterThan(
+      Number(merged[1].style?.strokeWidth)
+    );
+  });
+
+  it("keeps one edge's errors off its healthy sibling", () => {
+    const healthy = makeEdge({
+      id: "healthy",
+      data: { originalLabel: "a", targetFunctions: ["healthy_tool"] },
+    });
+    const broken = makeEdge({
+      id: "broken",
+      data: { originalLabel: "b", targetFunctions: ["broken_tool"] },
+    });
+
+    const merged = mergeEdgeStatsIntoEdges([healthy, broken], [
+      makeStat({ source: "caller", target: "prov", target_function: "healthy_tool", error_rate: 0 }),
+      makeStat({ source: "caller", target: "prov", target_function: "broken_tool", error_rate: 100, error_count: 10 }),
+    ]);
+
+    expect(merged[0].style?.stroke).toBe(EDGE_HEAT_COLORS.clean);
+    expect(merged[1].style?.stroke).toBe(EDGE_HEAT_COLORS.failing);
+  });
+
+  it("does not match a row belonging to a different pair", () => {
+    const edge = makeEdge({ data: { originalLabel: "reports", targetFunctions: ["run_report"] } });
+    const merged = mergeEdgeStatsIntoEdges([edge], [
+      // Right function, wrong caller.
+      makeStat({ source: "someone-else", target: "prov", target_function: "run_report" }),
+    ]);
+    expect(merged[0]).toBe(edge);
+  });
+});
+
+describe("an edge with no recorded traffic keeps its structural style", () => {
+  // No traffic recorded and zero traffic are DIFFERENT FACTS, and the second is
+  // a claim the payload does not support. Python streaming tools publish no span
+  // at all, and Java's synthetic dependency tools create capability rows no span
+  // ever names — both real edges, both permanently without a row. Neither was
+  // visible before, because a pair-level average lent them a sibling's numbers.
+
+  it("is returned untouched when its function has no row", () => {
+    const edge = makeEdge({ data: { originalLabel: "reports", targetFunctions: ["streaming_tool"] } });
+    const merged = mergeEdgeStatsIntoEdges([edge], [
+      makeStat({ source: "caller", target: "prov", target_function: "some_other_tool" }),
+    ]);
+    // Identity, not equality: nothing was rebuilt, so no default can have crept
+    // into the style or the label.
+    expect(merged[0]).toBe(edge);
+    expect(merged[0].style?.stroke).toBe(EDGE_COLORS.dependency);
+    expect(merged[0].style?.strokeWidth).toBeUndefined();
+    expect(merged[0].label).toBe("reports");
+  });
+
+  it("is not painted with a pair-level fallback when a SIBLING edge has traffic", () => {
+    // The precise regression: the same two agents are exchanging plenty of
+    // traffic on another tool. That must not reach this edge.
+    const silent = makeEdge({ id: "silent", data: { originalLabel: "stream", targetFunctions: ["streaming_tool"] } });
+    const busy = makeEdge({ id: "busy", data: { originalLabel: "lookup", targetFunctions: ["lookup"] } });
+
+    const merged = mergeEdgeStatsIntoEdges([silent, busy], [
+      makeStat({ source: "caller", target: "prov", target_function: "lookup", error_rate: 50, call_count: 900 }),
+    ]);
+
+    expect(merged[0]).toBe(silent);
+    expect(merged[0].style?.stroke).toBe(EDGE_COLORS.dependency);
+    expect(merged[1].style?.stroke).toBe(EDGE_HEAT_COLORS.failing);
+  });
+
+  it("is returned untouched when the resolution carried no mcp_tool at all", () => {
+    // Then the edge has no function to join on. Matching on the pair instead
+    // would be the old behaviour, reintroduced through the back door.
+    const edge = makeEdge({ data: { originalLabel: "reports" } });
+    const merged = mergeEdgeStatsIntoEdges([edge], [
+      makeStat({ source: "caller", target: "prov", target_function: "run_report" }),
+    ]);
+    expect(merged[0]).toBe(edge);
+  });
+});
+
+describe("one edge standing for several provider functions", () => {
+  // Routine, not exotic. An edge is keyed `kind|src|dst|label`, and an LLM tool
+  // edge's label is `llm:<filter_capability>` — but the registry writes one
+  // resolution row PER MATCHED TOOL, and a TAGS-ONLY filter leaves the
+  // capability empty, so every tool that filter matched on one provider lands
+  // on the identical label `llm:`. One line on screen, N functions behind it.
+  //
+  // Joining that line to one of the N and showing its numbers as the edge's own
+  // is what snapshot order would decide. These two agents produce it.
+  const tagsOnlyFilter = (toolNames: string[]): Agent[] => [
+    {
+      id: "caller-11111111",
+      name: "caller",
+      agent_type: "mcp_agent",
+      status: "healthy",
+      endpoint: "http://caller:8080",
+      total_dependencies: 0,
+      dependencies_resolved: 0,
+      capabilities: [],
+      llm_tool_resolutions: toolNames.map((tool) => ({
+        function_name: "chat",
+        filter_capability: "",
+        filter_tags: ["reporting"],
+        status: "available" as const,
+        provider_agent_id: "prov-22222222",
+        mcp_tool: tool,
+      })),
+    },
+    {
+      id: "prov-22222222",
+      name: "prov",
+      agent_type: "mcp_agent",
+      status: "healthy",
+      endpoint: "http://prov:8080",
+      total_dependencies: 0,
+      dependencies_resolved: 0,
+      capabilities: toolNames.map((tool) => ({
+        function_name: tool,
+        name: tool,
+        version: "1.0.0",
+        tags: ["reporting"],
+      })),
+    },
+  ];
+
+  it("collapses onto one edge that names ALL of them, in a fixed order", () => {
+    const forward = buildGraphFromAgents(tagsOnlyFilter(["lookup", "summarise", "export"]));
+    const reversed = buildGraphFromAgents(tagsOnlyFilter(["export", "summarise", "lookup"]));
+
+    expect(forward.edges).toHaveLength(1);
+    expect(reversed.edges).toHaveLength(1);
+
+    // Sorted, so the two arrival orders are byte-identical rather than merely
+    // containing the same names.
+    expect(forward.edges[0].data?.targetFunctions).toEqual(["export", "lookup", "summarise"]);
+    expect(reversed.edges[0].data?.targetFunctions).toEqual(
+      forward.edges[0].data?.targetFunctions
+    );
+  });
+
+  it("shows the SUM of its functions, not whichever one arrived first", () => {
+    const stats: EdgeStat[] = [
+      makeStat({ source: "caller", target: "prov", target_function: "lookup", call_count: 90, avg_latency_ms: 10, error_count: 0, error_rate: 0 }),
+      makeStat({ source: "caller", target: "prov", target_function: "summarise", call_count: 10, avg_latency_ms: 1000, error_count: 5, error_rate: 50 }),
+    ];
+
+    const { edges } = buildGraphFromAgents(tagsOnlyFilter(["lookup", "summarise"]));
+    const merged = mergeEdgeStatsIntoEdges(edges, stats);
+
+    // 90 calls at 10ms plus 10 at 1000ms is 10,900ms over 100 calls = 109ms.
+    // NOT 10 (first-seen), NOT 1000 (other-seen), and not the 505 an unweighted
+    // mean of the two averages would give.
+    expect(String(merged[0].label)).toContain("109");
+    expect(String(merged[0].label)).not.toContain("505");
+
+    // 5 errors in 100 calls is 5%, which is elevated — neither the clean edge
+    // the fast tool alone would paint nor the failing one the slow tool would.
+    expect(merged[0].style?.stroke).toBe(EDGE_HEAT_COLORS.elevated);
+  });
+
+  it("gives the same answer whichever order the rows arrive in", () => {
+    const rows: EdgeStat[] = [
+      makeStat({ source: "caller", target: "prov", target_function: "lookup", call_count: 90, avg_latency_ms: 10 }),
+      makeStat({ source: "caller", target: "prov", target_function: "summarise", call_count: 10, avg_latency_ms: 1000, error_count: 5, error_rate: 50 }),
+    ];
+    const graph = () => buildGraphFromAgents(tagsOnlyFilter(["lookup", "summarise"])).edges;
+
+    const forward = mergeEdgeStatsIntoEdges(graph(), rows);
+    const backward = mergeEdgeStatsIntoEdges(graph(), [...rows].reverse());
+
+    expect(forward[0].label).toBe(backward[0].label);
+    expect(forward[0].style?.stroke).toBe(backward[0].style?.stroke);
+    expect(forward[0].style?.strokeWidth).toBe(backward[0].style?.strokeWidth);
+  });
+
+  it("reports only the functions that have rows, and nothing when none do", () => {
+    const { edges } = buildGraphFromAgents(tagsOnlyFilter(["lookup", "never_called"]));
+
+    // Partial coverage: one of the two functions was recorded. The edge shows
+    // that traffic rather than blanking, and rather than averaging in a zero
+    // for a function that simply has no observations.
+    const partial = mergeEdgeStatsIntoEdges(edges, [
+      makeStat({ source: "caller", target: "prov", target_function: "lookup", call_count: 90, avg_latency_ms: 10 }),
+    ]);
+    expect(String(partial[0].label)).toContain("10");
+
+    // No coverage at all: structural style, untouched.
+    const none = mergeEdgeStatsIntoEdges(edges, [
+      makeStat({ source: "caller", target: "prov", target_function: "unrelated" }),
+    ]);
+    expect(none[0]).toBe(edges[0]);
+  });
+
+  it("scales stroke width against the busiest EDGE, so a sum cannot overflow the scale", () => {
+    // The collapsed edge's 100 calls exceed either row on its own. A denominator
+    // taken from the rows would put this edge past the top of the scale.
+    const { edges } = buildGraphFromAgents(tagsOnlyFilter(["lookup", "summarise"]));
+    const merged = mergeEdgeStatsIntoEdges(edges, [
+      makeStat({ source: "caller", target: "prov", target_function: "lookup", call_count: 50 }),
+      makeStat({ source: "caller", target: "prov", target_function: "summarise", call_count: 50 }),
+    ]);
+    expect(Number(merged[0].style?.strokeWidth)).toBeLessThanOrEqual(4);
+    expect(Number(merged[0].style?.strokeWidth)).toBeCloseTo(4);
+  });
+});
+
+describe("replica grouping still lines the two sides up", () => {
+  // Stats are recorded per REAL agent name; the graph collapses replicas into
+  // one node keyed `group:<name>`. The merge resolves a node key back to that
+  // base name, and adding the function as a third component must not disturb it.
+  const twoReplicasEachSide: Agent[] = [
+    {
+      id: "caller-aaaa1111",
+      name: "caller",
+      agent_type: "mcp_agent",
+      status: "healthy",
+      endpoint: "http://caller:8080",
+      total_dependencies: 1,
+      dependencies_resolved: 1,
+      capabilities: [],
+      dependency_resolutions: [
+        { function_name: "consume", capability: "reports", status: "available", provider_agent_id: "prov-cccc3333", mcp_tool: "run_report" },
+      ],
+    },
+    {
+      id: "caller-bbbb2222",
+      name: "caller",
+      agent_type: "mcp_agent",
+      status: "healthy",
+      endpoint: "http://caller2:8080",
+      total_dependencies: 1,
+      dependencies_resolved: 1,
+      capabilities: [],
+      dependency_resolutions: [
+        { function_name: "consume", capability: "reports", status: "available", provider_agent_id: "prov-dddd4444", mcp_tool: "run_report" },
+      ],
+    },
+    {
+      id: "prov-cccc3333",
+      name: "prov",
+      agent_type: "mcp_agent",
+      status: "healthy",
+      endpoint: "http://prov:8080",
+      total_dependencies: 0,
+      dependencies_resolved: 0,
+      capabilities: [{ function_name: "run_report", name: "reports", version: "1.0.0" }],
+    },
+    {
+      id: "prov-dddd4444",
+      name: "prov",
+      agent_type: "mcp_agent",
+      status: "healthy",
+      endpoint: "http://prov2:8080",
+      total_dependencies: 0,
+      dependencies_resolved: 0,
+      capabilities: [{ function_name: "run_report", name: "reports", version: "1.0.0" }],
+    },
+  ];
+
+  it("matches a stat keyed by base agent name onto the collapsed group edge", () => {
+    const { nodes, edges } = buildGraphFromAgents(twoReplicasEachSide);
+    expect(nodes.map((n) => n.id).sort()).toEqual(["group:caller", "group:prov"]);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].data?.targetFunctions).toEqual(["run_report"]);
+
+    const merged = mergeEdgeStatsIntoEdges(edges, [
+      makeStat({ source: "caller", target: "prov", target_function: "run_report", avg_latency_ms: 42 }),
+    ]);
+    expect(String(merged[0].label)).toMatch(/42/);
+    expect(merged[0].style?.stroke).toBe(EDGE_HEAT_COLORS.clean);
+  });
+});
+
+describe("the Traffic table shows one row per called function", () => {
+  const response: TrafficResponse = {
+    enabled: true,
+    window: "all",
+    total_calls: 3,
+    total_errors: 0,
+    edge_stats: [
+      makeStat({ source: "caller", target: "prov", target_function: "summarise", avg_latency_ms: 1500, call_count: 3 }),
+      makeStat({ source: "caller", target: "prov", target_function: "lookup", avg_latency_ms: 4, call_count: 77 }),
+    ],
+    agent_stats: [],
+    model_stats: [],
+  };
+
+  it("renders both rows of a single route, each with its own function and numbers", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => response })
+    );
+    const { default: TrafficPage } = await import("../app/traffic/page");
+    render(<TrafficPage />);
+
+    await waitFor(() => expect(screen.getByText("lookup")).toBeInTheDocument());
+    expect(screen.getByText("summarise")).toBeInTheDocument();
+
+    // Two rows for ONE route: the route names appear twice over.
+    expect(screen.getAllByText("caller")).toHaveLength(2);
+    expect(screen.getAllByText("prov")).toHaveLength(2);
+
+    // And the numbers belong to their own row rather than to the pair.
+    const lookupRow = screen.getByText("lookup").closest("tr");
+    expect(lookupRow).not.toBeNull();
+    expect(within(lookupRow!).getByText("77")).toBeInTheDocument();
+    expect(within(lookupRow!).getByText("4.0ms")).toBeInTheDocument();
+
+    const summariseRow = screen.getByText("summarise").closest("tr");
+    expect(within(summariseRow!).getByText("3")).toBeInTheDocument();
+    expect(within(summariseRow!).getByText("1500.0ms")).toBeInTheDocument();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("shows the same rows on the dashboard's own traffic widget", () => {
+    // A SECOND surface renders these rows, fed by SSE rather than by the
+    // windowed endpoint. Keyed by the route alone it would now emit duplicate
+    // React keys for one route's several functions, and draw rows that look
+    // identical while carrying different numbers.
+    mockEdgeStats.length = 0;
+    mockEdgeStats.push(...response.edge_stats);
+    render(<TrafficTable />);
+
+    expect(screen.getByText("Function")).toBeInTheDocument();
+    expect(screen.getAllByText("caller")).toHaveLength(2);
+
+    const lookupRow = screen.getByText("lookup").closest("tr");
+    expect(within(lookupRow!).getByText("77")).toBeInTheDocument();
+    const summariseRow = screen.getByText("summarise").closest("tr");
+    expect(within(summariseRow!).getByText("3")).toBeInTheDocument();
+
+    mockEdgeStats.length = 0;
+  });
+
+  it("names the column so the second value on a route is readable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => response })
+    );
+    const { default: TrafficPage } = await import("../app/traffic/page");
+    render(<TrafficPage />);
+
+    await waitFor(() => expect(screen.getByText("Function")).toBeInTheDocument());
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/ui/__tests__/traffic-per-function.test.tsx
+++ b/src/ui/__tests__/traffic-per-function.test.tsx
@@ -8,7 +8,7 @@
 //
 // Both surfaces are asserted: the graph merge (which joins a stat row to the
 // edge that produced it) and the Traffic table (which now shows the rows).
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import type { Edge } from "@xyflow/react";
 import type { Agent, EdgeStat, TrafficResponse } from "../lib/types";
@@ -23,6 +23,16 @@ const mockEdgeStats: EdgeStat[] = [];
 vi.mock("../lib/mesh-context", () => ({
   useMesh: () => ({ edgeStats: mockEdgeStats, traceActivity: {}, setPaused: () => {} }),
 }));
+
+// Both pieces of shared state — the stubbed `fetch` and the mocked SSE rows —
+// are torn down HERE rather than in the body of the test that set them up. An
+// in-body cleanup does not run when the test fails before reaching it, so one
+// real failure would leak a stub into every test after it and bury its own cause
+// under a cascade.
+afterEach(() => {
+  vi.unstubAllGlobals();
+  mockEdgeStats.length = 0;
+});
 
 function makeStat(overrides: Partial<EdgeStat> & Pick<EdgeStat, "source" | "target" | "target_function">): EdgeStat {
   return {
@@ -389,8 +399,6 @@ describe("the Traffic table shows one row per called function", () => {
     const summariseRow = screen.getByText("summarise").closest("tr");
     expect(within(summariseRow!).getByText("3")).toBeInTheDocument();
     expect(within(summariseRow!).getByText("1500.0ms")).toBeInTheDocument();
-
-    vi.unstubAllGlobals();
   });
 
   it("shows the same rows on the dashboard's own traffic widget", () => {
@@ -398,7 +406,6 @@ describe("the Traffic table shows one row per called function", () => {
     // windowed endpoint. Keyed by the route alone it would now emit duplicate
     // React keys for one route's several functions, and draw rows that look
     // identical while carrying different numbers.
-    mockEdgeStats.length = 0;
     mockEdgeStats.push(...response.edge_stats);
     render(<TrafficTable />);
 
@@ -409,8 +416,6 @@ describe("the Traffic table shows one row per called function", () => {
     expect(within(lookupRow!).getByText("77")).toBeInTheDocument();
     const summariseRow = screen.getByText("summarise").closest("tr");
     expect(within(summariseRow!).getByText("3")).toBeInTheDocument();
-
-    mockEdgeStats.length = 0;
   });
 
   it("names the column so the second value on a route is readable", async () => {
@@ -422,6 +427,5 @@ describe("the Traffic table shows one row per called function", () => {
     render(<TrafficPage />);
 
     await waitFor(() => expect(screen.getByText("Function")).toBeInTheDocument());
-    vi.unstubAllGlobals();
   });
 });

--- a/src/ui/app/traffic/page.tsx
+++ b/src/ui/app/traffic/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/table";
 import { Segmented } from "@/components/ui/segmented";
 import { formatBytes, formatTokenCount, getTraffic } from "@/lib/api";
+import { compareEdgeStats, edgeRowKey } from "@/lib/edge-stats";
 import { AgentStat, EdgeStat, ModelStat, TrafficWindow } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import {
@@ -139,12 +140,22 @@ export default function TrafficPage() {
 
         const edges = data.edge_stats || [];
         setEdgeStats(edges);
+        const live = new Set<string>();
         for (const edge of edges) {
-          const key = `${edge.source}->${edge.target}`;
+          const key = edgeRowKey(edge);
+          live.add(key);
           const history = historyRef.current.get(key) || [];
           history.push(edge.avg_latency_ms);
           if (history.length > MAX_HISTORY) history.shift();
           historyRef.current.set(key, history);
+        }
+        // Drop series for keys that stopped arriving, so the map tracks what is
+        // on screen rather than everything that ever was. It is keyed per
+        // (route, function) now, which multiplies what an unpruned map holds
+        // over a long session, and rows move in and out of the response as
+        // traffic shifts under the server's row budget.
+        for (const key of historyRef.current.keys()) {
+          if (!live.has(key)) historyRef.current.delete(key);
         }
         setTick((t) => t + 1);
         setError(null);
@@ -189,14 +200,8 @@ export default function TrafficPage() {
     return { totalCalls, successRate, totalTokens, totalData };
   }, [agentStats, totalCalls, totalErrors]);
 
-  // Sorted edges by route name
-  const sortedEdges = useMemo(() => {
-    return [...edgeStats].sort((a, b) => {
-      const routeA = `${a.source}->${a.target}`;
-      const routeB = `${b.source}->${b.target}`;
-      return routeA.localeCompare(routeB);
-    });
-  }, [edgeStats]);
+  // By route, then by the function called on the target — see lib/edge-stats.ts.
+  const sortedEdges = useMemo(() => [...edgeStats].sort(compareEdgeStats), [edgeStats]);
 
   // Sorted agent stats by agent name (stable across SSE updates)
   const sortedAgentStats = useMemo(() => {
@@ -376,6 +381,7 @@ export default function TrafficPage() {
                 <TableHeader>
                   <TableRow>
                     <TableHead>Route</TableHead>
+                    <TableHead>Function</TableHead>
                     <TableHead className="text-right">Calls</TableHead>
                     <TableHead className="text-right">Errors</TableHead>
                     <TableHead className="text-right">Error Rate</TableHead>
@@ -386,7 +392,7 @@ export default function TrafficPage() {
                 </TableHeader>
                 <TableBody>
                   {sortedEdges.map((edge) => {
-                    const key = `${edge.source}->${edge.target}`;
+                    const key = edgeRowKey(edge);
                     const history = historyRef.current.get(key) || [];
 
                     return (
@@ -401,6 +407,9 @@ export default function TrafficPage() {
                               {edge.target}
                             </span>
                           </div>
+                        </TableCell>
+                        <TableCell className="font-mono text-muted-foreground">
+                          {edge.target_function || "-"}
                         </TableCell>
                         <TableCell className="text-right font-mono">
                           {edge.call_count}

--- a/src/ui/components/dashboard/TrafficTable.tsx
+++ b/src/ui/components/dashboard/TrafficTable.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { EdgeStat } from "@/lib/types";
+import { compareEdgeStats, edgeRowKey } from "@/lib/edge-stats";
 import { useMesh } from "@/lib/mesh-context";
 import {
   Table,
@@ -13,6 +13,13 @@ import { cn } from "@/lib/utils";
 import { ArrowRight, RadioTower } from "lucide-react";
 
 const MAX_HISTORY = 30; // ~5 min at 10s intervals
+
+// Rows this dashboard widget will draw. The stream it reads from carries a much
+// larger budget than a widget wants, because the topology graph is its other
+// consumer and needs a row for every edge it draws (edgeStatsStreamLimit, Go
+// side). This keeps that budget off the dashboard: the busiest routes, which is
+// what the server used to send and all this card ever displayed.
+const MAX_ROWS = 20;
 
 function getErrorRateColor(rate: number): string {
   if (rate === 0) return "text-green-400";
@@ -74,28 +81,38 @@ function Sparkline({ points, width = 80, height = 24 }: {
 export function TrafficTable() {
   const { edgeStats } = useMesh();
 
-  // Ring buffer: accumulate edge stats snapshots keyed by route
+  // Ring buffer: accumulate edge stats snapshots, one series per
+  // (route, called function) — see lib/edge-stats.ts.
   const historyRef = useRef<Map<string, number[]>>(new Map());
   const [, setTick] = useState(0);
 
   useEffect(() => {
     if (edgeStats.length === 0) return;
+    const live = new Set<string>();
     for (const edge of edgeStats) {
-      const key = `${edge.source}->${edge.target}`;
+      const key = edgeRowKey(edge);
+      live.add(key);
       const history = historyRef.current.get(key) || [];
       history.push(edge.avg_latency_ms);
       if (history.length > MAX_HISTORY) history.shift();
       historyRef.current.set(key, history);
     }
+    // Drop series for keys that have stopped arriving. The map is keyed per
+    // (route, function) and never shrank, so it grew for the life of the tab
+    // with every route that ever appeared — a finer key multiplies that, and
+    // rows drop in and out of the payload as traffic shifts under the server's
+    // budget. A vanished series has nothing to draw anyway.
+    for (const key of historyRef.current.keys()) {
+      if (!live.has(key)) historyRef.current.delete(key);
+    }
     setTick((t) => t + 1); // force re-render so sparklines update
   }, [edgeStats]);
 
   const sorted = useMemo(() => {
-    return [...edgeStats].sort((a, b) => {
-      const routeA = `${a.source}->${a.target}`;
-      const routeB = `${b.source}->${b.target}`;
-      return routeA.localeCompare(routeB);
-    });
+    const busiest = [...edgeStats]
+      .sort((a, b) => b.call_count - a.call_count || compareEdgeStats(a, b))
+      .slice(0, MAX_ROWS);
+    return busiest.sort(compareEdgeStats);
   }, [edgeStats]);
 
   if (sorted.length === 0) {
@@ -113,6 +130,7 @@ export function TrafficTable() {
       <TableHeader>
         <TableRow>
           <TableHead>Route</TableHead>
+          <TableHead>Function</TableHead>
           <TableHead className="text-right">Calls</TableHead>
           <TableHead className="text-right">Errors</TableHead>
           <TableHead className="text-right">Error Rate</TableHead>
@@ -123,7 +141,7 @@ export function TrafficTable() {
       </TableHeader>
       <TableBody>
         {sorted.map((edge) => {
-          const key = `${edge.source}->${edge.target}`;
+          const key = edgeRowKey(edge);
           const history = historyRef.current.get(key) || [];
 
           return (
@@ -134,6 +152,9 @@ export function TrafficTable() {
                   <ArrowRight className="h-3 w-3 text-muted-foreground shrink-0" />
                   <span className="font-medium text-foreground">{edge.target}</span>
                 </div>
+              </TableCell>
+              <TableCell className="font-mono text-muted-foreground">
+                {edge.target_function || "-"}
               </TableCell>
               <TableCell className="text-right font-mono">
                 {edge.call_count}

--- a/src/ui/components/topology/TopologyGraph.tsx
+++ b/src/ui/components/topology/TopologyGraph.tsx
@@ -162,8 +162,13 @@ export function mergeEdgeStatsIntoEdges(edges: Edge[], edgeStats: EdgeStat[]): E
 
   const statsMap = new Map<string, EdgeStat>();
   for (const stat of edgeStats) {
-    // edgeRowKey rather than edgeStatKey, so an older registry's row without a
-    // function is indexed under the empty function on both sides of the join.
+    // edgeRowKey rather than edgeStatKey so a row missing its function is
+    // indexed under the empty function instead of under `undefined`. Nothing
+    // matches it either way: the topology side of the join takes its function
+    // from the resolution's `mcp_tool`, which every edge-producing resolution
+    // carries, so no edge is ever keyed under the empty function. Such a row
+    // simply contributes to no edge, and the edge it might have described keeps
+    // its structural style — the right outcome for a row that names nothing.
     statsMap.set(edgeRowKey(stat), stat);
   }
 

--- a/src/ui/components/topology/TopologyGraph.tsx
+++ b/src/ui/components/topology/TopologyGraph.tsx
@@ -13,6 +13,7 @@ import {
 import "@xyflow/react/dist/style.css";
 import { Agent, EdgeStat } from "@/lib/types";
 import { buildGraphFromAgents, buildIdToNodeKey, computeStructureHash } from "@/lib/topology";
+import { edgeRowKey, edgeStatKey } from "@/lib/edge-stats";
 import { EDGE_HEAT_COLORS } from "@/lib/edge-palette";
 import { extractAgentName, formatDuration } from "@/lib/api";
 import { useMesh } from "@/lib/mesh-context";
@@ -84,33 +85,122 @@ function computeStrokeWidth(callCount: number, maxCount: number): number {
   return 1 + ratio * 3; // min 1, max 4
 }
 
-function mergeEdgeStatsIntoEdges(edges: Edge[], edgeStats: EdgeStat[]): Edge[] {
+// What one edge's stat rows add up to. Only these three numbers are drawn, and
+// all three combine exactly: a count sums, and a per-row mean recovers its total
+// by multiplying back through the count it was taken over.
+interface EdgeTraffic {
+  callCount: number;
+  errorRate: number;
+  avgLatencyMs: number;
+}
+
+// Sum the stat rows belonging to one drawn edge, or null when it has none.
+//
+// An edge stands for its whole `data.targetFunctions` set, which is usually one
+// function and is several whenever the registry emitted a resolution row per
+// matched tool under a shared label (see topology.ts). Summing is what makes
+// the answer independent of which member came first in the snapshot; picking
+// one member would not be.
+//
+// Rows are matched by (base source name, base target name, function), so a
+// function with no row contributes nothing rather than a zero: an edge whose
+// set is partly covered reports the traffic that was actually recorded.
+function aggregateEdgeTraffic(
+  edge: Edge,
+  statsMap: Map<string, EdgeStat>
+): EdgeTraffic | null {
+  const targetFunctions = edge.data?.targetFunctions;
+  if (!Array.isArray(targetFunctions) || targetFunctions.length === 0) return null;
+
+  const sourceName = nodeKeyToBaseName(edge.source);
+  const targetName = nodeKeyToBaseName(edge.target);
+
+  let callCount = 0;
+  let totalLatencyMs = 0;
+  let totalErrorRate = 0;
+  let matched = 0;
+
+  for (const fn of targetFunctions) {
+    if (typeof fn !== "string" || fn === "") continue;
+    const stat = statsMap.get(edgeStatKey(sourceName, targetName, fn));
+    if (!stat) continue;
+    matched++;
+    callCount += stat.call_count;
+    totalLatencyMs += stat.avg_latency_ms * stat.call_count;
+    // Weighted from the row's OWN error rate rather than recomputed from its
+    // error count. The two are the same number on every payload the registry
+    // produces (both server paths derive the rate from the counts), and
+    // weighting the reported field means this never contradicts the rate the
+    // Traffic table prints for the same row.
+    totalErrorRate += stat.error_rate * stat.call_count;
+  }
+
+  if (matched === 0) return null;
+  if (callCount === 0) return { callCount: 0, errorRate: 0, avgLatencyMs: 0 };
+
+  return {
+    callCount,
+    errorRate: totalErrorRate / callCount,
+    avgLatencyMs: totalLatencyMs / callCount,
+  };
+}
+
+// Overlay recorded traffic onto the structural graph.
+//
+// Matching on the agent pair alone was the bug: a pair exchanging a regular
+// tool, an LLM-filtered tool and a MeshJob draws three correctly-coloured
+// edges, and all three were stamped with one average across all of it. Each
+// edge knows which provider functions it resolved to — `data.targetFunctions`,
+// written from the resolutions' `mcp_tool` — so it joins to the rows that
+// actually describe it.
+//
+// Exported for __tests__/traffic-per-function.test.tsx: the join is the whole
+// point of the change and is not observable from the rendered graph, where two
+// edges differ only by a stroke width and a label suffix.
+export function mergeEdgeStatsIntoEdges(edges: Edge[], edgeStats: EdgeStat[]): Edge[] {
   if (edgeStats.length === 0) return edges;
 
   const statsMap = new Map<string, EdgeStat>();
   for (const stat of edgeStats) {
-    statsMap.set(`${stat.source}->${stat.target}`, stat);
+    // edgeRowKey rather than edgeStatKey, so an older registry's row without a
+    // function is indexed under the empty function on both sides of the join.
+    statsMap.set(edgeRowKey(stat), stat);
   }
 
-  const maxCallCount = Math.max(...edgeStats.map((e) => e.call_count), 1);
+  const traffic = edges.map((edge) => aggregateEdgeTraffic(edge, statsMap));
 
-  return edges.map((edge) => {
-    const sourceName = nodeKeyToBaseName(edge.source);
-    const targetName = nodeKeyToBaseName(edge.target);
-    const stat = statsMap.get(`${sourceName}->${targetName}`);
+  // The stroke-width denominator is the busiest DRAWN EDGE, not the busiest
+  // row: an edge standing for several functions carries their sum, which a
+  // per-row maximum would let exceed the scale's top.
+  const maxCallCount = Math.max(
+    ...traffic.map((t) => (t ? t.callCount : 0)),
+    1
+  );
+
+  return edges.map((edge, i) => {
+    // NO TRAFFIC RECORDED IS NOT ZERO TRAFFIC. An edge with no matching row
+    // keeps its structural style and its plain label — no latency, no heat
+    // colour, no stroke weight — rather than being drawn as an idle edge. Some
+    // real edges legitimately have no row: Python streaming tools publish no
+    // span at all, and Java's synthetic dependency tools create capability rows
+    // no span ever names. Both were already uncovered; a pair-level average
+    // used to hide them behind a sibling's numbers.
+    const stat = traffic[i];
     if (!stat) return edge;
 
     // Use stored original label to prevent accumulation on repeated merges
     const baseLabel = (edge.data?.originalLabel as string) || edge.label || "";
-    const mergedLabel = baseLabel ? `${baseLabel}  ${formatDuration(stat.avg_latency_ms)}` : `${formatDuration(stat.avg_latency_ms)}`;
+    const mergedLabel = baseLabel ? `${baseLabel}  ${formatDuration(stat.avgLatencyMs)}` : `${formatDuration(stat.avgLatencyMs)}`;
 
     return {
       ...edge,
       label: mergedLabel,
       style: {
         ...edge.style,
-        stroke: getEdgeHeatColor(stat.error_rate),
-        strokeWidth: computeStrokeWidth(stat.call_count, maxCallCount),
+        stroke: getEdgeHeatColor(stat.errorRate),
+        // Relative to the busiest EDGE now, not the busiest pair, which is
+        // the same change of denominator the rest of this merge makes.
+        strokeWidth: computeStrokeWidth(stat.callCount, maxCallCount),
       },
     };
   });

--- a/src/ui/lib/edge-stats.ts
+++ b/src/ui/lib/edge-stats.ts
@@ -1,0 +1,53 @@
+import { EdgeStat } from "./types";
+
+/**
+ * The identity of an edge-stat row: (source agent, target agent, function on
+ * the target). Issue #1531 — the server keys traffic by all three, so every
+ * consumer that indexes, de-duplicates or joins on a row has to use all three
+ * too. Two of them is what made a pair's several tools share one number.
+ *
+ * Structured rather than concatenated with a separator. Every component is a
+ * user-chosen name and none of them has a delimiter that cannot appear inside
+ * it: the server's previous `source + " -> " + target` key had to be taken
+ * apart again by scanning for the first " -> ", which an agent named with that
+ * sequence in it split in the wrong place.
+ */
+export function edgeStatKey(
+  source: string,
+  target: string,
+  targetFunction: string
+): string {
+  return JSON.stringify([source, target, targetFunction]);
+}
+
+/**
+ * `target_function` as a string, whatever arrived.
+ *
+ * The field is required by the payload contract and by the type, and the server
+ * always emits it — but these rows come off the network, and a registry
+ * predating #1531 emits a payload without it. The type says `string`, so an
+ * absent one is `undefined` at runtime while every reader believes otherwise,
+ * and `undefined.localeCompare` throws inside a sort — taking the whole Traffic
+ * page down rather than degrading. An older registry's rows are pair-level, and
+ * an empty function is exactly what this file already means by "a row that
+ * names no function".
+ */
+function functionOf(edge: EdgeStat): string {
+  return edge.target_function ?? "";
+}
+
+/** edgeStatKey for a whole row — its React key, and its history-map key. */
+export function edgeRowKey(edge: EdgeStat): string {
+  return edgeStatKey(edge.source, edge.target, functionOf(edge));
+}
+
+/**
+ * Sort comparator for the traffic tables: by route, then by the function called
+ * on the target, so the several rows one route now contributes stay together
+ * and in a stable order across polls.
+ */
+export function compareEdgeStats(a: EdgeStat, b: EdgeStat): number {
+  const byRoute = `${a.source}->${a.target}`.localeCompare(`${b.source}->${b.target}`);
+  if (byRoute !== 0) return byRoute;
+  return functionOf(a).localeCompare(functionOf(b));
+}

--- a/src/ui/lib/edge-stats.ts
+++ b/src/ui/lib/edge-stats.ts
@@ -23,14 +23,16 @@ export function edgeStatKey(
 /**
  * `target_function` as a string, whatever arrived.
  *
- * The field is required by the payload contract and by the type, and the server
- * always emits it — but these rows come off the network, and a registry
- * predating #1531 emits a payload without it. The type says `string`, so an
- * absent one is `undefined` at runtime while every reader believes otherwise,
- * and `undefined.localeCompare` throws inside a sort — taking the whole Traffic
- * page down rather than degrading. An older registry's rows are pair-level, and
- * an empty function is exactly what this file already means by "a row that
- * names no function".
+ * DEFENCE IN DEPTH, NOT A SUPPORTED SHAPE. The field is required by the type and
+ * by the payload contract, and there is no version of the payload that omits it:
+ * every producer is meshui's own binary — the live accumulator, its Tempo
+ * fallback and the windowed replay — and that same binary embeds the SPA reading
+ * them, so the two cannot be different versions. What this guards is a
+ * MALFORMED payload, where the type says `string` but the value is `undefined`
+ * at runtime, and `undefined.localeCompare` throws inside a sort — taking the
+ * whole Traffic page down rather than degrading. An empty function is what this
+ * file already means by "a row that names no function", so such a row lands
+ * there instead.
  */
 function functionOf(edge: EdgeStat): string {
   return edge.target_function ?? "";
@@ -42,12 +44,19 @@ export function edgeRowKey(edge: EdgeStat): string {
 }
 
 /**
- * Sort comparator for the traffic tables: by route, then by the function called
- * on the target, so the several rows one route now contributes stay together
- * and in a stable order across polls.
+ * Sort comparator for the traffic tables: by source, then target, then by the
+ * function called on the target, so the several rows one route now contributes
+ * stay together and in a stable order across polls.
+ *
+ * Field by field, never on a joined string. `${source}->${target}` would order
+ * by a separator that can appear inside an agent name, which orders such a name
+ * against the wrong neighbour — the same fault that made the server's delimited
+ * edge key a struct in #1531.
  */
 export function compareEdgeStats(a: EdgeStat, b: EdgeStat): number {
-  const byRoute = `${a.source}->${a.target}`.localeCompare(`${b.source}->${b.target}`);
-  if (byRoute !== 0) return byRoute;
+  const bySource = a.source.localeCompare(b.source);
+  if (bySource !== 0) return bySource;
+  const byTarget = a.target.localeCompare(b.target);
+  if (byTarget !== 0) return byTarget;
   return functionOf(a).localeCompare(functionOf(b));
 }

--- a/src/ui/lib/topology.ts
+++ b/src/ui/lib/topology.ts
@@ -161,6 +161,17 @@ function resolvesToJob(
   // `mcp_tool` names the exact function the dependency resolved to, so when it
   // is on the wire it decides on its own — falling back to the capability name
   // here would re-admit the ambiguity it exists to settle.
+  //
+  // The name branch below is DEFENSIVE, not a live path. Reaching it needs a
+  // resolution that has a provider_agent_id but no mcp_tool, and the registry
+  // does not produce one: the two are written in a single chained statement or
+  // neither is (ent_service.go, SetNillableProviderAgentID +
+  // SetNillableProviderFunctionName), and a capability row cannot exist with an
+  // empty function name in the first place (ent_service.go refuses to persist
+  // one). The edge loop has already required provider_agent_id by the time this
+  // is called. Kept anyway, in the same spirit as the degraded-vs-degraded
+  // precedence rule in addEdge below: it is an invariant of a different process,
+  // this file cannot enforce it, and nothing here would notice it being relaxed.
   if (dep.mcp_tool) return entry.functions.has(dep.mcp_tool);
   return entry.names.has(dep.capability);
 }
@@ -205,14 +216,52 @@ export function buildGraphFromAgents(agents: Agent[]): { nodes: Node[]; edges: E
   // Edge merging note: when multiple replicas' edges collapse into one, we keep
   // the first seen edge's base style/label and let downstream edge-stats merge
   // update the label/stroke. This is a simplification — latency/call stats are
-  // not summed here because edgeStats are keyed by base name (extractAgentName),
-  // which already aligns with the group node ID. See mergeEdgeStatsIntoEdges
-  // in TopologyGraph.tsx.
+  // not summed here because edgeStats are keyed by base agent name, which
+  // already aligns with the group node ID. See mergeEdgeStatsIntoEdges in
+  // TopologyGraph.tsx.
+  //
+  // `data.targetFunctions` is carried for that merge: each is a resolution's
+  // `mcp_tool`, the PROVIDER's function name, and it joins to an edge stat's
+  // `target_function` (issue #1531).
+  //
+  // A SET, not one name, because one drawn edge routinely stands for several
+  // provider functions. An edge is keyed `kind|src|dst|label`, and an LLM tool
+  // edge's label is `llm:<filter_capability>` — while the registry writes ONE
+  // resolution row PER MATCHED TOOL (ent_service.go), all sharing that filter.
+  // A tags-only filter leaves the capability empty, so every tool it matched on
+  // one provider lands on the identical label. Replica collapse and two
+  // same-named capabilities do the same thing on the dependency path.
+  //
+  // Taking one member's name would join the edge to one of N functions and show
+  // its numbers as if they described the whole edge, picked by snapshot order —
+  // the same order-dependence addEdge's merge rules exist to eliminate. The set
+  // is deduped and sorted, so it is a pure function of the snapshot's CONTENT,
+  // and mergeEdgeStatsIntoEdges aggregates every row it matches.
   type EdgeKind = "dep" | "llm" | "prov";
   const edgeMap = new Map<string, Edge>();
+  // Accumulated alongside edgeMap rather than inside each edge's `data` so the
+  // union is independent of which contribution won the style merge below.
+  const edgeFunctions = new Map<string, Set<string>>();
 
-  function addEdge(kind: EdgeKind, src: string, dst: string, label: string, base: Edge) {
+  function addEdge(
+    kind: EdgeKind,
+    src: string,
+    dst: string,
+    label: string,
+    targetFunction: string | undefined,
+    base: Edge
+  ) {
     const key = `${kind}|${src}|${dst}|${label}`;
+
+    if (targetFunction) {
+      const functions = edgeFunctions.get(key);
+      if (functions) {
+        functions.add(targetFunction);
+      } else {
+        edgeFunctions.set(key, new Set([targetFunction]));
+      }
+    }
+
     const existing = edgeMap.get(key);
     if (!existing) {
       edgeMap.set(key, base);
@@ -301,7 +350,7 @@ export function buildGraphFromAgents(agents: Agent[]): { nodes: Node[]; edges: E
         ? EDGE_COLORS.job
         : EDGE_COLORS.dependency;
       const label = dep.capability;
-      addEdge("dep", src, dst, label, {
+      addEdge("dep", src, dst, label, dep.mcp_tool, {
         id: `dep|${src}|${dst}|${label}`,
         source: src,
         target: dst,
@@ -333,7 +382,7 @@ export function buildGraphFromAgents(agents: Agent[]): { nodes: Node[]; edges: E
       // before the callee is consulted, so no `task` lookup happens on this
       // path at all.
       const label = `llm:${llm.filter_capability}`;
-      addEdge("llm", src, dst, label, {
+      addEdge("llm", src, dst, label, llm.mcp_tool, {
         id: `llm|${src}|${dst}|${label}`,
         source: src,
         target: dst,
@@ -353,7 +402,7 @@ export function buildGraphFromAgents(agents: Agent[]): { nodes: Node[]; edges: E
       if (!dst || !validNodeKeys.has(dst)) continue;
 
       const label = `provider:${prov.required_capability}`;
-      addEdge("prov", src, dst, label, {
+      addEdge("prov", src, dst, label, prov.mcp_tool, {
         id: `prov|${src}|${dst}|${label}`,
         source: src,
         target: dst,
@@ -368,7 +417,19 @@ export function buildGraphFromAgents(agents: Agent[]): { nodes: Node[]; edges: E
     }
   }
 
-  const edges: Edge[] = Array.from(edgeMap.values());
+  // Attach each edge's function set last, once every contribution has been
+  // seen. Sorted so two snapshots carrying the same resolutions in a different
+  // order produce identical edges.
+  const edges: Edge[] = Array.from(edgeMap.entries()).map(([key, edge]) => {
+    const functions = edgeFunctions.get(key);
+    return {
+      ...edge,
+      data: {
+        ...edge.data,
+        targetFunctions: functions ? Array.from(functions).sort() : [],
+      },
+    };
+  });
 
   return applyDagreLayout(nodes, edges);
 }

--- a/src/ui/lib/types.ts
+++ b/src/ui/lib/types.ts
@@ -202,10 +202,36 @@ export interface TraceDetail {
 export interface EdgeStat {
   source: string;
   target: string;
+  /**
+   * The function ON THE TARGET that these calls landed on — one stat row per
+   * (source, target, target_function), not one per agent pair (issue #1531).
+   *
+   * Named for the target deliberately. `DependencyResolution.function_name` is
+   * the CONSUMER's function, and the provider's is what a resolution calls
+   * `mcp_tool`; this is that value, arriving from the callee's span rather than
+   * from the resolution. Reusing either name here would read as the other side
+   * of the edge.
+   *
+   * Empty string when the callee's span carried no operation, which only a
+   * malformed span produces. Such a row joins to no topology edge.
+   */
+  target_function: string;
   call_count: number;
   error_count: number;
   error_rate: number;
   avg_latency_ms: number;
+  /**
+   * The 99th percentile over a ROLLING WINDOW of the row's recent calls, and a
+   * bucket estimate that rounds up rather than down (registry:
+   * latency_histogram.go). Its window is what distinguishes it from every other
+   * number in this row: call_count, error_count, avg/max/min are exact figures
+   * for the whole life of the row, so a spike stays in the max forever and
+   * leaves the P99 once enough calls have happened since.
+   *
+   * That split is not new — the registry always computed this one over recent
+   * samples and the others over everything — but it is the reason this number
+   * can fall while max_latency_ms does not.
+   */
   p99_latency_ms: number;
   max_latency_ms: number;
   min_latency_ms: number;


### PR DESCRIPTION
## Summary

Two agents can be connected by several edges, one per capability. Edge stats were keyed by agent pair alone, so a single average was stamped identically onto all of them — the tool edge, the LLM edge and the MeshJob edge between the same pair showed the same latency, the same heat colour and the same stroke width. After #1529 the edges say what they are; the numbers on them described something else.

**The callee function was already in scope at the record site and thrown away.** `accumulator.go` had `s.Operation` in hand and built the key from the other two values. It is now part of the key, as a struct rather than a longer string — the emit side used to re-split on the first `" -> "`, which breaks on an agent name containing that sequence.

**It joins to a topology edge with no lookup table.** For MCP tools — the only surface that produces a capability row, and therefore the only one that can be a resolution target — the span's operation and the registry's `capability.function_name` are the same expression evaluated on the same object in all three runtimes (`func.__name__`, `def.name`, `method.getName()`), with no normalisation on either path. The edge is attributed from the **callee's** span; the caller publishes `proxy_call_wrapper`. So the provider function the registry already echoes as `mcp_tool` is the join key. An explicit `capability=` that differs from the function name doesn't break it — those are separate columns.

## What multiplying the key count forced

**Memory.** Each key held up to 10,000 `int64` latencies — ~80 KB for a hot edge — purely to compute P99 at read time. That is now a log-linear histogram: one bucket per millisecond below 16 ms (exact, since the values are integers), eight per octave above, 240 buckets covering 49.7 days. **Flat 1,928 bytes per key**, worst-case error 12.5% and one-sided — `Quantile` returns the bucket's upper bound, so it can only overstate, then clamps to the exact observed max. Min, max and avg stay exact; they never needed samples.

**P99's window, which nobody asked to change.** The ring buffer held the last 10,000 samples, so a latency spike aged out. An accumulating histogram would have silently made P99 lifetime-cumulative on an edge whose key never expires — one incident and the number never recovers. Two generations rotating at 10,000 samples restore the old semantics at **no memory cost** (counters narrow to `uint32`, safe by construction since rotation caps them).

**Truncation, which was the blocker.** The 20-row budget was chosen when one row meant one pair. Per-function rows let a single pair exchanging 25 tools take every slot, silently dropping the rest of the mesh from the SSE feed that is the graph's *only* source — no error, no empty state, just structural strokes. Raising the number moves the cliff without removing it, and the two consumers want different things: the graph needs a row for every edge it draws, the Traffic page wants a ranked top-N. So selection is now fair across pairs — every pair contributes its busiest function before any pair contributes its second — and the stream has its own budget sized for drawn edges.

## LLM edges collapse, so they aggregate

`addEdge` keys on `kind|src|dst|label`, and for LLM tool edges the label is `llm:${filter_capability}` — which is empty for a tags-only filter, while the registry creates one resolution per matched tool. All of them collapse into one edge. Showing one arbitrary member's numbers would have reintroduced exactly the snapshot-order dependence the merge rules were written to eliminate, so the edge carries a sorted union of its functions and aggregates the rows: summed calls, call-weighted latency, call-weighted error rate. Verified order-independent in both agent order and stat-row order; 90 calls at 10 ms plus 10 at 1000 ms reads 109 ms, not 505.

An edge with **no** matching row keeps its structural style. No traffic recorded and zero traffic are different facts.

## Known gaps — pre-existing, previously hidden inside a pair average

- Python streaming tools publish no span at all (`_make_stream_wrapper` never constructs an `ExecutionTracer`).
- Java's synthetic dependency tools (`__mesh_route_deps` and siblings) create capability rows no span ever names.

Those edges will show no stat. Documented rather than fixed.

## Also folded in

`resolvesToJob`'s `mcp_tool` fallback had a comment implying absence is a live path. It is not reachable: the edge loop requires `provider_agent_id`; that and `provider_function_name` are written in one chained statement or neither; and a capability row cannot exist with an empty function name. The defensive branch stays, the comment now states the invariant — same treatment as the degraded-vs-degraded note in #1529.

## Verification

- Every mutation probed: degrading fair selection to head truncation fails 3 tests; coarsening the histogram fails the error-bound test *and* the derived bucket-count assertion; dropping the function from the UI join key makes a sibling edge inherit the wrong colour and latency.
- `go test ./src/core/...` 10 packages, `npm test` 107 tests, `tsc --noEmit`, `eslint`, `go build ./...`, `make docs-scroll-build`, `mkdocs build` all clean.
- All changed Go files gofmt-clean. Note `make fmt-check` fails identically at HEAD (45 files repo-wide, unrelated) and is not wired into CI.
- Dashboard CSS 77,284 B, demo CSS 98,799 B, demo JS 193,813 B — all unchanged. Demo fixtures untouched.

Not verified: no live mesh was run. This is code-level verification plus unit tests, not an end-to-end observation of a real dashboard.

Closes #1531

Unblocks #1530 — an override that is accurate per edge is a very different proposition from one painting three edges with one pair average.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Traffic statistics now distinguish calls by source, destination, and target function.
  * Traffic tables include a Function column with separate latency, error, and call metrics.
  * Topology visualizations aggregate traffic across functions while preserving function-specific attribution.
  * Edge statistics are sorted deterministically and distributed fairly across connection pairs when limits apply.
  * Expanded edge-stat streaming provides broader topology coverage.
* **Bug Fixes**
  * Improved P99 latency estimates using rolling measurements.
  * Prevented stale traffic history and incorrect aggregation when functions appear or disappear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->