### PR TITLE
tracing: make the registry's consumer group configurable, and correct the multi-replica claims

### DIFF
--- a/docs/07-observability.md
+++ b/docs/07-observability.md
@@ -65,6 +65,7 @@ export TEMPO_URL=http://localhost:3200
 | `MCP_MESH_TELEMETRY_AGGREGATE_RETENTION` | `24h` | Age-out window for the in-memory per-agent / per-model / per-edge dashboard aggregates (`0` disables age pruning) |
 | `MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES` | `10000` | Hard key ceiling per aggregate map, evicting least-recently-seen first (`0` disables the ceiling). An edge key costs ~2.1 KB, so the default admits ~20 MB of edge aggregates |
 | `MCP_MESH_UI_TRACE_CONSUMER_GROUP` | `mcp-mesh-ui-dashboard` | Redis consumer group meshui reads `mesh:trace` with. Redis delivers each entry to one consumer per group, so a second meshui on the default group takes traces from a running dashboard — give an extra reader its own group |
+| `MCP_MESH_TRACE_CONSUMER_GROUP` | `mcp-mesh-registry-processors` | The same knob for the registry. Point a second registry process at a live mesh to diagnose it and this is what keeps it from taking half the running registry's span events |
 
 See the [environment variables reference](environment-variables.md) for the full list.
 

--- a/docs/concepts/registry.md
+++ b/docs/concepts/registry.md
@@ -204,6 +204,18 @@ services:
 > rolling-restart procedure and [Long-Running Jobs](jobs.md) for how
 > claims/leases survive replica rotation.
 
+> **Correlation-mode tracing assumes one replica.** The default exporter is
+> replica-safe: each replica streams the spans it consumes straight through to
+> Tempo, which reassembles a trace by its ID however the spans were split on
+> the way in. Under `TRACE_EXPORTER_TYPE=console` or `json` a replica instead
+> assembles each trace in its own memory, and Redis hands each trace-stream
+> entry to exactly one consumer in the shared consumer group — so at N
+> replicas every logical trace completes as N fragments, and `meshctl trace`
+> answers from whichever fragment the replica behind the load balancer holds.
+> Stay at one instance in those modes, or export through Tempo. The registry
+> warns at startup whenever correlation mode is active. See
+> [Observability](../07-observability.md).
+
 ## Troubleshooting
 
 ### Agent Not Registering

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -512,6 +512,13 @@ export MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES=10000
 # Default: mcp-mesh-ui-dashboard.
 export MCP_MESH_UI_TRACE_CONSUMER_GROUP=mcp-mesh-ui-dashboard
 
+# The same knob for the registry, which reads the stream through its own group.
+# A second registry process pointed at a live mesh and left on the default
+# would take roughly half of the running registry's span events and acknowledge
+# them away. Give the extra reader its own group and both see the whole stream.
+# Default: mcp-mesh-registry-processors.
+export MCP_MESH_TRACE_CONSUMER_GROUP=mcp-mesh-registry-processors
+
 # Trace output options
 export TRACE_PRETTY_OUTPUT=false
 export TRACE_ENABLE_STATS=true

