### PR TITLE
tracing: stop the registry building a TraceAccumulator nothing reads

### DIFF
--- a/src/core/registry/trace_routes_test.go
+++ b/src/core/registry/trace_routes_test.go
@@ -1,0 +1,208 @@
+package registry
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"mcp-mesh/src/core/registry/tracing"
+)
+
+// The registry serves exactly four /trace/* routes, and #1540 removed the
+// TraceAccumulator that sat behind none of them. This file is the executable
+// form of that table: it drives all four against a real stream-through
+// TracingManager and a stub Tempo, so "the accumulator is unreachable from the
+// registry" is a passing test rather than a grep of the handlers.
+//
+//	GET /trace/status     -> GetInfo()  (config + consumer + correlator)
+//	GET /trace/info       -> GetInfo()  (same)
+//	GET /trace/stats      -> GetStats() (nil in stream-through mode)
+//	GET /trace/:trace_id  -> GetTrace() (Tempo in stream-through mode)
+
+const stubTempoTrace = `{"batches":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"agent-a"}}]},` +
+	`"scopeSpans":[{"spans":[{"traceId":"abc123","spanId":"s1","name":"do_work",` +
+	`"startTimeUnixNano":"1700000000000000000","endTimeUnixNano":"1700000000500000000","attributes":[]}]}]}]}`
+
+// newTraceRouteFixture wires the four routes onto a Server carrying the manager
+// the registry actually builds, plus a stub Tempo that serves one trace and
+// 404s "missingtrace". Returns the engine and the manager.
+func newTraceRouteFixture(t *testing.T, exporter string) (*gin.Engine, *tracing.TracingManager, *int32) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	var tempoHits int32
+	tempo := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tempoHits, 1)
+		if strings.HasSuffix(r.URL.Path, "/api/traces/missingtrace") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(stubTempoTrace))
+	}))
+	t.Cleanup(tempo.Close)
+
+	tm, err := tracing.NewTracingManager(&tracing.TracingConfig{
+		Enabled:           true,
+		RedisURL:          "redis://127.0.0.1:1", // never dialled; nothing calls Start
+		StreamName:        "mesh:trace",
+		ConsumerGroup:     tracing.DefaultTraceConsumerGroup,
+		ConsumerName:      "registry-route-test",
+		BatchSize:         100,
+		BlockTimeout:      time.Second,
+		TraceTimeout:      5 * time.Minute,
+		TraceRetention:    0,
+		ExporterType:      exporter,
+		EnableStats:       true,
+		TelemetryEndpoint: "localhost:4317",
+		TelemetryProtocol: "grpc",
+		TempoQueryURL:     tempo.URL,
+	})
+	if err != nil {
+		t.Fatalf("NewTracingManager(%s): %v", exporter, err)
+	}
+
+	s := &Server{tracingManager: tm}
+	e := gin.New()
+	e.GET("/trace/status", s.handleTracingStatus)
+	e.GET("/trace/stats", s.handleTracingStats)
+	e.GET("/trace/info", s.handleTracingInfo)
+	e.GET("/trace/:trace_id", s.handleTraceGet)
+	return e, tm, &tempoHits
+}
+
+func getJSON(t *testing.T, e *gin.Engine, path string) (int, map[string]interface{}) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	e.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("GET %s: response is not a JSON object: %v (%s)", path, err, w.Body.String())
+	}
+	return w.Code, body
+}
+
+// TestTraceRoutesServedWithoutAccumulator drives every registry trace route
+// against a manager that has no accumulator. Each must answer exactly as it
+// always has: the accumulator was never in any of these paths, so removing it
+// can only be visible here as a panic or an empty answer.
+func TestTraceRoutesServedWithoutAccumulator(t *testing.T) {
+	e, tm, tempoHits := newTraceRouteFixture(t, "otlp")
+
+	if tm.GetAccumulator() != nil {
+		t.Fatal("the registry manager built an accumulator; #1540 removed it")
+	}
+
+	t.Run("status, info and stats make no network call", func(t *testing.T) {
+		for _, path := range []string{"/trace/status", "/trace/info", "/trace/stats"} {
+			if code, _ := getJSON(t, e, path); code != http.StatusOK {
+				t.Fatalf("GET %s = %d, want 200", path, code)
+			}
+		}
+		if n := atomic.LoadInt32(tempoHits); n != 0 {
+			t.Errorf("Tempo was queried %d times by status/info/stats; those routes answer from local state, "+
+				"and a fallback that starts dialling is worse than one that never ran", n)
+		}
+	})
+
+	t.Run("status and info answer from config and consumer", func(t *testing.T) {
+		for _, path := range []string{"/trace/status", "/trace/info"} {
+			code, body := getJSON(t, e, path)
+			if code != http.StatusOK {
+				t.Fatalf("GET %s = %d, want 200", path, code)
+			}
+			if body["enabled"] != true {
+				t.Errorf("GET %s: enabled = %v, want true", path, body["enabled"])
+			}
+			if body["stream_through_mode"] != true {
+				t.Errorf("GET %s: stream_through_mode = %v, want true", path, body["stream_through_mode"])
+			}
+			if body["exporter_type"] != "otlp" {
+				t.Errorf("GET %s: exporter_type = %v, want otlp", path, body["exporter_type"])
+			}
+			consumer, ok := body["consumer"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("GET %s: no consumer block: %v", path, body)
+			}
+			if consumer["consumer_group"] != tracing.DefaultTraceConsumerGroup {
+				t.Errorf("GET %s: consumer_group = %v", path, consumer["consumer_group"])
+			}
+			// Stream-through mode has no correlator, and never had an
+			// accumulator block to lose.
+			if _, present := body["correlator"]; present {
+				t.Errorf("GET %s: unexpected correlator block in stream-through mode", path)
+			}
+		}
+	})
+
+	t.Run("stats reports unavailable", func(t *testing.T) {
+		code, body := getJSON(t, e, "/trace/stats")
+		if code != http.StatusOK {
+			t.Fatalf("GET /trace/stats = %d, want 200", code)
+		}
+		if body["stats_available"] != false {
+			t.Errorf("stats_available = %v, want false (GetStats returns nil in stream-through mode)", body["stats_available"])
+		}
+	})
+
+	t.Run("trace lookup is served by Tempo", func(t *testing.T) {
+		code, body := getJSON(t, e, "/trace/abc123")
+		if code != http.StatusOK {
+			t.Fatalf("GET /trace/abc123 = %d, want 200: the Tempo path is the sink that matters", code)
+		}
+		if body["TraceID"] != "abc123" {
+			t.Errorf("TraceID = %v, want abc123", body["TraceID"])
+		}
+		spans, _ := body["Spans"].([]interface{})
+		if len(spans) != 1 {
+			t.Fatalf("Spans = %d, want 1 (from the stub Tempo)", len(spans))
+		}
+
+		code, body = getJSON(t, e, "/trace/missingtrace")
+		if code != http.StatusNotFound {
+			t.Errorf("GET /trace/missingtrace = %d, want 404", code)
+		}
+		if body["error"] != "trace not found" {
+			t.Errorf("error = %v, want \"trace not found\"", body["error"])
+		}
+	})
+}
+
+// TestTraceRoutesUnchangedInCorrelationMode covers the branch #1540 did not
+// touch. Correlation mode never had an accumulator, so its answers must be
+// identical: a correlator block on status/info, and a local (empty) trace
+// lookup that does NOT reach out to Tempo.
+func TestTraceRoutesUnchangedInCorrelationMode(t *testing.T) {
+	e, tm, tempoHits := newTraceRouteFixture(t, "console")
+
+	if tm.GetAccumulator() != nil {
+		t.Fatal("correlation mode built an accumulator")
+	}
+
+	code, body := getJSON(t, e, "/trace/status")
+	if code != http.StatusOK {
+		t.Fatalf("GET /trace/status = %d, want 200", code)
+	}
+	if body["stream_through_mode"] != false {
+		t.Errorf("stream_through_mode = %v, want false", body["stream_through_mode"])
+	}
+	if _, ok := body["correlator"].(map[string]interface{}); !ok {
+		t.Errorf("correlation mode lost its correlator block: %v", body)
+	}
+
+	// The correlator holds nothing, and the stub Tempo must not be consulted:
+	// a fallback that starts making network calls would be a regression even
+	// though it returns the "right" shape.
+	code, _ = getJSON(t, e, "/trace/abc123")
+	if code != http.StatusNotFound {
+		t.Errorf("GET /trace/abc123 in correlation mode = %d, want 404 from the empty local correlator", code)
+	}
+	if n := atomic.LoadInt32(tempoHits); n != 0 {
+		t.Errorf("correlation mode queried Tempo %d times; it must answer from the local correlator", n)
+	}
+}

--- a/src/core/registry/tracing/aggregates.go
+++ b/src/core/registry/tracing/aggregates.go
@@ -62,8 +62,12 @@ type AggregateBounds struct {
 var defaultAggregateBounds = LoadAggregateBoundsFromEnv()
 
 // DefaultAggregateBounds returns the process-wide aggregate bounds derived
-// from the environment at init time. Both the registry and meshui construct
-// their aggregate maps from this.
+// from the environment at init time.
+//
+// Since #1540 the only process that builds an aggregate map is MESHUI — both
+// its TraceAccumulator and its MetricsProcessor. The registry exports spans to
+// Tempo and aggregates nothing, so these bounds no longer describe any registry
+// memory. That is why the docs call them dashboard aggregates.
 func DefaultAggregateBounds() AggregateBounds {
 	return defaultAggregateBounds
 }

--- a/src/core/registry/tracing/manager.go
+++ b/src/core/registry/tracing/manager.go
@@ -167,11 +167,32 @@ func NewTracingManager(config *TracingConfig) (*TracingManager, error) {
 			}
 		}
 
-		// Create stream-through processor and wrap with accumulator
-		streamProcessor := NewStreamThroughProcessor(otlpExporter)
-		accumulator := NewTraceAccumulator(200, manager.logger)
-		manager.accumulator = accumulator
-		manager.processor = NewMultiProcessor(manager.logger, streamProcessor, accumulator)
+		// Export and nothing else. Deliberately NO TraceAccumulator here
+		// (#1540): nothing on the registry side ever read one. Every manager
+		// method that consults tm.accumulator — ListTraces, SearchTraces,
+		// GetTraceCount, GetRecentTraces, GetEdgeStats, GetAgentActivity,
+		// GetTotalFinalized, GetTotalErrors, GetAccumulator — is called only
+		// from src/core/ui, and meshui builds its own manager through
+		// NewAccumulatorOnlyManager with its own accumulator, consumer and
+		// consumer group. The registry's four /trace/* routes reach none of
+		// them: /trace/status and /trace/info answer from GetInfo (config +
+		// consumer + correlator), /trace/stats returns nil unconditionally,
+		// and /trace/:trace_id answers from Tempo in this mode.
+		//
+		// It was also a trap. The accumulator is fed from a Redis consumer
+		// group, and Redis hands each stream entry to exactly one consumer in
+		// a group, so at N registry replicas each accumulator would hold
+		// roughly 1/N of the mesh's traffic. Wiring any registry route to it —
+		// the obvious move, with the data right there on the manager — would
+		// have under-reported by about the replica count, silently. Leaving
+		// the field nil means that route has to go and find a real source.
+		//
+		// The nil is what the tm.accumulator == nil guards throughout this
+		// file were already written for, so the manager's API shape is
+		// unchanged: the list/search/count methods return empty as they did
+		// when tracing was off, and GetRecentTraces/GetEdgeStats fall through
+		// to Tempo, which sees every replica's spans rather than one's.
+		manager.processor = NewStreamThroughProcessor(otlpExporter)
 
 	} else {
 		// Use traditional correlation approach for other exporters
@@ -222,6 +243,7 @@ func (tm *TracingManager) Start() error {
 		return nil
 	}
 
+	// Nil on the registry path since #1540 — only meshui accumulates.
 	if tm.accumulator != nil {
 		tm.accumulator.Start()
 	}
@@ -263,7 +285,9 @@ func (tm *TracingManager) trimLoop() {
 }
 
 // Stop stops the tracing manager. The consumer is stopped first so that
-// in-flight spans can still be processed by the accumulator before it shuts down.
+// in-flight spans can still be processed by the accumulator before it shuts
+// down. Since #1540 only meshui's manager has an accumulator; the registry's
+// takes the nil branch and stops consumer, processor and exporter alone.
 func (tm *TracingManager) Stop() error {
 	if !tm.enabled {
 		return nil

--- a/src/core/registry/tracing/registry_no_accumulator_test.go
+++ b/src/core/registry/tracing/registry_no_accumulator_test.go
@@ -1,0 +1,262 @@
+package tracing
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// newRegistryManagerForTest builds the manager the REGISTRY builds, in the mode
+// the charts ship (TRACE_EXPORTER_TYPE=otlp). The Redis URL is never dialled:
+// NewStreamConsumer connects lazily and nothing here calls Start.
+func newRegistryManagerForTest(t *testing.T, exporter string) *TracingManager {
+	t.Helper()
+
+	tm, err := NewTracingManager(&TracingConfig{
+		Enabled:           true,
+		RedisURL:          "redis://127.0.0.1:1",
+		StreamName:        "mesh:trace",
+		ConsumerGroup:     DefaultTraceConsumerGroup,
+		ConsumerName:      "registry-test",
+		BatchSize:         100,
+		BlockTimeout:      time.Second,
+		TraceTimeout:      time.Minute,
+		TraceRetention:    0, // no trim loop; nothing is Start()ed here
+		ExporterType:      exporter,
+		TelemetryEndpoint: "localhost:4317",
+		TelemetryProtocol: "grpc",
+	})
+	if err != nil {
+		t.Fatalf("NewTracingManager(%s): %v", exporter, err)
+	}
+	t.Cleanup(func() {
+		if tm.consumer != nil {
+			tm.consumer.cancel()
+		}
+	})
+	return tm
+}
+
+// newUIManagerForTest builds the manager MESHUI builds, exactly as
+// cmd/mcp-mesh-ui does: NewAccumulatorOnlyManager with an extra processor.
+func newUIManagerForTest(t *testing.T) *TracingManager {
+	t.Helper()
+
+	tm, err := NewAccumulatorOnlyManager(&TracingConfig{
+		Enabled:        true,
+		RedisURL:       "redis://127.0.0.1:1",
+		StreamName:     "mesh:trace",
+		ConsumerGroup:  "mcp-mesh-ui-dashboard",
+		ConsumerName:   "ui-test",
+		BatchSize:      100,
+		BlockTimeout:   time.Second,
+		TraceRetention: 0,
+	}, noopProcessor{})
+	if err != nil {
+		t.Fatalf("NewAccumulatorOnlyManager: %v", err)
+	}
+	t.Cleanup(func() {
+		if tm.consumer != nil {
+			tm.consumer.cancel()
+		}
+	})
+	return tm
+}
+
+// TestRegistryManagerBuildsNoAccumulator is the guard for #1540. The registry
+// built a TraceAccumulator that nothing on the registry side ever read: every
+// method that consults it is called only from src/core/ui, and meshui builds
+// its own manager. It cost two goroutines, ~90 ns and ~25 B of accumulator work
+// on every span event, and up to ~21 MB of edge aggregates per replica.
+//
+// It was also a trap: fed from a Redis consumer group, each of N replicas would
+// hold roughly 1/N of the mesh's traffic, so any registry route later wired to
+// GetEdgeStats or GetRecentTraces would have under-reported by about the
+// replica count with no error and no warning.
+//
+// The assertion is paired ON PURPOSE. TracingManager is the same struct for
+// both processes, so "accumulator is nil" alone would be a false invariant —
+// meshui's accumulator is the point of that process. What must hold is the
+// DIFFERENCE: the registry constructor leaves it nil, the meshui constructor
+// does not.
+func TestRegistryManagerBuildsNoAccumulator(t *testing.T) {
+	registry := newRegistryManagerForTest(t, "otlp")
+	if registry.GetAccumulator() != nil {
+		t.Error("the registry's stream-through manager built a TraceAccumulator; " +
+			"nothing on the registry side reads one, and at N replicas it would hold ~1/N of the traffic (#1540)")
+	}
+
+	ui := newUIManagerForTest(t)
+	if ui.GetAccumulator() == nil {
+		t.Error("meshui's accumulator-only manager has no TraceAccumulator; " +
+			"the dashboard reads that accumulator and #1540 must not have touched this path")
+	}
+}
+
+// TestRegistryProcessorDoesNotFanOutToAccumulator closes the gap the field
+// check alone leaves. Setting tm.accumulator and adding the accumulator to the
+// processor fan-out are two separate lines, so an accumulator could be
+// reattached to the pipeline — paying the per-event cost and holding the
+// memory — while GetAccumulator still returned nil. The registry's processor
+// must therefore BE the stream-through exporter, not a fan-out containing one.
+func TestRegistryProcessorDoesNotFanOutToAccumulator(t *testing.T) {
+	registry := newRegistryManagerForTest(t, "otlp")
+
+	switch p := registry.processor.(type) {
+	case *StreamThroughProcessor:
+		// Export and nothing else, which is the whole point.
+	case *MultiProcessor:
+		for _, sub := range p.processors {
+			if _, isAcc := sub.(*TraceAccumulator); isAcc {
+				t.Fatal("the registry's processor fans out to a TraceAccumulator (#1540)")
+			}
+		}
+		t.Errorf("the registry's processor is a %T; stream-through mode exports and does nothing else", p)
+	default:
+		t.Errorf("the registry's processor is a %T, want *StreamThroughProcessor", p)
+	}
+}
+
+// TestRegistryManagerReadsReturnEmptyWithoutAccumulator pins the API shape the
+// nil field leaves behind. These methods are not called from the registry
+// today; if one ever is, it must return empty rather than panic.
+func TestRegistryManagerReadsReturnEmptyWithoutAccumulator(t *testing.T) {
+	tm := newRegistryManagerForTest(t, "otlp")
+
+	if got := tm.ListTraces(10, 0); len(got) != 0 {
+		t.Errorf("ListTraces = %d traces, want 0", len(got))
+	}
+	if got := tm.SearchTraces(TraceSearchCriteria{Limit: 10}); len(got) != 0 {
+		t.Errorf("SearchTraces = %d traces, want 0", len(got))
+	}
+	if got := tm.GetTraceCount(); got != 0 {
+		t.Errorf("GetTraceCount = %d, want 0", got)
+	}
+	if got := tm.GetTotalFinalized(); got != 0 {
+		t.Errorf("GetTotalFinalized = %d, want 0", got)
+	}
+	if got := tm.GetTotalErrors(); got != 0 {
+		t.Errorf("GetTotalErrors = %d, want 0", got)
+	}
+	if got := tm.GetAgentActivity(); len(got) != 0 {
+		t.Errorf("GetAgentActivity = %v, want empty", got)
+	}
+
+	// GetRecentTraces and GetEdgeStats fall through to Tempo when the
+	// accumulator is nil. With no Tempo client configured they must return
+	// empty and not dial anything.
+	if tm.tempoClient != nil {
+		t.Fatal("test fixture configured a Tempo client; it must not have one")
+	}
+	recent, err := tm.GetRecentTraces(10)
+	if err != nil || len(recent) != 0 {
+		t.Errorf("GetRecentTraces = (%d, %v), want (0, nil)", len(recent), err)
+	}
+	edges, err := tm.GetEdgeStats(10)
+	if err != nil || len(edges) != 0 {
+		t.Errorf("GetEdgeStats = (%d, %v), want (0, nil)", len(edges), err)
+	}
+}
+
+// TestRegistryStartStopWithNilAccumulator exercises the sequencing that used to
+// be guaranteed by the accumulator existing. Start must still start the
+// consumer, Stop must not dereference the nil accumulator, and the pair must
+// leave no goroutine behind — including the trim loop, whose Stop ordering runs
+// before the accumulator branch.
+func TestRegistryStartStopWithNilAccumulator(t *testing.T) {
+	tm, err := NewTracingManager(&TracingConfig{
+		Enabled:           true,
+		RedisURL:          "redis://127.0.0.1:1", // refused; the consumer retries in the background
+		StreamName:        "mesh:trace",
+		ConsumerGroup:     DefaultTraceConsumerGroup,
+		ConsumerName:      "registry-startstop",
+		BatchSize:         100,
+		BlockTimeout:      100 * time.Millisecond,
+		TraceTimeout:      time.Minute,
+		TraceRetention:    time.Hour, // non-zero: the trim loop must run and stop
+		ExporterType:      "otlp",
+		TelemetryEndpoint: "localhost:4317",
+		TelemetryProtocol: "grpc",
+	})
+	if err != nil {
+		t.Fatalf("NewTracingManager: %v", err)
+	}
+	if tm.GetAccumulator() != nil {
+		t.Fatal("fixture built an accumulator; the point of this test is the nil path")
+	}
+
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	if err := tm.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if running, _ := tm.consumer.GetConsumerInfo()["running"].(bool); !running {
+		t.Error("Start returned but the consumer is not running; dropping the accumulator must not skip the consumer")
+	}
+	if tm.trimStop == nil {
+		t.Error("Start did not launch the trim loop")
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	if err := tm.Stop(); err != nil {
+		// A refused Redis connection can surface as a consumer stop error; the
+		// nil-accumulator path is what is under test, and a panic would have
+		// failed the test already.
+		t.Logf("Stop returned: %v (tolerated: Redis is intentionally unreachable)", err)
+	}
+
+	// Give the consumer's background loops a moment to unwind.
+	deadline := time.Now().Add(5 * time.Second)
+	var after int
+	for time.Now().Before(deadline) {
+		runtime.GC()
+		after = runtime.NumGoroutine()
+		if after <= before {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if after > before {
+		buf := make([]byte, 1<<16)
+		buf = buf[:runtime.Stack(buf, true)]
+		t.Errorf("goroutines %d -> %d after Start/Stop; leak:\n%s", before, after, buf)
+	}
+}
+
+// TestAccumulatorOnlyManagerStillAccumulates proves meshui's pipeline is
+// untouched end to end, not merely that its field is non-nil: a span event fed
+// to the manager's processor must still reach the accumulator's aggregates.
+func TestAccumulatorOnlyManagerStillAccumulates(t *testing.T) {
+	tm := newUIManagerForTest(t)
+
+	// Fed through tm.processor, not the accumulator directly: the fan-out is
+	// part of what meshui relies on and part of what #1540 touched.
+	events := []*TraceEvent{
+		makeCalleeSpan("t1", "span-parent", "", "caller", "handle", 1, true),
+		makeCalleeSpan("t1", "span-child", "span-parent", "provider", "do_work", 42, true),
+	}
+	for _, e := range events {
+		if err := tm.processor.ProcessTraceEvent(e); err != nil {
+			t.Fatalf("ProcessTraceEvent: %v", err)
+		}
+	}
+
+	acc := tm.GetAccumulator()
+	if acc == nil {
+		t.Fatal("meshui manager has no accumulator")
+	}
+	acc.FinalizeAllActive()
+
+	if got := acc.EdgeStatCount(); got != 1 {
+		t.Fatalf("meshui accumulator recorded %d edges, want 1: its pipeline must be unaffected by #1540", got)
+	}
+	edges, err := tm.GetEdgeStats(10)
+	if err != nil {
+		t.Fatalf("GetEdgeStats: %v", err)
+	}
+	if len(edges) != 1 || edges[0].Source != "caller" || edges[0].Target != "provider" || edges[0].TargetFunction != "do_work" {
+		t.Fatalf("meshui GetEdgeStats = %+v, want one caller->provider/do_work edge", edges)
+	}
+}


### PR DESCRIPTION
## Summary

In the default OTLP mode the registry builds a `TraceAccumulator` alongside the stream-through processor, so **every span event is processed twice** — once to export to Tempo, once to accumulate.

Nothing in the registry reads the second one. Every `TracingManager` method that touches it has callers only in `src/core/ui`, which is constructed only in the meshui binary — and meshui builds its own via `NewAccumulatorOnlyManager`, with its own accumulator, consumer and (since #1533) consumer group. The registry's four `/trace/*` routes never reach it: two return config and consumer metadata, one returns `nil` unconditionally, and the trace lookup goes to Tempo.

## Measured, not estimated

The issue carried an unmeasured ~20 MB guess. Measured on an M5 Pro:

| | measured |
|---|---|
| edge aggregates at the default `MAX_ENTRIES=10000` | **21.02 MB** (2,204 B/key) |
| goroutines | 2 (`cleanupLoop`, `debounceLoop`), clean on `Stop` |
| per span event | **+90 ns, +25 B** against an export-only leg that inlines to 0.38 ns |

Per registry replica, permanently, for numbers nobody reads.

## Why it was worth removing rather than ignoring

It was **latently wrong**, not merely wasteful. Under more than one replica the consumer group splits the stream, so each replica accumulated roughly 1/N of it. Harmless while unread — and a silent correctness bug the moment anyone wired a registry route to `GetEdgeStats`, which looks like a two-line change and would have shipped under-reported traffic with no error.

That risk now resolves in the safe direction: with the field nil, those methods take the Tempo branch and get the **complete** picture. Nothing calls them today, so no network call happens — asserted, not assumed.

## Two things my issue got wrong

- **The reader list was short by two.** `GetTotalFinalized` and `GetTotalErrors` also touch the accumulator. Both nil-guarded and UI-only, so the conclusion held, but the enumeration didn't.
- **`DefaultAggregateBounds`' doc comment said "Both the registry and meshui construct their aggregate maps from this"** — which this change makes false. `MCP_MESH_TELEMETRY_AGGREGATE_*` now bounds meshui only. Corrected. No user-facing docs needed changing; they already describe these as dashboard aggregates.

## The guard, and why it isn't "assert nil"

A naive test would assert the accumulator is nil — but that's a **false invariant**, because meshui's manager legitimately has one and shares the struct. The guard asserts the *difference between the two managers* instead.

A second guard type-switches the processor, because setting the field and adding it to the fan-out are separate lines: checking only the field would miss a reattachment that still double-processes every event.

Verified by reattaching the accumulator — `TestRegistryManagerBuildsNoAccumulator` fails.

## Verification

- Route responses **byte-identical** before and after: captured JSON for `status`, `stats`, `info`, a Tempo hit and a Tempo miss, across both exporter modes.
- `TestTraceRoutesServedWithoutAccumulator` asserts the routes hit a stub Tempo **zero** times, so the fallback isn't quietly firing.
- `TestRegistryStartStopWithNilAccumulator` runs a full `Start` → `Stop` with a non-zero retention so the trim loop runs, asserts the consumer actually started, and fails with a stack dump on any leaked goroutine.
- `NewMultiProcessor` survives with a real production caller — meshui fans out to its accumulator plus its `MetricsProcessor` — so it isn't left as a test-only constructor.

`go build ./...`, `go test ./...` (whole repo), tracing package under `-race`, and the doc-claim checks added in #1542 all clean.

Closes #1540

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq