### PR TITLE
feat: make health_check a routing answer, not a health taxonomy

### DIFF
--- a/api/mcp-mesh-agent.openapi.yaml
+++ b/api/mcp-mesh-agent.openapi.yaml
@@ -359,19 +359,27 @@ components:
           type: string
           enum: [healthy, degraded, unhealthy, unknown, starting]
           description: |
-            The health check's verdict. A check ANSWERS with `healthy` or
-            `unhealthy` — the routing contract is binary, and only `unhealthy`
-            withdraws the agent from dependency resolution. The other three are
-            assigned by the runtime and appear here only: `starting` is the
-            placeholder served before the first refresh has run; `unknown` is
-            what a dict carrying an unrecognized status STRING is recorded as;
-            an unrecognized return TYPE, and a check that raised, are recorded
-            as `degraded` instead, so a coding defect in the check cannot
-            withdraw an agent whose upstream is fine. `unknown` is Python-only:
-            TypeScript and Java have no such verdict (both map an unreadable
-            status to `degraded`), so a consumer of this shared schema must
-            accept it but will only ever see it from a Python agent. Only
-            `healthy` answers 200.
+            What is OBSERVABLE here, which is wider than what a check answers.
+
+            A check answers `healthy` or `unhealthy` — the routing contract is
+            binary, and only `unhealthy` withdraws the agent from dependency
+            resolution.
+
+            The other three report the runtime's own state and are not a third
+            routing answer; everything that is not `unhealthy` stays in
+            resolution. `starting` is the placeholder served before the first
+            refresh has run. `degraded` is where the runtime records a verdict
+            it could not trust — a check that raised, or returned an unusable
+            type — so a coding defect in the check cannot withdraw an agent
+            whose upstream is fine; a check may also still RETURN it, which is
+            deprecated (issue #1515), warns once, and routes exactly like
+            `healthy` until it is removed no earlier than 4.0. `unknown` is
+            Python-only: it is what a dict carrying a status Python could not
+            read is recorded as, where TypeScript and Java use `degraded`, so a
+            consumer of this shared schema must accept it but will only ever
+            see it from a Python agent.
+
+            Only `healthy` answers 200.
         agent:
           type: string
           example: "hello-world"

--- a/api/mcp-mesh-agent.openapi.yaml
+++ b/api/mcp-mesh-agent.openapi.yaml
@@ -359,10 +359,19 @@ components:
           type: string
           enum: [healthy, degraded, unhealthy, unknown, starting]
           description: |
-            The health check's verdict. `starting` is the placeholder served
-            before the first refresh has run; `unknown` is what a check that
-            returned an unrecognized type is recorded as. Only `healthy` answers
-            200.
+            The health check's verdict. A check ANSWERS with `healthy` or
+            `unhealthy` — the routing contract is binary, and only `unhealthy`
+            withdraws the agent from dependency resolution. The other three are
+            assigned by the runtime and appear here only: `starting` is the
+            placeholder served before the first refresh has run; `unknown` is
+            what a dict carrying an unrecognized status STRING is recorded as;
+            an unrecognized return TYPE, and a check that raised, are recorded
+            as `degraded` instead, so a coding defect in the check cannot
+            withdraw an agent whose upstream is fine. `unknown` is Python-only:
+            TypeScript and Java have no such verdict (both map an unreadable
+            status to `degraded`), so a consumer of this shared schema must
+            accept it but will only ever see it from a Python agent. Only
+            `healthy` answers 200.
         agent:
           type: string
           example: "hello-world"

--- a/cmd/meshctl/templates/java/a2a-consumer/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/a2a-consumer/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -77,10 +77,10 @@ public class {{ .NamePascal }}Application {
     // JVM and a fresh Spring context.
     //
     // They also disagree about exceptions, deliberately. A health check that
-    // throws is recorded as DEGRADED and keeps heartbeating - a buggy probe
-    // must not withdraw a working bridge from a mesh that may have no other
-    // one. A startup check that throws FAILS: at boot an indeterminate answer
-    // is not a reason to admit a possibly-misconfigured agent.
+    // throws keeps heartbeating - a buggy probe must not withdraw a working
+    // bridge from a mesh that may have no other one. A startup check that throws
+    // FAILS: at boot an indeterminate answer is not a reason to admit a
+    // possibly-misconfigured agent.
 
     /** Can this bridge serve right now? */
     @MeshHealthCheck(ttlSeconds = 30)

--- a/cmd/meshctl/templates/java/api/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/api/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -82,10 +82,9 @@ public class {{ .NamePascal }}Application {
     // a fresh JVM and a fresh Spring context.
     //
     // They also disagree about exceptions, deliberately. A health check that
-    // throws is recorded as DEGRADED and keeps heartbeating - a buggy probe
-    // must not withdraw a working gateway. A startup check that throws FAILS:
-    // at boot an indeterminate answer is not a reason to admit a
-    // possibly-misconfigured agent.
+    // throws keeps heartbeating - a buggy probe must not withdraw a working
+    // gateway. A startup check that throws FAILS: at boot an indeterminate
+    // answer is not a reason to admit a possibly-misconfigured agent.
 
     /** Can this gateway serve right now? */
     @MeshHealthCheck(ttlSeconds = 30)

--- a/cmd/meshctl/templates/java/basic/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/basic/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -73,10 +73,10 @@ public class {{ .NamePascal }}Application {
     // fresh Spring context.
     //
     // They also disagree about exceptions, deliberately. A health check that
-    // throws is recorded as DEGRADED and keeps heartbeating - a buggy probe
-    // must not withdraw a working agent from a mesh that may have no other
-    // one. A startup check that throws FAILS: at boot an indeterminate answer
-    // is not a reason to admit a possibly-misconfigured agent.
+    // throws keeps heartbeating - a buggy probe must not withdraw a working
+    // agent from a mesh that may have no other one. A startup check that throws
+    // FAILS: at boot an indeterminate answer is not a reason to admit a
+    // possibly-misconfigured agent.
 
     /** Can this agent serve right now? */
     @MeshHealthCheck(ttlSeconds = 30)

--- a/cmd/meshctl/templates/java/llm-agent/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -74,10 +74,10 @@ public class {{ .NamePascal }}Application {
     // fresh Spring context.
     //
     // They also disagree about exceptions, deliberately. A health check that
-    // throws is recorded as DEGRADED and keeps heartbeating - a buggy probe
-    // must not withdraw a working agent from a mesh that may have no other
-    // one. A startup check that throws FAILS: at boot an indeterminate answer
-    // is not a reason to admit a possibly-misconfigured agent.
+    // throws keeps heartbeating - a buggy probe must not withdraw a working
+    // agent from a mesh that may have no other one. A startup check that throws
+    // FAILS: at boot an indeterminate answer is not a reason to admit a
+    // possibly-misconfigured agent.
     //
     // Neither one belongs on the LLM provider this agent resolves through. The
     // provider holds the vendor credential and probes the vendor itself; this

--- a/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -99,10 +99,10 @@ public class {{ .NamePascal }}Application {
     // configuration is wrong", which is the signal this hook exists to produce.
     //
     // They also disagree about exceptions, deliberately. A health check that
-    // throws is recorded as DEGRADED and keeps heartbeating — a buggy probe
-    // must not withdraw a working provider from a mesh that may have no other
-    // one. A startup check that throws FAILS: at boot an indeterminate answer
-    // is not a reason to admit a possibly-misconfigured agent.
+    // throws keeps heartbeating — a buggy probe must not withdraw a working
+    // provider from a mesh that may have no other one. A startup check that throws
+    // FAILS: at boot an indeterminate answer is not a reason to admit a
+    // possibly-misconfigured agent.
 {{ if eq $probeVendor "anthropic" }}
     private static final HttpClient HTTP = HttpClient.newBuilder()
         .connectTimeout(Duration.ofSeconds(5))
@@ -149,21 +149,21 @@ public class {{ .NamePascal }}Application {
                     .withError("Anthropic API key is invalid");
             }
             // The vendor answered and it is not serving. Unhealthy: this is the
-            // outage the mesh has to route around, and DEGRADED would keep
-            // heartbeating and keep consumers pointed here.
+            // outage the mesh has to route around, and anything else keeps
+            // heartbeating and keeps consumers pointed here.
             return health
                 .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
                 .withCheck("anthropic_api_reachable", false)
                 .withError("Anthropic API returned status: " + status);
         } catch (InterruptedException e) {
-            // Degraded, deliberately: the probe was cut short, which says
-            // nothing about the vendor. Withdrawing on an indeterminate
-            // result would take the agent out on shutdown or thread interrupt.
+            // Indeterminate, deliberately: the probe was cut short, which says
+            // nothing about the vendor. Restore the interrupt and rethrow -
+            // the runtime keeps the agent in dependency resolution for a check
+            // that threw, so an answer here is one this probe never reached.
+            // Withdrawing on it would take the agent out on shutdown or thread
+            // interrupt.
             Thread.currentThread().interrupt();
-            return health
-                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
-                .withCheck("anthropic_api_reachable", false)
-                .withError("Anthropic API probe interrupted");
+            throw new IllegalStateException("Anthropic API probe interrupted", e);
         } catch (Exception e) {
             // The vendor is not answering at all (DNS, connect, timeout, TLS).
             return health
@@ -215,21 +215,21 @@ public class {{ .NamePascal }}Application {
                     .withError("OpenAI API key is invalid");
             }
             // The vendor answered and it is not serving. Unhealthy: this is the
-            // outage the mesh has to route around, and DEGRADED would keep
-            // heartbeating and keep consumers pointed here.
+            // outage the mesh has to route around, and anything else keeps
+            // heartbeating and keeps consumers pointed here.
             return health
                 .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
                 .withCheck("openai_api_reachable", false)
                 .withError("OpenAI API returned status: " + status);
         } catch (InterruptedException e) {
-            // Degraded, deliberately: the probe was cut short, which says
-            // nothing about the vendor. Withdrawing on an indeterminate
-            // result would take the agent out on shutdown or thread interrupt.
+            // Indeterminate, deliberately: the probe was cut short, which says
+            // nothing about the vendor. Restore the interrupt and rethrow -
+            // the runtime keeps the agent in dependency resolution for a check
+            // that threw, so an answer here is one this probe never reached.
+            // Withdrawing on it would take the agent out on shutdown or thread
+            // interrupt.
             Thread.currentThread().interrupt();
-            return health
-                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
-                .withCheck("openai_api_reachable", false)
-                .withError("OpenAI API probe interrupted");
+            throw new IllegalStateException("OpenAI API probe interrupted", e);
         } catch (Exception e) {
             // The vendor is not answering at all (DNS, connect, timeout, TLS).
             return health
@@ -283,21 +283,21 @@ public class {{ .NamePascal }}Application {
                     .withError("Google API key is invalid");
             }
             // The vendor answered and it is not serving. Unhealthy: this is the
-            // outage the mesh has to route around, and DEGRADED would keep
-            // heartbeating and keep consumers pointed here.
+            // outage the mesh has to route around, and anything else keeps
+            // heartbeating and keeps consumers pointed here.
             return health
                 .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
                 .withCheck("gemini_api_reachable", false)
                 .withError("Gemini API returned status: " + status);
         } catch (InterruptedException e) {
-            // Degraded, deliberately: the probe was cut short, which says
-            // nothing about the vendor. Withdrawing on an indeterminate
-            // result would take the agent out on shutdown or thread interrupt.
+            // Indeterminate, deliberately: the probe was cut short, which says
+            // nothing about the vendor. Restore the interrupt and rethrow -
+            // the runtime keeps the agent in dependency resolution for a check
+            // that threw, so an answer here is one this probe never reached.
+            // Withdrawing on it would take the agent out on shutdown or thread
+            // interrupt.
             Thread.currentThread().interrupt();
-            return health
-                .withStatus(io.mcpmesh.MeshHealthStatus.DEGRADED)
-                .withCheck("gemini_api_reachable", false)
-                .withError("Gemini API probe interrupted");
+            throw new IllegalStateException("Gemini API probe interrupted", e);
         } catch (Exception e) {
             // The vendor is not answering at all (DNS, connect, timeout, TLS).
             return health

--- a/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/src/main/java/{{ .JavaPackagePath }}/{{ .NamePascal }}Application.java.tmpl
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
      (providerTagsByFamily) so the three language templates cannot drift. */}}
 {{- if $probeVendor }}
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -148,12 +149,12 @@ public class {{ .NamePascal }}Application {
                     .withCheck("anthropic_api_key_valid", false)
                     .withError("Anthropic API key is invalid");
             }
-            // The vendor answered and it is not serving. Unhealthy: this is the
-            // outage the mesh has to route around, and anything else keeps
-            // heartbeating and keeps consumers pointed here.
+            // The vendor ANSWERED, so it is reachable - it is just not serving.
+            // Unhealthy: this is the outage the mesh has to route around, and
+            // anything else keeps heartbeating and keeps consumers pointed here.
             return health
                 .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
-                .withCheck("anthropic_api_reachable", false)
+                .withCheck("anthropic_api_reachable", true)
                 .withError("Anthropic API returned status: " + status);
         } catch (InterruptedException e) {
             // Indeterminate, deliberately: the probe was cut short, which says
@@ -164,8 +165,14 @@ public class {{ .NamePascal }}Application {
             // interrupt.
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Anthropic API probe interrupted", e);
-        } catch (Exception e) {
+        } catch (IOException e) {
             // The vendor is not answering at all (DNS, connect, timeout, TLS).
+            // IOException ONLY: that is what HttpClient.send throws when the
+            // request never got a response. Anything else raised in here is a
+            // defect in this probe, and it propagates rather than being
+            // reported as a vendor outage - the runtime records an
+            // indeterminate verdict and keeps this agent serving. A broken
+            // probe must not be able to withdraw a working provider.
             return health
                 .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
                 .withCheck("anthropic_api_reachable", false)
@@ -214,12 +221,12 @@ public class {{ .NamePascal }}Application {
                     .withCheck("openai_api_key_valid", false)
                     .withError("OpenAI API key is invalid");
             }
-            // The vendor answered and it is not serving. Unhealthy: this is the
-            // outage the mesh has to route around, and anything else keeps
-            // heartbeating and keeps consumers pointed here.
+            // The vendor ANSWERED, so it is reachable - it is just not serving.
+            // Unhealthy: this is the outage the mesh has to route around, and
+            // anything else keeps heartbeating and keeps consumers pointed here.
             return health
                 .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
-                .withCheck("openai_api_reachable", false)
+                .withCheck("openai_api_reachable", true)
                 .withError("OpenAI API returned status: " + status);
         } catch (InterruptedException e) {
             // Indeterminate, deliberately: the probe was cut short, which says
@@ -230,8 +237,14 @@ public class {{ .NamePascal }}Application {
             // interrupt.
             Thread.currentThread().interrupt();
             throw new IllegalStateException("OpenAI API probe interrupted", e);
-        } catch (Exception e) {
+        } catch (IOException e) {
             // The vendor is not answering at all (DNS, connect, timeout, TLS).
+            // IOException ONLY: that is what HttpClient.send throws when the
+            // request never got a response. Anything else raised in here is a
+            // defect in this probe, and it propagates rather than being
+            // reported as a vendor outage - the runtime records an
+            // indeterminate verdict and keeps this agent serving. A broken
+            // probe must not be able to withdraw a working provider.
             return health
                 .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
                 .withCheck("openai_api_reachable", false)
@@ -282,12 +295,12 @@ public class {{ .NamePascal }}Application {
                     .withCheck("google_api_key_valid", false)
                     .withError("Google API key is invalid");
             }
-            // The vendor answered and it is not serving. Unhealthy: this is the
-            // outage the mesh has to route around, and anything else keeps
-            // heartbeating and keeps consumers pointed here.
+            // The vendor ANSWERED, so it is reachable - it is just not serving.
+            // Unhealthy: this is the outage the mesh has to route around, and
+            // anything else keeps heartbeating and keeps consumers pointed here.
             return health
                 .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
-                .withCheck("gemini_api_reachable", false)
+                .withCheck("gemini_api_reachable", true)
                 .withError("Gemini API returned status: " + status);
         } catch (InterruptedException e) {
             // Indeterminate, deliberately: the probe was cut short, which says
@@ -298,8 +311,14 @@ public class {{ .NamePascal }}Application {
             // interrupt.
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Gemini API probe interrupted", e);
-        } catch (Exception e) {
+        } catch (IOException e) {
             // The vendor is not answering at all (DNS, connect, timeout, TLS).
+            // IOException ONLY: that is what HttpClient.send throws when the
+            // request never got a response. Anything else raised in here is a
+            // defect in this probe, and it propagates rather than being
+            // reported as a vendor outage - the runtime records an
+            // indeterminate verdict and keeps this agent serving. A broken
+            // probe must not be able to withdraw a working provider.
             return health
                 .withStatus(io.mcpmesh.MeshHealthStatus.UNHEALTHY)
                 .withCheck("gemini_api_reachable", false)
@@ -375,13 +394,17 @@ public class {{ .NamePascal }}Application {
             return MeshHealth.healthy()
                 .withCheck("anthropic_api_key_present", true)
                 .withCheck("anthropic_api_reachable", false);
-        } catch (Exception e) {
+        } catch (IOException e) {
             // The vendor could not be reached at all (DNS, connect, timeout,
             // TLS). An outage, not a misconfiguration: startup PASSES and the
             // health check withdraws this agent for as long as it lasts.
             // Failing here would crash-loop a correctly configured pod, and
             // would dilute CrashLoopBackOff from "your configuration is wrong"
             // into "something somewhere is unwell".
+            //
+            // IOException ONLY. A defect in this probe is not an outage, so it
+            // propagates and fails startup - which is what a check that
+            // reached no conclusion should do at boot.
             return MeshHealth.healthy()
                 .withCheck("anthropic_api_key_present", true)
                 .withCheck("anthropic_api_reachable", false);
@@ -440,13 +463,17 @@ public class {{ .NamePascal }}Application {
             return MeshHealth.healthy()
                 .withCheck("openai_api_key_present", true)
                 .withCheck("openai_api_reachable", false);
-        } catch (Exception e) {
+        } catch (IOException e) {
             // The vendor could not be reached at all (DNS, connect, timeout,
             // TLS). An outage, not a misconfiguration: startup PASSES and the
             // health check withdraws this agent for as long as it lasts.
             // Failing here would crash-loop a correctly configured pod, and
             // would dilute CrashLoopBackOff from "your configuration is wrong"
             // into "something somewhere is unwell".
+            //
+            // IOException ONLY. A defect in this probe is not an outage, so it
+            // propagates and fails startup - which is what a check that
+            // reached no conclusion should do at boot.
             return MeshHealth.healthy()
                 .withCheck("openai_api_key_present", true)
                 .withCheck("openai_api_reachable", false);
@@ -505,13 +532,17 @@ public class {{ .NamePascal }}Application {
             return MeshHealth.healthy()
                 .withCheck("google_api_key_present", true)
                 .withCheck("gemini_api_reachable", false);
-        } catch (Exception e) {
+        } catch (IOException e) {
             // The vendor could not be reached at all (DNS, connect, timeout,
             // TLS). An outage, not a misconfiguration: startup PASSES and the
             // health check withdraws this agent for as long as it lasts.
             // Failing here would crash-loop a correctly configured pod, and
             // would dilute CrashLoopBackOff from "your configuration is wrong"
             // into "something somewhere is unwell".
+            //
+            // IOException ONLY. A defect in this probe is not an outage, so it
+            // propagates and fails startup - which is what a check that
+            // reached no conclusion should do at boot.
             return MeshHealth.healthy()
                 .withCheck("google_api_key_present", true)
                 .withCheck("gemini_api_reachable", false);

--- a/cmd/meshctl/templates/python/a2a-consumer/main.py.tmpl
+++ b/cmd/meshctl/templates/python/a2a-consumer/main.py.tmpl
@@ -66,10 +66,10 @@ app = FastMCP("{{ toPascalCase .Name }} Bridge")
 # reported by startup_check crash-loops a pod whose configuration was fine.
 #
 # They also disagree about exceptions, deliberately. A health_check that
-# raises is recorded as degraded and keeps heartbeating - a buggy probe must
-# not withdraw a working bridge from a mesh that may have no other one. A
-# startup_check that raises FAILS: at boot an indeterminate answer is not a
-# reason to admit a possibly-misconfigured agent.
+# raises keeps heartbeating - a buggy probe must not withdraw a working
+# bridge from a mesh that may have no other one. A startup_check that raises
+# FAILS: at boot an indeterminate answer is not a reason to admit a
+# possibly-misconfigured agent.
 
 
 async def health_check() -> dict:

--- a/cmd/meshctl/templates/python/basic/main.py.tmpl
+++ b/cmd/meshctl/templates/python/basic/main.py.tmpl
@@ -44,10 +44,10 @@ app = FastMCP("{{ toPascalCase .Name }} Service")
 # startup_check crash-loops a pod whose configuration was fine all along.
 #
 # They also disagree about exceptions, deliberately. A health_check that
-# raises is recorded as degraded and keeps heartbeating - a buggy probe must
-# not withdraw a working agent from a mesh that may have no other one. A
-# startup_check that raises FAILS: at boot an indeterminate answer is not a
-# reason to admit a possibly-misconfigured agent.
+# raises keeps heartbeating - a buggy probe must not withdraw a working
+# agent from a mesh that may have no other one. A startup_check that raises
+# FAILS: at boot an indeterminate answer is not a reason to admit a
+# possibly-misconfigured agent.
 
 
 async def health_check() -> dict:

--- a/cmd/meshctl/templates/python/llm-agent/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/main.py.tmpl
@@ -47,10 +47,10 @@ app = FastMCP("{{ toPascalCase .Name }} Service")
 # startup_check crash-loops a pod whose configuration was fine all along.
 #
 # They also disagree about exceptions, deliberately. A health_check that
-# raises is recorded as degraded and keeps heartbeating - a buggy probe must
-# not withdraw a working agent from a mesh that may have no other one. A
-# startup_check that raises FAILS: at boot an indeterminate answer is not a
-# reason to admit a possibly-misconfigured agent.
+# raises keeps heartbeating - a buggy probe must not withdraw a working
+# agent from a mesh that may have no other one. A startup_check that raises
+# FAILS: at boot an indeterminate answer is not a reason to admit a
+# possibly-misconfigured agent.
 #
 # Neither one belongs on the LLM provider this agent resolves through. The
 # provider holds the vendor credential and probes the vendor itself; this

--- a/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
@@ -47,10 +47,10 @@ app = FastMCP("{{ toPascalCase .Name }}")
 # wrong", which is the signal this hook exists to produce.
 #
 # They also disagree about exceptions, deliberately. A health_check that
-# raises is recorded as degraded and keeps heartbeating - a buggy probe must
-# not withdraw a working provider from a mesh that may have no other one. A
-# startup_check that raises FAILS: at boot an indeterminate answer is not a
-# reason to admit a possibly-misconfigured agent.
+# raises keeps heartbeating - a buggy probe must not withdraw a working
+# provider from a mesh that may have no other one. A startup_check that raises
+# FAILS: at boot an indeterminate answer is not a reason to admit a
+# possibly-misconfigured agent.
 {{ if eq .ProbeVendor "anthropic" }}
 async def health_check() -> dict:
     """
@@ -100,7 +100,7 @@ async def health_check() -> dict:
                 else:
                     # The vendor answered and it is not serving. Unhealthy:
                     # this is the outage the mesh has to route around, and
-                    # "degraded" would keep heartbeating and keep consumers
+                    # anything else keeps heartbeating and keeps consumers
                     # pointed here.
                     checks["anthropic_api_reachable"] = False
                     errors.append(f"Anthropic API returned status: {response.status_code}")
@@ -162,7 +162,7 @@ async def health_check() -> dict:
                 else:
                     # The vendor answered and it is not serving. Unhealthy:
                     # this is the outage the mesh has to route around, and
-                    # "degraded" would keep heartbeating and keep consumers
+                    # anything else keeps heartbeating and keeps consumers
                     # pointed here.
                     checks["openai_api_reachable"] = False
                     errors.append(f"OpenAI API returned status: {response.status_code}")
@@ -223,7 +223,7 @@ async def health_check() -> dict:
                 else:
                     # The vendor answered and it is not serving. Unhealthy:
                     # this is the outage the mesh has to route around, and
-                    # "degraded" would keep heartbeating and keep consumers
+                    # anything else keeps heartbeating and keeps consumers
                     # pointed here.
                     checks["gemini_api_reachable"] = False
                     errors.append(f"Gemini API returned status: {response.status_code}")

--- a/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/main.py.tmpl
@@ -78,9 +78,9 @@ async def health_check() -> dict:
 
     # Check API connectivity (uses /v1/models - free, no tokens consumed)
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     "https://api.anthropic.com/v1/models",
@@ -98,15 +98,20 @@ async def health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["anthropic_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["anthropic_api_reachable"] = True
                     errors.append(f"Anthropic API returned status: {response.status_code}")
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
             status = "unhealthy"
@@ -143,9 +148,9 @@ async def health_check() -> dict:
 
     # Check API connectivity
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     "https://api.openai.com/v1/models",
@@ -160,15 +165,20 @@ async def health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["openai_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["openai_api_reachable"] = True
                     errors.append(f"OpenAI API returned status: {response.status_code}")
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
             status = "unhealthy"
@@ -205,9 +215,9 @@ async def health_check() -> dict:
 
     # Check API connectivity (uses /v1beta/models - metadata only, no tokens consumed)
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}",
@@ -221,15 +231,20 @@ async def health_check() -> dict:
                     errors.append("Google API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["gemini_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["gemini_api_reachable"] = True
                     errors.append(f"Gemini API returned status: {response.status_code}")
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["gemini_api_reachable"] = False
             errors.append(f"Gemini API unreachable: {str(e)}")
             status = "unhealthy"
@@ -299,9 +314,9 @@ async def startup_check() -> dict:
     # the startup path is acceptable because a startupProbe stops polling once
     # it passes - this runs a handful of times, not every ten seconds forever.
     checks = {"anthropic_api_key_present": True}
-    try:
-        import httpx
+    import httpx
 
+    try:
         async with httpx.AsyncClient(timeout=5.0) as client:
             response = await client.get(
                 "https://api.anthropic.com/v1/models",
@@ -310,13 +325,17 @@ async def startup_check() -> dict:
                     "x-api-key": api_key,
                 },
             )
-    except Exception:
+    except httpx.RequestError:
         # The vendor could not be reached at all (DNS, connect, timeout, TLS).
         # An outage, not a misconfiguration: startup PASSES and health_check
         # withdraws this agent for as long as it lasts. Failing here would
         # crash-loop a correctly configured pod, and would dilute
         # CrashLoopBackOff from "your configuration is wrong" into "something
         # somewhere is unwell".
+        #
+        # Transport failures ONLY. A defect in this probe is not an outage, so
+        # it propagates and fails startup — which is what a check that reached
+        # no conclusion should do at boot.
         checks["anthropic_api_reachable"] = False
         return {"status": "healthy", "checks": checks, "errors": []}
 
@@ -360,21 +379,25 @@ async def startup_check() -> dict:
     # the startup path is acceptable because a startupProbe stops polling once
     # it passes - this runs a handful of times, not every ten seconds forever.
     checks = {"openai_api_key_present": True}
-    try:
-        import httpx
+    import httpx
 
+    try:
         async with httpx.AsyncClient(timeout=5.0) as client:
             response = await client.get(
                 "https://api.openai.com/v1/models",
                 headers={"Authorization": f"Bearer {api_key}"},
             )
-    except Exception:
+    except httpx.RequestError:
         # The vendor could not be reached at all (DNS, connect, timeout, TLS).
         # An outage, not a misconfiguration: startup PASSES and health_check
         # withdraws this agent for as long as it lasts. Failing here would
         # crash-loop a correctly configured pod, and would dilute
         # CrashLoopBackOff from "your configuration is wrong" into "something
         # somewhere is unwell".
+        #
+        # Transport failures ONLY. A defect in this probe is not an outage, so
+        # it propagates and fails startup — which is what a check that reached
+        # no conclusion should do at boot.
         checks["openai_api_reachable"] = False
         return {"status": "healthy", "checks": checks, "errors": []}
 
@@ -418,20 +441,24 @@ async def startup_check() -> dict:
     # the startup path is acceptable because a startupProbe stops polling once
     # it passes - this runs a handful of times, not every ten seconds forever.
     checks = {"google_api_key_present": True}
-    try:
-        import httpx
+    import httpx
 
+    try:
         async with httpx.AsyncClient(timeout=5.0) as client:
             response = await client.get(
                 f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}",
             )
-    except Exception:
+    except httpx.RequestError:
         # The vendor could not be reached at all (DNS, connect, timeout, TLS).
         # An outage, not a misconfiguration: startup PASSES and health_check
         # withdraws this agent for as long as it lasts. Failing here would
         # crash-loop a correctly configured pod, and would dilute
         # CrashLoopBackOff from "your configuration is wrong" into "something
         # somewhere is unwell".
+        #
+        # Transport failures ONLY. A defect in this probe is not an outage, so
+        # it propagates and fails startup — which is what a check that reached
+        # no conclusion should do at boot.
         checks["gemini_api_reachable"] = False
         return {"status": "healthy", "checks": checks, "errors": []}
 

--- a/cmd/meshctl/templates/typescript/a2a-consumer/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/a2a-consumer/src/index.ts.tmpl
@@ -66,10 +66,10 @@ const server = new FastMCP({
 // reported by startupCheck crash-loops a pod whose configuration was fine.
 //
 // They also disagree about exceptions, deliberately. A healthCheck that
-// throws is recorded as "degraded" and keeps heartbeating - a buggy probe
-// must not withdraw a working bridge from a mesh that may have no other one.
-// A startupCheck that throws FAILS: at boot an indeterminate answer is not a
-// reason to admit a possibly-misconfigured agent.
+// throws keeps heartbeating - a buggy probe must not withdraw a working
+// bridge from a mesh that may have no other one. A startupCheck that throws
+// FAILS: at boot an indeterminate answer is not a reason to admit a
+// possibly-misconfigured agent.
 
 /** Can this bridge serve right now? */
 async function healthCheck(): Promise<MeshHealthResult> {

--- a/cmd/meshctl/templates/typescript/basic/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/src/index.ts.tmpl
@@ -52,10 +52,10 @@ const server = new FastMCP({
 // startupCheck crash-loops a pod whose configuration was fine all along.
 //
 // They also disagree about exceptions, deliberately. A healthCheck that
-// throws is recorded as "degraded" and keeps heartbeating - a buggy probe
-// must not withdraw a working agent from a mesh that may have no other one. A
-// startupCheck that throws FAILS: at boot an indeterminate answer is not a
-// reason to admit a possibly-misconfigured agent.
+// throws keeps heartbeating - a buggy probe must not withdraw a working
+// agent from a mesh that may have no other one. A startupCheck that throws
+// FAILS: at boot an indeterminate answer is not a reason to admit a
+// possibly-misconfigured agent.
 
 /** Can this agent serve right now? */
 async function healthCheck(): Promise<MeshHealthResult> {

--- a/cmd/meshctl/templates/typescript/llm-agent/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/src/index.ts.tmpl
@@ -44,10 +44,10 @@ const server = new FastMCP({
 // startupCheck crash-loops a pod whose configuration was fine all along.
 //
 // They also disagree about exceptions, deliberately. A healthCheck that
-// throws is recorded as "degraded" and keeps heartbeating - a buggy probe
-// must not withdraw a working agent from a mesh that may have no other one. A
-// startupCheck that throws FAILS: at boot an indeterminate answer is not a
-// reason to admit a possibly-misconfigured agent.
+// throws keeps heartbeating - a buggy probe must not withdraw a working
+// agent from a mesh that may have no other one. A startupCheck that throws
+// FAILS: at boot an indeterminate answer is not a reason to admit a
+// possibly-misconfigured agent.
 //
 // Neither one belongs on the LLM provider this agent resolves through. The
 // provider holds the vendor credential and probes the vendor itself; this

--- a/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
@@ -46,10 +46,10 @@ const server = new FastMCP({
 // wrong", which is the signal this hook exists to produce.
 //
 // They also disagree about exceptions, deliberately. A healthCheck that
-// throws is recorded as "degraded" and keeps heartbeating - a buggy probe
-// must not withdraw a working provider from a mesh that may have no other
-// one. A startupCheck that throws FAILS: at boot an indeterminate answer is
-// not a reason to admit a possibly-misconfigured agent.
+// throws keeps heartbeating - a buggy probe must not withdraw a working
+// provider from a mesh that may have no other one. A startupCheck that throws
+// FAILS: at boot an indeterminate answer is not a reason to admit a
+// possibly-misconfigured agent.
 {{ if .ProbeVendor }}
 /**
  * Ceiling for one probe. `AbortSignal.timeout` rejects with a
@@ -58,8 +58,9 @@ const server = new FastMCP({
  * to route around.
  *
  * If you add cancellation of your own — an `AbortController` you abort on
- * shutdown — handle its "AbortError" separately and report "degraded":
- * a probe you cut short concluded nothing about the vendor.
+ * shutdown — let its "AbortError" propagate instead of reporting a verdict:
+ * a probe you cut short concluded nothing about the vendor, and the runtime
+ * keeps the agent in dependency resolution for a check that threw.
  */
 const HEALTH_PROBE_TIMEOUT_MS = 5_000;
 
@@ -112,8 +113,8 @@ async function healthCheck(): Promise<MeshHealthResult> {
       };
     }
     // The vendor answered and it is not serving. Unhealthy: this is the
-    // outage the mesh has to route around, and "degraded" would keep
-    // heartbeating and keep consumers pointed here.
+    // outage the mesh has to route around, and anything else keeps
+    // heartbeating and keeps consumers pointed here.
     checks.anthropic_api_reachable = false;
     return {
       status: "unhealthy",
@@ -172,8 +173,8 @@ async function healthCheck(): Promise<MeshHealthResult> {
       };
     }
     // The vendor answered and it is not serving. Unhealthy: this is the
-    // outage the mesh has to route around, and "degraded" would keep
-    // heartbeating and keep consumers pointed here.
+    // outage the mesh has to route around, and anything else keeps
+    // heartbeating and keeps consumers pointed here.
     checks.openai_api_reachable = false;
     return {
       status: "unhealthy",
@@ -232,8 +233,8 @@ async function healthCheck(): Promise<MeshHealthResult> {
       };
     }
     // The vendor answered and it is not serving. Unhealthy: this is the
-    // outage the mesh has to route around, and "degraded" would keep
-    // heartbeating and keep consumers pointed here.
+    // outage the mesh has to route around, and anything else keeps
+    // heartbeating and keeps consumers pointed here.
     checks.gemini_api_reachable = false;
     return {
       status: "unhealthy",
@@ -281,8 +282,8 @@ async function healthCheck(): Promise<MeshHealthResult> {
  *       : { status: "unhealthy", errors: [`vendor returned ${response.status}`] };
  *   } catch (err) {
  *     // DNS, connect, timeout and TLS all mean the vendor did not answer:
- *     // a real outage, so "unhealthy". Report "degraded" only for a probe
- *     // YOU cut short (your own AbortController) — that concluded nothing.
+ *     // a real outage, so "unhealthy". A probe YOU cut short (your own
+ *     // AbortController) concluded nothing — rethrow rather than answer.
  *     return { status: "unhealthy", errors: [`vendor unreachable: ${err}`] };
  *   }
  *

--- a/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/src/index.ts.tmpl
@@ -67,6 +67,23 @@ const HEALTH_PROBE_TIMEOUT_MS = 5_000;
 function describeError(err: unknown): string {
   return err instanceof Error ? err.message || err.name : String(err);
 }
+
+/**
+ * Whether a thrown value is the vendor failing to ANSWER, as opposed to a
+ * defect in this probe.
+ *
+ * `fetch` rejects with a TypeError when no response was ever received - DNS,
+ * connect, TLS - and with a "TimeoutError" when the deadline above fires.
+ * Anything else concluded nothing about the vendor: a typo, a helper that
+ * throws, an "AbortError" from cancellation of your own. Those are rethrown,
+ * and the runtime records its own indeterminate verdict, which keeps this
+ * agent in dependency resolution. A broken probe must not be able to withdraw
+ * a working provider.
+ */
+function isVendorUnreachable(err: unknown): boolean {
+  if (err instanceof TypeError) return true;
+  return (err as { name?: string } | null | undefined)?.name === "TimeoutError";
+}
 {{ end }}
 {{- if eq .ProbeVendor "anthropic" }}
 /**
@@ -112,18 +129,19 @@ async function healthCheck(): Promise<MeshHealthResult> {
         errors: ["Anthropic API key is invalid"],
       };
     }
-    // The vendor answered and it is not serving. Unhealthy: this is the
-    // outage the mesh has to route around, and anything else keeps
-    // heartbeating and keeps consumers pointed here.
-    checks.anthropic_api_reachable = false;
+    // The vendor ANSWERED, so it is reachable - it is just not serving.
+    // Unhealthy: this is the outage the mesh has to route around, and
+    // anything else keeps heartbeating and keeps consumers pointed here.
+    checks.anthropic_api_reachable = true;
     return {
       status: "unhealthy",
       checks,
       errors: [`Anthropic API returned status: ${response.status}`],
     };
   } catch (err) {
-    checks.anthropic_api_reachable = false;
+    if (!isVendorUnreachable(err)) throw err;
     // The vendor is not answering at all (DNS, connect, timeout, TLS).
+    checks.anthropic_api_reachable = false;
     return {
       status: "unhealthy",
       checks,
@@ -172,18 +190,19 @@ async function healthCheck(): Promise<MeshHealthResult> {
         errors: ["OpenAI API key is invalid"],
       };
     }
-    // The vendor answered and it is not serving. Unhealthy: this is the
-    // outage the mesh has to route around, and anything else keeps
-    // heartbeating and keeps consumers pointed here.
-    checks.openai_api_reachable = false;
+    // The vendor ANSWERED, so it is reachable - it is just not serving.
+    // Unhealthy: this is the outage the mesh has to route around, and
+    // anything else keeps heartbeating and keeps consumers pointed here.
+    checks.openai_api_reachable = true;
     return {
       status: "unhealthy",
       checks,
       errors: [`OpenAI API returned status: ${response.status}`],
     };
   } catch (err) {
-    checks.openai_api_reachable = false;
+    if (!isVendorUnreachable(err)) throw err;
     // The vendor is not answering at all (DNS, connect, timeout, TLS).
+    checks.openai_api_reachable = false;
     return {
       status: "unhealthy",
       checks,
@@ -232,18 +251,19 @@ async function healthCheck(): Promise<MeshHealthResult> {
         errors: ["Google API key is invalid"],
       };
     }
-    // The vendor answered and it is not serving. Unhealthy: this is the
-    // outage the mesh has to route around, and anything else keeps
-    // heartbeating and keeps consumers pointed here.
-    checks.gemini_api_reachable = false;
+    // The vendor ANSWERED, so it is reachable - it is just not serving.
+    // Unhealthy: this is the outage the mesh has to route around, and
+    // anything else keeps heartbeating and keeps consumers pointed here.
+    checks.gemini_api_reachable = true;
     return {
       status: "unhealthy",
       checks,
       errors: [`Gemini API returned status: ${response.status}`],
     };
   } catch (err) {
-    checks.gemini_api_reachable = false;
+    if (!isVendorUnreachable(err)) throw err;
     // The vendor is not answering at all (DNS, connect, timeout, TLS).
+    checks.gemini_api_reachable = false;
     return {
       status: "unhealthy",
       checks,
@@ -333,7 +353,8 @@ async function startupCheck(): Promise<MeshHealthResult> {
       },
       signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
     });
-  } catch {
+  } catch (err) {
+    if (!isVendorUnreachable(err)) throw err;
     // The vendor could not be reached at all (DNS, connect, timeout, TLS).
     // An outage, not a misconfiguration: startup PASSES and healthCheck
     // withdraws this agent for as long as it lasts. Failing here would
@@ -391,7 +412,8 @@ async function startupCheck(): Promise<MeshHealthResult> {
       headers: { Authorization: `Bearer ${apiKey}` },
       signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
     });
-  } catch {
+  } catch (err) {
+    if (!isVendorUnreachable(err)) throw err;
     // The vendor could not be reached at all (DNS, connect, timeout, TLS).
     // An outage, not a misconfiguration: startup PASSES and healthCheck
     // withdraws this agent for as long as it lasts. Failing here would
@@ -449,7 +471,8 @@ async function startupCheck(): Promise<MeshHealthResult> {
       `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`,
       { signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS) },
     );
-  } catch {
+  } catch (err) {
+    if (!isVendorUnreachable(err)) throw err;
     // The vendor could not be reached at all (DNS, connect, timeout, TLS).
     // An outage, not a misconfiguration: startup PASSES and healthCheck
     // withdraws this agent for as long as it lasts. Failing here would

--- a/docs/concepts/health-discovery.md
+++ b/docs/concepts/health-discovery.md
@@ -153,10 +153,14 @@ Never point liveness or startup at `/ready` or `/health`. `/health` reflects you
 
 ### Health States
 
-| State       | Description                                                       |
-| ----------- | ----------------------------------------------------------------- |
-| `healthy`   | Agent can serve. Stays in dependency resolution.                   |
-| `unhealthy` | Agent cannot serve. Withdrawn from dependency resolution.          |
+What a check returns is one of two answers:
+
+| State       | Description                                               |
+| ----------- | --------------------------------------------------------- |
+| `healthy`   | Agent can serve. Stays in dependency resolution.           |
+| `unhealthy` | Agent cannot serve. Withdrawn from dependency resolution.  |
+
+What you can OBSERVE on `/health` is wider, because the runtime reports its own state there too: `starting` before the first refresh has run, and `degraded` (Python may also report `unknown`) where it recorded a verdict it could not trust - a check that raised, returned an unusable type, or answered with a status it could not read. Those are not a third answer to route on: everything that is not `unhealthy` stays in dependency resolution. `degraded` is also still accepted as a return value, deprecated since 3.7 and removed no earlier than 4.0; it warns once and routes exactly like `healthy`.
 
 ## Discovery
 

--- a/docs/concepts/health-discovery.md
+++ b/docs/concepts/health-discovery.md
@@ -55,13 +55,11 @@ async def my_health_check():
     """Custom health check."""
     # Check database connection
     if not db.is_connected():
-        return {"status": "unhealthy", "reason": "db disconnected"}
+        return {"status": "unhealthy", "errors": ["db disconnected"]}
 
-    # Check memory
-    if memory_usage() > 90:
-        return {"status": "degraded", "reason": "high memory"}
-
-    return {"status": "healthy"}
+    # An impairment you can still serve through stays healthy - report it
+    # in `checks` so an operator sees it on /health.
+    return {"status": "healthy", "checks": {"memory_ok": memory_usage() <= 90}}
 
 @mesh.agent(
     name="my-agent",
@@ -81,10 +79,11 @@ public MeshHealth healthCheck() {
         return MeshHealth.unhealthy("db disconnected")
             .withCheck("db_connected", false);
     }
-    if (memoryUsage() > 90) {
-        return MeshHealth.degraded("high memory");
-    }
-    return MeshHealth.healthy().withCheck("db_connected", true);
+    // An impairment you can still serve through stays healthy - report it
+    // in checks so an operator sees it on /health.
+    return MeshHealth.healthy()
+        .withCheck("db_connected", true)
+        .withCheck("memory_ok", memoryUsage() <= 90);
 }
 ```
 
@@ -101,10 +100,12 @@ const agent = mesh(server, {
     if (!db.isConnected()) {
       return { status: "unhealthy", errors: ["db disconnected"] };
     }
-    if (memoryUsage() > 90) {
-      return { status: "degraded", errors: ["high memory"] };
-    }
-    return { status: "healthy", checks: { db_connected: true } };
+    // An impairment you can still serve through stays healthy - report it
+    // in `checks` so an operator sees it on /health.
+    return {
+      status: "healthy",
+      checks: { db_connected: true, memory_ok: memoryUsage() <= 90 },
+    };
   },
 });
 ```
@@ -115,9 +116,17 @@ One check per agent. Returning `boolean` works too: `true` is healthy, `false` u
 
 While the check reports `unhealthy` the agent stops heartbeating. The registry's staleness sweep then marks it unhealthy, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent - no restart, no redeploy. This is what lets a provider whose upstream vendor is down take itself out of rotation.
 
-Only an explicit unhealthy result does that. A check that raises is recorded as `degraded` and keeps heartbeating, in all three runtimes: a bug in the health check must not be able to remove a working agent from the mesh.
+Only an explicit unhealthy result does that. A check that raises keeps heartbeating and stays in dependency resolution, in all three runtimes: a bug in the health check must not be able to remove a working agent from the mesh.
 
-`degraded` shows on the diagnostic surface only, on all three runtimes: the agent keeps heartbeating and stays in dependency resolution, and `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict.
+Those verdicts show on the diagnostic surface only, on all three runtimes: `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict.
+
+### When Every Provider Withdraws
+
+A health check is per-agent, but the failure it reports usually is not. Broken egress, an expired shared credential, a vendor that is down for everyone: each provider of a capability observes it independently and each withdraws itself, so the capability can go from several providers to none within one refresh period.
+
+Mesh does not keep a last provider in rotation to prevent that. Routing to something that has just reported it cannot serve trades an unresolved dependency — fast, and clearly attributable — for a call that is guaranteed to fail slowly at the far end, and it makes the health check a suggestion. Withdrawal is also cheap: the agent keeps running, keeps its resolved dependencies, and re-registers by itself the moment its check passes again, so getting it wrong costs one refresh period. There is deliberately no damping, hysteresis or grace period on it.
+
+It is not silent, though. When the registry withdraws the last healthy provider of a capability it logs a warning naming that capability, so a total outage is something the registry says rather than something you infer from a scatter of consumer errors.
 
 Route (`@mesh.route` / `@MeshRoute` / `mesh.route`) and A2A agents are no longer exempt: a failing check pauses their heartbeat too, and the registry stops advertising the gateway. The hook means the same thing on every agent type - "I am not available" - and mesh does the same thing with it everywhere: it stops wiring that agent. What differs is topology, not meaning. A provider is something others route _to_; a gateway is where requests _enter_, and the ingress it keeps serving was never mesh-routed in the first place.
 
@@ -144,11 +153,10 @@ Never point liveness or startup at `/ready` or `/health`. `/health` reflects you
 
 ### Health States
 
-| State       | Description                 |
-| ----------- | --------------------------- |
-| `healthy`   | Agent is fully operational  |
-| `degraded`  | Agent works but with issues |
-| `unhealthy` | Agent cannot serve requests |
+| State       | Description                                                       |
+| ----------- | ----------------------------------------------------------------- |
+| `healthy`   | Agent can serve. Stays in dependency resolution.                   |
+| `unhealthy` | Agent cannot serve. Withdrawn from dependency resolution.          |
 
 ## Discovery
 
@@ -272,17 +280,21 @@ export DEFAULT_TIMEOUT_THRESHOLD=20
 
 ```python
 async def health():
-    # Check all critical dependencies
+    # Report every probe; decide on the ones you cannot serve without.
     checks = {
         "database": await check_db(),
         "cache": await check_cache(),
         "memory": check_memory(),
     }
 
-    if all(c["ok"] for c in checks.values()):
-        return {"status": "healthy", "checks": checks}
-    return {"status": "degraded", "checks": checks}
+    # A cold cache is slower, not unserving, and a memory warning is not an
+    # outage - both stay healthy and ride along in `checks`.
+    if not checks["database"]["ok"]:
+        return {"status": "unhealthy", "checks": checks, "errors": ["database unreachable"]}
+    return {"status": "healthy", "checks": checks}
 ```
+
+The verdict answers one question — should the mesh keep routing to this agent? — so return `unhealthy` only for the failures that make the answer no. An impairment you can still serve through is `healthy`; put the detail in `checks` and it still reaches `/health` for an operator to read.
 
 ### 2. Handle Failures Gracefully
 

--- a/docs/typescript/mesh-functions.md
+++ b/docs/typescript/mesh-functions.md
@@ -47,7 +47,7 @@ const agent = mesh(server, {
 });
 ```
 
-`healthCheck` is what lets a provider take itself out of rotation. While it returns `{ status: "unhealthy" }` (or `false`) the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider — restored automatically when it passes again, with no restart. A check that throws is recorded as `degraded` and keeps heartbeating, so a bug in the check cannot remove a working agent. The verdict also drives the probe endpoints: `/ready` and `/health` answer 200 only while it reports `healthy`. `MCP_MESH_HEALTH_CHECK_TTL` overrides `healthCheckTtl`. See [Health & Discovery](../concepts/health-discovery.md).
+`healthCheck` is what lets a provider take itself out of rotation. While it returns `{ status: "unhealthy" }` (or `false`) the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider — restored automatically when it passes again, with no restart. A check that throws keeps heartbeating, so a bug in the check cannot remove a working agent. The verdict drives `/health`, which answers 200 only while it reports `healthy`. It does not drive `/ready`, which reports whether the mesh runtime is up: pausing the heartbeat is the whole withdrawal, and a 503 on `/ready` would additionally drop the pod from the Service that mesh traffic arrives on. `MCP_MESH_HEALTH_CHECK_TTL` overrides `healthCheckTtl`. See [Health & Discovery](../concepts/health-discovery.md).
 
 > **Import `FastMCP` from `@mcpmesh/sdk`**, which re-exports it — not directly from `"fastmcp"`. A direct `"fastmcp"` import can trigger duplicate class-identity type errors under `tsc` against the SDK's own bundled copy.
 

--- a/examples/docker-examples/agents/claude-provider/main.py
+++ b/examples/docker-examples/agents/claude-provider/main.py
@@ -45,9 +45,9 @@ async def health_check() -> dict:
 
     # Check API connectivity
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.head(
                     "https://api.anthropic.com/v1/messages",
@@ -65,17 +65,22 @@ async def health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["anthropic_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["anthropic_api_reachable"] = True
                     errors.append(
                         f"Anthropic API returned status: {response.status_code}"
                     )
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
             status = "unhealthy"

--- a/examples/docker-examples/agents/claude-provider/main.py
+++ b/examples/docker-examples/agents/claude-provider/main.py
@@ -65,15 +65,20 @@ async def health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["anthropic_api_reachable"] = False
                     errors.append(
                         f"Anthropic API returned status: {response.status_code}"
                     )
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/examples/docker-examples/agents/openai-provider/main.py
+++ b/examples/docker-examples/agents/openai-provider/main.py
@@ -62,13 +62,18 @@ async def health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["openai_api_reachable"] = False
                     errors.append(f"OpenAI API returned status: {response.status_code}")
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/examples/docker-examples/agents/openai-provider/main.py
+++ b/examples/docker-examples/agents/openai-provider/main.py
@@ -45,9 +45,9 @@ async def health_check() -> dict:
 
     # Check API connectivity
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     "https://api.openai.com/v1/models",
@@ -62,15 +62,20 @@ async def health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["openai_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["openai_api_reachable"] = True
                     errors.append(f"OpenAI API returned status: {response.status_code}")
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
             status = "unhealthy"

--- a/examples/multi-agent-poc/claude_provider.py
+++ b/examples/multi-agent-poc/claude_provider.py
@@ -65,15 +65,20 @@ async def claude_health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["anthropic_api_reachable"] = False
                     errors.append(
                         f"Anthropic API returned unexpected status: {response.status_code}"
                     )
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/examples/multi-agent-poc/claude_provider.py
+++ b/examples/multi-agent-poc/claude_provider.py
@@ -44,9 +44,9 @@ async def claude_health_check() -> dict:
 
     # Check 2: API connectivity (lightweight HEAD request)
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.head(
                     "https://api.anthropic.com/v1/messages",
@@ -65,17 +65,22 @@ async def claude_health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["anthropic_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["anthropic_api_reachable"] = True
                     errors.append(
                         f"Anthropic API returned unexpected status: {response.status_code}"
                     )
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
             status = "unhealthy"

--- a/examples/multi-agent-poc/openai_provider.py
+++ b/examples/multi-agent-poc/openai_provider.py
@@ -44,9 +44,9 @@ async def openai_health_check() -> dict:
 
     # Check 2: API connectivity (lightweight GET request to models endpoint)
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 # Use GET /models endpoint which is lightweight
                 response = await client.get(
@@ -65,17 +65,22 @@ async def openai_health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["openai_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["openai_api_reachable"] = True
                     errors.append(
                         f"OpenAI API returned unexpected status: {response.status_code}"
                     )
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
             status = "unhealthy"

--- a/examples/multi-agent-poc/openai_provider.py
+++ b/examples/multi-agent-poc/openai_provider.py
@@ -65,15 +65,20 @@ async def openai_health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["openai_api_reachable"] = False
                     errors.append(
                         f"OpenAI API returned unexpected status: {response.status_code}"
                     )
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/examples/simple/health-check-example.py
+++ b/examples/simple/health-check-example.py
@@ -52,11 +52,11 @@ async def my_health_check() -> dict:
 
     # Check 2: Test LLM API connectivity with a lightweight HTTP request
     if api_key:
-        try:
-            # Simple HTTP HEAD request to check API reachability
-            # This is fast and doesn't consume credits
-            import httpx
+        # Simple HTTP HEAD request to check API reachability
+        # This is fast and doesn't consume credits
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 # Simple HEAD request to check if endpoint exists
                 # This is the fastest way to test connectivity without consuming credits
@@ -87,20 +87,25 @@ async def my_health_check() -> dict:
                     status = "unhealthy"
                     print("❌ LLM API key is invalid (401)")
                 else:
-                    checks["llm_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["llm_api_reachable"] = True
                     errors.append(
                         f"LLM API returned unexpected status: {response.status_code}"
                     )
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
                     status = "unhealthy"
                     print(
                         f"⚠️ LLM API returned unexpected status: {response.status_code}"
                     )
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["llm_api_reachable"] = False
             errors.append(f"LLM API unreachable: {str(e)}")
             status = "unhealthy"

--- a/examples/simple/health-check-example.py
+++ b/examples/simple/health-check-example.py
@@ -28,7 +28,7 @@ async def my_health_check() -> dict:
 
     Can return:
     - bool: True = HEALTHY, False = UNHEALTHY
-    - dict: {"status": "healthy/degraded/unhealthy", "checks": {...}, "errors": [...]}
+    - dict: {"status": "healthy/unhealthy", "checks": {...}, "errors": [...]}
 
     Returns:
         dict: Health status with checks and errors
@@ -37,7 +37,7 @@ async def my_health_check() -> dict:
 
     checks = {}
     errors = []
-    status = "healthy"  # Can be: "healthy", "degraded", "unhealthy"
+    status = "healthy"  # Can be: "healthy" or "unhealthy"
 
     # Check 1: LLM API Key presence
     api_key = os.getenv("ANTHROPIC_API_KEYS")
@@ -91,14 +91,19 @@ async def my_health_check() -> dict:
                     errors.append(
                         f"LLM API returned unexpected status: {response.status_code}"
                     )
-                    status = "degraded"
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
+                    status = "unhealthy"
                     print(
                         f"⚠️ LLM API returned unexpected status: {response.status_code}"
                     )
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["llm_api_reachable"] = False
             errors.append(f"LLM API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
             print(f"⚠️ LLM API unreachable: {e}")
 
     # Check 3: Any other custom checks

--- a/examples/simple/health-check-simple.py
+++ b/examples/simple/health-check-simple.py
@@ -22,7 +22,7 @@ async def simple_health_check() -> dict:
 
     Can return:
     - bool: True = HEALTHY, False = UNHEALTHY
-    - dict: {"status": "healthy/degraded/unhealthy", "checks": {...}, "errors": [...]}
+    - dict: {"status": "healthy/unhealthy", "checks": {...}, "errors": [...]}
 
     Returns:
         dict: Health status with checks and errors
@@ -31,7 +31,7 @@ async def simple_health_check() -> dict:
 
     checks = {}
     errors = []
-    status = "healthy"  # Can be: "healthy", "degraded", "unhealthy"
+    status = "healthy"  # Can be: "healthy" or "unhealthy"
 
     # Check 1: Required environment variables
     required_vars = ["ANTHROPIC_API_KEY"]  # Add your required vars here
@@ -40,9 +40,11 @@ async def simple_health_check() -> dict:
             checks[f"env_{var.lower()}"] = True
             print(f"✅ {var} is configured")
         else:
+            # A missing credential means this agent cannot serve, so it should
+            # be withdrawn from dependency resolution until it is set.
             checks[f"env_{var.lower()}"] = False
             errors.append(f"{var} not set")
-            status = "degraded"
+            status = "unhealthy"
             print(f"⚠️ {var} is not configured")
 
     # Check 2: Disk space (example)
@@ -55,9 +57,13 @@ async def simple_health_check() -> dict:
             checks["disk_space"] = True
             print(f"✅ Disk space OK ({free_gb:.1f}GB free)")
         else:
+            # An impairment this agent can still serve through: the verdict
+            # stays healthy and the detail rides along in `checks` and
+            # `errors`, both of which an operator reads on /health. Reporting
+            # unhealthy here would withdraw an agent that is answering calls
+            # perfectly well.
             checks["disk_space"] = False
             errors.append(f"Low disk space: {free_gb:.1f}GB")
-            status = "degraded"
             print(f"⚠️ Low disk space: {free_gb:.1f}GB")
     except Exception as e:
         checks["disk_space"] = False

--- a/examples/toolcalls/claude-provider-py/main.py
+++ b/examples/toolcalls/claude-provider-py/main.py
@@ -65,15 +65,20 @@ async def health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["anthropic_api_reachable"] = False
                     errors.append(
                         f"Anthropic API returned status: {response.status_code}"
                     )
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/examples/toolcalls/claude-provider-py/main.py
+++ b/examples/toolcalls/claude-provider-py/main.py
@@ -45,9 +45,9 @@ async def health_check() -> dict:
 
     # Check API connectivity (uses /v1/models - free, no tokens consumed)
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     "https://api.anthropic.com/v1/models",
@@ -65,17 +65,22 @@ async def health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["anthropic_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["anthropic_api_reachable"] = True
                     errors.append(
                         f"Anthropic API returned status: {response.status_code}"
                     )
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
             status = "unhealthy"

--- a/examples/toolcalls/gemini-provider-py/main.py
+++ b/examples/toolcalls/gemini-provider-py/main.py
@@ -45,9 +45,9 @@ async def health_check() -> dict:
 
     # Check API connectivity (uses /v1beta/models - metadata only, no tokens consumed)
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}",
@@ -61,15 +61,20 @@ async def health_check() -> dict:
                     errors.append("Google API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["gemini_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["gemini_api_reachable"] = True
                     errors.append(f"Gemini API returned status: {response.status_code}")
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["gemini_api_reachable"] = False
             errors.append(f"Gemini API unreachable: {str(e)}")
             status = "unhealthy"

--- a/examples/toolcalls/gemini-provider-py/main.py
+++ b/examples/toolcalls/gemini-provider-py/main.py
@@ -61,13 +61,18 @@ async def health_check() -> dict:
                     errors.append("Google API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["gemini_api_reachable"] = False
                     errors.append(f"Gemini API returned status: {response.status_code}")
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["gemini_api_reachable"] = False
             errors.append(f"Gemini API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/examples/toolcalls/openai-provider-py/main.py
+++ b/examples/toolcalls/openai-provider-py/main.py
@@ -62,13 +62,18 @@ async def health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["openai_api_reachable"] = False
                     errors.append(f"OpenAI API returned status: {response.status_code}")
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/examples/toolcalls/openai-provider-py/main.py
+++ b/examples/toolcalls/openai-provider-py/main.py
@@ -45,9 +45,9 @@ async def health_check() -> dict:
 
     # Check API connectivity
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     "https://api.openai.com/v1/models",
@@ -62,15 +62,20 @@ async def health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["openai_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["openai_api_reachable"] = True
                     errors.append(f"OpenAI API returned status: {response.status_code}")
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
             status = "unhealthy"

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -293,7 +293,7 @@ public MeshHealth healthCheck() {
 }
 ```
 
-While the check returns unhealthy the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider - restored automatically when the check passes, with no restart. Returning `boolean` works too: `true` is healthy, `false` unhealthy. A check that throws is recorded as `degraded` and keeps heartbeating, so a bug in the check cannot take a working agent out of the mesh. `MCP_MESH_HEALTH_CHECK_TTL` overrides `ttlSeconds`.
+While the check returns unhealthy the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider - restored automatically when the check passes, with no restart. Returning `boolean` works too: `true` is healthy, `false` unhealthy. A check that throws keeps heartbeating, so a bug in the check cannot take a working agent out of the mesh. `MCP_MESH_HEALTH_CHECK_TTL` overrides `ttlSeconds`.
 
 Route-only (`api`) and A2A agents are no exception: their check pauses the heartbeat too, so the registry stops advertising the gateway. It keeps serving the ingress it already had - `/ready` reports the mesh runtime on every agent type, so the pod keeps its Service endpoints. Both hooks are declared the same way there, on any Spring bean, and the starter serves the four paths below from one controller whatever the agent type - so a `@GetMapping` of your own for any of them is an ambiguous mapping and the application does not start.
 

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -231,7 +231,7 @@ There are four of them, and Kubernetes probes must not share one:
 - `/ready` - `readinessProbe`. Whether the mesh runtime is up. Your `healthCheck` does not reach it: a failing check pauses the heartbeat and the registry stops resolving to this agent, which is the whole withdrawal, and a 503 here would also empty the Service that mesh traffic arrives on.
 - `/health` - no probe. Your `healthCheck`'s verdict plus the `checks` and `errors` it returned, answering 200 only while it reports `healthy`. An agent with no `healthCheck` - or one whose first run has not finished - is healthy, so it is unaffected.
 
-`/health` answers 503 while the check reports `degraded` or `unhealthy`, so pointing liveness at it turns a vendor outage into a pod restart, which cannot fix it. Probe Wiring below has the manifest.
+`/health` answers 503 whenever the check is not reporting `healthy`, so pointing liveness at it turns a vendor outage into a pod restart, which cannot fix it. Probe Wiring below has the manifest.
 
 Pass a `healthCheck` to `mesh()` to say what "able to serve" means for this agent:
 
@@ -256,7 +256,7 @@ const agent = mesh(server, {
 });
 ```
 
-While the check returns unhealthy the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider - restored automatically when the check passes, with no restart. Returning `boolean` works too: `true` is healthy, `false` unhealthy. A check that throws is recorded as `degraded` and keeps heartbeating, so a bug in the check cannot take a working agent out of the mesh. `MCP_MESH_HEALTH_CHECK_TTL` overrides `healthCheckTtl` (default 15s).
+While the check returns unhealthy the agent stops heartbeating, the registry withdraws it, and consumers resolve to another provider - restored automatically when the check passes, with no restart. Returning `boolean` works too: `true` is healthy, `false` unhealthy. A check that throws keeps heartbeating, so a bug in the check cannot take a working agent out of the mesh. `MCP_MESH_HEALTH_CHECK_TTL` overrides `healthCheckTtl` (default 15s).
 
 Route (`mesh.route`) and A2A agents are no exception: a `healthCheck` declared in the `meshExpress` config pauses the heartbeat too, so the registry stops advertising the gateway. It keeps serving the ingress it already had - `/ready` reports the mesh runtime on every agent type, so the pod keeps its Service endpoints.
 

--- a/src/core/cli/man/content/health.md
+++ b/src/core/cli/man/content/health.md
@@ -138,7 +138,9 @@ class MyAgent:
     pass
 ```
 
-One check per agent. Return a `{"status", "checks", "errors"}` dict for full detail, or a `bool` for the terse form (`True` healthy, `False` unhealthy). `health_check_ttl` is how often it re-runs (default 15); `MCP_MESH_HEALTH_CHECK_TTL` overrides it.
+One check per agent, sync or async. Return a `{"status", "checks", "errors"}` dict for full detail, or a `bool` for the terse form (`True` healthy, `False` unhealthy). A status is matched case-insensitively and surrounding whitespace is ignored; omitting it - or passing `None` - means healthy, so a result carrying only `checks` is reporting success. `health_check_ttl` is how often it re-runs (default 15); `MCP_MESH_HEALTH_CHECK_TTL` overrides it.
+
+A sync check is run on a worker thread, so a blocking probe cannot stall the loop it was scheduled on - which for a route or A2A gateway is the heartbeat loop. Keep it thread-safe: an async check is awaited on the calling loop and is the one to use for anything loop-affine, such as a connection pool built in the agent's lifespan.
 
 ### What a Failing Check Does
 
@@ -150,9 +152,17 @@ The verdict drives `/health`, which answers 200 only while the check reports `he
 
 ### Only an Explicit Unhealthy Withdraws the Agent
 
-A check that **raises** is recorded as `degraded`, not unhealthy, and keeps heartbeating. So is one that returns something other than a dict, a `bool` or a `HealthStatus`. A bug in a health check must not be able to remove a working agent from the mesh. Return `False` or `{"status": "unhealthy"}` to actually withdraw.
+A check that **raises** keeps heartbeating and stays in dependency resolution. So does one that returns something other than a dict, a `bool` or a `HealthStatus`. A bug in a health check must not be able to remove a working agent from the mesh. Return `False` or `{"status": "unhealthy"}` to actually withdraw.
 
-`degraded` shows on the diagnostic surface only: the agent keeps heartbeating and stays in dependency resolution, and `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict; readiness reports the mesh runtime and nothing else.
+Those verdicts show on the diagnostic surface only: `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict; readiness reports the mesh runtime and nothing else.
+
+### When Every Provider Withdraws
+
+A health check is per-agent, but the failure it reports usually is not. Broken egress, an expired shared credential, a vendor that is down for everyone: each provider of a capability observes it independently and each withdraws itself, so the capability can go from several providers to none within one refresh period.
+
+Mesh does not keep a last provider in rotation to prevent that. Routing to something that has just reported it cannot serve trades an unresolved dependency - fast, and clearly attributable - for a call that is guaranteed to fail slowly at the far end, and it makes the health check a suggestion. Withdrawal is also cheap: the agent keeps running, keeps its resolved dependencies, and re-registers by itself the moment its check passes again, so getting it wrong costs one refresh period.
+
+It is not silent, though. When the registry withdraws the last healthy provider of a capability it logs a warning naming that capability, so a total outage is something the registry says rather than something you infer from a scatter of consumer errors.
 
 ### Route and A2A Agents
 

--- a/src/core/cli/man/content/health_java.md
+++ b/src/core/cli/man/content/health_java.md
@@ -60,9 +60,17 @@ The verdict drives `/health`, which answers 503 while unhealthy and carries the 
 
 ### Only an Explicit Unhealthy Withdraws the Agent
 
-A check that **throws** is recorded as `degraded`, not unhealthy, and keeps heartbeating. A bug in a health check must not be able to remove a working agent from the mesh. Return `false` or `MeshHealth.unhealthy(...)` to actually withdraw.
+A check that **throws** keeps heartbeating and stays in dependency resolution, and so does one whose return value cannot be read. A bug in a health check must not be able to remove a working agent from the mesh. Return `false` or `MeshHealth.unhealthy(...)` to actually withdraw.
 
-`degraded` shows on the diagnostic surface only, the same way it does on Python: the agent keeps heartbeating and stays in dependency resolution, and `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict; readiness reports the mesh runtime and nothing else.
+Those verdicts show on the diagnostic surface only, the same way they do on Python: `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict; readiness reports the mesh runtime and nothing else.
+
+### When Every Provider Withdraws
+
+A health check is per-agent, but the failure it reports usually is not. Broken egress, an expired shared credential, a vendor that is down for everyone: each provider of a capability observes it independently and each withdraws itself, so the capability can go from several providers to none within one refresh period.
+
+Mesh does not keep a last provider in rotation to prevent that. Routing to something that has just reported it cannot serve trades an unresolved dependency - fast, and clearly attributable - for a call that is guaranteed to fail slowly at the far end, and it makes the health check a suggestion. Withdrawal is also cheap: the agent keeps running, keeps its resolved dependencies, and re-registers by itself the moment its check passes again, so getting it wrong costs one refresh period.
+
+It is not silent, though. When the registry withdraws the last healthy provider of a capability it logs a warning naming that capability, so a total outage is something the registry says rather than something you infer from a scatter of consumer errors.
 
 ### Route and A2A Agents
 

--- a/src/core/cli/man/content/health_typescript.md
+++ b/src/core/cli/man/content/health_typescript.md
@@ -64,7 +64,7 @@ const agent = mesh(server, {
 });
 ```
 
-One check per agent. Return `{ status, checks, errors }` for full detail, or a `boolean` for the terse form (`true` healthy, `false` unhealthy). `healthCheckTtl` is how often it re-runs (default 15); `MCP_MESH_HEALTH_CHECK_TTL` overrides it.
+One check per agent, sync or async. Return `{ status, checks, errors }` for full detail, or a `boolean` for the terse form (`true` healthy, `false` unhealthy). A status is matched case-insensitively and surrounding whitespace is ignored; omitting it - or passing `null` - means healthy, so a result carrying only `checks` is reporting success. `healthCheckTtl` is how often it re-runs (default 15); `MCP_MESH_HEALTH_CHECK_TTL` overrides it.
 
 The verdict drives `/health`, which answers 200 only while the check reports `healthy` and carries the `checks` and `errors` it returned. It does not drive `/ready`, which reports whether the mesh runtime is up: pausing the heartbeat already withdraws the agent, and a 503 on `/ready` would additionally empty the Service that mesh traffic arrives on. `/livez` never consults it either - a restart cannot fix a vendor outage.
 
@@ -72,9 +72,13 @@ The verdict drives `/health`, which answers 200 only while the check reports `he
 
 While the check reports unhealthy the agent **stops heartbeating**. The registry marks it unhealthy after the staleness window, dependency resolution stops selecting it, and consumers move to another provider. When the check passes again the heartbeat resumes and the registry restores the agent through the `410 Gone` re-register path - no restart. The TTL is the cadence, not the end-to-end latency: it only bounds how long until the next check runs. Withdrawal costs that plus the registry's staleness window once heartbeats stop, and recovery costs it plus the heartbeat resume and re-register round trip.
 
-Report `unhealthy` only for conditions the mesh should route around: the upstream this agent needs is genuinely not serving. A check that **throws**, or that could not reach a conclusion, is recorded as `degraded` and keeps heartbeating - a broken probe says nothing about the upstream, and withdrawing a working agent over one is the worse failure.
+Report `unhealthy` only for conditions the mesh should route around: the upstream this agent needs is genuinely not serving. A check that **throws**, or that could not reach a conclusion, keeps heartbeating and stays in dependency resolution - a broken probe says nothing about the upstream, and withdrawing a working agent over one is the worse failure.
 
-`degraded` shows on the diagnostic surface only, the same way it does on Python and Java: the agent keeps heartbeating and stays in dependency resolution, and `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict; readiness reports the mesh runtime and nothing else.
+Those verdicts show on the diagnostic surface only, the same way they do on Python and Java: `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict; readiness reports the mesh runtime and nothing else.
+
+A health check is per-agent, but the failure it reports usually is not. Broken egress, an expired shared credential, a vendor that is down for everyone: each provider of a capability observes it independently and each withdraws itself, so the capability can go from several providers to none within one refresh period.
+
+Mesh does not keep a last provider in rotation to prevent that. Routing to something that has just reported it cannot serve trades an unresolved dependency - fast, and clearly attributable - for a call that is guaranteed to fail slowly at the far end, and it makes the health check a suggestion. Withdrawal is also cheap: the agent keeps running, keeps its resolved dependencies, and re-registers by itself the moment its check passes again, so getting it wrong costs one refresh period. It is not silent, though: when the registry withdraws the last healthy provider of a capability it logs a warning naming that capability, so a total outage is something the registry says rather than something you infer from a scatter of consumer errors.
 
 A `mesh.route` or A2A gateway runs the check exactly as an MCP agent does, and a failing one pauses its heartbeat too, so the registry stops advertising it. Nothing else changes: the Express server keeps listening, the dependencies it already resolved stay wired, and `/ready` still answers 200 - the pod keeps its Service endpoints and keeps taking ingress. A withdrawn gateway stops being discovered; it does not go dark.
 

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -354,6 +354,35 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // is plain prose and adds none. Prose throughout, so the list goldens hold.
 // The `docs/tutorial/day-10-whats-next.md` twin carries the same correction at
 // tutorial length and is not sampled here.
+// Issue #1517: +2 / +0 / +0, both in `health.md`'s one-paragraph description of
+// what a check may return, which now states the parsing rules the runtimes
+// agreed on: `None` (the new span) reads as an absent status, and a result
+// carrying only `checks` (the second span) is reporting success. "sync or
+// async", case-insensitivity and whitespace trimming are prose and add none.
+// The `_typescript` variant gained the same sentence with `null` in place of
+// `None`, and as ever moves nothing here — these constants sample the default
+// variant alone.
+// Issue #1515: -2 / +0 / +0, both of them the word `degraded` leaving
+// `health.md`'s "Only an Explicit Unhealthy Withdraws the Agent" section. RFC
+// #1515 makes the return contract binary, so per the project's deprecation
+// convention the value comes out of the teaching surface entirely and the
+// runtime warning is the discovery path. Both paragraphs keep their meaning and
+// state it as a consequence instead: a check that raises "keeps heartbeating
+// and stays in dependency resolution", and "those verdicts" show on the
+// diagnostic surface only. No span is added in either — the removals are the
+// whole delta. The `_java` and `_typescript` variants lost the same two,
+// `deployment_java.md` one and `deployment_typescript.md` two (one of them the
+// `degraded`/`unhealthy` pair in "answers 503 while the check reports ...",
+// which becomes the single `healthy` of "whenever the check is not reporting
+// ..."). None of those five files are sampled here — these constants sample
+// the default variant alone, and `deployment.md` is untouched.
+//
+// The same issue ADDS a "When Every Provider Withdraws" section to all three
+// health pages — the answer to RFC #1515's open question 1 (no floor, and a
+// registry warning when a capability drops to zero providers), recorded where
+// the operator who sees that warning will look. It is deliberately span-free:
+// it names no identifier, no endpoint and no env var, only behaviour, so the
+// three goldens below are unmoved by it.
 const (
 	wantInlineCodeSpans = 1769
 	wantListCodeSpans   = 522

--- a/src/core/cli/scaffold/health_check_template_test.go
+++ b/src/core/cli/scaffold/health_check_template_test.go
@@ -98,7 +98,7 @@ var javaEntry = filepath.Join(
 // on purpose — they are what makes this guard a matrix rather than nine
 // hand-written cases.
 const (
-	outageMarker    = "vendor answered and it is not serving"
+	outageMarker    = "vendor ANSWERED, so it is reachable"
 	transportMarker = "The vendor is not answering at all"
 )
 
@@ -116,17 +116,23 @@ type runtimeProbe struct {
 	bannedVerdict string
 	// Text proving the check is actually wired to the agent.
 	wiring []string
+	// Text proving the probe's error handling is narrowed to transport
+	// failures, and text proving it is not catch-all.
+	narrowHandler string
+	broadHandler  string
 }
 
 var runtimeProbes = []runtimeProbe{
 	{
 		language:      "python",
 		entry:         "main.py",
-		outageEnd:     "except Exception",
+		outageEnd:     "except httpx.RequestError",
 		transportEnd:  "return {",
 		wantVerdict:   `status = "unhealthy"`,
 		bannedVerdict: `status = "degraded"`,
 		wiring:        []string{"health_check=health_check", "health_check_ttl="},
+		narrowHandler: "except httpx.RequestError",
+		broadHandler:  "except Exception",
 	},
 	{
 		language:      "typescript",
@@ -136,17 +142,22 @@ var runtimeProbes = []runtimeProbe{
 		wantVerdict:   `status: "unhealthy"`,
 		bannedVerdict: `status: "degraded"`,
 		wiring:        []string{"  healthCheck,", "healthCheckTtl:"},
+		// TypeScript cannot name a transport failure in the catch clause, so
+		// the narrowing is the rethrow on the first line of the handler.
+		narrowHandler: "if (!isVendorUnreachable(err)) throw err;",
 	},
 	{
 		language: "java",
 		entry:    javaEntry,
 		// Java's transport branch is the LAST catch, after the
-		// InterruptedException one that is legitimately degraded.
+		// InterruptedException one, which restores the interrupt and rethrows.
 		outageEnd:     "catch (InterruptedException",
 		transportEnd:  "\n    }",
 		wantVerdict:   "MeshHealthStatus.UNHEALTHY",
 		bannedVerdict: "MeshHealthStatus.DEGRADED",
 		wiring:        []string{"@MeshHealthCheck(ttlSeconds ="},
+		narrowHandler: "catch (IOException e)",
+		broadHandler:  "catch (Exception e)",
 	},
 }
 
@@ -197,6 +208,84 @@ func TestLlmProviderTemplates_TransportFailureIsUnhealthy(t *testing.T) {
 				require.NotContains(t, branch, rt.bannedVerdict,
 					"reporting degraded when the vendor is unreachable keeps the "+
 						"heartbeat alive and makes the provider unable to withdraw itself")
+			})
+		}
+	}
+}
+
+// The two branches disagree about REACHABILITY, and the disagreement is the
+// point: a vendor that answers with a 503 is reachable and not serving, while
+// one that never answers is not reachable at all. Reporting the first as
+// unreachable puts a claim on /health that the probe just disproved — the
+// connection succeeded — and it did so in the same function that gets 401
+// right two lines above.
+//
+// Both branches still report unhealthy; only the sub-check differs. That is
+// what makes this a separate guard from the two above rather than a widening
+// of them.
+func TestLlmProviderTemplates_VendorOutageReportsReachable(t *testing.T) {
+	// The rendered `reachable` sub-check, per runtime: false in the transport
+	// branch, true in the outage branch.
+	reachableTrue := map[string]string{
+		"python":     `_api_reachable"] = True`,
+		"typescript": "_api_reachable = true;",
+		"java":       `_api_reachable", true)`,
+	}
+	reachableFalse := map[string]string{
+		"python":     `_api_reachable"] = False`,
+		"typescript": "_api_reachable = false;",
+		"java":       `_api_reachable", false)`,
+	}
+
+	for _, rt := range runtimeProbes {
+		for _, vendor := range probeVendors {
+			t.Run(rt.language+" "+vendor.name, func(t *testing.T) {
+				content := renderProvider(t, rt.language, vendor.model, rt.entry)
+
+				outage := section(t, content, outageMarker, rt.outageEnd)
+				require.Contains(t, outage, reachableTrue[rt.language],
+					"the vendor ANSWERED in this branch, so it is reachable — the "+
+						"failure is the status it answered with, which the error string "+
+						"already carries")
+				require.NotContains(t, outage, reachableFalse[rt.language],
+					"reporting unreachable for a vendor that just answered contradicts "+
+						"the 401 branch of the same probe and misleads whoever reads "+
+						"/health during an outage")
+
+				transport := section(t, content, transportMarker, rt.transportEnd)
+				require.Contains(t, transport, reachableFalse[rt.language],
+					"nothing answered in this branch: this is the one case that is "+
+						"genuinely unreachable")
+			})
+		}
+	}
+}
+
+// A catch-all handler reports a DEFECT IN THE PROBE as a vendor outage, and a
+// vendor outage withdraws the agent. So a typo in the probe — a NameError, a
+// ReferenceError — would take a provider whose vendor is perfectly healthy out
+// of dependency resolution, permanently, because it recurs on every refresh.
+//
+// The runtime already refuses to do that: an exception that escapes a health
+// check is recorded as the indeterminate verdict, which keeps the agent
+// serving (issue #1477). The templates have to LET it escape to get that, so
+// each one names the transport failure it means and rethrows the rest.
+func TestLlmProviderTemplates_ProbeHandlersAreNarrow(t *testing.T) {
+	for _, rt := range runtimeProbes {
+		for _, vendor := range probeVendors {
+			t.Run(rt.language+" "+vendor.name, func(t *testing.T) {
+				content := renderProvider(t, rt.language, vendor.model, rt.entry)
+
+				require.Contains(t, content, rt.narrowHandler,
+					"the probe must answer only for the failure it can actually "+
+						"recognize — the vendor not answering — and let a defect in "+
+						"itself propagate to the runtime's indeterminate verdict")
+				if rt.broadHandler != "" {
+					require.NotContains(t, content, rt.broadHandler,
+						"a catch-all handler turns a bug in this probe into a vendor "+
+							"outage, and a vendor outage withdraws a working provider "+
+							"from the mesh")
+				}
 			})
 		}
 	}

--- a/src/core/cli/scaffold/health_check_template_test.go
+++ b/src/core/cli/scaffold/health_check_template_test.go
@@ -31,6 +31,13 @@ import (
 // Java's, so on Python and TypeScript a cancel branch would be unreachable
 // code — `AbortSignal.timeout` rejects with a "TimeoutError", which is a
 // transport failure and belongs in the unhealthy branch asserted below.
+//
+// RFC #1515 makes the contract binary and takes `degraded` out of the teaching
+// surface entirely, so the branch-scoped bans above are joined by a WHOLE-FILE
+// one (TestScaffoldedAgentsNeverMentionDegraded). Java's interrupt branch was
+// the last selection left: it now restores the interrupt and rethrows, which
+// lands on the runtime's own indeterminate verdict — the same outcome, chosen
+// by the runtime rather than named by the author.
 
 func templatesRoot(t *testing.T) string {
 	t.Helper()
@@ -209,6 +216,72 @@ func TestLlmProviderTemplates_HealthCheckIsWired(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// RFC #1515: `degraded` is out of the teaching surface, scaffold comments
+// included. The per-branch bans above stop the INVERSION; this stops the
+// vocabulary from coming back at all — as a returned value, as advice in a
+// comment, or as the "here is what the runtime does with a throw" aside that
+// three templates carried and that reads, to someone skimming for what to
+// return, like a third option.
+//
+// A whole-file assertion is only possible because nothing legitimate needs the
+// word any more. It is also the only assertion that would have caught the
+// original bug at its source: every template that shipped the inversion
+// mentioned `degraded` in prose first and returned it second.
+//
+// Every template gets this, not just llm-provider — basic, llm-agent,
+// a2a-consumer and api all carry the same health/startup preamble, and a
+// re-added mention in any one of them is a re-added mention. All five
+// templates in all three languages, so the table is the whole matrix.
+func TestScaffoldedAgentsNeverMentionDegraded(t *testing.T) {
+	templates := []struct {
+		language string
+		template string
+		entry    string
+	}{
+		{"python", "basic", "main.py"},
+		{"python", "llm-agent", "main.py"},
+		{"python", "llm-provider", "main.py"},
+		{"python", "a2a-consumer", "main.py"},
+		{"python", "api", "main.py"},
+		{"typescript", "basic", filepath.Join("src", "index.ts")},
+		{"typescript", "llm-agent", filepath.Join("src", "index.ts")},
+		{"typescript", "llm-provider", filepath.Join("src", "index.ts")},
+		{"typescript", "a2a-consumer", filepath.Join("src", "index.ts")},
+		{"typescript", "api", filepath.Join("src", "index.ts")},
+		{"java", "basic", javaEntry},
+		{"java", "llm-agent", javaEntry},
+		{"java", "llm-provider", javaEntry},
+		{"java", "a2a-consumer", javaEntry},
+		{"java", "api", javaEntry},
+	}
+
+	for _, tpl := range templates {
+		t.Run(tpl.language+" "+tpl.template, func(t *testing.T) {
+			ctx := &ScaffoldContext{
+				Name:        "verdict-probe",
+				Description: "verdict probe",
+				Language:    tpl.language,
+				OutputDir:   t.TempDir(),
+				Port:        9400,
+				Model:       "anthropic/claude-sonnet-5",
+				Template:    tpl.template,
+				TemplateDir: templatesRoot(t),
+			}
+			require.NoError(t, NewStaticProvider().Execute(ctx))
+
+			content, err := os.ReadFile(filepath.Join(ctx.OutputDir, ctx.Name, tpl.entry))
+			require.NoError(t, err)
+
+			require.NotContains(t, strings.ToLower(string(content)), "degraded",
+				"a health check answers one binary question — keep routing here, or "+
+					"stop — and `degraded` is the same answer as healthy on every mesh "+
+					"path. Naming it in scaffolded code is what produced the inversion "+
+					"this file exists to catch, so it stays out of the generated "+
+					"output entirely (RFC #1515)")
+		})
 	}
 }
 

--- a/src/core/registry/capability_outage.go
+++ b/src/core/registry/capability_outage.go
@@ -1,0 +1,163 @@
+package registry
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"mcp-mesh/src/core/ent/agent"
+	"mcp-mesh/src/core/ent/capability"
+)
+
+// capability_outage.go answers open question 1 of RFC #1515.
+//
+// # The question
+//
+// A health check that withdraws its agent is per-agent, but the CONDITION it
+// reports usually is not. Broken egress, an expired shared credential, a vendor
+// that is down for everyone: each provider of a capability observes it
+// independently, each reports unhealthy independently, and the capability goes
+// from N providers to zero within one TTL. A partial outage becomes a total one
+// with nothing left advertising the capability.
+//
+// # The decision: no floor, and it belongs nowhere
+//
+// A "keep the last provider" rule would route to something that has just told
+// us it cannot serve. It trades a clean 503 — a fast, typed, retryable answer
+// that says "this capability has no provider" — for a guaranteed failure at the
+// far end of a call the consumer had to make first, with the provider's own
+// error shape and the provider's own latency. That is a worse outcome on every
+// axis, and it makes the health check a suggestion.
+//
+// The floor does not belong at the consumer either, for the same reason. A
+// consumer cannot distinguish "the last provider is degraded but limping" from
+// "the last provider has withdrawn deliberately" — only the provider knows, and
+// it has already said so.
+//
+// This is also the general position mesh takes on withdrawal: it is cheap and
+// self-correcting. A withdrawn agent keeps running, keeps its resolved
+// dependencies and re-registers by itself the moment its check passes, so the
+// cost of withdrawing one too eagerly is bounded by one TTL. Damping,
+// hysteresis and grace periods all buy time against a transition that costs
+// almost nothing to reverse, and pay for it with a window where mesh knowingly
+// routes to something broken. None are added here.
+//
+// # What IS added: the signal
+//
+// "Correct" and "silent" are different things. Every provider withdrawing is
+// the right mechanical outcome and a serious operational event, and without a
+// signal an operator discovers it through consumer errors — one layer removed
+// from the cause, at whatever rate consumers happen to call. So the registry
+// says it out loud at the moment it becomes true.
+//
+// # Why here and not in the resolver
+//
+// The resolver already knows when a lookup finds no candidate
+// (findHealthyProviderWithTrace), and that is the tempting place. It is the
+// wrong one twice over. It is per-resolution — every heartbeat of every consumer
+// re-resolves, so a single unserved capability would log at the aggregate
+// heartbeat rate indefinitely. And it cannot tell an OUTAGE from a capability
+// that simply has no provider and never did, which is the normal, benign state
+// of every unsatisfied optional dependency in a partly-deployed mesh.
+//
+// A withdrawal is a transition, so it is reported on the transition: the health
+// monitor already has the set of agents it just marked unhealthy, and the check
+// below runs only when that set is non-empty. A steady-state mesh pays nothing.
+//
+// Scope is deliberately the staleness sweep and not graceful unregister. A
+// suppressed heartbeat is how a failing health check withdraws an agent, so this
+// is the path RFC #1515's failure mode travels. An unregister is an operator
+// action with an operator watching, and reporting it would make every rolling
+// deploy of a single-replica agent log a total outage it planned.
+
+// capabilitiesLeftWithoutHealthyProvider returns the capability names that the
+// given agents were serving and that now have no healthy provider left, sorted
+// for deterministic output.
+//
+// Two queries, both reached only after at least one agent has actually been
+// withdrawn: the capabilities those agents own, then which of those names any
+// healthy agent still provides. Errors are returned rather than logged so the
+// caller can decide — a diagnostic must not become a source of noise of its own.
+func (s *EntService) capabilitiesLeftWithoutHealthyProvider(
+	ctx context.Context,
+	agentIDs []string,
+) ([]string, error) {
+	if len(agentIDs) == 0 {
+		return nil, nil
+	}
+
+	// Only the name column: the report names capabilities, and a capability row
+	// carries the full tool schema. Selecting the rest would pull every input and
+	// output schema of every capability of every withdrawn agent across the wire
+	// to build a list of strings.
+	var lost []string
+	err := s.entDB.Capability.Query().
+		Where(capability.HasAgentWith(agent.IDIn(agentIDs...))).
+		Select(capability.FieldCapability).
+		Scan(ctx, &lost)
+	if err != nil {
+		return nil, err
+	}
+	if len(lost) == 0 {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(lost))
+	seen := map[string]bool{}
+	for _, name := range lost {
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+
+	// Deliberately re-queried rather than derived from the withdrawn set: another
+	// agent may provide the same capability, and it may have registered or
+	// recovered since. The DB is the only thing that knows what is serving NOW.
+	var survivors []string
+	err = s.entDB.Capability.Query().
+		Where(
+			capability.CapabilityIn(names...),
+			capability.HasAgentWith(agent.StatusEQ(agent.StatusHealthy)),
+		).
+		Select(capability.FieldCapability).
+		Scan(ctx, &survivors)
+	if err != nil {
+		return nil, err
+	}
+	for _, name := range survivors {
+		delete(seen, name)
+	}
+
+	unserved := make([]string, 0, len(seen))
+	for name := range seen {
+		unserved = append(unserved, name)
+	}
+	sort.Strings(unserved)
+	return unserved, nil
+}
+
+// reportCapabilitiesLeftWithoutProvider warns once per capability that has just
+// lost its last healthy provider.
+//
+// WARNING, not ERROR: nothing is broken in the registry, and the state is
+// self-correcting the moment a provider's check passes again. It is above INFO
+// because every consumer of that capability is now resolving to nothing, and
+// that is the kind of thing an operator wants to find in a log search rather
+// than infer from a scatter of consumer-side 503s.
+func (h *AgentHealthMonitor) reportCapabilitiesLeftWithoutProvider(ctx context.Context, agentIDs []string) {
+	unserved, err := h.entService.capabilitiesLeftWithoutHealthyProvider(ctx, agentIDs)
+	if err != nil {
+		h.logger.Debug("Could not check for capabilities left without a provider: %v", err)
+		return
+	}
+	if len(unserved) == 0 {
+		return
+	}
+	h.logger.Warning(
+		"No healthy provider remains for %d capability/capabilities: %s. "+
+			"Consumers resolving these will get no candidate until a provider "+
+			"re-registers or its health check passes again.",
+		len(unserved), strings.Join(unserved, ", "))
+}

--- a/src/core/registry/capability_outage_test.go
+++ b/src/core/registry/capability_outage_test.go
@@ -1,0 +1,262 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"mcp-mesh/src/core/config"
+	"mcp-mesh/src/core/database"
+	"mcp-mesh/src/core/ent"
+	"mcp-mesh/src/core/ent/agent"
+	"mcp-mesh/src/core/ent/enttest"
+	"mcp-mesh/src/core/logger"
+)
+
+// RFC #1515 open question 1. A health check that withdraws its agent is
+// per-agent; the CONDITION it reports usually is not. When a shared failure
+// takes every provider of a capability out within one TTL, mesh does NOT keep a
+// floor — see capability_outage.go for why — but it must not do that silently
+// either. These tests pin the detection: it fires exactly when a capability has
+// gone from served to unserved, and stays quiet on every neighbouring case that
+// looks similar.
+
+// seedCapabilityFor attaches one capability row to an existing agent.
+func seedCapabilityFor(t *testing.T, client *ent.Client, agentID, capName, fnName string) {
+	t.Helper()
+	_, err := client.Capability.Create().
+		SetAgentID(agentID).
+		SetFunctionName(fnName).
+		SetCapability(capName).
+		SetVersion("1.0.0").
+		SetTags([]string{}).
+		Save(context.Background())
+	if err != nil {
+		t.Fatalf("seed capability %s on %s: %v", capName, agentID, err)
+	}
+}
+
+// The shared-failure case the RFC names: both providers of a capability report
+// unhealthy in the same window, so it drops to zero providers.
+func TestCapabilityOutage_ReportsWhenLastProviderWithdraws(t *testing.T) {
+	client, service, _, cleanup := newHealthMonitorTestEnv(t, time.Minute)
+	defer cleanup()
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	seedAgent(t, client, "provider-a", agent.StatusHealthy, now)
+	seedAgent(t, client, "provider-b", agent.StatusHealthy, now)
+	seedCapabilityFor(t, client, "provider-a", "llm", "chat")
+	seedCapabilityFor(t, client, "provider-b", "llm", "chat")
+
+	// Both withdrawn (the state the health monitor leaves behind).
+	for _, id := range []string{"provider-a", "provider-b"} {
+		if err := client.Agent.UpdateOneID(id).SetStatus(agent.StatusUnhealthy).Exec(ctx); err != nil {
+			t.Fatalf("withdraw %s: %v", id, err)
+		}
+	}
+
+	unserved, err := service.capabilitiesLeftWithoutHealthyProvider(ctx, []string{"provider-a", "provider-b"})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if len(unserved) != 1 || unserved[0] != "llm" {
+		t.Errorf("unserved = %v, want [llm] — every provider of 'llm' withdrew, "+
+			"so the capability is advertised by nothing and consumers resolve to "+
+			"no candidate", unserved)
+	}
+}
+
+// A PARTIAL outage is the case a floor would have been for, and it is exactly
+// the case that must stay silent: one provider left is a working mesh.
+func TestCapabilityOutage_SilentWhileAnyProviderSurvives(t *testing.T) {
+	client, service, _, cleanup := newHealthMonitorTestEnv(t, time.Minute)
+	defer cleanup()
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	seedAgent(t, client, "provider-a", agent.StatusHealthy, now)
+	seedAgent(t, client, "provider-b", agent.StatusHealthy, now)
+	seedCapabilityFor(t, client, "provider-a", "llm", "chat")
+	seedCapabilityFor(t, client, "provider-b", "llm", "chat")
+
+	if err := client.Agent.UpdateOneID("provider-a").SetStatus(agent.StatusUnhealthy).Exec(ctx); err != nil {
+		t.Fatalf("withdraw provider-a: %v", err)
+	}
+
+	unserved, err := service.capabilitiesLeftWithoutHealthyProvider(ctx, []string{"provider-a"})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if len(unserved) != 0 {
+		t.Errorf("unserved = %v, want none — provider-b still serves 'llm', so "+
+			"failover is doing its job and there is nothing to report", unserved)
+	}
+}
+
+// An agent withdrawing several capabilities loses each independently, and the
+// report names only the ones nothing else covers.
+func TestCapabilityOutage_ReportsOnlyTheUncoveredCapabilities(t *testing.T) {
+	client, service, _, cleanup := newHealthMonitorTestEnv(t, time.Minute)
+	defer cleanup()
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	seedAgent(t, client, "multi", agent.StatusHealthy, now)
+	seedAgent(t, client, "backup", agent.StatusHealthy, now)
+	seedCapabilityFor(t, client, "multi", "alpha", "do_alpha")
+	seedCapabilityFor(t, client, "multi", "beta", "do_beta")
+	seedCapabilityFor(t, client, "backup", "beta", "do_beta")
+
+	if err := client.Agent.UpdateOneID("multi").SetStatus(agent.StatusUnhealthy).Exec(ctx); err != nil {
+		t.Fatalf("withdraw multi: %v", err)
+	}
+
+	unserved, err := service.capabilitiesLeftWithoutHealthyProvider(ctx, []string{"multi"})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if len(unserved) != 1 || unserved[0] != "alpha" {
+		t.Errorf("unserved = %v, want [alpha] — 'beta' is still served by backup", unserved)
+	}
+}
+
+// No withdrawal, no query, no report: the steady-state mesh must pay nothing
+// for this diagnostic.
+func TestCapabilityOutage_NoWithdrawalIsANoOp(t *testing.T) {
+	client, service, _, cleanup := newHealthMonitorTestEnv(t, time.Minute)
+	defer cleanup()
+
+	seedAgent(t, client, "provider-a", agent.StatusHealthy, time.Now().UTC())
+	seedCapabilityFor(t, client, "provider-a", "llm", "chat")
+
+	unserved, err := service.capabilitiesLeftWithoutHealthyProvider(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if unserved != nil {
+		t.Errorf("unserved = %v, want nil for an empty withdrawal set", unserved)
+	}
+}
+
+// runSweepCapturingWarnings runs one staleness sweep and returns everything the
+// monitor's logger wrote.
+//
+// The redirect wraps CONSTRUCTION as well as the run: logger.New binds
+// os.Stdout at construction, so a swap made afterwards would capture nothing.
+// The level is WARNING rather than the ERROR the other tests use, because the
+// line under test is a warning — the outage report is the registry TELLING an
+// operator, and a test that cannot see it can only assert on the helper the
+// monitor is assumed to call.
+func runSweepCapturingWarnings(
+	t *testing.T,
+	heartbeatTimeout time.Duration,
+	seed func(client *ent.Client),
+) string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	captured := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		captured <- buf.String()
+	}()
+
+	func() {
+		defer func() {
+			_ = w.Close()
+			os.Stdout = orig
+		}()
+
+		client := enttest.Open(t, "sqlite3", "file:capoutage_"+t.Name()+"?mode=memory&cache=shared&_fk=1")
+		defer client.Close()
+
+		testLogger := logger.New(&config.Config{LogLevel: "WARNING"})
+		service := NewEntService(&database.EntDatabase{Client: client}, nil, testLogger)
+		service.DisableStatusChangeHooks()
+		monitor := NewAgentHealthMonitor(service, testLogger, heartbeatTimeout, time.Minute)
+
+		seed(client)
+		monitor.checkUnhealthyAgents()
+	}()
+
+	return <-captured
+}
+
+// End-to-end through the monitor, asserted on what the monitor EMITS.
+//
+// The earlier version of this test called capabilitiesLeftWithoutHealthyProvider
+// itself, which made it a second test of the detection rather than a test of
+// the wiring: deleting the reportCapabilitiesLeftWithoutProvider call from
+// checkUnhealthyAgents — the whole feature — left it green. The warning is the
+// only thing the feature produces, so it is the only thing that can fail when
+// the feature is removed.
+func TestCapabilityOutage_WiredIntoTheStalenessSweep(t *testing.T) {
+	stale := time.Now().UTC().Add(-2 * time.Minute)
+
+	output := runSweepCapturingWarnings(t, time.Minute, func(client *ent.Client) {
+		seedAgent(t, client, "only-provider", agent.StatusHealthy, stale)
+		seedCapabilityFor(t, client, "only-provider", "llm", "chat")
+	})
+
+	if !strings.Contains(output, "No healthy provider remains") {
+		t.Fatalf("the sweep withdrew the only provider of 'llm' and said nothing.\n"+
+			"An operator learns about a total outage from consumer errors one layer "+
+			"removed from the cause unless the registry reports it.\ngot:\n%s", output)
+	}
+	if !strings.Contains(output, "llm") {
+		t.Errorf("the report must NAME the capability — that is what makes it "+
+			"searchable.\ngot:\n%s", output)
+	}
+}
+
+// The neighbouring case, through the same surface: a surviving provider means
+// the sweep says nothing. Without this, a report that fired unconditionally on
+// every withdrawal would pass the test above.
+func TestCapabilityOutage_SweepIsSilentWhileAProviderSurvives(t *testing.T) {
+	stale := time.Now().UTC().Add(-2 * time.Minute)
+
+	output := runSweepCapturingWarnings(t, time.Minute, func(client *ent.Client) {
+		seedAgent(t, client, "provider-a", agent.StatusHealthy, stale)
+		seedAgent(t, client, "provider-b", agent.StatusHealthy, time.Now().UTC())
+		seedCapabilityFor(t, client, "provider-a", "llm", "chat")
+		seedCapabilityFor(t, client, "provider-b", "llm", "chat")
+	})
+
+	if strings.Contains(output, "No healthy provider remains") {
+		t.Errorf("provider-b still serves 'llm' — failover is doing its job and "+
+			"there is nothing to report.\ngot:\n%s", output)
+	}
+}
+
+// A race lost to a concurrent heartbeat must not be reported as an outage: the
+// monitor only passes on the agents it actually flipped, and that agent is still
+// healthy and still serving.
+func TestCapabilityOutage_RaceLostAgentIsNotReported(t *testing.T) {
+	client, service, _, cleanup := newHealthMonitorTestEnv(t, time.Minute)
+	defer cleanup()
+
+	seedAgent(t, client, "provider-a", agent.StatusHealthy, time.Now().UTC())
+	seedCapabilityFor(t, client, "provider-a", "llm", "chat")
+
+	// The agent is still healthy — exactly the state a race-loser is left in.
+	unserved, err := service.capabilitiesLeftWithoutHealthyProvider(context.Background(), []string{"provider-a"})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if len(unserved) != 0 {
+		t.Errorf("unserved = %v, want none — the agent won its heartbeat race and "+
+			"is still serving 'llm'", unserved)
+	}
+}

--- a/src/core/registry/health_monitor.go
+++ b/src/core/registry/health_monitor.go
@@ -111,6 +111,9 @@ func (h *AgentHealthMonitor) checkUnhealthyAgents() {
 	// Individual updates needed because Ent's UpdateDefault(time.Now) would
 	// auto-bump updated_at in a batch update, making agents appear recently seen.
 	var agentsUpdated, racesLost int
+	// Only the race-winners: an agent whose heartbeat beat us is still serving,
+	// so counting it here would report an outage that did not happen.
+	var withdrawn []string
 	for _, a := range agentsToUpdate {
 		won, err := h.markAgentUnhealthyIfUnchanged(ctx, a)
 		if err != nil {
@@ -124,6 +127,7 @@ func (h *AgentHealthMonitor) checkUnhealthyAgents() {
 			continue
 		}
 		agentsUpdated++
+		withdrawn = append(withdrawn, a.ID)
 
 		// Flip all resolution rows that point at this now-offline provider to
 		// unavailable so consumer-side state stays consistent (see
@@ -141,6 +145,12 @@ func (h *AgentHealthMonitor) checkUnhealthyAgents() {
 	} else {
 		h.logger.Info("Health monitor: marked %d agents as unhealthy", agentsUpdated)
 	}
+
+	// RFC #1515 open question 1. A shared failure withdraws every provider of a
+	// capability at once, and mesh does not floor that — see capability_outage.go
+	// for why no floor belongs anywhere. It does report it: this runs only after
+	// a withdrawal actually landed, so a steady-state mesh never reaches it.
+	h.reportCapabilitiesLeftWithoutProvider(ctx, withdrawn)
 }
 
 // markAgentUnhealthyIfUnchanged flips a single agent to unhealthy using an

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealth.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealth.java
@@ -63,7 +63,21 @@ public record MeshHealth(
      * Impaired but still serving — keeps heartbeating and stays in resolution.
      *
      * @param errors reasons, rendered into {@code /health}; nulls are dropped
+     * @deprecated since 3.7.0 (issue #1515). The question a health check answers
+     *     is binary — stay in dependency resolution, or withdraw — and this
+     *     factory gives the same answer {@link #healthy()} does: the agent
+     *     keeps heartbeating and consumers keep routing to it. It differs only
+     *     in the status code of {@code /health}, which nothing probes.
+     *     <p>Use {@link #healthy()} for an impairment you can serve through,
+     *     recording the detail with {@link #withCheck(String, Object)} so an
+     *     operator still sees it, and {@link #unhealthy(String...)} for one you
+     *     cannot. To report an INDETERMINATE probe — one cut short, so it
+     *     concluded nothing — throw: the runtime records that itself and keeps
+     *     the agent in resolution.
+     *     <p>Behaviour is unchanged and this still compiles and runs; it emits
+     *     a one-time runtime warning. Removal no earlier than 4.0.
      */
+    @Deprecated(since = "3.7.0")
     public static MeshHealth degraded(String... errors) {
         return new MeshHealth(MeshHealthStatus.DEGRADED, null, cleanErrors(errors));
     }
@@ -80,14 +94,57 @@ public record MeshHealth(
     }
 
     /**
-     * Build from a wire status string, mapping anything unrecognized to
-     * {@link MeshHealthStatus#DEGRADED} rather than unhealthy.
+     * The {@link #checks()} key the runtime sets when it could not READ the
+     * status it was given, as opposed to acting on one it could.
+     *
+     * <p>Same key and same {@code false} value TypeScript's
+     * {@code normalizeHealthResult} uses, so {@code /health} reads identically
+     * on both runtimes. It is also what tells the deprecation warning apart
+     * from a real selection: a {@code DEGRADED} carrying this marker is the
+     * runtime's verdict about an unreadable string, not the author's about
+     * their upstream, and warning at them would be pointing at an API they
+     * never used.
+     */
+    public static final String UNREADABLE_STATUS_CHECK = "health_check_status_value";
+
+    /**
+     * Build from a wire status string.
+     *
+     * <p>A value that cannot be read — including null — becomes the runtime's
+     * own indeterminate verdict: {@link MeshHealthStatus#DEGRADED}, so the
+     * agent keeps heartbeating and stays in resolution, carrying
+     * {@link #UNREADABLE_STATUS_CHECK} and an error naming the value so an
+     * operator sees on {@code /health} that the status was the problem.
+     * Deliberately not {@link MeshHealthStatus#UNHEALTHY}: withdrawing an agent
+     * because its status string could not be parsed is a far worse failure than
+     * keeping it.
      *
      * @param status wire value: {@code healthy} / {@code degraded} / {@code unhealthy}
      * @param errors reasons; nulls are dropped
      */
     public static MeshHealth of(String status, String... errors) {
-        return new MeshHealth(MeshHealthStatus.fromWire(status), null, cleanErrors(errors));
+        MeshHealthStatus parsed = MeshHealthStatus.parseWire(status);
+        if (parsed == null) {
+            List<String> reasons = new ArrayList<>(cleanErrors(errors));
+            reasons.add("Unrecognized health status: " + status);
+            return new MeshHealth(
+                MeshHealthStatus.DEGRADED, Map.of(UNREADABLE_STATUS_CHECK, false), reasons);
+        }
+        return new MeshHealth(parsed, null, cleanErrors(errors));
+    }
+
+    /**
+     * Whether this verdict is one the RUNTIME assigned because it could not
+     * read the status it was handed, rather than one the author selected.
+     *
+     * <p>Only {@link #of(String, String...)} produces one — every other route
+     * to {@code DEGRADED} on this type ({@link #degraded(String...)},
+     * {@link #withStatus(MeshHealthStatus)}, the canonical constructor) is a
+     * choice — and it is the one the deprecation warning must skip.
+     */
+    public boolean isUnreadableStatus() {
+        return status == MeshHealthStatus.DEGRADED
+            && Boolean.FALSE.equals(checks.get(UNREADABLE_STATUS_CHECK));
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealthStatus.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshHealthStatus.java
@@ -13,11 +13,18 @@ public enum MeshHealthStatus {
     HEALTHY("healthy"),
 
     /**
-     * Working, but impaired. Still heartbeats and stays in resolution — the
-     * mesh does not withdraw an agent that says it can still serve.
+     * Where the RUNTIME puts a verdict it could not trust: a check that threw,
+     * a check it could not invoke, an unusable return type, and a status string
+     * it could not parse. The agent keeps heartbeating and stays in resolution —
+     * an indeterminate probe concluded nothing about the upstream, and
+     * withdrawing a working agent over one is the worse failure.
      *
-     * <p>Also where the runtime puts a verdict it could not trust: a check that
-     * threw, and a status string it could not parse.
+     * <p>The enum constant is not deprecated: it names the verdict the runtime
+     * assigns and the one {@code /health} reports. SELECTING it from a health
+     * check is deprecated (issue #1515) — see
+     * {@link MeshHealth#degraded(String...)}. It is indistinguishable from
+     * {@link #HEALTHY} on every mesh path, so the runtime warns once and keeps
+     * the agent serving.
      */
     DEGRADED("degraded"),
 
@@ -50,10 +57,34 @@ public enum MeshHealthStatus {
      * because its status string could not be read is a far worse failure than
      * keeping it. Mirrors Python's {@code publish_health_status_to_core}.
      *
+     * <p>Total, so it cannot report WHICH of the two things happened — a status
+     * the author wrote as {@code "degraded"}, or one the runtime could not read.
+     * Callers that must tell those apart use {@link #parseWire(String)}; this is
+     * for the ones that just need a verdict.
+     *
      * @param value wire value; may be null
      * @return the matching status, or {@link #DEGRADED}
      */
     public static MeshHealthStatus fromWire(String value) {
+        MeshHealthStatus parsed = parseWire(value);
+        return parsed != null ? parsed : DEGRADED;
+    }
+
+    /**
+     * Parse a wire value, reporting an unreadable one DISTINCTLY.
+     *
+     * <p>{@link #fromWire(String)} folds "the author wrote degraded" and "the
+     * runtime could not read this" into the same constant, and the two must not
+     * be treated the same: only the first is a choice the author made, and only
+     * the first is deprecated (issue #1515). Returning null for the second is
+     * what lets {@link MeshHealth#of(String, String...)} record it as the
+     * runtime's own indeterminate verdict rather than as a selection, so the
+     * deprecation warning cannot fire at an author who never used the API.
+     *
+     * @param value wire value; may be null
+     * @return the matching status, or null when there is none
+     */
+    public static MeshHealthStatus parseWire(String value) {
         if (value != null) {
             for (MeshHealthStatus status : values()) {
                 if (status.wireValue.equalsIgnoreCase(value.trim())) {
@@ -61,6 +92,6 @@ public enum MeshHealthStatus {
                 }
             }
         }
-        return DEGRADED;
+        return null;
     }
 }

--- a/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshHealthTest.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/test/java/io/mcpmesh/MeshHealthTest.java
@@ -10,7 +10,16 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/** {@link MeshHealth} construction rules (issue #1474). */
+/**
+ * {@link MeshHealth} construction rules (issue #1474).
+ *
+ * <p>{@link MeshHealth#degraded} is deprecated (issue #1515) and still under
+ * test on purpose: the deprecation promises source compatibility until 4.0, so
+ * the factory has to keep constructing exactly what it always did. The
+ * suppression is what keeps that promise visible instead of drowning the build
+ * in notices about a call this class exists to make.
+ */
+@SuppressWarnings("deprecation")
 class MeshHealthTest {
 
     @Test
@@ -112,6 +121,39 @@ class MeshHealthTest {
         assertEquals(MeshHealthStatus.DEGRADED, MeshHealthStatus.fromWire(null));
         assertEquals(MeshHealthStatus.UNHEALTHY, MeshHealthStatus.fromWire(" UNHEALTHY "));
         assertEquals("unhealthy", MeshHealthStatus.UNHEALTHY.wireValue());
+    }
+
+    // The verdict is the same DEGRADED either way; what differs is whether the
+    // runtime can tell it assigned it. `fromWire` folds the two together, so
+    // `of()` parses instead — otherwise `MeshHealth.of(vendorStatus)` with an
+    // unreadable string warns the author about MeshHealth.degraded(), an API
+    // they never called (issue #1515).
+    @Test
+    void anUnreadableStatusIsMarkedAsTheRuntimesOwnVerdict() {
+        MeshHealth health = MeshHealth.of("mostly fine", "vendor said so");
+
+        assertEquals(MeshHealthStatus.DEGRADED, health.status());
+        assertTrue(health.isUnreadableStatus());
+        assertEquals(false, health.checks().get(MeshHealth.UNREADABLE_STATUS_CHECK));
+        // The caller's own reasons survive; the parse failure is appended.
+        assertEquals(List.of("vendor said so", "Unrecognized health status: mostly fine"),
+            health.errors());
+
+        assertTrue(MeshHealth.of(null).isUnreadableStatus());
+        assertNull(MeshHealthStatus.parseWire("mostly fine"));
+        assertNull(MeshHealthStatus.parseWire(null));
+    }
+
+    @Test
+    void aReadableStatusIsNotMarked() {
+        assertFalse(MeshHealth.of(" DeGrAdEd ").isUnreadableStatus());
+        assertEquals(MeshHealthStatus.DEGRADED, MeshHealth.of(" DeGrAdEd ").status());
+        assertFalse(MeshHealth.of("healthy").isUnreadableStatus());
+        assertFalse(MeshHealth.unhealthy("down").isUnreadableStatus());
+        assertFalse(MeshHealth.degraded("slow").isUnreadableStatus());
+        assertTrue(MeshHealth.of("mostly fine").checks().containsKey(
+            MeshHealth.UNREADABLE_STATUS_CHECK));
+        assertTrue(MeshHealth.of("healthy").checks().isEmpty());
     }
 
     @Test

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckRegistry.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Holds the agent's single {@link MeshHealthCheck} and the latest verdict it
@@ -174,14 +175,20 @@ public class MeshHealthCheckRegistry {
      * <p>Warned once per process, not once per refresh — the check re-runs every
      * TTL (15s by default), and a per-tick line would be several thousand
      * identical warnings a day from an agent doing what its author intended.
+     *
+     * <p>An {@link AtomicBoolean} rather than a volatile flag: health checks run
+     * on the scheduler's thread and on whichever thread serves {@code /health},
+     * so a check-then-assign can interleave and log twice. Python guards the
+     * same flag with a lock and TypeScript is single-threaded; ONCE has to mean
+     * once here too, or the deduplication that justifies warning at all stops
+     * holding on exactly the multi-threaded runtime.
      */
-    private static volatile boolean degradedReturnWarned = false;
+    private static final AtomicBoolean degradedReturnWarned = new AtomicBoolean(false);
 
     private static void warnDegradedReturnOnce() {
-        if (degradedReturnWarned) {
+        if (!degradedReturnWarned.compareAndSet(false, true)) {
             return;
         }
-        degradedReturnWarned = true;
         log.warn("@MeshHealthCheck returned degraded — this agent stays in dependency "
             + "resolution and consumers will keep routing to it. Return "
             + "MeshHealth.unhealthy(...) to withdraw.");
@@ -189,7 +196,7 @@ public class MeshHealthCheckRegistry {
 
     /** Re-arm the once-per-process deprecation warning. Tests only. */
     static void resetDegradedReturnWarning() {
-        degradedReturnWarned = false;
+        degradedReturnWarned.set(false);
     }
 
     /**

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckRegistry.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthCheckRegistry.java
@@ -159,13 +159,66 @@ public class MeshHealthCheckRegistry {
     }
 
     /**
+     * {@code degraded} as a RETURN VALUE is deprecated (issue #1515).
+     *
+     * <p>The question a health check answers is binary: stay in dependency
+     * resolution, or withdraw. {@code DEGRADED} and {@code HEALTHY} are the same
+     * answer to it, so the third word buys a 503 on an endpoint nothing probes
+     * and costs the failure rate of a name that reads like withdrawal to
+     * everyone who picks it when their upstream is down.
+     *
+     * <p>The BEHAVIOUR is unchanged, deliberately: remapping it to
+     * {@code UNHEALTHY} would fix the common intent and silently withdraw every
+     * agent whose author used the word correctly.
+     *
+     * <p>Warned once per process, not once per refresh — the check re-runs every
+     * TTL (15s by default), and a per-tick line would be several thousand
+     * identical warnings a day from an agent doing what its author intended.
+     */
+    private static volatile boolean degradedReturnWarned = false;
+
+    private static void warnDegradedReturnOnce() {
+        if (degradedReturnWarned) {
+            return;
+        }
+        degradedReturnWarned = true;
+        log.warn("@MeshHealthCheck returned degraded — this agent stays in dependency "
+            + "resolution and consumers will keep routing to it. Return "
+            + "MeshHealth.unhealthy(...) to withdraw.");
+    }
+
+    /** Re-arm the once-per-process deprecation warning. Tests only. */
+    static void resetDegradedReturnWarning() {
+        degradedReturnWarned = false;
+    }
+
+    /**
      * Convert a health-check return value. The accepted shapes are enforced at
      * boot by {@link MeshHealthCheckBeanPostProcessor}, so the fallback here is
      * defence in depth, not a supported path — and it degrades rather than
      * withdrawing.
+     *
+     * <p>The runtime-assigned {@code DEGRADED} below does NOT warn — nothing the
+     * author can act on happened. Only a {@code DEGRADED} the author SELECTED
+     * does, and this is the single chokepoint for that:
+     * {@link MeshHealth#degraded(String...)},
+     * {@code withStatus(MeshHealthStatus.DEGRADED)},
+     * {@code new MeshHealth(DEGRADED, ...)} and
+     * {@link MeshHealth#of(String, String...)} given a readable
+     * {@code "degraded"} all pass through here.
+     *
+     * <p>{@code of()} is the one route that can reach the {@link MeshHealth}
+     * branch WITHOUT a selection: it maps a status string it cannot read to
+     * {@code DEGRADED} too, so {@code return MeshHealth.of(vendorStatus)} with
+     * {@code vendorStatus} of {@code "down"} would otherwise warn an author
+     * about {@code degraded()}, an API they never called. Those verdicts carry
+     * {@link MeshHealth#UNREADABLE_STATUS_CHECK} and are skipped here.
      */
     static MeshHealth coerce(Object raw) {
         if (raw instanceof MeshHealth health) {
+            if (health.status() == MeshHealthStatus.DEGRADED && !health.isUnreadableStatus()) {
+                warnDegradedReturnOnce();
+            }
             return health;
         }
         if (raw instanceof Boolean ok) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckBeanPostProcessorTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckBeanPostProcessorTest.java
@@ -14,6 +14,11 @@ import static org.junit.jupiter.api.Assertions.*;
  * from a permanently-degraded verdict on a live provider is exactly the failure
  * this feature exists to prevent.
  */
+// MeshHealth.degraded is deprecated (issue #1515) and still exercised here: the
+// deprecation promises source compatibility until 4.0, so the paths that carry a
+// degraded verdict have to keep working. Suppressed rather than rewritten so the
+// promise stays under test.
+@SuppressWarnings("deprecation")
 class MeshHealthCheckBeanPostProcessorTest {
 
     static class Valid {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckRegistryTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckRegistryTest.java
@@ -17,6 +17,11 @@ import static org.junit.jupiter.api.Assertions.*;
  * agent. A check that throws, or whose verdict cannot be read, is DEGRADED —
  * it keeps heartbeating.
  */
+// MeshHealth.degraded is deprecated (issue #1515) and still exercised here: the
+// deprecation promises source compatibility until 4.0, so the paths that carry a
+// degraded verdict have to keep working. Suppressed rather than rewritten so the
+// promise stays under test.
+@SuppressWarnings("deprecation")
 class MeshHealthCheckRegistryTest {
 
     static class Checks {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckSchedulerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthCheckSchedulerTest.java
@@ -31,6 +31,11 @@ import static org.mockito.Mockito.*;
  *       #1473's exemption).</li>
  * </ul>
  */
+// MeshHealth.degraded is deprecated (issue #1515) and still exercised here: the
+// deprecation promises source compatibility until 4.0, so the paths that carry a
+// degraded verdict have to keep working. Suppressed rather than rewritten so the
+// promise stays under test.
+@SuppressWarnings("deprecation")
 class MeshHealthCheckSchedulerTest {
 
     static class Checks {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthControllerTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthControllerTest.java
@@ -25,6 +25,11 @@ import static org.mockito.Mockito.*;
  *       still drives {@code /health}, which nothing probes.
  * </ul>
  */
+// MeshHealth.degraded is deprecated (issue #1515) and still exercised here: the
+// deprecation promises source compatibility until 4.0, so the paths that carry a
+// degraded verdict have to keep working. Suppressed rather than rewritten so the
+// promise stays under test.
+@SuppressWarnings("deprecation")
 class MeshHealthControllerTest {
 
     private static MeshRuntime runtimeWith(boolean running) {

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthDegradedDeprecationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthDegradedDeprecationTest.java
@@ -123,6 +123,46 @@ class MeshHealthDegradedDeprecationTest {
         assertEquals(1, deprecationWarnings().size());
     }
 
+    // ONCE has to mean once on the runtime that can actually race. Health
+    // checks run on the scheduler's thread and on whichever thread serves
+    // /health, so a check-then-assign on a plain flag interleaves and logs
+    // twice — the deduplication that justifies warning at all stops holding
+    // on exactly the multi-threaded runtime. Python guards the same flag with
+    // a lock and TypeScript is single-threaded; this is the compareAndSet.
+    @Test
+    void warnsOnceUnderConcurrentCallers() throws Exception {
+        int threads = 16;
+        var start = new java.util.concurrent.CountDownLatch(1);
+        var done = new java.util.concurrent.CountDownLatch(threads);
+        var pool = java.util.concurrent.Executors.newFixedThreadPool(threads);
+        var failures = new java.util.concurrent.CopyOnWriteArrayList<Throwable>();
+
+        try {
+            for (int i = 0; i < threads; i++) {
+                pool.execute(() -> {
+                    try {
+                        start.await();
+                        MeshHealthCheckRegistry.coerce(MeshHealth.degraded("upstream slow"));
+                    } catch (Throwable t) {
+                        failures.add(t);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(10, java.util.concurrent.TimeUnit.SECONDS),
+                "concurrent coerce calls did not finish");
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertEquals(List.of(), failures, failures.toString());
+        assertEquals(1, deprecationWarnings().size(),
+            "two callers both passed the check before either assigned, so the "
+                + "once-per-process warning fired twice");
+    }
+
     // The indeterminate paths keep the internal state and say nothing: the
     // runtime assigned that verdict, so there is nothing for the author to fix.
     @Test

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthDegradedDeprecationTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshHealthDegradedDeprecationTest.java
@@ -1,0 +1,231 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshHealth;
+import io.mcpmesh.MeshHealthStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code degraded} as a health-check RETURN VALUE is deprecated (issue #1515).
+ *
+ * <p>The question a health check answers is binary: stay in dependency
+ * resolution, or withdraw. {@code DEGRADED} and {@code HEALTHY} are the same
+ * answer to it — both keep the heartbeat alive and both keep consumers routing
+ * here — so the third word buys a 503 on an endpoint nothing probes and costs
+ * the failure rate of a name that reads like withdrawal to everyone who picks
+ * it when their upstream is down.
+ *
+ * <p>Two things are pinned here, and the second matters more than the first:
+ *
+ * <ol>
+ *   <li>selecting {@code DEGRADED} warns, naming the CONSEQUENCE rather than
+ *       the value;
+ *   <li><b>behaviour is unchanged.</b> Remapping it to {@code UNHEALTHY} would
+ *       fix the common intent and silently withdraw every agent whose author
+ *       used the word correctly.
+ * </ol>
+ *
+ * <p>The runtime's OWN degraded verdicts — a check that threw, one it could not
+ * invoke, an unusable return type — must NOT warn: nothing the author can act
+ * on happened.
+ *
+ * <p>Java is also the source-compatibility case. {@link MeshHealth#degraded}
+ * is a public factory, so it carries {@code @Deprecated} and keeps working;
+ * removal is no earlier than 4.0. The {@code @SuppressWarnings} below is the
+ * point of this file, not an oversight — it must still COMPILE.
+ */
+@SuppressWarnings("deprecation")
+class MeshHealthDegradedDeprecationTest {
+
+    private LogCapture logs;
+
+    @BeforeEach
+    void setUp() {
+        MeshHealthCheckRegistry.resetDegradedReturnWarning();
+        logs = LogCapture.attach(MeshHealthCheckRegistry.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logs.detach();
+        MeshHealthCheckRegistry.resetDegradedReturnWarning();
+    }
+
+    private List<String> deprecationWarnings() {
+        return logs.events.stream()
+            .filter(e -> "WARN".equals(e.level()))
+            .map(LogCapture.LogEvent::message)
+            .filter(m -> m.contains("keep routing to it"))
+            .toList();
+    }
+
+    // The consequence, not the value. An author who reads "degraded is
+    // deprecated" learns nothing; one who reads "consumers will keep routing to
+    // it" learns whether they meant it.
+    @Test
+    void selectingDegradedWarnsAndNamesTheConsequence() {
+        MeshHealth health = MeshHealthCheckRegistry.coerce(MeshHealth.degraded("upstream slow"));
+
+        assertEquals(MeshHealthStatus.DEGRADED, health.status());
+        List<String> warnings = deprecationWarnings();
+        assertEquals(1, warnings.size(), "expected exactly one deprecation warning");
+        assertTrue(warnings.get(0).contains("stays in dependency resolution"), warnings.get(0));
+        assertTrue(warnings.get(0).contains("consumers will keep routing to it"), warnings.get(0));
+        assertTrue(warnings.get(0).contains("MeshHealth.unhealthy(...)"), warnings.get(0));
+    }
+
+    // Every route to a user-selected DEGRADED funnels through coerce, so all
+    // three must warn — a guard on the factory alone would miss two of them.
+    @Test
+    void everyRouteToASelectedDegradedWarns() {
+        MeshHealthCheckRegistry.coerce(MeshHealth.of("degraded", "via of()"));
+        assertEquals(1, deprecationWarnings().size(), "MeshHealth.of(\"degraded\") is a selection");
+
+        MeshHealthCheckRegistry.resetDegradedReturnWarning();
+        logs.events.clear();
+        MeshHealthCheckRegistry.coerce(
+            MeshHealth.healthy().withStatus(MeshHealthStatus.DEGRADED));
+        assertEquals(1, deprecationWarnings().size(), "withStatus(DEGRADED) is a selection");
+    }
+
+    // The whole point of warning rather than remapping: an author who used the
+    // word correctly — impaired, still serving — keeps serving.
+    @Test
+    void behaviourIsUnchanged() {
+        MeshHealth health = MeshHealthCheckRegistry.coerce(
+            MeshHealth.degraded("cache cold").withCheck("cache_warm", false));
+
+        assertEquals(MeshHealthStatus.DEGRADED, health.status(),
+            "remapping degraded to unhealthy would withdraw every agent whose "
+                + "author used the word correctly");
+        assertNotEquals(MeshHealthStatus.UNHEALTHY, health.status());
+        assertTrue(health.isServing(), "a degraded agent stays in dependency resolution");
+        assertEquals(false, health.checks().get("cache_warm"));
+        assertEquals(List.of("cache cold"), health.errors());
+    }
+
+    // A check re-runs every TTL; at the 15s default a per-tick warning is
+    // ~5,760 identical lines a day from an agent doing what its author intended.
+    @Test
+    void warnsOncePerProcess() {
+        for (int i = 0; i < 5; i++) {
+            assertEquals(MeshHealthStatus.DEGRADED,
+                MeshHealthCheckRegistry.coerce(MeshHealth.degraded("slow")).status());
+        }
+        assertEquals(1, deprecationWarnings().size());
+    }
+
+    // The indeterminate paths keep the internal state and say nothing: the
+    // runtime assigned that verdict, so there is nothing for the author to fix.
+    @Test
+    void runtimeAssignedDegradedIsSilent() {
+        assertEquals(MeshHealthStatus.DEGRADED,
+            MeshHealthCheckRegistry.coerce("a string is not a verdict").status());
+        assertEquals(MeshHealthStatus.DEGRADED,
+            MeshHealthCheckRegistry.coerce(null).status());
+        assertEquals(MeshHealthStatus.DEGRADED,
+            MeshHealthCheckRegistry.coerce(42).status());
+
+        assertEquals(List.of(), deprecationWarnings(),
+            "the author did not choose these — the runtime assigned them because "
+                + "it had no verdict it could trust");
+    }
+
+    // The one runtime-assigned DEGRADED that arrives on the MeshHealth branch,
+    // and the only way to warn an author about an API they never called.
+    // `MeshHealth.of(vendorStatus)` with an unreadable string is a REPORTING
+    // fact, not a verdict the author chose; Python maps the same input to
+    // UNKNOWN and TypeScript returns before its guard, so Java was the only
+    // runtime that leaked here.
+    @Test
+    void anUnreadableStatusStringIsNotASelection() {
+        MeshHealth health = MeshHealthCheckRegistry.coerce(MeshHealth.of("down"));
+
+        assertEquals(MeshHealthStatus.DEGRADED, health.status());
+        assertTrue(health.isUnreadableStatus());
+        assertEquals(false, health.checks().get(MeshHealth.UNREADABLE_STATUS_CHECK),
+            "the operator still learns on /health that the STATUS was the problem");
+        assertTrue(health.errors().get(0).contains("down"), health.errors().toString());
+        assertEquals(List.of(), deprecationWarnings(),
+            "warning here tells an author to stop calling MeshHealth.degraded(), "
+                + "which they did not call");
+    }
+
+    // fromWire maps null to DEGRADED, so a null status used to land on the
+    // deprecation warning by the same route.
+    @Test
+    void aNullStatusStringIsNotASelectionEither() {
+        MeshHealth health = MeshHealthCheckRegistry.coerce(MeshHealth.of(null));
+
+        assertEquals(MeshHealthStatus.DEGRADED, health.status());
+        assertTrue(health.isUnreadableStatus());
+        assertEquals(List.of(), deprecationWarnings());
+    }
+
+    // The distinction is the status STRING, not the marker: a readable
+    // "degraded" through the same factory is still a selection.
+    @Test
+    void aReadableDegradedThroughOfIsStillASelection() {
+        MeshHealth health = MeshHealthCheckRegistry.coerce(MeshHealth.of(" DeGrAdEd "));
+
+        assertEquals(MeshHealthStatus.DEGRADED, health.status());
+        assertFalse(health.isUnreadableStatus());
+        assertEquals(1, deprecationWarnings().size());
+    }
+
+    @Test
+    void healthyAndUnhealthyAreSilent() {
+        assertEquals(MeshHealthStatus.HEALTHY,
+            MeshHealthCheckRegistry.coerce(MeshHealth.healthy()).status());
+        assertEquals(MeshHealthStatus.HEALTHY,
+            MeshHealthCheckRegistry.coerce(Boolean.TRUE).status());
+        assertEquals(MeshHealthStatus.UNHEALTHY,
+            MeshHealthCheckRegistry.coerce(MeshHealth.unhealthy("vendor down")).status());
+        assertEquals(MeshHealthStatus.UNHEALTHY,
+            MeshHealthCheckRegistry.coerce(Boolean.FALSE).status());
+
+        assertEquals(List.of(), deprecationWarnings());
+    }
+
+    /** Minimal Logback appender recording level + message for a target logger. */
+    static final class LogCapture {
+        final java.util.List<LogEvent> events = new java.util.concurrent.CopyOnWriteArrayList<>();
+        private final ch.qos.logback.classic.Logger target;
+        private final ch.qos.logback.core.AppenderBase<ch.qos.logback.classic.spi.ILoggingEvent> appender;
+
+        private LogCapture(ch.qos.logback.classic.Logger target) {
+            this.target = target;
+            this.appender = new ch.qos.logback.core.AppenderBase<>() {
+                @Override
+                protected void append(ch.qos.logback.classic.spi.ILoggingEvent event) {
+                    events.add(new LogEvent(event.getLevel().toString(), event.getFormattedMessage()));
+                }
+            };
+        }
+
+        static LogCapture attach(Class<?> loggerClass) {
+            ch.qos.logback.classic.Logger logger =
+                (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(loggerClass);
+            LogCapture capture = new LogCapture(logger);
+            capture.appender.setContext(logger.getLoggerContext());
+            capture.appender.start();
+            logger.addAppender(capture.appender);
+            return capture;
+        }
+
+        void detach() {
+            target.detachAppender(appender);
+            appender.stop();
+        }
+
+        record LogEvent(String level, String message) {}
+    }
+}

--- a/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
+++ b/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
@@ -438,19 +438,40 @@ def _parse_health_result(
             # and landed on DEGRADED (issue #1517).
             _warn_null_status_once()
             raw_status = "healthy"
-        # Stripped, matching TypeScript's `toStatus` and Java's
-        # `MeshHealthStatus.fromWire`, which have always trimmed. This one is a
-        # ROUTING change, not just a parsing tidy-up: `{"status": " unhealthy "}`
-        # used to fall through to UNKNOWN, which keeps heartbeating, so an agent
-        # that had declared itself unable to serve stayed in resolution. It now
-        # withdraws, which is what it asked for.
-        status_str = raw_status.strip().lower()
-        status_map = {
-            "healthy": HealthStatusType.HEALTHY,
-            "degraded": HealthStatusType.DEGRADED,
-            "unhealthy": HealthStatusType.UNHEALTHY,
-        }
-        status_type = status_map.get(status_str, HealthStatusType.UNKNOWN)
+        if isinstance(raw_status, str):
+            # Stripped, matching TypeScript's `toStatus` and Java's
+            # `MeshHealthStatus.fromWire`, which have always trimmed. This one is
+            # a ROUTING change, not just a parsing tidy-up:
+            # `{"status": " unhealthy "}` used to fall through to UNKNOWN, which
+            # keeps heartbeating, so an agent that had declared itself unable to
+            # serve stayed in resolution. It now withdraws, which is what it
+            # asked for.
+            status_str = raw_status.strip().lower()
+            status_map = {
+                "healthy": HealthStatusType.HEALTHY,
+                "degraded": HealthStatusType.DEGRADED,
+                "unhealthy": HealthStatusType.UNHEALTHY,
+            }
+            status_type = status_map.get(status_str, HealthStatusType.UNKNOWN)
+        else:
+            # A status that is not a string at all — `{"status": 503}`,
+            # `{"status": True}` — is unreadable in exactly the way an
+            # unrecognized string is, so it gets the same verdict: UNKNOWN, which
+            # keeps the agent heartbeating. TypeScript's `toStatus` already
+            # returns null for a non-string and Java's `parseWire` already fails
+            # to match one, so this is the shape the other two runtimes have.
+            #
+            # It used to call `.strip()` on the value, raise, and be recorded by
+            # the handler in `_execute_health_check` as a check that FAILED —
+            # the same routing outcome by accident, reported as an exception the
+            # author cannot find in their own code (issue #1517).
+            #
+            # Silent here, like the unrecognized-string case it joins: this
+            # recurs identically on every refresh, and the UNKNOWN verdict is
+            # already reported by `logger.info` above and warned about once per
+            # tick by `publish_health_status_to_core`. A third line would be the
+            # same defect said three times, 5,760 times a day.
+            status_type = HealthStatusType.UNKNOWN
         if status_type is HealthStatusType.DEGRADED:
             _warn_degraded_return_once()
         checks = user_result.get("checks", {})

--- a/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
+++ b/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
@@ -5,9 +5,12 @@ Consolidates health check storage, caching, and Kubernetes endpoint response
 generation into a single module.
 """
 
+import asyncio
+import inspect
 import logging
 import os
 import re
+import threading
 import time
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
@@ -184,6 +187,85 @@ def clear_health_check_result() -> None:
 
 
 # =============================================================================
+# `degraded` as a RETURN VALUE is deprecated (issue #1515)
+# =============================================================================
+#
+# The contract a health check answers is binary: stay in dependency
+# resolution, or withdraw. `degraded` and `healthy` are the same answer to
+# it — both keep the heartbeat alive and both keep consumers routing here —
+# so the third word buys a 503 on an endpoint nothing probes, and costs the
+# failure rate of a name that reads like withdrawal to everyone who picks it
+# when their upstream is down. The reference templates themselves picked it
+# wrong in all three runtimes.
+#
+# The BEHAVIOUR is unchanged, deliberately. Remapping `degraded` to
+# `unhealthy` would fix the common intent and silently withdraw every agent
+# whose author used the word correctly, so this warns and waits.
+#
+# The internal HealthStatusType.DEGRADED survives: a check that raises and a
+# check that returns an unusable type both need a verdict that is neither
+# trusted-healthy nor withdraw. Those paths do NOT warn — nothing the author
+# can act on happened. Only a verdict the author SELECTED reaches here.
+_degraded_return_deprecation_logged = False
+_degraded_return_lock = threading.Lock()
+
+
+def _warn_degraded_return_once() -> None:
+    """Warn that a selected ``degraded`` no longer differs from ``healthy``.
+
+    Once per process, not once per refresh. The check re-runs every TTL (15s
+    by default), so a per-call warning would be several thousand identical
+    lines a day from an agent that is doing exactly what its author intended
+    — which trains operators to filter the line rather than read it.
+    """
+    global _degraded_return_deprecation_logged
+    with _degraded_return_lock:
+        if _degraded_return_deprecation_logged:
+            return
+        _degraded_return_deprecation_logged = True
+    logger.warning(
+        "health_check returned `degraded` — this agent stays in dependency "
+        "resolution and consumers will keep routing to it. Return `False` to "
+        "withdraw."
+    )
+
+
+def _reset_degraded_return_warning() -> None:
+    """Re-arm the once-per-process warning. Tests only."""
+    global _degraded_return_deprecation_logged
+    with _degraded_return_lock:
+        _degraded_return_deprecation_logged = False
+
+
+# A null status is a defect in the same shape as a selected `degraded`: it
+# recurs identically on every refresh, so it gets the same treatment. At the
+# 15s default a per-tick line is ~5,760 identical warnings a day.
+_null_status_warning_logged = False
+_null_status_lock = threading.Lock()
+
+
+def _warn_null_status_once() -> None:
+    """Warn that a present-but-null status was read as healthy. Once."""
+    global _null_status_warning_logged
+    with _null_status_lock:
+        if _null_status_warning_logged:
+            return
+        _null_status_warning_logged = True
+    logger.warning(
+        "Health check returned a null status — treating it as healthy "
+        "(an absent status already means healthy). Return 'healthy' or "
+        "'unhealthy' if a verdict was intended."
+    )
+
+
+def _reset_null_status_warning() -> None:
+    """Re-arm the once-per-process warning. Tests only."""
+    global _null_status_warning_logged
+    with _null_status_lock:
+        _null_status_warning_logged = False
+
+
+# =============================================================================
 # TTL-Based Health Cache
 # =============================================================================
 
@@ -195,7 +277,7 @@ _max_cache_size = 100
 
 async def get_health_status_with_cache(
     agent_id: str,
-    health_check_fn: Callable[[], Awaitable[Any]] | None,
+    health_check_fn: Callable[[], Any] | Callable[[], Awaitable[Any]] | None,
     agent_config: dict[str, Any],
     startup_context: dict[str, Any],
     ttl: int = 15,
@@ -205,12 +287,12 @@ async def get_health_status_with_cache(
 
     User health check can return:
     - bool: True = HEALTHY, False = UNHEALTHY
-    - dict: {"status": "healthy/degraded/unhealthy", "checks": {...}, "errors": [...]}
+    - dict: {"status": "healthy/unhealthy", "checks": {...}, "errors": [...]}
     - HealthStatus: Full object
 
     Args:
         agent_id: Unique identifier for the agent
-        health_check_fn: Optional async function for health check
+        health_check_fn: Optional sync or async function for health check
         agent_config: Agent configuration dict
         startup_context: Full startup context with capabilities
         ttl: Cache TTL in seconds (default: 15)
@@ -254,17 +336,43 @@ async def get_health_status_with_cache(
 
 async def _execute_health_check(
     agent_id: str,
-    health_check_fn: Callable[[], Awaitable[Any]] | None,
+    health_check_fn: Callable[[], Any] | Callable[[], Awaitable[Any]] | None,
     agent_config: dict[str, Any],
     startup_context: dict[str, Any],
 ) -> HealthStatus:
-    """Execute health check function and build HealthStatus."""
+    """Execute health check function and build HealthStatus.
+
+    Sync and async checks are both accepted, matching ``run_startup_check``.
+    A bare ``await health_check_fn()`` raised ``TypeError`` on a ``def``
+    check, which the handler below recorded as DEGRADED — so an author who
+    forgot ``async`` got a check that appeared to run, never reported a real
+    verdict, and could never withdraw the agent (issue #1517).
+
+    A sync check runs on a worker thread, not inline. ``run_startup_check``
+    can call one inline because it runs once, at boot; this runs every TTL for
+    the life of the process, and the natural sync probe is a blocking
+    ``requests.get(vendor, timeout=5)``. Inline, that stalls whichever loop the
+    refresh was scheduled on — and for ``api``/``a2a`` gateways
+    (``health_refresh.py``) that is the HEARTBEAT thread's loop, so a slow
+    probe would delay the very heartbeats whose absence withdraws the agent.
+    Accepting sync checks without offloading them would have invited exactly
+    that.
+    """
     capabilities = _get_capabilities(startup_context, agent_config)
 
     if health_check_fn:
         try:
             logger.debug(f"Executing health check for agent '{agent_id}'")
-            user_result = await health_check_fn()
+            if inspect.iscoroutinefunction(health_check_fn):
+                user_result = await health_check_fn()
+            else:
+                user_result = await asyncio.to_thread(health_check_fn)
+                if inspect.isawaitable(user_result):
+                    # A `def` that returns an awaitable: a lambda wrapping an
+                    # async call, an object with an async __call__. Building
+                    # the coroutine off-loop is harmless; awaiting it here runs
+                    # it on this loop, which is where it belongs.
+                    user_result = await user_result
             status_type, checks, errors = _parse_health_result(user_result)
 
             logger.info(f"Health check for '{agent_id}': {status_type.value}")
@@ -319,18 +427,39 @@ def _parse_health_result(
         errors = [] if user_result else ["Health check returned False"]
 
     elif isinstance(user_result, dict):
-        status_str = user_result.get("status", "healthy").lower()
+        raw_status = user_result.get("status", "healthy")
+        if raw_status is None:
+            # An explicit None is treated exactly like an absent key, which
+            # already defaults to healthy here and in TypeScript — a result
+            # carrying only `checks` is reporting success. It still warns:
+            # `"status": None` is far likelier to be an unset variable than an
+            # intent, and the warning is what separates the two cases without
+            # changing routing. Left unhandled it called None.lower(), raised,
+            # and landed on DEGRADED (issue #1517).
+            _warn_null_status_once()
+            raw_status = "healthy"
+        # Stripped, matching TypeScript's `toStatus` and Java's
+        # `MeshHealthStatus.fromWire`, which have always trimmed. This one is a
+        # ROUTING change, not just a parsing tidy-up: `{"status": " unhealthy "}`
+        # used to fall through to UNKNOWN, which keeps heartbeating, so an agent
+        # that had declared itself unable to serve stayed in resolution. It now
+        # withdraws, which is what it asked for.
+        status_str = raw_status.strip().lower()
         status_map = {
             "healthy": HealthStatusType.HEALTHY,
             "degraded": HealthStatusType.DEGRADED,
             "unhealthy": HealthStatusType.UNHEALTHY,
         }
         status_type = status_map.get(status_str, HealthStatusType.UNKNOWN)
+        if status_type is HealthStatusType.DEGRADED:
+            _warn_degraded_return_once()
         checks = user_result.get("checks", {})
         errors = user_result.get("errors", [])
 
     elif isinstance(user_result, HealthStatus):
         status_type = user_result.status
+        if status_type is HealthStatusType.DEGRADED:
+            _warn_degraded_return_once()
         checks = user_result.checks
         errors = user_result.errors
 

--- a/src/runtime/python/_mcp_mesh/shared/support_types.py
+++ b/src/runtime/python/_mcp_mesh/shared/support_types.py
@@ -22,6 +22,15 @@ class HealthStatusType(str, Enum):  # noqa: UP042
     but ``"healthy"`` under ``StrEnum``, so the swap would silently change
     any interpolated/serialized value. That is a behaviour change, not a
     style fix.
+
+    ``HEALTHY`` and ``UNHEALTHY`` are the two verdicts a health check
+    answers with; they are the whole routing contract. ``DEGRADED`` and
+    ``UNKNOWN`` are what the RUNTIME records when it has no verdict it can
+    trust — a check that raised, an unusable return type, an unreadable
+    status string — and both keep the agent in dependency resolution.
+    Selecting ``DEGRADED`` from a health check is deprecated (issue #1515):
+    it is indistinguishable from ``HEALTHY`` on every mesh path, so
+    ``_parse_health_result`` warns and keeps the agent serving.
     """
 
     HEALTHY = "healthy"

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -1485,7 +1485,7 @@ def agent(
     enable_http: bool = True,
     namespace: str = "default",
     heartbeat_interval: int = 5,
-    health_check: Callable[[], Awaitable[Any]] | None = None,
+    health_check: Callable[[], Any] | Callable[[], Awaitable[Any]] | None = None,
     health_check_ttl: int = 15,
     startup_check: Callable[[], Any] | None = None,
     auto_run: bool = True,  # Changed to True by default!
@@ -1512,7 +1512,8 @@ def agent(
             Environment variable: MCP_MESH_NAMESPACE (takes precedence)
         heartbeat_interval: Heartbeat interval in seconds (default: 5)
             Environment variable: MCP_MESH_HEALTH_INTERVAL (takes precedence)
-        health_check: Optional async function that returns HealthStatus
+        health_check: Optional sync or async function returning a bool, a
+            {status, checks, errors} dict, or a HealthStatus
             Called before heartbeat and on /health endpoint with TTL caching
         health_check_ttl: Cache TTL for health check results in seconds (default: 15)
             Reduces expensive health check calls by caching results
@@ -1609,7 +1610,7 @@ def agent(
             raise ValueError("auto_run_interval must be at least 1 second")
 
         if health_check is not None and not callable(health_check):
-            raise ValueError("health_check must be a callable (async function)")
+            raise ValueError("health_check must be a callable (sync or async)")
 
         if not isinstance(health_check_ttl, int):
             raise ValueError("health_check_ttl must be an integer")

--- a/src/runtime/python/tests/unit/test_degraded_return_deprecation_1515.py
+++ b/src/runtime/python/tests/unit/test_degraded_return_deprecation_1515.py
@@ -1,0 +1,238 @@
+"""`degraded` as a health-check RETURN VALUE is deprecated (#1515).
+
+The question a health check answers is binary: stay in dependency resolution,
+or withdraw. ``degraded`` and ``healthy`` are the same answer to it — both keep
+the heartbeat alive and both keep consumers routing here — so the third word
+buys a 503 on an endpoint nothing probes and costs the failure rate of a name
+that reads like withdrawal to everyone who picks it when their upstream is
+down.
+
+Two things are pinned here, and the second matters more than the first:
+
+1. selecting ``degraded`` warns, naming the CONSEQUENCE rather than the value;
+2. **behaviour is unchanged.** An agent returning ``degraded`` still records
+   DEGRADED, still heartbeats and still resolves. Remapping it to ``unhealthy``
+   would fix the common intent and silently withdraw every agent whose author
+   used the word correctly, so the deprecation warns and waits.
+
+The runtime's OWN degraded verdicts — a check that raised, an unusable return
+type — must NOT warn: nothing the author can act on happened, and a warning
+there would tell them to change code that is already right.
+"""
+
+import logging
+from typing import Any
+
+import pytest
+
+from _mcp_mesh.shared.health_check_manager import (
+    _reset_degraded_return_warning,
+    clear_health_cache,
+    get_health_status_with_cache,
+)
+from _mcp_mesh.shared.support_types import HealthStatus, HealthStatusType
+
+AGENT_CONFIG: dict[str, Any] = {
+    "name": "deprecation-agent",
+    "version": "1.0.0",
+    "capabilities": ["test-capability"],
+}
+
+# The consequence, not the value. An author who reads "degraded is deprecated"
+# learns nothing; one who reads "consumers will keep routing to it" learns
+# whether they meant it.
+WARNING_FRAGMENTS = (
+    "stays in dependency resolution",
+    "consumers will keep routing to it",
+    "Return `False` to withdraw",
+)
+
+
+@pytest.fixture(autouse=True)
+def fresh_state():
+    clear_health_cache()
+    _reset_degraded_return_warning()
+    yield
+    clear_health_cache()
+    _reset_degraded_return_warning()
+
+
+async def run_check(check, agent_id: str) -> HealthStatus:
+    """Run one uncached health check and return its recorded status."""
+    return await get_health_status_with_cache(
+        agent_id=agent_id,
+        health_check_fn=check,
+        agent_config=AGENT_CONFIG,
+        startup_context={},
+        ttl=15,
+    )
+
+
+def degraded_warnings(caplog) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "keep routing to it" in r.getMessage()
+    ]
+
+
+class TestSelectingDegradedWarns:
+    """A verdict the AUTHOR chose is the only one that warns."""
+
+    @pytest.mark.asyncio
+    async def test_dict_status_degraded_warns(self, caplog):
+        async def check():
+            return {"status": "degraded", "errors": ["upstream slow"]}
+
+        with caplog.at_level(logging.WARNING):
+            await run_check(check, "dict-degraded")
+
+        warnings = degraded_warnings(caplog)
+        assert len(warnings) == 1, f"expected one deprecation warning, got {warnings}"
+        for fragment in WARNING_FRAGMENTS:
+            assert fragment in warnings[0], (
+                f"the warning must name the consequence: {fragment!r} missing from "
+                f"{warnings[0]!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_case_and_whitespace_variants_still_warn(self, caplog):
+        """The parser strips and lowercases, so the warning must follow it.
+
+        A deprecation that only fires on the exact literal would let
+        ``" DEGRADED "`` through silently while routing it identically.
+        """
+
+        async def check():
+            return {"status": "  DeGrAdEd  "}
+
+        with caplog.at_level(logging.WARNING):
+            status = await run_check(check, "spaced-degraded")
+
+        assert status.status == HealthStatusType.DEGRADED
+        assert len(degraded_warnings(caplog)) == 1
+
+    @pytest.mark.asyncio
+    async def test_health_status_object_degraded_warns(self, caplog):
+        """A returned ``HealthStatus`` is a selection too, not an internal path."""
+
+        async def check():
+            return HealthStatus(
+                agent_name="deprecation-agent",
+                status=HealthStatusType.DEGRADED,
+                capabilities=["test-capability"],
+                checks={},
+                errors=[],
+            )
+
+        with caplog.at_level(logging.WARNING):
+            await run_check(check, "object-degraded")
+
+        assert len(degraded_warnings(caplog)) == 1
+
+
+class TestBehaviourIsUnchanged:
+    """The whole point of warning rather than remapping.
+
+    An author who used ``degraded`` correctly — impaired, still serving — must
+    keep serving. If any of these flip to UNHEALTHY, the deprecation has
+    silently withdrawn working agents from the mesh.
+    """
+
+    @pytest.mark.asyncio
+    async def test_degraded_still_records_degraded(self):
+        async def check():
+            return {"status": "degraded", "checks": {"cache_warm": False}}
+
+        status = await run_check(check, "still-degraded")
+
+        assert status.status == HealthStatusType.DEGRADED, (
+            "remapping degraded to unhealthy would withdraw every agent whose "
+            "author used the word correctly"
+        )
+        assert status.checks == {"cache_warm": False}
+
+    @pytest.mark.asyncio
+    async def test_degraded_is_not_a_withdrawal(self):
+        """The routing question, asked directly.
+
+        ``unhealthy`` is the only verdict the core suppresses the heartbeat on,
+        so a degraded agent stays in dependency resolution — which is exactly
+        what the warning tells its author.
+        """
+
+        async def check():
+            return {"status": "degraded"}
+
+        status = await run_check(check, "not-withdrawn")
+
+        assert status.status != HealthStatusType.UNHEALTHY
+
+
+class TestRuntimeAssignedDegradedIsSilent:
+    """The four indeterminate paths keep the internal state and say nothing."""
+
+    @pytest.mark.asyncio
+    async def test_a_raising_check_does_not_warn(self, caplog):
+        async def check():
+            raise RuntimeError("probe blew up")
+
+        with caplog.at_level(logging.WARNING):
+            status = await run_check(check, "raising")
+
+        assert status.status == HealthStatusType.DEGRADED
+        assert degraded_warnings(caplog) == [], (
+            "the author did not choose this verdict — the runtime assigned it "
+            "because the probe reached no conclusion"
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_unusable_return_type_does_not_warn(self, caplog):
+        async def check():
+            return 42
+
+        with caplog.at_level(logging.WARNING):
+            status = await run_check(check, "bad-type")
+
+        assert status.status == HealthStatusType.DEGRADED
+        assert degraded_warnings(caplog) == []
+
+    @pytest.mark.asyncio
+    async def test_healthy_and_unhealthy_do_not_warn(self, caplog):
+        async def healthy():
+            return {"status": "healthy"}
+
+        async def unhealthy():
+            return False
+
+        with caplog.at_level(logging.WARNING):
+            assert (await run_check(healthy, "ok")).status == HealthStatusType.HEALTHY
+            assert (
+                await run_check(unhealthy, "down")
+            ).status == HealthStatusType.UNHEALTHY
+
+        assert degraded_warnings(caplog) == []
+
+
+class TestWarnedOncePerProcess:
+    """A check re-runs every TTL; a per-tick warning is not a warning.
+
+    At the 15s default that is ~5,760 identical lines a day from an agent doing
+    exactly what its author intended, which trains an operator to filter the
+    line rather than read it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_repeated_degraded_warns_once(self, caplog):
+        async def check():
+            return {"status": "degraded"}
+
+        with caplog.at_level(logging.WARNING):
+            for i in range(5):
+                # Distinct agent ids: the TTL cache would otherwise serve the
+                # first result and the check would run once regardless, so the
+                # test would pass without the dedup being there at all.
+                status = await run_check(check, f"repeat-{i}")
+                assert status.status == HealthStatusType.DEGRADED
+
+        assert len(degraded_warnings(caplog)) == 1

--- a/src/runtime/python/tests/unit/test_health_check_result_1517.py
+++ b/src/runtime/python/tests/unit/test_health_check_result_1517.py
@@ -1,0 +1,288 @@
+"""Health-check return-value parsing, and where it used to diverge (#1517).
+
+Four independent divergences, each small, each reachable from ordinary user
+code and none of them loud:
+
+1. a ``def health_check()`` was awaited unguarded, so it raised ``TypeError``
+   and was recorded as DEGRADED — a check that appeared to run and could never
+   withdraw the agent;
+2. a status string was lowercased but not stripped, so ``" degraded "`` became
+   UNKNOWN;
+3. an explicit ``{"status": None}`` called ``None.lower()``, raised, and landed
+   on DEGRADED, while TypeScript read it as healthy;
+4. the OpenAPI description had the UNKNOWN and DEGRADED cases the wrong way
+   round.
+
+DEGRADED vs UNHEALTHY is a behavioural difference, not a reporting one: only
+``unhealthy`` suppresses the heartbeat, so a check that silently degrades is a
+check that cannot do the one thing it exists for.
+"""
+
+import logging
+import threading
+from typing import Any
+
+import pytest
+
+from _mcp_mesh.shared.health_check_manager import (
+    _reset_null_status_warning,
+    clear_health_cache,
+    get_health_status_with_cache,
+)
+from _mcp_mesh.shared.support_types import HealthStatus, HealthStatusType
+
+AGENT_CONFIG: dict[str, Any] = {
+    "name": "verdict-agent",
+    "version": "1.0.0",
+    "capabilities": ["test-capability"],
+}
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    clear_health_cache()
+    _reset_null_status_warning()
+    yield
+    clear_health_cache()
+    _reset_null_status_warning()
+
+
+async def run_check(check, agent_id: str) -> HealthStatus:
+    """Run one uncached health check and return its recorded status."""
+    return await get_health_status_with_cache(
+        agent_id=agent_id,
+        health_check_fn=check,
+        agent_config=AGENT_CONFIG,
+        startup_context={},
+        ttl=15,
+    )
+
+
+class TestSyncAndAsyncBothAccepted:
+    """Divergence 1: a sync check must produce its real verdict.
+
+    ``startup_check`` has accepted both since it shipped; the two hooks
+    disagreeing is what made this a silent trap rather than a documented
+    restriction.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sync_dict_check_withdraws(self):
+        def health_check() -> dict:
+            return {"status": "unhealthy", "errors": ["vendor down"]}
+
+        result = await run_check(health_check, "sync-dict")
+
+        # The assertion that fails if the unguarded await comes back: the
+        # TypeError it raised was recorded as DEGRADED, which keeps
+        # heartbeating.
+        assert result.status == HealthStatusType.UNHEALTHY
+        assert result.errors == ["vendor down"]
+
+    @pytest.mark.asyncio
+    async def test_sync_bool_check(self):
+        assert (
+            await run_check(lambda: True, "sync-true")
+        ).status == HealthStatusType.HEALTHY
+        assert (
+            await run_check(lambda: False, "sync-false")
+        ).status == HealthStatusType.UNHEALTHY
+
+    @pytest.mark.asyncio
+    async def test_sync_health_status_check(self):
+        def health_check() -> HealthStatus:
+            return HealthStatus(
+                agent_name="verdict-agent",
+                status=HealthStatusType.UNHEALTHY,
+                capabilities=["test"],
+            )
+
+        result = await run_check(health_check, "sync-healthstatus")
+        assert result.status == HealthStatusType.UNHEALTHY
+
+    @pytest.mark.asyncio
+    async def test_async_check_still_works(self):
+        async def health_check() -> dict:
+            return {"status": "unhealthy", "errors": ["vendor down"]}
+
+        result = await run_check(health_check, "async-dict")
+        assert result.status == HealthStatusType.UNHEALTHY
+        assert result.errors == ["vendor down"]
+
+    @pytest.mark.asyncio
+    async def test_a_sync_check_that_raises_still_degrades(self):
+        """The sync path keeps the "a broken probe does not withdraw" rule."""
+
+        def health_check() -> dict:
+            raise RuntimeError("boom")
+
+        result = await run_check(health_check, "sync-raises")
+        assert result.status == HealthStatusType.DEGRADED
+        assert result.checks["health_check_execution"] is False
+        assert "boom" in result.errors[0]
+
+    @pytest.mark.asyncio
+    async def test_a_sync_check_does_not_block_the_loop(self):
+        """Accepting sync checks is what makes this necessary.
+
+        The natural sync probe is a blocking ``requests.get(vendor,
+        timeout=5)``. Unlike ``startup_check`` this runs every TTL forever,
+        and on ``api``/``a2a`` gateways it runs on the HEARTBEAT thread's
+        loop — so a slow probe run inline would delay the very heartbeats
+        whose absence withdraws the agent.
+        """
+        ran_on: dict[str, int] = {}
+
+        def health_check() -> dict:
+            # A real blocking call would sleep here; the thread identity is
+            # the whole assertion, so the sleep is not needed.
+            ran_on["thread"] = threading.get_ident()
+            return {"status": "healthy"}
+
+        loop_thread = threading.get_ident()
+        result = await run_check(health_check, "sync-offloaded")
+
+        assert result.status == HealthStatusType.HEALTHY
+        assert ran_on["thread"] != loop_thread, (
+            "a sync health check must not run inline on the event loop — every "
+            "TTL, for the life of the process"
+        )
+
+    @pytest.mark.asyncio
+    async def test_an_async_check_still_runs_on_the_loop(self):
+        """The offload is for sync checks only.
+
+        An ``async def`` check is awaited on the calling loop, which is what
+        lets the provider path see loop-affine resources (asyncpg pools,
+        redis.asyncio clients) built in the user's ``lifespan``.
+        """
+        ran_on: dict[str, int] = {}
+
+        async def health_check() -> dict:
+            ran_on["thread"] = threading.get_ident()
+            return {"status": "healthy"}
+
+        loop_thread = threading.get_ident()
+        await run_check(health_check, "async-on-loop")
+
+        assert ran_on["thread"] == loop_thread
+
+
+class TestStatusStringIsStripped:
+    """Divergence 2: whitespace around a status is not a verdict change.
+
+    TypeScript's ``toStatus`` and Java's ``MeshHealthStatus.fromWire`` both
+    trim; Python lowercased only, so ``" unhealthy "`` mapped to UNKNOWN and
+    the agent kept heartbeating.
+    """
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (" unhealthy ", HealthStatusType.UNHEALTHY),
+            ("\tunhealthy\n", HealthStatusType.UNHEALTHY),
+            (" degraded ", HealthStatusType.DEGRADED),
+            (" healthy ", HealthStatusType.HEALTHY),
+            (" UNHEALTHY ", HealthStatusType.UNHEALTHY),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_surrounding_whitespace_and_case(self, raw, expected):
+        async def health_check() -> dict:
+            return {"status": raw}
+
+        result = await run_check(
+            health_check, f"strip-{raw.strip().lower()}-{len(raw)}"
+        )
+        assert result.status == expected
+
+
+class TestNullStatusIsHealthyAndWarns:
+    """Divergence 3: an explicit null status reads as an absent one.
+
+    An absent ``status`` already defaults to healthy in Python and TypeScript,
+    so making ``None`` mean something else would be surprising. It warns
+    because ``{"status": None}`` is far likelier to be an unset variable than
+    an intent — and a warning separates the two cases without changing routing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_null_status_is_healthy_and_warns(self, caplog):
+        async def health_check() -> dict:
+            return {"status": None, "checks": {"api_reachable": True}}
+
+        with caplog.at_level(
+            logging.WARNING, logger="_mcp_mesh.shared.health_check_manager"
+        ):
+            result = await run_check(health_check, "null-status")
+
+        assert result.status == HealthStatusType.HEALTHY
+        # Not DEGRADED: that was the old outcome, reached by raising on
+        # None.lower() rather than by any decision.
+        assert result.status != HealthStatusType.DEGRADED
+        assert result.checks == {"api_reachable": True}
+        assert any("null status" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_absent_status_is_healthy_and_silent(self, caplog):
+        async def health_check() -> dict:
+            return {"checks": {"api_reachable": True}}
+
+        with caplog.at_level(
+            logging.WARNING, logger="_mcp_mesh.shared.health_check_manager"
+        ):
+            result = await run_check(health_check, "absent-status")
+
+        assert result.status == HealthStatusType.HEALTHY
+        assert not [r for r in caplog.records if "null status" in r.message]
+
+    @pytest.mark.asyncio
+    async def test_the_null_status_warning_is_once_per_process(self, caplog):
+        """Same repetition profile as the `degraded` deprecation, same dedup.
+
+        A null status recurs identically on every refresh, so an
+        undeduplicated line is ~5,760 a day at the 15s default TTL — which
+        trains an operator to filter it rather than read it.
+        """
+
+        async def health_check() -> dict:
+            return {"status": None}
+
+        with caplog.at_level(
+            logging.WARNING, logger="_mcp_mesh.shared.health_check_manager"
+        ):
+            for i in range(5):
+                # Distinct agent ids: the TTL cache would otherwise serve the
+                # first verdict and the check would run once regardless.
+                result = await run_check(health_check, f"null-repeat-{i}")
+                assert result.status == HealthStatusType.HEALTHY
+
+        assert len([r for r in caplog.records if "null status" in r.message]) == 1
+
+
+class TestUnknownIsAStatusStringNotAReturnType:
+    """Divergence 4: what the shared OpenAPI schema now says.
+
+    ``AgentHealthResponse.status`` described ``unknown`` as the verdict for an
+    unrecognized return TYPE. It is the opposite, and the two cases behave
+    differently, so the description mattered: a bad type degrades with an error
+    naming the type, while a bad status string is recorded as UNKNOWN.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_status_string_is_unknown(self):
+        async def health_check() -> dict:
+            return {"status": "down"}
+
+        result = await run_check(health_check, "unknown-status-string")
+        assert result.status == HealthStatusType.UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_return_type_is_degraded(self):
+        async def health_check() -> Any:
+            return 42
+
+        result = await run_check(health_check, "bad-return-type")
+        assert result.status == HealthStatusType.DEGRADED
+        assert result.checks["health_check_return_type"] is False
+        assert "int" in result.errors[0]

--- a/src/runtime/python/tests/unit/test_health_probe_error_narrowing.py
+++ b/src/runtime/python/tests/unit/test_health_probe_error_narrowing.py
@@ -1,0 +1,251 @@
+"""A defect in a health probe must not withdraw a working agent (#1477).
+
+The scaffolded provider probes report a vendor OUTAGE as ``unhealthy``, which
+is the whole point of the hook: it suppresses the heartbeat and the registry
+takes the agent out of dependency resolution. Their handlers used to be
+``except Exception``, so any defect inside the probe — a ``NameError`` from a
+typo, an ``AttributeError`` from a renamed field — was reported as that same
+outage. It recurs identically on every refresh, so the agent stays withdrawn
+for as long as the typo lives, while the vendor is perfectly healthy.
+
+The runtime already refuses to draw that conclusion: an exception that escapes
+a health check is recorded as the indeterminate verdict, which keeps the agent
+heartbeating. The probes have to LET it escape to get that, which is what
+narrowing the handler to ``httpx.RequestError`` does.
+
+These tests run the two probe shapes through the real health-check path and
+follow the verdict all the way to what the Rust core is told, because that —
+not the recorded status — is what actually suppresses a heartbeat.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+
+from _mcp_mesh.shared import simple_shutdown
+from _mcp_mesh.shared.health_check_manager import (
+    clear_health_cache,
+    get_health_status_with_cache,
+    publish_health_status_to_core,
+)
+from _mcp_mesh.shared.support_types import HealthStatus, HealthStatusType
+
+AGENT_CONFIG: dict[str, Any] = {
+    "name": "probe-agent",
+    "version": "1.0.0",
+    "capabilities": ["llm"],
+}
+
+
+class FakeCoreHealthStatus:
+    """Stand-in for the Rust ``mcp_mesh_core.HealthStatus`` pyclass enum."""
+
+    Healthy = "core.Healthy"
+    Degraded = "core.Degraded"
+    Unhealthy = "core.Unhealthy"
+
+
+class FakeHandle:
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    def update_health(self, status):
+        self.calls.append(status)
+        return True
+
+
+@pytest.fixture
+def core_handle(monkeypatch):
+    """A live core handle, so the verdict has somewhere to be published."""
+    monkeypatch.setitem(
+        sys.modules, "mcp_mesh_core", SimpleNamespace(HealthStatus=FakeCoreHealthStatus)
+    )
+    handle = FakeHandle()
+    monkeypatch.setattr(simple_shutdown, "_active_handles", [handle])
+    return handle
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    clear_health_cache()
+    yield
+    clear_health_cache()
+
+
+async def run_check(check, agent_id: str) -> HealthStatus:
+    return await get_health_status_with_cache(
+        agent_id=agent_id,
+        health_check_fn=check,
+        agent_config=AGENT_CONFIG,
+        startup_context={},
+        ttl=15,
+    )
+
+
+# --------------------------------------------------------------------------
+# The two probe shapes, written the way the templates write them.
+# --------------------------------------------------------------------------
+
+
+def narrowed_probe(fail_with: BaseException):
+    """The scaffolded probe: it answers for transport failures only."""
+
+    async def health_check() -> dict:
+        checks: dict[str, Any] = {"anthropic_api_key_present": True}
+        errors: list[str] = []
+        try:
+            raise fail_with
+        except httpx.RequestError as e:
+            checks["anthropic_api_reachable"] = False
+            errors.append(f"Anthropic API unreachable: {e}")
+            return {"status": "unhealthy", "checks": checks, "errors": errors}
+        return {"status": "healthy", "checks": checks, "errors": errors}
+
+    return health_check
+
+
+def catch_all_probe(fail_with: BaseException):
+    """The shape this test exists to keep out: it answers for everything."""
+
+    async def health_check() -> dict:
+        checks: dict[str, Any] = {"anthropic_api_key_present": True}
+        try:
+            raise fail_with
+        except Exception as e:  # noqa: BLE001 - the defect being demonstrated
+            checks["anthropic_api_reachable"] = False
+            return {
+                "status": "unhealthy",
+                "checks": checks,
+                "errors": [f"Anthropic API unreachable: {e}"],
+            }
+
+    return health_check
+
+
+class TestADefectInTheProbeDoesNotWithdrawTheAgent:
+    @pytest.mark.asyncio
+    async def test_non_transport_error_propagates_to_the_indeterminate_verdict(self):
+        """A ``NameError`` in the probe reaches the runtime, not the vendor branch."""
+        probe = narrowed_probe(NameError("name 'reponse' is not defined"))
+
+        result = await run_check(probe, "narrowed-defect")
+
+        # The runtime's own verdict for a check it could not trust.
+        assert result.status is HealthStatusType.DEGRADED
+        assert result.checks == {"health_check_execution": False}
+        assert "reponse" in result.errors[0]
+
+    @pytest.mark.asyncio
+    async def test_the_agent_keeps_heartbeating_through_that_defect(self, core_handle):
+        """The verdict that reaches the core is not the one that withdraws."""
+        probe = narrowed_probe(AttributeError("'NoneType' object has no attribute 'x'"))
+
+        result = await run_check(probe, "narrowed-defect-publish")
+        published = publish_health_status_to_core(result.status.value)
+
+        assert published is True
+        assert core_handle.calls == [FakeCoreHealthStatus.Degraded]
+        # Unhealthy is what suppresses the heartbeat. Nothing else does.
+        assert FakeCoreHealthStatus.Unhealthy not in core_handle.calls
+
+    @pytest.mark.asyncio
+    async def test_a_catch_all_handler_would_have_withdrawn_it(self, core_handle):
+        """The regression, made explicit: same defect, same probe, wider handler.
+
+        This is the outcome the narrowing prevents — and the reason it is not
+        merely tidier. The verdict is indistinguishable from a real vendor
+        outage, so the agent stays out of dependency resolution for as long as
+        the typo lives.
+        """
+        probe = catch_all_probe(NameError("name 'reponse' is not defined"))
+
+        result = await run_check(probe, "catch-all-defect")
+        publish_health_status_to_core(result.status.value)
+
+        assert result.status is HealthStatusType.UNHEALTHY
+        assert core_handle.calls == [FakeCoreHealthStatus.Unhealthy]
+
+
+class TestATransportFailureStillWithdrawsTheAgent:
+    """The narrowing must not have cost the probe the case it exists for."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "failure",
+        [
+            httpx.ConnectError("[Errno 8] nodename nor servname provided"),
+            httpx.ReadTimeout("timed out"),
+            httpx.ConnectTimeout("timed out"),
+            httpx.RemoteProtocolError("server disconnected"),
+        ],
+        ids=["dns", "read-timeout", "connect-timeout", "protocol"],
+    )
+    async def test_transport_failures_report_unhealthy(self, failure, core_handle):
+        probe = narrowed_probe(failure)
+
+        result = await run_check(probe, f"transport-{type(failure).__name__}")
+        publish_health_status_to_core(result.status.value)
+
+        assert result.status is HealthStatusType.UNHEALTHY
+        assert result.checks["anthropic_api_reachable"] is False
+        assert core_handle.calls == [FakeCoreHealthStatus.Unhealthy]
+
+
+class TestNonStringStatusIsUnknownNotAnException:
+    """A status that is not a string is unreadable, not a failed check.
+
+    ``{"status": 503}`` used to reach ``.strip()``, raise, and be recorded by
+    the handler as a check that FAILED — the same routing outcome by accident,
+    reported to the author as an exception they cannot find in their own code.
+    It now takes the same verdict an unrecognized status STRING takes.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status",
+        [503, 1, 0.0, ["unhealthy"], {"status": "unhealthy"}, object()],
+        ids=["int", "one", "float", "list", "dict", "object"],
+    )
+    async def test_non_string_status_is_unknown(self, status):
+        async def health_check() -> dict:
+            return {"status": status, "checks": {"api": True}}
+
+        result = await run_check(health_check, f"non-string-{type(status).__name__}")
+
+        assert result.status is HealthStatusType.UNKNOWN
+        # Not the throw path: the check ran and its `checks` survived.
+        assert result.checks == {"api": True}
+        assert result.errors == []
+
+    @pytest.mark.asyncio
+    async def test_a_bool_status_is_not_read_as_a_verdict(self):
+        """``{"status": False}`` is not ``False``.
+
+        A bare ``False`` return withdraws the agent; wrapping it in a dict
+        under ``status`` does not, because the value is not a status string.
+        Unknown keeps the agent heartbeating, which is the safe reading of a
+        result nobody can interpret.
+        """
+
+        async def health_check() -> dict:
+            return {"status": False}
+
+        result = await run_check(health_check, "bool-status")
+        assert result.status is HealthStatusType.UNKNOWN
+        assert result.status is not HealthStatusType.UNHEALTHY
+
+    @pytest.mark.asyncio
+    async def test_unknown_keeps_the_agent_heartbeating(self, core_handle):
+        async def health_check() -> dict:
+            return {"status": 503}
+
+        result = await run_check(health_check, "non-string-publish")
+        publish_health_status_to_core(result.status.value)
+
+        assert core_handle.calls == [FakeCoreHealthStatus.Degraded]
+        assert FakeCoreHealthStatus.Unhealthy not in core_handle.calls

--- a/src/runtime/typescript/src/__tests__/degraded-return-deprecation.spec.ts
+++ b/src/runtime/typescript/src/__tests__/degraded-return-deprecation.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * `degraded` as a health-check RETURN VALUE is deprecated (issue #1515).
+ *
+ * The question a health check answers is binary: stay in dependency
+ * resolution, or withdraw. `degraded` and `healthy` are the same answer to it —
+ * both keep the heartbeat alive and both keep consumers routing here — so the
+ * third word buys a 503 on an endpoint nothing probes and costs the failure
+ * rate of a name that reads like withdrawal to everyone who picks it when
+ * their upstream is down.
+ *
+ * Two things are pinned here, and the second matters more than the first:
+ *
+ * 1. selecting `degraded` warns, naming the CONSEQUENCE rather than the value;
+ * 2. **behaviour is unchanged.** A check returning `degraded` still produces a
+ *    `degraded` verdict, which still heartbeats and still resolves. Remapping
+ *    it to `unhealthy` would fix the common intent and silently withdraw every
+ *    agent whose author used the word correctly.
+ *
+ * The runtime's OWN degraded verdicts — a check that threw, one that missed
+ * its deadline, an unusable return type, an unreadable status string — must
+ * NOT warn: nothing the author can act on happened.
+ *
+ * Lives in its own file rather than alongside the #1476 verdict table because
+ * the warning is deduplicated at module scope, and that file returns
+ * `degraded` in several unrelated cases that would consume the one warning.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  normalizeHealthResult,
+  runHealthCheck,
+  __resetDegradedReturnWarning,
+} from "../health-check.js";
+
+// The consequence, not the value. An author who reads "degraded is deprecated"
+// learns nothing; one who reads "consumers will keep routing to it" learns
+// whether they meant it.
+const WARNING_FRAGMENTS = [
+  "stays in dependency resolution",
+  "consumers will keep routing to it",
+  "Return false to withdraw",
+];
+
+describe("degraded return-value deprecation (#1515)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    __resetDegradedReturnWarning();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    warnSpy.mockRestore();
+    __resetDegradedReturnWarning();
+  });
+
+  const deprecationCalls = (): string[] =>
+    warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes("keep routing to it"));
+
+  describe("a verdict the author selected", () => {
+    it("warns, naming the consequence", () => {
+      const verdict = normalizeHealthResult({
+        status: "degraded",
+        errors: ["upstream slow"],
+      });
+
+      expect(verdict.status).toBe("degraded");
+      const warnings = deprecationCalls();
+      expect(warnings).toHaveLength(1);
+      for (const fragment of WARNING_FRAGMENTS) {
+        expect(warnings[0]).toContain(fragment);
+      }
+    });
+
+    // `toStatus` trims and lowercases, so the deprecation must follow it: a
+    // guard on the exact literal would let " DEGRADED " through silently while
+    // routing it identically.
+    it.each(["  degraded  ", "DEGRADED", "  DeGrAdEd "])(
+      "warns for %j too",
+      (status) => {
+        expect(normalizeHealthResult({ status }).status).toBe("degraded");
+        expect(deprecationCalls()).toHaveLength(1);
+      },
+    );
+
+    it("warns once per process, not once per refresh", async () => {
+      // At the 15s default TTL a per-tick warning is ~5,760 identical lines a
+      // day from an agent doing exactly what its author intended, which trains
+      // an operator to filter the line rather than read it.
+      for (let i = 0; i < 5; i++) {
+        expect(normalizeHealthResult({ status: "degraded" }).status).toBe(
+          "degraded",
+        );
+      }
+      await runHealthCheck(() => ({ status: "degraded" }), "provider");
+
+      expect(deprecationCalls()).toHaveLength(1);
+    });
+  });
+
+  describe("behaviour is unchanged", () => {
+    it("still reports degraded, so the agent stays in resolution", () => {
+      const verdict = normalizeHealthResult({
+        status: "degraded",
+        checks: { cache_warm: false },
+        errors: ["cache cold"],
+      });
+
+      expect(verdict.status).toBe("degraded");
+      expect(verdict.status).not.toBe("unhealthy");
+      expect(verdict.checks).toEqual({ cache_warm: false });
+      expect(verdict.errors).toEqual(["cache cold"]);
+    });
+
+    it("only unhealthy withdraws, and it still does", () => {
+      expect(normalizeHealthResult({ status: "unhealthy" }).status).toBe(
+        "unhealthy",
+      );
+      expect(normalizeHealthResult(false).status).toBe("unhealthy");
+      expect(deprecationCalls()).toHaveLength(0);
+    });
+  });
+
+  describe("verdicts the runtime assigned stay silent", () => {
+    it("a check that throws does not warn", async () => {
+      const verdict = await runHealthCheck(() => {
+        throw new Error("probe blew up");
+      }, "provider");
+
+      expect(verdict.status).toBe("degraded");
+      expect(deprecationCalls()).toHaveLength(0);
+    });
+
+    it.each([
+      ["an unusable return type", 42],
+      ["null", null],
+      ["an unreadable status string", { status: "down" }],
+    ])("%s does not warn", async (_label, raw) => {
+      expect(normalizeHealthResult(raw).status).toBe("degraded");
+      expect(deprecationCalls()).toHaveLength(0);
+    });
+
+    it("healthy does not warn", () => {
+      expect(normalizeHealthResult({ status: "healthy" }).status).toBe(
+        "healthy",
+      );
+      expect(normalizeHealthResult(true).status).toBe("healthy");
+      expect(deprecationCalls()).toHaveLength(0);
+    });
+  });
+});

--- a/src/runtime/typescript/src/__tests__/health-check.spec.ts
+++ b/src/runtime/typescript/src/__tests__/health-check.spec.ts
@@ -17,6 +17,7 @@ import {
   resolveHealthCheckTtlFromEnv,
   startHealthCheckLoop,
   describeThrown,
+  __resetNullStatusWarning,
   DEFAULT_HEALTH_CHECK_TTL_SECONDS,
   HEALTH_CHECK_TTL_ENV,
   type MeshHealthStatus,
@@ -48,6 +49,55 @@ describe("normalizeHealthResult — verdict table", () => {
       "healthy",
     );
     expect(normalizeHealthResult({}).status).toBe("healthy");
+  });
+
+  // Issue #1517: a present-but-null status is the same verdict as an absent
+  // one — Python reached `degraded` here by raising on `None.lower()` — but
+  // it warns, because `{ status: undefined }` is far likelier to be an unset
+  // variable than an intent. The warning is what separates the two cases
+  // without changing routing.
+  describe("a present-but-null status is healthy, and warns", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      __resetNullStatusWarning();
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+      __resetNullStatusWarning();
+    });
+
+    it.each([
+      ["null", null],
+      ["undefined", undefined],
+    ])("%s status is healthy and warns", (_label, status) => {
+      const verdict = normalizeHealthResult({
+        status: status as unknown as string,
+        checks: { api: true },
+      });
+      expect(verdict.status).toBe("healthy");
+      expect(verdict.checks).toEqual({ api: true });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0][0])).toContain("null status");
+    });
+
+    it("an absent status does not warn", () => {
+      expect(normalizeHealthResult({ checks: { api: true } }).status).toBe(
+        "healthy",
+      );
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    // Same repetition profile as the `degraded` deprecation ten lines away,
+    // so the same dedup: a check re-runs every TTL, and at the 15s default an
+    // undeduplicated line is ~5,760 identical warnings a day.
+    it("warns once per process, not once per refresh", () => {
+      for (let i = 0; i < 5; i++) {
+        expect(normalizeHealthResult({ status: null }).status).toBe("healthy");
+      }
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("carries checks and errors through untouched", () => {

--- a/src/runtime/typescript/src/__tests__/health-check.spec.ts
+++ b/src/runtime/typescript/src/__tests__/health-check.spec.ts
@@ -73,7 +73,7 @@ describe("normalizeHealthResult — verdict table", () => {
       ["undefined", undefined],
     ])("%s status is healthy and warns", (_label, status) => {
       const verdict = normalizeHealthResult({
-        status: status as unknown as string,
+        status,
         checks: { api: true },
       });
       expect(verdict.status).toBe("healthy");

--- a/src/runtime/typescript/src/health-check.ts
+++ b/src/runtime/typescript/src/health-check.ts
@@ -58,8 +58,14 @@ export interface MeshHealthResult {
    * carries only `checks` is reporting success (Python parity:
    * `user_result.get("status", "healthy")`). A present-but-null status
    * means the same, and warns.
+   *
+   * `null` is in the type because the runtime handles it deliberately, not
+   * by accident: `{ status: undefined }` is what a check with an unset
+   * variable returns, and the type has to be able to describe the value
+   * {@link normalizeHealthResult} documents a verdict for. Leaving it out
+   * only forced a cast at every call site that constructed the case.
    */
-  status?: MeshHealthStatus | string;
+  status?: MeshHealthStatus | string | null;
   /** Named sub-probes, surfaced verbatim for operators. */
   checks?: Record<string, unknown>;
   /** Human-readable reasons, surfaced verbatim for operators. */

--- a/src/runtime/typescript/src/health-check.ts
+++ b/src/runtime/typescript/src/health-check.ts
@@ -34,7 +34,18 @@
  * wiring that agent. What differs is topology, not meaning.
  */
 
-/** The verdict vocabulary shared by all three runtimes. */
+/**
+ * The verdict vocabulary shared by all three runtimes.
+ *
+ * `"healthy"` and `"unhealthy"` are the two answers a check gives; they are
+ * the whole routing contract. `"degraded"` is what the RUNTIME records when
+ * it has no verdict it can trust — a check that threw, one that missed its
+ * deadline, an unusable return type, an unreadable status string — and it
+ * keeps the agent in dependency resolution. Returning it from a `healthCheck`
+ * is deprecated (issue #1515): it is indistinguishable from `"healthy"` on
+ * every mesh path, so {@link normalizeHealthResult} warns and keeps the agent
+ * serving.
+ */
 export type MeshHealthStatus = "healthy" | "degraded" | "unhealthy";
 
 /**
@@ -43,9 +54,10 @@ export type MeshHealthStatus = "healthy" | "degraded" | "unhealthy";
  */
 export interface MeshHealthResult {
   /**
-   * `"healthy"`, `"degraded"` or `"unhealthy"`. Omitted means healthy —
-   * a result that carries only `checks` is reporting success (Python
-   * parity: `user_result.get("status", "healthy")`).
+   * `"healthy"` or `"unhealthy"`. Omitted means healthy — a result that
+   * carries only `checks` is reporting success (Python parity:
+   * `user_result.get("status", "healthy")`). A present-but-null status
+   * means the same, and warns.
    */
   status?: MeshHealthStatus | string;
   /** Named sub-probes, surfaced verbatim for operators. */
@@ -60,7 +72,8 @@ export interface MeshHealthResult {
  * Return `unhealthy` only for conditions the mesh should route AROUND —
  * the upstream this agent needs is genuinely not serving. An
  * indeterminate probe (cancelled, cut short) says nothing about the
- * upstream and must be `degraded`, which keeps the heartbeat alive.
+ * upstream, so let it throw: the runtime keeps the agent in dependency
+ * resolution rather than withdrawing it on a conclusion never reached.
  */
 export type MeshHealthCheck = () =>
   | boolean
@@ -99,12 +112,71 @@ export function describeThrown(err: unknown): string {
 }
 
 /**
+ * `degraded` as a RETURN VALUE is deprecated (issue #1515).
+ *
+ * The contract a health check answers is binary: stay in dependency
+ * resolution, or withdraw. `degraded` and `healthy` are the same answer to
+ * it, so the third word buys a 503 on an endpoint nothing probes and costs
+ * the failure rate of a name that reads like withdrawal to everyone who
+ * picks it when their upstream is down.
+ *
+ * The BEHAVIOUR is unchanged, deliberately: remapping it to `unhealthy`
+ * would fix the common intent and silently withdraw every agent whose
+ * author used the word correctly.
+ *
+ * Warned once per process, not once per refresh — the check re-runs every
+ * TTL (15s by default), and a per-tick line would be several thousand
+ * identical warnings a day from an agent doing what its author intended.
+ */
+let degradedReturnWarned = false;
+
+function warnDegradedReturnOnce(): void {
+  if (degradedReturnWarned) return;
+  degradedReturnWarned = true;
+  console.warn(
+    `[mesh-health] healthCheck returned 'degraded' — this agent stays in ` +
+      `dependency resolution and consumers will keep routing to it. Return ` +
+      `false to withdraw.`,
+  );
+}
+
+/** Re-arm the once-per-process deprecation warning. Tests only. */
+export function __resetDegradedReturnWarning(): void {
+  degradedReturnWarned = false;
+}
+
+/**
+ * A null status is a defect in the same shape as a selected `degraded`: it
+ * recurs identically on every refresh, so it gets the same dedup. At the 15s
+ * default TTL a per-tick line is ~5,760 identical warnings a day.
+ */
+let nullStatusWarned = false;
+
+function warnNullStatusOnce(): void {
+  if (nullStatusWarned) return;
+  nullStatusWarned = true;
+  console.warn(
+    `[mesh-health] health check returned a null status — treating it as ` +
+      `healthy (an absent status already means healthy). Return ` +
+      `'healthy' or 'unhealthy' if a verdict was intended.`,
+  );
+}
+
+/** Re-arm the once-per-process null-status warning. Tests only. */
+export function __resetNullStatusWarning(): void {
+  nullStatusWarned = false;
+}
+
+/**
  * Convert whatever a health check returned into a verdict.
  *
  * Never throws. Anything unrecognized becomes `degraded`, NOT
  * `unhealthy`: an unparseable result is a reporting defect, and
  * withdrawing a working agent from the mesh over one is a far worse
  * failure than keeping it. Same rule as Java's `MeshHealthCheckRegistry.coerce`.
+ *
+ * Those runtime-assigned `degraded` verdicts do NOT warn — nothing the
+ * author can act on happened. Only a `degraded` the author SELECTED does.
  */
 export function normalizeHealthResult(raw: unknown): HealthVerdict {
   if (typeof raw === "boolean") {
@@ -121,11 +193,17 @@ export function normalizeHealthResult(raw: unknown): HealthVerdict {
   if (raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
     const result = raw as MeshHealthResult;
     const rawStatus = result.status;
+    const nullish = rawStatus === undefined || rawStatus === null;
     // A result with no `status` is reporting success (Python parity).
-    const status =
-      rawStatus === undefined || rawStatus === null
-        ? "healthy"
-        : toStatus(rawStatus);
+    //
+    // A status that is PRESENT and nullish is treated the same way — the same
+    // verdict Python reaches — but warns: `{ status: undefined }` is far
+    // likelier to be an unset variable than an intent, and the warning is what
+    // separates the two cases without changing routing (issue #1517).
+    if (nullish && "status" in result) {
+      warnNullStatusOnce();
+    }
+    const status = nullish ? "healthy" : toStatus(rawStatus);
     if (status === null) {
       return {
         status: "degraded",
@@ -133,6 +211,7 @@ export function normalizeHealthResult(raw: unknown): HealthVerdict {
         errors: [`Unrecognized health status: ${describeThrown(rawStatus)}`],
       };
     }
+    if (status === "degraded") warnDegradedReturnOnce();
     return {
       status,
       checks: isPlainRecord(result.checks) ? result.checks : {},

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -289,14 +289,14 @@ export interface AgentConfig {
    *
    * While it reports `unhealthy` the agent stops heartbeating, so the
    * registry withdraws it from dependency resolution and consumers fail
-   * over to a surviving provider. Reporting `healthy` (or `degraded`)
-   * again restores it — the process keeps running throughout.
+   * over to a surviving provider. Reporting `healthy` again restores it —
+   * the process keeps running throughout.
    *
    * Return `unhealthy` only for conditions the mesh should route AROUND:
    * the upstream this agent needs is genuinely not serving. A check that
-   * throws, or that could not reach a conclusion, is `degraded` and keeps
-   * the heartbeat alive — a broken probe says nothing about the upstream,
-   * and withdrawing a working agent over one is the worse failure.
+   * throws, or that could not reach a conclusion, keeps the heartbeat
+   * alive — a broken probe says nothing about the upstream, and
+   * withdrawing a working agent over one is the worse failure.
    *
    * Honoured on EVERY agent type since RFC #1502 — MCP agents
    * (`mesh(server, ...)`) and `mesh.route` gateways (`meshExpress`) alike.

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/main.py
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/main.py
@@ -65,15 +65,20 @@ async def health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["anthropic_api_reachable"] = False
                     errors.append(
                         f"Anthropic API returned status: {response.status_code}"
                     )
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/main.py
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/main.py
@@ -45,9 +45,9 @@ async def health_check() -> dict:
 
     # Check API connectivity (uses /v1/models - free, no tokens consumed)
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     "https://api.anthropic.com/v1/models",
@@ -65,17 +65,22 @@ async def health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["anthropic_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["anthropic_api_reachable"] = True
                     errors.append(
                         f"Anthropic API returned status: {response.status_code}"
                     )
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
             status = "unhealthy"

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/main.py
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/main.py
@@ -45,9 +45,9 @@ async def health_check() -> dict:
 
     # Check API connectivity (uses /v1beta/models - metadata only, no tokens consumed)
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}",
@@ -61,15 +61,20 @@ async def health_check() -> dict:
                     errors.append("Google API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["gemini_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["gemini_api_reachable"] = True
                     errors.append(f"Gemini API returned status: {response.status_code}")
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["gemini_api_reachable"] = False
             errors.append(f"Gemini API unreachable: {str(e)}")
             status = "unhealthy"

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/main.py
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/main.py
@@ -61,13 +61,18 @@ async def health_check() -> dict:
                     errors.append("Google API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["gemini_api_reachable"] = False
                     errors.append(f"Gemini API returned status: {response.status_code}")
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["gemini_api_reachable"] = False
             errors.append(f"Gemini API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/main.py
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/main.py
@@ -62,13 +62,18 @@ async def health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["openai_api_reachable"] = False
                     errors.append(f"OpenAI API returned status: {response.status_code}")
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/main.py
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/main.py
@@ -45,9 +45,9 @@ async def health_check() -> dict:
 
     # Check API connectivity
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     "https://api.openai.com/v1/models",
@@ -62,15 +62,20 @@ async def health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["openai_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["openai_api_reachable"] = True
                     errors.append(f"OpenAI API returned status: {response.status_code}")
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
             status = "unhealthy"

--- a/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/main.py
+++ b/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/main.py
@@ -65,15 +65,20 @@ async def health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["anthropic_api_reachable"] = False
                     errors.append(
                         f"Anthropic API returned status: {response.status_code}"
                     )
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/main.py
+++ b/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/main.py
@@ -45,9 +45,9 @@ async def health_check() -> dict:
 
     # Check API connectivity (uses /v1/models - free, no tokens consumed)
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     "https://api.anthropic.com/v1/models",
@@ -65,17 +65,22 @@ async def health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["anthropic_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["anthropic_api_reachable"] = True
                     errors.append(
                         f"Anthropic API returned status: {response.status_code}"
                     )
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
             status = "unhealthy"

--- a/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/main.py
+++ b/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/main.py
@@ -62,13 +62,18 @@ async def health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["openai_api_reachable"] = False
                     errors.append(f"OpenAI API returned status: {response.status_code}")
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/main.py
+++ b/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/main.py
@@ -45,9 +45,9 @@ async def health_check() -> dict:
 
     # Check API connectivity
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     "https://api.openai.com/v1/models",
@@ -62,15 +62,20 @@ async def health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["openai_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["openai_api_reachable"] = True
                     errors.append(f"OpenAI API returned status: {response.status_code}")
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
             status = "unhealthy"

--- a/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/main.py
+++ b/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/main.py
@@ -45,9 +45,9 @@ async def health_check() -> dict:
 
     # Check API connectivity (uses /v1beta/models - metadata only, no tokens consumed)
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}",
@@ -61,15 +61,20 @@ async def health_check() -> dict:
                     errors.append("Google API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["gemini_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["gemini_api_reachable"] = True
                     errors.append(f"Gemini API returned status: {response.status_code}")
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["gemini_api_reachable"] = False
             errors.append(f"Gemini API unreachable: {str(e)}")
             status = "unhealthy"

--- a/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/main.py
+++ b/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/main.py
@@ -61,13 +61,18 @@ async def health_check() -> dict:
                     errors.append("Google API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["gemini_api_reachable"] = False
                     errors.append(f"Gemini API returned status: {response.status_code}")
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["gemini_api_reachable"] = False
             errors.append(f"Gemini API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/main.py
+++ b/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/main.py
@@ -44,9 +44,9 @@ async def health_check() -> dict:
 
     # Check API connectivity (uses /v1/models - free, no tokens consumed)
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     "https://api.anthropic.com/v1/models",
@@ -64,15 +64,20 @@ async def health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["anthropic_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["anthropic_api_reachable"] = True
                     errors.append(f"Anthropic API returned status: {response.status_code}")
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
             status = "unhealthy"

--- a/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/main.py
+++ b/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/main.py
@@ -64,13 +64,18 @@ async def health_check() -> dict:
                     errors.append("Anthropic API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["anthropic_api_reachable"] = False
                     errors.append(f"Anthropic API returned status: {response.status_code}")
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["anthropic_api_reachable"] = False
             errors.append(f"Anthropic API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/main.py
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/main.py
@@ -45,9 +45,9 @@ async def health_check() -> dict:
 
     # Check API connectivity (uses /v1beta/models - metadata only, no tokens consumed)
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     f"https://generativelanguage.googleapis.com/v1beta/models?key={api_key}",
@@ -61,15 +61,20 @@ async def health_check() -> dict:
                     errors.append("Google API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["gemini_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["gemini_api_reachable"] = True
                     errors.append(f"Gemini API returned status: {response.status_code}")
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["gemini_api_reachable"] = False
             errors.append(f"Gemini API unreachable: {str(e)}")
             status = "unhealthy"

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/main.py
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/main.py
@@ -61,13 +61,18 @@ async def health_check() -> dict:
                     errors.append("Google API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["gemini_api_reachable"] = False
                     errors.append(f"Gemini API returned status: {response.status_code}")
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["gemini_api_reachable"] = False
             errors.append(f"Gemini API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/main.py
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/main.py
@@ -62,13 +62,18 @@ async def health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
+                    # The vendor answered and it is not serving. Unhealthy:
+                    # this is the outage the mesh has to route around, and
+                    # anything else keeps heartbeating and keeps consumers
+                    # pointed here.
                     checks["openai_api_reachable"] = False
                     errors.append(f"OpenAI API returned status: {response.status_code}")
-                    status = "degraded"
+                    status = "unhealthy"
         except Exception as e:
+            # The vendor is not answering at all (DNS, connect, timeout, TLS).
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
-            status = "degraded"
+            status = "unhealthy"
 
     return {
         "status": status,

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/main.py
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/main.py
@@ -45,9 +45,9 @@ async def health_check() -> dict:
 
     # Check API connectivity
     if api_key:
-        try:
-            import httpx
+        import httpx
 
+        try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(
                     "https://api.openai.com/v1/models",
@@ -62,15 +62,20 @@ async def health_check() -> dict:
                     errors.append("OpenAI API key is invalid")
                     status = "unhealthy"
                 else:
-                    # The vendor answered and it is not serving. Unhealthy:
-                    # this is the outage the mesh has to route around, and
-                    # anything else keeps heartbeating and keeps consumers
-                    # pointed here.
-                    checks["openai_api_reachable"] = False
+                    # The vendor ANSWERED, so it is reachable — it is just not
+                    # serving. Unhealthy: this is the outage the mesh has to route
+                    # around, and anything else keeps heartbeating and keeps
+                    # consumers pointed here.
+                    checks["openai_api_reachable"] = True
                     errors.append(f"OpenAI API returned status: {response.status_code}")
                     status = "unhealthy"
-        except Exception as e:
+        except httpx.RequestError as e:
             # The vendor is not answering at all (DNS, connect, timeout, TLS).
+            # Transport failures ONLY: anything else raised in here is a defect
+            # in this probe, and it propagates rather than being reported as a
+            # vendor outage — the runtime records an indeterminate verdict and
+            # keeps this agent serving. A broken probe must not be able to
+            # withdraw a working provider.
             checks["openai_api_reachable"] = False
             errors.append(f"OpenAI API unreachable: {str(e)}")
             status = "unhealthy"


### PR DESCRIPTION
## Summary

`health_check` accepted three verdicts and had **two behaviours**: `healthy` and `degraded` are identical on every mesh path, and only `unhealthy` withdraws an agent. The middle value's name argues for a behaviour it does not have — it is accurate about the *agent* (the process is fine, one upstream is not) and wrong about the *routing decision*, and the field is named after the agent.

That is not a documentation problem. The Python `llm-provider` scaffold carried the inversion from #183 until #1475, Java and TypeScript shipped it too, and sixteen example copies still teach it today. When the reference implementation picks the wrong value in three runtimes independently, the API is inviting the error.

**The contract becomes binary.** Return true to keep serving, false to withdraw. Returning a dict or object to populate `checks` and `errors` still works and still flows to `/health`; it just never affects routing. Selecting `degraded` is deprecated with a warning naming the consequence rather than the value.

## One routing behaviour does change, and it isn't `degraded`

`degraded` behaves exactly as before — remapping it would silently withdraw agents whose authors used it correctly, so the warning waits.

But **Python now strips whitespace from the status string**. `{"status": " unhealthy "}` previously parsed to `UNKNOWN` and kept the agent in resolution; it now withdraws. TypeScript and Java already trimmed, so only Python moves. That is the divergence fix working as intended, but it is a routing change and belongs in the release notes.

An earlier draft of this description said flatly that behaviour does not change. Review caught that as too broad — it is true of `degraded` and false of this.

## Java needed more than a deprecated factory

`MeshHealth.of()` folded "the author wrote degraded" and "I could not read this" into one constant, so a pass-through like `MeshHealth.of(vendorStatus)` warned about an API the author never used — and the javadoc directly above the warning asserted that could not happen. An unreadable status is now the runtime's own indeterminate verdict, carrying the same marker and error detail TypeScript already emitted. That also closes a parity gap: Java previously swallowed an unreadable status with no operator-visible detail at all.

## The four divergences (#1517)

- **A sync check silently degraded in Python.** `def` instead of `async def` raised `TypeError`, which the outer handler recorded as degraded — a check that appeared to run and could never fire. The sibling startup hook already had the guard.
- Accepting sync brought its own hazard: an inline blocking probe stalls whichever loop it is scheduled on, and on `api`/`a2a` gateways that is the **heartbeat loop whose silence withdraws the agent**. Sync checks now run on a worker thread.
- **Status strings are trimmed** (the routing change above).
- **A null status** is treated as absent — which both runtimes already resolve to healthy — and warned about once per process, since an explicit `None` is likelier an unset variable than an intent.
- **The agent OpenAPI description had `unknown` and `degraded` backwards.**

Java turned out to have no dict path at all — it rejects any return type other than `MeshHealth` or boolean at boot — so two of these could not be expressed there.

## Sixteen stale examples (#1516)

Provider examples mapped a vendor outage to `degraded`, which keeps the heartbeat alive, so the registry never aged the agent out and consumers kept resolving to a provider whose vendor was down. Failover defeated. All sixteen now withdraw, using the same wording the corrected templates emit.

## The RFC's open question, resolved

**No floor when every provider of a capability withdraws at once.** Keeping the last one routes to something known-broken and trades a clean 503 for a guaranteed failure.

But correct and silent are different things, so the registry now says so out loud. The signal is transition-triggered from the health monitor, not the resolver — the resolver cannot distinguish an outage from a capability that simply never had a provider, and would log at heartbeat rate forever. It costs nothing when no withdrawal happened, cannot fire for a never-provided capability, and cannot re-fire in steady state.

## Verification

Every guard was mutation-tested rather than assumed:

- Deleting the zero-provider call from the health monitor fails with *"the sweep withdrew the only provider of 'llm' and said nothing"* — the original version of that test called the query directly and stayed green when the whole feature was deleted.
- Reverting sync checks to run inline fails `test_a_sync_check_does_not_block_the_loop`.
- Reintroducing the original inversion into a scaffold template fails the new whole-file ban.

The scaffold pin is strengthened from branch-scoped bans to asserting the word appears nowhere in any rendered entry file, across all thirteen language×template combinations — the assertion that would have caught this at source in 2026-06.

`go build`, `go test ./src/core/...` (10 packages), Python unit suite, TypeScript 1437 tests, Java `mvn test` on sdk + starter with no deprecation warnings, man corpus goldens all clean.

## Follow-up worth filing

Python has no deadline around the health check where TypeScript bounds it. `to_thread` removes the loop-blocking harm but not a thread leak on a hung probe. The right home is `health_refresh.py`'s tick, wrapping both the refresh and the core publish — not the cache path, which is also called from `/health` handlers that have their own deadline.

Closes #1515
Closes #1516
Closes #1517

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Health checks support synchronous and asynchronous callbacks.
  - Missing or null statuses default to healthy with diagnostics.
  - Registry warnings identify capabilities with no remaining healthy providers.
- **Bug Fixes**
  - Health-check exceptions no longer withdraw functioning agents.
  - Vendor responses that indicate outages remain reachable but unhealthy.
  - Only connectivity failures are classified as unreachable; unexpected probe errors remain visible.
  - `/health` and `/ready` behavior is clarified and independent.
- **Documentation**
  - Updated health-check guidance across generated examples and supported languages.
- **Deprecation**
  - Explicit `degraded` results now generate a warning; use healthy or unhealthy instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->