--- a/helm/mcp-mesh-core/README.md
+++ b/helm/mcp-mesh-core/README.md
@@ -578,8 +578,8 @@ mcp-mesh-registry:
   replicaCount: 3
 ```
 
-That is the only required change. At more than one replica the chart
-automatically adds:
+That is the only required change, with one exception for non-default tracing
+noted below. At more than one replica the chart automatically adds:
 
 - **Soft topology spread** across zones and nodes (`ScheduleAnyway`,
   `maxSkew: 1`) — a no-op on single-node clusters, replica spreading
@@ -605,6 +605,18 @@ mcp-mesh-registry:
 Multi-replica and autoscaling require an external database — with
 `registry.database.type=sqlite` the template fails, since sqlite is a
 single-writer local file.
+
+Correlation-mode tracing is the exception to "stateless". The chart's default
+exporter (`registry.observability.exporterType: otlp`) is replica-safe: every
+replica streams the spans it consumes straight through to Tempo, which
+reassembles a trace by its ID however the spans were split on the way in.
+Override the exporter to `console` or `json` and each replica instead
+assembles traces in its own memory, while Redis hands each `mesh:trace` entry
+to exactly one consumer in the shared consumer group — so at N replicas every
+logical trace completes as N fragments and `meshctl trace <id>` answers from
+whichever fragment the replica behind the Service holds. Keep the registry at
+one replica in those modes, or leave the exporter at `otlp`. The registry
+warns at startup whenever correlation mode is active.
 
 ## Architecture
 

--- a/helm/mcp-mesh-registry/README.md
+++ b/helm/mcp-mesh-registry/README.md
@@ -168,6 +168,18 @@ safe to enable. Autoscaling (and `replicaCount > 1`) with
 `registry.database.type=sqlite` fails at template time: sqlite is a
 single-writer local file and cannot be shared across replicas.
 
+Correlation-mode tracing is the one exception to "stateless". The default
+exporter (`registry.observability.exporterType: otlp`) is replica-safe: every
+replica streams the spans it consumes straight through to Tempo, which
+reassembles a trace by its ID however the spans were split on the way in.
+Override it to `console` or `json` and each replica instead assembles traces
+in its own memory, while Redis hands each `mesh:trace` entry to exactly one
+consumer in the shared consumer group — so at N replicas every logical trace
+completes as N fragments, and `meshctl trace <id>` answers from whichever
+fragment the replica behind the Service holds. Keep the registry at one
+replica in those modes, or leave the exporter at `otlp`. The registry warns at
+startup whenever correlation mode is active.
+
 ### HA Scheduling
 
 | Parameter                       | Description                                                                                                        | Default |
@@ -306,6 +318,10 @@ registry:
 ```
 
 ### Production Configuration
+
+This keeps `registry.observability.exporterType` at its `otlp` default, which
+is what makes `replicaCount: 3` safe for tracing — see
+[Autoscaling](#autoscaling).
 
 ```yaml
 replicaCount: 3

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -378,6 +378,11 @@ export MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES=10000
 # (default: mcp-mesh-ui-dashboard)
 export MCP_MESH_UI_TRACE_CONSUMER_GROUP=mcp-mesh-ui-dashboard
 
+# The same knob for the registry. A second registry process pointed at a live
+# mesh needs its own group or it takes span events away from the running one
+# (default: mcp-mesh-registry-processors)
+export MCP_MESH_TRACE_CONSUMER_GROUP=mcp-mesh-registry-processors
+
 # Header propagation across agents (comma-separated prefixes)
 export MCP_MESH_PROPAGATE_HEADERS=x-request-id,x-trace
 

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -105,6 +105,7 @@ Default credentials: `admin` / `admin`
 | `MCP_MESH_TELEMETRY_AGGREGATE_RETENTION` | Age-out window for in-memory dashboard aggregates (`0` = no age pruning) | `24h` |
 | `MCP_MESH_TELEMETRY_AGGREGATE_MAX_ENTRIES` | Key ceiling per aggregate map, LRU eviction (`0` = no ceiling). An edge key costs ~2.1 KB, so the default admits ~20 MB of edge aggregates | `10000` |
 | `MCP_MESH_UI_TRACE_CONSUMER_GROUP`      | Redis consumer group meshui reads `mesh:trace` with. One consumer per group gets each entry, so a second meshui needs its own group or it takes traces from the first | `mcp-mesh-ui-dashboard` |
+| `MCP_MESH_TRACE_CONSUMER_GROUP`         | The same knob for the registry. A second registry pointed at a live mesh needs its own group or it takes span events from the running one | `mcp-mesh-registry-processors` |
 
 ## Troubleshooting
 

--- a/src/core/cli/man/content/registry.md
+++ b/src/core/cli/man/content/registry.md
@@ -187,15 +187,23 @@ Drain state is **per-replica** (in-memory, not shared). In a multi-replica deplo
 
 ## High Availability
 
-The registry supports multiple replicas for high availability. All replicas share the same PostgreSQL database — no additional configuration is needed.
+The registry supports multiple replicas for high availability. All replicas share the same PostgreSQL database, and registration needs no additional configuration. Tracing does, in one mode — see below.
 
 ### How It Works
 
 - All agent state (registrations, heartbeats, capabilities) is stored in PostgreSQL
-- No in-memory state affects cross-replica consistency
+- No in-memory registration state affects cross-replica consistency
 - Heartbeat updates use optimistic locking to prevent concurrent update conflicts
 - Each replica runs an independent health monitor against the shared database
 - Startup cleanup only evicts agents that haven't heartbeated to any replica within the threshold
+
+### Tracing at More Than One Replica
+
+The default exporter is replica-safe. Every replica streams the spans it consumes straight through to Tempo, which reassembles a trace by its ID however the spans were split on the way in.
+
+Correlation mode is not. Under `TRACE_EXPORTER_TYPE=console` or `json` a replica assembles each trace in its own memory, and Redis hands each trace-stream entry to exactly one consumer in the shared consumer group — so at N replicas every logical trace completes as N fragments, and `meshctl trace <id>` returns whichever fragment the replica behind the Service happens to hold, or nothing at all. Stay at one replica in those modes, or export through Tempo. The registry warns at startup whenever correlation mode is active.
+
+To read the trace stream from a second process without taking entries from the running registry, give it its own consumer group with `MCP_MESH_TRACE_CONSUMER_GROUP`. A distinct consumer *name* does not help — the group is the unit of distribution.
 
 ### Kubernetes Deployment
 

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -383,8 +383,21 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // the operator who sees that warning will look. It is deliberately span-free:
 // it names no identifier, no endpoint and no env var, only behaviour, so the
 // three goldens below are unmoved by it.
+// Issue #1536: +4 / +0 / +0, all four in a new "Tracing at More Than One
+// Replica" section in `registry.md`. That page claimed multi-replica needed no
+// additional configuration, which holds for the default stream-through
+// exporter (Tempo reassembles by trace ID) and not for correlation mode, which
+// correlates in one process's memory. The added spans are
+// `TRACE_EXPORTER_TYPE=console`, `json`, `meshctl trace <id>` and
+// `MCP_MESH_TRACE_CONSUMER_GROUP`, all in prose. The section's own bullet-free
+// shape plus the one edited bullet above it ("No in-memory registration
+// state", a word added to existing prose) leave both list goldens unmoved.
+// The same issue documents `MCP_MESH_TRACE_CONSUMER_GROUP` in
+// `observability.md` as a table row and in `environment.md` inside the bash
+// fence; renderStyled takes other branches for both, so neither is sampled
+// here.
 const (
-	wantInlineCodeSpans = 1769
+	wantInlineCodeSpans = 1773
 	wantListCodeSpans   = 522
 	wantMarkupListLines = 448
 )

--- a/src/core/registry/tracing/consumer.go
+++ b/src/core/registry/tracing/consumer.go
@@ -1023,7 +1023,7 @@ func DefaultStreamConsumerConfig() *StreamConsumerConfig {
 	return &StreamConsumerConfig{
 		RedisURL:      redisURL,
 		StreamName:    "mesh:trace", // Matches Python publisher
-		ConsumerGroup: "mcp-mesh-registry-processors",
+		ConsumerGroup: TraceConsumerGroupFromEnv(),
 		ConsumerName:  "", // Will be auto-generated
 		BatchSize:     batchSize,
 		BlockTimeout:  5 * time.Second,

--- a/src/core/registry/tracing/consumer_group_test.go
+++ b/src/core/registry/tracing/consumer_group_test.go
@@ -1,0 +1,162 @@
+package tracing
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The literal the registry has always used. Spelled out here rather than
+// referenced through the constant so a rename of DefaultTraceConsumerGroup's
+// VALUE cannot slip through green: existing deployments already have this
+// group on their Redis stream, and changing it silently would make an upgraded
+// registry re-read from wherever the new group's cursor starts.
+const historicalConsumerGroup = "mcp-mesh-registry-processors"
+
+func TestTraceConsumerGroupFromEnv(t *testing.T) {
+	t.Run("unset keeps the historical default", func(t *testing.T) {
+		// t.Setenv registers the restore; unset after it to test the absent case.
+		t.Setenv("MCP_MESH_TRACE_CONSUMER_GROUP", "")
+		if err := os.Unsetenv("MCP_MESH_TRACE_CONSUMER_GROUP"); err != nil {
+			t.Fatalf("unsetenv: %v", err)
+		}
+		if got := TraceConsumerGroupFromEnv(); got != historicalConsumerGroup {
+			t.Errorf("TraceConsumerGroupFromEnv() = %q, want %q", got, historicalConsumerGroup)
+		}
+	})
+
+	t.Run("empty is treated as unset", func(t *testing.T) {
+		t.Setenv("MCP_MESH_TRACE_CONSUMER_GROUP", "")
+		if got := TraceConsumerGroupFromEnv(); got != historicalConsumerGroup {
+			t.Errorf("TraceConsumerGroupFromEnv() = %q, want %q", got, historicalConsumerGroup)
+		}
+	})
+
+	t.Run("set overrides", func(t *testing.T) {
+		t.Setenv("MCP_MESH_TRACE_CONSUMER_GROUP", "mcp-mesh-registry-scratch")
+		if got := TraceConsumerGroupFromEnv(); got != "mcp-mesh-registry-scratch" {
+			t.Errorf("TraceConsumerGroupFromEnv() = %q, want %q", got, "mcp-mesh-registry-scratch")
+		}
+	})
+}
+
+// TestConsumerGroupDefaultsAreOneSource guards the reason the two literals were
+// collapsed (#1536): manager.go and consumer.go each carried the same string,
+// only one of them was the effective default, and a future change could move
+// one without the other. Both configs now resolve through the same helper.
+func TestConsumerGroupDefaultsAreOneSource(t *testing.T) {
+	t.Setenv("MCP_MESH_TRACE_CONSUMER_GROUP", "")
+	if err := os.Unsetenv("MCP_MESH_TRACE_CONSUMER_GROUP"); err != nil {
+		t.Fatalf("unsetenv: %v", err)
+	}
+
+	if got := DefaultTracingConfig().ConsumerGroup; got != historicalConsumerGroup {
+		t.Errorf("DefaultTracingConfig().ConsumerGroup = %q, want %q", got, historicalConsumerGroup)
+	}
+	if got := DefaultStreamConsumerConfig().ConsumerGroup; got != historicalConsumerGroup {
+		t.Errorf("DefaultStreamConsumerConfig().ConsumerGroup = %q, want %q", got, historicalConsumerGroup)
+	}
+
+	t.Setenv("MCP_MESH_TRACE_CONSUMER_GROUP", "mcp-mesh-registry-scratch")
+	if got := DefaultTracingConfig().ConsumerGroup; got != "mcp-mesh-registry-scratch" {
+		t.Errorf("DefaultTracingConfig().ConsumerGroup = %q, want the override", got)
+	}
+	if got := DefaultStreamConsumerConfig().ConsumerGroup; got != "mcp-mesh-registry-scratch" {
+		t.Errorf("DefaultStreamConsumerConfig().ConsumerGroup = %q, want the override", got)
+	}
+}
+
+func TestSingleReaderWarning(t *testing.T) {
+	t.Run("silent in stream-through mode", func(t *testing.T) {
+		if got := singleReaderWarning(true, "otlp"); got != "" {
+			t.Errorf("singleReaderWarning(stream-through) = %q, want empty", got)
+		}
+	})
+
+	for _, exporter := range []string{"console", "json"} {
+		t.Run("fires for "+exporter, func(t *testing.T) {
+			got := singleReaderWarning(false, exporter)
+			if got == "" {
+				t.Fatalf("singleReaderWarning(correlation, %q) is empty, want a warning", exporter)
+			}
+			if !strings.Contains(got, exporter) {
+				t.Errorf("warning does not name the exporter that triggered it: %q", got)
+			}
+			if !strings.Contains(got, "replica") {
+				t.Errorf("warning does not mention replicas: %q", got)
+			}
+		})
+	}
+}
+
+// TestNewTracingManagerWarnsOnlyInCorrelationMode exercises the constructor
+// rather than the helper, because the helper returning a string proves nothing
+// about whether an operator ever sees it.
+//
+// The redirect wraps CONSTRUCTION: log.New binds os.Stdout when the manager's
+// logger is built, so a swap made afterwards would capture nothing.
+func TestNewTracingManagerWarnsOnlyInCorrelationMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		exporter    string
+		wantWarning bool
+	}{
+		{"console correlates locally", "console", true},
+		{"otlp streams through to Tempo", "otlp", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config := DefaultTracingConfig()
+			config.Enabled = true
+			config.ExporterType = tc.exporter
+			config.TraceRetention = 0 // no trim loop; nothing is Start()ed here
+			config.RedisURL = "redis://127.0.0.1:6379"
+
+			out := captureStdout(t, func() {
+				manager, err := NewTracingManager(config)
+				if err != nil {
+					t.Fatalf("NewTracingManager(%s): %v", tc.exporter, err)
+				}
+				if err := manager.Stop(); err != nil {
+					t.Errorf("Stop(): %v", err)
+				}
+			})
+
+			gotWarning := strings.Contains(out, "assumes a single registry reader")
+			if gotWarning != tc.wantWarning {
+				t.Errorf("warning present = %v, want %v.\ncaptured:\n%s", gotWarning, tc.wantWarning, out)
+			}
+		})
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	captured := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		captured <- buf.String()
+	}()
+
+	func() {
+		defer func() {
+			_ = w.Close()
+			os.Stdout = orig
+		}()
+		fn()
+	}()
+
+	return <-captured
+}

--- a/src/core/registry/tracing/manager.go
+++ b/src/core/registry/tracing/manager.go
@@ -29,6 +29,53 @@ const (
 	trimTickInterval      = 5 * time.Minute
 )
 
+// DefaultTraceConsumerGroup is the Redis consumer group the registry reads
+// mesh:trace with. Single source of truth: every registry-side config that
+// needs the group resolves it through TraceConsumerGroupFromEnv, so the
+// default cannot drift between the manager and the raw consumer config.
+const DefaultTraceConsumerGroup = "mcp-mesh-registry-processors"
+
+// TraceConsumerGroupFromEnv returns the Redis consumer group the registry
+// reads mesh:trace with, from MCP_MESH_TRACE_CONSUMER_GROUP.
+//
+// Configurable because Redis hands each stream entry to exactly one consumer
+// within a group. A second registry process pointed at a live mesh under the
+// default group would take roughly half the running registry's span events
+// and XAck them, so neither process sees the whole stream. Give the extra
+// reader its own group and both do. Unset or empty keeps the historical
+// default, so existing deployments are unchanged.
+func TraceConsumerGroupFromEnv() string {
+	if group := os.Getenv("MCP_MESH_TRACE_CONSUMER_GROUP"); group != "" {
+		return group
+	}
+	return DefaultTraceConsumerGroup
+}
+
+// singleReaderWarning returns the startup warning for correlation mode, or ""
+// when the exporter streams spans through to a shared backend.
+//
+// Correlation mode assembles each trace in THIS process's memory and answers
+// GET /trace/:trace_id (what `meshctl trace` calls) from that memory. A
+// process cannot know its own replica count, but it can say that the mode it
+// just entered assumes a single reader: with more than one registry replica,
+// Redis splits mesh:trace across the replicas' shared consumer group and each
+// one completes a different fragment of the same logical trace, so the answer
+// depends on which replica the Service picked.
+//
+// Stream-through (otlp/telemetry) has no such assumption — the spans go to
+// Tempo, which reassembles by trace ID no matter which replica delivered
+// them — so the warning stays silent for the default exporter.
+func singleReaderWarning(streamThroughMode bool, exporterType string) string {
+	if streamThroughMode {
+		return ""
+	}
+	return fmt.Sprintf("⚠️  Correlation mode (TRACE_EXPORTER_TYPE=%s) correlates spans in this process's memory "+
+		"and assumes a single registry reader. With more than one replica on this Redis, each one completes a "+
+		"fragment of every trace and GET /trace/:trace_id (meshctl trace) answers from whichever replica served "+
+		"the request. Use the default otlp exporter for a multi-replica registry.",
+		exporterType)
+}
+
 // TracingManager manages the entire distributed tracing pipeline
 type TracingManager struct {
 	config            *TracingConfig
@@ -157,6 +204,9 @@ func NewTracingManager(config *TracingConfig) (*TracingManager, error) {
 	manager.consumer = consumer
 
 	manager.logger.Printf("Distributed tracing: enabled, exporter=%s, mode=%s, endpoint=%s", config.ExporterType, mode, config.TelemetryEndpoint)
+	if warning := singleReaderWarning(manager.streamThroughMode, config.ExporterType); warning != "" {
+		manager.logger.Print(warning)
+	}
 	if config.TraceRetention > 0 {
 		manager.logger.Printf("Trace stream retention: %s (XTRIM MINID on connect and every %s; override via MCP_MESH_TRACE_RETENTION)",
 			config.TraceRetention, trimTickInterval)
@@ -542,7 +592,7 @@ func DefaultTracingConfig() *TracingConfig {
 		Enabled:             enabled,
 		RedisURL:            redisURL,
 		StreamName:          "mesh:trace", // Matches Python publisher
-		ConsumerGroup:       "mcp-mesh-registry-processors",
+		ConsumerGroup:       TraceConsumerGroupFromEnv(),
 		ConsumerName:        "", // Will be auto-generated
 		BatchSize:           batchSize,
 		BlockTimeout:        5 * time.Second,


### PR DESCRIPTION
## Summary

The registry's Redis consumer group was a hardcoded literal. Redis hands each stream entry to exactly **one** consumer within a group, so a second registry process sharing that group splits `mesh:trace` with the first — the same hazard #1533 fixed for meshui, and the change that made it possible to verify #1531/#1532 against a live mesh without degrading it.

It is now `MCP_MESH_TRACE_CONSUMER_GROUP`, defaulting to the existing value so behaviour is unchanged when unset.

## Two premises in the issue were wrong, and the investigation found a real bug instead

I filed #1536 claiming a multi-replica registry would silently under-report user-visible stats, and that per-replica trimming could delete history. Both are false:

- **The registry's `TraceAccumulator` has no reader.** Every method that reads it is called only from `src/core/ui`, and `ui.NewServer` is constructed only in the meshui binary with its own group. The registry's four `/trace/*` routes never consult it.
- **Trimming is idempotent.** `XTRIM MINID` derives from wall-clock minus retention, retention comes from one ConfigMap value, and `manager_ui.go` already documents concurrent trimmers as harmless. N replicas means N redundant calls.
- **The default OTLP path is harmless under N replicas** — Tempo reassembles by trace ID, so split delivery still yields a complete trace.

**But `TRACE_EXPORTER_TYPE=console|json` genuinely breaks.** That mode builds a per-trace-stateful `SpanCorrelator` instead, so N replicas fragment one logical trace into N partial "completed" traces, and `GET /trace/:trace_id` — which `meshctl trace` calls — returns a fragment or a 404 depending on which pod the Service picked.

Meanwhile the docs actively invite multi-replica and say no caveat applies:

- `man registry` said *"multiple replicas for high availability … no additional configuration is needed"*
- `helm/mcp-mesh-core/README.md` said `replicaCount: 3` and *"That is the only required change"*
- `helm/mcp-mesh-registry/README.md` ships `replicaCount: 3` as the **Production Configuration**

Those are accurate for the default and wrong for console/json. Corrected across the man page, `docs/concepts/registry.md`, and both chart READMEs. The Production Configuration example itself is left alone — it leaves `exporterType` at `otlp`, so it is correct; it gained a sentence saying so and pointing at the caveat.

## A startup warning, deliberately

The registry cannot know its own replica count, but it can say the mode assumes a single reader. It fires only when tracing is explicitly enabled *and* the exporter is explicitly moved off `otlp`, so the single-replica majority never sees it. Factored so the mode logic is unit-testable, with a second test redirecting stdout around manager construction to prove an operator actually sees it for `console` and does not for `otlp`.

## Also found

`DefaultStreamConsumerConfig` in `consumer.go` **has no callers at all** — exported dead config carrying a second copy of the literal, which would have drifted silently. Both now resolve through one helper, with a test asserting it.

And `man registry` claimed *"No in-memory state affects cross-replica consistency"*, which is false as written — drain state is per-replica, as the same page says four lines earlier. Narrowed to *registration* state.

## Not done here — filed as #1540

The registry constructs an accumulator nothing reads: a 200-entry ring plus an edge map bounded at 10,000 keys (~20 MB per replica) and two goroutines, fed every event. It is also latently wrong — it becomes a correctness bug the moment someone wires a registry route to `GetEdgeStats`. Removing a component during release prep is a different risk profile from adding an env var, so it is filed with the evidence rather than rushed in.

## Verification

Both guards mutation-tested: changing the default fails the assertion; making the warning unconditional fails the mode test.

`go build ./...` and `go test ./...` (whole repo) clean. Man goldens hold at 1773, the delta being exactly the four prose spans added.

Closes #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq