### PR TITLE
release: v3.7.0

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version tag (e.g., v3.6.0)"
+        description: "Version tag (e.g., v3.7.0)"
         required: true
-        default: "v3.6.0"
+        default: "v3.7.0"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version (e.g., v3.6.0)"
+        description: "Version (e.g., v3.7.0)"
         required: true
-        default: "v3.6.0"
+        default: "v3.7.0"
       environment:
         description: "Environment"
         type: choice

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,54 @@
 # MCP Mesh Release Notes
 
-[Unreleased changes](https://github.com/dhyansraj/mcp-mesh/compare/v3.6.0...HEAD)
+[Unreleased changes](https://github.com/dhyansraj/mcp-mesh/compare/v3.7.0...HEAD)
+
+[Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.6.0...v3.7.0)
+
+## v3.7.0 (2026-08-22)
+
+`health_check` is a routing answer, not a health taxonomy (#1539). It accepted three verdicts and had two behaviours — `healthy` and `degraded` were identical on every path, and only `unhealthy` withdrew. The contract is now binary: return true to keep the agent in dependency resolution, false to withdraw it. Returning a dict or object to populate `checks` and `errors` still works and still reaches `/health`; it just never affects routing. Alongside it, the dashboard's topology and traffic views tell the truth about which function is being called, and registry tracing gains a read-only consumer group.
+
+> **⚠️ Two things are easy to miss.** Python now trims the status string, which is a genuine routing change, and selecting `degraded` now emits a deprecation warning. Both in Notes.
+
+### 🩺 Health
+
+- **The `health_check` contract is binary (#1539, closes #1515, #1516, #1517).** True keeps the agent in dependency resolution, false withdraws it. `degraded` still behaves exactly as it did — see Notes.
+- **⚠️ Python trims the status string.** `{"status": " unhealthy "}` previously parsed as `UNKNOWN` and kept the agent in resolution; it now withdraws. TypeScript and Java already trimmed, so only Python moves.
+- **A sync `health_check` runs instead of silently degrading (#1539).** `def` instead of `async def` raised `TypeError`, which was recorded as degraded — a check that appeared to run and could never fire. Sync checks are now accepted and run on a worker thread, so a blocking probe cannot stall the heartbeat loop.
+- **A null status is treated as absent** and warned about once per process, rather than read as a verdict (#1539).
+- **Probe handlers narrowed to transport errors (#1539)**, so a bug in a probe no longer withdraws a working provider.
+- **Sixteen provider examples now withdraw on a vendor outage (#1539).** They mapped it to `degraded`, which keeps the heartbeat alive — the registry never aged the agent out, and failover was defeated.
+
+### 📊 Dashboard
+
+- **Topology edges are coloured by what is being called, not who is calling (#1529).** The "API dependency" colour is gone — an API agent cannot be a resolution target — and a MeshJob colour is added.
+- **Traffic stats are keyed by callee function, not just agent pair (#1532).** Several edges between two agents no longer collapse into one blended average. Latency percentiles now come from a fixed-bucket histogram rather than a per-key sample reservoir.
+- **The Traffic page shows a function column (#1533)**, and its row budget no longer collapses to one row per route.
+- **Traffic heat only repaints an edge when there are errors (#1537).** It used to overwrite every edge colour including healthy ones, hiding the palette.
+- **`MCP_MESH_UI_TRACE_CONSUMER_GROUP` lets a second meshui read a live mesh (#1533)** without taking traces from the running dashboard.
+
+### 🔭 Registry tracing
+
+- **`MCP_MESH_TRACE_CONSUMER_GROUP` does the same for the registry (#1541).** It also documents that `TRACE_EXPORTER_TYPE=console|json` assumes a single replica: the correlator is per-trace stateful, so replicas fragment traces. The default `otlp` path is unaffected.
+- **The registry no longer builds a trace accumulator nothing read (#1543)** — roughly 21 MB per replica and a duplicate processing pass per span.
+
+### 🌐 Website
+
+- **A scroll-driven topology animation on the mcp-mesh.ai homepage (#1523)**, built from the real dashboard components, then prerendered to drop React and React Flow at 8.5× smaller (#1525). Its prose now ships in the served HTML so it reaches crawlers and screen readers (#1527), and the dashboard ships the Geist fonts it has always declared (#1528). No runtime impact.
+
+### 🔧 Maintenance
+
+- **The docs demo no longer pollutes the dashboard's Tailwind scan (#1526).**
+- **Generated files are no longer tracked, and `pre-commit run --all-files` runs clean (#1538).**
+- **Man-page claims are checked against the code they describe (#1542).**
+- **The integration suite is adapted to tsuite 0.8.0 (#1544).**
+
+### ⚠️ Notes
+
+- **⚠️ Python now trims the status string, and that changes routing.** A status with surrounding whitespace — `{"status": " unhealthy "}` — used to parse as `UNKNOWN` and keep the agent in dependency resolution; it now withdraws. This is the divergence fix working as intended: TypeScript and Java have always trimmed. It is the only routing behaviour that moves in this release.
+- **⚠️ Selecting `degraded` now warns, naming the consequence.** The behaviour is unchanged: a `degraded` agent keeps heartbeating and stays in resolution, exactly as before. Remapping it would silently withdraw agents whose authors used it correctly, so the warning comes first and the behaviour does not follow in this release. Java's `MeshHealth.degraded(...)` is `@Deprecated`, with removal no earlier than 4.0.
+- **Returning a dict or object from `health_check` still works.** `checks` and `errors` are still populated and still reach `/health`; only the routing decision is now taken from true/false.
+- **No upgrade ordering is required.** Nothing in this release needs the chart and the runtime images to move together.
 
 [Full Changelog](https://github.com/dhyansraj/mcp-mesh/compare/v3.5.2...v3.6.0)
 

--- a/cmd/meshctl/templates/java/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.6.0
+FROM mcpmesh/java-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/a2a-consumer/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/a2a-consumer/pom.xml.tmpl
@@ -26,7 +26,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.6.0
+FROM mcpmesh/java-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/api/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/api/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.6.0
+FROM mcpmesh/java-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/basic/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/basic/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.6.0
+FROM mcpmesh/java-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-agent/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.6.0
+FROM mcpmesh/java-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
+++ b/cmd/meshctl/templates/java/llm-provider/pom.xml.tmpl
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/cmd/meshctl/templates/python/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/python/llm-provider/requirements.txt.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/requirements.txt.tmpl
@@ -9,5 +9,5 @@
 # is NOT part of the base install or the python-runtime base image. Without
 # this line the agent starts and registers normally, then fails on its first
 # LLM call.
-mcp-mesh[litellm]==3.6.0
+mcp-mesh[litellm]==3.7.0
 {{- end }}

--- a/cmd/meshctl/templates/typescript/a2a-consumer/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/a2a-consumer/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} A2A consumer bridge
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/a2a-consumer/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/a2a-consumer/package.json.tmpl
@@ -13,7 +13,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/cmd/meshctl/templates/typescript/api/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/api/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh API gateway
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/api/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/api/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/basic/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/basic/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-agent/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/Dockerfile.tmpl
@@ -1,5 +1,5 @@
 # Dockerfile for {{ .Name }} MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
+++ b/cmd/meshctl/templates/typescript/llm-provider/package.json.tmpl
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/docs/00-why-mcp-mesh/index.md
+++ b/docs/00-why-mcp-mesh/index.md
@@ -121,7 +121,7 @@ meshctl scaffold --compose --observability
 
 # Or deploy to Kubernetes (OCI registry)
 helm install my-mesh oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 -n mcp-mesh --create-namespace
+  --version 3.7.0 -n mcp-mesh --create-namespace
 ```
 
 ### 5. Built-in Observability

--- a/docs/02-local-development.md
+++ b/docs/02-local-development.md
@@ -97,7 +97,7 @@ graph LR
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0</version>
     </dependency>
     ```
 

--- a/docs/03-docker-deployment.md
+++ b/docs/03-docker-deployment.md
@@ -24,10 +24,10 @@ MCP Mesh publishes official images to Docker Hub:
 
 | Image                            | Purpose                                          |
 | -------------------------------- | ------------------------------------------------ |
-| `mcpmesh/registry:3.6.0`           | Go-based registry service                        |
-| `mcpmesh/python-runtime:3.6.0`     | Python agent runtime (includes mcp-mesh SDK)     |
-| `mcpmesh/java-runtime:3.6.0`       | Java agent runtime (includes mcp-mesh SDK)       |
-| `mcpmesh/typescript-runtime:3.6.0` | TypeScript agent runtime (includes @mcpmesh/sdk) |
+| `mcpmesh/registry:3.7.0`           | Go-based registry service                        |
+| `mcpmesh/python-runtime:3.7.0`     | Python agent runtime (includes mcp-mesh SDK)     |
+| `mcpmesh/java-runtime:3.7.0`       | Java agent runtime (includes mcp-mesh SDK)       |
+| `mcpmesh/typescript-runtime:3.7.0` | TypeScript agent runtime (includes @mcpmesh/sdk) |
 
 ## Using Scaffold to Generate Compose Files
 
@@ -53,7 +53,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:3.6.0
+        image: mcpmesh/registry:3.7.0
         ports:
           - "8000:8000"
         healthcheck:
@@ -63,7 +63,7 @@ meshctl scaffold --compose --dry-run -d ./agents
           retries: 3
 
       my-agent:
-        image: mcpmesh/python-runtime:3.6.0
+        image: mcpmesh/python-runtime:3.7.0
         ports:
           - "8080:8080"
         volumes:
@@ -88,7 +88,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:3.6.0
+        image: mcpmesh/registry:3.7.0
         ports:
           - "8000:8000"
         healthcheck:
@@ -122,7 +122,7 @@ meshctl scaffold --compose --dry-run -d ./agents
 
     services:
       registry:
-        image: mcpmesh/registry:3.6.0
+        image: mcpmesh/registry:3.7.0
         ports:
           - "8000:8000"
         healthcheck:
@@ -132,7 +132,7 @@ meshctl scaffold --compose --dry-run -d ./agents
           retries: 3
 
       my-agent:
-        image: mcpmesh/typescript-runtime:3.6.0
+        image: mcpmesh/typescript-runtime:3.7.0
         ports:
           - "8080:8080"
         volumes:
@@ -161,12 +161,12 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:3.6.0
+        image: mcpmesh/registry:3.7.0
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/python-runtime:3.6.0
+        image: mcpmesh/python-runtime:3.7.0
         volumes:
           - ./agent.py:/app/agent.py:ro
         command: ["python", "/app/agent.py"]
@@ -185,7 +185,7 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:3.6.0
+        image: mcpmesh/registry:3.7.0
         ports:
           - "8000:8000"
 
@@ -206,12 +206,12 @@ If you prefer manual control, here's a minimal compose file:
 
     services:
       registry:
-        image: mcpmesh/registry:3.6.0
+        image: mcpmesh/registry:3.7.0
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/typescript-runtime:3.6.0
+        image: mcpmesh/typescript-runtime:3.7.0
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]
@@ -232,7 +232,7 @@ If you didn't use scaffold, here's a sample Dockerfile:
 === "Python"
 
     ```dockerfile
-    FROM mcpmesh/python-runtime:3.6.0
+    FROM mcpmesh/python-runtime:3.7.0
 
     COPY ./my-agent /app/agent
 
@@ -257,7 +257,7 @@ If you didn't use scaffold, here's a sample Dockerfile:
 === "TypeScript"
 
     ```dockerfile
-    FROM mcpmesh/typescript-runtime:3.6.0
+    FROM mcpmesh/typescript-runtime:3.7.0
 
     WORKDIR /app/agent
     COPY ./my-agent/package*.json ./
@@ -284,12 +284,12 @@ version: "3.8"
 
 services:
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     ports:
       - "8000:8000"
 
   auth-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     volumes:
       - ./agents/auth:/app/agent:ro
     command: ["python", "/app/agent/main.py"]
@@ -298,7 +298,7 @@ services:
       - MCP_MESH_HTTP_PORT=8080
 
   data-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     volumes:
       - ./agents/data:/app/agent:ro
     command: ["python", "/app/agent/main.py"]
@@ -307,7 +307,7 @@ services:
       - MCP_MESH_HTTP_PORT=8080
 
   api-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     volumes:
       - ./agents/api:/app/agent:ro
     command: ["python", "/app/agent/main.py"]

--- a/docs/03-docker-deployment/04-networking.md
+++ b/docs/03-docker-deployment/04-networking.md
@@ -31,12 +31,12 @@ graph TD
     # docker-compose.yml
     services:
       registry:
-        image: mcpmesh/registry:3.6.0
+        image: mcpmesh/registry:3.7.0
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/python-runtime:3.6.0
+        image: mcpmesh/python-runtime:3.7.0
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["python", "/app/agent/main.py"]
@@ -44,7 +44,7 @@ graph TD
           - MCP_MESH_REGISTRY_URL=http://registry:8000
 
       another-agent:
-        image: mcpmesh/python-runtime:3.6.0
+        image: mcpmesh/python-runtime:3.7.0
         volumes:
           - ./another-agent:/app/agent:ro
         command: ["python", "/app/agent/main.py"]
@@ -62,12 +62,12 @@ graph TD
     # docker-compose.yml
     services:
       registry:
-        image: mcpmesh/registry:3.6.0
+        image: mcpmesh/registry:3.7.0
         ports:
           - "8000:8000"
 
       my-agent:
-        image: mcpmesh/typescript-runtime:3.6.0
+        image: mcpmesh/typescript-runtime:3.7.0
         volumes:
           - ./my-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]
@@ -75,7 +75,7 @@ graph TD
           - MCP_MESH_REGISTRY_URL=http://registry:8000
 
       another-agent:
-        image: mcpmesh/typescript-runtime:3.6.0
+        image: mcpmesh/typescript-runtime:3.7.0
         volumes:
           - ./another-agent:/app/agent:ro
         command: ["npx", "tsx", "/app/agent/src/index.ts"]

--- a/docs/04-kubernetes-basics.md
+++ b/docs/04-kubernetes-basics.md
@@ -18,7 +18,7 @@ The `mcp-mesh-core` chart deploys registry + PostgreSQL + Redis + Grafana + Temp
 ```bash
 # Deploy core (OCI registry - no "helm repo add" needed)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh --create-namespace
 
 # Wait for registry
@@ -68,7 +68,7 @@ Build the image:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=my-agent \
@@ -79,7 +79,7 @@ For cloud deployments, use your full registry path:
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   --namespace mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
@@ -141,7 +141,7 @@ resources:
 ```bash
 # Core without Grafana/Tempo (lighter footprint)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh --create-namespace \
   --set grafana.enabled=false \
   --set tempo.enabled=false
@@ -152,7 +152,7 @@ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
 ```bash
 # Just the registry, no database or observability
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 3.6.0 \
+  --version 3.7.0 \
   --namespace mcp-mesh
 ```
 
@@ -164,12 +164,12 @@ namespace — change `-n` and nothing else:
 ```bash
 # Deploy core to a custom namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n my-namespace --create-namespace
 
 # Deploy agent to the same namespace
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n my-namespace \
   -f helm-values.yaml
 ```
@@ -182,12 +182,12 @@ For **multi-tenant** clusters (separate core per team), deploy each core to its 
 ```bash
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n team-a --create-namespace
 
 # Team B — same values, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n team-b --create-namespace
 ```
 
@@ -195,7 +195,7 @@ For **cross-namespace** access (agent in one namespace, core in another), use FQ
 
 ```bash
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 -n other-ns \
+  --version 3.7.0 -n other-ns \
   --set mesh.registryUrl=http://mcp-core-mcp-mesh-registry.team-a.svc.cluster.local:8000
 ```
 
@@ -207,13 +207,13 @@ helm list -n mcp-mesh
 
 # Upgrade an agent
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   --namespace mcp-mesh \
   --set image.tag=v2
 
 # Scale replicas
 helm upgrade my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   --namespace mcp-mesh \
   --reuse-values \
   --set replicaCount=3

--- a/docs/04-kubernetes-basics/05-troubleshooting.md
+++ b/docs/04-kubernetes-basics/05-troubleshooting.md
@@ -373,7 +373,7 @@ kubectl exec <pod-name> -n mcp-mesh -- df -h
 **Symptoms:**
 
 ```
-Failed to pull image "mcpmesh/python-runtime:3.6.0": rpc error: code = Unknown desc = Error response from daemon: pull access denied
+Failed to pull image "mcpmesh/python-runtime:3.7.0": rpc error: code = Unknown desc = Error response from daemon: pull access denied
 ```
 
 **Solutions:**

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -146,7 +146,7 @@ field that broke CI while local environments stayed green (#1453).
 
 ## :star: Project Status
 
-- **Latest Release**: v3.6.0
+- **Latest Release**: v3.7.0
 - **Languages**: Python 3.11+, TypeScript/Node.js 18+, and Java 17+ (runtime), Go 1.23+ (registry)
 - **Status**: Production-ready, actively developed
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,7 @@ docker-compose up
 ```bash
 # Quick start (OCI registry - no helm repo add needed)
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 3.6.0 -n mcp-mesh --create-namespace
+  --version 3.7.0 -n mcp-mesh --create-namespace
 ```
 
 [:material-arrow-right: Kubernetes Guide](04-kubernetes-basics.md){ .md-button .md-button--primary }
@@ -117,7 +117,7 @@ For Kubernetes, configure TLS via Helm values:
 
 ```bash
 helm install mcp-registry oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-registry \
-  --version 3.6.0 -n mcp-mesh --create-namespace \
+  --version 3.7.0 -n mcp-mesh --create-namespace \
   --set registry.security.tls.mode=strict \
   --set registry.security.trust.backend=k8s-secrets
 ```

--- a/docs/dev-to-production.md
+++ b/docs/dev-to-production.md
@@ -85,10 +85,10 @@ The [TSuite](https://github.com/dhyansraj/mcp-mesh-test-suite) integration testi
 
     ```bash
     helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-      --version 3.6.0 -n mcp-mesh --create-namespace
+      --version 3.7.0 -n mcp-mesh --create-namespace
 
     helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 3.6.0 -n mcp-mesh -f helm-values.yaml
+      --version 3.7.0 -n mcp-mesh -f helm-values.yaml
     ```
 
 Same agent code runs locally, in Docker, and in Kubernetes — no changes needed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ The same agent, in each language.
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0</version>
     </dependency>
     ```
 

--- a/docs/java/examples.md
+++ b/docs/java/examples.md
@@ -132,7 +132,7 @@ class AssistantAgentTest {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     ports:
       - "8000:8000"
     healthcheck:

--- a/docs/java/getting-started/index.md
+++ b/docs/java/getting-started/index.md
@@ -89,7 +89,7 @@ Create `pom.xml`:
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>3.6.0</version>
+            <version>3.7.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/docs/java/getting-started/prerequisites.md
+++ b/docs/java/getting-started/prerequisites.md
@@ -60,7 +60,7 @@ Add the Spring Boot starter to your `pom.xml`:
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -108,10 +108,10 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.6.0`           | Registry service            |
-| `mcpmesh/python-runtime:3.6.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.6.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.6.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.7.0`           | Registry service            |
+| `mcpmesh/python-runtime:3.7.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.7.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.7.0` | TypeScript runtime with SDK |
 
 Java agents use standard Maven-based Docker builds (see Docker Deployment guide).
 

--- a/docs/java/index.md
+++ b/docs/java/index.md
@@ -27,7 +27,7 @@ The MCP Mesh Java SDK provides an annotation-based API for building distributed 
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>3.6.0</version>
+    <version>3.7.0</version>
 </dependency>
 ```
 

--- a/docs/java/local-development/01-getting-started.md
+++ b/docs/java/local-development/01-getting-started.md
@@ -45,7 +45,7 @@ The recommended way is to use `meshctl scaffold` (see next page). If you prefer 
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/docs/java/local-development/troubleshooting.md
+++ b/docs/java/local-development/troubleshooting.md
@@ -38,7 +38,7 @@ Ensure the dependency version matches an available release:
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>3.6.0</version>
+    <version>3.7.0</version>
 </dependency>
 ```
 

--- a/docs/java/spring-boot-integration.md
+++ b/docs/java/spring-boot-integration.md
@@ -23,7 +23,7 @@ MCP Mesh provides the `@MeshRoute` annotation for Spring Boot REST controllers t
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/docs/python/getting-started/prerequisites.md
+++ b/docs/python/getting-started/prerequisites.md
@@ -97,17 +97,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.6.0`           | Registry service            |
-| `mcpmesh/python-runtime:3.6.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.6.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.6.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.7.0`           | Registry service            |
+| `mcpmesh/python-runtime:3.7.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.7.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.7.0` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:3.6.0
-docker pull mcpmesh/python-runtime:3.6.0
-docker pull mcpmesh/java-runtime:3.6.0
-docker pull mcpmesh/typescript-runtime:3.6.0
+docker pull mcpmesh/registry:3.7.0
+docker pull mcpmesh/python-runtime:3.7.0
+docker pull mcpmesh/java-runtime:3.7.0
+docker pull mcpmesh/typescript-runtime:3.7.0
 ```
 
 ### Generate Docker Compose
@@ -145,12 +145,12 @@ Available from OCI registry (no `helm repo add` needed):
 ```bash
 # Install core infrastructure
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/docs/tutorial/day-08-docker-compose.md
+++ b/docs/tutorial/day-08-docker-compose.md
@@ -379,7 +379,7 @@ $ docker compose down -v
 ## Troubleshooting
 
 **Docker build fails with missing requirements.** The compose file uses
-`mcpmesh/python-runtime:3.6.0` images with a dev-mode entrypoint that
+`mcpmesh/python-runtime:3.7.0` images with a dev-mode entrypoint that
 installs `requirements.txt` on startup. If an agent has dependencies not
 in the base image, check that `requirements.txt` exists in the agent
 directory and lists all dependencies.

--- a/docs/tutorial/day-09-kubernetes.md
+++ b/docs/tutorial/day-09-kubernetes.md
@@ -212,7 +212,7 @@ and Grafana as a single Helm release:
 
 ```shell
 $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-    --version 3.6.0 \
+    --version 3.7.0 \
     -n trip-planner \
     -f helm/values-core.yaml \
     --wait --timeout 5m
@@ -250,7 +250,7 @@ $ for agent in "${AGENTS[@]}"; do
     echo "Installing $agent..."
     helm install "$agent" \
       oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 3.6.0 \
+      --version 3.7.0 \
       -n trip-planner \
       -f "helm/values-${agent}.yaml"
   done

--- a/docs/typescript/examples.md
+++ b/docs/typescript/examples.md
@@ -127,7 +127,7 @@ describe("Agent Integration", () => {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     ports:
       - "8000:8000"
     healthcheck:

--- a/docs/typescript/getting-started/prerequisites.md
+++ b/docs/typescript/getting-started/prerequisites.md
@@ -85,17 +85,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.6.0`           | Registry service            |
-| `mcpmesh/python-runtime:3.6.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.6.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.6.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.7.0`           | Registry service            |
+| `mcpmesh/python-runtime:3.7.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.7.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.7.0` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:3.6.0
-docker pull mcpmesh/python-runtime:3.6.0
-docker pull mcpmesh/java-runtime:3.6.0
-docker pull mcpmesh/typescript-runtime:3.6.0
+docker pull mcpmesh/registry:3.7.0
+docker pull mcpmesh/python-runtime:3.7.0
+docker pull mcpmesh/java-runtime:3.7.0
+docker pull mcpmesh/typescript-runtime:3.7.0
 ```
 
 ### Generate Docker Compose

--- a/examples/docker-examples/agents/claude-provider/Dockerfile
+++ b/examples/docker-examples/agents/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/docker-examples/agents/claude-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/claude-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying claude-provider with mcp-mesh-agent chart
 # Usage: helm install claude-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 3.6.0 -f helm-values.yaml
+#        --version 3.7.0 -f helm-values.yaml
 
 image:
   repository: your-registry/claude-provider

--- a/examples/docker-examples/agents/claude-provider/requirements.txt
+++ b/examples/docker-examples/agents/claude-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=3.6.0
+mcp-mesh>=3.7.0
 
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0

--- a/examples/docker-examples/agents/openai-provider/Dockerfile
+++ b/examples/docker-examples/agents/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/docker-examples/agents/openai-provider/helm-values.yaml
+++ b/examples/docker-examples/agents/openai-provider/helm-values.yaml
@@ -1,6 +1,6 @@
 # Helm values for deploying openai-provider with mcp-mesh-agent chart
 # Usage: helm install openai-provider oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#        --version 3.6.0 -f helm-values.yaml
+#        --version 3.7.0 -f helm-values.yaml
 
 image:
   repository: your-registry/openai-provider

--- a/examples/docker-examples/agents/openai-provider/requirements.txt
+++ b/examples/docker-examples/agents/openai-provider/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Mesh SDK
-mcp-mesh>=3.6.0
+mcp-mesh>=3.7.0
 
 # FastMCP for MCP server
 fastmcp>=3.0.0,<4.0.0

--- a/examples/docker-examples/docker-compose.llm-delegation.yml
+++ b/examples/docker-examples/docker-compose.llm-delegation.yml
@@ -53,7 +53,7 @@ services:
       - mcp-mesh-llm-delegation-test
 
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     container_name: mcp-mesh-registry-llm-delegation-test
     ports:
       - "8002:8000"
@@ -78,7 +78,7 @@ services:
 
   # Test PT-008: LLM Provider Registration
   test-pt-008-provider:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-pt-008-provider
     profiles:
       - test-pt-008
@@ -116,7 +116,7 @@ services:
 
   # Test PT-009: Basic Mesh Delegation - Provider
   test-pt-009-provider:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-pt-009-provider
     profiles:
       - test-pt-009
@@ -154,7 +154,7 @@ services:
 
   # Test PT-009: Basic Mesh Delegation - Consumer
   test-pt-009-consumer:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-pt-009-consumer
     profiles:
       - test-pt-009

--- a/examples/docker-examples/docker-compose.llm-tests.yml
+++ b/examples/docker-examples/docker-compose.llm-tests.yml
@@ -64,7 +64,7 @@ services:
 
   # MCP Mesh Registry
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     container_name: mcp-mesh-registry-llm-test
     ports:
       - "8000:8000"
@@ -105,7 +105,7 @@ services:
 
   # System Agent - provides date_service, info, uptime_info capabilities
   system-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-system-agent-llm-test
     hostname: system-agent
     ports:
@@ -160,7 +160,7 @@ services:
 
   # Test 1: Basic LLM Agent (no tools)
   test-001-basic-llm:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-001-basic-llm
     hostname: test-001-basic-llm
     ports:
@@ -216,7 +216,7 @@ services:
 
   # Test 2: LLM Agent with Time Tools
   test-002-chat-with-time:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-002-chat-with-time
     hostname: test-002-chat-with-time
     ports:
@@ -272,7 +272,7 @@ services:
 
   # Test 3: Multi-Tool Chat Agent
   test-003-multi-tool:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-003-multi-tool
     hostname: test-003-multi-tool
     ports:
@@ -328,7 +328,7 @@ services:
 
   # Test 4a: System Analyst LLM Agent (specialist)
   test-004-analyst:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-004-analyst
     hostname: test-004-analyst
     ports:
@@ -384,7 +384,7 @@ services:
 
   # Test 4b: Orchestrator LLM Agent (coordinator)
   test-004-orchestrator:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-004-orchestrator
     hostname: test-004-orchestrator
     ports:

--- a/examples/docker-examples/docker-compose.multi-agent-poc.yml
+++ b/examples/docker-examples/docker-compose.multi-agent-poc.yml
@@ -39,7 +39,7 @@ services:
       - mcp-mesh-ma-poc
 
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     container_name: mcp-mesh-registry-ma-poc
     ports:
       - "8003:8000"
@@ -64,7 +64,7 @@ services:
 
   # Executor Agent - Provides basic tools (bash, write_file, read_file, grep_files)
   executor-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-executor-agent
     environment:
       MCP_MESH_REGISTRY_URL: http://registry:8000
@@ -101,7 +101,7 @@ services:
 
   # Claude Provider - LLM provider for specialist agents (Preferred)
   claude-provider:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-claude-provider
     environment:
       MCP_MESH_REGISTRY_URL: http://registry:8000
@@ -137,7 +137,7 @@ services:
 
   # OpenAI Provider - LLM provider for specialist agents (Fallback)
   openai-provider:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-openai-provider
     environment:
       MCP_MESH_REGISTRY_URL: http://registry:8000
@@ -173,7 +173,7 @@ services:
 
   # Developer Agent - Software development specialist using mesh delegation
   developer-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-developer-agent
     environment:
       MCP_MESH_REGISTRY_URL: http://registry:8000
@@ -213,7 +213,7 @@ services:
 
   # QA Agent - Quality Assurance specialist
   qa-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-qa-agent
     environment:
       MCP_MESH_REGISTRY_URL: http://registry:8000
@@ -253,7 +253,7 @@ services:
 
   # Intent Agent - Conversational orchestrator
   intent-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-intent-agent
     environment:
       MCP_MESH_REGISTRY_URL: http://registry:8000

--- a/examples/docker-examples/docker-compose.prompt-templates.yml
+++ b/examples/docker-examples/docker-compose.prompt-templates.yml
@@ -54,7 +54,7 @@ services:
       - mcp-mesh-prompt-template-test
 
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     container_name: mcp-mesh-registry-prompt-template-test
     ports:
       - "8002:8000" # Different port
@@ -79,7 +79,7 @@ services:
 
   # System agent (provides base tools for tests)
   system-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-system-agent-prompt-template-test
     environment:
       MCP_MESH_REGISTRY_URL: http://registry:8000
@@ -111,7 +111,7 @@ services:
 
   # Test PT-001: Basic Template with Dict Context
   test-pt-001-basic-template:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-pt-001-basic-template
     profiles:
       - test-pt-001
@@ -149,7 +149,7 @@ services:
 
   # Test PT-002: MeshContextModel with Field Descriptions
   test-pt-002-context-model:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-pt-002-context-model
     profiles:
       - test-pt-002
@@ -189,7 +189,7 @@ services:
 
   # Test PT-003: Convention-Based Context Detection
   test-pt-003-convention:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-pt-003-convention
     profiles:
       - test-pt-003
@@ -227,7 +227,7 @@ services:
 
   # Test PT-004: Control Structures
   test-pt-004-control-structures:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-pt-004-control-structures
     profiles:
       - test-pt-004
@@ -267,7 +267,7 @@ services:
 
   # Test PT-005: Hierarchical Context Models
   test-pt-005-hierarchical:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-pt-005-hierarchical
     profiles:
       - test-pt-005
@@ -307,7 +307,7 @@ services:
 
   # Test PT-006: LLM Chain - Analyzer
   test-pt-006-analyzer:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-pt-006-analyzer
     profiles:
       - test-pt-006
@@ -345,7 +345,7 @@ services:
 
   # Test PT-006: LLM Chain - Orchestrator
   test-pt-006-orchestrator:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-pt-006-orchestrator
     profiles:
       - test-pt-006
@@ -385,7 +385,7 @@ services:
 
   # Test PT-007: Dual Injection (LLM + MCP Agent)
   test-pt-007-dual-injection:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-test-pt-007-dual-injection
     profiles:
       - test-pt-007

--- a/examples/docker-examples/docker-compose.yml
+++ b/examples/docker-examples/docker-compose.yml
@@ -2,12 +2,12 @@
 # Demonstrates Go registry + Python agents architecture using published Docker images
 #
 # Services:
-# - registry: Go-based registry with SQLite storage (mcpmesh/registry:3.6.0)
-# - hello-world-agent: Python agent with greeting capabilities (mcpmesh/python-runtime:3.6.0)
-# - system-agent: Python agent with system monitoring capabilities (mcpmesh/python-runtime:3.6.0)
-# - fastmcp-agent: FastMCP service with mesh integration (mcpmesh/python-runtime:3.6.0)
-# - dependent-agent: Service that depends on fastmcp-agent (mcpmesh/python-runtime:3.6.0)
-# - fastapi-app: FastAPI application with mesh integration (mcpmesh/python-runtime:3.6.0)
+# - registry: Go-based registry with SQLite storage (mcpmesh/registry:3.7.0)
+# - hello-world-agent: Python agent with greeting capabilities (mcpmesh/python-runtime:3.7.0)
+# - system-agent: Python agent with system monitoring capabilities (mcpmesh/python-runtime:3.7.0)
+# - fastmcp-agent: FastMCP service with mesh integration (mcpmesh/python-runtime:3.7.0)
+# - dependent-agent: Service that depends on fastmcp-agent (mcpmesh/python-runtime:3.7.0)
+# - fastapi-app: FastAPI application with mesh integration (mcpmesh/python-runtime:3.7.0)
 #
 # Usage:
 #   docker-compose up
@@ -69,7 +69,7 @@ services:
 
   # Go-based registry service (built locally)
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     container_name: mcp-mesh-registry
     ports:
       - "8000:8000"
@@ -115,7 +115,7 @@ services:
 
   # Hello World Python agent - built locally
   hello-world-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-hello-world
     hostname: hello-world-agent
     ports:
@@ -168,7 +168,7 @@ services:
 
   # System Agent Python service - built locally
   system-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-system-agent
     hostname: system-agent
     ports:
@@ -221,7 +221,7 @@ services:
 
   # FastMCP Agent with mesh integration - built locally
   fastmcp-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-fastmcp-agent
     hostname: fastmcp-agent
     ports:
@@ -274,7 +274,7 @@ services:
 
   # Dependent Agent that uses FastMCP agent's time service - built locally
   dependent-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-dependent-agent
     hostname: dependent-agent
     ports:
@@ -327,7 +327,7 @@ services:
 
   # FastAPI App with mesh integration - built locally
   fastapi-app:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-fastapi-app
     hostname: fastapi-app
     ports:
@@ -380,7 +380,7 @@ services:
 
   # Simple FastAPI Router App (Maya-style APIRouter pattern) - built locally
   simple-router-app:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-simple-router-app
     hostname: simple-router-app
     ports:
@@ -433,7 +433,7 @@ services:
 
   # LLM With Deps Agent - demonstrates both static dependencies AND LLM provider
   llm-with-deps-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-llm-with-deps
     hostname: llm-with-deps-agent
     ports:
@@ -485,7 +485,7 @@ services:
 
   # OpenAI LLM Provider - Provides OpenAI GPT API access to mesh
   openai-provider:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-openai-provider
     hostname: openai-provider
     ports:
@@ -539,7 +539,7 @@ services:
 
   # Claude LLM Provider - Provides Anthropic Claude API access to mesh
   claude-provider:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: mcp-mesh-claude-provider
     hostname: claude-provider
     ports:

--- a/examples/java/basic-tool-agent/pom.xml
+++ b/examples/java/basic-tool-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/benchmark-chain/svc-a/pom.xml
+++ b/examples/java/benchmark-chain/svc-a/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-b/pom.xml
+++ b/examples/java/benchmark-chain/svc-b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-c/pom.xml
+++ b/examples/java/benchmark-chain/svc-c/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-d/pom.xml
+++ b/examples/java/benchmark-chain/svc-d/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/benchmark-chain/svc-e/pom.xml
+++ b/examples/java/benchmark-chain/svc-e/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/consumer-date-agent/pom.xml
+++ b/examples/java/consumer-date-agent/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/consumer-report-agent-sse/pom.xml
+++ b/examples/java/consumer-report-agent-sse/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/consumer-report-agent/pom.xml
+++ b/examples/java/consumer-report-agent/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/dependency-agent/pom.xml
+++ b/examples/java/dependency-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/direct-openai-agent/pom.xml
+++ b/examples/java/direct-openai-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/java/employee-service/pom.xml
+++ b/examples/java/employee-service/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/gemini-provider-agent/pom.xml
+++ b/examples/java/gemini-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/java/gpt-provider-agent/pom.xml
+++ b/examples/java/gpt-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/java/header-api/pom.xml
+++ b/examples/java/header-api/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/health-block-test-agent/pom.xml
+++ b/examples/java/health-block-test-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-accurate-provider/pom.xml
+++ b/examples/java/java-accurate-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-alpha-provider/pom.xml
+++ b/examples/java/java-alpha-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-beta-provider/pom.xml
+++ b/examples/java/java-beta-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-booking-consumer/pom.xml
+++ b/examples/java/java-booking-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-calculator/pom.xml
+++ b/examples/java/java-calculator/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-deprecated-provider/pom.xml
+++ b/examples/java/java-deprecated-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-dual-consumer/pom.xml
+++ b/examples/java/java-dual-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-fast-provider/pom.xml
+++ b/examples/java/java-fast-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-math-agent/pom.xml
+++ b/examples/java/java-math-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-schedule-agent/pom.xml
+++ b/examples/java/java-schedule-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-tag-consumer/pom.xml
+++ b/examples/java/java-tag-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/java-weather-agent/pom.xml
+++ b/examples/java/java-weather-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/llm-mesh-agent/pom.xml
+++ b/examples/java/llm-mesh-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/llm-provider-agent/pom.xml
+++ b/examples/java/llm-provider-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/java/media-consumer-agent/pom.xml
+++ b/examples/java/media-consumer-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/media-producer-agent/pom.xml
+++ b/examples/java/media-producer-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/multijar-api-gateway/pom.xml
+++ b/examples/java/multijar-api-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/multijar-payment-service/pom.xml
+++ b/examples/java/multijar-payment-service/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/producer-date-agent/pom.xml
+++ b/examples/java/producer-date-agent/pom.xml
@@ -29,7 +29,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/java/producer-report-agent/pom.xml
+++ b/examples/java/producer-report-agent/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/rest-api-consumer/pom.xml
+++ b/examples/java/rest-api-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/service-view/caption-provider/Dockerfile
+++ b/examples/java/service-view/caption-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for caption-provider MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.6.0
+FROM mcpmesh/java-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/java/service-view/caption-provider/pom.xml
+++ b/examples/java/service-view/caption-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/service-view/media-gateway/Dockerfile
+++ b/examples/java/service-view/media-gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for media-gateway MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.6.0
+FROM mcpmesh/java-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/java/service-view/media-gateway/pom.xml
+++ b/examples/java/service-view/media-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/service-view/thumbnail-provider/Dockerfile
+++ b/examples/java/service-view/thumbnail-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for thumbnail-provider MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.6.0
+FROM mcpmesh/java-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/java/service-view/thumbnail-provider/pom.xml
+++ b/examples/java/service-view/thumbnail-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/java/service-view/transcribe-provider/Dockerfile
+++ b/examples/java/service-view/transcribe-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for transcribe-provider MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.6.0
+FROM mcpmesh/java-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/java/service-view/transcribe-provider/pom.xml
+++ b/examples/java/service-view/transcribe-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/jobs-java/event-aware-consumer-java/pom.xml
+++ b/examples/jobs-java/event-aware-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/event-aware-provider-java/pom.xml
+++ b/examples/jobs-java/event-aware-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/long-task-consumer-java/pom.xml
+++ b/examples/jobs-java/long-task-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/long-task-provider-java/pom.xml
+++ b/examples/jobs-java/long-task-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/superseded-consumer-java/pom.xml
+++ b/examples/jobs-java/superseded-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/jobs-java/superseded-provider-java/pom.xml
+++ b/examples/jobs-java/superseded-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/observability-test/docker-compose.yml
+++ b/examples/observability-test/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       retries: 5
 
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     container_name: trace-test-registry
     hostname: registry
     ports:
@@ -61,7 +61,7 @@ services:
   # ============== Agents ==============
 
   orchestrator:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trace-test-orchestrator
     hostname: orchestrator
     ports:
@@ -114,7 +114,7 @@ services:
     restart: unless-stopped
 
   processor:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trace-test-processor
     hostname: processor
     ports:
@@ -164,7 +164,7 @@ services:
     restart: unless-stopped
 
   analyzer:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trace-test-analyzer
     hostname: analyzer
     ports:
@@ -214,7 +214,7 @@ services:
     restart: unless-stopped
 
   storage:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trace-test-storage
     hostname: storage
     ports:

--- a/examples/parallel-tools/consumer-claude-java/pom.xml
+++ b/examples/parallel-tools/consumer-claude-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-gemini-java/pom.xml
+++ b/examples/parallel-tools/consumer-gemini-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-gemini-ts/package.json
+++ b/examples/parallel-tools/consumer-gemini-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/consumer-openai-java/pom.xml
+++ b/examples/parallel-tools/consumer-openai-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/consumer-openai-ts/package.json
+++ b/examples/parallel-tools/consumer-openai-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/parallel-consumer-java/pom.xml
+++ b/examples/parallel-tools/parallel-consumer-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/parallel-consumer-ts/package.json
+++ b/examples/parallel-tools/parallel-consumer-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/parallel-tools/slow-tool-java/pom.xml
+++ b/examples/parallel-tools/slow-tool-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/parallel-tools/slow-tool-ts/package.json
+++ b/examples/parallel-tools/slow-tool-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/python/service-view/caption-provider/Dockerfile
+++ b/examples/python/service-view/caption-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for caption-provider MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/python/service-view/media-gateway/Dockerfile
+++ b/examples/python/service-view/media-gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for media-gateway MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/python/service-view/thumbnail-provider/Dockerfile
+++ b/examples/python/service-view/thumbnail-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for thumbnail-provider MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/python/service-view/transcribe-provider/Dockerfile
+++ b/examples/python/service-view/transcribe-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for transcribe-provider MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/required-dependency/java/data-provider/Dockerfile
+++ b/examples/required-dependency/java/data-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for data-provider MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.6.0
+FROM mcpmesh/java-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/required-dependency/java/data-provider/pom.xml
+++ b/examples/required-dependency/java/data-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/required-dependency/java/report-consumer/Dockerfile
+++ b/examples/required-dependency/java/report-consumer/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for report-consumer MCP Mesh agent (Java/Spring Boot)
-FROM mcpmesh/java-runtime:3.6.0
+FROM mcpmesh/java-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/required-dependency/java/report-consumer/pom.xml
+++ b/examples/required-dependency/java/report-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/examples/required-dependency/python/data-provider/Dockerfile
+++ b/examples/required-dependency/python/data-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for data-provider MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/required-dependency/python/report-consumer/Dockerfile
+++ b/examples/required-dependency/python/report-consumer/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for report-consumer MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/schema-corpus/java/pom.xml
+++ b/examples/schema-corpus/java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/consumer/pom.xml
+++ b/examples/schema/java/consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/producer-bad/pom.xml
+++ b/examples/schema/java/producer-bad/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/schema/java/producer-good/pom.xml
+++ b/examples/schema/java/producer-good/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/streaming/chatbot-demo/chatbot-agent/Dockerfile
+++ b/examples/streaming/chatbot-demo/chatbot-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chatbot-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/streaming/chatbot-demo/gateway/Dockerfile
+++ b/examples/streaming/chatbot-demo/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/streaming/chatbot-demo/weather-tool/Dockerfile
+++ b/examples/streaming/chatbot-demo/weather-tool/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/chatbot-agent/Dockerfile
+++ b/examples/streaming/fixtures/chatbot-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chatbot-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/gateway-agent/Dockerfile
+++ b/examples/streaming/fixtures/gateway-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway-agent MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/streaming/fixtures/passthrough-agent/Dockerfile
+++ b/examples/streaming/fixtures/passthrough-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for passthrough-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-java/pom.xml
+++ b/examples/toolcalls/analyst-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/toolcalls/analyst-py/Dockerfile
+++ b/examples/toolcalls/analyst-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for analyst-py MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-ts/Dockerfile
+++ b/examples/toolcalls/analyst-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for analyst-ts MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/analyst-ts/package.json
+++ b/examples/toolcalls/analyst-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/claude-provider-java/pom.xml
+++ b/examples/toolcalls/claude-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/claude-provider-py/Dockerfile
+++ b/examples/toolcalls/claude-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/claude-provider-ts/Dockerfile
+++ b/examples/toolcalls/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/claude-provider-ts/package.json
+++ b/examples/toolcalls/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/gemini-provider-java/pom.xml
+++ b/examples/toolcalls/gemini-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/gemini-provider-py/Dockerfile
+++ b/examples/toolcalls/gemini-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/gemini-provider-ts/Dockerfile
+++ b/examples/toolcalls/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/gemini-provider-ts/package.json
+++ b/examples/toolcalls/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/openai-provider-java/pom.xml
+++ b/examples/toolcalls/openai-provider-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
         <spring-ai.version>2.0.0</spring-ai.version>
     </properties>
 

--- a/examples/toolcalls/openai-provider-py/Dockerfile
+++ b/examples/toolcalls/openai-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-py MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/openai-provider-ts/Dockerfile
+++ b/examples/toolcalls/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/openai-provider-ts/package.json
+++ b/examples/toolcalls/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/toolcalls/weather-tool-java/pom.xml
+++ b/examples/toolcalls/weather-tool-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/examples/toolcalls/weather-tool-py/Dockerfile
+++ b/examples/toolcalls/weather-tool-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool-py MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/weather-tool-ts/Dockerfile
+++ b/examples/toolcalls/weather-tool-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-tool-ts MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/toolcalls/weather-tool-ts/package.json
+++ b/examples/toolcalls/weather-tool-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/tutorial/trip-planner/day-01/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-01/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-02/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-02/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-03/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-03/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-04/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-04/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-05/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-05/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-06/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-06/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-07/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-07/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/docker-compose.yml
+++ b/examples/tutorial/trip-planner/day-08/python/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - trip-planner-network
 
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     container_name: trip-planner-registry
     hostname: registry
     ports:
@@ -81,7 +81,7 @@ services:
 
   # --8<-- [start:mesh_ui]
   mesh-ui:
-    image: mcpmesh/ui:3.6.0
+    image: mcpmesh/ui:3.7.0
     container_name: trip-planner-mesh-ui
     hostname: mesh-ui
     ports:
@@ -172,7 +172,7 @@ services:
   # --8<-- [start:gateway]
   # FastAPI Gateway: manually added (scaffold detects @mesh.agent, not @mesh.route)
   gateway:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trip-planner-gateway
     hostname: gateway
     user: root
@@ -213,7 +213,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   adventure-advisor:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trip-planner-adventure-advisor
     hostname: adventure-advisor
     user: root
@@ -256,7 +256,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   budget-analyst:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trip-planner-budget-analyst
     hostname: budget-analyst
     user: root
@@ -299,7 +299,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   chat-history-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trip-planner-chat-history-agent
     hostname: chat-history-agent
     user: root
@@ -342,7 +342,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   claude-provider:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trip-planner-claude-provider
     hostname: claude-provider
     user: root
@@ -386,7 +386,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   flight-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trip-planner-flight-agent
     hostname: flight-agent
     user: root
@@ -429,7 +429,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   hotel-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trip-planner-hotel-agent
     hostname: hotel-agent
     user: root
@@ -472,7 +472,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   logistics-planner:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trip-planner-logistics-planner
     hostname: logistics-planner
     user: root
@@ -515,7 +515,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   openai-provider:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trip-planner-openai-provider
     hostname: openai-provider
     user: root
@@ -559,7 +559,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   planner-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trip-planner-planner-agent
     hostname: planner-agent
     user: root
@@ -602,7 +602,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   poi-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trip-planner-poi-agent
     hostname: poi-agent
     user: root
@@ -645,7 +645,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   user-prefs-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trip-planner-user-prefs-agent
     hostname: user-prefs-agent
     user: root
@@ -688,7 +688,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   weather-agent:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: trip-planner-weather-agent
     hostname: weather-agent
     user: root

--- a/examples/tutorial/trip-planner/day-08/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-08/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-08/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/helm/install.sh
+++ b/examples/tutorial/trip-planner/day-09/helm/install.sh
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 NAMESPACE="trip-planner"
-CHART_VERSION="3.6.0"
+CHART_VERSION="3.7.0"
 AGENT_CHART="oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent"
 CORE_CHART="oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/examples/tutorial/trip-planner/day-09/helm/values-core.yaml
+++ b/examples/tutorial/trip-planner/day-09/helm/values-core.yaml
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-#     --version 3.6.0 -n trip-planner --create-namespace -f values-core.yaml
+#     --version 3.7.0 -n trip-planner --create-namespace -f values-core.yaml
 
 # install.sh creates the namespace with kubectl; the chart renders no Namespace
 # of its own — see "Namespace handling" in the mcp-mesh-core chart README.

--- a/examples/tutorial/trip-planner/day-09/helm/values-flight-agent.yaml
+++ b/examples/tutorial/trip-planner/day-09/helm/values-flight-agent.yaml
@@ -1,7 +1,7 @@
 # --8<-- [start:full_file]
 # Helm values for flight-agent — scaffolded by meshctl, adapted for k8s
 # Usage: helm install flight-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#          --version 3.6.0 -n trip-planner -f values-flight-agent.yaml
+#          --version 3.7.0 -n trip-planner -f values-flight-agent.yaml
 
 image:
   repository: trip-planner/flight-agent

--- a/examples/tutorial/trip-planner/day-09/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-09/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-09/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh streaming API gateway
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/bonus-ui/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh streaming LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/helm/install.sh
+++ b/examples/tutorial/trip-planner/day-10/helm/install.sh
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 NAMESPACE="trip-planner"
-CHART_VERSION="3.6.0"
+CHART_VERSION="3.7.0"
 AGENT_CHART="oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent"
 CORE_CHART="oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/examples/tutorial/trip-planner/day-10/helm/values-core.yaml
+++ b/examples/tutorial/trip-planner/day-10/helm/values-core.yaml
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-#     --version 3.6.0 -n trip-planner --create-namespace -f values-core.yaml
+#     --version 3.7.0 -n trip-planner --create-namespace -f values-core.yaml
 
 # install.sh creates the namespace with kubectl; the chart renders no Namespace
 # of its own — see "Namespace handling" in the mcp-mesh-core chart README.

--- a/examples/tutorial/trip-planner/day-10/helm/values-flight-agent.yaml
+++ b/examples/tutorial/trip-planner/day-10/helm/values-flight-agent.yaml
@@ -1,7 +1,7 @@
 # --8<-- [start:full_file]
 # Helm values for flight-agent — scaffolded by meshctl, adapted for k8s
 # Usage: helm install flight-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-#          --version 3.6.0 -n trip-planner -f values-flight-agent.yaml
+#          --version 3.7.0 -n trip-planner -f values-flight-agent.yaml
 
 image:
   repository: trip-planner/flight-agent

--- a/examples/tutorial/trip-planner/day-10/python/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/day-10/python/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/day-10/python/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/adventure-advisor/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/adventure-advisor/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for adventure-advisor MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/budget-analyst/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/budget-analyst/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for budget-analyst MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/chat-history-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/chat-history-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for chat-history-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/claude-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/flight-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/flight-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for flight-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/gateway/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/gateway/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gateway MCP Mesh API gateway
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/hotel-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/hotel-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for hotel-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/k8s/helm/values-core.yaml
+++ b/examples/tutorial/trip-planner/final_product/k8s/helm/values-core.yaml
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-#     --version 3.6.0 -n trip-planner --create-namespace -f values-core.yaml
+#     --version 3.7.0 -n trip-planner --create-namespace -f values-core.yaml
 
 # install.sh creates the namespace with kubectl; the chart renders no Namespace
 # of its own — see "Namespace handling" in the mcp-mesh-core chart README.

--- a/examples/tutorial/trip-planner/final_product/k8s/install.sh
+++ b/examples/tutorial/trip-planner/final_product/k8s/install.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 
 NAMESPACE="${1:-trip-planner}"
 DRY_RUN=""
-CHART_VERSION="3.6.0"
+CHART_VERSION="3.7.0"
 AGENT_CHART="oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent"
 CORE_CHART="oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/examples/tutorial/trip-planner/final_product/logistics-planner/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/logistics-planner/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for logistics-planner MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/openai-provider/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/planner-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/planner-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for planner-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/poi-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/poi-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for poi-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/user-prefs-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/user-prefs-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for user-prefs-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/tutorial/trip-planner/final_product/weather-agent/Dockerfile
+++ b/examples/tutorial/trip-planner/final_product/weather-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for weather-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/typescript/benchmark-chain/svc-a/package.json
+++ b/examples/typescript/benchmark-chain/svc-a/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-b/package.json
+++ b/examples/typescript/benchmark-chain/svc-b/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-c/package.json
+++ b/examples/typescript/benchmark-chain/svc-c/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-d/package.json
+++ b/examples/typescript/benchmark-chain/svc-d/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/benchmark-chain/svc-e/package.json
+++ b/examples/typescript/benchmark-chain/svc-e/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/examples/typescript/context-self-dep-ts-mesh/Dockerfile
+++ b/examples/typescript/context-self-dep-ts-mesh/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for context-self-dep-ts-mesh MCP Mesh LLM agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/examples/typescript/header-api/package.json
+++ b/examples/typescript/header-api/package.json
@@ -11,7 +11,7 @@
     "dev": "tsx watch index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/examples/typescript/llm-consumer/package.json
+++ b/examples/typescript/llm-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/examples/typescript/llm-provider/package.json
+++ b/examples/typescript/llm-provider/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/helm/mcp-mesh-agent/Chart.yaml
+++ b/helm/mcp-mesh-agent/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-agent
 description: MCP Mesh Agent - Python runtime for MCP agents with mesh capabilities
 type: application
-version: 3.6.0
-appVersion: "3.6.0"
+version: 3.7.0
+appVersion: "3.7.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-agent/README.md
+++ b/helm/mcp-mesh-agent/README.md
@@ -255,7 +255,7 @@ existingSecret: my-secret
 ### Python
 
 ```dockerfile
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 COPY . /app/
 CMD ["-m", "myagent"]
@@ -264,7 +264,7 @@ CMD ["-m", "myagent"]
 ### TypeScript
 
 ```dockerfile
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 COPY . /app/
 CMD ["src/index.ts"]
@@ -273,7 +273,7 @@ CMD ["src/index.ts"]
 ### Java
 
 ```dockerfile
-FROM mcpmesh/java-runtime:3.6.0
+FROM mcpmesh/java-runtime:3.7.0
 
 COPY target/myagent.jar /app/
 CMD ["/app/myagent.jar"]

--- a/helm/mcp-mesh-agent/values.yaml
+++ b/helm/mcp-mesh-agent/values.yaml
@@ -45,7 +45,7 @@ image:
   repository: mcpmesh/python-runtime
   pullPolicy: IfNotPresent
   # Minor version tag tracks latest patch (0.8 → 0.8.x)
-  tag: "3.6"
+  tag: "3.7"
 
 # Pull secrets for this chart's pods, merged with global.imagePullSecrets
 # (deduplicated by name). Standard shape:

--- a/helm/mcp-mesh-core/Chart.lock
+++ b/helm/mcp-mesh-core/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: mcp-mesh-postgres
   repository: file://../mcp-mesh-postgres
-  version: 3.6.0
+  version: 3.7.0
 - name: mcp-mesh-redis
   repository: file://../mcp-mesh-redis
-  version: 3.6.0
+  version: 3.7.0
 - name: mcp-mesh-registry
   repository: file://../mcp-mesh-registry
-  version: 3.6.0
+  version: 3.7.0
 - name: mcp-mesh-grafana
   repository: file://../mcp-mesh-grafana
-  version: 3.6.0
+  version: 3.7.0
 - name: mcp-mesh-tempo
   repository: file://../mcp-mesh-tempo
-  version: 3.6.0
+  version: 3.7.0
 - name: mcp-mesh-ui
   repository: file://../mcp-mesh-ui
-  version: 3.6.0
+  version: 3.7.0
 digest: sha256:c6f1d7c4f6c45142e298d219a79825ffe99c0664e8f08a9f8ebdae86fbe9364f
 generated: "2026-08-07T09:54:06.327272-04:00"

--- a/helm/mcp-mesh-core/Chart.yaml
+++ b/helm/mcp-mesh-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-core
 description: MCP Mesh Core Infrastructure - Registry, PostgreSQL, Redis, and Observability
 type: application
-version: 3.6.0
-appVersion: "3.6.0"
+version: 3.7.0
+appVersion: "3.7.0"
 keywords:
   - mcp
   - mesh
@@ -28,26 +28,26 @@ annotations:
   "artifacthub.io/containsSecurityUpdates": "false"
 dependencies:
   - name: mcp-mesh-postgres
-    version: "3.6.0"
+    version: "3.7.0"
     repository: "file://../mcp-mesh-postgres"
     condition: postgres.enabled
   - name: mcp-mesh-redis
-    version: "3.6.0"
+    version: "3.7.0"
     repository: "file://../mcp-mesh-redis"
     condition: redis.enabled
   - name: mcp-mesh-registry
-    version: "3.6.0"
+    version: "3.7.0"
     repository: "file://../mcp-mesh-registry"
     condition: registry.enabled
   - name: mcp-mesh-grafana
-    version: "3.6.0"
+    version: "3.7.0"
     repository: "file://../mcp-mesh-grafana"
     condition: grafana.enabled
   - name: mcp-mesh-tempo
-    version: "3.6.0"
+    version: "3.7.0"
     repository: "file://../mcp-mesh-tempo"
     condition: tempo.enabled
   - name: mcp-mesh-ui
-    version: "3.6.0"
+    version: "3.7.0"
     repository: "file://../mcp-mesh-ui"
     condition: ui.enabled

--- a/helm/mcp-mesh-core/values.yaml
+++ b/helm/mcp-mesh-core/values.yaml
@@ -153,7 +153,7 @@ mcp-mesh-redis:
 mcp-mesh-registry:
   image:
     repository: mcpmesh/registry
-    tag: "3.6" # Minor version tracks latest patch
+    tag: "3.7" # Minor version tracks latest patch
   registry:
     # Database configuration (connects to PostgreSQL). The endpoint and
     # credentials are inherited from global.postgres above; set

--- a/helm/mcp-mesh-grafana/Chart.yaml
+++ b/helm/mcp-mesh-grafana/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-grafana
 description: Grafana observability component for MCP Mesh
 type: application
-version: 3.6.0
+version: 3.7.0
 appVersion: "12.3.1"
 keywords:
   - grafana

--- a/helm/mcp-mesh-ingress/Chart.yaml
+++ b/helm/mcp-mesh-ingress/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ingress
 description: Ingress configuration for MCP Mesh services with flexible DNS routing
 type: application
-version: 3.6.0
-appVersion: "3.6.0"
+version: 3.7.0
+appVersion: "3.7.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-postgres/Chart.yaml
+++ b/helm/mcp-mesh-postgres/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-postgres
 description: PostgreSQL database for MCP Mesh Registry
 type: application
-version: 3.6.0
+version: 3.7.0
 appVersion: "15"
 keywords:
   - mcp

--- a/helm/mcp-mesh-redis/Chart.yaml
+++ b/helm/mcp-mesh-redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-redis
 description: Redis cache for MCP Mesh session storage
 type: application
-version: 3.6.0
+version: 3.7.0
 appVersion: "7"
 keywords:
   - mcp

--- a/helm/mcp-mesh-registry/Chart.yaml
+++ b/helm/mcp-mesh-registry/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-registry
 description: MCP Mesh Registry Service - Central service registry for MCP agents
 type: application
-version: 3.6.0
-appVersion: "3.6.0"
+version: 3.7.0
+appVersion: "3.7.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-registry/values.yaml
+++ b/helm/mcp-mesh-registry/values.yaml
@@ -15,7 +15,7 @@ image:
   repository: mcpmesh/registry
   pullPolicy: IfNotPresent
   # Minor version tag tracks latest patch (0.8 → 0.8.x)
-  tag: "3.6"
+  tag: "3.7"
 
 # Image for the wait-for-db init container (rendered for non-sqlite databases;
 # disable the init container via registry.database.waitForDatabase: false).

--- a/helm/mcp-mesh-tempo/Chart.yaml
+++ b/helm/mcp-mesh-tempo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mcp-mesh-tempo
 description: Tempo distributed tracing component for MCP Mesh
 type: application
-version: 3.6.0
+version: 3.7.0
 appVersion: "2.9.0"
 keywords:
   - tempo

--- a/helm/mcp-mesh-ui/Chart.yaml
+++ b/helm/mcp-mesh-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mcp-mesh-ui
 description: MCP Mesh Dashboard UI Server - Web dashboard for monitoring MCP agents
 type: application
-version: 3.6.0
-appVersion: "3.6.0"
+version: 3.7.0
+appVersion: "3.7.0"
 keywords:
   - mcp
   - mesh

--- a/helm/mcp-mesh-ui/values.yaml
+++ b/helm/mcp-mesh-ui/values.yaml
@@ -7,7 +7,7 @@ image:
   registry: ""
   repository: mcpmesh/ui
   pullPolicy: IfNotPresent
-  tag: "3.6"
+  tag: "3.7"
 
 # Pull secrets for this chart's pods, merged with global.imagePullSecrets
 # (deduplicated by name). Standard shape:

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/cli",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "CLI for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration",
   "license": "MIT",
   "repository": {
@@ -23,10 +23,10 @@
     "node": ">=18"
   },
   "optionalDependencies": {
-    "@mcpmesh/cli-linux-x64": "3.6.0",
-    "@mcpmesh/cli-linux-arm64": "3.6.0",
-    "@mcpmesh/cli-darwin-x64": "3.6.0",
-    "@mcpmesh/cli-darwin-arm64": "3.6.0"
+    "@mcpmesh/cli-linux-x64": "3.7.0",
+    "@mcpmesh/cli-linux-arm64": "3.7.0",
+    "@mcpmesh/cli-darwin-x64": "3.7.0",
+    "@mcpmesh/cli-darwin-arm64": "3.7.0"
   },
   "keywords": [
     "mcp",

--- a/packaging/homebrew/mcp-mesh.rb
+++ b/packaging/homebrew/mcp-mesh.rb
@@ -2,7 +2,7 @@
 class McpMesh < Formula
   desc "Kubernetes-native platform for distributed MCP applications"
   homepage "https://github.com/dhyansraj/mcp-mesh"
-  version "3.6.0"  # Will be updated by release automation
+  version "3.7.0"  # Will be updated by release automation
 
   if OS.mac?
     if Hardware::CPU.arm?

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "3.6.0"
+version = "3.7.0"
 description = "Python SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration"
 readme = "README.md"
 license = { text = "MIT" }
@@ -58,7 +58,7 @@ requires-python = ">=3.11"
 # LiteLLM.
 dependencies = [
     # Rust core runtime (required - no Python fallback)
-    "mcp-mesh-core>=3.6.0",
+    "mcp-mesh-core>=3.7.0",
     # Floor raised to 0.135.0 (#1402). Anything below 0.133.0 is not merely
     # old, it is unresolvable against our own mcp/fastmcp pins: mcp==1.28.1
     # wants anyio>=4.5 while old FastAPI caps anyio<4.0.0, and fastmcp==3.4.3

--- a/packaging/scoop/mcp-mesh.json
+++ b/packaging/scoop/mcp-mesh.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Kubernetes-native platform for distributed MCP applications",
   "homepage": "https://github.com/dhyansraj/mcp-mesh",
   "license": "MIT",

--- a/src/core/cli/handlers/java_handler.go
+++ b/src/core/cli/handlers/java_handler.go
@@ -79,7 +79,7 @@ func (h *JavaHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns Java Dockerfile content
 func (h *JavaHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh Java agent
-FROM mcpmesh/java-runtime:3.6.0
+FROM mcpmesh/java-runtime:3.7.0
 
 WORKDIR /app
 
@@ -156,7 +156,7 @@ func (h *JavaHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the Java runtime Docker image
 func (h *JavaHandler) GetDockerImage() string {
-	return "mcpmesh/java-runtime:3.6.0"
+	return "mcpmesh/java-runtime:3.7.0"
 }
 
 // ValidatePrerequisites checks Java environment
@@ -304,7 +304,7 @@ const javaPomTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>3.6.0</version>
+            <version>3.7.0</version>
         </dependency>
     </dependencies>
 

--- a/src/core/cli/handlers/language_test.go
+++ b/src/core/cli/handlers/language_test.go
@@ -202,7 +202,7 @@ func TestDetectLanguage_PythonDirectoryRequirements(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Create requirements.txt
-	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==3.6.0"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "requirements.txt"), []byte("mcp-mesh==3.7.0"), 0644); err != nil {
 		t.Fatalf("Failed to create requirements.txt: %v", err)
 	}
 
@@ -401,7 +401,7 @@ func TestPythonHandler_GetDockerImage(t *testing.T) {
 	// Must equal the exact release tag GetDockerImage() ships (kept in sync by
 	// scripts/bump_version.py). Hard failure, not a log — this is the assertion
 	// that should have caught the 2.8.0 partial bump.
-	if want := "mcpmesh/python-runtime:3.6.0"; image != want {
+	if want := "mcpmesh/python-runtime:3.7.0"; image != want {
 		t.Errorf("GetDockerImage() = %q, want %q", image, want)
 	}
 }
@@ -415,7 +415,7 @@ func TestTypeScriptHandler_GetDockerImage(t *testing.T) {
 	// Must equal the exact release tag GetDockerImage() ships (kept in sync by
 	// scripts/bump_version.py). Hard failure, not a log — this is the assertion
 	// that should have caught the 2.8.0 partial bump.
-	if want := "mcpmesh/typescript-runtime:3.6.0"; image != want {
+	if want := "mcpmesh/typescript-runtime:3.7.0"; image != want {
 		t.Errorf("GetDockerImage() = %q, want %q", image, want)
 	}
 }

--- a/src/core/cli/handlers/python_handler.go
+++ b/src/core/cli/handlers/python_handler.go
@@ -86,7 +86,7 @@ func (h *PythonHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns Python Dockerfile content
 func (h *PythonHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh Python agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 
@@ -170,7 +170,7 @@ func (h *PythonHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the Python runtime Docker image
 func (h *PythonHandler) GetDockerImage() string {
-	return "mcpmesh/python-runtime:3.6.0"
+	return "mcpmesh/python-runtime:3.7.0"
 }
 
 // ValidatePrerequisites checks Python environment
@@ -248,5 +248,5 @@ const pythonInitTemplate = `# {{.Name}} MCP Mesh Agent
 const pythonMainModuleTemplate = `from .main import *
 `
 
-const pythonRequirementsTemplate = `mcp-mesh>=3.6.0
+const pythonRequirementsTemplate = `mcp-mesh>=3.7.0
 `

--- a/src/core/cli/handlers/typescript_handler.go
+++ b/src/core/cli/handlers/typescript_handler.go
@@ -92,7 +92,7 @@ func (h *TypeScriptHandler) GenerateAgent(config ScaffoldConfig) error {
 // GenerateDockerfile returns TypeScript Dockerfile content
 func (h *TypeScriptHandler) GenerateDockerfile() string {
 	return `# Dockerfile for MCP Mesh TypeScript agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 
@@ -167,7 +167,7 @@ func (h *TypeScriptHandler) ParseAgentFile(path string) (*AgentInfo, error) {
 
 // GetDockerImage returns the TypeScript runtime Docker image
 func (h *TypeScriptHandler) GetDockerImage() string {
-	return "mcpmesh/typescript-runtime:3.6.0"
+	return "mcpmesh/typescript-runtime:3.7.0"
 }
 
 // ValidatePrerequisites checks TypeScript environment
@@ -269,7 +269,7 @@ const typescriptPackageTemplate = `{
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "fastmcp": "^3.26.0",
     "zod": "^3.23.0"
   },

--- a/src/core/cli/man/content/deployment.md
+++ b/src/core/cli/man/content/deployment.md
@@ -10,12 +10,12 @@ MCP Mesh supports multiple deployment patterns from local development to product
 
 | Image                              | Description                                        |
 | ---------------------------------- | -------------------------------------------------- |
-| `mcpmesh/registry:3.6.0`             | Registry service for agent discovery               |
-| `mcpmesh/python-runtime:3.6.0`       | Python runtime with mcp-mesh SDK pre-installed     |
-| `mcpmesh/typescript-runtime:3.6.0`   | TypeScript runtime with @mcpmesh/sdk pre-installed |
-| `mcpmesh/java-runtime:3.6.0`         | Java runtime with mcp-mesh Spring Boot starter     |
-| `mcpmesh/ui:3.6.0`                   | Dashboard UI server (basePath: /ops/dashboard)     |
-| `mcpmesh/cli:3.6.0`                  | meshctl CLI for management                         |
+| `mcpmesh/registry:3.7.0`             | Registry service for agent discovery               |
+| `mcpmesh/python-runtime:3.7.0`       | Python runtime with mcp-mesh SDK pre-installed     |
+| `mcpmesh/typescript-runtime:3.7.0`   | TypeScript runtime with @mcpmesh/sdk pre-installed |
+| `mcpmesh/java-runtime:3.7.0`         | Java runtime with mcp-mesh Spring Boot starter     |
+| `mcpmesh/ui:3.7.0`                   | Dashboard UI server (basePath: /ops/dashboard)     |
+| `mcpmesh/cli:3.7.0`                  | meshctl CLI for management                         |
 
 ## Local Development
 
@@ -104,7 +104,7 @@ meshctl scaffold basic --name my-agent
 The generated Dockerfile uses the official runtime:
 
 ```dockerfile
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
@@ -132,7 +132,7 @@ meshctl scaffold --compose --observability
 Generated docker-compose.yml includes:
 
 - PostgreSQL database for registry
-- Registry service (`mcpmesh/registry:3.6.0`)
+- Registry service (`mcpmesh/registry:3.7.0`)
 - All detected agents with proper networking
 - Health checks and dependency ordering
 - Optional: Redis, Tempo, Grafana (with `--observability`)
@@ -155,12 +155,12 @@ For production Kubernetes deployment, use the official Helm charts from the MCP 
 # Install core infrastructure (registry + database + observability)
 # No "helm repo add" needed - uses OCI registry directly
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy agent using scaffold-generated helm-values.yaml
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -195,11 +195,11 @@ Deploy into any namespace — change `-n` and nothing else:
 
 ```bash
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n my-namespace --create-namespace
 
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n my-namespace \
   -f helm-values.yaml
 ```
@@ -218,19 +218,19 @@ its own namespace. Short service names resolve independently within each namespa
 ```bash
 # Team A
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n team-a --create-namespace
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 -n team-a -f greeter/helm-values.yaml
+  --version 3.7.0 -n team-a -f greeter/helm-values.yaml
 
 # Team B — same helm-values.yaml, different namespace
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n team-b --create-namespace
 
 helm install greeter oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 -n team-b -f greeter/helm-values.yaml
+  --version 3.7.0 -n team-b -f greeter/helm-values.yaml
 ```
 
 ### Available Helm Charts
@@ -284,7 +284,7 @@ docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.0.0 --pu
 # 3. Update helm-values.yaml with your image repository
 # 4. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \
@@ -296,14 +296,14 @@ helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
 ```bash
 # Core without observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh --create-namespace \
   --set grafana.enabled=false \
   --set tempo.enabled=false
 
 # Core without PostgreSQL (in-memory registry)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh --create-namespace \
   --set postgres.enabled=false
 ```
@@ -501,7 +501,7 @@ Or use the `mcp-mesh-ingress` chart which handles routing automatically.
 
 ```bash
 # Docker
-docker run -e MCP_MESH_UI_BASE_PATH=/my/custom/path mcpmesh/ui:3.6.0
+docker run -e MCP_MESH_UI_BASE_PATH=/my/custom/path mcpmesh/ui:3.7.0
 
 # Helm
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \

--- a/src/core/cli/man/content/deployment_java.md
+++ b/src/core/cli/man/content/deployment_java.md
@@ -16,7 +16,7 @@ MCP Mesh supports multiple deployment patterns for Java/Spring Boot agents. The 
 <dependency>
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-    <version>3.6.0</version>
+    <version>3.7.0</version>
 </dependency>
 ```
 
@@ -152,7 +152,7 @@ services:
       retries: 5
 
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     ports:
       - "8000:8000"
     environment:
@@ -207,12 +207,12 @@ For production Kubernetes deployment:
 # own. Run `meshctl man deployment` for the namespace rules, including
 # the upgrade order for a release installed with chart 3.4.x or earlier.
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy Java agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -249,7 +249,7 @@ docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.0.0 --pu
 
 # 2. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \

--- a/src/core/cli/man/content/deployment_typescript.md
+++ b/src/core/cli/man/content/deployment_typescript.md
@@ -10,8 +10,8 @@ MCP Mesh supports multiple deployment patterns for TypeScript agents. Use `meshc
 
 | Image                            | Description                                        |
 | -------------------------------- | -------------------------------------------------- |
-| `mcpmesh/registry:3.6.0`           | Registry service for agent discovery               |
-| `mcpmesh/typescript-runtime:3.6.0` | TypeScript runtime with @mcpmesh/sdk pre-installed |
+| `mcpmesh/registry:3.7.0`           | Registry service for agent discovery               |
+| `mcpmesh/typescript-runtime:3.7.0` | TypeScript runtime with @mcpmesh/sdk pre-installed |
 
 ## Local Development
 
@@ -75,7 +75,7 @@ meshctl stop               # Stop all
 
 ```dockerfile
 # Dockerfile for my-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 
@@ -123,8 +123,8 @@ meshctl scaffold --compose --observability
 Generated `docker-compose.yml` includes:
 
 - PostgreSQL database for registry
-- Registry service (`mcpmesh/registry:3.6.0`)
-- TypeScript agents with `mcpmesh/typescript-runtime:3.6.0`
+- Registry service (`mcpmesh/registry:3.7.0`)
+- TypeScript agents with `mcpmesh/typescript-runtime:3.7.0`
 - Health checks and dependency ordering
 - Optional: Redis, Tempo, Grafana (with `--observability`)
 
@@ -148,12 +148,12 @@ For production Kubernetes deployment:
 # own. Run `meshctl man deployment` for the namespace rules, including
 # the upgrade order for a release installed with chart 3.4.x or earlier.
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy TypeScript agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh \
   -f my-agent/helm-values.yaml
 ```
@@ -199,7 +199,7 @@ docker buildx build --platform linux/amd64 -t your-registry/my-agent:v1.0.0 --pu
 
 # 3. Deploy with Helm
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh \
   -f helm-values.yaml \
   --set image.repository=your-registry/my-agent \

--- a/src/core/cli/man/content/observability.md
+++ b/src/core/cli/man/content/observability.md
@@ -65,12 +65,12 @@ docker compose up -d
 ```bash
 # Install core with observability enabled (default)
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh --create-namespace
 
 # Or disable observability
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh --create-namespace \
   --set tempo.enabled=false \
   --set grafana.enabled=false

--- a/src/core/cli/man/content/prerequisites.md
+++ b/src/core/cli/man/content/prerequisites.md
@@ -89,17 +89,17 @@ docker compose version
 
 | Image                              | Description                 |
 | ---------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.6.0`           | Registry service            |
-| `mcpmesh/python-runtime:3.6.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.6.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.6.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.7.0`           | Registry service            |
+| `mcpmesh/python-runtime:3.7.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.7.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.7.0` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:3.6.0
-docker pull mcpmesh/python-runtime:3.6.0
-docker pull mcpmesh/java-runtime:3.6.0
-docker pull mcpmesh/typescript-runtime:3.6.0
+docker pull mcpmesh/registry:3.7.0
+docker pull mcpmesh/python-runtime:3.7.0
+docker pull mcpmesh/java-runtime:3.7.0
+docker pull mcpmesh/typescript-runtime:3.7.0
 ```
 
 ### Generate Docker Compose
@@ -140,12 +140,12 @@ Available from OCI registry (no `helm repo add` needed):
 # own. Run `meshctl man deployment` for the namespace rules, including
 # the upgrade order for a release installed with chart 3.4.x or earlier.
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh --create-namespace
 
 # Deploy an agent
 helm install my-agent oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh \
   -f helm-values.yaml
 ```

--- a/src/core/cli/man/content/prerequisites_java.md
+++ b/src/core/cli/man/content/prerequisites_java.md
@@ -52,7 +52,7 @@ Add the Spring Boot starter to your `pom.xml`:
     <dependency>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -100,10 +100,10 @@ docker compose version
 
 | Image                              | Description                 |
 | ---------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.6.0`           | Registry service            |
-| `mcpmesh/python-runtime:3.6.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.6.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.6.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.7.0`           | Registry service            |
+| `mcpmesh/python-runtime:3.7.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.7.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.7.0` | TypeScript runtime with SDK |
 
 Java agents use standard Maven-based Docker builds (see Docker Deployment guide).
 

--- a/src/core/cli/man/content/prerequisites_typescript.md
+++ b/src/core/cli/man/content/prerequisites_typescript.md
@@ -77,17 +77,17 @@ docker compose version
 
 | Image                            | Description                 |
 | -------------------------------- | --------------------------- |
-| `mcpmesh/registry:3.6.0`           | Registry service            |
-| `mcpmesh/python-runtime:3.6.0`     | Python runtime with SDK     |
-| `mcpmesh/java-runtime:3.6.0`       | Java runtime with SDK       |
-| `mcpmesh/typescript-runtime:3.6.0` | TypeScript runtime with SDK |
+| `mcpmesh/registry:3.7.0`           | Registry service            |
+| `mcpmesh/python-runtime:3.7.0`     | Python runtime with SDK     |
+| `mcpmesh/java-runtime:3.7.0`       | Java runtime with SDK       |
+| `mcpmesh/typescript-runtime:3.7.0` | TypeScript runtime with SDK |
 
 ```bash
 # Pull images
-docker pull mcpmesh/registry:3.6.0
-docker pull mcpmesh/python-runtime:3.6.0
-docker pull mcpmesh/java-runtime:3.6.0
-docker pull mcpmesh/typescript-runtime:3.6.0
+docker pull mcpmesh/registry:3.7.0
+docker pull mcpmesh/python-runtime:3.7.0
+docker pull mcpmesh/java-runtime:3.7.0
+docker pull mcpmesh/typescript-runtime:3.7.0
 ```
 
 ### Generate Docker Compose

--- a/src/core/cli/man/content/quickstart_java.md
+++ b/src/core/cli/man/content/quickstart_java.md
@@ -81,7 +81,7 @@ Create `pom.xml`:
         <dependency>
             <groupId>io.mcp-mesh</groupId>
             <artifactId>mcp-mesh-spring-boot-starter</artifactId>
-            <version>3.6.0</version>
+            <version>3.7.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/core/cli/man/content/registry.md
+++ b/src/core/cli/man/content/registry.md
@@ -210,7 +210,7 @@ To read the trace stream from a second process without taking entries from the r
 ```bash
 # Scale registry replicas
 helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-  --version 3.6.0 \
+  --version 3.7.0 \
   -n mcp-mesh --create-namespace \
   --set registry.replicas=3
 ```

--- a/src/core/cli/man/content/security.md
+++ b/src/core/cli/man/content/security.md
@@ -208,7 +208,7 @@ Admin endpoints (`/admin/rotate`, `/admin/entities`) are served only on the admi
 ```yaml
 services:
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     command: ["--tls-auto"]
     ports: ["8000:8000"]
     volumes:

--- a/src/core/cli/man/content/testing_java.md
+++ b/src/core/cli/man/content/testing_java.md
@@ -124,7 +124,7 @@ class AssistantAgentTest {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     ports:
       - "8000:8000"
     healthcheck:

--- a/src/core/cli/man/content/testing_typescript.md
+++ b/src/core/cli/man/content/testing_typescript.md
@@ -119,7 +119,7 @@ describe("Agent Integration", () => {
 # docker-compose.test.yml
 services:
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     ports:
       - "8000:8000"
     healthcheck:

--- a/src/core/cli/man/content/tutorial.md
+++ b/src/core/cli/man/content/tutorial.md
@@ -1698,7 +1698,7 @@ $ kubectl -n trip-planner create secret generic llm-keys \
 
 ```shell
 $ helm install mcp-core oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core \
-    --version 3.6.0 \
+    --version 3.7.0 \
     -n trip-planner \
     -f helm/values-core.yaml \
     --wait --timeout 5m
@@ -1721,7 +1721,7 @@ $ for agent in "${AGENTS[@]}"; do
     echo "Installing $agent..."
     helm install "$agent" \
       oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-agent \
-      --version 3.6.0 \
+      --version 3.7.0 \
       -n trip-planner \
       -f "helm/values-${agent}.yaml"
   done

--- a/src/core/cli/scaffold.go
+++ b/src/core/cli/scaffold.go
@@ -72,9 +72,9 @@ Documentation:
 
 Infrastructure:
   Docker Images:
-    mcpmesh/registry:3.6.0            - Registry service
-    mcpmesh/python-runtime:3.6.0      - Python agent runtime (has mcp-mesh SDK)
-    mcpmesh/typescript-runtime:3.6.0  - TypeScript agent runtime (has @mcpmesh/sdk)
+    mcpmesh/registry:3.7.0            - Registry service
+    mcpmesh/python-runtime:3.7.0      - Python agent runtime (has mcp-mesh SDK)
+    mcpmesh/typescript-runtime:3.7.0  - TypeScript agent runtime (has @mcpmesh/sdk)
 
   Helm Charts (for Kubernetes - OCI registry, no helm repo add needed):
     oci://ghcr.io/dhyansraj/mcp-mesh/mcp-mesh-core   - Registry + PostgreSQL + observability

--- a/src/core/cli/scaffold/compose.go
+++ b/src/core/cli/scaffold/compose.go
@@ -1087,7 +1087,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
 #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
 {{ .Name }}:
-  image: mcpmesh/python-runtime:3.6.0
+  image: mcpmesh/python-runtime:3.7.0
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1136,7 +1136,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # NOTE: In dev mode, npm install runs on startup and source is mounted.
 #       In production (Dockerfile), dependencies are pre-installed in the image.
 {{ .Name }}:
-  image: mcpmesh/typescript-runtime:3.6.0
+  image: mcpmesh/typescript-runtime:3.7.0
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1179,7 +1179,7 @@ const agentServicesTemplate = `{{- range .Agents }}
 # Agent: {{ .Name }} (Java/Spring Boot)
 # NOTE: In dev mode, maven builds on startup. In production, use the Dockerfile.
 {{ .Name }}:
-  image: mcpmesh/java-runtime:3.6.0
+  image: mcpmesh/java-runtime:3.7.0
   container_name: {{ $.ProjectName }}-{{ .Name }}
   hostname: {{ .Name }}
   user: root
@@ -1860,7 +1860,7 @@ services:
       - {{ .NetworkName }}
 
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
     container_name: {{ .ProjectName }}-registry
     hostname: registry
     ports:
@@ -1969,7 +1969,7 @@ services:
   # NOTE: In dev mode, entrypoint is overridden to install requirements on startup.
   #       In production (Dockerfile), base image ENTRYPOINT ["python"] is used with CMD ["main.py"]
   {{ .Name }}:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root
@@ -2019,7 +2019,7 @@ services:
   # NOTE: In dev mode, npm install runs on startup and source is mounted.
   #       In production (Dockerfile), dependencies are pre-installed in the image.
   {{ .Name }}:
-    image: mcpmesh/typescript-runtime:3.6.0
+    image: mcpmesh/typescript-runtime:3.7.0
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root
@@ -2063,7 +2063,7 @@ services:
   # Java Agent: {{ .Name }}
   # NOTE: In dev mode, maven builds on startup. In production, use the Dockerfile.
   {{ .Name }}:
-    image: mcpmesh/java-runtime:3.6.0
+    image: mcpmesh/java-runtime:3.7.0
     container_name: {{ $.ProjectName }}-{{ .Name }}
     hostname: {{ .Name }}
     user: root

--- a/src/core/cli/scaffold/compose_test.go
+++ b/src/core/cli/scaffold/compose_test.go
@@ -52,9 +52,9 @@ services:
     environment:
       POSTGRES_USER: customuser
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
   agent1:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     container_name: test-agent1
     environment:
       CUSTOM_VAR: "user-added-value"
@@ -110,9 +110,9 @@ func TestGenerateDockerCompose_ForceRegenerate(t *testing.T) {
   postgres:
     image: postgres:15-alpine
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
   agent1:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     environment:
       CUSTOM_VAR: "should-be-gone"
 networks:
@@ -157,9 +157,9 @@ func TestGenerateDockerCompose_NoNewAgents(t *testing.T) {
   postgres:
     image: postgres:15-alpine
   registry:
-    image: mcpmesh/registry:3.6.0
+    image: mcpmesh/registry:3.7.0
   agent1:
-    image: mcpmesh/python-runtime:3.6.0
+    image: mcpmesh/python-runtime:3.7.0
     environment:
       CUSTOM_VAR: "preserved"
 networks:

--- a/src/runtime/core/Cargo.toml
+++ b/src/runtime/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-mesh-core"
-version = "3.6.0"
+version = "3.7.0"
 edition = "2021"
 # MSRV. CI builds with moving stable (dtolnay/rust-toolchain@stable);
 # this floor documents the newest stdlib API the crate relies on

--- a/src/runtime/core/pyproject.toml
+++ b/src/runtime/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mcp-mesh-core"
-version = "3.6.0"
+version = "3.7.0"
 description = "Rust core runtime for MCP Mesh agents"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/core/typescript/package.json
+++ b/src/runtime/core/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/core",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "MCP Mesh Rust core bindings for Node.js",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/runtime/java/mcp-mesh-bom/pom.xml
+++ b/src/runtime/java/mcp-mesh-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-bom</artifactId>
-    <version>3.6.0</version>
+    <version>3.7.0</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh BOM</name>

--- a/src/runtime/java/mcp-mesh-core/pom.xml
+++ b/src/runtime/java/mcp-mesh-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0</version>
     </parent>
 
     <artifactId>mcp-mesh-core</artifactId>

--- a/src/runtime/java/mcp-mesh-native/pom.xml
+++ b/src/runtime/java/mcp-mesh-native/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0</version>
     </parent>
 
     <artifactId>mcp-mesh-native</artifactId>

--- a/src/runtime/java/mcp-mesh-sdk/pom.xml
+++ b/src/runtime/java/mcp-mesh-sdk/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0</version>
     </parent>
 
     <artifactId>mcp-mesh-sdk</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-ai/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-ai/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-ai</artifactId>

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.mcp-mesh</groupId>
         <artifactId>mcp-mesh-parent</artifactId>
-        <version>3.6.0</version>
+        <version>3.7.0</version>
     </parent>
 
     <artifactId>mcp-mesh-spring-boot-starter</artifactId>

--- a/src/runtime/java/pom.xml
+++ b/src/runtime/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mcp-mesh</groupId>
     <artifactId>mcp-mesh-parent</artifactId>
-    <version>3.6.0</version>
+    <version>3.7.0</version>
     <packaging>pom</packaging>
 
     <name>MCP Mesh Java SDK</name>

--- a/src/runtime/python/_mcp_mesh/__init__.py
+++ b/src/runtime/python/_mcp_mesh/__init__.py
@@ -31,7 +31,7 @@ from .engine.decorator_registry import (
     get_decorator_stats,
 )
 
-__version__ = "3.6.0"
+__version__ = "3.7.0"
 
 # Store reference to runtime processor if initialized
 _runtime_processor = None

--- a/src/runtime/python/mesh/__init__.py
+++ b/src/runtime/python/mesh/__init__.py
@@ -34,7 +34,7 @@ from .types import (
 # Note: helpers.llm_provider is imported lazily in __getattr__ to avoid
 # initialization timing issues with @mesh.agent auto_run in tests
 
-__version__ = "3.6.0"
+__version__ = "3.7.0"
 
 
 # Helper function to create FastMCP server with proper naming

--- a/src/runtime/python/pyproject.toml
+++ b/src/runtime/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-mesh"
-version = "3.6.0"
+version = "3.7.0"
 description = "Python SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration"
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/runtime/typescript/package.json
+++ b/src/runtime/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpmesh/sdk",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "TypeScript SDK for MCP Mesh — build distributed AI agents with auto-discovery, dependency injection, and LLM integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -102,12 +102,12 @@ Edit `config.yaml` to set versions:
 
 ```yaml
 packages:
-  cli_version: "3.6.0" # @mcpmesh/cli
-  sdk_python_version: "3.6.0" # mcp-mesh (pip) - PEP 440 format
-  sdk_typescript_version: "3.6.0" # @mcpmesh/sdk
+  cli_version: "3.7.0" # @mcpmesh/cli
+  sdk_python_version: "3.7.0" # mcp-mesh (pip) - PEP 440 format
+  sdk_typescript_version: "3.7.0" # @mcpmesh/sdk
 
 docker:
-  base_image: "tsuite-mesh:3.6.0"
+  base_image: "tsuite-mesh:3.7.0"
 ```
 
 ## Environment Variables

--- a/tests/integration/suites/README.md
+++ b/tests/integration/suites/README.md
@@ -108,7 +108,7 @@ const agent = mesh(server, {
 ```bash
 docker run --rm -it \
   -v $(pwd)/suites/uc01_registry/artifacts:/uc-artifacts:ro \
-  tsuite-mesh:3.6.0 bash
+  tsuite-mesh:3.7.0 bash
 ```
 
 ### Common issues:
@@ -123,9 +123,9 @@ Available in test.yaml via `${config.X}`:
 
 | Variable                                 | Example      |
 | ---------------------------------------- | ------------ |
-| `config.packages.cli_version`            | 3.6.0 |
-| `config.packages.sdk_python_version`     | 3.6.0 |
-| `config.packages.sdk_typescript_version` | 3.6.0 |
+| `config.packages.cli_version`            | 3.7.0 |
+| `config.packages.sdk_python_version`     | 3.7.0 |
+| `config.packages.sdk_typescript_version` | 3.7.0 |
 
 ## Issue Reporting Policy
 

--- a/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-multi-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
+++ b/tests/integration/suites/uc01_registry/artifacts/ts-simple-agent/package.json
@@ -9,7 +9,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-calculator-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-optional-dep-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-optional-dep-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/Dockerfile
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-report-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
+++ b/tests/integration/suites/uc02_tools/artifacts/ts-report-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-accurate-provider/package.json
@@ -9,7 +9,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-deprecated-provider/package.json
@@ -9,7 +9,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-fast-provider/package.json
@@ -9,7 +9,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
+++ b/tests/integration/suites/uc03_capabilities/artifacts/ts-tag-consumer/package.json
@@ -9,7 +9,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc11_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-calculator-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-calculator-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-calculator-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc12_ts_or_alternatives_fallback/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-alpha-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-alpha-provider/package.json
@@ -9,7 +9,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-beta-provider/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-beta-provider/package.json
@@ -9,7 +9,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-dual-consumer/package.json
+++ b/tests/integration/suites/uc03_capabilities/tc19_ts_dep_index_alignment/artifacts/ts-dual-consumer/package.json
@@ -9,7 +9,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-caller/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-caller/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-provider/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc08_pydantic_chain_ts/artifacts/ts-typed-provider/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-caller/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-caller/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-provider/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc09_pydantic_chain_java/artifacts/java-typed-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/java-slow-agent/pom.xml
+++ b/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/java-slow-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/ts-slow-agent/package.json
+++ b/tests/integration/suites/uc03_tool_calling/tc10_timeout_chain_propagation/artifacts/ts-slow-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/gemini-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/artifacts/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc01_claude_provider_py/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc02_claude_provider_ts/artifacts/claude-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "@ai-sdk/anthropic": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc03_openai_provider/artifacts/openai-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for openai-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc04_openai_provider_ts/artifacts/openai-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "@ai-sdk/openai": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc05_gemini_provider_py/artifacts/gemini-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider-ts MCP Mesh LLM provider
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc06_gemini_provider_ts/artifacts/gemini-provider-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0"
   },

--- a/tests/integration/suites/uc04_llm_integration/tc07_llm_agent_py/artifacts/llm-agent/Dockerfile
+++ b/tests/integration/suites/uc04_llm_integration/tc07_llm_agent_py/artifacts/llm-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for llm-agent MCP Mesh LLM agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc04_llm_integration/tc23_structured_output_ts_consumer_py_provider/artifacts/structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc23_structured_output_ts_consumer_py_provider/artifacts/structured-consumer-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc28_structured_output_ts_consumer_java_provider/artifacts/structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc28_structured_output_ts_consumer_java_provider/artifacts/structured-consumer-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc32_structured_output_ts_consumer_py_openai_provider/artifacts/structured-consumer-openai-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc32_structured_output_ts_consumer_py_openai_provider/artifacts/structured-consumer-openai-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc38_streaming_structured_output_config_ts_py/artifacts/streaming-structured-consumer-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc43_output_mode_hint_override_openai_ts/artifacts/hint-override-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc43_output_mode_hint_override_openai_ts/artifacts/hint-override-consumer-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc44_output_mode_hint_override_openai_java/artifacts/hint-override-java/pom.xml
+++ b/tests/integration/suites/uc04_llm_integration/tc44_output_mode_hint_override_openai_java/artifacts/hint-override-java/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <java.version>17</java.version>
         <!-- maven-install handler aligns this from the container's ~/.m2 repo -->
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc04_llm_integration/tc47_max_iterations_cross_runtime_java_py/artifacts/max-iterations-java/pom.xml
+++ b/tests/integration/suites/uc04_llm_integration/tc47_max_iterations_cross_runtime_java_py/artifacts/max-iterations-java/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <java.version>17</java.version>
         <!-- maven-install handler aligns this from the container's ~/.m2 repo -->
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc04_llm_integration/tc49_max_iterations_ts_forwarding_py/artifacts/ticket-consumer-ts/package.json
+++ b/tests/integration/suites/uc04_llm_integration/tc49_max_iterations_ts_forwarding_py/artifacts/ticket-consumer-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc04_llm_integration/tc50_max_iterations_streaming_java_py/artifacts/stream-gateway-java/pom.xml
+++ b/tests/integration/suites/uc04_llm_integration/tc50_max_iterations_streaming_java_py/artifacts/stream-gateway-java/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <java.version>17</java.version>
         <!-- maven-install handler aligns this from the container's ~/.m2 repo -->
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
+++ b/tests/integration/suites/uc05_meshctl/artifacts/java-non-mesh-app/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-calculator-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/Dockerfile
+++ b/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-auto-port-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
+++ b/tests/integration/suites/uc05_meshctl/tc07_auto_port_detection_ts/artifacts/ts-auto-port-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc05_meshctl/tc33_ts_api_port_isolation/artifacts/ts-api-app/package.json
+++ b/tests/integration/suites/uc05_meshctl/tc33_ts_api_port_isolation/artifacts/ts-api-app/package.json
@@ -10,7 +10,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "3.6.0",
+    "@mcpmesh/sdk": "3.7.0",
     "express": "^4.21.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc06_observability/artifacts/express-api/package.json
+++ b/tests/integration/suites/uc06_observability/artifacts/express-api/package.json
@@ -10,7 +10,7 @@
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc06_observability/artifacts/py-calculator/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/py-calculator/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for py-calculator MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/py-math-agent/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/py-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for py-math-agent MCP Mesh agent
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/Dockerfile
+++ b/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ts-math-agent MCP Mesh agent
-FROM mcpmesh/typescript-runtime:3.6.0
+FROM mcpmesh/typescript-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc06_observability/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/Dockerfile
+++ b/tests/integration/suites/uc08_llm_prompt_templates/artifacts/claude-provider/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for claude-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-echo-ts/package.json
+++ b/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-echo-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-relay-ts/package.json
+++ b/tests/integration/suites/uc11_header_propagation/tc02_typescript_header_chain/artifacts/header-relay-ts/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-echo-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
+++ b/tests/integration/suites/uc11_header_propagation/tc03_java_header_chain/artifacts/header-relay-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc12_registration_trust/artifacts/java-greeter/pom.xml
+++ b/tests/integration/suites/uc12_registration_trust/artifacts/java-greeter/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc14_multimedia/tc30_download_media_typescript/artifacts/ts-download-agent/package.json
+++ b/tests/integration/suites/uc14_multimedia/tc30_download_media_typescript/artifacts/ts-download-agent/package.json
@@ -11,7 +11,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
+++ b/tests/integration/suites/uc14_multimedia/tc31_download_media_java/artifacts/java-download-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/Dockerfile
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/gemini-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/Dockerfile
+++ b/tests/integration/suites/uc15_parallel_tool_calls/artifacts/openai-provider-py/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for gemini-provider MCP Mesh LLM provider
-FROM mcpmesh/python-runtime:3.6.0
+FROM mcpmesh/python-runtime:3.7.0
 
 WORKDIR /app
 

--- a/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
+++ b/tests/integration/suites/uc16_schema_filtering/artifacts/java-schema-agent/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc16_schema_filtering/artifacts/ts-schema-agent/package.json
+++ b/tests/integration/suites/uc16_schema_filtering/artifacts/ts-schema-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc17_ui_server/artifacts/ts-math-agent/package.json
+++ b/tests/integration/suites/uc17_ui_server/artifacts/ts-math-agent/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/pom.xml
+++ b/tests/integration/suites/uc18_streaming/artifacts/streaming/java-stream-gateway/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-x-ts/package.json
@@ -10,7 +10,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/bystander-y-ts/package.json
@@ -10,7 +10,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/downstream-sleeper-ts/package.json
@@ -10,7 +10,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-consumer-ts/package.json
@@ -10,7 +10,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/long-task-provider-ts/package.json
@@ -10,7 +10,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/package.json
+++ b/tests/integration/suites/uc22_meshjob_ts/fixtures/orchestrator-agent-ts/package.json
@@ -10,7 +10,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-x-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/bystander-y-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/downstream-sleeper-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-consumer-java/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/long-task-provider-java/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
+++ b/tests/integration/suites/uc23_meshjob_java/fixtures/orchestrator-agent-java/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <!--

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts-b/package.json
@@ -11,7 +11,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-date-agent-ts/package.json
@@ -11,7 +11,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts-sse/package.json
@@ -11,7 +11,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/package.json
+++ b/tests/integration/suites/uc26_a2a_consumer_typescript/fixtures/consumer-report-agent-ts/package.json
@@ -11,7 +11,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "fastmcp": "^3.34.0",
     "zod": "^3.24.0"
   },

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java-b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-date-agent-java/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java-sse/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java-sse/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java/pom.xml
+++ b/tests/integration/suites/uc27_a2a_consumer_java/fixtures/consumer-report-agent-java/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-agent-java/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-date-auth-agent-java/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/pom.xml
+++ b/tests/integration/suites/uc28_a2a_producer_java/fixtures/producer-report-agent-java/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-agent-ts/package.json
@@ -11,7 +11,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-auth-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-date-auth-agent-ts/package.json
@@ -11,7 +11,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-report-agent-ts/package.json
+++ b/tests/integration/suites/uc29_a2a_producer_ts/fixtures/producer-report-agent-ts/package.json
@@ -11,7 +11,7 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/pom.xml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-a2a-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/pom.xml
+++ b/tests/integration/suites/uc30_spring_constructor_inject_java/artifacts/spring-route-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/pom.xml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/a2a-strict-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/pom.xml
+++ b/tests/integration/suites/uc31_a2a_schema_match_parity/artifacts/route-strict-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-consumer/pom.xml
+++ b/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-provider/pom.xml
+++ b/tests/integration/suites/uc32_empty_return_values/artifacts/java-empty-provider/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc32_empty_return_values/artifacts/ts-empty-consumer/package.json
+++ b/tests/integration/suites/uc32_empty_return_values/artifacts/ts-empty-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/pom.xml
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/java-route-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/package.json
+++ b/tests/integration/suites/uc34_required_dependencies/fixtures/ts-required-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/pom.xml
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc37_service_view_java/fixtures/java-view-producer/pom.xml
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/java-view-producer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc37_service_view_java/fixtures/ts-view-consumer/package.json
+++ b/tests/integration/suites/uc37_service_view_java/fixtures/ts-view-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-consumer/pom.xml
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-consumer/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-provider/pom.xml
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/java-signal-provider/pom.xml
@@ -31,7 +31,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-consumer/package.json
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0"
+    "@mcpmesh/sdk": "^3.7.0"
   },
   "devDependencies": {
     "@types/node": "^22.18.0",

--- a/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/package.json
+++ b/tests/integration/suites/uc38_superseded_signal/fixtures/ts-signal-provider/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "fastmcp": "^4.3.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc41_health_check_withdrawal/artifacts/java-hc-consumer/pom.xml
+++ b/tests/integration/suites/uc41_health_check_withdrawal/artifacts/java-hc-consumer/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc41_health_check_withdrawal/artifacts/java-hc-provider-a/pom.xml
+++ b/tests/integration/suites/uc41_health_check_withdrawal/artifacts/java-hc-provider-a/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc41_health_check_withdrawal/artifacts/java-hc-provider-b/pom.xml
+++ b/tests/integration/suites/uc41_health_check_withdrawal/artifacts/java-hc-provider-b/pom.xml
@@ -21,7 +21,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <mcp-mesh.version>3.6.0</mcp-mesh.version>
+        <mcp-mesh.version>3.7.0</mcp-mesh.version>
     </properties>
 
     <dependencies>

--- a/tests/integration/suites/uc41_health_check_withdrawal/artifacts/ts-hc-consumer/package.json
+++ b/tests/integration/suites/uc41_health_check_withdrawal/artifacts/ts-hc-consumer/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc41_health_check_withdrawal/artifacts/ts-hc-gateway/package.json
+++ b/tests/integration/suites/uc41_health_check_withdrawal/artifacts/ts-hc-gateway/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "express": "^4.21.2"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc41_health_check_withdrawal/artifacts/ts-hc-provider-a/package.json
+++ b/tests/integration/suites/uc41_health_check_withdrawal/artifacts/ts-hc-provider-a/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/tests/integration/suites/uc41_health_check_withdrawal/artifacts/ts-hc-provider-b/package.json
+++ b/tests/integration/suites/uc41_health_check_withdrawal/artifacts/ts-hc-provider-b/package.json
@@ -12,7 +12,7 @@
     "dev": "tsx watch src/index.ts"
   },
   "dependencies": {
-    "@mcpmesh/sdk": "^3.6.0",
+    "@mcpmesh/sdk": "^3.7.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/tests/lib-tests/README.md
+++ b/tests/lib-tests/README.md
@@ -68,7 +68,7 @@ tsuite --uc uc04_build_image
 
 After successful run, you'll have:
 
-- `tsuite-mesh:3.6.0` (or current version) Docker image
+- `tsuite-mesh:3.7.0` (or current version) Docker image
 
 Verify with:
 
@@ -82,11 +82,11 @@ Edit `config.yaml` to update versions:
 
 ```yaml
 packages:
-  cli_version: "3.6.0"
-  sdk_python_version: "3.6.0" # PEP 440 format for Python
-  sdk_typescript_version: "3.6.0"
-  core_version: "3.6.0"
-  sdk_java_version: "3.6.0"
+  cli_version: "3.7.0"
+  sdk_python_version: "3.7.0" # PEP 440 format for Python
+  sdk_typescript_version: "3.7.0"
+  core_version: "3.7.0"
+  sdk_java_version: "3.7.0"
 ```
 
 ## Next Steps

--- a/tests/lib-tests/config.yaml
+++ b/tests/lib-tests/config.yaml
@@ -10,11 +10,11 @@ suite:
 
 packages:
   # Version to test - update this for each release
-  cli_version: "3.6.0"
-  sdk_python_version: "3.6.0" # PEP 440 format for pip
-  sdk_typescript_version: "3.6.0"
-  core_version: "3.6.0"
-  sdk_java_version: "3.6.0"
+  cli_version: "3.7.0"
+  sdk_python_version: "3.7.0" # PEP 440 format for pip
+  sdk_typescript_version: "3.7.0"
+  core_version: "3.7.0"
+  sdk_java_version: "3.7.0"
 
 # Docker settings for the base image build
 docker:


### PR DESCRIPTION
Twelve PRs since 3.6.0. Full detail in `RELEASE_NOTES.md`.

## The headline

`health_check` is a routing answer, not a health taxonomy (#1539). It accepted three verdicts and had **two** behaviours — `healthy` and `degraded` were identical on every path, and only `unhealthy` withdrew. The contract is now binary.

## Two things to read before merging

**Python now trims the status string, and that changes routing.** `{"status": " unhealthy "}` used to parse as `UNKNOWN` and keep the agent in dependency resolution; it now withdraws. TypeScript and Java have always trimmed, so only Python moves. This is the only routing behaviour that changes in the release — and it is easy to overlook precisely because everything about `degraded` deliberately stayed put.

**Selecting `degraded` now emits a deprecation warning.** Behaviour is unchanged: a `degraded` agent keeps heartbeating and stays in resolution. Remapping it would silently withdraw agents whose authors used it correctly, so the warning comes first and the behaviour does not follow in this release. Java's `MeshHealth.degraded(...)` is `@Deprecated`, removal no earlier than 4.0.

No upgrade ordering is required — nothing here needs the chart and images to move together.

## How the bump was reviewed

Not glanced at. `bump_version.py` does textual replacement, and an unanchored handler once rewrote `maven-jar-plugin` to a version that does not exist, failing `publish-java-sdk` *after* PyPI, npm and crates had published.

- **Sentinel first.** Bumped `3.6.0 → 9.9.9` on a scratch branch, where an over-match is unmistakable; a real next-version bump can hide one.
- **Two independent reductions, agreeing.** The script's own over-match guard (new since the last release — the hardening that was missing) reports all 702 changed lines provably mesh-owned. My own reduction from the incident write-up found **22 suspects**, all mesh-owned sites that merely lack the token: workflow input defaults, the `contributing.md` release line, tutorial chart versions, `mesh/__init__.py`, test config.
- **The two foreign pins that coincide with 3.6.0 were checked directly**, since a nearby mesh dependency in the same file can mask them from the heuristic. `matplotlib>=3.6.0` and `recharts ^3.6.0` are both untouched — the #1379 anchoring holds.
- **Lockfiles**: `Chart.lock` and `constraints.txt` moved the mesh version and nothing else.

## Verification

474 files bumped, consistent across Python, TypeScript, Rust, Java, npm and Helm. `go build ./...`, `go test ./src/core/...` (10 packages), and the doc-claim checks all clean.

Integration suite was green on this content before the bump: **566 passed, 0 failed, 9 skipped**, after 12/12 src-tests.

## After merge

Per the release gate: push the tag first and inspect before firing the publish workflow. Post-release, mesh-expert needs a `git pull` and restart to re-embed the man pages — they changed substantially this cycle, and the doc-claim checker is new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq