### PR TITLE
fix: only let traffic heat repaint an edge when something is wrong

### DIFF
--- a/src/ui/__tests__/topology-edges.test.tsx
+++ b/src/ui/__tests__/topology-edges.test.tsx
@@ -9,14 +9,25 @@
 // The provider's matching capability decides `dep` colour; nothing reads the
 // consumer's type.
 //
-// The last block renders the legend. Everything before it compares modules and
-// builder output with each other, which is half the palette contract — the
-// half that cannot see a swatch written back to a literal colour.
+// The colours a person sees are the builder's output AFTER the traffic merge,
+// so one block asserts against that rather than against the builder (#1530),
+// and the last one renders the legend. The middle blocks compare modules and
+// builder output with each other, which is only part of the palette contract —
+// they cannot see a swatch written back to a literal colour, and they could not
+// see the merge painting over every stroke they had just checked.
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import type { Agent, Capability, DependencyResolution } from "../lib/types";
+import type { Edge } from "@xyflow/react";
+import type { Agent, Capability, DependencyResolution, EdgeStat } from "../lib/types";
 import { buildGraphFromAgents } from "../lib/topology";
-import { EDGE_COLORS, EDGE_HEAT_COLORS, EDGE_LEGEND } from "../lib/edge-palette";
+import { mergeEdgeStatsIntoEdges } from "../components/topology/TopologyGraph";
+import { extractAgentName, formatDuration } from "../lib/api";
+import {
+  EDGE_COLORS,
+  EDGE_HEAT_COLORS,
+  EDGE_HEAT_LEGEND,
+  EDGE_LEGEND,
+} from "../lib/edge-palette";
 import { EdgeLegend } from "../components/topology/EdgeLegend";
 
 function makeAgent(overrides: Partial<Agent> = {}): Agent {
@@ -501,26 +512,20 @@ describe("the legend and the builder cannot drift apart", () => {
     new Set(buildGraphFromAgents(everyBranch).edges.map((e) => e.style?.stroke as string));
 
   it("every colour the BUILDER emits has a legend row", () => {
-    // Scoped to the builder on purpose, and it is not the whole screen: the
-    // traffic-heat scale in TopologyGraph.tsx paints over these strokes, and
-    // one of its three values has no legend row and no way to acquire one from
-    // this palette. The next assertion states that rather than leaving this one
-    // to be read as a claim about what is rendered.
+    // Half the contract. The other half — every colour the MERGE emits, which
+    // is what a person actually looks at — is the block below, and was where
+    // `elevated` used to escape the key entirely (issue #1530).
     const legend = new Set<string>(EDGE_LEGEND.map((e) => EDGE_COLORS[e.key]));
     expect([...emitted()].filter((c) => !legend.has(c))).toEqual([]);
   });
 
-  it("the heat scale is outside the legend contract, deliberately and knowingly", () => {
-    // Heat is a second axis (see lib/edge-palette.ts) and is NOT expected to
-    // have rows. Pinned so that its absence stays a recorded decision rather
-    // than something the suite silently overlooks: `elevated` is a seventh
-    // colour a reader of the graph has no key for, which is a question about
-    // the override, tracked on its own.
-    const legend = new Set<string>(EDGE_LEGEND.map((e) => EDGE_COLORS[e.key]));
-    expect(legend.has(EDGE_HEAT_COLORS.elevated)).toBe(false);
-    // The other two collide with palette entries by taste, not by meaning, so
-    // no assertion is made about them either way.
-    expect(Object.values(EDGE_COLORS)).not.toContain(EDGE_HEAT_COLORS.elevated);
+  it("the two axes have no colour in common", () => {
+    // Not just separate modules: disjoint sets. A hex in both puts two rows in
+    // the key for one stroke, and a reader has no way to tell which of the two
+    // they are looking at — which is what `failing` and `unavailable` did until
+    // the heat scale moved off that red (see lib/edge-palette.ts).
+    const kinds = new Set<string>(Object.values(EDGE_COLORS));
+    expect(Object.values(EDGE_HEAT_COLORS).filter((c) => kinds.has(c))).toEqual([]);
   });
 
   it("every legend row names a colour the builder can emit", () => {
@@ -545,6 +550,242 @@ describe("the legend and the builder cannot drift apart", () => {
   });
 });
 
+// What the graph is actually STROKED with, which is the builder's output after
+// mergeEdgeStatsIntoEdges has had it (issue #1530).
+//
+// The builder's colours were never the last word: the merge repainted any edge
+// with a stat row, a zero error rate included, so on any mesh with tracing on
+// the kind palette was thrown away nearly everywhere — and the colour it was
+// replaced with, `clean`, said only "this one is fine", which was true of
+// nearly every edge. Now heat paints ONLY over an edge with errors, so both
+// axes are legible at once and the legend can cover both.
+//
+// These assertions are deliberately made against the merge rather than the
+// builder: the previous contract was scoped to the builder and passed happily
+// while `elevated` was on screen with nothing in the key to explain it.
+describe("the colours the merge actually puts on screen", () => {
+  /** Every edge kind, each carrying an mcp_tool so a stat row can join to it. */
+  const everyKindUnderTraffic: Agent[] = [
+    makeAgent({
+      id: "caller-11111111",
+      name: "caller",
+      dependency_resolutions: [
+        { ...dep("reports", "prov-22222222"), mcp_tool: "fn_reports" },
+        { ...dep("bulk_export", "prov-22222222"), mcp_tool: "fn_bulk_export" },
+        { ...dep("broken", "prov-22222222", "unavailable"), mcp_tool: "fn_broken" },
+        { ...dep("pending", "prov-22222222", "unresolved"), mcp_tool: "fn_pending" },
+      ],
+      llm_tool_resolutions: [
+        {
+          function_name: "plan",
+          filter_capability: "reports",
+          status: "available",
+          provider_agent_id: "prov-22222222",
+          mcp_tool: "fn_reports",
+        },
+      ],
+      llm_provider_resolutions: [
+        {
+          function_name: "plan",
+          required_capability: "llm",
+          status: "available",
+          provider_agent_id: "model-33333333",
+          mcp_tool: "fn_llm",
+        },
+      ],
+    }),
+    provider("prov-22222222", "prov", [
+      cap("reports"),
+      cap("bulk_export", true),
+      cap("broken"),
+      cap("pending"),
+    ]),
+    provider("model-33333333", "model", [cap("llm")]),
+  ];
+
+  const AVG_LATENCY_MS = 5;
+  /**
+   * Large enough that every rate below is a whole number of errors: at a
+   * hundred calls, 9.99% is not a count anything could have recorded, and
+   * `error_count` would have had to round to a figure disagreeing with
+   * `error_rate`. Nothing reads the count today — the merge weights the rate
+   * the row reports — but TopologyGraph.tsx keeps the option of deriving one
+   * from the other open, and a boundary fixture whose two fields describe
+   * different meshes would flip bands silently on the day it is taken.
+   */
+  const CALL_COUNT = 10_000;
+  /** Every band and both sides of the boundary, in percent. */
+  const RATES = [0, 0.5, 9.99, 10, 100];
+
+  /** One stat row per (base source, base target, function) an edge joins on. */
+  function rowsAt(errorRate: number, edges: Edge[]): EdgeStat[] {
+    const rows = new Map<string, EdgeStat>();
+    for (const edge of edges) {
+      for (const fn of (edge.data?.targetFunctions as string[]) ?? []) {
+        const source = extractAgentName(edge.source);
+        const target = extractAgentName(edge.target);
+        rows.set(`${source}|${target}|${fn}`, {
+          source,
+          target,
+          target_function: fn,
+          call_count: CALL_COUNT,
+          error_count: (CALL_COUNT * errorRate) / 100,
+          error_rate: errorRate,
+          avg_latency_ms: AVG_LATENCY_MS,
+          p99_latency_ms: 9,
+          max_latency_ms: 12,
+          min_latency_ms: 1,
+        });
+      }
+    }
+    return [...rows.values()];
+  }
+
+  /** Stroke by edge id, before and after the merge, at one error rate. */
+  function strokesAt(errorRate: number) {
+    const { edges } = buildGraphFromAgents(everyKindUnderTraffic);
+    const merged = mergeEdgeStatsIntoEdges(edges, rowsAt(errorRate, edges));
+    const byId = (list: Edge[]) =>
+      Object.fromEntries(list.map((e) => [e.id, e.style?.stroke as string]));
+    return { built: byId(edges), merged: byId(merged), builtEdges: edges, mergedEdges: merged };
+  }
+
+  /**
+   * The strokes HEAT put on the graph, and only those: each merged edge's
+   * stroke against the same edge's built stroke, keeping the ones that changed.
+   *
+   * Derived rather than read off the merged output, because the property being
+   * asserted is about what the merge paints and must not depend on which hexes
+   * the two palettes happen to hold. A union of every merged stroke lets an
+   * edge KIND stand in for a heat colour that shares its value — which is what
+   * made the reverse legend check below pass for `failing` while heat had
+   * painted nothing at all.
+   */
+  function heatStrokes(rates: number[]): Set<string> {
+    const painted = new Set<string>();
+    for (const rate of rates) {
+      const { built, merged } = strokesAt(rate);
+      for (const [id, stroke] of Object.entries(merged)) {
+        if (stroke !== built[id]) painted.add(stroke);
+      }
+    }
+    return painted;
+  }
+
+  it("every kind of edge in the fixture really does pick up its stat row", () => {
+    // Otherwise the tests below would pass by joining to nothing. Two tells,
+    // both written only for a matched edge: the latency appended to the label,
+    // asserted as the whole string rather than by looking for a digit in it,
+    // and a stroke width where the builder set none.
+    const { builtEdges, mergedEdges } = strokesAt(0);
+    expect(mergedEdges).toHaveLength(6);
+    mergedEdges.forEach((edge, i) => {
+      expect(String(edge.label)).toBe(
+        `${String(builtEdges[i].label)}  ${formatDuration(AVG_LATENCY_MS)}`
+      );
+      expect(builtEdges[i].style?.strokeWidth).toBeUndefined();
+      expect(edge.style?.strokeWidth).toBeGreaterThan(1);
+    });
+  });
+
+  it("an edge with no errors keeps the colour its KIND gave it", () => {
+    const { built, merged } = strokesAt(0);
+    // Every kind, by id, unchanged — not merely "some green survived".
+    expect(merged).toEqual(built);
+    expect(new Set(Object.values(merged))).toEqual(
+      new Set([
+        EDGE_COLORS.dependency,
+        EDGE_COLORS.job,
+        EDGE_COLORS.llmTool,
+        EDGE_COLORS.llmProvider,
+        EDGE_COLORS.unavailable,
+        EDGE_COLORS.unresolved,
+      ])
+    );
+  });
+
+  it("an edge with errors is repainted whatever kind it is", () => {
+    // Including the MeshJob edge, whose colour #1521 added and which the old
+    // merge meant a reader could never see under traffic — and which now, quite
+    // deliberately, still yields to an error.
+    const { built, merged } = strokesAt(50);
+    expect(new Set(Object.values(merged))).toEqual(new Set([EDGE_HEAT_COLORS.failing]));
+    expect(merged).not.toEqual(built);
+  });
+
+  it("bands on either side of the ten-percent boundary", () => {
+    // The unit is a percentage, 0-100, on both registry paths that emit it.
+    //
+    // Read off RATES rather than from its own literals, so that this is also
+    // the record of what the two legend checks below cover: they union over the
+    // same list, and a band dropped from it would leave them asserting less
+    // while still passing.
+    const strokeOf = (rate: number) => {
+      const { merged } = strokesAt(rate);
+      return merged["dep|caller-11111111|prov-22222222|reports"];
+    };
+    expect(RATES.map(strokeOf)).toEqual([
+      EDGE_COLORS.dependency, // 0 — no errors, so the kind colour stands
+      EDGE_HEAT_COLORS.elevated, // 0.5
+      EDGE_HEAT_COLORS.elevated, // 9.99, the last rate under the boundary
+      EDGE_HEAT_COLORS.failing, // 10, the boundary itself
+      EDGE_HEAT_COLORS.failing, // 100
+    ]);
+  });
+
+  it("a rate that reports nothing paints nothing", () => {
+    // Defensive: the field is required and both server paths populate it. What
+    // is being pinned is the DIRECTION of the failure — a rate that is negative
+    // or not a number at all must fall out as nothing to say, not through both
+    // band comparisons and into the colour reserved for the worst edges on the
+    // graph, which is where the natural way of writing the guard sends it.
+    for (const rate of [-1, Number.NaN]) {
+      const { built, merged } = strokesAt(rate);
+      expect(merged).toEqual(built);
+    }
+  });
+
+  it("every colour the MERGE can emit has a legend row", () => {
+    // The contract the old one was scoped short of. The union over the whole
+    // range of error rates is every stroke that can reach a person, and the
+    // union of the two legends is every colour the key explains. Every stroke
+    // is the right set in THIS direction: an unexplained colour is unexplained
+    // whichever axis put it there.
+    const key = new Set<string>([
+      ...EDGE_LEGEND.map((e) => EDGE_COLORS[e.key]),
+      ...EDGE_HEAT_LEGEND.map((e) => EDGE_HEAT_COLORS[e.key]),
+    ]);
+    const reachable = new Set<string>();
+    for (const rate of RATES) {
+      for (const stroke of Object.values(strokesAt(rate).merged)) reachable.add(stroke);
+    }
+    expect([...reachable].filter((c) => !key.has(c))).toEqual([]);
+  });
+
+  it("every heat row names a colour the merge actually paints", () => {
+    // The other direction, which is what caught the stale row in #1521, and the
+    // one that is easy to write vacuously: over every merged stroke, a heat row
+    // is satisfied by any edge KIND holding the same colour, with heat never
+    // having run. Over the strokes the merge CHANGED it says what it means —
+    // remove a branch from `getEdgeHeatColor` and this fails, whatever the two
+    // palettes contain.
+    //
+    // A row for the healthy case would fail here too: nothing repaints a clean
+    // edge any more, so no stroke it could name is ever one the merge changed.
+    // That is why `EDGE_HEAT_COLORS` no longer holds a value for it.
+    const painted = heatStrokes(RATES);
+    expect(
+      EDGE_HEAT_LEGEND.filter((e) => !painted.has(EDGE_HEAT_COLORS[e.key])).map((e) => e.label)
+    ).toEqual([]);
+  });
+
+  it("the heat legend shows every heat colour there is", () => {
+    expect(EDGE_HEAT_LEGEND.map((e) => e.key).sort()).toEqual(
+      Object.keys(EDGE_HEAT_COLORS).sort()
+    );
+  });
+});
+
 // Everything above this line is data: two modules and a builder, compared with
 // each other. None of it renders anything, so none of it can see the half of
 // the contract that reaches a person — the swatches. Restating a colour there
@@ -558,6 +799,9 @@ describe("the legend a person actually sees", () => {
   };
 
   const swatchFor = (key: string) => screen.getByTestId(`edge-legend-swatch-${key}`);
+  // A separate id space, because the two key sets are unrelated and could one
+  // day hold the same word — see the note on the element itself.
+  const heatSwatchFor = (key: string) => screen.getByTestId(`edge-legend-heat-swatch-${key}`);
 
   it("renders one row per legend entry, labels and all", () => {
     render(<EdgeLegend />);
@@ -576,6 +820,27 @@ describe("the legend a person actually sees", () => {
         : swatch.style.backgroundColor;
       expect(painted).toBe(asRendered(EDGE_COLORS[entry.key]));
     }
+  });
+
+  it("renders the heat rows too, in the heat colours", () => {
+    // `elevated` was a colour on screen with no row at all (issue #1530): a
+    // reader saw it and the key could not tell them what it was.
+    render(<EdgeLegend />);
+    for (const entry of EDGE_HEAT_LEGEND) {
+      expect(screen.getByText(entry.label)).toBeInTheDocument();
+      expect(heatSwatchFor(entry.key).style.backgroundColor).toBe(
+        asRendered(EDGE_HEAT_COLORS[entry.key])
+      );
+    }
+  });
+
+  it("says that an error colour supersedes the kind rows", () => {
+    // The two groups are disjoint colours, so the caption is not there to break
+    // a tie — it is there because an erroring edge shows nothing of its kind,
+    // and without saying so the key reads as six rows describing every edge on
+    // screen when in fact any of them can be missing.
+    render(<EdgeLegend />);
+    expect(screen.getByText(/overrides/i)).toBeInTheDocument();
   });
 
   it("carries no colour of its own — every swatch reads it from the palette", () => {
@@ -600,6 +865,9 @@ describe("the legend a person actually sees", () => {
       // Empty means the colour arrived some other way — a literal class, most
       // likely — and the assertion above it would then be comparing nothing.
       expect(painted).not.toBe("");
+    }
+    for (const entry of EDGE_HEAT_LEGEND) {
+      expect(heatSwatchFor(entry.key).style.backgroundColor).not.toBe("");
     }
   });
 });

--- a/src/ui/__tests__/traffic-per-function.test.tsx
+++ b/src/ui/__tests__/traffic-per-function.test.tsx
@@ -108,7 +108,11 @@ describe("the graph joins a stat to the edge that produced it", () => {
       makeStat({ source: "caller", target: "prov", target_function: "broken_tool", error_rate: 100, error_count: 10 }),
     ]);
 
-    expect(merged[0].style?.stroke).toBe(EDGE_HEAT_COLORS.clean);
+    // The healthy one keeps its KIND colour rather than being repainted green
+    // (issue #1530) — heat speaks only when there is an error to report. What
+    // this test is really pinning is still the isolation: the broken sibling's
+    // 100% did not reach it.
+    expect(merged[0].style?.stroke).toBe(EDGE_COLORS.dependency);
     expect(merged[1].style?.stroke).toBe(EDGE_HEAT_COLORS.failing);
   });
 
@@ -243,8 +247,9 @@ describe("one edge standing for several provider functions", () => {
     expect(String(merged[0].label)).toContain("109");
     expect(String(merged[0].label)).not.toContain("505");
 
-    // 5 errors in 100 calls is 5%, which is elevated — neither the clean edge
-    // the fast tool alone would paint nor the failing one the slow tool would.
+    // 5 errors in 100 calls is 5%, which is elevated — neither the untouched
+    // stroke the fast tool alone would leave nor the failing one the slow tool
+    // would paint.
     expect(merged[0].style?.stroke).toBe(EDGE_HEAT_COLORS.elevated);
   });
 
@@ -357,7 +362,9 @@ describe("replica grouping still lines the two sides up", () => {
       makeStat({ source: "caller", target: "prov", target_function: "run_report", avg_latency_ms: 42 }),
     ]);
     expect(String(merged[0].label)).toMatch(/42/);
-    expect(merged[0].style?.stroke).toBe(EDGE_HEAT_COLORS.clean);
+    // Matched, and error-free, so the latency reached the label while the kind
+    // colour stayed put.
+    expect(merged[0].style?.stroke).toBe(EDGE_COLORS.dependency);
   });
 });
 

--- a/src/ui/components/topology/EdgeLegend.tsx
+++ b/src/ui/components/topology/EdgeLegend.tsx
@@ -1,4 +1,4 @@
-import { EDGE_COLORS, EDGE_LEGEND } from "@/lib/edge-palette";
+import { EDGE_COLORS, EDGE_HEAT_COLORS, EDGE_HEAT_LEGEND, EDGE_LEGEND } from "@/lib/edge-palette";
 
 /**
  * The topology's edge key, rendered from lib/edge-palette.ts — the same module
@@ -15,6 +15,11 @@ import { EDGE_COLORS, EDGE_LEGEND } from "@/lib/edge-palette";
  * arbitrary-value class is a literal string the stylesheet generator has to
  * find by scanning source text, so a value read from a module could never
  * produce one.
+ *
+ * The second group is the traffic-heat scale, which reaches the screen only on
+ * an edge that is erroring (issue #1530) and therefore needs saying: it is the
+ * one case where a stroke means something other than what the rows above claim.
+ * Before this, an edge could be drawn in a colour the key did not contain.
  */
 export function EdgeLegend() {
   return (
@@ -39,6 +44,27 @@ export function EdgeLegend() {
             <span className="text-[10px] text-muted-foreground">{entry.label}</span>
           </div>
         ))}
+      </div>
+      <div className="mt-2 pt-2 border-t border-border">
+        <p className="text-[10px] font-medium text-muted-foreground mb-1.5 uppercase tracking-wider">Errors</p>
+        <div className="space-y-1">
+          {EDGE_HEAT_LEGEND.map((entry) => (
+            <div key={entry.key} className="flex items-center gap-2">
+              <div
+                // Its own test-id space. The two loops run over unrelated sets
+                // of keys, and nothing stops the same word appearing in both —
+                // an `unavailable` heat band is an entirely plausible addition
+                // — at which point a shared prefix would give two elements the
+                // same id and break whichever tests happened to look one up.
+                data-testid={`edge-legend-heat-swatch-${entry.key}`}
+                className="w-5 h-0.5 rounded"
+                style={{ backgroundColor: EDGE_HEAT_COLORS[entry.key] }}
+              />
+              <span className="text-[10px] text-muted-foreground">{entry.label}</span>
+            </div>
+          ))}
+        </div>
+        <p className="mt-2 text-[10px] text-muted-foreground">Overrides the edge colour above.</p>
       </div>
     </div>
   );

--- a/src/ui/components/topology/TopologyGraph.tsx
+++ b/src/ui/components/topology/TopologyGraph.tsx
@@ -71,10 +71,28 @@ function getForwardNeighborIds(
 }
 
 // Traffic heat, NOT edge kind. The scale is its own axis and its own constant
-// (lib/edge-palette.ts) for the reasons written there; two of its three values
-// coinciding with palette entries is not a duplication to collapse.
-function getEdgeHeatColor(errorRate: number): string {
-  if (errorRate === 0) return EDGE_HEAT_COLORS.clean;
+// (lib/edge-palette.ts) for the reasons written there, and it shares no value
+// with the kind palette — a stroke from here can never be read as a kind.
+//
+// `null` MEANS SAY NOTHING, and an edge with no errors gets it (issue #1530).
+// The caller then leaves that edge's kind stroke alone, because "this one is
+// fine" is true of nearly every edge on a healthy mesh and is not worth the
+// only channel that can say what an edge is. Errors do take the channel: at
+// that point the error is the more urgent of the two facts.
+function getEdgeHeatColor(errorRate: number): string | null {
+  // Negated rather than `<= 0` so that zero, a negative and a rate that is not
+  // a number at all all come out as nothing to say. Written the other way
+  // round, a non-finite value fails both comparisons below and leaves with the
+  // loudest colour on the scale — the one outcome a rate reporting nothing
+  // must not produce. The field is required and both server paths populate it,
+  // so this is a guard rather than a case that is expected to arise.
+  if (!(errorRate > 0)) return null;
+  // THE UNIT IS A PERCENTAGE, 0-100. Both registry paths that emit this field
+  // multiply the ratio by 100 before sending it (tracing/manager.go,
+  // tracing/accumulator.go), and the Traffic table prints it with a % sign
+  // against this same boundary. Were it a fraction instead, every real rate
+  // would land under 10 and `failing` would be unreachable — so the unit, not
+  // the number, is what makes both bands appear.
   if (errorRate < 10) return EDGE_HEAT_COLORS.elevated;
   return EDGE_HEAT_COLORS.failing;
 }
@@ -197,12 +215,19 @@ export function mergeEdgeStatsIntoEdges(edges: Edge[], edgeStats: EdgeStat[]): E
     const baseLabel = (edge.data?.originalLabel as string) || edge.label || "";
     const mergedLabel = baseLabel ? `${baseLabel}  ${formatDuration(stat.avgLatencyMs)}` : `${formatDuration(stat.avgLatencyMs)}`;
 
+    // Only an erroring edge is repainted; a clean one keeps the stroke the
+    // builder gave it and is still marked as carrying traffic by the two
+    // channels that do not collide with kind — the latency in its label and its
+    // width. Spreading `edge.style` first is what preserves the kind colour, so
+    // do not lift `stroke` out of the conditional.
+    const heat = getEdgeHeatColor(stat.errorRate);
+
     return {
       ...edge,
       label: mergedLabel,
       style: {
         ...edge.style,
-        stroke: getEdgeHeatColor(stat.errorRate),
+        ...(heat === null ? {} : { stroke: heat }),
         // Relative to the busiest EDGE now, not the busiest pair, which is
         // the same change of denominator the rest of this merge makes.
         strokeWidth: computeStrokeWidth(stat.callCount, maxCallCount),

--- a/src/ui/lib/edge-palette.ts
+++ b/src/ui/lib/edge-palette.ts
@@ -5,7 +5,9 @@
 // longer emitted (issue #1521).
 //
 // The traffic-heat scale at the foot of this file is a second, deliberately
-// separate axis. Read its note before merging anything into `EDGE_COLORS`.
+// separate axis. Read its note before merging anything into `EDGE_COLORS`. It
+// now paints only over an edge with errors, so both palettes reach the screen
+// at once and both are in the legend (issue #1530).
 //
 // The legend swatches read these values as INLINE STYLES. That is not a
 // stylistic choice: the swatches were arbitrary-value classes, which are literal
@@ -62,29 +64,71 @@ export const EDGE_LEGEND: EdgeLegendEntry[] = [
 
 /**
  * The traffic-heat scale. A SEPARATE AXIS from `EDGE_COLORS`, kept apart on
- * purpose — do not fold the two together on the grounds that they share two
- * values.
+ * purpose — do not fold the two together, and do not reach for a value from one
+ * while writing the other.
  *
  * `EDGE_COLORS` answers WHAT AN EDGE IS, which is a fact about the topology and
  * changes when the mesh is rewired. These answer HOW IT IS GOING, which is a
  * fact about the last window of calls and changes while nothing is rewired at
- * all. That `clean` and `failing` happen to hold the same two hexes as
- * `dependency` and `unavailable` is a coincidence of taste, not a shared
- * meaning: if the dependency stroke were ever restyled, a healthy edge under
- * traffic should not move with it, and a single constant would drag it along.
+ * all.
  *
- * These have no legend row — `elevated` in particular is a colour the legend
- * cannot explain — because they are painted OVER the palette above by
- * `mergeEdgeStatsIntoEdges` in components/topology/TopologyGraph.tsx. That the
- * heat scale overrides edge kind at all is a known and separate question; the
- * legend contract asserted in `__tests__/topology-edges.test.tsx` is therefore
- * scoped to the builder, and says so.
+ * NO VALUE HERE SHARES A HEX WITH `EDGE_COLORS`, and that is a requirement now
+ * rather than an accident. `failing` held the same red as `unavailable` until
+ * both axes started appearing in the key together, at which point a reader
+ * looking at a red edge had two rows and no way to choose between them — and a
+ * caption saying which one wins settles precedence, not identity. So heat has a
+ * ramp of its own, amber then a warmer step, in a hue no edge kind occupies,
+ * and red is left meaning exactly one thing.
+ *
+ * That ramp also orders the two axes the way you want them read. An edge whose
+ * provider is unavailable is in worse shape than one still succeeding nine
+ * times in ten, so the unavailable stroke outranking the failing one is the
+ * correct reading rather than a compromise the palette forced.
+ *
+ * ONLY ERRORS PAINT (issue #1530). `mergeEdgeStatsIntoEdges` in
+ * components/topology/TopologyGraph.tsx used to repaint every edge that carried
+ * any traffic at all, a zero error rate included — so wherever tracing is on,
+ * the palette above was thrown away almost everywhere in order to report a
+ * state almost every edge is in. One measured mesh ran 2,495 calls with 1 error
+ * across 326 edges, every one of them sampled at 0.000. An edge with no errors
+ * now keeps its kind stroke, and only an edge with errors takes a colour from
+ * here, because at that point the error is the more urgent fact.
+ *
+ * So both values below are reachable on screen, and both have a legend row.
+ * `__tests__/topology-edges.test.tsx` asserts that against the MERGED strokes
+ * rather than against the builder alone, and in the direction that matters here
+ * — is this row a colour anything paints? — against only the strokes the merge
+ * CHANGED, so no row can be satisfied by an edge kind that happens to match.
+ *
+ * There is deliberately no third value for the healthy case. It had one, and it
+ * lost its last consumer the moment a clean edge stopped being repainted;
+ * keeping it would have left a green nothing draws and a legend row saying so.
  */
 export const EDGE_HEAT_COLORS = {
-  /** No errors observed on this edge. */
-  clean: "#22c55e",
   /** Errors, but under the threshold that counts as failing. */
   elevated: "#eab308",
-  /** Failing often enough to be the first thing you should look at. */
-  failing: "#ef4444",
+  /**
+   * Failing often enough to be the first thing you should look at — but still
+   * a step below `unavailable`, which is why it is not that red.
+   */
+  failing: "#f97316",
 } as const;
+
+export type EdgeHeatKey = keyof typeof EDGE_HEAT_COLORS;
+
+/**
+ * The heat rows of the legend, in render order. The same two-way contract
+ * `EDGE_LEGEND` carries, over this axis: every colour HEAT can put on screen is
+ * named here, and every row here is a colour heat actually paints. The second
+ * direction is checked against the strokes the merge CHANGED rather than every
+ * stroke it emits — a row that named a colour only some edge kind draws would
+ * otherwise pass while heat never painted it at all.
+ *
+ * The boundary in the labels is the one `getEdgeHeatColor` applies, and it is a
+ * PERCENTAGE of an edge's calls — see the note on that function for why the
+ * unit is the load-bearing part.
+ */
+export const EDGE_HEAT_LEGEND: { key: EdgeHeatKey; label: string }[] = [
+  { key: "elevated", label: "Errors under 10%" },
+  { key: "failing", label: "Errors 10% or more" },
+];


### PR DESCRIPTION
## Summary

Traffic heat replaced every edge's stroke for **any** edge carrying stats — including a zero error rate, which mapped to a green "clean". On a real mesh that erased the palette #1529 settled.

Measured against wisefolio while verifying #1532: **2,495 calls, 1 error**, across 232 dependency edges, 75 LLM tool edges and 19 LLM provider edges. Every edge sampled read `error_rate 0.000`. So the override was discarding what each edge *is* in order to communicate something true of nearly all of them, while the single edge actually worth attention got no distinct treatment at all.

**A clean edge now keeps its kind colour. An erroring edge is still repainted**, because at that point the error is the more urgent fact. The latency label and volume-driven stroke width are separate channels and are untouched.

This is a fourth option, not one of the three the issue listed — it needs no toggle and no new visual channel, which is what those were reaching for.

## Both bands are real, and that needed checking

`error_rate` is a percentage in 0–100 — both producers compute `100.0 * errors / calls` (`manager.go:815`, `accumulator.go:509`) — so the boundary at 10 means what it reads as, and both bands fire. Had it been a fraction, `failing` would have been the unreachable band instead. The unit is now pinned in a comment at the function that depends on it.

Both bands gain legend rows. Neither had one, so `elevated` was a colour on screen with nothing in the key explaining it.

## The failing band moves off `#ef4444`

Sharing the hex with the `unavailable` kind put the same red in the legend twice under contradictory labels — "Unavailable — or LLM unresolved" and "Errors 10% or more" — so a red edge could not be read off the key. That fails this change's own goal.

Amber → orange also encodes the right severity order: an edge whose dependency is *unavailable* is in worse shape than one succeeding 90% of the time, so red outranking orange is correct rather than a compromise.

Worth knowing: the orange is the `--accent` token's hue, and Tailwind's orange badges the Java runtime chip inside the graph. That's the same relationship green, amber and red already have with the healthy dot, the Python chip and the unhealthy border — node chips and edge strokes are different shapes in different places. Flagged rather than buried, since resolving it from the other side would mean editing `globals.css`, which both bundles import.

## The assertion that should have caught this

The "every legend row is reachable" check unioned every merged stroke — and the `unavailable` edge's own **kind** colour put that red into the set before heat painted anything. Both hex collisions made rows look reachable that heat never produced, so:

- restoring a healthy heat row would have passed, though a comment claimed it "would fail here";
- deleting the `failing` branch entirely would have passed.

It now derives the reachable set by diffing each merged edge's stroke against **that same edge's** built stroke and keeping only what changed — so it holds whatever hexes the two palettes use. Verified by reverting the hex: the assertion still passes (it no longer depends on uniqueness) and the new disjointness guard trips instead, which is the correct division of labour.

Three comments claimed that assertion caught regressions it could not. Fixed by strengthening the assertion, not by softening the words.

## Also

- A non-finite `error_rate` fell through both guards to the loudest colour; `!(errorRate > 0)` now covers zero, negative and NaN together.
- Heat swatches get their own test-id space — both loops were emitting into one, and `unavailable` is a plausible future heat key.
- The boundary fixture's `error_count` and `error_rate` disagreed at 9.99; the counts are now exact, since the code contemplates deriving the rate from them.

## Numbers

| | before | after |
|---|---|---|
| dashboard CSS | 77,284 B | **77,284 B** (same content hash) |
| demo CSS | 98,799 B | **98,799 B** |
| demo JS | 193,813 B | **193,813 B** |
| dashboard JS | 724,820 B | 724,824 B (+4, accounted) |

`go build ./...`, `npm test` (122), `tsc --noEmit`, `eslint`, `make docs-scroll-build`, `mkdocs build` all clean. Demo fixtures untouched.

Closes #1530

## Test plan

- [x] Each kind keeps its colour at rate 0; all kinds overridden at 50
- [x] Boundary at 0 / 0.5 / 9.99 / 10 / 100, plus negative and NaN
- [x] Reverse legend assertion made hex-independent; verified it survives reverting the hex and fails on removing the band
- [x] Disjointness guard trips when the two palettes share a colour
- [x] Legend renders both groups with the override caption

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Errors** legend to topology views, showing error-rate thresholds and clarifying when error colors override structural edge colors.
  * Improved topology edge coloring to preserve dependency colors for error-free traffic while highlighting elevated and failing error rates.
  * Updated failing-error visualization to use orange for clearer distinction from structural colors.

* **Bug Fixes**
  * Corrected handling of zero, invalid, and unavailable error-rate values so they no longer receive misleading heat colors.
  * Improved consistency between rendered edge colors, palettes, and legends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->