### PR TITLE
test: connect man-page claims to the code they describe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,16 @@ jobs:
       - name: Run the direct entry point
         run: python3 scripts/test_bump_version.py
 
+      # Issue #1500: the man pages and docs/ assert things about the four
+      # runtimes and nothing connected them, so #1499 shipped three false
+      # Actuator claims — one of them a `curl` that 404s — through a fully
+      # green build. The check runs here rather than in a docs job because its
+      # evidence is source: Go/Python/TypeScript/Java route registrations, the
+      # starter's POM, and the probe handlers themselves. Stdlib only, under a
+      # second. Its own tests are collected by the pytest step above.
+      - name: Check doc claims against the code they describe
+        run: python3 scripts/check_doc_claims.py
+
   # Issue #1407: a version bump must not re-resolve the Rust dependency graph.
   # The bump reminder used to say `cargo generate-lockfile`, which does exactly
   # that, so v3.2.3 and v3.3.1 each shipped six third-party crate moves — the

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,3 +147,36 @@ repos:
         files: ^src/core/registry/.*\.go$
         exclude: ^src/core/registry/generated/.*$
         description: "🤖 Validates Go code compiles with generated handlers"
+
+  # 5. Doc claims against the code they describe (#1500)
+  #
+  # Runs on a doc edit OR on an edit to the evidence — a route registration,
+  # the starter's POM, a probe handler. Both directions matter: #1499 was a
+  # doc that was never true, and the RFC #1502 case was a doc that stopped
+  # being true when the runtime changed under it.
+  #
+  # `pass_filenames: false` because the check is whole-corpus by nature: the
+  # served-path inventory has to be built from every runtime whichever file
+  # was touched, and a per-file run would report a curl as unserved simply
+  # because the file defining the route was not staged.
+  - repo: local
+    hooks:
+      - id: check-doc-claims
+        name: Check Doc Claims Against Code
+        entry: python3 scripts/check_doc_claims.py
+        language: system
+        pass_filenames: false
+        files: >-
+          (?x)^(
+            src/core/cli/man/content/.*\.md|
+            docs/.*\.md|
+            helm/[^/]+/README\.md|
+            README\.md|
+            src/core/.*\.go|
+            src/runtime/python/.*\.py|
+            src/runtime/typescript/src/.*\.ts|
+            src/runtime/java/.*\.(java|xml)|
+            examples/.*\.(py|ts|java)|
+            scripts/check_doc_claims\.py
+          )$
+        description: "🤖 Man pages and docs may not assert what the code does not do"

--- a/scripts/check_doc_claims.py
+++ b/scripts/check_doc_claims.py
@@ -1,0 +1,1113 @@
+#!/usr/bin/env python3
+"""Connect prose claims in the shipped docs to the code they describe.
+
+`src/core/cli/man/content/<topic>.md`, `<topic>_java.md` and
+`<topic>_typescript.md` are hand-maintained parallel surfaces, and `docs/`
+restates the same facts a third time. A claim written once and copied into a
+sibling has nothing checking it, and the man corpus tests in
+`src/core/cli/man/renderer_test.go` cannot help: they assert that markup
+*renders*, not that sentences are *true*.
+
+Issue #1500 filed this after the failure bit twice:
+
+  #1499 -- three surfaces said the Spring Boot starter integrates with
+  Actuator. `mcp-mesh-spring-boot-starter/pom.xml` has no Actuator dependency
+  and `MeshHealthCheckBeanPostProcessor` records that registering a
+  `HealthIndicator` was considered and rejected. One of the three was
+  `curl http://localhost:8080/actuator/health`, which 404s on a stock agent --
+  a false claim a developer RUNS and then reasonably concludes their agent is
+  broken.
+
+  RFC #1502 -- `docs/typescript/mesh-functions.md` said `/ready` and `/health`
+  answer 200 only while the agent reports healthy. `/ready` reports the mesh
+  runtime and is unmoved by the verdict; that is the whole point of the RFC, so
+  that a withdrawn gateway keeps its Service endpoints. A reader following that
+  page would expect their pod to leave Service endpoints on a vendor outage.
+
+Three checks, in the order of value #1500 puts them in.
+
+CURL PATHS (check A). Every `curl` example naming a local host must name a path
+something in this repo actually serves. The served set is derived from source
+-- Go route registrations, FastAPI/Starlette decorators, Hono/Express
+registrations, Spring mappings -- across the runtimes AND `examples/`, because
+a doc that curls `/plan` is teaching the tutorial gateway, which defines it.
+This is the check that catches the Actuator `curl` on its own.
+
+DEPENDENCY CLAIMS (check B). A general "no page claims a dependency the module
+does not declare" is not tractable; an explicit table of
+(claim term -> build file -> evidence) is. If the build file does not carry the
+evidence, the term may still appear -- documented absence is often the right
+answer, and #1499 chose it -- but only in a NEGATED mention. This catches the
+two prose surfaces of #1499 that carried no `curl`.
+
+VERDICT COUPLING (check C). #1500 calls this the valuable and hardest one, and
+it is only tractable in halves, so it is built in halves and both are asserted:
+
+  1. The code half is exact. For each runtime, the named `/ready` handler must
+     not reference the health-verdict symbols, and the named `/health` handler
+     must. That is RFC #1502's contract stated where it can be mechanically
+     checked, and nothing else pins it.
+  2. The doc half is a bounded scan, NOT prose comprehension. It looks for the
+     specific coupling idioms these pages use ("reflects your", "drives",
+     "answers 200 only while", ...) inside one markdown unit that also names a
+     probe path, and requires the polarity to match part 1. It is deliberately
+     narrow: see WHAT THIS CANNOT SEE.
+
+WHAT THIS CANNOT SEE
+  - Whether a sentence with no coupling idiom is true. Check C recognises the
+    idioms this corpus uses to express "endpoint X is driven by the health
+    check". A page that states the same falsehood in words not on that list
+    passes. The list is a floor, not a parser, and it must not be treated as
+    licence to stop reading the prose in review -- see
+    `.claude/review-checklist.md`.
+  - Any claim that is not a path, a dependency name, or a verdict coupling.
+    Most of what these pages assert is still checked by a human alone.
+  - Whether a served path is served on the port or by the runtime the example
+    implies. The inventory is path-level and repo-wide.
+
+Usage: python3 scripts/check_doc_claims.py   (run from anywhere)
+       python3 scripts/check_doc_claims.py --list-paths
+Exit code 0 = every checked claim is connected to code that backs it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# ---------------------------------------------------------------------------
+# Documents whose claims are checked.
+# ---------------------------------------------------------------------------
+
+# Globs, relative to the repo root. Deliberately every man page including the
+# `_java` / `_typescript` variants, which no existing test samples at all.
+DOC_GLOBS = (
+    "src/core/cli/man/content/*.md",
+    "docs/**/*.md",
+    "helm/*/README.md",
+    "README.md",
+)
+
+# Directories whose markdown is not a claim about this repo's behaviour.
+DOC_SKIP_PARTS = ("node_modules", "site", "target", "dist", ".venv")
+
+
+def iter_docs(root: Path) -> list[Path]:
+    seen: dict[Path, None] = {}
+    for pattern in DOC_GLOBS:
+        for path in sorted(root.glob(pattern)):
+            if any(part in DOC_SKIP_PARTS for part in path.parts):
+                continue
+            seen.setdefault(path, None)
+    return list(seen)
+
+
+# ---------------------------------------------------------------------------
+# Route inventory: what the code actually serves.
+# ---------------------------------------------------------------------------
+
+SOURCE_SKIP_PARTS = (
+    "node_modules",
+    "dist",
+    "build",
+    "target",
+    ".venv",
+    "__pycache__",
+    "generated_client",
+)
+
+
+def _is_source_of_interest(path: Path) -> bool:
+    if any(part in SOURCE_SKIP_PARTS for part in path.parts):
+        return False
+    name = path.name
+    # Test sources register throwaway routes; they are not a contract.
+    if name.endswith("_test.go") or name.endswith(".test.ts"):
+        return False
+    if name.startswith("test_") or name.endswith("_test.py"):
+        return False
+    parts = path.parts
+    if "tests" in parts or ("src" in parts and "test" in parts):
+        return False
+    return True
+
+
+# Go: gin/httprouter registrations, plus the `Group("/api")` prefix idiom used
+# by the meshui server. `options.BaseURL +` is the oapi-codegen generated form.
+GO_ROUTE_RE = re.compile(
+    r"\.(?:GET|POST|PUT|DELETE|HEAD|PATCH|OPTIONS|Handle|HandleFunc)\("
+    r'\s*(?:[A-Za-z_.]+\s*\+\s*)?"(/[^"]*)"'
+)
+GO_GROUP_RE = re.compile(r'\.Group\(\s*"(/[^"]*)"')
+
+# Python: FastAPI/Starlette decorators and imperative registration, plus the
+# `X_PATH = "/livez"` module constants the probe endpoints are registered from
+# and the `mount_path = "/mcp"` the MCP app is mounted at.
+PY_ROUTE_RE = re.compile(
+    r"(?:@[A-Za-z_][\w.]*|\b[A-Za-z_][\w.]*)"
+    r"\.(?:get|post|put|delete|head|patch|api_route|add_api_route|mount|route|"
+    r"add_route|add_websocket_route)\("
+    r"\s*[\"'](/[^\"']*)[\"']"
+)
+PY_PATH_CONST_RE = re.compile(
+    r"^\s*[A-Z_]*(?:PATH|ROUTE|ENDPOINT|MOUNT)\s*=\s*[\"'](/[^\"']*)[\"']", re.M
+)
+
+# TypeScript: Express routers and FastMCP's Hono app (`app.on([...], "/x", h)`).
+TS_ROUTE_RE = re.compile(
+    r"\.(?:get|post|put|delete|head|patch|all|use|on)\("
+    r"\s*(?:\[[^\]]*\]\s*,\s*)?[\"'`](/[^\"'`]*)[\"'`]"
+)
+
+# Java: Spring mappings, with the class-level `@RequestMapping("/api")` prefix
+# composed against the method-level mappings in the same file.
+JAVA_MAPPING_RE = re.compile(
+    r"@(?:Get|Post|Put|Delete|Patch|Request)Mapping\("
+    r'\s*(?:value\s*=\s*)?"(/[^"]*)"'
+)
+JAVA_CLASS_PREFIX_RE = re.compile(
+    r'@RequestMapping\(\s*(?:value\s*=\s*)?"(/[^"]*)"[^)]*\)\s*(?:@\w+(?:\([^)]*\))?\s*)*'
+    r"(?:public\s+|final\s+|abstract\s+)*class\b"
+)
+
+
+def _strip_comment_lines(text: str, markers: tuple[str, ...]) -> str:
+    """Drop whole-line comments so JSDoc examples do not enter the inventory.
+
+    `api-runtime.ts` documents `app.post("/compute", mesh.route(...))` in a
+    docblock. Counting that as a served path would let a doc curl `/compute`
+    on any agent and stay green.
+    """
+    kept = []
+    for line in text.split("\n"):
+        if line.lstrip().startswith(markers):
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def collect_served_paths(root: Path) -> dict[str, set[str]]:
+    """Return {runtime: {path pattern}} for everything this repo serves.
+
+    Runtimes are the four the mesh ships plus `examples`, whose routes are
+    real: a tutorial page that curls `/plan` is describing a gateway whose
+    source is in this repo, and treating that as unserved would be wrong.
+    """
+    found: dict[str, set[str]] = {
+        "go": set(),
+        "python": set(),
+        "typescript": set(),
+        "java": set(),
+        "examples": set(),
+    }
+
+    def bucket(path: Path, default: str) -> str:
+        return "examples" if "examples" in path.parts else default
+
+    for path in sorted((root / "src" / "core").rglob("*.go")):
+        if not _is_source_of_interest(path):
+            continue
+        text = _strip_comment_lines(path.read_text(encoding="utf-8"), ("//",))
+        literals = set(GO_ROUTE_RE.findall(text))
+        prefixes = set(GO_GROUP_RE.findall(text))
+        found["go"] |= literals
+        found["go"] |= {_join(p, lit) for p in prefixes for lit in literals}
+
+    py_roots = [root / "src" / "runtime" / "python", root / "examples"]
+    for py_root in py_roots:
+        for path in sorted(py_root.rglob("*.py")):
+            if not _is_source_of_interest(path):
+                continue
+            text = _strip_comment_lines(path.read_text(encoding="utf-8"), ("#",))
+            hits = set(PY_ROUTE_RE.findall(text)) | set(PY_PATH_CONST_RE.findall(text))
+            found[bucket(path, "python")] |= hits
+
+    ts_roots = [root / "src" / "runtime" / "typescript" / "src", root / "examples"]
+    for ts_root in ts_roots:
+        for path in sorted(ts_root.rglob("*.ts")):
+            if not _is_source_of_interest(path):
+                continue
+            text = _strip_comment_lines(
+                path.read_text(encoding="utf-8"), ("//", "*", "/*")
+            )
+            found[bucket(path, "typescript")] |= set(TS_ROUTE_RE.findall(text))
+
+    java_roots = [root / "src" / "runtime" / "java", root / "examples"]
+    for java_root in java_roots:
+        for path in sorted(java_root.rglob("*.java")):
+            if not _is_source_of_interest(path):
+                continue
+            raw = path.read_text(encoding="utf-8")
+            prefixes = set(JAVA_CLASS_PREFIX_RE.findall(raw))
+            text = _strip_comment_lines(raw, ("//", "*", "/*"))
+            literals = set(JAVA_MAPPING_RE.findall(text))
+            key = bucket(path, "java")
+            found[key] |= literals
+            found[key] |= {_join(p, lit) for p in prefixes for lit in literals}
+
+    return found
+
+
+def _join(prefix: str, suffix: str) -> str:
+    return (prefix.rstrip("/") + "/" + suffix.lstrip("/")).replace("//", "/")
+
+
+# A path served by a registration this extractor cannot read as a literal.
+# Each entry cites the site it was read from, and `check_supplement_sites`
+# re-reads that site every run: if the evidence moves or is renamed, the
+# supplement fails rather than quietly outliving the route it stands for.
+# This is what stops the maintained half from becoming the stale list it is
+# meant to replace.
+@dataclass(frozen=True)
+class Supplement:
+    path: str
+    runtime: str
+    why: str
+    site: str  # repo-relative file
+    evidence: str  # substring that must still be present at `site`
+
+
+SUPPLEMENTS: tuple[Supplement, ...] = (
+    Supplement(
+        path="/mcp",
+        runtime="python",
+        why="FastMCP is mounted at a path held in a local variable, so the "
+        "literal is on the assignment rather than on the mount call.",
+        site="src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py",
+        evidence='mount_path = "/mcp"',
+    ),
+    Supplement(
+        path="/mcp",
+        runtime="typescript",
+        why="FastMCP owns the MCP endpoint, so no SDK source registers it. "
+        "The proxy proves the agreed path by normalising every peer endpoint "
+        "onto it.",
+        site="src/runtime/typescript/src/proxy.ts",
+        evidence='endsWith("/mcp")',
+    ),
+    Supplement(
+        path="/mcp",
+        runtime="java",
+        why="The MCP endpoint is configured on the Spring transport provider "
+        "from a constant, not declared with a @RequestMapping.",
+        site="src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshMcpServerConfiguration.java",
+        evidence='MCP_ENDPOINT = "/mcp"',
+    ),
+)
+
+
+# Paths a doc curls that nothing serves BY DESIGN: they stand in for an
+# endpoint the reader writes. Each must stay referenced by some doc -- an
+# entry no doc uses is a stale exemption and fails, so this list cannot grow
+# quietly the way the prose it guards did.
+@dataclass(frozen=True)
+class IllustrativePath:
+    path: str
+    why: str
+
+
+ILLUSTRATIVE_PATHS: tuple[IllustrativePath, ...] = (
+    IllustrativePath(
+        path="/api/process",
+        why="headers*.md: stands in for the reader's own gateway route, in an "
+        "example about what mesh forwards, not about what mesh serves.",
+    ),
+)
+
+
+# If the extractor stops matching a runtime's idiom it returns fewer paths and
+# every curl example passes for the wrong reason. These anchors are re-derived
+# every run: they are the guard on the mechanical half.
+INVENTORY_ANCHORS: dict[str, tuple[str, ...]] = {
+    "go": ("/health", "/agents", "/heartbeat", "/jobs"),
+    "python": ("/livez", "/ready", "/health", "/startupz"),
+    "typescript": ("/livez", "/ready", "/health", "/startupz"),
+    "java": ("/livez", "/ready", "/health", "/startupz"),
+    "examples": ("/plan",),
+}
+
+
+def path_matcher(pattern: str) -> re.Pattern[str]:
+    """Compile a route pattern into a matcher for a concrete request path.
+
+    Handles the four parameter spellings in play: gin's `:id` and `*path`,
+    Spring's `{id}` and Starlette's `{id}`.
+    """
+    out = ["^"]
+    for segment in pattern.strip("/").split("/"):
+        if not segment:
+            continue
+        out.append("/")
+        if segment.startswith("*"):
+            out.append(".+")
+        elif segment.startswith(":") or (
+            segment.startswith("{") and segment.endswith("}")
+        ):
+            out.append("[^/]+")
+        else:
+            out.append(re.escape(segment))
+    if len(out) == 1:
+        out.append("/")
+    out.append("/?$")
+    return re.compile("".join(out))
+
+
+# ---------------------------------------------------------------------------
+# Check A: curl examples name a path something serves.
+# ---------------------------------------------------------------------------
+
+# Only hosts that mean "something you are running". An external host is
+# somebody else's contract and this repo cannot assert anything about it.
+LOCAL_HOST_RE = re.compile(
+    r"^(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|host\.docker\.internal|"
+    r"[\w.$%{}<>-]+:\d+|\$\{?[A-Z_]+\}?)$"
+)
+URL_RE = re.compile(r"https?://[^\s'\"`)\\|]+")
+
+
+@dataclass
+class Finding:
+    doc: str
+    line: int
+    detail: str
+
+
+def _rel(doc: Path, root: Path) -> str:
+    """Repo-relative label, falling back to the absolute path.
+
+    Tests hand these checks fixture documents outside the tree; a label is
+    cosmetic and must not be the reason a check cannot be exercised.
+    """
+    try:
+        return str(doc.relative_to(root))
+    except ValueError:
+        return str(doc)
+
+
+def _curl_urls(text: str):
+    """Yield (line number, url) for every URL that is an argument to curl.
+
+    Shell line continuations are folded first: the URL is regularly on the
+    line after the `curl`.
+    """
+    lines = text.split("\n")
+    folded: list[tuple[int, str]] = []
+    i = 0
+    while i < len(lines):
+        start = i
+        buf = lines[i]
+        while buf.rstrip().endswith("\\") and i + 1 < len(lines):
+            i += 1
+            buf = buf.rstrip().rstrip("\\") + " " + lines[i]
+        folded.append((start + 1, buf))
+        i += 1
+
+    for lineno, buf in folded:
+        idx = buf.find("curl")
+        if idx == -1:
+            continue
+        for url in URL_RE.findall(buf[idx:]):
+            yield lineno, url.rstrip(".,;:)\"'")
+
+
+def split_url(url: str) -> tuple[str, str]:
+    body = url.split("://", 1)[1]
+    host, _, rest = body.partition("/")
+    path = "/" + rest
+    path = path.split("?", 1)[0].split("#", 1)[0]
+    return host, path
+
+
+def check_curl_paths(
+    docs: list[Path], root: Path, served: dict[str, set[str]]
+) -> list[Finding]:
+    matchers = [
+        path_matcher(p) for paths in served.values() for p in paths if p
+    ]
+    matchers += [path_matcher(s.path) for s in SUPPLEMENTS]
+    illustrative = {i.path for i in ILLUSTRATIVE_PATHS}
+
+    findings: list[Finding] = []
+    for doc in docs:
+        rel = _rel(doc, root)
+        for lineno, url in _curl_urls(doc.read_text(encoding="utf-8")):
+            host, path = split_url(url)
+            if not LOCAL_HOST_RE.match(host):
+                continue
+            if path in illustrative:
+                continue
+            if any(m.match(path) for m in matchers):
+                continue
+            findings.append(
+                Finding(
+                    rel,
+                    lineno,
+                    f"curl example targets {path!r}, which nothing in this "
+                    f"repo serves (url: {url}). Either the claim is wrong, or "
+                    f"the route exists somewhere this checker cannot read it "
+                    f"-- add a Supplement with the site that proves it.",
+                )
+            )
+    return findings
+
+
+def check_illustrative_still_used(
+    docs: list[Path], root: Path
+) -> list[Finding]:
+    used = set()
+    for doc in docs:
+        for _, url in _curl_urls(doc.read_text(encoding="utf-8")):
+            used.add(split_url(url)[1])
+    findings = []
+    for entry in ILLUSTRATIVE_PATHS:
+        if entry.path not in used:
+            findings.append(
+                Finding(
+                    "scripts/check_doc_claims.py",
+                    0,
+                    f"ILLUSTRATIVE_PATHS still exempts {entry.path!r}, which "
+                    f"no doc curls any more. Delete the entry.",
+                )
+            )
+    return findings
+
+
+def check_supplement_sites(root: Path) -> list[Finding]:
+    findings = []
+    for sup in SUPPLEMENTS:
+        site = root / sup.site
+        if not site.exists():
+            findings.append(
+                Finding(
+                    "scripts/check_doc_claims.py",
+                    0,
+                    f"SUPPLEMENTS cites {sup.site}, which no longer exists. "
+                    f"The claim that {sup.path!r} is served needs a new site.",
+                )
+            )
+            continue
+        if sup.evidence not in site.read_text(encoding="utf-8"):
+            findings.append(
+                Finding(
+                    sup.site,
+                    0,
+                    f"SUPPLEMENTS claims {sup.path!r} is served here, on the "
+                    f"evidence of {sup.evidence!r}, which is no longer in the "
+                    f"file. Re-read the registration and update or drop the "
+                    f"entry.",
+                )
+            )
+    return findings
+
+
+def check_inventory_anchors(served: dict[str, set[str]]) -> list[Finding]:
+    findings = []
+    for runtime, anchors in INVENTORY_ANCHORS.items():
+        have = served.get(runtime, set())
+        for anchor in anchors:
+            if anchor not in have:
+                findings.append(
+                    Finding(
+                        "scripts/check_doc_claims.py",
+                        0,
+                        f"route extraction found no {anchor!r} for {runtime}. "
+                        f"Either the route was removed, or the registration "
+                        f"idiom changed and this extractor is now reading "
+                        f"less than it thinks. Do not relax the anchor to go "
+                        f"green -- an empty inventory passes every curl.",
+                    )
+                )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check B: no page claims a dependency the module does not declare.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DependencyClaim:
+    term: str  # case-insensitive word the docs use for the dependency
+    build_file: str  # repo-relative build file that would declare it
+    evidence: str  # case-insensitive substring that proves the declaration
+    subject: str  # what the module is, for the failure message
+
+
+DEPENDENCY_CLAIMS: tuple[DependencyClaim, ...] = (
+    DependencyClaim(
+        term="actuator",
+        build_file="src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml",
+        evidence="actuator",
+        subject="the MCP Mesh Spring Boot starter",
+    ),
+)
+
+# A mention of an undeclared dependency is fine when the page is saying it is
+# absent -- #1499 was fixed by documenting the absence, not by deleting the
+# subject. These are the markers that make a mention a denial. They are matched
+# in the same markdown unit as the term.
+NEGATION_MARKERS = (
+    r"\bnot\b",
+    r"\bno\b",
+    r"\bnever\b",
+    r"\bnothing\b",
+    r"\bwithout\b",
+    r"\bneither\b",
+    r"\bdoes ?n[o']t\b",
+    r"\bis ?n[o']t\b",
+    r"\brather than\b",
+    r"\binstead of\b",
+    r"\bif your application adds\b",
+)
+NEGATION_RE = re.compile("|".join(NEGATION_MARKERS), re.I)
+
+
+def markdown_blocks(text: str) -> list[tuple[int, str]]:
+    """Split markdown into (line number, block) chunks that carry one claim.
+
+    A block is one paragraph, one list item with its wrapped continuation
+    lines, or one table row. Fenced blocks and headings are dropped: a code
+    sample is not a prose claim, and a heading is too short to carry a
+    polarity.
+
+    Block granularity is what check B wants. A paragraph that opens by denying
+    a dependency and then explains what the absent thing does is one claim,
+    and splitting it into sentences would report the explanation as an
+    unqualified assertion.
+    """
+    blocks: list[tuple[int, str]] = []
+    buf: list[str] = []
+    buf_line = 0
+    in_fence = False
+
+    def flush():
+        nonlocal buf
+        if buf:
+            joined = " ".join(s.strip() for s in buf).strip()
+            if joined:
+                blocks.append((buf_line, joined))
+        buf = []
+
+    for i, line in enumerate(text.split("\n"), start=1):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            flush()
+            continue
+        if in_fence:
+            continue
+        if not stripped or stripped.startswith("#"):
+            flush()
+            continue
+        if stripped.startswith("|"):
+            flush()
+            for cell in stripped.strip("|").split("|"):
+                cell = cell.strip()
+                if cell:
+                    blocks.append((i, cell))
+            continue
+        if re.match(r"^\s*(?:[-*+]\s|\d+\.\s)", line):
+            flush()
+        if not buf:
+            buf_line = i
+        buf.append(line)
+    flush()
+    return blocks
+
+
+def markdown_clauses(text: str) -> list[tuple[int, str]]:
+    """Blocks, split again on sentence terminators and the man pages' " - ".
+
+    Clause granularity is what check C wants. A block regularly contrasts two
+    endpoints ("`/health` answers 503 while `/ready` is unmoved"), and a check
+    that asks which endpoint an idiom belongs to can only answer inside one
+    clause.
+    """
+    clauses: list[tuple[int, str]] = []
+    for lineno, block in markdown_blocks(text):
+        for piece in re.split(r"(?<=[.!?])\s+|\s+-\s+|;\s+", block):
+            piece = piece.strip()
+            if piece:
+                clauses.append((lineno, piece))
+    return clauses
+
+
+def check_dependency_claims(
+    docs: list[Path], root: Path
+) -> list[Finding]:
+    findings: list[Finding] = []
+    for claim in DEPENDENCY_CLAIMS:
+        build_file = root / claim.build_file
+        if not build_file.exists():
+            findings.append(
+                Finding(
+                    "scripts/check_doc_claims.py",
+                    0,
+                    f"DEPENDENCY_CLAIMS points at {claim.build_file}, which "
+                    f"does not exist. The claim has no evidence either way.",
+                )
+            )
+            continue
+        declared = (
+            claim.evidence.lower() in build_file.read_text(encoding="utf-8").lower()
+        )
+        if declared:
+            continue
+
+        term_re = re.compile(re.escape(claim.term), re.I)
+        for doc in docs:
+            rel = _rel(doc, root)
+            for lineno, unit in markdown_blocks(doc.read_text(encoding="utf-8")):
+                if not term_re.search(unit):
+                    continue
+                if NEGATION_RE.search(unit):
+                    continue
+                findings.append(
+                    Finding(
+                        rel,
+                        lineno,
+                        f"asserts {claim.term!r} without qualification, but "
+                        f"{claim.build_file} declares no {claim.evidence!r}, "
+                        f"so {claim.subject} does not have it. Either the "
+                        f"dependency belongs in the build file, or the page "
+                        f"must say it is absent.\n      unit: {unit[:200]}",
+                    )
+                )
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check C: probe endpoints are documented with the polarity their handler has.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HandlerFact:
+    runtime: str
+    path: str
+    site: str
+    handler: str  # regex locating the handler body's opening
+    consults_verdict: bool
+    verdict_symbols: tuple[str, ...]  # symbols that read the health check
+    note: str
+
+
+# The code half of check C. `consults_verdict` is asserted against the handler
+# body, so this table cannot drift away from the runtimes: if someone wires the
+# verdict back into `/ready`, the assertion fails here before any doc is read.
+HANDLER_FACTS: tuple[HandlerFact, ...] = (
+    HandlerFact(
+        runtime="python",
+        path="/ready",
+        site="src/runtime/python/_mcp_mesh/shared/health_check_manager.py",
+        handler=r"def build_ready_response\(",
+        consults_verdict=False,
+        verdict_symbols=("get_health_check_result", "_last_health_check_result"),
+        note="RFC #1502: a provider's readiness reports the mesh runtime "
+        "only, so a withdrawn agent keeps its Service endpoints.",
+    ),
+    HandlerFact(
+        runtime="python",
+        path="/health",
+        site="src/runtime/python/_mcp_mesh/shared/health_check_manager.py",
+        handler=r"def build_health_response\(",
+        consults_verdict=True,
+        verdict_symbols=("get_health_check_result", "_last_health_check_result"),
+        note="The diagnostic surface: nothing probes it, so it is free to "
+        "carry the verdict.",
+    ),
+    HandlerFact(
+        runtime="python",
+        path="/ready",
+        site="src/runtime/python/_mcp_mesh/pipeline/shared/health_endpoints.py",
+        handler=r"async def ready\(",
+        consults_verdict=False,
+        verdict_symbols=("get_health_check_result",),
+        note="The gateway pipeline's readiness, same rule as a provider's.",
+    ),
+    HandlerFact(
+        runtime="python",
+        path="/health",
+        site="src/runtime/python/_mcp_mesh/pipeline/shared/health_endpoints.py",
+        handler=r"async def health\(",
+        consults_verdict=True,
+        verdict_symbols=("get_health_check_result",),
+        note="A withdrawn gateway must be observable somewhere.",
+    ),
+    HandlerFact(
+        runtime="typescript",
+        path="/ready",
+        site="src/runtime/typescript/src/health-routes.ts",
+        handler=r'app\.on\(\["GET", "HEAD"\], "/ready"',
+        consults_verdict=False,
+        verdict_symbols=("snapshot()", "getVerdict", "buildHealthBody"),
+        note="RFC #1502, mirrored from Python.",
+    ),
+    HandlerFact(
+        runtime="typescript",
+        path="/health",
+        site="src/runtime/typescript/src/health-routes.ts",
+        handler=r'app\.on\(\["GET", "HEAD"\], "/health"',
+        consults_verdict=True,
+        verdict_symbols=("snapshot()", "getVerdict", "buildHealthBody"),
+        note="The diagnostic surface.",
+    ),
+    HandlerFact(
+        runtime="java",
+        path="/ready",
+        site="src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java",
+        handler=r"ResponseEntity<Map<String, Object>> ready\(",
+        consults_verdict=False,
+        verdict_symbols=("latestResult(", "healthChecks"),
+        note="#1488 plus RFC #1502: a gateway that 503s readiness leaves its "
+        "Service endpoints and takes the application down.",
+    ),
+    HandlerFact(
+        runtime="java",
+        path="/health",
+        site="src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshHealthController.java",
+        handler=r"ResponseEntity<Map<String, Object>> health\(",
+        consults_verdict=True,
+        verdict_symbols=("latestResult(",),
+        note="The diagnostic surface.",
+    ),
+    HandlerFact(
+        runtime="typescript",
+        path="/livez",
+        site="src/runtime/typescript/src/livez-route.ts",
+        handler=r'app\.on\(\["GET", "HEAD"\], "/livez"',
+        consults_verdict=False,
+        verdict_symbols=("getVerdict", "snapshot", "HealthVerdict"),
+        note="Liveness consults nothing: a restart cannot fix a dependency.",
+    ),
+)
+
+
+def _handler_body(text: str, handler_re: str) -> str | None:
+    """Return the source of the handler the anchor names, or None.
+
+    Language-agnostic and deliberately simple: from the anchor's line, read
+    until the first non-blank line indented no further than the anchor. That
+    rule alone would stop on a multi-line signature -- Python's
+    ``def build_ready_response(\\n    agent_name,\\n) -> ...:`` closes at
+    column 0 -- so it is only applied once the delimiters opened on the anchor
+    line have balanced, which is the end of the signature in Python and the
+    end of the whole registration in TypeScript's ``app.on(..., (c) => {...})``.
+
+    The result is a superset of the handler in the TypeScript case and exact
+    elsewhere, which is the safe direction: it can only make a "does not
+    consult the verdict" assertion harder to pass, never easier.
+    """
+    match = re.search(handler_re, text)
+    if match is None:
+        return None
+    line_start = text.rfind("\n", 0, match.start()) + 1
+    lines = text[line_start:].split("\n")
+    indent = len(lines[0]) - len(lines[0].lstrip())
+
+    out: list[str] = []
+    depth = 0
+    signature_closed = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if (
+            i > 0
+            and signature_closed
+            and stripped
+            and len(line) - len(line.lstrip()) <= indent
+        ):
+            break
+        out.append(line)
+        depth += sum(line.count(c) for c in "([{") - sum(line.count(c) for c in ")]}")
+        if i >= 0 and depth <= 0:
+            signature_closed = True
+    return "\n".join(out)
+
+
+def check_handler_facts(root: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for fact in HANDLER_FACTS:
+        site = root / fact.site
+        if not site.exists():
+            findings.append(
+                Finding(
+                    "scripts/check_doc_claims.py",
+                    0,
+                    f"HANDLER_FACTS cites {fact.site}, which no longer "
+                    f"exists. {fact.runtime} {fact.path} needs a new site.",
+                )
+            )
+            continue
+        text = site.read_text(encoding="utf-8")
+        body = _handler_body(text, fact.handler)
+        if body is None:
+            findings.append(
+                Finding(
+                    fact.site,
+                    0,
+                    f"HANDLER_FACTS cannot find the {fact.runtime} "
+                    f"{fact.path} handler ({fact.handler!r}). The endpoint "
+                    f"may have moved; docs are being checked against a fact "
+                    f"nothing verifies until this is fixed.",
+                )
+            )
+            continue
+        consults = any(sym in body for sym in fact.verdict_symbols)
+        if consults != fact.consults_verdict:
+            expected = "consult" if fact.consults_verdict else "not consult"
+            findings.append(
+                Finding(
+                    fact.site,
+                    0,
+                    f"{fact.runtime} {fact.path} should {expected} the health "
+                    f"verdict and now does the opposite. {fact.note}\n"
+                    f"      If the behaviour change is intended, every page "
+                    f"describing {fact.path} has to change with it.",
+                )
+            )
+    return findings
+
+
+PROBE_PATHS = ("/livez", "/startupz", "/ready", "/health")
+
+# The idioms this corpus uses to say "endpoint X is driven by the health
+# check". Not a parser -- a floor. See WHAT THIS CANNOT SEE.
+COUPLING_IDIOMS = (
+    r"reflects?\s+(?:your|the|its|a)",
+    r"driv(?:es|en by)",
+    r"answers?\s+(?:200|503)\s+(?:only\s+)?(?:while|when|until|unless)",
+    r"answers?\s+(?:200|503)\s+(?:only\s+)?(?:if|iff)",
+    r"carr(?:y|ies)\s+(?:the\s+)?(?:same\s+)?verdict",
+    r"report(?:s)?\s+(?:your|the)\s+(?:health[_ ]?check|healthCheck|verdict)",
+    r"gated?\s+(?:on|by)",
+    r"consults?\s+(?:the\s+)?(?:health[_ ]?check|healthCheck|verdict)",
+    r"on top of",
+    # "Your `health_check` does not reach it" is how every current deployment
+    # page words the denial, so the affirmative is the shape the next mistake
+    # will take. Same for the pre-RFC-#1502 "their check feeds `/health` only".
+    r"\breach(?:es)?\b",
+    r"\bfeeds?\b",
+)
+COUPLING_RE = re.compile("|".join(COUPLING_IDIOMS), re.I)
+
+VERDICT_TERMS = re.compile(
+    r"health[_ ]?check|healthCheck|MeshHealthCheck|\bverdict\b|"
+    r"\bunhealthy\b|\bit reports\b|\bthe check\b",
+    re.I,
+)
+
+# Denials of the coupling. Matched anywhere in the unit, because a unit is
+# already one clause by the time it gets here.
+DECOUPLING_RE = re.compile(
+    r"\bdoes ?n[o']t\b|\bdo ?n[o']t\b|\bnot\b|\bnever\b|\bnothing\b|"
+    r"\bunmoved\b|\bignores?\b|\brather than\b|\binstead of\b|"
+    r"\band nothing else\b|\bonly whether\b|\bexcept\b|\bregardless\b",
+    re.I,
+)
+
+# Check C's doc half runs over the pages that state the probe contract. This
+# is a narrow list on purpose: the idiom scan is only trustworthy where the
+# prose is about endpoints, and a repo-wide sweep would trade its precision
+# for reach it does not need. Each entry is a page this contract is taught on.
+PROBE_DOC_GLOBS = (
+    "src/core/cli/man/content/health*.md",
+    "src/core/cli/man/content/deployment*.md",
+    "docs/concepts/health-discovery.md",
+    "docs/python/mesh-decorators.md",
+    "docs/typescript/mesh-functions.md",
+    "docs/java/mesh-annotations.md",
+    "docs/tutorial/day-10-whats-next.md",
+    "helm/mcp-mesh-agent/README.md",
+)
+
+
+def probe_docs(root: Path) -> list[Path]:
+    out: dict[Path, None] = {}
+    for pattern in PROBE_DOC_GLOBS:
+        for path in sorted(root.glob(pattern)):
+            out.setdefault(path, None)
+    return list(out)
+
+
+PROBE_PATH_RE = re.compile("|".join(re.escape(p) for p in PROBE_PATHS))
+# Text that joins two path mentions without saying anything about either:
+# "`/ready` and `/health` answer 200 only while ..." predicates the idiom of
+# both. Anything longer is a contrast ("`/health` answers 503 while `/ready`
+# is unmoved") and the idiom belongs to one of them, which is exactly the
+# judgement this cannot make.
+BARE_CONJUNCTION_RE = re.compile(r"^[\s,`]*(?:and|or|/|,)?[\s,`]*$")
+
+
+def clause_subjects(clause: str) -> list[str]:
+    """Return the probe paths a clause's predicate applies to.
+
+    Empty when the clause names several paths that are not simply listed
+    together, because attributing the predicate would be a guess.
+    """
+    hits = [(m.start(), m.end(), m.group(0)) for m in PROBE_PATH_RE.finditer(clause)]
+    if not hits:
+        return []
+    distinct: list[tuple[int, int, str]] = []
+    for hit in hits:
+        if not any(d[2] == hit[2] for d in distinct):
+            distinct.append(hit)
+    if len(distinct) == 1:
+        return [distinct[0][2]]
+    # Several distinct paths: they must be a bare list, and the whole run of
+    # mentions must be contiguous, or the predicate is not shared.
+    ordered = sorted(hits, key=lambda h: h[0])
+    for left, right in zip(ordered, ordered[1:]):
+        if not BARE_CONJUNCTION_RE.match(clause[left[1]:right[0]]):
+            return []
+    return [d[2] for d in distinct]
+
+
+def check_verdict_coupling(
+    root: Path, docs: list[Path] | None = None
+) -> list[Finding]:
+    """Assert documented probe polarity matches HANDLER_FACTS.
+
+    A clause that names a probe path, uses a coupling idiom and names the
+    verdict is a claim about whether that endpoint is driven by the health
+    check. Only paths every runtime's handler agrees are verdict-FREE are
+    checked; `/health` legitimately carries the verdict, and asserting the
+    positive direction would mostly exempt itself, since half of what the
+    corpus writes about `/health` opens with "Nothing probes it".
+
+    This is a regression guard and, on a corrected corpus, asserts nothing:
+    the clauses it would fail are the ones that were deleted to fix #1499 and
+    RFC #1502. `scripts/test_check_doc_claims.py` replays both, which is what
+    keeps it honest -- a guard nobody has seen fail is a guard nobody knows
+    works.
+    """
+    polarity: dict[str, set[bool]] = {}
+    for fact in HANDLER_FACTS:
+        polarity.setdefault(fact.path, set()).add(fact.consults_verdict)
+
+    findings: list[Finding] = []
+    for doc in probe_docs(root) if docs is None else docs:
+        rel = _rel(doc, root)
+        text = doc.read_text(encoding="utf-8")
+        seen: set[tuple[int, str]] = set()
+        for lineno, unit in _coupling_units(text):
+            subjects = [
+                p
+                for p in clause_subjects(unit)
+                if polarity.get(p) == {False}
+            ]
+            if not subjects:
+                continue
+            if not COUPLING_RE.search(unit) or not VERDICT_TERMS.search(unit):
+                continue
+            if DECOUPLING_RE.search(unit):
+                continue
+            named = ", ".join(subjects)
+            if (lineno, named) in seen:
+                continue
+            seen.add((lineno, named))
+            findings.append(
+                Finding(
+                    rel,
+                    lineno,
+                    f"couples {named} to the health check, which no runtime's "
+                    f"handler for it consults (see HANDLER_FACTS). A reader "
+                    f"following this expects the pod to leave its Service "
+                    f"endpoints on a dependency outage.\n      unit: "
+                    f"{unit[:200]}",
+                )
+            )
+    return findings
+
+
+def _coupling_units(text: str):
+    """Clauses, plus whole blocks that are about exactly one probe endpoint.
+
+    Clause granularity alone misses the shape the deployment pages use, where
+    the endpoint is a bullet's subject and its behaviour is stated sentences
+    later:
+
+        - `/ready` - `readinessProbe`. Whether traffic should be routed here;
+          reflects your `@MeshHealthCheck` on top of the mesh runtime state.
+
+    That bullet is the pre-RFC-#1502 text and is exactly the claim this check
+    exists for, so a block naming ONE probe path and no other is evaluated
+    whole -- everything in it predicates that endpoint. Blocks naming two are
+    left to the clause pass, which is where the contrast cases are handled.
+    """
+    yield from markdown_clauses(text)
+    for lineno, block in markdown_blocks(text):
+        if len({m.group(0) for m in PROBE_PATH_RE.finditer(block)}) == 1:
+            yield lineno, block
+
+
+# ---------------------------------------------------------------------------
+
+
+CHECKS = (
+    ("route inventory anchors", lambda r, d, s: check_inventory_anchors(s)),
+    ("supplement sites", lambda r, d, s: check_supplement_sites(r)),
+    ("curl paths", lambda r, d, s: check_curl_paths(d, r, s)),
+    ("illustrative-path exemptions", lambda r, d, s: check_illustrative_still_used(d, r)),
+    ("dependency claims", lambda r, d, s: check_dependency_claims(d, r)),
+    ("probe handler facts", lambda r, d, s: check_handler_facts(r)),
+    ("probe verdict coupling", lambda r, d, s: check_verdict_coupling(r)),
+)
+
+
+def run(root: Path) -> int:
+    docs = iter_docs(root)
+    served = collect_served_paths(root)
+
+    failed = 0
+    for name, fn in CHECKS:
+        findings = fn(root, docs, served)
+        if findings:
+            failed += len(findings)
+            print(f"FAIL  {name}")
+            for f in findings:
+                where = f"{f.doc}:{f.line}" if f.line else f.doc
+                print(f"    {where}: {f.detail}")
+        else:
+            print(f"ok    {name}")
+
+    if failed:
+        print(f"\n{failed} doc claim(s) are not backed by the code they describe.")
+        print(
+            "Fix the claim, not the check: a page that has to be reworded to "
+            "pass is a page that was wrong."
+        )
+        return 1
+    print("\nAll checked doc claims are backed by the code they describe.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--root", type=Path, default=REPO_ROOT)
+    parser.add_argument(
+        "--list-paths",
+        action="store_true",
+        help="print the derived route inventory and exit",
+    )
+    args = parser.parse_args()
+
+    if args.list_paths:
+        served = collect_served_paths(args.root)
+        for runtime in sorted(served):
+            print(f"[{runtime}]")
+            for path in sorted(served[runtime]):
+                print(f"  {path}")
+        for sup in SUPPLEMENTS:
+            print(f"[{sup.runtime}] {sup.path}  (supplement: {sup.site})")
+        return 0
+
+    return run(args.root)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_doc_claims.py
+++ b/scripts/check_doc_claims.py
@@ -143,7 +143,15 @@ GO_ROUTE_RE = re.compile(
     r"\.(?:GET|POST|PUT|DELETE|HEAD|PATCH|OPTIONS|Handle|HandleFunc)\("
     r'\s*(?:[A-Za-z_.]+\s*\+\s*)?"(/[^"]*)"'
 )
-GO_GROUP_RE = re.compile(r'\.Group\(\s*"(/[^"]*)"')
+# The same registration, with the receiver it was called on. A group prefix
+# scopes the routes registered ON the group, so the receiver is what says
+# which those are -- see `_go_paths`.
+GO_RECEIVER_ROUTE_RE = re.compile(
+    r"\b(\w+)\.(?:GET|POST|PUT|DELETE|HEAD|PATCH|OPTIONS|Handle|HandleFunc)\("
+    r'\s*(?:[A-Za-z_.]+\s*\+\s*)?"(/[^"]*)"'
+)
+# `api := engine.Group("/api")`: binder, parent, prefix.
+GO_GROUP_ASSIGN_RE = re.compile(r'(\w+)\s*:?=\s*([\w.]+)\.Group\(\s*"(/[^"]*)"')
 
 # Python: FastAPI/Starlette decorators and imperative registration, plus the
 # `X_PATH = "/livez"` module constants the probe endpoints are registered from
@@ -191,6 +199,67 @@ def _strip_comment_lines(text: str, markers: tuple[str, ...]) -> str:
     return "\n".join(kept)
 
 
+def _go_group_prefixes(text: str) -> dict[str, str]:
+    """Map each group binder in a file to the full prefix it scopes with.
+
+    Nested groups compose (`v1 := api.Group("/v1")` scopes with `/api/v1`),
+    resolved by walking each binder back to a receiver that is not itself a
+    group.
+    """
+    raw = {
+        m.group(1): (m.group(2), m.group(3))
+        for m in GO_GROUP_ASSIGN_RE.finditer(text)
+    }
+    resolved: dict[str, str] = {}
+    for binder in raw:
+        parts: list[str] = []
+        cursor = binder
+        seen: set[str] = set()
+        while cursor in raw and cursor not in seen:
+            seen.add(cursor)
+            parent, prefix = raw[cursor]
+            parts.append(prefix)
+            cursor = parent
+        full = "/"
+        for prefix in reversed(parts):
+            full = _join(full, prefix)
+        resolved[binder] = full
+    return resolved
+
+
+def _go_paths(text: str) -> set[str]:
+    """Return the paths a Go file registers, prefixes applied to their own routes.
+
+    Crossing every group prefix in a file with every route literal in it
+    invents paths: a file holding groups `/api` and `/admin` and routes `/foo`
+    and `/bar` would claim to serve `/api/bar` and `/admin/foo`. Nothing in
+    `src/core` has two groups today, so the cross-product invents nothing --
+    but an over-permissive inventory is the one thing check A cannot afford,
+    because a `curl` to a path nothing serves passes on a conjured entry.
+
+    The gin idiom binds the prefix to a receiver, so the receiver is a reliable
+    reading of which routes a prefix scopes: `api := engine.Group("/api")`
+    followed by `api.GET("/agents")` serves `/api/agents`, and
+    `engine.GET("/api/ui-health")` in the same file serves only itself.
+    """
+    prefixes = _go_group_prefixes(text)
+    paths: set[str] = set()
+    scoped: set[str] = set()
+    for m in GO_RECEIVER_ROUTE_RE.finditer(text):
+        receiver, route = m.group(1), m.group(2)
+        if receiver in prefixes:
+            paths.add(_join(prefixes[receiver], route))
+            scoped.add(route)
+        else:
+            paths.add(route)
+    # A registration whose receiver is not a plain identifier -- a chained
+    # `Group("/x").GET(...)`, say -- enters unprefixed rather than vanishing.
+    # Reading it as unscoped is the same reading as before; dropping it would
+    # shrink the inventory, which is the failure INVENTORY_ANCHORS exists for.
+    paths |= set(GO_ROUTE_RE.findall(text)) - scoped
+    return paths
+
+
 def collect_served_paths(root: Path) -> dict[str, set[str]]:
     """Return {runtime: {path pattern}} for everything this repo serves.
 
@@ -209,14 +278,14 @@ def collect_served_paths(root: Path) -> dict[str, set[str]]:
     def bucket(path: Path, default: str) -> str:
         return "examples" if "examples" in path.parts else default
 
+    # `examples/` holds no Go source: every example agent is Python, TypeScript
+    # or Java. If one ever serves routes, this walk has to grow an `examples`
+    # root the way the other three runtimes have, or a doc curling it fails.
     for path in sorted((root / "src" / "core").rglob("*.go")):
         if not _is_source_of_interest(path):
             continue
         text = _strip_comment_lines(path.read_text(encoding="utf-8"), ("//",))
-        literals = set(GO_ROUTE_RE.findall(text))
-        prefixes = set(GO_GROUP_RE.findall(text))
-        found["go"] |= literals
-        found["go"] |= {_join(p, lit) for p in prefixes for lit in literals}
+        found[bucket(path, "go")] |= _go_paths(text)
 
     py_roots = [root / "src" / "runtime" / "python", root / "examples"]
     for py_root in py_roots:
@@ -363,9 +432,24 @@ def path_matcher(pattern: str) -> re.Pattern[str]:
 
 # Only hosts that mean "something you are running". An external host is
 # somebody else's contract and this repo cannot assert anything about it.
+#
+# The last alternative is deliberately dot-free. A dotted name with a port is
+# somebody's domain -- `registry.example.com:8443`, `api.anthropic.com:443` --
+# and reading it as local does not merely check too much: it FAILS, and tells
+# the reader to add a Supplement for a path this repo cannot serve. Dotted
+# names that are local are spelled out above; everything else needs a
+# single-label host (`registry:8000`, `myhost:9000`) or a placeholder
+# (`${REGISTRY_HOST}:8000`, `<agent>:8080`).
+LOCAL_HOST_ALTERNATIVES = (
+    r"localhost",
+    r"127\.0\.0\.1",
+    r"0\.0\.0\.0",
+    r"\[[0-9A-Fa-f:]+\]",
+    r"host\.docker\.internal",
+    r"[\w$%{}<>-]+",
+)
 LOCAL_HOST_RE = re.compile(
-    r"^(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]|host\.docker\.internal|"
-    r"[\w.$%{}<>-]+:\d+|\$\{?[A-Z_]+\}?)$"
+    r"^(?:" + "|".join(LOCAL_HOST_ALTERNATIVES) + r")(?::\d+)?$"
 )
 URL_RE = re.compile(r"https?://[^\s'\"`)\\|]+")
 
@@ -918,9 +1002,9 @@ PROBE_DOC_GLOBS = (
     "src/core/cli/man/content/health*.md",
     "src/core/cli/man/content/deployment*.md",
     "docs/concepts/health-discovery.md",
-    "docs/python/mesh-decorators.md",
+    "docs/python/decorators.md",
     "docs/typescript/mesh-functions.md",
-    "docs/java/mesh-annotations.md",
+    "docs/java/annotations.md",
     "docs/tutorial/day-10-whats-next.md",
     "helm/mcp-mesh-agent/README.md",
 )
@@ -932,6 +1016,32 @@ def probe_docs(root: Path) -> list[Path]:
         for path in sorted(root.glob(pattern)):
             out.setdefault(path, None)
     return list(out)
+
+
+def check_probe_doc_globs(root: Path) -> list[Finding]:
+    """A pattern that matches nothing narrows check C's doc half in silence.
+
+    `PROBE_DOC_GLOBS` is a maintained list like SUPPLEMENTS and
+    ILLUSTRATIVE_PATHS, and it rots the same way: rename or move
+    `docs/concepts/health-discovery.md` and the page stops being scanned while
+    the run stays green -- the exact shape of rot the rest of this file guards
+    against. The wildcards can go stale too: `content/health*.md` covers three
+    variant pages by name, and a renamed corpus takes them all out at once.
+    """
+    findings = []
+    for pattern in PROBE_DOC_GLOBS:
+        if not any(root.glob(pattern)):
+            findings.append(
+                Finding(
+                    "scripts/check_doc_claims.py",
+                    0,
+                    f"PROBE_DOC_GLOBS lists {pattern!r}, which now matches no "
+                    f"file. The page it stands for is no longer scanned for "
+                    f"probe coupling. Point the pattern at where the prose "
+                    f"moved, or drop it if the page is gone.",
+                )
+            )
+    return findings
 
 
 PROBE_PATH_RE = re.compile("|".join(re.escape(p) for p in PROBE_PATHS))
@@ -1055,6 +1165,7 @@ CHECKS = (
     ("illustrative-path exemptions", lambda r, d, s: check_illustrative_still_used(d, r)),
     ("dependency claims", lambda r, d, s: check_dependency_claims(d, r)),
     ("probe handler facts", lambda r, d, s: check_handler_facts(r)),
+    ("probe doc globs", lambda r, d, s: check_probe_doc_globs(r)),
     ("probe verdict coupling", lambda r, d, s: check_verdict_coupling(r)),
 )
 

--- a/scripts/test_check_doc_claims.py
+++ b/scripts/test_check_doc_claims.py
@@ -39,7 +39,9 @@ def served():
 
 def _doc(tmp_path: pathlib.Path, name: str, body: str) -> pathlib.Path:
     path = tmp_path / name
-    path.write_text(body)
+    # The checker reads every document as UTF-8; a fixture written in the
+    # platform default would be a different document on a machine that has one.
+    path.write_text(body, encoding="utf-8")
     return path
 
 
@@ -118,7 +120,7 @@ def test_dependency_claim_evidence_is_read_from_the_build_file():
     claim = next(c for c in cdc.DEPENDENCY_CLAIMS if c.term == "actuator")
     pom = ROOT / claim.build_file
     assert pom.exists(), "the starter POM moved; the claim has no evidence"
