### PR TITLE
fix: stop the llm-provider scaffold emitting consumer-only tag operators

### DIFF
--- a/src/core/cli/scaffold/llm_provider_tags_test.go
+++ b/src/core/cli/scaffold/llm_provider_tags_test.go
@@ -1,0 +1,241 @@
+package scaffold
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mcp-mesh/src/core/registry"
+)
+
+// `+` and `-` are a CONSUMER-side construct. `meshctl man tags` states it
+// outright — "Operators are for consumers only. When declaring tags on your
+// tool, use plain strings without +/- prefixes" — and the matcher enforces it
+// by construction: it strips the operator from what the CONSUMER asked for and
+// then compares the remainder to the provider's tags with exact string equality
+// (registry.containsTag). A provider tag of "+fallback" is therefore a literal
+// tag spelled with a plus, and no pin a consumer can write will ever equal it.
+//
+// The scaffold shipped exactly that (issue #1546): every generated provider
+// carried an operator tag, and for `litellm-fallback` the operator form was the
+// ONLY fallback-ish tag, so the `+fallback` pin the scaffold itself prints for
+// the consumer matched nothing. It failed silently, which is the whole reason
+// this file exists — a preferred tag carries a bonus when present and NO
+// penalty when absent, so the pin did not error, did not narrow the candidate
+// set and did not fail resolution. It scored zero and the consumer resolved to
+// whichever provider won on other criteria.
+//
+// So the guards below come in two halves that fail for different reasons:
+//
+//   - the operator BAN (no generated provider tag is operator-prefixed) is the
+//     general shape, and would have caught all four vendors at source;
+//   - the round-trip (the vendor's own consumer pin actually SCORES against the
+//     vendor's own provider tags, through the real matcher) is what catches the
+//     half of the bug that survives a naive fix. Stripping "+fallback" without
+//     adding "fallback" satisfies the ban and leaves the pin just as dead.
+//
+// They are asserted on the map AND on the rendered agent, because the map is
+// not what a user runs. The llm-provider subcommand always sets ctx.Tags, which
+// selects the `{{ if .Tags }}` arm of all three templates — the `{{ else }}`
+// arm, backed by ProviderTagsForModel, is a different code path and is covered
+// separately below.
+
+// operatorPrefixed reports whether tag carries a consumer-side operator.
+func operatorPrefixed(tag string) bool {
+	return strings.HasPrefix(tag, "+") || strings.HasPrefix(tag, "-")
+}
+
+// No vendor's provider tag list may carry an operator.
+func TestVendorProviderTagsCarryNoOperators(t *testing.T) {
+	for _, vendor := range SupportedLLMVendors() {
+		t.Run(vendor, func(t *testing.T) {
+			tags := VendorToProviderTags(vendor)
+			require.NotEmpty(t, tags, "no discovery tags for vendor %s", vendor)
+			for _, tag := range tags {
+				require.Falsef(t, operatorPrefixed(tag),
+					"provider tag %q on vendor %s carries a consumer-side operator: the "+
+						"matcher compares provider tags by exact string equality, so this "+
+						"is a literal tag spelled with an operator and no consumer pin can "+
+						"match it (issue #1546)", tag, vendor)
+			}
+		})
+	}
+}
+
+// The other producer of provider tags — the `{{ else }}` arm of the same three
+// templates, and the interactive wizard — is held to the same rule.
+func TestModelFamilyProviderTagsCarryNoOperators(t *testing.T) {
+	models := []string{
+		"anthropic/claude-sonnet-5",
+		"openai/gpt-4o",
+		"gemini/gemini-2.5-flash",
+		"bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+		"vertex_ai/gemini-2.5-flash",
+		"cohere/command-r-plus",
+		"",
+	}
+	for _, model := range models {
+		t.Run(model, func(t *testing.T) {
+			for _, tag := range ProviderTagsForModel(model) {
+				require.Falsef(t, operatorPrefixed(tag),
+					"provider tag %q for model %q carries a consumer-side operator", tag, model)
+			}
+		})
+	}
+}
+
+// The half a naive fix misses: the consumer tag the scaffold PRINTS must
+// actually score against the provider tags the scaffold GENERATES. Run through
+// the real matcher rather than a hand-rolled restatement of it, because the
+// silence is the bug — the matcher returns (true, 0) for a pin that matched
+// nothing, which is indistinguishable from success at every caller.
+func TestVendorConsumerPinScoresAgainstItsOwnProvider(t *testing.T) {
+	matcher := registry.NewMatcher(nil)
+
+	for _, vendor := range SupportedLLMVendors() {
+		t.Run(vendor, func(t *testing.T) {
+			providerTags := VendorToProviderTags(vendor)
+			consumerTag := VendorToConsumerTag(vendor)
+			require.NotEmpty(t, consumerTag, "no consumer pin for vendor %s", vendor)
+
+			matched, score := matcher.MatchTags(providerTags, []string{consumerTag}, nil)
+			require.True(t, matched, "pin %q rejected provider tags %v", consumerTag, providerTags)
+			require.Equalf(t, 10, score,
+				"the pin %q that `meshctl scaffold llm-provider --vendor %s` tells the "+
+					"user to put on their consumer scored %d against the provider tags %v "+
+					"that the same command generates. A preferred tag that matches nothing "+
+					"scores 0 and costs nothing, so the consumer still resolves — to some "+
+					"other provider, with no error anywhere (issue #1546)",
+				consumerTag, vendor, score, providerTags)
+		})
+	}
+}
+
+// For the big-3 the two producers of provider tags must agree. They render into
+// the same decorator through different arms of the same template line, so a
+// divergence means the same `--vendor claude` provider advertises one tag set
+// from the subcommand and another from the wizard, and a consumer pin resolves
+// one of them.
+//
+// litellm-fallback is deliberately exempt: its default model is openai/gpt-4o,
+// but it is a general fallback route and must NOT claim the openai family's
+// tags, so it carries the generic list plus its own "fallback".
+func TestVendorProviderTagsMatchModelFamilyTags(t *testing.T) {
+	for _, vendor := range SupportedLLMVendors() {
+		if vendor == "litellm-fallback" {
+			continue
+		}
+		t.Run(vendor, func(t *testing.T) {
+			require.Equal(t, ProviderTagsForModel(VendorToModel(vendor)), VendorToProviderTags(vendor),
+				"the tags the llm-provider subcommand pins and the tags the templates "+
+					"derive from the model have diverged for %s", vendor)
+		})
+	}
+}
+
+// providerEntryFile is where each runtime puts the agent whose tags we read.
+// The Java path is derived by the scaffolder from the agent name, so it is
+// pinned to the name used below.
+var providerEntryFile = map[string]string{
+	"python":     "main.py",
+	"typescript": filepath.Join("src", "index.ts"),
+	"java": filepath.Join(
+		"src", "main", "java", "com", "example", "tagprobe", "TagProbeApplication.java"),
+}
+
+// renderedTagsLiteral is the tag list as each runtime's template emits it when
+// ctx.Tags is set. Python and TypeScript go through toJSON (compact, no space
+// after the comma); Java hand-renders with ", ".
+func renderedTagsLiteral(language string, tags []string) string {
+	switch language {
+	case "python":
+		return "tags=" + toJSON(tags)
+	case "typescript":
+		return "tags: " + toJSON(tags)
+	default:
+		quoted := make([]string, len(tags))
+		for i, tag := range tags {
+			quoted[i] = `"` + tag + `"`
+		}
+		return "tags = {" + strings.Join(quoted, ", ") + "}"
+	}
+}
+
+// scaffoldProviderEntry runs the real llm-provider subcommand for a vendor and
+// runtime and returns the generated entry file. Going through the command, not
+// through a hand-built ScaffoldContext, is the point: the operator tags reached
+// users because the subcommand populates ctx.Tags, and a test that builds its
+// own context would not exercise that.
+func scaffoldProviderEntry(t *testing.T, vendor, language string) string {
+	t.Helper()
+	t.Chdir(findRepoRoot(t))
+
+	out := t.TempDir()
+	cmd := newScaffoldLLMProviderCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	require.NoError(t, cmd.Flags().Set("vendor", vendor))
+	require.NoError(t, cmd.Flags().Set("runtime", language))
+	require.NoError(t, cmd.Flags().Set("name", "tag-probe"))
+	require.NoError(t, cmd.Flags().Set("output", out))
+	require.NoError(t, runScaffoldLLMProvider(cmd, nil))
+
+	content, err := os.ReadFile(filepath.Join(out, "tag-probe", providerEntryFile[language]))
+	require.NoError(t, err)
+	return string(content)
+}
+
+// declaredTagsLine returns the single line on which the generated agent declares
+// its discovery tags, so the operator ban below is scoped to the declaration
+// instead of the whole file. The templates legitimately mention "+claude" and
+// "+openai" in the consumer-usage comment they carry, and a whole-file ban would
+// hit those — which are correct usage.
+func declaredTagsLine(t *testing.T, content, language string) string {
+	t.Helper()
+	prefix := map[string]string{
+		"python":     "tags=[",
+		"typescript": "tags: [",
+		"java":       "tags = {",
+	}[language]
+
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), prefix) {
+			return line
+		}
+	}
+	t.Fatalf("no line declaring tags (prefix %q) in the generated %s agent — the "+
+		"template moved and this guard would otherwise pass by finding nothing", prefix, language)
+	return ""
+}
+
+// The map edit is not the deliverable; the generated agent is. Every vendor in
+// every runtime.
+func TestScaffoldedProviderDeclaresOperatorFreeTags(t *testing.T) {
+	for _, vendor := range SupportedLLMVendors() {
+		for _, language := range []string{"python", "typescript", "java"} {
+			t.Run(vendor+" "+language, func(t *testing.T) {
+				content := scaffoldProviderEntry(t, vendor, language)
+
+				want := renderedTagsLiteral(language, VendorToProviderTags(vendor))
+				require.Contains(t, content, want,
+					"the vendor's discovery tags did not reach the generated agent")
+
+				line := declaredTagsLine(t, content, language)
+				for _, tag := range VendorToProviderTags(vendor) {
+					require.Falsef(t, operatorPrefixed(tag),
+						"generated %s agent declares operator tag %q: %s", language, tag, line)
+				}
+				require.NotContains(t, line, `"+`,
+					"an operator-prefixed tag on the provider side matches no consumer pin "+
+						"and fails silently (issue #1546): %s", line)
+				require.NotContains(t, line, `"-`,
+					"an operator-prefixed tag on the provider side matches no consumer pin "+
+						"and fails silently (issue #1546): %s", line)
+			})
+		}
+	}
+}

--- a/src/core/cli/scaffold/llm_subcommand.go
+++ b/src/core/cli/scaffold/llm_subcommand.go
@@ -25,11 +25,25 @@ var vendorToModel = map[string]string{
 
 // vendorToProviderTags maps a vendor shortcut to the discovery tags applied to the
 // generated `@mesh.llm_provider` so consumers can pin to it via `+claude`, `+openai`, etc.
+//
+// These are PLAIN tags, never operator-prefixed. `+`/`-` are a consumer-side
+// construct (`meshctl man tags`): the matcher strips the operator from what the
+// consumer asked for and then compares it to the provider's tags with exact
+// string equality, so a provider tag of `"+fallback"` is a literal tag spelled
+// with a plus and matches nothing a consumer can write. Issue #1546 — the
+// generated `litellm-fallback` provider carried only `"+fallback"`, so the
+// `+fallback` pin the scaffold itself prints for the consumer scored zero. A
+// preferred tag has no penalty when absent, so nothing failed: the consumer just
+// resolved to whichever provider won on other criteria.
+//
+// For the big-3 these must stay in step with providerTagsByFamily, which is what
+// the same templates render when no tags are passed in — see
+// TestVendorProviderTagsMatchModelFamilyTags.
 var vendorToProviderTags = map[string][]string{
-	"claude":           {"llm", "claude", "anthropic", "provider", "+claude"},
-	"openai":           {"llm", "openai", "gpt", "provider", "+openai"},
-	"gemini":           {"llm", "gemini", "google", "provider", "+gemini"},
-	"litellm-fallback": {"llm", "provider", "+fallback"},
+	"claude":           {"llm", "claude", "anthropic", "provider"},
+	"openai":           {"llm", "openai", "gpt", "provider"},
+	"gemini":           {"llm", "gemini", "google", "provider"},
+	"litellm-fallback": {"llm", "provider", "fallback"},
 }
 
 // vendorToConsumerTag is the single discovery tag a consumer should request to pin a provider.

--- a/src/core/cli/scaffold/llm_subcommand_test.go
+++ b/src/core/cli/scaffold/llm_subcommand_test.go
@@ -36,15 +36,21 @@ func TestVendorToModel(t *testing.T) {
 	assert.Equal(t, "", VendorToModel("unknown"))
 }
 
+// The tag a consumer pins with is asserted WITHOUT its operator here: a
+// provider declares plain tags, and this assertion used to read
+// `Contains(tags, "+claude")` — it passed against the buggy value that issue
+// #1546 is about. The operator-free contract itself is guarded in
+// llm_provider_tags_test.go.
 func TestVendorToProviderTags(t *testing.T) {
 	for _, v := range []string{"claude", "openai", "gemini", "litellm-fallback"} {
 		tags := VendorToProviderTags(v)
 		require.NotEmpty(t, tags, "expected tags for %s", v)
 		assert.Contains(t, tags, "llm")
 	}
-	assert.Contains(t, VendorToProviderTags("claude"), "+claude")
-	assert.Contains(t, VendorToProviderTags("openai"), "+openai")
-	assert.Contains(t, VendorToProviderTags("gemini"), "+gemini")
+	assert.Contains(t, VendorToProviderTags("claude"), "claude")
+	assert.Contains(t, VendorToProviderTags("openai"), "openai")
+	assert.Contains(t, VendorToProviderTags("gemini"), "gemini")
+	assert.Contains(t, VendorToProviderTags("litellm-fallback"), "fallback")
 }
 
 func TestVendorToConsumerTag(t *testing.T) {
@@ -205,7 +211,10 @@ func TestRunScaffoldLLMProvider_DryRun_Python(t *testing.T) {
 	output := out.String()
 	assert.Contains(t, output, "Dry-run")
 	assert.Contains(t, output, "anthropic/claude-sonnet-5")
-	assert.Contains(t, output, "+claude")
+	// The provider declares plain tags. This used to assert "+claude" on the
+	// rendered file, which is the buggy value from issue #1546 — a provider tag
+	// spelled with an operator that no consumer pin can ever match.
+	assert.Contains(t, output, `tags=["llm","claude","anthropic","provider"]`)
 }
 
 func TestRunScaffoldLLMConsumer_DryRun_Python(t *testing.T) {


### PR DESCRIPTION
`meshctl scaffold llm-provider` put `+`-prefixed tags in the generated **provider's** tag list. `man tags` says operators are consumer-only, and for one vendor this made the documented pin silently never match.

Found by a downstream session evaluating the scaffold before adopting it.

## Why it failed silently

`containsTag` is exact string equality (`matcher.go:244-251`) — no prefix stripping on the provider side. A consumer's `+fallback` becomes `preferredTag = "fallback"` and asks for a tag the provider doesn't have.

The `+` branch is *"bonus points if present, **no penalty if missing**"*. So the pin doesn't error, doesn't narrow the candidate set, and doesn't fail resolution. It scores 0 and the consumer resolves to whichever provider wins on other criteria.

## Only one of four was actually broken

This is the part that makes the obvious fix wrong:

| vendor | plain tag present? | effect |
| --- | --- | --- |
| claude / openai / gemini | **yes** | `+claude` matched on the plain `claude` and scored. The operator entry was inert noise. |
| litellm-fallback | **no** | `"+fallback"` was the only fallback-ish tag, so the pin never scored. |

Stripping the operators from all four *without adding* `fallback` leaves the bug in place while looking fixed. Removing `"+claude"` *along with* `"claude"` breaks the three that worked.

```go
"claude":           {"llm", "claude", "anthropic", "provider"},
"litellm-fallback": {"llm", "provider", "fallback"},
```

`vendorToConsumerTag` was already correct and is untouched — operators belong on the consumer side.

## Two existing tests were pinning the bug

`TestVendorToProviderTags` asserted `Contains(..., "+claude")` directly, and a dry-run test asserted `"+claude"` in the rendered file. Both encoded the defect, which is part of why nothing caught it. Now they assert the plain tags and the exact rendered `tags=[...]` literal.

## Why the existing guards missed it

The `#1539`-era scaffold pins render through a helper that leaves `ctx.Tags` empty, while the real subcommand populates it — so the templates were pinned but the path users actually take was not. The new render guard goes through `runScaffoldLLMProvider` for that reason.

## The guard asserts score, not `matched`

Five guards, but the load-bearing one round-trips the consumer pin through the real `registry.MatchTags` and requires **score 10**. Asserting `matched` would be useless: the bug returns `(true, 0)` — it matches fine, it just doesn't prefer.

Three mutations, all caught:

| mutation | caught by |
| --- | --- |
| the original bug restored | the operator ban, on the map and on all 12 renders |
| **the naive fix** — operators stripped, `fallback` not added | *only* the matcher round-trip: `scored 0 against the provider tags [llm provider]` |
| `"+claude"` removed *and* `"claude"` removed with it | round-trip + family-agreement |

The middle row is why the round-trip exists — the ban and the render guard both pass it.

## It reached further than the agent code

The generated README echoes the provider's tag list as a *consumer* selector, so the fallback README told users to write `tags: ["llm","provider","+fallback"]` — requiring `llm` and `provider`, and preferring a tag that did not exist.

## Not fixed here

`examples/llm-mesh-delegation/test_008_provider_registration.py:24` has the same defect outside the scaffold — `tags=["claude", "test", "+budget"]` on a provider. Inert today, since nothing pins `+budget`. Reported rather than widening the diff.

No doc change was needed: every provider-side example in the man pages already declares plain tags, and every `+` occurrence there is a consumer selector. The docs were right; the code was wrong.

Closes #1546

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated LLM provider tags so they match consumer pin requests correctly.
  * Removed unsupported operator prefixes from provider tags across vendor and model-family scaffolding.
  * Improved fallback provider tag handling for consistent matching.
* **Tests**
  * Added coverage to verify generated tags, rendered agent declarations, and provider commands remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->