### PR TITLE
fix: let the Traffic page show a route's functions, and a second meshui read safely

### DIFF
--- a/cmd/mcp-mesh-ui/main.go
+++ b/cmd/mcp-mesh-ui/main.go
@@ -54,6 +54,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  DATABASE_URL             - Path to SQLite database or PostgreSQL URL (default: mcp_mesh_registry.db)\n")
 		fmt.Fprintf(os.Stderr, "  MCP_MESH_DISTRIBUTED_TRACING_ENABLED - Enable trace streaming (default: false)\n")
 		fmt.Fprintf(os.Stderr, "  REDIS_URL                - Redis URL for trace streaming (default: redis://localhost:6379)\n")
+		fmt.Fprintf(os.Stderr, "  MCP_MESH_UI_TRACE_CONSUMER_GROUP - Redis consumer group for mesh:trace; give a second meshui its own group so it does not take traces from the first (default: mcp-mesh-ui-dashboard)\n")
 		fmt.Fprintf(os.Stderr, "  TEMPO_URL              - Tempo HTTP query URL (default: http://localhost:3200)\n")
 		fmt.Fprintf(os.Stderr, "  TELEMETRY_ENDPOINT     - OTLP endpoint; Tempo URL auto-derived if TEMPO_URL not set\n")
 		fmt.Fprintf(os.Stderr, "  MCP_MESH_UI_BASE_PATH    - Base path for path-based ingress (default: empty)\n")
@@ -162,7 +163,7 @@ func main() {
 			Enabled:       true,
 			RedisURL:      resolveRedisURL(redisURL),
 			StreamName:    "mesh:trace",
-			ConsumerGroup: "mcp-mesh-ui-dashboard",
+			ConsumerGroup: resolveConsumerGroup(),
 			ConsumerName:  fmt.Sprintf("ui-%s", hostname),
 			BatchSize:     100,
 			BlockTimeout:  2 * time.Second,
@@ -233,6 +234,20 @@ func resolveRedisURL(flagValue string) string {
 		return flagValue
 	}
 	return getEnvDefault("REDIS_URL", "redis://localhost:6379")
+}
+
+// defaultConsumerGroup is the Redis consumer group meshui reads mesh:trace with.
+const defaultConsumerGroup = "mcp-mesh-ui-dashboard"
+
+// resolveConsumerGroup returns the consumer group for the mesh:trace stream.
+//
+// Configurable because Redis hands each stream entry to exactly one consumer
+// within a group: a second meshui run against a live mesh under the default
+// group would take roughly half the running dashboard's traces and XAck them,
+// halving what that dashboard shows for as long as it ran. Give the second
+// reader its own group and both see the whole stream.
+func resolveConsumerGroup() string {
+	return getEnvDefault("MCP_MESH_UI_TRACE_CONSUMER_GROUP", defaultConsumerGroup)
 }
 
 func resolveTempoURL(flagValue string) string {

--- a/cmd/mcp-mesh-ui/main_test.go
+++ b/cmd/mcp-mesh-ui/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveConsumerGroup(t *testing.T) {
+	t.Run("unset keeps the historical default", func(t *testing.T) {
+		// t.Setenv registers the restore; unset after it to test the absent case.
+		t.Setenv("MCP_MESH_UI_TRACE_CONSUMER_GROUP", "")
+		if err := os.Unsetenv("MCP_MESH_UI_TRACE_CONSUMER_GROUP"); err != nil {
+			t.Fatalf("unsetenv: %v", err)
+		}
+		if got := resolveConsumerGroup(); got != "mcp-mesh-ui-dashboard" {
+			t.Errorf("resolveConsumerGroup() = %q, want %q", got, "mcp-mesh-ui-dashboard")
+		}
+	})
+
+	t.Run("empty is treated as unset", func(t *testing.T) {
+		t.Setenv("MCP_MESH_UI_TRACE_CONSUMER_GROUP", "")
+		if got := resolveConsumerGroup(); got != "mcp-mesh-ui-dashboard" {
+			t.Errorf("resolveConsumerGroup() = %q, want %q", got, "mcp-mesh-ui-dashboard")
+		}
+	})
+
+	t.Run("set overrides", func(t *testing.T) {
+		t.Setenv("MCP_MESH_UI_TRACE_CONSUMER_GROUP", "mcp-mesh-ui-scratch")
+		if got := resolveConsumerGroup(); got != "mcp-mesh-ui-scratch" {
+			t.Errorf("resolveConsumerGroup() = %q, want %q", got, "mcp-mesh-ui-scratch")
+		}
+	})
+}

--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -64,6 +64,7 @@ export TEMPO_URL=http://localhost:3200
 | `MCP_MESH_TRACE_STREAM_MAXLEN` | `100000` | Producer-side `XADD MAXLEN ~` ceiling on `mesh:trace`, applied by every agent runtime. Bounds the stream even with no consumer alive (`0` disables) |
 | `MCP_MESH_TELEMETRY_AGGREGATE_RETENTION` | `24h` | Age-out window for the in-memory per-agent / per-model / per-edge dashboard aggregates (`0` disables age pruning) |
 | `MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES` | `10000` | Hard key ceiling per aggregate map, evicting least-recently-seen first (`0` disables the ceiling). An edge key costs ~2.1 KB, so the default admits ~20 MB of edge aggregates |
+| `MCP_MESH_UI_TRACE_CONSUMER_GROUP` | `mcp-mesh-ui-dashboard` | Redis consumer group meshui reads `mesh:trace` with. Redis delivers each entry to one consumer per group, so a second meshui on the default group takes traces from a running dashboard — give an extra reader its own group |
 
 See the [environment variables reference](environment-variables.md) for the full list.
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -505,6 +505,13 @@ export MCP_MESH_TRACE_STREAM_MAXLEN=100000
 export MCP_MESH_TELEMETRY_AGGREGATE_RETENTION=24h
 export MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES=10000
 
+# Redis consumer group meshui reads mesh:trace with. Redis hands each stream
+# entry to exactly one consumer within a group, so a second meshui left on the
+# default would take roughly half of a running dashboard's traces and acknowledge
+# them away. Give an extra reader its own group and both see the whole stream.
+# Default: mcp-mesh-ui-dashboard.
+export MCP_MESH_UI_TRACE_CONSUMER_GROUP=mcp-mesh-ui-dashboard
+
 # Trace output options
 export TRACE_PRETTY_OUTPUT=false
 export TRACE_ENABLE_STATS=true

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -372,6 +372,12 @@ export MCP_MESH_TRACE_STREAM_MAXLEN=100000
 export MCP_MESH_TELEMETRY_AGGREGATE_RETENTION=24h
 export MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES=10000
 
+# Redis consumer group meshui reads mesh:trace with. Redis gives each entry to
+# one consumer per group, so a second meshui on the default group takes traces
+# away from a running dashboard — give an extra reader its own group
+# (default: mcp-mesh-ui-dashboard)
+export MCP_MESH_UI_TRACE_CONSUMER_GROUP=mcp-mesh-ui-dashboard
+
 # Header propagation across agents (comma-separated prefixes)
 export MCP_MESH_PROPAGATE_HEADERS=x-request-id,x-trace
 

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -104,6 +104,7 @@ Default credentials: `admin` / `admin`
 | `MCP_MESH_TRACE_STREAM_MAXLEN`         | Producer-side `XADD MAXLEN ~` ceiling on `mesh:trace` (`0` = no cap) | `100000` |
 | `MCP_MESH_TELEMETRY_AGGREGATE_RETENTION` | Age-out window for in-memory dashboard aggregates (`0` = no age pruning) | `24h` |
 | `MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES` | Key ceiling per aggregate map, LRU eviction (`0` = no ceiling). An edge key costs ~2.1 KB, so the default admits ~20 MB of edge aggregates | `10000` |
+| `MCP_MESH_UI_TRACE_CONSUMER_GROUP`      | Redis consumer group meshui reads `mesh:trace` with. One consumer per group gets each entry, so a second meshui needs its own group or it takes traces from the first | `mcp-mesh-ui-dashboard` |
 
 ## Troubleshooting
 

--- a/src/core/registry/tracing/edge_selection.go
+++ b/src/core/registry/tracing/edge_selection.go
@@ -52,10 +52,17 @@ func SortEdgeStats(edges []EdgeStats) {
 // a pair with one 1,000-call tool ahead of a pair with ten 500-call ones, and
 // the old payload ranked the second pair five times higher.
 //
-// This bounds the damage; it does not remove it. A consumer that needs a row for
-// every edge it draws needs a budget large enough for them — see
-// edgeStatsStreamLimit in the ui package, which is why the graph's feed and the
-// tables' feed no longer share one number.
+// This bounds the damage; it does not remove it, and the bound has a shape every
+// caller has to size its budget against: FAIRNESS SPENDS THE FIRST `pairs` SLOTS
+// ON ONE ROW EACH. A budget at or below the number of pairs therefore returns
+// exactly one row per pair and no pair's second function at all — coverage
+// without depth, which is what a graph wants and the opposite of what a table
+// wants. A consumer that needs a row for every edge it DRAWS needs a budget
+// above the drawn-edge count (edgeStatsStreamLimit in the ui package); a
+// consumer that wants a route's several FUNCTIONS side by side needs one
+// comfortably above the pair count (trafficMaxLimit, which the Traffic page asks
+// for by name). That is why the graph's feed and the table's feed no longer
+// share one number, and why neither of them is the endpoint default.
 func SelectEdgeStats(edges []EdgeStats, limit int) []EdgeStats {
 	if limit <= 0 || len(edges) <= limit {
 		return edges

--- a/src/core/ui/trace_poller_test.go
+++ b/src/core/ui/trace_poller_test.go
@@ -14,17 +14,16 @@ import (
 // traffic, and it is also what the dashboard's traffic widget reads. Those two
 // want different things from one payload — a graph wants a row for every edge it
 // draws, a widget wants a screenful — which is why the stream has a budget of
-// its own rather than the tables' 20.
+// its own rather than the tables' ceiling.
 
 // TestEdgeStatsStreamBudgetIsNotTableSized pins the relationship rather than the
 // number: whatever edgeStatsStreamLimit is set to, it has to be far above what a
 // table asks for, or the graph is back to being served by a ranking that can
 // starve it.
 func TestEdgeStatsStreamBudgetIsNotTableSized(t *testing.T) {
-	const tableCap = 100 // the ceiling handleTraffic/handleEdgeStats clamp to
-	if edgeStatsStreamLimit <= tableCap {
+	if edgeStatsStreamLimit <= trafficMaxLimit {
 		t.Fatalf("edgeStatsStreamLimit = %d, which is within the tables' ceiling of %d — "+
-			"the graph's feed is sized for a table again", edgeStatsStreamLimit, tableCap)
+			"the graph's feed is sized for a table again", edgeStatsStreamLimit, trafficMaxLimit)
 	}
 }
 
@@ -78,9 +77,16 @@ func TestEdgeStatsStreamBudgetCoversAMeshOfDrawnEdges(t *testing.T) {
 		t.Fatalf("published %d rows, want one per drawn edge (%d)", len(published), 40+120)
 	}
 
-	// Contrast: the table budget could not have done this.
-	tableSized := tracing.SelectEdgeStats(acc.GetEdgeStats(), 20)
-	if len(tableSized) != 20 {
-		t.Fatalf("table-sized selection returned %d rows, want 20", len(tableSized))
+	// Contrast: the table's ceiling could not have done this. It covers all 61
+	// pairs — that is what fairness buys — but it cannot carry a row for each of
+	// the 160 edges the graph draws, which is the difference between a budget
+	// sized for depth in a table and one sized for a graph's coverage.
+	tableSized := tracing.SelectEdgeStats(acc.GetEdgeStats(), trafficMaxLimit)
+	if len(tableSized) != trafficMaxLimit {
+		t.Fatalf("table-ceiling selection returned %d rows, want %d", len(tableSized), trafficMaxLimit)
+	}
+	if len(tableSized) >= len(published) {
+		t.Fatalf("table ceiling (%d rows) is no smaller than the stream's payload (%d rows)",
+			len(tableSized), len(published))
 	}
 }

--- a/src/core/ui/traffic_handler.go
+++ b/src/core/ui/traffic_handler.go
@@ -20,6 +20,16 @@ const (
 	windowReadBatch  = 1000
 )
 
+// Row budget for /trace/traffic. trafficDefaultLimit is what an ad-hoc caller
+// gets without asking; trafficMaxLimit is the ceiling a request is clamped to,
+// and it is what the Traffic page asks for by name (TRAFFIC_ROW_LIMIT in the
+// SPA's lib/api.ts). The two must stay reachable from the tests that pin the
+// budget's effect, which is why they are named rather than written inline.
+const (
+	trafficDefaultLimit = 20
+	trafficMaxLimit     = 100
+)
+
 // trafficCacheTTL bounds how long a windowed (1h/1d) result is reused. It is
 // deliberately SHORTER than the dashboard's 5s poll interval so consecutive
 // polls from a single viewer see fresh data while concurrent viewers (and
@@ -103,19 +113,27 @@ func replayWindow(events []*tracing.TraceEvent, limit int) (edges []tracing.Edge
 // filter. window=all (default) serves the live all-time aggregates unchanged;
 // window=1h/1d re-aggregate over a bounded XRANGE of the Redis trace stream.
 //
-// This endpoint feeds a TABLE, so a screenful-sized budget is the right budget
-// and the 20/100 below are unchanged. The topology graph does NOT read it — its
-// rows arrive over SSE, on a budget of its own (edgeStatsStreamLimit), because a
-// graph needs a row per edge it draws and a table does not.
+// This endpoint feeds a TABLE, and a table wants DEPTH WITHIN A ROUTE: since
+// #1531 a row is one (caller, provider, function), so the several tools a pair
+// exchanges are the detail the page exists to show. Fair-across-pairs truncation
+// (tracing.SelectEdgeStats) hands out one pass per rank, so a budget at or below
+// the number of pairs resolves to exactly one row per pair — every route on
+// screen, every route showing a single function. A screenful-sized budget is
+// therefore NOT the right budget here any more, and the page asks for
+// trafficMaxLimit rather than taking trafficDefaultLimit.
+//
+// The topology graph does NOT read this endpoint — its rows arrive over SSE, on
+// a budget of its own (edgeStatsStreamLimit), because a graph needs a row per
+// edge it draws and a scrollable table does not.
 func (s *Server) handleTraffic(c *gin.Context) {
-	limit := 20
+	limit := trafficDefaultLimit
 	if l := c.Query("limit"); l != "" {
 		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
 			limit = parsed
 		}
 	}
-	if limit > 100 {
-		limit = 100
+	if limit > trafficMaxLimit {
+		limit = trafficMaxLimit
 	}
 
 	windowParam := c.Query("window")

--- a/src/core/ui/traffic_handler_test.go
+++ b/src/core/ui/traffic_handler_test.go
@@ -202,6 +202,104 @@ func TestReplayWindowTruncatesFairlyAcrossPairs(t *testing.T) {
 	}
 }
 
+// TestTrafficBudgetCarriesARoutesFunctions is the server half of a defect whose
+// other half is in the SPA: fair-across-pairs truncation spends its first `pairs`
+// slots on ONE ROW EACH, so a budget at or below the pair count returns exactly
+// one row per pair — coverage without depth. Against a live mesh of 42 pairs the
+// Traffic page's old budget of 20 produced 40 rows over 40 routes with not one
+// route showing a second function, which is the page's entire purpose since
+// #1531.
+//
+// So the budget the page asks for (trafficMaxLimit) has to be large enough that
+// a route's several functions survive the truncation, and this pins that against
+// the measured shape rather than against a number someone hopes is comfortable.
+func TestTrafficBudgetCarriesARoutesFunctions(t *testing.T) {
+	now := time.Now()
+	var events []*tracing.TraceEvent
+	seq := 0
+
+	call := func(source, target, calleeOp string) {
+		seq++
+		id := "t" + strconv.Itoa(seq)
+		spans := makeCall(id, "r"+strconv.Itoa(seq), source, target, now, true)
+		spans[1].Operation = calleeOp
+		events = append(events, spans...)
+	}
+
+	// The measured mesh: 42 pairs, 19 of them multi-function, the busiest with 8.
+	const (
+		pairCount            = 42
+		multiFunctionPairs   = 19
+		busiestPairFunctions = 8
+	)
+	functionsOn := func(pair int) int {
+		if pair == 0 {
+			return busiestPairFunctions
+		}
+		if pair < multiFunctionPairs {
+			return 2
+		}
+		return 1
+	}
+	totalRows := 0
+	for p := 0; p < pairCount; p++ {
+		id := strconv.Itoa(p)
+		for fn := 0; fn < functionsOn(p); fn++ {
+			totalRows++
+			call("caller-"+id, "provider-"+id, "tool_"+id+"_"+strconv.Itoa(fn))
+		}
+	}
+	if totalRows <= pairCount {
+		t.Fatalf("fixture has %d rows over %d pairs and cannot show the defect", totalRows, pairCount)
+	}
+
+	countRows := func(edges []tracing.EdgeStats) (pairs int, deepest int) {
+		perPair := make(map[string]int, len(edges))
+		for _, e := range edges {
+			perPair[e.Source+" -> "+e.Target]++
+		}
+		for _, n := range perPair {
+			if n > deepest {
+				deepest = n
+			}
+		}
+		return len(perPair), deepest
+	}
+
+	// The budget the page asks for: every row survives, so the busiest route
+	// arrives with all 8 of its functions.
+	atCap, _, _, _, _ := replayWindow(events, trafficMaxLimit)
+	pairs, deepest := countRows(atCap)
+	if pairs != pairCount {
+		t.Fatalf("at the page's budget the payload covers %d pairs, want %d", pairs, pairCount)
+	}
+	if deepest != busiestPairFunctions {
+		t.Fatalf("at the page's budget the busiest route shows %d functions, want %d — "+
+			"the Traffic page is back to one row per route", deepest, busiestPairFunctions)
+	}
+	if len(atCap) != totalRows {
+		t.Fatalf("at the page's budget the payload has %d rows, want all %d", len(atCap), totalRows)
+	}
+
+	// The contrast, and the failure as it was measured: the endpoint DEFAULT is
+	// at or below this pair count, so it flattens the same data to one row each.
+	// This is not a bug in the default — it is why the page must not take it.
+	if trafficDefaultLimit > pairCount {
+		t.Skipf("trafficDefaultLimit (%d) now exceeds the measured pair count (%d); "+
+			"the flattening contrast no longer applies", trafficDefaultLimit, pairCount)
+	}
+	atDefault, _, _, _, _ := replayWindow(events, trafficDefaultLimit)
+	if _, deepestAtDefault := countRows(atDefault); deepestAtDefault != 1 {
+		t.Fatalf("at the endpoint default the deepest route shows %d functions, want 1 — "+
+			"fair selection no longer spends its first pass one row per pair, so the "+
+			"reasoning behind the page's budget needs revisiting", deepestAtDefault)
+	}
+	if trafficMaxLimit <= pairCount {
+		t.Fatalf("trafficMaxLimit (%d) is at or below a realistic pair count (%d), so the "+
+			"page's budget buys it exactly one row per route", trafficMaxLimit, pairCount)
+	}
+}
+
 // TestParseWindow covers the accepted values and rejection of unknown windows.
 func TestParseWindow(t *testing.T) {
 	cases := []struct {

--- a/src/ui/__tests__/traffic-row-budget.test.tsx
+++ b/src/ui/__tests__/traffic-row-budget.test.tsx
@@ -1,0 +1,165 @@
+// The Traffic page has to ASK FOR ENOUGH ROWS to show a route's functions.
+//
+// The defect this covers, measured against a live mesh carrying traffic on 42
+// agent pairs: the page rendered 40 rows across 40 distinct routes, not one of
+// them showing a second function, while the same endpoint at limit=100 returned
+// 87 rows over 42 routes — 19 of them multi-function and one with 8. Nothing was
+// wrong with the merge, the grouping or the rendering. The page asked for 20.
+//
+// WHY 20 BECAME WRONG WITHOUT ANYONE CHANGING IT. The server hands out a short
+// budget FAIRLY ACROSS PAIRS: every pair's busiest function, then every pair's
+// second, and so on. That is right for the topology graph, which wants coverage.
+// Against 40+ pairs a budget of 20 spends every slot on the first pass, so the
+// response is exactly one row per route by construction — the page becomes
+// structurally incapable of showing the per-function detail it exists for, and
+// it looks correct while doing it, because one row per route is precisely what
+// the page used to be.
+//
+// WHY THE EXISTING SUITE MISSED IT. The Go tests assert fairness ACROSS pairs
+// and the UI tests assert the merge and the grouping WITHIN a route, each with a
+// fixture smaller than the budget. Nobody asserted the one property that spans
+// the two: the number the page requests has to clear the number of routes it
+// expects back, or fairness flattens the result before any of that code runs.
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import type { EdgeStat, TrafficResponse } from "../lib/types";
+import { TRAFFIC_ROW_LIMIT } from "../lib/api";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// Shaped like the measured mesh: 42 routes, 19 of them carrying more than one
+// function, the busiest carrying 8.
+const ROUTE_COUNT = 42;
+const MULTI_FUNCTION_ROUTES = 19;
+const BUSIEST_ROUTE_FUNCTIONS = 8;
+
+function functionsOnRoute(route: number): number {
+  if (route === 0) return BUSIEST_ROUTE_FUNCTIONS;
+  return route < MULTI_FUNCTION_ROUTES ? 2 : 1;
+}
+
+function liveShapedResponse(): TrafficResponse {
+  const edge_stats: EdgeStat[] = [];
+  for (let route = 0; route < ROUTE_COUNT; route++) {
+    const id = String(route).padStart(2, "0");
+    for (let fn = 0; fn < functionsOnRoute(route); fn++) {
+      edge_stats.push({
+        source: `caller-${id}`,
+        target: `provider-${id}`,
+        target_function: `tool_${id}_${fn}`,
+        call_count: 100 - fn,
+        error_count: 0,
+        error_rate: 0,
+        avg_latency_ms: 5,
+        p99_latency_ms: 9,
+        max_latency_ms: 12,
+        min_latency_ms: 1,
+      });
+    }
+  }
+  return {
+    enabled: true,
+    window: "all",
+    total_calls: edge_stats.reduce((n, e) => n + e.call_count, 0),
+    total_errors: 0,
+    edge_stats,
+    agent_stats: [],
+    model_stats: [],
+  };
+}
+
+/** The `limit` the page put on the wire, as a number. */
+function requestedLimit(fetchMock: ReturnType<typeof vi.fn>): number {
+  expect(fetchMock).toHaveBeenCalled();
+  const url = String(fetchMock.mock.calls[0][0]);
+  const value = new URL(url, "http://localhost").searchParams.get("limit");
+  expect(value).not.toBeNull();
+  return Number(value);
+}
+
+async function renderTrafficPage(response: TrafficResponse) {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => response });
+  vi.stubGlobal("fetch", fetchMock);
+  const { default: TrafficPage } = await import("../app/traffic/page");
+  render(<TrafficPage />);
+  return fetchMock;
+}
+
+describe("the row budget the Traffic page requests", () => {
+  it("clears the number of routes, so a route can be served a second function", async () => {
+    const response = liveShapedResponse();
+    const fetchMock = await renderTrafficPage(response);
+    await waitFor(() => expect(screen.getByText("tool_00_0")).toBeInTheDocument());
+
+    const routes = new Set(response.edge_stats.map((e) => `${e.source}->${e.target}`));
+    expect(routes.size).toBe(ROUTE_COUNT);
+
+    // THE PROPERTY. Fair-across-pairs truncation spends its first `routes` slots
+    // on one row each, so anything at or below the route count comes back one
+    // row per route however many functions those routes have. A budget of 20
+    // against these 42 routes passes every other assertion in this suite and
+    // still puts a single function on screen per route.
+    expect(requestedLimit(fetchMock)).toBeGreaterThan(routes.size);
+  });
+
+  it("does not exceed the ceiling the endpoint clamps to, which would silently reduce it", () => {
+    // Asking for 500 and being served 100 is indistinguishable at the call site
+    // from asking for 100 — the request states an intent the response does not
+    // honour, and the next reader sizes the page against a number that never
+    // reached it. Parsed from the Go source rather than restated, so lowering
+    // the ceiling fails here instead of on a live mesh.
+    // __dirname, not import.meta.url: under the jsdom environment the module
+    // URL has an http scheme and readFileSync rejects it.
+    const handler = readFileSync(
+      path.resolve(__dirname, "..", "..", "core", "ui", "traffic_handler.go"),
+      "utf8"
+    );
+    const declared = handler.match(/trafficMaxLimit\s*=\s*(\d+)/);
+    expect(declared, "trafficMaxLimit is no longer a named constant in traffic_handler.go").not.toBeNull();
+
+    const ceiling = Number(declared![1]);
+    expect(TRAFFIC_ROW_LIMIT).toBeLessThanOrEqual(ceiling);
+    expect(TRAFFIC_ROW_LIMIT).toBe(ceiling);
+  });
+
+  it("is the number that actually goes on the wire", async () => {
+    const fetchMock = await renderTrafficPage(liveShapedResponse());
+    await waitFor(() => expect(screen.getByText("tool_00_0")).toBeInTheDocument());
+    expect(requestedLimit(fetchMock)).toBe(TRAFFIC_ROW_LIMIT);
+  });
+});
+
+describe("every row the server sends reaches the table", () => {
+  // The budget only matters if the page draws what it is given. A client-side
+  // cap on top of it would reintroduce the same symptom one layer up, and a cap
+  // sized like the old server budget would reintroduce it exactly.
+
+  it("renders all 8 functions of the busiest route, together", async () => {
+    await renderTrafficPage(liveShapedResponse());
+    await waitFor(() => expect(screen.getByText("tool_00_0")).toBeInTheDocument());
+
+    for (let fn = 0; fn < BUSIEST_ROUTE_FUNCTIONS; fn++) {
+      expect(screen.getByText(`tool_00_${fn}`)).toBeInTheDocument();
+    }
+    // One row per function of that one route, so its route name repeats.
+    expect(screen.getAllByText("caller-00")).toHaveLength(BUSIEST_ROUTE_FUNCTIONS);
+  });
+
+  it("draws a row for every stat, not a screenful of them", async () => {
+    const response = liveShapedResponse();
+    await renderTrafficPage(response);
+    await waitFor(() => expect(screen.getByText("tool_00_0")).toBeInTheDocument());
+
+    const table = screen.getByText("Route").closest("table");
+    expect(table).not.toBeNull();
+    // Header row plus one row per stat. More rows than routes is the point: the
+    // table is scrollable, and depth below the fold is still depth.
+    const rows = within(table!).getAllByRole("row");
+    expect(rows).toHaveLength(response.edge_stats.length + 1);
+    expect(response.edge_stats.length).toBeGreaterThan(ROUTE_COUNT);
+  });
+});

--- a/src/ui/app/traffic/page.tsx
+++ b/src/ui/app/traffic/page.tsx
@@ -11,7 +11,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Segmented } from "@/components/ui/segmented";
-import { formatBytes, formatTokenCount, getTraffic } from "@/lib/api";
+import { formatBytes, formatTokenCount, getTraffic, TRAFFIC_ROW_LIMIT } from "@/lib/api";
 import { compareEdgeStats, edgeRowKey } from "@/lib/edge-stats";
 import { AgentStat, EdgeStat, ModelStat, TrafficWindow } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -128,7 +128,10 @@ export default function TrafficPage() {
     const load = async (isInitial: boolean) => {
       if (!isInitial) setRefetching(true);
       try {
-        const data = await getTraffic(requestedWindow);
+        // The budget is passed rather than defaulted: it is a property of what
+        // THIS page renders (a route's functions together), and a reader of the
+        // fetch has to be able to see which one it gets — see TRAFFIC_ROW_LIMIT.
+        const data = await getTraffic(requestedWindow, TRAFFIC_ROW_LIMIT);
         if (cancelled || requestedWindow !== timeWindow) return;
 
         setEnabled(data.enabled);

--- a/src/ui/lib/api.ts
+++ b/src/ui/lib/api.ts
@@ -212,6 +212,25 @@ export async function getEdgeStats(limit: number = 20): Promise<EdgeStatsRespons
 }
 
 /**
+ * Rows the Traffic page asks /trace/traffic for.
+ *
+ * It is the endpoint's own ceiling (trafficMaxLimit in src/core/ui), picked so
+ * the request cannot be silently clamped to something smaller than it asked for,
+ * and so the page is never the reason a route's second function is missing.
+ *
+ * WHY NOT A SCREENFUL. The old 20 was chosen when one row meant one agent pair.
+ * Since #1531 a row is one (route, function), and the server hands the budget out
+ * fairly across pairs — every pair's busiest function before any pair's second.
+ * A budget at or below the pair count therefore resolves to exactly one row per
+ * route, so a 40-pair mesh rendered 40 single-function rows and the page could
+ * not show the per-function detail it exists for. The budget has to clear the
+ * pair count for a route's functions to appear together, not merely fill a
+ * viewport — this is a scrollable table, and rows below the fold are still
+ * reachable.
+ */
+export const TRAFFIC_ROW_LIMIT = 100;
+
+/**
  * Windowed traffic aggregates. `window=all` returns live all-time stats;
  * "1h"/"1d" return trailing-window aggregates. Element shapes match the
  * live EdgeStat/AgentStat/ModelStat, so the Traffic page reuses the same
@@ -219,7 +238,7 @@ export async function getEdgeStats(limit: number = 20): Promise<EdgeStatsRespons
  */
 export async function getTraffic(
   window: TrafficWindow,
-  limit: number = 20
+  limit: number = TRAFFIC_ROW_LIMIT
 ): Promise<TrafficResponse> {
   const res = await fetch(
     `${API_BASE}/trace/traffic?window=${window}&limit=${limit}`,


### PR DESCRIPTION
Both defects were found by running #1532's build against a live mesh — the verification that PR shipped without.

## The Traffic page could not show what the change was for

Against a live mesh with 42 agent pairs carrying traffic, the page rendered **40 rows across 40 distinct routes, with not one route showing a second function**. At that same moment the API held 87 rows over those pairs, 19 with several functions and one with eight.

Fair-across-pairs selection spends its first `pairs` slots on one row each, so a budget of 20 against 42 pairs resolves to exactly one row per route *by construction*. The Traffic page's entire purpose after #1532 is per-function detail, and it was structurally incapable of showing a route's second function.

The fairness rule is not wrong — it guarantees coverage on a mesh larger than the budget, which a ranked head does not. But 20 was chosen when a row meant a pair, and the graph has had its own larger budget since the blocker fix in #1532. The page now requests the endpoint's ceiling, the largest value that cannot be silently clamped.

**Nothing caught this because every fixture was smaller than the budget.** The Go tests asserted coverage across pairs; the UI tests asserted the merge and the grouping; none asserted that a route's functions can actually reach the table. That property is now covered on both sides against a live-shaped fixture, with the ceiling parsed out of the handler rather than restated — so lowering the Go cap fails in CI instead of on someone's dashboard.

Reverting the limit to 20 fails the new UI test with `expected 20 to be greater than 42`; capping the handler at 42 fails the new Go test with `the busiest route shows 1 functions, want 8`. The pre-existing suite passes in both cases.

## A second meshui could not read a live mesh without taking from the first

The Redis consumer group was hardcoded. Redis hands each stream entry to exactly one consumer *within a group*, so a second meshui pointed at a running mesh would have split the trace stream with that mesh's dashboard and `XAck`ed its half — halving what the live dashboard showed for as long as it ran. There was no way to verify anything against a real mesh without degrading it.

It is now `MCP_MESH_UI_TRACE_CONSUMER_GROUP`, defaulting to the existing value so behaviour is unchanged when unset (asserted, not eyeballed). Stream trimming needed no change — `MCP_MESH_TRACE_RETENTION=0` already disables it.

This is what made the verification possible. During the run our group reached lag 16575 while both production groups stayed at **lag 0**, and it was destroyed afterwards, leaving the stream as found.

**The registry has the same hardcoded group and the same hazard.** Not changed here — it deserves its own decision.

## What the live run confirmed about #1532

Worth recording, since the PR merged without it:

| | |
|---|---|
| resolutions missing `mcp_tool` | **0 of 232** — the join key is always present, as reasoned |
| rows with an empty `target_function` | **0 of 87** |
| pairs connected by more than one capability | **39 of 55** |
| widest latency spread hidden by the old pair-level average | **5340×** (`recommender→market-data`: blended 2541ms over functions spanning 3ms–16s) |

And on #1529's colouring: of 232 dependency edges, **58 were pink under the old caller-based rule** — every edge out of the one `api` agent — and are now ordinary green. Exactly **1** edge is genuinely a MeshJob. Pink now means one thing.

## Test plan

- [x] Both defects reproduced against a live mesh before fixing
- [x] New coverage fails when either budget is reverted; the pre-existing suite passes in both cases
- [x] Consumer-group default asserted unchanged when the variable is unset
- [x] Live environment left as found — our group destroyed, production groups at lag 0
- [x] `go build ./...`, `go test ./src/core/...` (10 packages), `npm test` (112), `tsc --noEmit`, `eslint`, gofmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the Redis consumer group used by MeshUI trace monitoring.
  - Increased the traffic table’s maximum row budget to 100, helping display more routes, functions, and edge statistics.

- **Bug Fixes**
  - Improved traffic data loading to consistently request and render the full table budget.

- **Documentation**
  - Documented the new trace consumer-group setting, its default value, and guidance for running multiple dashboards independently.
  - Clarified traffic selection limits and fairness considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->