-    assert claim.evidence.lower() not in pom.read_text().lower(), (
+    assert claim.evidence.lower() not in pom.read_text(encoding="utf-8").lower(), (
         "the starter now declares Actuator. That is a product change: the "
         "pages that say it does not have to change with it, and this check "
         "stops applying."
@@ -242,7 +244,7 @@ def test_no_ready_handler_consults_the_verdict():
 def test_handler_bodies_are_located_and_bounded(fact):
     """A body the extractor cannot find, or one that swallowed the file, would
     make `check_handler_facts` assert nothing while reporting ok."""
-    text = (ROOT / fact.site).read_text()
+    text = (ROOT / fact.site).read_text(encoding="utf-8")
     body = cdc._handler_body(text, fact.handler)
     assert body is not None
     lines = body.splitlines()
@@ -273,7 +275,7 @@ def test_supplement_sites_still_prove_their_paths():
     assert cdc.check_supplement_sites(ROOT) == []
 
 
-def test_supplement_with_stale_evidence_fails(tmp_path):
+def test_supplement_with_stale_evidence_fails(monkeypatch):
     stale = cdc.Supplement(
         path="/nowhere",
         runtime="python",
@@ -281,27 +283,36 @@ def test_supplement_with_stale_evidence_fails(tmp_path):
         site="scripts/check_doc_claims.py",
         evidence="this string is not in the checker",
     )
-    original = cdc.SUPPLEMENTS
-    cdc.SUPPLEMENTS = (stale,)
-    try:
-        assert cdc.check_supplement_sites(ROOT)
-    finally:
-        cdc.SUPPLEMENTS = original
+    monkeypatch.setattr(cdc, "SUPPLEMENTS", (stale,))
+    assert cdc.check_supplement_sites(ROOT)
+
+
+def test_probe_doc_globs_all_match_something():
+    """Check C's doc half is a maintained list too, and it rots the same way.
+
+    Two of these patterns named pages that had never existed
+    (`docs/python/mesh-decorators.md`), so the Python and Java surfaces of the
+    probe contract were being reported ok without being read.
+    """
+    assert cdc.check_probe_doc_globs(ROOT) == []
+
+
+def test_probe_doc_glob_that_matches_nothing_fails(monkeypatch):
+    monkeypatch.setattr(cdc, "PROBE_DOC_GLOBS", ("docs/no/such/page.md",))
+    assert cdc.check_probe_doc_globs(ROOT)
 
 
 def test_illustrative_exemptions_are_all_still_used():
     assert cdc.check_illustrative_still_used(cdc.iter_docs(ROOT), ROOT) == []
 
 
-def test_unused_illustrative_exemption_fails(tmp_path):
-    original = cdc.ILLUSTRATIVE_PATHS
-    cdc.ILLUSTRATIVE_PATHS = (
-        cdc.IllustrativePath(path="/no-doc-curls-this", why="fixture"),
+def test_unused_illustrative_exemption_fails(monkeypatch):
+    monkeypatch.setattr(
+        cdc,
+        "ILLUSTRATIVE_PATHS",
+        (cdc.IllustrativePath(path="/no-doc-curls-this", why="fixture"),),
     )
-    try:
-        assert cdc.check_illustrative_still_used(cdc.iter_docs(ROOT), ROOT)
-    finally:
-        cdc.ILLUSTRATIVE_PATHS = original
+    assert cdc.check_illustrative_still_used(cdc.iter_docs(ROOT), ROOT)
 
 
 # ---------------------------------------------------------------------------
@@ -325,6 +336,46 @@ def test_path_matcher(pattern, path, want):
     assert bool(cdc.path_matcher(pattern).match(path)) is want
 
 
+GO_TWO_GROUPS = """\
+func register(engine *gin.Engine) {
+	api := engine.Group("/api")
+	api.GET("/foo", h)
+	admin := engine.Group("/admin")
+	admin.GET("/bar", h)
+	engine.GET("/api/ui-health", h)
+}
+"""
+
+
+def test_go_prefixes_compose_only_with_their_own_routes():
+    """Crossing every prefix with every literal conjures paths nothing serves.
+
+    An inventory that is too large is the one failure check A cannot survive: a
+    `curl` to a path nothing serves passes because the cross-product invented
+    it. Nothing in `src/core` has two groups today, so this is the shape that
+    would have made it live.
+    """
+    assert cdc._go_paths(GO_TWO_GROUPS) == {
+        "/api/foo",
+        "/admin/bar",
+        "/api/ui-health",
+    }
+
+
+def test_go_nested_groups_compose():
+    assert cdc._go_paths(
+        'api := engine.Group("/api")\nv1 := api.Group("/v1")\nv1.GET("/agents", h)\n'
+    ) == {"/api/v1/agents"}
+
+
+def test_go_inventory_holds_the_real_meshui_prefix():
+    """`server.go` is the one file with a group; its routes must be prefixed."""
+    go_paths = cdc.collect_served_paths(ROOT)["go"]
+    assert "/api/agents" in go_paths
+    assert "/api/ui-health" in go_paths
+    assert "/api/api/ui-health" not in go_paths
+
+
 @pytest.mark.parametrize(
     "url,host,path",
     [
@@ -337,14 +388,61 @@ def test_split_url(url, host, path):
     assert cdc.split_url(url) == (host, path)
 
 
-def test_external_hosts_are_not_checked(tmp_path, served):
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://upstream.example.com/agents/forecast",
+        # A dotted name with a port is still somebody else's server. Reading it
+        # as local does not merely check too much: `/actuator/health` is served
+        # by nothing here, so it FAILS, and the message tells the reader to add
+        # a Supplement for a path this repo cannot serve.
+        "https://registry.example.com:8443/actuator/health",
+        "https://api.anthropic.com:443/v1/messages",
+    ],
+)
+def test_external_hosts_are_not_checked(tmp_path, served, url):
     """Somebody else's server is not this repo's claim to make."""
+    doc = _doc(tmp_path, "a2a.md", f"```bash\ncurl {url}\n```\n")
+    assert cdc.check_curl_paths([doc], ROOT, served) == []
+
+
+@pytest.mark.parametrize(
+    "host,want",
+    [
+        ("localhost", True),
+        ("localhost:8000", True),
+        ("127.0.0.1:8080", True),
+        ("0.0.0.0:9090", True),
+        ("host.docker.internal", True),
+        ("host.docker.internal:8080", True),
+        ("[::1]", True),
+        ("[::1]:8080", True),
+        # A single-label name is a container or a hosts entry, not a domain.
+        ("myhost:9000", True),
+        ("registry:8000", True),
+        ("mcp-core-mcp-mesh-registry:8000", True),
+        ("${REGISTRY_HOST}", True),
+        ("${REGISTRY_HOST}:8000", True),
+        ("<agent-host>:8080", True),
+        ("registry.example.com:8443", False),
+        ("api.anthropic.com:443", False),
+        ("raw.githubusercontent.com", False),
+        ("registry.mcp-mesh.local", False),
+        ("trip-planner.local", False),
+    ],
+)
+def test_local_host_classification(host, want):
+    assert bool(cdc.LOCAL_HOST_RE.match(host)) is want
+
+
+def test_a_local_host_with_a_port_is_still_checked(tmp_path, served):
+    """The narrowing must not have taken the port-bearing local form with it."""
     doc = _doc(
         tmp_path,
-        "a2a.md",
-        "```bash\ncurl https://upstream.example.com/agents/forecast\n```\n",
+        "networking.md",
+        "```bash\ncurl http://registry:8000/not-a-real-path\n```\n",
     )
-    assert cdc.check_curl_paths([doc], ROOT, served) == []
+    assert len(cdc.check_curl_paths([doc], ROOT, served)) == 1
 
 
 def test_curl_folds_shell_continuations(tmp_path, served):

--- a/scripts/test_check_doc_claims.py
+++ b/scripts/test_check_doc_claims.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Checks for scripts/check_doc_claims.py (#1500).
+
+The point of these is not that the checker runs. It is that the two failures
+that motivated it -- both of which stayed green through review, CI and a
+release -- go RED when replayed. A doc-claim guard that has only ever been
+seen passing is indistinguishable from one that matches nothing, which is
+exactly the state the man corpus tests were in when #1499 shipped.
+
+So the two central tests carry the historical prose verbatim, taken from the
+commits that removed it:
+
+  #1499 -- 6f2c07039^ `health_java.md` and `deployment_java.md`
+  RFC #1502 -- 2fdab722f^ `docs/typescript/mesh-functions.md`
+
+They run against the REAL repository for the evidence half (the real route
+inventory, the real starter `pom.xml`, the real handlers), because a fixture
+repo would prove only that the checker can read a fixture.
+"""
+
+import pathlib
+import sys
+
+import pytest
+
+# Imported by name rather than loaded from a spec: the checker's module-level
+# `@dataclass`es need their own module registered in `sys.modules` to resolve
+# annotations, which a bare `exec_module` does not do.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import check_doc_claims as cdc  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="module")
+def served():
+    return cdc.collect_served_paths(ROOT)
+
+
+def _doc(tmp_path: pathlib.Path, name: str, body: str) -> pathlib.Path:
+    path = tmp_path / name
+    path.write_text(body)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# The corpus as it stands must be clean, or nothing below means anything.
+# ---------------------------------------------------------------------------
+
+
+def test_repository_is_clean():
+    assert cdc.run(ROOT) == 0
+
+
+# ---------------------------------------------------------------------------
+# #1499: three surfaces claimed the Spring Boot starter integrates with
+# Actuator. Two carried the claim in prose; one was a curl that 404s.
+# ---------------------------------------------------------------------------
+
+HEALTH_JAVA_1499 = """\
+## Spring Boot Health Actuator
+
+The MCP Mesh Spring Boot starter automatically integrates with Spring Boot's \
+health actuator. The `/actuator/health` endpoint includes mesh status:
+
+```bash
+curl http://localhost:8080/actuator/health
+```
+"""
+
+DEPLOYMENT_JAVA_1499 = """\
+### Health Checks
+
+Spring Boot agents automatically expose `/actuator/health`. The MCP Mesh \
+starter integrates with Spring Boot's health system.
+"""
+
+
+def test_1499_curl_that_404s_is_caught(tmp_path, served):
+    doc = _doc(tmp_path, "health_java.md", HEALTH_JAVA_1499)
+    findings = cdc.check_curl_paths([doc], ROOT, served)
+    assert len(findings) == 1
+    assert "/actuator/health" in findings[0].detail
+
+
+def test_1499_prose_claims_are_caught(tmp_path):
+    docs = [
+        _doc(tmp_path, "health_java.md", HEALTH_JAVA_1499),
+        _doc(tmp_path, "deployment_java.md", DEPLOYMENT_JAVA_1499),
+    ]
+    findings = cdc.check_dependency_claims(docs, ROOT)
+    assert {f.doc.rsplit("/", 1)[-1] for f in findings} == {
+        "health_java.md",
+        "deployment_java.md",
+    }
+
+
+def test_1499_corrected_prose_passes(tmp_path):
+    """The fix documented the absence rather than deleting the subject.
+
+    A checker that could not tell a denial from an assertion would have made
+    that fix impossible, and the page would have gone silent on the one
+    question every Spring developer asks.
+    """
+    corrected = _doc(
+        tmp_path,
+        "health_java.md",
+        "Actuator is not a starter dependency, and mesh registers no "
+        "`HealthIndicator` - deliberately. Actuator aggregates every "
+        "registered indicator (datasource, disk, mail), while mesh gates "
+        "traffic only on what `@MeshHealthCheck` says gates it.\n",
+    )
+    assert cdc.check_dependency_claims([corrected], ROOT) == []
+
+
+def test_dependency_claim_evidence_is_read_from_the_build_file():
+    """The Actuator entry must be answering from the POM, not from a constant."""
+    claim = next(c for c in cdc.DEPENDENCY_CLAIMS if c.term == "actuator")
+    pom = ROOT / claim.build_file
+    assert pom.exists(), "the starter POM moved; the claim has no evidence"
+    assert claim.evidence.lower() not in pom.read_text().lower(), (
+        "the starter now declares Actuator. That is a product change: the "
+        "pages that say it does not have to change with it, and this check "
+        "stops applying."
+    )
+
+
+# ---------------------------------------------------------------------------
+# RFC #1502: `/ready` reports the mesh runtime and is unmoved by the health
+# verdict, so a withdrawn gateway keeps its Service endpoints.
+# ---------------------------------------------------------------------------
+
+MESH_FUNCTIONS_1502 = """\
+`healthCheck` is what lets a provider take itself out of rotation. While it \
+returns `{ status: "unhealthy" }` (or `false`) the agent stops heartbeating, \
+the registry withdraws it, and consumers resolve to another provider. The \
+verdict also drives the probe endpoints: `/ready` and `/health` answer 200 \
+only while it reports `healthy`. `MCP_MESH_HEALTH_CHECK_TTL` overrides \
+`healthCheckTtl`.
+"""
+
+MESH_FUNCTIONS_CORRECTED = """\
+`healthCheck` is what lets a provider take itself out of rotation. The \
+verdict drives `/health`, which answers 200 only while it reports `healthy`. \
+It does not drive `/ready`, which reports whether the mesh runtime is up: \
+pausing the heartbeat is the whole withdrawal, and a 503 on `/ready` would \
+additionally drop the pod from the Service that mesh traffic arrives on.
+"""
+
+
+def test_1502_ready_coupling_is_caught(tmp_path):
+    doc = _doc(tmp_path, "mesh-functions.md", MESH_FUNCTIONS_1502)
+    findings = cdc.check_verdict_coupling(ROOT, [doc])
+    assert len(findings) == 1
+    assert "/ready" in findings[0].detail
+
+
+def test_1502_corrected_prose_passes(tmp_path):
+    doc = _doc(tmp_path, "mesh-functions.md", MESH_FUNCTIONS_CORRECTED)
+    assert cdc.check_verdict_coupling(ROOT, [doc]) == []
+
+
+def test_1502_pre_rfc_deployment_bullet_is_caught(tmp_path):
+    """The bullet `deployment_java.md` carried before RFC #1502 step 2.
+
+    It is the other real shape of this mistake: not a sentence, a list item,
+    and it says "reflects your" rather than "answers 200 only while".
+    """
+    doc = _doc(
+        tmp_path,
+        "deployment_java.md",
+        "- `/ready` - `readinessProbe`. Whether traffic should be routed "
+        "here; reflects your `@MeshHealthCheck` on top of the mesh runtime "
+        "state.\n",
+    )
+    findings = cdc.check_verdict_coupling(ROOT, [doc])
+    assert len(findings) == 1
+
+
+def test_1502_inverted_denial_is_caught(tmp_path):
+    """"Your `health_check` does not reach it" is what every deployment page
+    says today, so dropping the "does not" is the shape the next regression
+    takes. The affirmative must go red."""
+    doc = _doc(
+        tmp_path,
+        "deployment.md",
+        "- `/ready` - `readinessProbe`. Whether the mesh runtime is up. Your "
+        "`health_check` reaches it.\n",
+    )
+    assert len(cdc.check_verdict_coupling(ROOT, [doc])) == 1
+
+
+def test_1502_current_denial_passes(tmp_path):
+    doc = _doc(
+        tmp_path,
+        "deployment.md",
+        "- `/ready` - `readinessProbe`. Whether the mesh runtime is up. Your "
+        "`health_check` does not reach it.\n",
+    )
+    assert cdc.check_verdict_coupling(ROOT, [doc]) == []
+
+
+def test_contrasting_clause_is_not_guessed_at(tmp_path):
+    """Two endpoints being compared is the judgement this cannot make.
+
+    `health.md` genuinely says this, and reporting it would be a false alarm
+    that gets 'fixed' by rewording correct prose -- the worst outcome for a
+    check over hand-written docs.
+    """
+    doc = _doc(
+        tmp_path,
+        "health.md",
+        "Those verdicts show on the diagnostic surface only: `/health` "
+        "answers 503 while `/ready` is unmoved.\n",
+    )
+    assert cdc.check_verdict_coupling(ROOT, [doc]) == []
+
+
+# ---------------------------------------------------------------------------
+# The code half of check C. These are live assertions about today's runtimes,
+# not regression fixtures: nothing else pins RFC #1502's contract in source.
+# ---------------------------------------------------------------------------
+
+
+def test_handler_facts_cover_every_runtime():
+    runtimes = {f.runtime for f in cdc.HANDLER_FACTS}
+    assert runtimes == {"python", "typescript", "java"}
+    ready = {f.runtime for f in cdc.HANDLER_FACTS if f.path == "/ready"}
+    assert ready == {"python", "typescript", "java"}, (
+        "a runtime whose /ready is unpinned can grow a verdict dependency "
+        "without any check noticing"
+    )
+
+
+def test_no_ready_handler_consults_the_verdict():
+    assert cdc.check_handler_facts(ROOT) == []
+
+
+@pytest.mark.parametrize(
+    "fact", cdc.HANDLER_FACTS, ids=lambda f: f"{f.runtime}{f.path}:{f.site[-24:]}"
+)
+def test_handler_bodies_are_located_and_bounded(fact):
+    """A body the extractor cannot find, or one that swallowed the file, would
+    make `check_handler_facts` assert nothing while reporting ok."""
+    text = (ROOT / fact.site).read_text()
+    body = cdc._handler_body(text, fact.handler)
+    assert body is not None
+    lines = body.splitlines()
+    assert 1 < len(lines) < len(text.splitlines()) // 2
+
+
+# ---------------------------------------------------------------------------
+# The guards on the maintained halves.
+# ---------------------------------------------------------------------------
+
+
+def test_inventory_anchors_hold():
+    assert cdc.check_inventory_anchors(cdc.collect_served_paths(ROOT)) == []
+
+
+def test_an_empty_inventory_fails_rather_than_passing_everything():
+    """The failure mode that would make check A worthless.
+
+    If a runtime changes registration idiom, the extractor returns fewer paths
+    and every curl example passes for the wrong reason. The anchors are the
+    only thing standing between that and a green run.
+    """
+    empty = {runtime: set() for runtime in cdc.INVENTORY_ANCHORS}
+    assert cdc.check_inventory_anchors(empty)
+
+
+def test_supplement_sites_still_prove_their_paths():
+    assert cdc.check_supplement_sites(ROOT) == []
+
+
+def test_supplement_with_stale_evidence_fails(tmp_path):
+    stale = cdc.Supplement(
+        path="/nowhere",
+        runtime="python",
+        why="fixture",
+        site="scripts/check_doc_claims.py",
+        evidence="this string is not in the checker",
+    )
+    original = cdc.SUPPLEMENTS
+    cdc.SUPPLEMENTS = (stale,)
+    try:
+        assert cdc.check_supplement_sites(ROOT)
+    finally:
+        cdc.SUPPLEMENTS = original
+
+
+def test_illustrative_exemptions_are_all_still_used():
+    assert cdc.check_illustrative_still_used(cdc.iter_docs(ROOT), ROOT) == []
+
+
+def test_unused_illustrative_exemption_fails(tmp_path):
+    original = cdc.ILLUSTRATIVE_PATHS
+    cdc.ILLUSTRATIVE_PATHS = (
+        cdc.IllustrativePath(path="/no-doc-curls-this", why="fixture"),
+    )
+    try:
+        assert cdc.check_illustrative_still_used(cdc.iter_docs(ROOT), ROOT)
+    finally:
+        cdc.ILLUSTRATIVE_PATHS = original
+
+
+# ---------------------------------------------------------------------------
+# Pieces.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "pattern,path,want",
+    [
+        ("/agents/:agent_id", "/agents/hello-world", True),
+        ("/agents/:agent_id", "/agents/a/b", False),
+        ("/agents", "/agents/", True),
+        ("/jobs/*path", "/jobs/a/b/c", True),
+        ("/payments/student/{studentId}", "/payments/student/42", True),
+        ("/health", "/actuator/health", False),
+        ("/health", "/healthz", False),
+    ],
+)
+def test_path_matcher(pattern, path, want):
+    assert bool(cdc.path_matcher(pattern).match(path)) is want
+
+
+@pytest.mark.parametrize(
+    "url,host,path",
+    [
+        ("http://localhost:8080/actuator/health", "localhost:8080", "/actuator/health"),
+        ("http://localhost:8080/api/greet?name=World", "localhost:8080", "/api/greet"),
+        ("https://raw.githubusercontent.com/x/y.sh", "raw.githubusercontent.com", "/x/y.sh"),
+    ],
+)
+def test_split_url(url, host, path):
+    assert cdc.split_url(url) == (host, path)
+
+
+def test_external_hosts_are_not_checked(tmp_path, served):
+    """Somebody else's server is not this repo's claim to make."""
+    doc = _doc(
+        tmp_path,
+        "a2a.md",
+        "```bash\ncurl https://upstream.example.com/agents/forecast\n```\n",
+    )
+    assert cdc.check_curl_paths([doc], ROOT, served) == []
+
+
+def test_curl_folds_shell_continuations(tmp_path, served):
+    doc = _doc(
+        tmp_path,
+        "testing.md",
+        "```bash\ncurl -s -X POST \\\n  http://localhost:8080/not-a-real-path \\\n"
+        '  -d \'{}\'\n```\n',
+    )
+    findings = cdc.check_curl_paths([doc], ROOT, served)
+    assert len(findings) == 1
+    assert "/not-a-real-path" in findings[0].detail
+
+
+def test_fenced_code_is_not_prose(tmp_path):
+    """A sample that mentions a term is not a claim about the build file."""
+    doc = _doc(
+        tmp_path,
+        "x.md",
+        "```xml\n<artifactId>spring-boot-starter-actuator</artifactId>\n```\n",
+    )
+    assert cdc.check_dependency_claims([doc], ROOT) == []
+
+
+@pytest.mark.parametrize(
+    "clause,want",
+    [
+        ("`/ready` and `/health` answer 200", ["/ready", "/health"]),
+        ("`/health` answers 503 while `/ready` is unmoved", []),
+        ("`/ready` reports the runtime, and a 503 on `/ready` drops it", ["/ready"]),
+        ("nothing here", []),
+    ],
+)
+def test_clause_subjects(clause, want):
+    assert cdc.clause_subjects(clause) == want
+
+
+def test_markdown_blocks_keep_a_paragraph_whole():
+    blocks = cdc.markdown_blocks("one. two.\nthree.\n\nfour.\n")
+    assert [b for _, b in blocks] == ["one. two. three.", "four."]
+
+
+def test_markdown_clauses_split_a_paragraph():
+    clauses = [c for _, c in cdc.markdown_clauses("one. two.\nthree.\n")]
+    assert clauses == ["one.", "two.", "three."]

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -396,6 +396,19 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // `observability.md` as a table row and in `environment.md` inside the bash
 // fence; renderStyled takes other branches for both, so neither is sampled
 // here.
+//
+// Issue #1500: the sentence most annotations above end on — that the `_java`
+// and `_typescript` files are invisible here, so a review of them cannot lean
+// on this test — is still true of THESE constants and no longer true of this
+// package. `variant_corpus_test.go` renders all 34 variant pages and carries
+// its own single golden; a variant-only edit moves that one, not these. The
+// three below stay default-variant on purpose, so their history remains a
+// readable record of one corpus rather than a sum of two.
+//
+// Neither file says anything about whether the prose is TRUE. That is
+// `scripts/check_doc_claims.py`, which can read the four runtimes' source and
+// the starter's POM; a test in this package cannot, and #1499 shipped three
+// false claims through a green run here.
 const (
 	wantInlineCodeSpans = 1773
 	wantListCodeSpans   = 522

--- a/src/core/cli/man/variant_corpus_test.go
+++ b/src/core/cli/man/variant_corpus_test.go
@@ -1,0 +1,279 @@
+package man
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Issue #1500. The three corpus tests in renderer_test.go sample the DEFAULT
+// variant of each listed topic, and every one of their golden comments has had
+// to end by saying so: "a review of those files cannot lean on this test". The
+// `_java` and `_typescript` pages — 34 of the 61 files in content/ — were
+// rendered by nothing here.
+//
+// That is not a theoretical hole. #1499's three false Actuator claims all lived
+// in `_java` pages, and RFC #1502 rewrote both `_java` and `_typescript` health
+// and deployment pages while the goldens below did not move by construction.
+//
+// These tests are about RENDERING, which is all a test in this package can
+// speak to. Whether a variant page's PROSE matches the runtime it describes is
+// checked by scripts/check_doc_claims.py, which can read the four runtimes'
+// source; this file cannot, and pretending otherwise would be the same mistake
+// the pages made.
+
+// variantPages returns every (topic, variant) pair the registry advertises,
+// with its rendered content.
+func variantPages(t *testing.T) []variantPage {
+	t.Helper()
+
+	var pages []variantPage
+	for _, guide := range ListGuides() {
+		for _, variant := range []string{"typescript", "java"} {
+			if variant == "typescript" && !guide.HasTypeScriptVariant {
+				continue
+			}
+			if variant == "java" && !guide.HasJavaVariant {
+				continue
+			}
+			g, content, err := GetGuideWithVariant(guide.Name, variant)
+			if err != nil {
+				t.Fatalf("GetGuideWithVariant(%q, %q) failed: %v",
+					guide.Name, variant, err)
+			}
+			pages = append(pages, variantPage{
+				guide:   g,
+				name:    guide.Name + "_" + variant,
+				content: content,
+			})
+		}
+	}
+	return pages
+}
+
+type variantPage struct {
+	guide   *Guide
+	name    string
+	content string
+}
+
+// TestVariantFilesAndRegistryAgree is the structural half, and it guards a
+// silent failure the count goldens cannot see.
+//
+// GetGuideWithVariant FALLS BACK to the default page when a variant file is
+// missing, and reports no error. So deleting `health_java.md`, or renaming it,
+// leaves `meshctl man health --java` quietly serving the Python page to a Java
+// developer — every code sample in the wrong language, and a green build. The
+// inverse is just as quiet: a new `foo_java.md` whose registry entry never got
+// `HasJavaVariant: true` is a page that ships in the binary and can never be
+// reached.
+//
+// Asserting the two sides against each other costs no golden to maintain.
+func TestVariantFilesAndRegistryAgree(t *testing.T) {
+	entries, err := guideContent.ReadDir("content")
+	if err != nil {
+		t.Fatalf("reading embedded content: %v", err)
+	}
+
+	onDisk := map[string]bool{}
+	for _, e := range entries {
+		name := strings.TrimSuffix(e.Name(), ".md")
+		if strings.HasSuffix(name, "_java") || strings.HasSuffix(name, "_typescript") {
+			onDisk[name] = true
+		}
+	}
+
+	advertised := map[string]bool{}
+	for _, guide := range ListGuides() {
+		if guide.HasTypeScriptVariant {
+			advertised[guide.Name+"_typescript"] = true
+		}
+		if guide.HasJavaVariant {
+			advertised[guide.Name+"_java"] = true
+		}
+	}
+
+	for name := range advertised {
+		if !onDisk[name] {
+			t.Errorf("the registry advertises %s.md, which is not in content/. "+
+				"GetGuideWithVariant falls back to the default page without an "+
+				"error, so this ships as the wrong language rather than as a "+
+				"failure", name)
+		}
+	}
+	for name := range onDisk {
+		if !advertised[name] {
+			t.Errorf("content/%s.md ships in the binary but no registry entry "+
+				"sets the matching Has*Variant flag, so no meshctl invocation "+
+				"can reach it", name)
+		}
+	}
+
+	if len(advertised) == 0 {
+		t.Fatal("no variant pages advertised; every test in this file is inert")
+	}
+}
+
+// TestVariantPagesAreNotTheDefault pins the other half of the same fallback:
+// a variant that resolves must resolve to DIFFERENT content. A file that
+// exists but was truncated to a stub, or one accidentally overwritten with a
+// copy of the default, satisfies TestVariantFilesAndRegistryAgree and still
+// serves a Java developer Python.
+func TestVariantPagesAreNotTheDefault(t *testing.T) {
+	for _, guide := range ListGuides() {
+		_, base, err := GetGuide(guide.Name)
+		if err != nil {
+			t.Fatalf("GetGuide(%q) failed: %v", guide.Name, err)
+		}
+		for _, variant := range []string{"typescript", "java"} {
+			if variant == "typescript" && !guide.HasTypeScriptVariant {
+				continue
+			}
+			if variant == "java" && !guide.HasJavaVariant {
+				continue
+			}
+			_, got, err := GetGuideWithVariant(guide.Name, variant)
+			if err != nil {
+				t.Fatalf("GetGuideWithVariant(%q, %q) failed: %v",
+					guide.Name, variant, err)
+			}
+			// The cross-language header differs even on a fallback, so compare
+			// the bodies with it stripped.
+			if stripLangHeader(got) == stripLangHeader(base) {
+				t.Errorf("%s --%s serves the default page's content", guide.Name, variant)
+			}
+		}
+	}
+}
+
+func stripLangHeader(content string) string {
+	const marker = "\n\n**Also available:**"
+	idx := strings.Index(content, marker)
+	if idx == -1 {
+		return content
+	}
+	end := strings.Index(content[idx+2:], "\n")
+	if end == -1 {
+		return content[:idx]
+	}
+	return content[:idx] + content[idx+2+end:]
+}
+
+// Golden corpus size for the variant pages.
+//
+// ONE number, not the three renderer_test.go keeps for the default corpus, and
+// deliberately so. The two list goldens there exist to detect a topic dropping
+// out of ListGuides, and every comment added to them since #1401 has recorded
+// them as "unmoved". Here that failure is caught structurally and exactly by
+// TestVariantFilesAndRegistryAgree, which names the missing file instead of
+// reporting a number that changed. A second and third count over a corpus that
+// moves as often as this one would be maintenance without a defect class
+// behind it.
+//
+// A docs change that moves this is expected to move it — update the constant in
+// the same commit and confirm the delta is the size you intended, the same rule
+// the default corpus follows. Measured across all 34 variant pages at the
+// commit that added this test.
+const wantVariantInlineCodeSpans = 1662
+
+// TestVariantCorpusCodeSpans is TestStyleInlineCorpus plus
+// TestRenderStyledCorpusListItems, run over the pages neither of them sees.
+//
+// Both assertions are made per page: a code span must survive styleInline
+// verbatim, AND must survive into the fully rendered output, which is what
+// covers the list branches in renderStyled (the #1392 defect class).
+func TestVariantCorpusCodeSpans(t *testing.T) {
+	r := NewRenderer(false)
+	checked := 0
+	var pageNames []string
+
+	for _, page := range variantPages(t) {
+		pageNames = append(pageNames, page.name)
+		rendered := r.Render(page.guide, page.content)
+
+		inCodeBlock := false
+		for i, line := range strings.Split(page.content, "\n") {
+			if strings.HasPrefix(line, "```") {
+				inCodeBlock = !inCodeBlock
+				continue
+			}
+			if inCodeBlock || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "|") {
+				continue
+			}
+
+			isListLine := strings.HasPrefix(line, "- ") ||
+				strings.HasPrefix(line, "  - ") ||
+				numberedListRe.MatchString(line)
+
+			styled := r.styleInline(line)
+			for _, m := range inlineCodeRe.FindAllStringSubmatch(line, -1) {
+				checked++
+				want := green + m[1] + reset
+				if !strings.Contains(styled, want) {
+					t.Errorf("%s:%d code span %q corrupted by styleInline\n src: %q\n out: %q",
+						page.name, i+1, m[1], line, styled)
+				}
+				if isListLine && !strings.Contains(rendered, want) {
+					t.Errorf("%s:%d list-item code span %q not styled in the rendered page\n src: %q",
+						page.name, i+1, m[1], line)
+				}
+			}
+		}
+	}
+
+	sort.Strings(pageNames)
+	if checked == 0 {
+		t.Fatal("no inline code spans found in the variant pages; test is not exercising anything")
+	}
+	if got, want := checked, wantVariantInlineCodeSpans; got != want {
+		t.Errorf("the %d variant pages hold %d inline code spans, want %d "+
+			"(delta %+d).\nIf a docs change moved this, update "+
+			"wantVariantInlineCodeSpans in the same commit and confirm the "+
+			"delta is the size you intended. Pages sampled: %s",
+			len(pageNames), got, want, got-want, strings.Join(pageNames, ", "))
+	} else {
+		t.Logf("verified %d inline code spans across %d variant pages",
+			checked, len(pageNames))
+	}
+}
+
+// TestVariantCorpusLeavesNoLiteralMarkup renders every variant page and
+// asserts no markdown escaped the renderer into the output. This is the
+// symptom a reader of `meshctl man health --java` actually sees, and it is
+// checked against the whole page rather than against a count, so it needs no
+// golden and cannot drift.
+func TestVariantCorpusLeavesNoLiteralMarkup(t *testing.T) {
+	r := NewRenderer(false)
+
+	for _, page := range variantPages(t) {
+		body := strings.TrimPrefix(r.Render(page.guide, page.content), renderedHeader(page.guide))
+
+		inCodeBlock := false
+		for i, line := range strings.Split(page.content, "\n") {
+			if strings.HasPrefix(line, "```") {
+				inCodeBlock = !inCodeBlock
+				continue
+			}
+			if inCodeBlock {
+				continue
+			}
+			if !strings.HasPrefix(line, "- ") && !strings.HasPrefix(line, "  - ") &&
+				!numberedListRe.MatchString(line) {
+				continue
+			}
+			if !strings.Contains(line, "**") {
+				continue
+			}
+			for _, m := range inlineBoldRe.FindAllStringSubmatch(line, -1) {
+				text := m[1]
+				if text == "" {
+					text = m[2]
+				}
+				if strings.Contains(body, "**"+text+"**") {
+					t.Errorf("%s:%d bold %q rendered literally on a list line\n src: %q",
+						page.name, i+1, text, line)
+				}
+			}
+		}
+	}
+}

--- a/src/core/cli/man/variant_corpus_test.go
+++ b/src/core/cli/man/variant_corpus_test.go
@@ -261,7 +261,12 @@ func TestVariantCorpusLeavesNoLiteralMarkup(t *testing.T) {
 				!numberedListRe.MatchString(line) {
 				continue
 			}
-			if !strings.Contains(line, "**") {
+			// inlineBoldRe accepts both markdown spellings, so the pre-filter
+			// has to as well: filtering on "**" alone would mean a page that
+			// switched to __bold__ was never checked. No variant page uses the
+			// underscore form today, which is precisely why the gap would go
+			// unnoticed until one did.
+			if !strings.Contains(line, "**") && !strings.Contains(line, "__") {
 				continue
 			}
 			for _, m := range inlineBoldRe.FindAllStringSubmatch(line, -1) {
@@ -269,7 +274,11 @@ func TestVariantCorpusLeavesNoLiteralMarkup(t *testing.T) {
 				if text == "" {
 					text = m[2]
 				}
-				if strings.Contains(body, "**"+text+"**") {
+				// m[0] is the delimiters as written, which is what would show
+				// up in the body if the renderer left it alone. Rebuilding it
+				// from the capture would look for the asterisk form of an
+				// underscore span and find nothing.
+				if strings.Contains(body, m[0]) {
 					t.Errorf("%s:%d bold %q rendered literally on a list line\n src: %q",
 						page.name, i+1, text, line)
 				}


### PR DESCRIPTION
## Summary

`src/core/cli/man/content/<topic>.md` and its `_java` / `_typescript` siblings are hand-maintained parallel surfaces, and nothing tied a claim to the code it asserted. The existing corpus tests count spans, and **never sampled the variants at all** — so a page could assert the opposite of what the runtime does and stay green forever.

It did, twice. Both are now pinned as fixtures, replayed verbatim from the commits that removed them:

- **#1499** — three surfaces claimed the Spring Boot starter integrates with Actuator, including a `curl http://localhost:8080/actuator/health` that 404s on a stock agent. A false claim a developer *runs*, and then reasonably concludes their agent is broken.
- **RFC #1502** — `docs/typescript/mesh-functions.md` said `/ready` and `/health` answer 200 only while the agent reports healthy. `/ready` reports the mesh runtime and is unmoved by the verdict, which is the entire point of that RFC: a withdrawn gateway keeps its Service endpoints. A reader following that page expects their pod to drop out on a vendor outage.

A **third** shape turned up while building it — a single-endpoint bullet that clause-level scanning missed, which is why block-level evaluation exists.

## Three checks, placed by what each can reach

The issue asks whether this is a test, a lint, or a review-checklist item. It's all three, split by reach.

**Lint** (`scripts/check_doc_claims.py`) — the claims live in two trees and the evidence in four language trees plus a Maven POM. A Go test in `cli/man` sees one claim tree and would be this repo's only Go test walking outside its package.

**Test** (`variant_corpus_test.go`) — the sampling gap is purely about the man package, so it belongs where the content is embedded.

**Checklist** (`.claude/review-checklist.md`, gitignored per project convention) — the parts no lint can reach.

## Why the route inventory isn't a stale list in disguise

138 paths derived from Go, Python, TypeScript and Java. Three paths can't be derived (`/mcp` comes from a variable in Python, library config in TS, a constant in Java), so there's a 3-entry supplement list — with three guards so the maintained remainder can't rot:

- **Anchors re-derive known paths per runtime.** An extractor that silently stops matching an idiom returns fewer paths and would otherwise pass every curl. Verified by neutering one extractor: it fails with *"Do not relax the anchor to go green — an empty inventory passes every curl."*
- **Each supplement cites a file and a substring**, re-read every run.
- **The one illustrative path fails** if no doc still uses it.

`HANDLER_FACTS` gets the same treatment — 9 handler sites located and bounded every run.

## Honest about what each half does

Check C's **code** half is the load-bearing part: nine live assertions that no runtime's `/ready` handler consults the verdict. Nothing else in this repo pinned RFC #1502's contract in source.

Check C's **doc** half is a regression guard that asserts nothing about today's text — it evaluates 53 real units and finds zero hits, because the clauses it would fail are exactly the ones deleted to fix the two bugs. That's stated in its own docstring rather than left looking like coverage. It was deliberately not extended to the positive `/health` direction: 6 of 11 real `/health` clauses open with "Nothing probes it" or "…is not reporting healthy", so the lexicon would exempt them — coverage in appearance, noise in substance.

General prose polarity breaks down on sentences contrasting two endpoints, and that's pinned as deliberate: `"/health answers 503 while /ready is unmoved"` is correct prose, and a false alarm there gets "fixed" by rewording something true.

## An unguarded hole found along the way

`GetGuideWithVariant` falls back to the default **silently**, so a variant file deleted — or duplicated from its default — returned no error. Now caught structurally and by name.

## Verification

Both historical bugs reintroduced and confirmed to exit 1, then reverted to green. The anti-vacuity guard confirmed to fire on a broken extractor.

`go build ./...`, `go test ./src/core/...` (10 packages), `pytest scripts/` (182 tests) all clean. Goldens rebased on current numbers; the existing three are untouched, since a variant-only edit cannot move them by construction.

**No inaccuracies remain in the current corpus** — the expected result, given this release just rewrote these pages. An exploratory sweep over every inline `` `/path` `` span (not just curls) surfaced three, all legitimate.

Closes #1500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation to verify that documented routes, dependencies, health checks, and examples match the application’s runtime behavior.
  * Added support for checking documentation claims across supported language variants.

* **Bug Fixes**
  * Documentation checks now detect stale, unsupported, or inaccurate claims before changes are merged.

* **Tests**
  * Added comprehensive coverage for documentation validation, route handling, health-status behavior, variant pages, and formatting consistency.
  * Added continuous integration and pre-commit checks to run these validations automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->