### PR TITLE
fix: resolve annotations before matching injectable types

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -356,41 +356,29 @@ def _describe_skipped_params(func: Callable, params: list[inspect.Parameter]) ->
     the warning names every skipped parameter and WHY it was skipped
     (untyped vs annotated with a non-injectable type).
 
-    Reasons are classified with the SAME type resolution the eligibility
-    scan uses (``get_type_hints`` on the original function) — raw
+    Reasons are classified with the SAME type resolution the eligibility scan
+    uses (``resolve_param_annotations`` on the original function, #1548) — raw
     ``p.annotation`` values are strings under
     ``from __future__ import annotations`` and would misreport a perfectly
     valid ``db: "McpMeshTool"`` as the self-contradictory "annotated as
-    McpMeshTool, not McpMeshTool". When the hints themselves cannot be
-    resolved (TYPE_CHECKING-only imports, dangling forward references) —
-    which is exactly the condition that made the eligibility scan fall back
-    to "no eligible parameters" — the reason states that failure explicitly
-    instead of misdiagnosing the annotation.
+    McpMeshTool, not McpMeshTool". An annotation the resolver could not turn
+    into a type (TYPE_CHECKING-only imports, dangling forward references) stays
+    a string, and the reason states that failure explicitly instead of
+    misdiagnosing the annotation.
     """
-    from typing import get_type_hints
+    from .signature_analyzer import (
+        _is_mesh_tool_type,
+        resolve_param_annotations,
+    )
 
-    from .signature_analyzer import _get_original_func, _is_mesh_tool_type
-
-    hints: dict[str, Any] | None = None
-    try:
-        hints = get_type_hints(_get_original_func(func))
-    except Exception:
-        # Same failure the eligibility scan (``_scan_params``) swallowed —
-        # report it as the skip reason below rather than guessing from raw
-        # annotations.
-        hints = None
+    resolved_annotations = resolve_param_annotations(func)
 
     parts = []
     for p in params:
         if p.annotation is inspect.Parameter.empty:
             parts.append(f"'{p.name}' (untyped)")
-        elif hints is None:
-            parts.append(
-                f"'{p.name}' (type hints could not be resolved — check "
-                f"TYPE_CHECKING imports / forward references)"
-            )
         else:
-            resolved = hints.get(p.name)
+            resolved = resolved_annotations.get(p.name)
             if resolved is None:
                 parts.append(f"'{p.name}' (untyped)")
             elif _is_mesh_tool_type(resolved):
@@ -399,6 +387,12 @@ def _describe_skipped_params(func: Callable, params: list[inspect.Parameter]) ->
                 # if a future skew ever puts one here, never emit the
                 # contradictory "annotated as McpMeshTool, not McpMeshTool".
                 parts.append(f"'{p.name}' (McpMeshTool)")
+            elif isinstance(resolved, str):
+                parts.append(
+                    f"'{p.name}' (annotation {resolved!r} could not be resolved "
+                    f"to a type — check TYPE_CHECKING imports / forward "
+                    f"references)"
+                )
             else:
                 ann_name = getattr(resolved, "__name__", None) or str(resolved)
                 parts.append(f"'{p.name}' (annotated as {ann_name}, not McpMeshTool)")

--- a/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
+++ b/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
@@ -4,6 +4,7 @@ Function signature analysis for MCP Mesh dependency injection.
 
 import inspect
 import logging
+import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Optional, get_type_hints
@@ -35,8 +36,178 @@ def _get_original_func(func: Any) -> Any:
     return original
 
 
+#: Bare identifiers inside a string annotation, e.g. ``"mesh.MeshLlmAgent | None"``
+#: → ``["mesh", "MeshLlmAgent", "None"]``.
+_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+#: ``typing.get_type_hints`` key for the return annotation. Cannot collide with
+#: a parameter name — ``return`` is a keyword.
+_RETURN_KEY = "return"
+
+
+def resolve_param_annotations(func: Any) -> dict[str, Any]:
+    """Resolve a callable's parameter annotations to runtime type objects.
+
+    The single resolution step in front of every annotation-identity check in
+    the runtime — the ``McpMeshTool`` / ``McpMeshAgent`` / ``MeshJob`` /
+    service-view scans in this module and the ``MeshLlmAgent`` scan in
+    ``mesh.decorators`` — so the two surfaces cannot drift apart again
+    (issue #1548).
+
+    Under ``from __future__ import annotations`` (PEP 563) every annotation in
+    the module is a **string**, so comparing ``param.annotation`` to a class is
+    unconditionally False and a correctly written parameter goes undetected.
+    ``typing.get_type_hints`` undoes the stringification and (on every Python
+    this package supports, ``>=3.11``) returns the bare class without wrapping
+    a ``= None`` default in ``Optional`` — the auto-``Optional`` behaviour was
+    removed in 3.11 — so the existing ``== SomeClass`` comparisons keep working
+    once the annotation is resolved.
+
+    Resolution degrades in three steps and **never raises**. A module that
+    imports today must still import afterwards: turning an unresolvable
+    annotation into an import failure would be a worse version of the bug being
+    fixed.
+
+    1. function-wide :func:`typing.get_type_hints`;
+    2. per-parameter evaluation against the defining module's globals, because
+       ``get_type_hints`` is all-or-nothing — one ``TYPE_CHECKING``-only import
+       or dangling forward reference on ANY parameter (or the return
+       annotation) would otherwise blind the resolvable siblings;
+    3. the annotation exactly as written. Under PEP 563 that is a string, which
+       the ``_is_*_type`` predicates still match by name (see
+       :func:`_annotation_mentions`).
+
+    Returns:
+        Mapping of parameter name to resolved annotation. Unannotated
+        parameters are omitted, so callers can treat "absent" as untyped. The
+        return annotation is NOT included — use
+        :func:`resolve_return_annotation`.
+    """
+    resolved = _resolve_param_annotations(func)[0]
+    resolved.pop(_RETURN_KEY, None)
+    return resolved
+
+
+def resolve_return_annotation(func: Any) -> Any:
+    """Resolve a callable's **return** annotation through the same ladder as
+    :func:`resolve_param_annotations`.
+
+    Returns ``inspect.Signature.empty`` when the callable declares no return
+    annotation, matching ``inspect.Signature.return_annotation`` so callers can
+    swap one for the other. Never raises.
+
+    Same #1548 exposure as the parameters: under PEP 563 the raw return
+    annotation is the *string* ``"ChatResponse"``, which silently becomes the
+    ``@mesh.llm`` output type — failing the Pydantic-model check that drives
+    structured output.
+    """
+    resolved, _ = _resolve_param_annotations(func)
+    return resolved.get(_RETURN_KEY, inspect.Signature.empty)
+
+
+def _resolve_param_annotations(func: Any) -> tuple[dict[str, Any], bool]:
+    """Body of :func:`resolve_param_annotations`, additionally reporting
+    whether function-wide :func:`typing.get_type_hints` succeeded.
+
+    The flag is for callers that warn about degraded resolution (the RFC #1280
+    service-view scan); everything else wants the mapping alone.
+    """
+    func = _get_original_func(func)
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return {}, False
+
+    hints_ok = True
+    try:
+        hints = get_type_hints(func)
+    except Exception as e:
+        # NameError for an unimportable name, TypeError for a malformed
+        # annotation, anything else a __getattr__ on the module raises: all
+        # non-fatal, all handled by the per-parameter pass below.
+        logger.debug(
+            "resolve_param_annotations: get_type_hints failed for %s (%s); "
+            "falling back to per-parameter resolution",
+            getattr(func, "__qualname__", getattr(func, "__name__", "?")),
+            e,
+        )
+        hints = {}
+        hints_ok = False
+
+    globalns = getattr(func, "__globals__", None)
+    if globalns is None:
+        import sys
+
+        module = getattr(func, "__module__", None)
+        globalns = getattr(sys.modules.get(module), "__dict__", {}) if module else {}
+
+    def _resolve_one(name: str, raw: Any) -> Any:
+        if name in hints:
+            return hints[name]
+        if not isinstance(raw, str):
+            return raw
+        try:
+            return eval(raw, globalns)  # noqa: S307 - module-scoped
+        except Exception:
+            # Step 3: keep the string. The predicates match it by name so a
+            # parameter the developer spelled correctly still binds.
+            return raw
+
+    resolved: dict[str, Any] = {}
+    for name, param in sig.parameters.items():
+        if param.annotation is inspect.Parameter.empty:
+            continue
+        resolved[name] = _resolve_one(name, param.annotation)
+    if sig.return_annotation is not inspect.Signature.empty:
+        resolved[_RETURN_KEY] = _resolve_one(_RETURN_KEY, sig.return_annotation)
+    return resolved, hints_ok
+
+
+def _annotation_mentions(param_type: Any, *names: str) -> bool:
+    """Whether an **unresolved string** annotation names one of ``names``.
+
+    Last-resort arm of the resolution ladder in
+    :func:`resolve_param_annotations`: only strings reach here, and only when
+    both the function-wide and the per-parameter resolution failed — i.e. the
+    named type is not importable at module scope (a ``TYPE_CHECKING``-only
+    import being the realistic case). Matching the bare identifier is the same
+    class of heuristic as the long-standing ``__name__``-based fallbacks below,
+    applied to the one shape those cannot see.
+    """
+    if not isinstance(param_type, str):
+        return False
+    return any(token in names for token in _IDENTIFIER_RE.findall(param_type))
+
+
+def describe_unresolved_annotations(func: Any) -> str:
+    """Render the parameters whose annotations stayed strings after
+    :func:`resolve_param_annotations`, or ``""`` when every annotation resolved.
+
+    Used to append an accurate cause to "no parameter of type X" errors: a
+    string annotation means the name was not importable at module scope, which
+    is nothing like the "you forgot the parameter" the bare message implies.
+    """
+    unresolved = [
+        f"{name}: {value!r}"
+        for name, value in resolve_param_annotations(func).items()
+        if isinstance(value, str)
+    ]
+    if not unresolved:
+        return ""
+    return (
+        f" Note: the annotation(s) {', '.join(unresolved)} could not be resolved "
+        f"to a type. Under `from __future__ import annotations` every annotation "
+        f"is a string, and the name must be importable at module scope — not "
+        f"only under `if TYPE_CHECKING:`."
+    )
+
+
 def _is_mesh_tool_type(param_type: Any) -> bool:
     """Check if a type is McpMeshTool or deprecated McpMeshAgent."""
+    # Unresolved PEP 563 / forward-reference string (issue #1548).
+    if _annotation_mentions(param_type, "McpMeshTool", "McpMeshAgent"):
+        return True
+
     # Direct McpMeshTool type
     if (
         param_type == McpMeshTool
@@ -77,6 +248,10 @@ def _is_mesh_tool_type(param_type: Any) -> bool:
 
 def _is_mesh_llm_type(param_type: Any) -> bool:
     """Check if a type is MeshLlmAgent."""
+    # Unresolved PEP 563 / forward-reference string (issue #1548).
+    if _annotation_mentions(param_type, "MeshLlmAgent"):
+        return True
+
     # Direct MeshLlmAgent type
     if param_type == MeshLlmAgent or (
         hasattr(param_type, "__name__") and param_type.__name__ == "MeshLlmAgent"
@@ -102,6 +277,10 @@ def _is_mesh_job_type(param_type: Any) -> bool:
     ``Optional[MeshJob]`` / ``MeshJob | None`` unions per the resolver
     contract (``MESHJOB_DDDI_CONTRACT.md`` → "Optional / Union types").
     """
+    # Unresolved PEP 563 / forward-reference string (issue #1548).
+    if _annotation_mentions(param_type, "MeshJob"):
+        return True
+
     # Direct MeshJob type
     if param_type == MeshJob or (
         hasattr(param_type, "__name__") and param_type.__name__ == "MeshJob"
@@ -170,60 +349,25 @@ def analyze_service_view_params(func: Any) -> list:
     except (TypeError, ValueError):
         return []
 
-    try:
-        type_hints = get_type_hints(func)
-    except Exception:
-        # get_type_hints is all-or-nothing: one unresolvable annotation (e.g. a
-        # TYPE_CHECKING-only import under ``from __future__ import annotations``)
-        # breaks it for the WHOLE function — including ordinary view-free tools.
-        # Fall back to per-parameter resolution so a resolvable view isn't
-        # silently lost, and warn ONLY when a view is actually recovered (never
-        # for a view-free function whose hints happen to fail elsewhere).
-        return _recover_view_params_per_param(func, sig)
+    # Shared resolution ladder (#1548). ``get_type_hints`` is all-or-nothing:
+    # one unresolvable annotation (e.g. a TYPE_CHECKING-only import under
+    # ``from __future__ import annotations``) breaks it for the WHOLE function —
+    # including ordinary view-free tools. The resolver falls back to
+    # per-parameter resolution so a resolvable view isn't silently lost; we warn
+    # ONLY when a view is actually recovered that way (never for a view-free
+    # function whose hints happen to fail elsewhere), per RFC #1280's
+    # "don't spam" scoping.
+    resolved_annotations, hints_ok = _resolve_param_annotations(func)
 
     result: list = []
     for i, param_name in enumerate(sig.parameters.keys()):
-        if param_name not in type_hints:
+        if param_name not in resolved_annotations:
             continue
-        meta = _service_view_meta(type_hints[param_name])
-        if meta is not None:
-            result.append((i, param_name, meta))
-    return result
-
-
-def _recover_view_params_per_param(func: Any, sig: inspect.Signature) -> list:
-    """Best-effort per-parameter view detection when function-wide
-    :func:`get_type_hints` fails.
-
-    Resolves each parameter's annotation individually against the function's
-    module globals, so a view whose class IS importable survives a sibling
-    parameter's unresolvable annotation. Emits a single WARNING **only when a
-    view is recovered here** — that both names the ``from __future__`` cause AND
-    stays silent for ordinary view-free tools (whose hints fail for unrelated
-    reasons), satisfying RFC #1280's "don't spam" scoping.
-    """
-    import sys
-
-    module = getattr(func, "__module__", None)
-    globalns = getattr(sys.modules.get(module), "__dict__", {}) if module else {}
-
-    result: list = []
-    for i, (param_name, param) in enumerate(sig.parameters.items()):
-        raw = param.annotation
-        if raw is inspect.Parameter.empty:
-            continue
-        if isinstance(raw, str):
-            try:
-                resolved = eval(raw, globalns)  # noqa: S307 - module-scoped, best-effort
-            except Exception:
-                continue
-        else:
-            resolved = raw
-        meta = _service_view_meta(resolved)
+        meta = _service_view_meta(resolved_annotations[param_name])
         if meta is not None:
             result.append((i, param_name, meta))
 
-    if result:
+    if result and not hints_ok:
         logger.warning(
             "analyze_service_view_params: function '%s' has @mesh.service view "
             "parameter(s) %s but function-wide type-hint resolution failed "
@@ -260,22 +404,26 @@ def _scan_params(
     classifier predicate and whether positions (0-indexed) or names are
     returned (``want="positions"`` or ``want="names"``).
 
+    Annotations are resolved through :func:`resolve_param_annotations` (#1548)
+    so a module using ``from __future__ import annotations`` — where every
+    annotation is a string — is classified the same as one without it.
+
     The broad ``except Exception`` is intentional: any introspection failure
-    (unresolvable forward refs, missing imports, weird callables) is logged
-    at WARNing and yields an empty list so registration can proceed — the
+    (weird callables, a signature that cannot be taken at all) is logged at
+    WARNing and yields an empty list so registration can proceed — the
     function is still invokable as a plain tool, the typed slots just won't
     bind. Do NOT narrow this.
     """
     try:
         func = _get_original_func(func)
-        type_hints = get_type_hints(func)
+        resolved_annotations = resolve_param_annotations(func)
         sig = inspect.signature(func)
 
         result: list = []
         for i, param_name in enumerate(sig.parameters.keys()):
-            if param_name not in type_hints:
+            if param_name not in resolved_annotations:
                 continue
-            if predicate(type_hints[param_name]):
+            if predicate(resolved_annotations[param_name]):
                 result.append(i if want == "positions" else param_name)
         return result
 
@@ -351,17 +499,9 @@ def analyze_mesh_job_signature(func: Any) -> MeshJobResolution:
             parameter (Phase 1 disallows; future revisions may relax).
     """
     func = _get_original_func(func)
-    try:
-        type_hints = get_type_hints(func)
-    except Exception as e:
-        # If we can't resolve type hints (forward refs, missing imports),
-        # fall back to empty resolution — same defensive posture as the
-        # legacy positional analysers above. The caller can still invoke
-        # the function as a plain tool; jobs just won't bind.
-        logger.warning(
-            f"analyze_mesh_job_signature: get_type_hints failed for {func}: {e}"
-        )
-        return MeshJobResolution()
+    # Shared resolution ladder (#1548) — never raises, and classifies a
+    # ``from __future__ import annotations`` module the same as a plain one.
+    resolved_annotations = resolve_param_annotations(func)
 
     sig = inspect.signature(func)
     mesh_tool_positions: list[int] = []
@@ -369,9 +509,9 @@ def analyze_mesh_job_signature(func: Any) -> MeshJobResolution:
     mesh_job_param_name: str | None = None
 
     for i, (param_name, _param) in enumerate(sig.parameters.items()):
-        if param_name not in type_hints:
+        if param_name not in resolved_annotations:
             continue
-        param_type = type_hints[param_name]
+        param_type = resolved_annotations[param_name]
 
         # MeshTool: assigns next positional slot, increments the counter
         # (the counter being len(mesh_tool_positions)).
@@ -657,12 +797,10 @@ def get_context_parameter_name(
         sig = inspect.signature(func)
         param_names = list(sig.parameters.keys())
 
-        # Get type hints (may fail for some functions)
-        type_hints = {}
-        try:
-            type_hints = get_type_hints(func)
-        except Exception:
-            pass  # Continue without type hints
+        # Resolved annotations (shared ladder, #1548 — never raises; an
+        # annotation that stays a string simply fails the issubclass checks
+        # below and falls through to convention-based detection).
+        type_hints = resolve_param_annotations(func)
 
         # Strategy 1: Explicit name (highest priority)
         if explicit_name is not None:

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -3200,8 +3200,14 @@ def llm(
         resolved_config.update(kwargs)
 
         # Step 2: Extract output type from return annotation
-        sig = inspect.signature(func)
-        return_annotation = sig.return_annotation
+        #
+        # Resolved through the shared ladder (#1548): under
+        # ``from __future__ import annotations`` the raw return annotation is a
+        # string, which would become the LLM output type verbatim and fail the
+        # Pydantic-model check that drives structured output.
+        from _mcp_mesh.engine.signature_analyzer import resolve_return_annotation
+
+        return_annotation = resolve_return_annotation(func)
 
         # Issue #645 Phase 1: detect Stream[str] up front. When the function
         # is a streaming tool, the LLM-output type is implicitly str (the
@@ -3278,20 +3284,30 @@ def llm(
             resolved_config["provider"] = resolved_provider
 
         # Step 3: Find MeshLlmAgent parameter
-        from mesh.types import MeshLlmAgent
+        #
+        # Delegated to the shared scanner (#1548) rather than comparing raw
+        # ``param.annotation`` here: that comparison is False for every
+        # parameter in a module using ``from __future__ import annotations``
+        # (PEP 563 makes annotations strings), so a correctly declared
+        # ``llm: mesh.MeshLlmAgent`` was rejected by the error below. Sharing
+        # ``_is_mesh_llm_type`` with the McpMeshTool/MeshJob scans also stops
+        # the two implementations of this check drifting apart again.
+        from _mcp_mesh.engine.signature_analyzer import (
+            describe_unresolved_annotations,
+            get_llm_agent_parameter_names,
+        )
 
-        llm_params = []
-        for param_name, param in sig.parameters.items():
-            if param.annotation == MeshLlmAgent or (
-                hasattr(param.annotation, "__origin__")
-                and param.annotation.__origin__ == MeshLlmAgent
-            ):
-                llm_params.append(param_name)
+        llm_params = get_llm_agent_parameter_names(func)
 
         if not llm_params:
+            # The note is empty unless an annotation stayed a string. When it
+            # is not, it names the real cause instead of leaving the message
+            # restating a requirement the developer has already met.
+            unresolved_note = describe_unresolved_annotations(func)
             raise ValueError(
                 f"Function '{func.__name__}' decorated with @mesh.llm must have at least one parameter "
                 f"of type 'mesh.MeshLlmAgent'. Example: def {func.__name__}(..., llm: mesh.MeshLlmAgent = None)"
+                f"{unresolved_note}"
             )
 
         if len(llm_params) > 1:

--- a/src/runtime/python/tests/unit/_1548_plain_annotations.py
+++ b/src/runtime/python/tests/unit/_1548_plain_annotations.py
@@ -1,0 +1,62 @@
+"""Control module for issue #1548 — the SAME declarations, WITHOUT PEP 563.
+
+Deliberately has no ``from __future__ import annotations``. PEP 563 is a
+per-module compile flag that stringifies **every** annotation in the module
+where it appears, including annotations on functions defined inside test
+methods, so the "without the future import" half of the parity contract cannot
+live in the same file as the "with" half. It lives here.
+
+Nothing in this module is decorated: importing it must not touch the shared
+``DecoratorRegistry``. The decorated parity cases are built inside the tests
+(both worlds) where the registry fixture can isolate them.
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+import mesh
+from mesh.types import McpMeshAgent, McpMeshTool, MeshJob, MeshLlmAgent
+
+
+class Reply(BaseModel):
+    """Structured LLM response used by the return-annotation parity test."""
+
+    text: str
+
+
+def tool_dep(x: str, dep: McpMeshTool = None) -> str:
+    return x
+
+
+def agent_dep(x: str, dep: McpMeshAgent = None) -> str:
+    return x
+
+
+def llm_param(x: str, llm: MeshLlmAgent = None) -> str:
+    return x
+
+
+def job_param(x: str, job: MeshJob = None) -> str:
+    return x
+
+
+def qualified(
+    x: str,
+    dep: mesh.McpMeshTool = None,
+    job: mesh.MeshJob = None,
+    llm: mesh.MeshLlmAgent = None,
+) -> str:
+    return x
+
+
+def optional_forms(
+    a: Optional[McpMeshTool] = None,  # noqa: UP045 - both spellings on purpose
+    b: MeshJob | None = None,
+    c: MeshLlmAgent | None = None,
+) -> str:
+    return "x"
+
+
+def structured(x: str, llm: MeshLlmAgent = None) -> Reply:
+    return Reply(text=x)

--- a/src/runtime/python/tests/unit/test_12_dependency_injector.py
+++ b/src/runtime/python/tests/unit/test_12_dependency_injector.py
@@ -1863,13 +1863,12 @@ class TestPrescriptiveDiagnosticsAndStrictDI:
     # Skip reasons resolve hints the same way eligibility does
     # ------------------------------------------------------------------
 
-    def test_skip_reason_string_annotation_hint_failure_is_explicit(self, caplog):
-        """A valid-looking `db: "McpMeshTool"` whose name cannot be
-        resolved (TYPE_CHECKING-only import) made eligibility fall back to
-        "no eligible parameters"; the skip reason must report that
-        hint-resolution failure — not the self-contradictory
-        'annotated as McpMeshTool, not McpMeshTool' read off the raw
-        annotation string."""
+    def test_unresolvable_string_annotation_naming_mesh_tool_is_eligible(self, caplog):
+        """A valid-looking `db: "McpMeshTool"` whose name is not importable at
+        module scope (TYPE_CHECKING-only import) used to fall back to "no
+        eligible parameters". Since #1548 the last rung of the resolution
+        ladder matches the annotation by name, so the parameter the developer
+        spelled correctly binds — and no skip diagnostic fires at all."""
         ns: dict = {}
         exec(
             "def f(a, db: 'McpMeshTool' = None):\n    return db\n",
@@ -1880,20 +1879,16 @@ class TestPrescriptiveDiagnosticsAndStrictDI:
         with caplog.at_level(logging.WARNING):
             result = analyze_injection_strategy(f, ["cap0"])
 
-        assert result == []
-        text = caplog.text
-        assert "type hints could not be resolved" in text
-        assert "TYPE_CHECKING" in text
-        assert "annotated as McpMeshTool, not McpMeshTool" not in text
+        assert result == [1]
+        assert "Skipping injection" not in caplog.text
+        assert "annotated as McpMeshTool, not McpMeshTool" not in caplog.text
 
-    def test_skip_reason_optional_mesh_tool_not_misreported_under_hint_failure(
-        self, caplog
-    ):
+    def test_optional_mesh_tool_survives_unresolvable_sibling(self, caplog):
         """An eager Optional[McpMeshTool] param sharing a function with an
-        unresolvable forward ref: hints fail wholesale, so eligibility
-        skipped BOTH. The Optional[McpMeshTool] reason must state the
-        hint failure, not render the raw annotation as
-        'annotated as Union/Optional..., not McpMeshTool'."""
+        unresolvable forward ref. ``get_type_hints`` is all-or-nothing so it
+        fails wholesale, but the per-parameter rung of the #1548 ladder
+        resolves the Optional[McpMeshTool] on its own — the sibling no longer
+        blinds it."""
         from typing import Optional as _Optional
 
         from mesh.types import McpMeshTool
@@ -1909,12 +1904,29 @@ class TestPrescriptiveDiagnosticsAndStrictDI:
         with caplog.at_level(logging.WARNING):
             result = analyze_injection_strategy(f, ["cap0"])
 
+        assert result == [1]
+        assert "Skipping injection" not in caplog.text
+
+    def test_skip_reason_unresolvable_annotation_is_explicit(self, caplog):
+        """The residual diagnostic case: NO parameter is mesh-typed and one
+        annotation cannot be resolved to a type. The skip reason must name that
+        resolution failure rather than rendering the raw annotation string as a
+        type the developer never wrote."""
+        ns: dict = {}
+        exec(
+            "def f(a, db: 'SomeAppType' = None, c: int = 0):\n    return db\n",
+            ns,
+        )
+        f = ns["f"]
+
+        with caplog.at_level(logging.WARNING):
+            result = analyze_injection_strategy(f, ["cap0"])
+
         assert result == []
         text = caplog.text
-        assert "type hints could not be resolved" in text
-        # No reason may claim any parameter is annotated as something
-        # other than McpMeshTool — the hints never resolved.
-        assert "not McpMeshTool" not in text
+        assert "could not be resolved" in text
+        assert "TYPE_CHECKING" in text
+        assert "annotated as SomeAppType" not in text
 
     def test_string_annotation_that_resolves_is_eligible_no_skip_warning(self, caplog):
         """Parity check: when the string annotation DOES resolve, the

--- a/src/runtime/python/tests/unit/test_1548_pep563_annotations.py
+++ b/src/runtime/python/tests/unit/test_1548_pep563_annotations.py
@@ -1,0 +1,396 @@
+"""Issue #1548 — ``from __future__ import annotations`` must not change how
+mesh classifies a parameter.
+
+**This module carries the future import on purpose.** PEP 563 is a per-module
+compile flag: it stringifies every annotation in the file, including those on
+functions defined inside the test methods below. A string literal written into
+one annotation by hand is NOT the same thing (it stringifies the annotations
+the author remembered, not all of them), so a module that actually opts in is
+the only faithful way to exercise the bug. The "without the future import" half
+of each parity assertion lives in the sibling module
+``_1548_plain_annotations.py``, which deliberately does not opt in.
+
+Headline case: ``@mesh.llm`` compared ``param.annotation`` to the
+``MeshLlmAgent`` class, which is never equal to the string
+``"mesh.MeshLlmAgent"``, so a correctly declared parameter was rejected with an
+error naming the one thing that was not wrong. The other injectables
+(``McpMeshTool``, ``McpMeshAgent``, ``MeshJob``) already resolved their hints
+before comparing — the parity cases here pin that down so the two
+implementations of the check cannot drift apart again.
+
+A few cases need a namespace the import system cannot produce (a name that is
+importable only under ``if TYPE_CHECKING:``). Those use ``exec`` with
+``__future__.annotations.compiler_flag``, which gives the compiled function
+exactly the PEP 563 semantics this module has.
+"""
+
+from __future__ import annotations
+import __future__
+
+import asyncio
+import os
+from typing import Optional
+
+import pytest
+from pydantic import BaseModel
+
+import mesh
+from _mcp_mesh.engine import settle
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+from _mcp_mesh.engine.signature_analyzer import (
+    analyze_mesh_job_signature,
+    get_llm_agent_parameter_names,
+    get_mesh_agent_parameter_names,
+    get_mesh_agent_positions,
+)
+from mesh.types import McpMeshAgent, McpMeshTool, MeshJob, MeshLlmAgent
+
+from . import _1548_plain_annotations as plain
+
+PEP563_FLAG = __future__.annotations.compiler_flag
+
+
+def compile_pep563(source: str, namespace: dict) -> dict:
+    """Execute ``source`` with PEP 563 semantics in a caller-supplied namespace.
+
+    Lets a test build a module scope that lacks a name the annotation uses —
+    the ``if TYPE_CHECKING:`` shape — which cannot be expressed by importing a
+    fixture module.
+    """
+    exec(compile(source, "<pep563>", "exec", flags=PEP563_FLAG), namespace)
+    return namespace
+
+
+def _clear():
+    DecoratorRegistry.clear_all()
+    from _mcp_mesh.pipeline.mcp_startup import clear_debounce_coordinator
+
+    clear_debounce_coordinator()
+
+
+@pytest.fixture(autouse=True)
+def _isolate():
+    """Fresh registry + settled (no grace) settle state per test."""
+    _clear()
+    os.environ["MCP_MESH_SETTLE_TIMEOUT"] = "0"
+    settle._reset_settle_state_for_tests()
+    yield
+    os.environ.pop("MCP_MESH_SETTLE_TIMEOUT", None)
+    settle._reset_settle_state_for_tests()
+    _clear()
+
+
+class FakeProxy:
+    """Mirrors ``UnifiedMCPProxy.__call__(*args, **kwargs)``."""
+
+    def __init__(self, name):
+        self.name = name
+
+    async def __call__(self, *args, **kwargs):
+        return {"served": self.name}
+
+
+class Reply(BaseModel):
+    text: str
+
+
+# ===========================================================================
+# Parity: the same declaration, classified the same, with and without PEP 563
+# ===========================================================================
+
+
+class TestClassificationParity:
+    """Every injection type, both worlds, identical verdicts.
+
+    Each ``pep563_*`` local is the byte-for-byte twin of the same-named
+    function in ``_1548_plain_annotations``; only the module's future import
+    differs.
+    """
+
+    def test_mcp_mesh_tool_parity(self):
+        def pep563_tool_dep(x: str, dep: McpMeshTool = None) -> str:
+            return x
+
+        assert get_mesh_agent_positions(pep563_tool_dep) == [1]
+        assert get_mesh_agent_parameter_names(pep563_tool_dep) == ["dep"]
+        assert get_mesh_agent_positions(pep563_tool_dep) == get_mesh_agent_positions(
+            plain.tool_dep
+        )
+
+    def test_deprecated_mcp_mesh_agent_parity(self):
+        def pep563_agent_dep(x: str, dep: McpMeshAgent = None) -> str:
+            return x
+
+        assert get_mesh_agent_positions(pep563_agent_dep) == [1]
+        assert get_mesh_agent_positions(pep563_agent_dep) == get_mesh_agent_positions(
+            plain.agent_dep
+        )
+
+    def test_mesh_llm_agent_parity(self):
+        def pep563_llm_param(x: str, llm: MeshLlmAgent = None) -> str:
+            return x
+
+        assert get_llm_agent_parameter_names(pep563_llm_param) == ["llm"]
+        assert get_llm_agent_parameter_names(
+            pep563_llm_param
+        ) == get_llm_agent_parameter_names(plain.llm_param)
+
+    def test_mesh_job_parity(self):
+        def pep563_job_param(x: str, job: MeshJob = None) -> str:
+            return x
+
+        resolution = analyze_mesh_job_signature(pep563_job_param)
+        assert (resolution.mesh_job_param_index, resolution.mesh_job_param_name) == (
+            1,
+            "job",
+        )
+        assert resolution == analyze_mesh_job_signature(plain.job_param)
+
+    def test_module_qualified_spelling_parity(self):
+        """``mesh.McpMeshTool`` — the spelling the docs and the error message
+        use — stringifies to a dotted name, not a bare one."""
+
+        def pep563_qualified(
+            x: str,
+            dep: mesh.McpMeshTool = None,
+            job: mesh.MeshJob = None,
+            llm: mesh.MeshLlmAgent = None,
+        ) -> str:
+            return x
+
+        assert get_mesh_agent_positions(pep563_qualified) == [1]
+        assert get_llm_agent_parameter_names(pep563_qualified) == ["llm"]
+        assert analyze_mesh_job_signature(pep563_qualified).mesh_job_param_name == "job"
+
+        assert get_mesh_agent_positions(pep563_qualified) == get_mesh_agent_positions(
+            plain.qualified
+        )
+        assert get_llm_agent_parameter_names(
+            pep563_qualified
+        ) == get_llm_agent_parameter_names(plain.qualified)
+        assert (
+            analyze_mesh_job_signature(pep563_qualified).mesh_job_param_name
+            == analyze_mesh_job_signature(plain.qualified).mesh_job_param_name
+        )
+
+    def test_optional_and_union_forms_parity(self):
+        # ``Optional`` is imported at MODULE scope on purpose: PEP 563 strings
+        # are evaluated against the module globals, so a function-local import
+        # would make the annotation genuinely unresolvable and the test would
+        # be exercising the name-matching fallback instead of resolution.
+        def pep563_optional_forms(
+            a: Optional[McpMeshTool] = None,  # noqa: UP045 - both spellings on purpose
+            b: MeshJob | None = None,
+            c: MeshLlmAgent | None = None,
+        ) -> str:
+            return "x"
+
+        assert get_mesh_agent_positions(pep563_optional_forms) == [0]
+        assert analyze_mesh_job_signature(
+            pep563_optional_forms
+        ).mesh_job_param_name == ("b")
+        assert get_llm_agent_parameter_names(pep563_optional_forms) == ["c"]
+
+        assert get_mesh_agent_positions(
+            pep563_optional_forms
+        ) == get_mesh_agent_positions(plain.optional_forms)
+        assert get_llm_agent_parameter_names(
+            pep563_optional_forms
+        ) == get_llm_agent_parameter_names(plain.optional_forms)
+
+    def test_return_annotation_parity(self):
+        """The return annotation feeds the ``@mesh.llm`` output type; under
+        PEP 563 it arrived as the string ``'Reply'``."""
+        # Imported here, not at module scope: this helper is new in the #1548
+        # fix, and a module-level import would turn every test in the file into
+        # a collection error when the file is run against the unfixed runtime.
+        from _mcp_mesh.engine.signature_analyzer import resolve_return_annotation
+
+        def pep563_structured(x: str, llm: MeshLlmAgent = None) -> Reply:
+            return Reply(text=x)
+
+        assert resolve_return_annotation(pep563_structured) is Reply
+        assert resolve_return_annotation(plain.structured) is plain.Reply
+
+
+# ===========================================================================
+# The headline case: @mesh.llm decoration
+# ===========================================================================
+
+
+class TestLlmDecoratorUnderPep563:
+    def test_llm_decorator_accepts_the_declared_parameter(self):
+        """The repro: this decoration raised 'must have at least one parameter
+        of type mesh.MeshLlmAgent' on a function that has exactly that."""
+
+        @mesh.llm(provider={"capability": "llm"})
+        @mesh.tool(capability="ask")
+        def ask(prompt: str, llm: mesh.MeshLlmAgent = None) -> str:
+            return "x"
+
+        agents = list(DecoratorRegistry.get_mesh_llm_agents().values())
+        assert [a.param_name for a in agents] == ["llm"]
+
+    def test_llm_output_type_resolves_to_the_model_class(self):
+        """``output_type`` drives structured-output validation. A string here
+        is silently wrong: it is not a BaseModel subclass, so the schema the
+        provider is asked for never matches the model."""
+
+        @mesh.llm(provider={"capability": "llm"})
+        @mesh.tool(capability="structured")
+        def structured(prompt: str, llm: mesh.MeshLlmAgent = None) -> Reply:
+            return Reply(text="x")
+
+        agent = next(iter(DecoratorRegistry.get_mesh_llm_agents().values()))
+        assert agent.output_type is Reply
+
+    def test_llm_parameter_hidden_from_the_tool_schema(self):
+        """Detection drives the signature rewrite too — an undetected
+        parameter would leak into the MCP input schema."""
+        import inspect
+
+        @mesh.llm(provider={"capability": "llm"})
+        @mesh.tool(capability="hide_llm")
+        def hide_llm(prompt: str, llm: mesh.MeshLlmAgent = None) -> str:
+            return "x"
+
+        assert list(inspect.signature(hide_llm).parameters.keys()) == ["prompt"]
+
+    def test_llm_alongside_a_mesh_tool_dependency(self):
+        """Both injection types on one function, both string-annotated."""
+
+        @mesh.llm(provider={"capability": "llm"})
+        @mesh.tool(capability="combined", dependencies=["audit"])
+        def combined(
+            prompt: str,
+            audit: mesh.McpMeshTool = None,
+            llm: mesh.MeshLlmAgent = None,
+        ) -> str:
+            return "x"
+
+        agent = next(iter(DecoratorRegistry.get_mesh_llm_agents().values()))
+        assert agent.param_name == "llm"
+        assert get_mesh_agent_parameter_names(combined) == ["audit"]
+
+    def test_unresolvable_sibling_annotation_does_not_break_the_llm_scan(self):
+        """``get_type_hints`` is all-or-nothing: one TYPE_CHECKING-only
+        annotation anywhere on the function used to take the whole scan down
+        with it. Per-parameter resolution must rescue the llm parameter."""
+        ns: dict = {"mesh": mesh}
+        compile_pep563(
+            "def ask(payload: OnlyForTypeCheckers, llm: mesh.MeshLlmAgent = None)"
+            " -> str:\n    return 'x'\n",
+            ns,
+        )
+        assert get_llm_agent_parameter_names(ns["ask"]) == ["llm"]
+
+    def test_unresolvable_llm_annotation_still_binds_by_name(self):
+        """``if TYPE_CHECKING: from mesh.types import MeshLlmAgent`` — a real
+        pattern, and unresolvable at runtime by construction. The last rung of
+        the ladder matches the name so the agent still starts."""
+        ns: dict = {}
+        compile_pep563(
+            "def ask(prompt: str, llm: MeshLlmAgent = None) -> str:\n    return 'x'\n",
+            ns,
+        )
+        assert get_llm_agent_parameter_names(ns["ask"]) == ["llm"]
+
+    def test_missing_parameter_still_raises_the_documented_error(self):
+        """The check must not become permissive: a function with no
+        MeshLlmAgent parameter at all is still refused, with the unchanged
+        message and no misleading resolution note appended."""
+        with pytest.raises(ValueError) as exc:
+
+            @mesh.llm(provider={"capability": "llm"})
+            def no_param(prompt: str) -> str:
+                return "x"
+
+        message = str(exc.value)
+        assert "must have at least one parameter" in message
+        assert "mesh.MeshLlmAgent" in message
+        assert "could not be resolved" not in message
+
+    def test_error_names_an_unresolvable_annotation_instead_of_the_requirement(
+        self,
+    ):
+        """An aliased type mesh cannot recognise (``LlmAlias``, imported only
+        under TYPE_CHECKING) genuinely has no MeshLlmAgent parameter mesh can
+        see. The error must say the annotation did not resolve rather than
+        restate a requirement the developer believes they met."""
+        ns: dict = {"mesh": mesh}
+        with pytest.raises(ValueError) as exc:
+            compile_pep563(
+                "@mesh.llm(provider={'capability': 'llm'})\n"
+                "def ask(prompt: str, llm: LlmAlias = None) -> str:\n"
+                "    return 'x'\n",
+                ns,
+            )
+
+        message = str(exc.value)
+        assert "could not be resolved" in message
+        assert "'LlmAlias'" in message
+        assert "TYPE_CHECKING" in message
+
+
+# ===========================================================================
+# End to end: the value actually arrives at call time
+# ===========================================================================
+
+
+class TestInjectionUnderPep563:
+    def test_mesh_tool_dependency_is_injected(self):
+        """Detection is not the contract — arrival is. An undetected parameter
+        produces no error anywhere; the tool just receives ``None``."""
+
+        @mesh.tool(capability="consume", dependencies=["audit"])
+        async def consume(x: str, audit: mesh.McpMeshTool = None) -> dict:
+            assert audit is not None, "dependency was not injected"
+            return await audit()
+
+        consume._mesh_update_dependency(0, FakeProxy("audit"))
+        assert asyncio.run(consume(x="v"))["served"] == "audit"
+
+    def test_deprecated_mesh_agent_dependency_is_injected(self):
+        @mesh.tool(capability="consume_legacy", dependencies=["audit"])
+        async def consume_legacy(x: str, audit: mesh.McpMeshAgent = None) -> dict:
+            assert audit is not None, "dependency was not injected"
+            return await audit()
+
+        consume_legacy._mesh_update_dependency(0, FakeProxy("legacy"))
+        assert asyncio.run(consume_legacy(x="v"))["served"] == "legacy"
+
+    def test_mesh_job_slot_is_declared_and_positioned(self):
+        """A MeshJob parameter takes a positional dependency slot shared with
+        McpMeshTool; missing it would shift every slot after it."""
+
+        @mesh.tool(capability="submit", dependencies=["audit", "worker"])
+        async def submit(
+            x: str,
+            audit: mesh.McpMeshTool = None,
+            job: mesh.MeshJob = None,
+        ) -> str:
+            return x
+
+        resolution = analyze_mesh_job_signature(submit)
+        assert resolution.mesh_tool_positions == [1]
+        assert resolution.mesh_job_param_index == 2
+        assert resolution.mesh_job_param_name == "job"
+
+    def test_dependency_slot_count_validates(self):
+        """``validate_mesh_dependencies`` gates whether a tool is advertised at
+        all. Under-counting the typed slots silently drops the tool from the
+        heartbeat."""
+        from _mcp_mesh.engine.signature_analyzer import validate_mesh_dependencies
+
+        @mesh.tool(capability="counted", dependencies=["audit", "worker"])
+        async def counted(
+            x: str,
+            audit: mesh.McpMeshTool = None,
+            job: mesh.MeshJob = None,
+        ) -> str:
+            return x
+
+        is_valid, message = validate_mesh_dependencies(
+            counted, [{"capability": "audit"}, {"capability": "worker"}]
+        )
+        assert is_valid, message


### PR DESCRIPTION
A module that is correct in every visible respect fails at import, and the message points at the one thing that is not wrong.

```python
from __future__ import annotations   # the only difference
import mesh

@mesh.llm(provider={"capability": "llm"})
@mesh.tool(capability="ask")
def ask(prompt: str, llm: mesh.MeshLlmAgent = None) -> str: ...
```

```
ValueError: Function 'ask' decorated with @mesh.llm must have at least one parameter
of type 'mesh.MeshLlmAgent'. Example: def ask(..., llm: mesh.MeshLlmAgent = None)
```

The function has exactly that parameter, spelled exactly as suggested. Under PEP 563 the annotation is the *string* `"mesh.MeshLlmAgent"`, and `decorators.py:3285` compared it to the class object.

Reported by a downstream session that hit it onboarding onto 3.7.0.

## Scope is narrower than the issue claimed — and I was the one who got it wrong

I filed #1548 asserting that `McpMeshTool`, `McpMeshAgent` and `MeshJob` injection were blind under PEP 563 too, because I probed the private predicates (`_is_mesh_tool_type`, `_is_mesh_job_type`) directly and they returned `False` on string annotations.

**That was measuring something the system never does.** The real entry points already called `typing.get_type_hints` before reaching those predicates. Verified on `main` under PEP 563:

```
_scan_params(tool_dep, _is_mesh_tool_type) -> [1]
analyze_mesh_job_signature(job_dep)        -> mesh_job_param_index=1, name='job'
```

Both correct. `@mesh.llm` was the only site reading `param.annotation` raw. The DI blindness and the `None`-at-call-time I predicted did not happen.

## A second bug in the same block

`return_annotation` was also read raw, so under PEP 563 the `@mesh.llm` output type became the string `"Reply"` rather than the class. A string is never a `BaseModel` subclass, so structured output was silently misconfigured and the "not a Pydantic BaseModel" warning fired against a perfectly good model. Import succeeded — which is why nobody noticed.

## What changed

A shared resolution ladder in `signature_analyzer.py`, used by every site that needs a resolved annotation, so the two implementations cannot drift apart again. It never raises:

1. function-wide `get_type_hints`;
2. **per-parameter `eval` against the defining module's globals** — this rung matters because `get_type_hints` is all-or-nothing, so one `TYPE_CHECKING`-only annotation anywhere on a function otherwise blinds every sibling slot on it;
3. the annotation as written, matched by bare identifier.

Rung 3 is the one worth challenging. Without it, `if TYPE_CHECKING: from mesh.types import MeshLlmAgent` — legal, and only expressible *with* the future import — still hard-fails at import: the same bug, relocated. It is also not new looseness, since the pre-existing fallback already matches any class merely *named* `McpMeshTool`. It is reached only after both real resolutions fail.

The existing `__name__` and `__origin__` fallbacks are untouched; the string arm sits in front of them. `_recover_view_params_per_param` — a second parallel ladder added for RFC #1280 — is folded into the shared one rather than left to drift.

The error message now names an unresolvable annotation as the cause instead of restating a requirement the user has already met.

## Two intentional prior decisions were overridden

`test_skip_reason_string_annotation_hint_failure_is_explicit` and `test_skip_reason_optional_mesh_tool_not_misreported_under_hint_failure` asserted `result == []` — they encoded the *quality of a diagnostic* for a failure that no longer occurs, because both parameters are now correctly injected. The second flips on rung 2 alone, so declining rung 3 would not have preserved it. Both were rewritten to assert the injection, and a new test keeps the diagnostic covered for the residual case: an annotation that is unresolvable *and* names nothing mesh-related.

This is the one place established behaviour was deliberately changed, so it deserves a reviewer's eye.

## Python floor

`pyproject.toml` is `>=3.11`. Probed on 3.11.14, 3.13.12 and 3.14.6: `get_type_hints` returns the bare class and does **not** wrap a `= None` default in `Optional` on any of them — that behaviour was removed in 3.11, exactly at the floor — so the existing `== SomeClass` comparisons keep working with no unwrapping. On 3.14 the future import still stringifies despite PEP 649. The suite could not be run locally on 3.13/3.14 (no `mesh` on 3.13; stale per-version `.so` on 3.14), so that is CI's to confirm.

## Tests

`test_1548_pep563_annotations.py` carries the future import, with `_1548_plain_annotations.py` as the control — a string literal in an annotation is not equivalent, since PEP 563 stringifies *every* annotation in the module.

Against unfixed source, 8 of 19 new tests fail plus 2 of the 3 rewritten ones: the `@mesh.llm` decoration cases, the return-annotation parity case, and the unresolvable-annotation cases. The other 11 pass on `main` — precisely because my inference about the other injection types was wrong. They are kept as regression cover for paths that now share the ladder, not as evidence of a fix.

Closes #1548

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq