### PR TITLE
fix: stop reporting a task tool's job slot as an unfilled dependency

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
+++ b/src/runtime/python/_mcp_mesh/engine/dependency_injector.py
@@ -463,6 +463,36 @@ def _format_unfilled_slots_message(
     )
 
 
+def _job_slots_bound_outside_pairing(
+    func: Callable, mesh_job_positions: Iterable[int]
+) -> set[int]:
+    """MeshJob positions that positional pairing never fills (issue #1550).
+
+    On a ``@mesh.tool(task=True)`` producer the MeshJob slot belongs to
+    the job-dispatch layer, which binds it AFTER dependency injection has
+    run: a ``JobController`` when ``X-Mesh-Job-Id`` rides the call, an
+    explicit ``None`` when the task tool is invoked directly (the
+    documented direct-call contract — not a misconfiguration). Neither
+    outcome is visible from the pairing diagnostics, so they must not
+    report the slot as one that "will remain None".
+
+    Returns the positions to omit from the unfilled-slot REPORT only.
+    Callers must leave ``eligible_positions`` itself untouched — it drives
+    injection, and shrinking it would shift every dep→param pairing.
+    """
+    positions = set(mesh_job_positions)
+    if not positions:
+        return set()
+    try:
+        # Lazy import: mirrors the existing ``maybe_dispatch_as_job``
+        # call sites below — ``job_dispatch`` is imported inside functions
+        # here so the two modules never form a module-level cycle.
+        from .job_dispatch import is_task_tool
+    except Exception:  # noqa: BLE001
+        return set()
+    return positions if is_task_tool(func) else set()
+
+
 def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[int]:
     """
     Analyze function signature and determine McpMeshTool injection positions.
@@ -574,13 +604,30 @@ def analyze_injection_strategy(func: Callable, dependencies: list[str]) -> list[
             set(mesh_positions)
             | ({mesh_job_index} if mesh_job_index is not None else set())
         )
-        if len(dependencies) < len(typed_eligible_positions):
+        # Issue #1550: a task=True producer's MeshJob slot is bound by the
+        # job-dispatch layer, never by pairing — promoting it here made
+        # strict mode REFUSE DECORATION of a correctly-written task tool.
+        # Exempt only that slot: an unpaired McpMeshTool parameter on the
+        # same function is still a real misconfiguration and still raises.
+        _exempt = _job_slots_bound_outside_pairing(
+            func, {mesh_job_index} if mesh_job_index is not None else set()
+        )
+        untouched_positions = [
+            pos
+            for pos in typed_eligible_positions[len(dependencies) :]
+            if pos not in _exempt
+        ]
+        if untouched_positions:
             raise StrictDIError(
                 _format_unfilled_slots_message(
                     func_name,
                     typed_eligible_positions,
                     dependencies,
                     [p.name for p in params],
+                    unfilled_param_names=[
+                        params[pos].name if pos < len(params) else f"<arg {pos}>"
+                        for pos in untouched_positions
+                    ],
                 )
             )
 
@@ -808,13 +855,21 @@ def _prepare_injection_kwargs(
     if len(eligible_positions) > len(dependencies):
         unfilled_message = None
         try:
+            # Issue #1550: on a task=True tool the MeshJob slot is filled by
+            # the job-dispatch layer AFTER this point, so it is never
+            # "unfilled" — reported here it named the exact failure mode a
+            # MeshJob author fears and prescribed a fix that would break the
+            # producer. Excluded from the REPORT only: ``eligible_positions``
+            # still drives injection below, unchanged.
+            job_exempt = _job_slots_bound_outside_pairing(func, mesh_job_positions)
             # ``params`` above is resolved from the same original signature
             # the positions came from (#1105), so positions line up — and
             # the message builder bounds-guards regardless.
             genuinely_unfilled = [
                 params[pos] if pos < len(params) else f"<arg {pos}>"
                 for pos in eligible_positions[len(dependencies) :]
-                if not (
+                if pos not in job_exempt
+                and not (
                     pos < len(params)
                     and params[pos] in final_kwargs
                     and final_kwargs.get(params[pos]) is not None

--- a/src/runtime/python/tests/unit/test_12_dependency_injector.py
+++ b/src/runtime/python/tests/unit/test_12_dependency_injector.py
@@ -2144,3 +2144,204 @@ class TestStrictDIDecorationFailureRegistryCleanup:
         # returned wrapper, not the original.
         assert tools["no_params_tool"].function is wrapped
         assert tools["no_params_tool"].function is not original
+
+
+class TestTaskToolJobSlotIsNotAnUnfilledSlot:
+    """Issue #1550: a ``@mesh.tool(task=True)`` producer's ``MeshJob``
+    parameter is bound by the job-dispatch layer, not by positional
+    pairing — ``maybe_dispatch_as_job`` sets a ``JobController`` when an
+    ``X-Mesh-Job-Id`` rides the call and an explicit ``None`` when the
+    task tool is invoked directly (the documented direct-call contract).
+    Both happen AFTER dependency injection, so neither pairing diagnostic
+    can see the outcome and neither may report the slot as one that "will
+    remain None": that message names the exact failure a MeshJob author
+    fears (dead ``update_progress``, unrenewed lease) and its remediation
+    — add the job to ``dependencies=[...]``, or drop the ``MeshJob``
+    annotation — would damage a working producer.
+
+    The exemption is scoped to the JOB SLOT, and only on a task tool. An
+    unpaired ``McpMeshTool`` parameter on the same function is still a
+    real misconfiguration and is still reported; a ``MeshJob`` slot on a
+    NON-task tool is genuinely pairing's to fill (with a
+    ``MeshJobSubmitter``) and is still reported when no dependency
+    reaches it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_strict_cache(self):
+        from _mcp_mesh.engine import strict_di
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+        DecoratorRegistry.clear_all()
+        strict_di._reset_strict_di_cache()
+        yield
+        DecoratorRegistry.clear_all()
+        strict_di._reset_strict_di_cache()
+
+    @staticmethod
+    def _enable_strict(monkeypatch):
+        from _mcp_mesh.engine import strict_di
+
+        monkeypatch.setenv("MCP_MESH_STRICT_DI", "true")
+        strict_di._reset_strict_di_cache()
+
+    @staticmethod
+    def _as_task_tool(func):
+        """Stamp the ``task=True`` metadata exactly as ``@mesh.tool``
+        does (``mesh/decorators.py`` sets ``_mesh_tool_metadata`` on the
+        target BEFORE building the injection wrapper), which is what
+        ``job_dispatch.is_task_tool`` reads."""
+        from _mcp_mesh.engine.job_dispatch import is_task_tool
+
+        func._mesh_tool_metadata = {"capability": "long_work", "task": True}
+        assert is_task_tool(func) is True
+        return func
+
+    @staticmethod
+    def _prep(func, dependencies, kwargs=None):
+        """Drive _prepare_injection_kwargs like the runtime wrapper does."""
+        import logging as _log
+
+        from _mcp_mesh.engine.dependency_injector import _prepare_injection_kwargs
+        from _mcp_mesh.engine.signature_analyzer import get_mesh_agent_positions
+
+        return _prepare_injection_kwargs(
+            func,
+            kwargs or {},
+            get_mesh_agent_positions(func),
+            dependencies,
+            [None] * len(dependencies),
+            lambda _key: None,
+            _log.getLogger("test"),
+        )
+
+    # ------------------------------------------------------------------
+    # Call-time diagnostic (permissive mode — the reported symptom)
+    # ------------------------------------------------------------------
+
+    def test_task_tool_with_only_a_job_slot_warns_about_nothing(self, caplog):
+        """The reported false positive: the ONLY eligible slot is the
+        MeshJob the dispatch layer owns, so nothing is unfilled and no
+        warning may be emitted at all."""
+        from mesh import MeshJob
+
+        async def long_work(payload: str, job: MeshJob = None):
+            return payload
+
+        self._as_task_tool(long_work)
+
+        with caplog.at_level(logging.WARNING):
+            self._prep(long_work, [])
+
+        assert "will remain None" not in caplog.text
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_task_tool_still_reports_an_unfilled_tool_slot_only(self, caplog):
+        """A task tool can ALSO have an unpaired McpMeshTool parameter —
+        a genuine misconfiguration. It is still reported, and the report
+        names only that slot, never the job."""
+        from mesh import MeshJob
+        from mesh.types import McpMeshTool
+
+        async def long_work(db: McpMeshTool = None, job: MeshJob = None):
+            return (db, job)
+
+        self._as_task_tool(long_work)
+
+        with caplog.at_level(logging.WARNING):
+            self._prep(long_work, [])
+
+        text = caplog.text
+        assert "injection-eligible parameters (McpMeshTool/MeshJob)" in text
+        assert "will remain None" in text
+        assert "['db']" in text
+        # The job slot must not be named among the unfilled parameters.
+        assert "'job'" not in text
+
+    def test_non_task_tool_job_slot_is_still_reported(self, caplog):
+        """Control: without ``task=True`` nothing binds the MeshJob slot
+        outside pairing, so the existing diagnostic is unchanged."""
+        from mesh import MeshJob
+
+        async def consumer(payload: str, job: MeshJob = None):
+            return payload
+
+        with caplog.at_level(logging.WARNING):
+            self._prep(consumer, [])
+
+        text = caplog.text
+        assert "injection-eligible parameter (McpMeshTool/MeshJob)" in text
+        assert "['job']" in text
+
+    def test_caller_supplied_job_on_a_task_tool_is_left_alone(self):
+        """The exemption is diagnostic-only: it must not disturb the
+        documented contract that a caller may pass a fake for any
+        injectable slot."""
+        from mesh import MeshJob
+
+        async def long_work(payload: str, job: MeshJob = None):
+            return payload
+
+        self._as_task_tool(long_work)
+        fake = object()
+
+        final_kwargs, _count = self._prep(
+            long_work, [], kwargs={"payload": "x", "job": fake}
+        )
+
+        assert final_kwargs["job"] is fake
+
+    # ------------------------------------------------------------------
+    # Decoration-time promotion under MCP_MESH_STRICT_DI
+    # ------------------------------------------------------------------
+
+    def test_strict_di_accepts_a_correctly_written_task_producer(self, monkeypatch):
+        """Harder failure than the warning: under MCP_MESH_STRICT_DI the
+        same flawed check REFUSED DECORATION of a correct task producer,
+        so the agent could not start at all."""
+        import mesh
+
+        self._enable_strict(monkeypatch)
+
+        @mesh.tool(capability="long_work", task=True)
+        async def long_work(payload: str, job: mesh.MeshJob = None):
+            return payload
+
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+        assert "long_work" in DecoratorRegistry.get_mesh_tools()
+
+    def test_strict_di_still_raises_for_an_unpaired_tool_slot(self, monkeypatch):
+        """Strict mode keeps promoting the genuine misconfiguration, and
+        the raised message names only the McpMeshTool slot."""
+        from _mcp_mesh.engine.strict_di import StrictDIError
+        from mesh import MeshJob
+        from mesh.types import McpMeshTool
+
+        async def long_work(db: McpMeshTool = None, job: MeshJob = None):
+            return (db, job)
+
+        self._as_task_tool(long_work)
+        self._enable_strict(monkeypatch)
+
+        with pytest.raises(StrictDIError) as exc:
+            analyze_injection_strategy(long_work, [])
+
+        assert "['db']" in str(exc.value)
+        assert "'job'" not in str(exc.value)
+
+    def test_strict_di_still_raises_for_a_non_task_job_slot(self, monkeypatch):
+        """Control: a non-task MeshJob slot with no dependency to pair
+        against is still a strict-mode failure."""
+        from _mcp_mesh.engine.strict_di import StrictDIError
+        from mesh import MeshJob
+
+        async def consumer(payload: str, job: MeshJob = None):
+            return payload
+
+        self._enable_strict(monkeypatch)
+
+        with pytest.raises(StrictDIError) as exc:
+            analyze_injection_strategy(consumer, [])
+
+        assert "['job']" in str(exc.value)


### PR DESCRIPTION
A `@mesh.tool(task=True)` producer with `job: MeshJob = None` was told, on every call, that its job parameter would remain `None`. It would not — and under strict DI the same flaw stopped the producer from being decorated at all.

Reported by a downstream session running a task producer that spawns Kubernetes Jobs.

## The warning

```
⚠️ Function 'long_work' has 1 injection-eligible parameter (McpMeshTool/MeshJob) but only 0
dependencies declared. … Parameter ['job'] will remain None. Fix: add one entry per unfilled
parameter to dependencies=[...] … or remove the McpMeshTool/MeshJob annotation …
```

## Why it is wrong on both paths

The `MeshJob` slot is never the pairing mechanism's to fill. `job_dispatch.py` owns it either way:

- `:415` — `final_kwargs[mesh_job_param] = controller` when dispatched with `X-Mesh-Job-Id`
- `:347` — `final_kwargs[mesh_job_param] = None` **deliberately**, when a task tool is called without one

So the diagnostic is wrong when dispatched (the parameter *is* filled) and wrong when not (a `None` job outside a job context is documented behaviour, not a misconfiguration). It runs before `maybe_dispatch_as_job` and cannot observe either outcome.

## Why it was expensive rather than merely noisy

It asserts precisely the failure a MeshJob author should fear: if `job` really were `None`, every `update_progress()` would be a silent no-op, the lease would never renew, and two workers could run the same task. Disproving that costs real time.

And the remediation advice would have made things worse — adding the job to `dependencies=[...]` is not how MeshJob binding works, and removing the `MeshJob` annotation breaks the producer.

## Strict DI was the more serious half, and was not in the report

The decoration-time site had the same flaw with a harder failure. Metadata ordering makes it reachable — `decorators.py:1350` stamps `_mesh_tool_metadata` before `create_injection_wrapper` runs at `:1383` — so under `MCP_MESH_STRICT_DI` a correct task producer could not be decorated. Reproduced on `main`:

```
RESULT: FAILED AT DECORATION -> StrictDIError ⚠️ Function 'long_work' has 1 injection-eligible parameter …
```

The agent fails at import, not at call. Fixed in the same commit; verified it now decorates cleanly.

## The fix, and what it deliberately does not do

One helper, `_job_slots_bound_outside_pairing`, reusing the existing `job_dispatch.is_task_tool` rather than re-reading metadata. Both diagnostic sites filter through it.

**Only the job slot is exempted, and only for task tools.** A `task=True` function can also have unfilled `McpMeshTool` parameters, and those remain real misconfigurations worth reporting — the tests pin that the warning still fires and names only the tool slot.

`eligible_positions` is deliberately left untouched: it drives the injection loop, and shrinking it would shift every dependency→parameter pairing.

**No message text changed.** Once the wrong slot stops being reported, the remediation is only ever printed for slots it is correct for — `McpMeshTool` slots, and `MeshJob` slots on non-task tools, which genuinely are pairing's to fill with a `MeshJobSubmitter`. The bad advice was a symptom of the wrong slot, not the wording.

## Tests

Seven cases: job-slot-only task tool (no warning at all, not merely a quieter one), task tool with an unfilled tool slot (warns, names `['db']`, asserts `'job'` absent), non-task `MeshJob` control (still warns), caller-supplied `job` passes through, plus three strict-DI cases including real `@mesh.tool(task=True)` decoration succeeding.

Four of the seven fail on `main`; the three that pass are the intended controls, unchanged by design.

## Left alone, deliberately

A task tool declaring `(job: MeshJob, db: McpMeshTool)` — job *before* tool — with one dependency still pairs `dependencies[0]` to position 0, so the dep builds a submitter the dispatcher then overwrites and `db` stays unfilled. The warning correctly names `db`, but its advice does not fix it. That is pre-existing positional-pairing semantics on an unusual ordering, and changing it is a signature-indexing behaviour change — the class that gets discussed before it gets touched, not folded into a regression fix.

Closes #1550

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect dependency-injection warnings for task tools that receive job context automatically.
  * Task-tool job parameters are now correctly handled during direct calls and dispatched jobs.
  * Unpaired tool dependencies and job parameters on non-task tools continue to be reported as expected.
  * Caller-provided job values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->