### PR TITLE
fix: await the injected LLM agent in the Python scaffold and Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ app = FastMCP("ClaudeWeather")
     provider={"capability": "llm", "tags": ["+claude"]},
 )
 @mesh.tool(capability="weather", tags=["+claude"])
-def weather(destination: str, dates: str,
-            llm: mesh.MeshLlmAgent = None) -> Forecast:
-    return llm(f"Forecast for {destination} on {dates}")
+async def weather(destination: str, dates: str,
+                  llm: mesh.MeshLlmAgent = None) -> Forecast:
+    return await llm(f"Forecast for {destination} on {dates}")
 
 @mesh.agent(name="claude-weather", auto_run=True)
 class Agent: pass

--- a/cmd/meshctl/templates/python/llm-agent/main.py.tmpl
+++ b/cmd/meshctl/templates/python/llm-agent/main.py.tmpl
@@ -117,7 +117,7 @@ class {{ toPascalCase .Name }}Response(BaseModel):
     version="1.0.0",
     tags={{ if .Tags }}{{ toJSON .Tags }}{{ else }}["llm"]{{ end }},
 )
-def {{ toSnakeCase .Name }}(
+async def {{ toSnakeCase .Name }}(
     {{ .ContextParam }}: {{ toPascalCase .Name }}Context,
     llm: mesh.MeshLlmAgent = None,
 ){{ if eq .ResponseFormat "json" }} -> {{ toPascalCase .Name }}Response{{ else }} -> str{{ end }}:
@@ -132,9 +132,9 @@ def {{ toSnakeCase .Name }}(
         {{ if eq .ResponseFormat "json" }}Structured response with processing results{{ else }}Processing result as text{{ end }}
     """
     # To pass media (images, PDFs) to the LLM:
-    # return llm("Analyze this image", media=["file:///tmp/photo.png"])
-    # return llm("What is this?", media=[(png_bytes, "image/png")])
-    return llm("Process the input based on the context provided")
+    # return await llm("Analyze this image", media=["file:///tmp/photo.png"])
+    # return await llm("What is this?", media=[(png_bytes, "image/png")])
+    return await llm("Process the input based on the context provided")
 
 
 @mesh.agent(

--- a/cmd/meshctl/templates/python/llm-provider/README.md.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/README.md.tmpl
@@ -86,8 +86,8 @@ Other agents can use this provider with the `@mesh.llm` decorator:
     context_param="ctx",
 )
 @mesh.tool(...)
-def my_llm_tool(ctx: MyContext, llm: mesh.MeshLlmAgent = None):
-    return llm("Process this request")
+async def my_llm_tool(ctx: MyContext, llm: mesh.MeshLlmAgent = None):
+    return await llm("Process this request")
 ```
 
 ## Project Structure

--- a/docs/index.md
+++ b/docs/index.md
@@ -193,9 +193,9 @@ The same agent, in each language.
         provider={"capability": "llm", "tags": ["+claude"]},
     )
     @mesh.tool(capability="weather", tags=["+claude"])
-    def weather(destination: str, dates: str,
-                llm: mesh.MeshLlmAgent = None) -> Forecast:
-        return llm(f"Forecast for {destination} on {dates}")
+    async def weather(destination: str, dates: str,
+                      llm: mesh.MeshLlmAgent = None) -> Forecast:
+        return await llm(f"Forecast for {destination} on {dates}")
 
     @mesh.agent(name="claude-weather", auto_run=True)
     class Agent: pass

--- a/docs/python/decorators.md
+++ b/docs/python/decorators.md
@@ -132,8 +132,8 @@ Enables LLM-powered tools with automatic tool discovery.
     capability="smart_assistant",
     description="LLM-powered assistant",
 )
-def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
-    return llm("Help the user with their request")
+async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
+    return await llm("Help the user with their request")
 ```
 
 **Note**: Response format is determined by return type: `-> str` for text, `-> PydanticModel` for JSON. Use `response_model` to make the LLM emit a focused subset (validated against that model) while the return annotation still drives the tool's `outputSchema`; when omitted, the LLM schema falls back to the return annotation.

--- a/docs/python/dependency-injection.md
+++ b/docs/python/dependency-injection.md
@@ -111,8 +111,8 @@ For LLM agent injection in `@mesh.llm` decorated functions:
 
 ```python
 @mesh.llm(...)
-def smart_tool(ctx: Context, llm: mesh.MeshLlmAgent = None):
-    response = llm("Process this request")
+async def smart_tool(ctx: Context, llm: mesh.MeshLlmAgent = None):
+    response = await llm("Process this request")
 ```
 
 ## Graceful Degradation

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -65,8 +65,8 @@ export OPENAI_API_KEY=sk-...
     capability="smart_assistant",
     description="LLM-powered assistant",
 )
-def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
-    return llm("Help the user with their request")
+async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
+    return await llm("Help the user with their request")
 ```
 
 ## Parameters
@@ -97,12 +97,12 @@ Pass any LiteLLM parameter in the decorator as defaults:
     temperature=0.7,
     top_p=0.9,
 )
-def assist(ctx, llm: mesh.MeshLlmAgent = None):
+async def assist(ctx, llm: mesh.MeshLlmAgent = None):
     # Uses decorator defaults
-    return llm("Help the user")
+    return await llm("Help the user")
 
     # Override at call time
-    return llm("Help", max_tokens=8000)
+    return await llm("Help", max_tokens=8000)
 ```
 
 Call-time parameters take precedence over decorator defaults.
@@ -143,8 +143,8 @@ Override provider's default model at the consumer:
     provider={"capability": "llm", "tags": ["+claude"]},
     model="anthropic/claude-haiku",  # Override provider default
 )
-def fast_assist(ctx, llm: mesh.MeshLlmAgent = None):
-    return llm("Quick response needed")
+async def fast_assist(ctx, llm: mesh.MeshLlmAgent = None):
+    return await llm("Quick response needed")
 ```
 
 Vendor mismatch (e.g., requesting OpenAI model from Claude provider) logs a warning and falls back to provider default.
@@ -332,8 +332,8 @@ class AssistContext(BaseModel):
     preferences: dict = Field(default_factory=dict)
 
 @mesh.llm(context_param="ctx", ...)
-def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None):
-    return llm(f"Help with: {ctx.input_text}")
+async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None):
+    return await llm(f"Help with: {ctx.input_text}")
 ```
 
 ## Response Formats
@@ -350,8 +350,8 @@ The **return type annotation** always drives the tool's `outputSchema` (what cal
 ```python
 @mesh.llm(provider={"capability": "llm"}, ...)
 @mesh.tool(capability="summarize")
-def summarize(ctx: SummaryContext, llm: mesh.MeshLlmAgent = None) -> str:
-    return llm("Summarize the input")  # Returns plain text
+async def summarize(ctx: SummaryContext, llm: mesh.MeshLlmAgent = None) -> str:
+    return await llm("Summarize the input")  # Returns plain text
 ```
 
 ### Structured JSON Response
@@ -364,8 +364,8 @@ class AssistResponse(BaseModel):
 
 @mesh.llm(provider={"capability": "llm"}, ...)
 @mesh.tool(capability="smart_assistant")
-def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
-    return llm("Analyze and respond")  # Returns validated Pydantic object
+async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
+    return await llm("Analyze and respond")  # Returns validated Pydantic object
 ```
 
 ### Focusing the LLM Schema with `response_model`
@@ -402,8 +402,8 @@ Set `max_iterations` for multi-step reasoning:
     max_iterations=10,  # Allow up to 10 tool calls
     filter=[{"tags": ["tools"]}],
 )
-def complex_task(ctx: TaskContext, llm: mesh.MeshLlmAgent = None):
-    return llm("Complete this multi-step task")
+async def complex_task(ctx: TaskContext, llm: mesh.MeshLlmAgent = None):
+    return await llm("Complete this multi-step task")
 ```
 
 The LLM will:
@@ -422,18 +422,18 @@ Pass additional context at call time to merge with or override auto-populated co
     system_prompt="file://prompts/assistant.jinja2",
     context_param="ctx",
 )
-def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None):
+async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None):
     # Default: uses ctx from context_param
-    return llm("Help the user")
+    return await llm("Help the user")
 
     # Add extra context (runtime wins on conflicts)
-    return llm("Help", context={"extra_info": "value"})
+    return await llm("Help", context={"extra_info": "value"})
 
     # Auto context wins on conflicts
-    return llm("Help", context={"extra": "value"}, context_mode="prepend")
+    return await llm("Help", context={"extra": "value"}, context_mode="prepend")
 
     # Replace context entirely
-    return llm("Help", context={"only": "this"}, context_mode="replace")
+    return await llm("Help", context={"only": "this"}, context_mode="replace")
 ```
 
 ### Context Modes

--- a/src/core/cli/man/content/decorators.md
+++ b/src/core/cli/man/content/decorators.md
@@ -164,8 +164,8 @@ Enables LLM-powered tools with automatic tool discovery.
     capability="smart_assistant",
     description="LLM-powered assistant",
 )
-def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
-    return llm("Help the user with their request")
+async def assist(ctx: AssistContext, llm: mesh.MeshLlmAgent = None) -> AssistResponse:
+    return await llm("Help the user with their request")
 ```
 
 **Note**: Response format is determined by return type: `-> str` for text, `-> PydanticModel` for JSON. Use `response_model` to make the LLM emit a focused subset (validated against that model) while the return annotation still drives the tool's `outputSchema`; when omitted, the LLM schema falls back to the return annotation.

--- a/src/core/cli/man/content/dependency-injection.md
+++ b/src/core/cli/man/content/dependency-injection.md
@@ -171,8 +171,8 @@ For LLM agent injection in `@mesh.llm` decorated functions:
 
 ```python
 @mesh.llm(...)
-def smart_tool(ctx: Context, llm: mesh.MeshLlmAgent = None):
-    response = llm("Process this request")
+async def smart_tool(ctx: Context, llm: mesh.MeshLlmAgent = None):
+    response = await llm("Process this request")
 ```
 
 ## Graceful Degradation

--- a/src/core/cli/scaffold/llm_consumer_await_test.go
+++ b/src/core/cli/scaffold/llm_consumer_await_test.go
@@ -1,0 +1,181 @@
+package scaffold
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The object `@mesh.llm` injects into a Python consumer is
+// `_mcp_mesh/engine/mesh_llm_agent.py`'s `MeshLlmAgent`, whose `__call__` is
+// `async def`, and `mesh_llm_agent_injector.py` has exactly one construction
+// site for it — there is no sync variant of this proxy the way there is for
+// `McpMeshTool` (SelfDependencyProxy). So `llm(...)` is a coroutine, always,
+// and the only correct shape for the generated tool is `async def` + `await`.
+//
+// The scaffold shipped a sync `def` calling `llm(...)` bare (issue #1549), and
+// nothing caught it because that shape *appears* to work: FastMCP's
+// `function_tool.py` awaits an awaitable return value, so the one line the
+// template happened to emit — `return llm(...)` as the final statement —
+// round-trips. Anything a real agent does next does not:
+//
+//   - `response = llm(...)` then reading a field gets a coroutine attribute
+//     error, and the tool returns None;
+//   - two calls in sequence leak the first coroutine with a
+//     "never awaited" RuntimeWarning;
+//   - `f"{llm(...)}"` interpolates `<coroutine object ...>`.
+//
+// That is why this guard asserts the SHAPE (`async def`, every call awaited)
+// rather than round-tripping one generated agent through a live provider: a
+// behavioural test of the template's own line passes while the pattern it
+// teaches is broken.
+//
+// Two constraints this file is built around, both learned from #1546:
+//
+//   - it renders through the real `scaffold llm` entry point, because a
+//     hand-built ScaffoldContext does not populate what the subcommand does and
+//     a guard on the wrong context proves nothing about what users get;
+//   - the unawaited-call scan is scoped to the generated TOOL BODY. The rest of
+//     the file legitimately contains `@mesh.llm(` and a sync `startup_check`,
+//     and a whole-file ban would trip on prose that is not a call at all.
+
+// llmCallSite matches an invocation of the injected agent: the bare name `llm`
+// immediately followed by `(`. The word boundary keeps `mesh.llm(` (the
+// decorator) and `MeshLlmAgent` from matching.
+var llmCallSite = regexp.MustCompile(`\bllm\(`)
+
+// scaffoldLLMConsumer runs the real `meshctl scaffold llm` for a vendor and
+// response format and returns the generated Python entry file.
+func scaffoldLLMConsumer(t *testing.T, vendor, responseFormat string) string {
+	t.Helper()
+	t.Chdir(findRepoRoot(t))
+
+	out := t.TempDir()
+	cmd := newScaffoldLLMCommand()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	require.NoError(t, cmd.Flags().Set("vendor", vendor))
+	require.NoError(t, cmd.Flags().Set("lang", "python"))
+	require.NoError(t, cmd.Flags().Set("name", "await-probe"))
+	require.NoError(t, cmd.Flags().Set("output", out))
+	require.NoError(t, cmd.Flags().Set("response-format", responseFormat))
+	require.NoError(t, runScaffoldLLMConsumer(cmd, nil))
+
+	content, err := os.ReadFile(filepath.Join(out, "await-probe", "main.py"))
+	require.NoError(t, err)
+	return string(content)
+}
+
+// generatedToolBody returns the `def` line of the generated LLM tool and the
+// lines of its body. The signature spans several lines and closes on a line
+// that starts in column 0 (`) -> str:`), so the split is: signature ends at the
+// first line ending in `:`, and the body ends at the first non-empty line with
+// no leading whitespace after that.
+func generatedToolBody(t *testing.T, content, toolName string) (string, []string) {
+	t.Helper()
+	lines := strings.Split(content, "\n")
+
+	start := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, "def "+toolName+"(") ||
+			strings.HasPrefix(line, "async def "+toolName+"(") {
+			start = i
+			break
+		}
+	}
+	require.NotEqualf(t, -1, start,
+		"no definition of the generated tool %q in the rendered agent — the template "+
+			"moved and this guard would otherwise pass by scanning nothing:\n%s",
+		toolName, content)
+
+	sigEnd := -1
+	for i := start; i < len(lines); i++ {
+		if strings.HasSuffix(strings.TrimRight(lines[i], " \t"), ":") {
+			sigEnd = i
+			break
+		}
+	}
+	require.NotEqualf(t, -1, sigEnd, "unterminated signature for tool %q", toolName)
+
+	end := len(lines)
+	for i := sigEnd + 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" {
+			continue
+		}
+		if !strings.HasPrefix(lines[i], " ") && !strings.HasPrefix(lines[i], "\t") {
+			end = i
+			break
+		}
+	}
+
+	return lines[start], lines[sigEnd+1 : end]
+}
+
+// The generated Python LLM consumer must be `async def` and must await every
+// call it makes on the injected agent — including the commented media examples,
+// which are the lines a reader is most likely to copy.
+func TestScaffoldedPythonLLMConsumerAwaitsInjectedAgent(t *testing.T) {
+	for _, vendor := range SupportedLLMVendors() {
+		for _, responseFormat := range []string{"text", "json"} {
+			t.Run(vendor+" "+responseFormat, func(t *testing.T) {
+				content := scaffoldLLMConsumer(t, vendor, responseFormat)
+				defLine, body := generatedToolBody(t, content, "await_probe")
+
+				require.Truef(t, strings.HasPrefix(defLine, "async def "),
+					"the generated LLM tool is a sync def, but the injected agent's "+
+						"__call__ is async — every `llm(...)` in its body evaluates to a "+
+						"coroutine (issue #1549): %s", defLine)
+
+				calls := 0
+				for _, line := range body {
+					for _, loc := range llmCallSite.FindAllStringIndex(line, -1) {
+						before := line[:loc[0]]
+						if strings.HasSuffix(before, ".") {
+							continue // mesh.llm(...) — the decorator, not a call
+						}
+						calls++
+						require.Truef(t, strings.HasSuffix(before, "await "),
+							"the generated tool calls the injected LLM agent without "+
+								"awaiting it; `llm(...)` is a coroutine, so this line does "+
+								"not produce a completion (issue #1549): %s",
+							strings.TrimSpace(line))
+					}
+				}
+
+				require.Positivef(t, calls,
+					"found no call on the injected LLM agent in the generated tool body — "+
+						"the guard passed by scanning nothing:\n%s", strings.Join(body, "\n"))
+			})
+		}
+	}
+}
+
+// The commented media examples are teaching lines, not dead code: they carry
+// the media argument shape a user copies. Pin them explicitly so a future edit
+// cannot reintroduce a bare call there while the live `return` stays correct.
+func TestScaffoldedPythonLLMConsumerMediaExamplesAreAwaited(t *testing.T) {
+	content := scaffoldLLMConsumer(t, "claude", "text")
+	_, body := generatedToolBody(t, content, "await_probe")
+
+	commented := 0
+	for _, line := range body {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "#") || !llmCallSite.MatchString(trimmed) {
+			continue
+		}
+		commented++
+		require.Containsf(t, trimmed, "await llm(",
+			"a commented example calls the injected LLM agent without awaiting it; "+
+				"these are the lines a user uncomments (issue #1549): %s", trimmed)
+	}
+
+	require.Equalf(t, 2, commented,
+		"expected the two commented media examples in the generated tool body, found %d — "+
+			"the template changed and this pin needs revisiting", commented)
+}

--- a/src/runtime/python/mesh/types.py
+++ b/src/runtime/python/mesh/types.py
@@ -401,12 +401,12 @@ class MeshLlmAgent(Protocol):
             model="claude-3-5-sonnet-20241022"
         )
         @mesh.tool(capability="chat")
-        def chat(message: str, llm: MeshLlmAgent = None) -> ChatResponse:
+        async def chat(message: str, llm: MeshLlmAgent = None) -> ChatResponse:
             # Optional: Override system prompt
             llm.set_system_prompt("You are a helpful document assistant.")
 
             # Execute automatic agentic loop
-            return llm(message)
+            return await llm(message)
 
     Configuration Hierarchy:
         - Provider always comes from the decorator's ``provider={...}`` filter
@@ -435,7 +435,7 @@ class MeshLlmAgent(Protocol):
         """
         ...
 
-    def __call__(self, message: str | list[dict[str, Any]], **kwargs) -> Any:
+    async def __call__(self, message: str | list[dict[str, Any]], **kwargs) -> Any:
         """
         Execute automatic agentic loop and return typed response.
 
@@ -462,7 +462,7 @@ class MeshLlmAgent(Protocol):
             ToolExecutionError: If tool execution fails during agentic loop
 
         Example (single-turn):
-            response = llm("Analyze this document: /path/to/file.pdf")
+            response = await llm("Analyze this document: /path/to/file.pdf")
             # Returns ChatResponse(answer="...", confidence=0.95)
 
         Example (multi-turn):
@@ -471,7 +471,7 @@ class MeshLlmAgent(Protocol):
                 {"role": "assistant", "content": "I'd be happy to help! What do you need?"},
                 {"role": "user", "content": "How do I read a file?"}
             ]
-            response = llm(messages)
+            response = await llm(messages)
             # Returns ChatResponse with contextual answer
         """
         ...
@@ -544,8 +544,8 @@ try:
                 context_param="ctx"
             )
             @mesh.tool(capability="chat")
-            def chat(message: str, ctx: ChatContext, llm: MeshLlmAgent = None):
-                return llm(message)  # Template auto-rendered with ctx!
+            async def chat(message: str, ctx: ChatContext, llm: MeshLlmAgent = None):
+                return await llm(message)  # Template auto-rendered with ctx!
 
         Field Descriptions in LLM Chains:
             When a specialist LLM agent has MeshContextModel parameters, the Field
@@ -637,8 +637,8 @@ class MeshLlmRequest:
 
         Consumer side (future with provider=dict):
             @mesh.llm(provider={"capability": "llm", "tags": ["claude"]})
-            def chat(message: str, llm: MeshLlmAgent = None):
-                return llm(message)  # Converts to MeshLlmRequest internally
+            async def chat(message: str, llm: MeshLlmAgent = None):
+                return await llm(message)  # Converts to MeshLlmRequest internally
 
     Attributes:
         messages: List of message dicts with "role" and "content" keys (and optionally "tool_calls")


### PR DESCRIPTION
`meshctl scaffold llm --lang python` generated a sync `def` whose body calls an async injected agent, and the published Protocol agreed with it.

Reported by a downstream session onboarding onto 3.7.0.

## Two places, not one

`mesh/types.py:438` declared `def __call__` while the object actually injected is `async def __call__` (`mesh_llm_agent.py:902`), and there is exactly one construction site — so `llm(...)` is always a coroutine.

That means fixing only the template would leave the Protocol lying to everyone who ignores the scaffold and follows the type hints, with no complaint from a type checker. `set_system_prompt` is correctly sync in both and is unchanged.

## Why nothing caught it, and why the guard is shaped the way it is

The failure is narrower than it first appears. FastMCP awaits an awaitable result (`function_tool.py`, `if inspect.isawaitable(result)`), so `return llm(...)` **as the final statement** happens to work — which is why every `uc04` integration test using this exact shape passes.

It bites one step later:

- `response = llm(...)` then reading a field
- two calls in sequence — `RuntimeWarning` plus a leaked coroutine
- interpolating the result into an f-string

So a round-trip test would pass on the broken form. The guard asserts the **code shape** instead, and the test file's header records why.

## Not affected, verified rather than assumed

TypeScript already emitted `execute: async (...)` with `return await llm(...)`, including both media comments. Java uses a synchronous builder (`MeshLlmAgent.java:427 String generate()`), correct by design. Neither is touched.

## One related mismatch deliberately left alone

`McpMeshTool.__call__` is also sync-declared against an async proxy — but that Protocol has a **second** implementation, `SelfDependencyProxy.__call__`, which is genuinely sync and returns whatever the target returns. It is ambiguous by construction, and `async def` would be wrong for that path. `MeshLlmAgent` was the only unambiguous mismatch.

## The same sync call was taught on eight other surfaces

All fixed: the `llm-provider` README template (generated user-facing code), `docs/python/{llm/index,decorators,dependency-injection}.md`, both man-page halves of the pairs, `README.md`, `docs/index.md`, and four wrong-code docstring examples in `types.py` itself.

One had **drifted**: `man llm` was already fully async while its mkdocs half was not — the hand-maintained pair had diverged, and only this sweep surfaced it.

## The pin

Renders through `newScaffoldLLMCommand()` + `runScaffoldLLMConsumer` — the real entry point, not a hand-built context. That distinction is why #1546 reached users: the existing scaffold pins render through a helper that does not populate the same context the subcommand does.

The scan is scoped to the generated tool body — it locates the tool `def`, walks past the multi-line signature, and stops at the first unindented line — so the `@mesh.llm(` decorator and the sync `startup_check` stay outside it. It also fails loudly rather than vacuously if the template moves: no tool def found, zero call sites, or a media-comment count ≠ 2.

Three independent removals each proved to fail: reverting the `def`, dropping `await` from the live call only, and dropping it from the commented media examples only.

## Follow-up, filed separately rather than folded in

`examples/` still carries **71 sync call sites across 68 files** — the whole trip-planner tutorial, `llm-examples/`, `toolcalls/`, `multi-agent-poc/`, and ~20 generated provider READMEs. Same defect, but a distinct sweep: the tutorial agents are pulled into `docs/tutorial/*` via `--8<--` snippets and `docs/downloads/tutorial-complete.*` are generated from them, so it needs a regeneration pass and narrative review rather than a mechanical rewrite. The `uc04` integration artifacts have the same shape and want the same pass, so the fixtures keep teaching what the docs teach.

Closes #1549

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq