### PR TITLE
fix: fail at startup when a provider's model needs LiteLLM and it is absent

### DIFF
--- a/cmd/meshctl/templates/python/llm-provider/requirements.txt.tmpl
+++ b/cmd/meshctl/templates/python/llm-provider/requirements.txt.tmpl
@@ -7,7 +7,7 @@
 # mcp-mesh bundles native SDK adapters for Anthropic, OpenAI and Gemini only;
 # every other vendor dispatches through LiteLLM, which is an opt-in extra and
 # is NOT part of the base install or the python-runtime base image. Without
-# this line the agent starts and registers normally, then fails on its first
-# LLM call.
+# this line the agent refuses to start: the provider knows at decoration time
+# that it can never serve, so it fails at boot rather than on a first call.
 mcp-mesh[litellm]==3.7.0
 {{- end }}

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -42,9 +42,12 @@ export OPENAI_API_KEY=sk-...
     For containerized agents, add `mcp-mesh[litellm]==<version>` to the
     agent's `requirements.txt` so the image build picks it up — `meshctl
     scaffold` writes that pin for you when the selected model is not
-    Anthropic, OpenAI, Gemini or Vertex AI. Without it the agent starts and
-    registers normally and fails on its first LLM call, with an error naming
-    the extra. `vertex_ai/*` is native despite the long-tail-looking name: it
+    Anthropic, OpenAI, Gemini or Vertex AI. Without it the agent refuses to
+    start, with an error naming the extra: a provider knows its model at
+    decoration time, so a configuration that can never serve fails at boot
+    instead of on a consumer's first call. A model a consumer overrides per
+    request is still checked when it is dispatched.
+    `vertex_ai/*` is native despite the long-tail-looking name: it
     runs the same Gemini models through the same bundled SDK, only the auth
     differs (ADC / Workload Identity instead of an AI Studio API key).
 

--- a/docs/python/llm/index.md
+++ b/docs/python/llm/index.md
@@ -46,7 +46,10 @@ export OPENAI_API_KEY=sk-...
     start, with an error naming the extra: a provider knows its model at
     decoration time, so a configuration that can never serve fails at boot
     instead of on a consumer's first call. A model a consumer overrides per
-    request is still checked when it is dispatched.
+    request is still checked when it is dispatched. The same check applies to
+    a big-3 model that cannot dispatch natively — `MCP_MESH_NATIVE_LLM`
+    disabling native dispatch, or a missing vendor SDK — because such a
+    provider falls back to LiteLLM and needs the extra too.
     `vertex_ai/*` is native despite the long-tail-looking name: it
     runs the same Gemini models through the same bundled SDK, only the auth
     differs (ADC / Workload Identity instead of an AI Studio API key).

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -36,7 +36,10 @@ that pin for you when the selected model is not Anthropic, OpenAI, Gemini or
 Vertex AI. Without it the agent refuses to start, with an error naming the
 extra: a provider knows its model at decoration time, so a configuration that
 can never serve fails at boot instead of on a consumer's first call. A model a
-consumer overrides per request is still checked when it is dispatched.
+consumer overrides per request is still checked when it is dispatched. The same
+check applies to a big-3 model that cannot dispatch natively —
+`MCP_MESH_NATIVE_LLM` disabling native dispatch, or a missing vendor SDK —
+because such a provider falls back to LiteLLM and needs the extra too.
 `vertex_ai/*` is native despite
 the long-tail-looking name: it runs the same Gemini models through the same
 bundled SDK, only the auth differs (ADC / Workload Identity instead of an AI

--- a/src/core/cli/man/content/llm.md
+++ b/src/core/cli/man/content/llm.md
@@ -33,8 +33,11 @@ pip install 'mcp-mesh[litellm]'
 For containerized agents, add `mcp-mesh[litellm]==<version>` to the agent's
 `requirements.txt` so the image build picks it up — `meshctl scaffold` writes
 that pin for you when the selected model is not Anthropic, OpenAI, Gemini or
-Vertex AI. Without it the agent starts and registers normally and fails on its
-first LLM call, with an error naming the extra. `vertex_ai/*` is native despite
+Vertex AI. Without it the agent refuses to start, with an error naming the
+extra: a provider knows its model at decoration time, so a configuration that
+can never serve fails at boot instead of on a consumer's first call. A model a
+consumer overrides per request is still checked when it is dispatched.
+`vertex_ai/*` is native despite
 the long-tail-looking name: it runs the same Gemini models through the same
 bundled SDK, only the auth differs (ADC / Workload Identity instead of an AI
 Studio API key).

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -410,7 +410,7 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // the starter's POM; a test in this package cannot, and #1499 shipped three
 // false claims through a green run here.
 const (
-	wantInlineCodeSpans = 1773
+	wantInlineCodeSpans = 1774
 	wantListCodeSpans   = 522
 	wantMarkupListLines = 448
 )

--- a/src/core/cli/scaffold/model_dispatch_python_sync_test.go
+++ b/src/core/cli/scaffold/model_dispatch_python_sync_test.go
@@ -1,0 +1,117 @@
+package scaffold
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// nativeVendorPrefixes is a hand-copy of a table the Python runtime owns, and
+// the two comments saying so were the only thing holding them together. Issue
+// #1551 gave the Python side a second consumer — a startup assertion that
+// refuses to start a provider whose declared model needs the optional
+// `mcp-mesh[litellm]` extra — so drift is no longer just a wasted pip layer.
+// A vendor that gains a native adapter in Python but not here makes the
+// scaffolder pin an extra the agent will never load; the reverse direction
+// generates an agent WITHOUT the pin that now fails to start at all.
+//
+// This test reads the Python source and reconstructs
+// `ProviderHandlerRegistry.native_dispatch_vendors()` from it, so the halves
+// cannot drift silently: adding a vendor on either side alone fails the build.
+//
+// It reconstructs rather than imports for the same reason the duplicate exists
+// — `meshctl` must decide this with no Python available. Parsing is therefore
+// deliberately strict: anything it cannot read is a failure, never a skip. A
+// moved or restructured file must be noticed here, not quietly waved through.
+func TestGoNativeVendorsMatchPythonRegistry(t *testing.T) {
+	const registryPath = "../../../runtime/python/_mcp_mesh/engine/provider_handlers/provider_handler_registry.py"
+
+	registrySrc, err := os.ReadFile(registryPath)
+	require.NoError(t, err,
+		"cannot read the Python provider registry at %s. If it moved, update "+
+			"this path — do not delete this test: it is the only thing keeping "+
+			"nativeVendorPrefixes in sync with the runtime.", registryPath)
+
+	// `from .claude_handler import ClaudeHandler` -> ClaudeHandler lives in
+	// claude_handler.py. Needed because whether a handler dispatches natively
+	// is a property of its own module (does it override `_native_module`),
+	// not of the registry.
+	classModule := map[string]string{}
+	importRe := regexp.MustCompile(`(?m)^from \.(\w+) import (\w+)$`)
+	for _, m := range importRe.FindAllStringSubmatch(string(registrySrc), -1) {
+		classModule[m[2]] = m[1]
+	}
+	require.NotEmpty(t, classModule,
+		"parsed no handler imports out of %s — the parse, not the runtime, "+
+			"is what broke", registryPath)
+
+	// The `_handlers` mapping, up to its closing brace.
+	handlersBlock := regexp.MustCompile(`(?s)_handlers: dict\[str, type\[BaseProviderHandler\]\] = \{(.*?)\n    \}`)
+	blockMatch := handlersBlock.FindStringSubmatch(string(registrySrc))
+	require.Len(t, blockMatch, 2,
+		"could not locate the _handlers mapping in %s", registryPath)
+
+	entryRe := regexp.MustCompile(`"([\w_]+)":\s*(\w+)`)
+	entries := entryRe.FindAllStringSubmatch(blockMatch[1], -1)
+	require.NotEmpty(t, entries, "parsed no vendors out of the _handlers mapping")
+
+	// A handler ships a native adapter exactly when it overrides
+	// `_native_module` — the same derivation `native_dispatch_vendors()`
+	// performs at runtime. A vendor mapped to a handler that does not override
+	// it takes the LiteLLM path and must NOT appear in nativeVendorPrefixes.
+	pythonNative := map[string]bool{}
+	nativeByClass := map[string]bool{}
+	for _, e := range entries {
+		vendor, class := e[1], e[2]
+
+		isNative, seen := nativeByClass[class]
+		if !seen {
+			module, ok := classModule[class]
+			require.True(t, ok,
+				"handler %q is mapped in _handlers but never imported in %s",
+				class, registryPath)
+
+			handlerSrc, err := os.ReadFile(
+				filepath.Join(filepath.Dir(registryPath), module+".py"))
+			require.NoError(t, err, "cannot read handler module for %q", class)
+
+			isNative = strings.Contains(string(handlerSrc), "def _native_module(")
+			nativeByClass[class] = isNative
+		}
+
+		if isNative {
+			pythonNative[vendor] = true
+		}
+	}
+
+	require.NotEmpty(t, pythonNative,
+		"reconstructed an EMPTY native-vendor set from %s. Either every native "+
+			"adapter was removed, or `def _native_module(` is no longer how a "+
+			"handler declares one — in which case this test's derivation needs "+
+			"updating, not deleting.", registryPath)
+
+	require.Equal(t, sortedKeys(pythonNative), sortedKeys(nativeVendorPrefixes),
+		"nativeVendorPrefixes has drifted from the Python provider registry.\n"+
+			"  Go   (%s)\n"+
+			"  Py   (%s -> native_dispatch_vendors())\n"+
+			"A vendor present only in Python makes scaffolded agents miss the "+
+			"mcp-mesh[litellm] pin, and since #1551 such an agent fails to "+
+			"start. A vendor present only here pins an extra it never loads.",
+		"src/core/cli/scaffold/model_dispatch.go", registryPath)
+}
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k, v := range m {
+		if v {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/src/core/cli/scaffold/model_dispatch_python_sync_test.go
+++ b/src/core/cli/scaffold/model_dispatch_python_sync_test.go
@@ -1,6 +1,7 @@
 package scaffold
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -56,8 +57,9 @@ func TestGoNativeVendorsMatchPythonRegistry(t *testing.T) {
 	require.Len(t, blockMatch, 2,
 		"could not locate the _handlers mapping in %s", registryPath)
 
-	entryRe := regexp.MustCompile(`"([\w_]+)":\s*(\w+)`)
-	entries := entryRe.FindAllStringSubmatch(blockMatch[1], -1)
+	entries, err := parsePythonHandlerEntries(blockMatch[1])
+	require.NoError(t, err,
+		"could not read the _handlers mapping in %s: %v", registryPath, err)
 	require.NotEmpty(t, entries, "parsed no vendors out of the _handlers mapping")
 
 	// A handler ships a native adapter exactly when it overrides
@@ -67,7 +69,7 @@ func TestGoNativeVendorsMatchPythonRegistry(t *testing.T) {
 	pythonNative := map[string]bool{}
 	nativeByClass := map[string]bool{}
 	for _, e := range entries {
-		vendor, class := e[1], e[2]
+		vendor, class := e.vendor, e.handlerClass
 
 		isNative, seen := nativeByClass[class]
 		if !seen {
@@ -103,6 +105,117 @@ func TestGoNativeVendorsMatchPythonRegistry(t *testing.T) {
 			"mcp-mesh[litellm] pin, and since #1551 such an agent fails to "+
 			"start. A vendor present only here pins an extra it never loads.",
 		"src/core/cli/scaffold/model_dispatch.go", registryPath)
+}
+
+// TestPythonHandlerEntriesRejectUnreadableLines is the test for the test above.
+//
+// TestGoNativeVendorsMatchPythonRegistry compares a set it RECONSTRUCTS, so its
+// green is only worth as much as the reconstruction: an entry it cannot read is
+// an entry it does not compare, and nothing about the result would say so. The
+// forms below are not hypothetical Python — they are ordinary things a
+// maintainer might write in that mapping — and each one must stop the run
+// rather than shrink the set it is checking.
+func TestPythonHandlerEntriesRejectUnreadableLines(t *testing.T) {
+	unreadable := map[string]string{
+		"parenthesized value":  `"anthropic": (ClaudeHandler),`,
+		"call expression":      `"anthropic": pick_handler(),`,
+		"attribute access":     `"anthropic": handlers.ClaudeHandler,`,
+		"conditional value":    `"anthropic": ClaudeHandler if x else GenericHandler,`,
+		"value on next line":   `"anthropic":`,
+		"dict spread":          `**_EXTRA_HANDLERS,`,
+		"two entries one line": `"anthropic": ClaudeHandler, "openai": OpenAIHandler,`,
+		"single-quoted key":    `'anthropic': ClaudeHandler,`,
+	}
+
+	for name, line := range unreadable {
+		t.Run(name, func(t *testing.T) {
+			block := "\n        \"openai\": OpenAIHandler,\n        " + line + "\n"
+
+			entries, err := parsePythonHandlerEntries(block)
+
+			require.Error(t, err,
+				"parsed %q as if the mapping held only the entries it "+
+					"recognized. The vendor on that line would be missing from "+
+					"the reconstructed set and the drift comparison would pass "+
+					"without it — the failure this guard exists to make "+
+					"impossible.", line)
+			require.Nil(t, entries)
+			require.Contains(t, err.Error(), strings.TrimSpace(line),
+				"the error must name the line that could not be read")
+		})
+	}
+}
+
+// The forms the parser does accept, pinned so "reject everything" is not a way
+// to pass the test above. `"gemini": GeminiHandler,  # comment` is the shape
+// two of the four real entries are written in today.
+func TestPythonHandlerEntriesReadsTheFormsTheRegistryUses(t *testing.T) {
+	block := "\n" +
+		"        # Built-in vendor mappings.\n" +
+		"        \"anthropic\": ClaudeHandler,\n" +
+		"\n" +
+		"        \"gemini\": GeminiHandler,  # Google AI Studio (GOOGLE_API_KEY)\n" +
+		"        \"vertex_ai\": GeminiHandler\n"
+
+	entries, err := parsePythonHandlerEntries(block)
+
+	require.NoError(t, err)
+	require.Equal(t, []pythonHandlerEntry{
+		{vendor: "anthropic", handlerClass: "ClaudeHandler"},
+		{vendor: "gemini", handlerClass: "GeminiHandler"},
+		{vendor: "vertex_ai", handlerClass: "GeminiHandler"},
+	}, entries)
+}
+
+// pythonHandlerEntry is one `"vendor": HandlerClass,` line of the Python
+// registry's `_handlers` mapping.
+type pythonHandlerEntry struct {
+	vendor       string
+	handlerClass string
+}
+
+// handlerEntryRe matches a whole entry LINE, anchored at both ends, with an
+// optional trailing comma and an optional trailing `# comment`.
+var handlerEntryRe = regexp.MustCompile(`^"([\w_]+)":\s*(\w+),?(?:\s*#.*)?$`)
+
+// parsePythonHandlerEntries reads every entry out of the `_handlers` block,
+// and fails on any line it cannot read rather than skipping it.
+//
+// That distinction is the whole function. A `FindAllStringSubmatch` over the
+// block returns only what matched and says nothing about the rest, so an entry
+// written in a form the pattern does not cover — a parenthesized or
+// multi-line value, a call expression, a `**` spread, a conditional insert —
+// is silently dropped. That vendor never enters the reconstructed set, and the
+// comparison against nativeVendorPrefixes then passes while never having
+// checked it: a guard reporting green about a vendor it did not see is worse
+// than no guard, because it also stops anyone from looking.
+//
+// Blank lines and whole-line comments are the only things skipped. Anything
+// else is an error naming the offending line, so the fix (write the entry
+// plainly, or teach the parser the new form) is a decision someone makes on
+// purpose.
+func parsePythonHandlerEntries(block string) ([]pythonHandlerEntry, error) {
+	var entries []pythonHandlerEntry
+	for _, rawLine := range strings.Split(block, "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		m := handlerEntryRe.FindStringSubmatch(line)
+		if m == nil {
+			return nil, fmt.Errorf(
+				"unreadable line in the _handlers mapping:\n  %s\n"+
+					"Every entry must parse here — an unparsed one is dropped "+
+					"from the reconstructed vendor set, and the drift check "+
+					"then passes without ever having compared that vendor. "+
+					"Either write it as a plain `\"vendor\": HandlerClass,` "+
+					"line, or teach parsePythonHandlerEntries the new form",
+				line)
+		}
+		entries = append(entries, pythonHandlerEntry{vendor: m[1], handlerClass: m[2]})
+	}
+	return entries, nil
 }
 
 func sortedKeys(m map[string]bool) []string {

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/base_provider_handler.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/base_provider_handler.py
@@ -683,6 +683,45 @@ class BaseProviderHandler(ABC):
         """
         return
 
+    def native_dispatch_blocker(self) -> str | None:
+        """Why this handler will NOT dispatch natively, or None if it will.
+
+        The same verdict ``has_native()`` reaches, with the reason kept and
+        none of the logging. Returns a stable identifier, never user copy:
+
+          * ``"no-adapter"``   — the handler ships no native module at all
+            (``_native_module()`` is None), so the vendor is a LiteLLM vendor;
+          * ``"disabled-by-env"`` — ``MCP_MESH_NATIVE_LLM`` in {0,false,no,off},
+            the explicit opt-out, which wins over SDK availability;
+          * ``"sdk-missing"``  — a native adapter is wired up but the vendor
+            SDK is not importable here;
+          * ``None``           — native dispatch will really happen.
+
+        Silence is the point, not an accident. ``has_native()`` fires two
+        one-time latches (the dispatch-status DEBUG log and the fallback INFO
+        log), both of which are meant to mark the first *dispatch* decision.
+        Callers that ask this question outside a dispatch — the #1551 startup
+        assertion in ``mesh.helpers.llm_provider`` — would otherwise burn
+        those latches at import time, moving the records away from the event
+        they describe and re-arming them under tests that assert on them.
+
+        Note the SDK probe is a real (cached) import of the vendor SDK, so
+        asking early front-loads an import the first dispatch would do anyway.
+        """
+        native = self._native_module()
+        if native is None:
+            return "no-adapter"
+
+        flag = os.environ.get("MCP_MESH_NATIVE_LLM", "").strip().lower()
+        # Explicit opt-out wins over SDK availability.
+        if flag in ("0", "false", "no", "off"):
+            return "disabled-by-env"
+
+        if not native.is_available():
+            return "sdk-missing"
+
+        return None
+
     def has_native(self) -> bool:
         """Return True if this handler can dispatch via a native vendor SDK.
 
@@ -691,6 +730,11 @@ class BaseProviderHandler(ABC):
         ``MCP_MESH_NATIVE_LLM`` in {0,false,no,off} as an explicit opt-out that
         wins over SDK availability, and returns False (with a one-time fallback
         log) when the SDK is not importable.
+
+        This is the *dispatch-decision* form: the verdict comes from
+        ``native_dispatch_blocker()`` and everything added here is logging.
+        Callers that only want the verdict should use that instead — see its
+        docstring for why the difference matters.
         """
         native = self._native_module()
         if native is None:
@@ -701,20 +745,16 @@ class BaseProviderHandler(ABC):
         # is actually made — the most useful signal for ``--debug`` runs.
         self._log_dispatch_status()
 
-        flag = os.environ.get("MCP_MESH_NATIVE_LLM", "").strip().lower()
-        # Explicit opt-out wins over SDK availability.
-        if flag in ("0", "false", "no", "off"):
-            return False
+        blocker = self.native_dispatch_blocker()
 
-        if not native.is_available():
+        if blocker == "sdk-missing":
             # Skip the log call entirely once it has already fired — the
             # function dedupes internally, but on the no-native hot path
             # avoiding the call frame altogether is cheaper still.
             if not native.is_fallback_logged():
                 native.log_fallback_once()
-            return False
 
-        return True
+        return blocker is None
 
     async def complete(
         self,

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/provider_handler_registry.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/provider_handler_registry.py
@@ -196,10 +196,12 @@ class ProviderHandlerRegistry:
 
         Deliberately class-level. It answers "is a native adapter *wired up*
         for this vendor", not "would this call dispatch natively right now" —
-        the latter is ``has_native()``, which additionally imports the vendor
-        SDK and honours ``MCP_MESH_NATIVE_LLM``. Callers that need a cheap,
-        side-effect-free, env-independent verdict (e.g. the startup assertion
-        in ``mesh.helpers.llm_provider``) want this one.
+        the latter is ``has_native()`` / ``native_dispatch_blocker()``, which
+        additionally import the vendor SDK and honour ``MCP_MESH_NATIVE_LLM``.
+        Callers that need a cheap, side-effect-free, env-independent verdict
+        want this one; the #1551 startup assertion in
+        ``mesh.helpers.llm_provider`` asks both, in that order, because a
+        vendor with an adapter wired up can still fall back at runtime.
 
         A vendor added at runtime via ``register()`` appears here only if its
         handler actually overrides ``_native_module``; a plain

--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/provider_handler_registry.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/provider_handler_registry.py
@@ -185,6 +185,34 @@ class ProviderHandlerRegistry:
         }
 
     @classmethod
+    def native_dispatch_vendors(cls) -> frozenset[str]:
+        """The vendor prefixes that dispatch through a bundled native SDK.
+
+        Derived, not declared: a handler ships a native adapter exactly when it
+        overrides ``_native_module`` (the base returns ``None``, which is what
+        keeps ``has_native()`` False and sends the vendor down the LiteLLM
+        path). Reading the override rather than keeping a second list means a
+        new native handler cannot be added without this set following it.
+
+        Deliberately class-level. It answers "is a native adapter *wired up*
+        for this vendor", not "would this call dispatch natively right now" —
+        the latter is ``has_native()``, which additionally imports the vendor
+        SDK and honours ``MCP_MESH_NATIVE_LLM``. Callers that need a cheap,
+        side-effect-free, env-independent verdict (e.g. the startup assertion
+        in ``mesh.helpers.llm_provider``) want this one.
+
+        A vendor added at runtime via ``register()`` appears here only if its
+        handler actually overrides ``_native_module``; a plain
+        ``BaseProviderHandler`` subclass does not, and correctly stays on the
+        LiteLLM path.
+        """
+        return frozenset(
+            vendor
+            for vendor, handler_class in cls._handlers.items()
+            if handler_class._native_module is not BaseProviderHandler._native_module
+        )
+
+    @classmethod
     def clear_cache(cls) -> None:
         """
         Clear cached handler instances.

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -39,7 +39,11 @@ logger = logging.getLogger(__name__)
 _MAX_ITERATIONS_UNSET = object()
 
 
-def _require_litellm(model: str | None = None, vendor: str | None = None) -> Any:
+def _require_litellm(
+    model: str | None = None,
+    vendor: str | None = None,
+    subject: str = "This request",
+) -> Any:
     """Import and return the ``litellm`` module, or raise actionable guidance.
 
     LiteLLM is an OPTIONAL dependency (issue #1383). The big-3 vendors
@@ -48,6 +52,11 @@ def _require_litellm(model: str | None = None, vendor: str | None = None) -> Any
     GenericHandler/LiteLLM path genuinely needs the package. Call this at the
     point of genuine use — never at function top — so a big-3-only install
     stays fully functional without litellm present.
+
+    ``subject`` names what needs the package, and exists solely because the
+    #1551 startup check calls this before any request exists — "This request"
+    would be describing something that has not happened. Defaulting it keeps
+    the six dispatch-time messages byte-identical.
     """
     try:
         import litellm
@@ -81,7 +90,7 @@ def _require_litellm(model: str | None = None, vendor: str | None = None) -> Any
             target = f" for vendor '{vendor}'"
 
         raise ImportError(
-            f"This request{target} requires the optional LiteLLM provider path, "
+            f"{subject}{target} requires the optional LiteLLM provider path, "
             "but the 'litellm' package is not installed. mcp-mesh bundles native "
             "SDK adapters for Anthropic, OpenAI and Gemini; every other "
             "vendor/model dispatches through LiteLLM.\n"
@@ -2541,6 +2550,52 @@ def _infer_big3_vendor_from_bare_name(model: str) -> str | None:
     return None
 
 
+def _is_native_dispatch_model(model: str | None) -> bool:
+    """Whether ``model`` dispatches through a bundled native SDK adapter.
+
+    The two branches are the two ways a model names its vendor, and each
+    defers to the component that already owns that question:
+
+      * an explicit ``vendor/`` prefix is looked up in
+        ``ProviderHandlerRegistry.native_dispatch_vendors()`` — the registry
+        owns the vendor→handler table, so no vendor list is restated here;
+      * a bare name goes through ``_infer_big3_vendor_from_bare_name``, the
+        same normalization ``llm_provider`` applies before dispatch.
+
+    An empty/unset model is reported as native: nothing is known about it, and
+    a guess must not fail an agent that would have worked.
+
+    This is a *static* verdict about the declared model. It does not consult
+    ``MCP_MESH_NATIVE_LLM`` or whether the vendor SDK imports — for that,
+    ``handler.has_native()`` is the runtime question, asked per dispatch.
+
+    !! CROSS-LANGUAGE DUPLICATE (issue #1383) !!
+    ``meshctl scaffold`` re-implements this as ``IsNativeDispatchModel`` in
+    ``src/core/cli/scaffold/model_dispatch.go`` so it can decide whether a
+    generated ``requirements.txt`` needs the optional ``mcp-mesh[litellm]``
+    pin with no Python available. ``TestGoNativeVendorsMatchPythonRegistry``
+    there fails the Go build if the vendor halves drift apart.
+    """
+    if not model or not model.strip():
+        return True
+
+    name = model.lower().strip()
+    if "/" in name:
+        vendor = name.split("/", 1)[0]
+        return vendor in ProviderHandlerRegistry.native_dispatch_vendors()
+    return _infer_big3_vendor_from_bare_name(name) is not None
+
+
+def _model_requires_litellm(model: str | None) -> bool:
+    """Whether ``model`` needs the optional LiteLLM provider path (#1383).
+
+    The Python-side twin of the scaffold's ``RequiresLiteLLM``: what that
+    decides at scaffold time (does this agent's ``requirements.txt`` need the
+    pin) is what this decides at decoration time (was the pin actually there).
+    """
+    return not _is_native_dispatch_model(model)
+
+
 def _sanitize_sampling_params(
     completion_args: dict[str, Any], effective_model: str
 ) -> None:
@@ -2690,10 +2745,13 @@ def llm_provider(
 
     Raises:
         RuntimeError: If FastMCP 'app' not found in module
-        ImportError: At call time, if the model routes to the LiteLLM
-            long-tail path and ``litellm`` is not installed. Anthropic,
-            OpenAI and Gemini models dispatch through the bundled native SDK
-            adapters and do not require it.
+        ImportError: At decoration time, if ``model`` routes to the LiteLLM
+            long-tail path and ``litellm`` is not installed — the agent fails
+            to start rather than registering and failing on a consumer's
+            first call (issue #1551). Anthropic, OpenAI and Gemini models
+            dispatch through the bundled native SDK adapters and do not
+            require it. A model supplied per-request by a consumer is still
+            checked at call time.
     """
 
     def decorator(func):
@@ -2723,12 +2781,24 @@ def llm_provider(
                 f"✅ Extracted vendor '{vendor}' from model '{model}' "
                 f"using LiteLLM detection"
             )
-        except (ImportError, AttributeError, ValueError, KeyError) as e:
-            # Fallback: try to extract from model prefix
-            # ImportError: litellm not installed
-            # AttributeError: get_llm_provider doesn't exist
-            # ValueError: invalid model format
-            # KeyError: model not in provider mapping
+        except Exception as e:
+            # Fallback: extract from the model prefix, then (below) the RFC
+            # #1100 Gap #1 bare-name inference. Reasons this probe fails:
+            # litellm not installed, get_llm_provider missing or renamed, an
+            # invalid model format, a model absent from the provider mapping.
+            #
+            # Broad on purpose. It is a best-effort PROBE with two fallbacks
+            # behind it, so no failure of it is a reason to refuse to build the
+            # provider. It used to catch a four-exception tuple
+            # (ImportError/AttributeError/ValueError/KeyError) and litellm
+            # raises outside it: ``get_llm_provider`` reports an unresolvable
+            # bare name as ``litellm.BadRequestError``, an
+            # ``openai.APIStatusError`` subclass that is not a ValueError. So
+            # the two names Gap #1 exists FOR — ``claude-3-haiku``,
+            # ``gemini-3-pro`` — crashed at decoration with a litellm error
+            # about an LLM provider not being provided, and only for users who
+            # HAD litellm installed; without it the ModuleNotFoundError was
+            # caught and the inference ran correctly.
             #
             # Since #1383 litellm is an optional extra, so "not installed" is
             # the DEFAULT state of a big-3 install, not a degradation — logging
@@ -2790,6 +2860,34 @@ def llm_provider(
                 f"⚠️  Could not extract vendor from model '{model}', using "
                 f"'unknown'. It will dispatch through the LiteLLM long-tail "
                 f"path, which needs: pip install 'mcp-mesh[litellm]'"
+            )
+
+        # Issue #1551: a provider whose DECLARED model takes the LiteLLM path
+        # knows at decoration time that it can never serve a request. Without
+        # this, it registers, reports healthy, wins dependency resolution, and
+        # surfaces the ImportError on a consumer's call path instead of its
+        # own — the failure mode #1502 exists to prevent.
+        #
+        # Deliberately narrow, on both sides:
+        #
+        #  * Big-3 models never reach ``_require_litellm`` here, so the
+        #    optional dependency stays genuinely optional (#1383). The guard
+        #    is the model predicate, evaluated first and importing nothing.
+        #  * The DECLARED model only. A consumer may override the model per
+        #    request, so the six lazy ``_require_litellm`` call sites remain
+        #    the check for what is actually dispatched; this one cannot
+        #    replace them and does not try to.
+        #
+        # ``_require_litellm`` (not a bare import) so the actionable message
+        # and — the part easy to lose — the transitive-import distinction are
+        # the same here as at call time: a broken ``tokenizers`` propagates
+        # untouched rather than being relabelled as a missing ``litellm`` and
+        # sending the author to an install command that is already satisfied.
+        if _model_requires_litellm(model):
+            _require_litellm(
+                model=model,
+                vendor=vendor,
+                subject="This agent's LLM provider",
             )
 
         def _prepare_provider_request(

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -39,10 +39,17 @@ logger = logging.getLogger(__name__)
 _MAX_ITERATIONS_UNSET = object()
 
 
+_LITELLM_PATH_EXPLANATION = (
+    "mcp-mesh bundles native SDK adapters for Anthropic, OpenAI and Gemini; "
+    "every other vendor/model dispatches through LiteLLM."
+)
+
+
 def _require_litellm(
     model: str | None = None,
     vendor: str | None = None,
     subject: str = "This request",
+    explanation: str = _LITELLM_PATH_EXPLANATION,
 ) -> Any:
     """Import and return the ``litellm`` module, or raise actionable guidance.
 
@@ -55,8 +62,13 @@ def _require_litellm(
 
     ``subject`` names what needs the package, and exists solely because the
     #1551 startup check calls this before any request exists — "This request"
-    would be describing something that has not happened. Defaulting it keeps
-    the six dispatch-time messages byte-identical.
+    would be describing something that has not happened. ``explanation`` says
+    WHY this model is on the LiteLLM path, and exists because the default
+    sentence ("every other vendor/model dispatches through LiteLLM") is a lie
+    for a big-3 model that fell back — the one case where the reader most
+    needs to be told what actually happened. Both default to the wording the
+    six dispatch-time call sites already had, so their messages stay
+    byte-identical.
     """
     try:
         import litellm
@@ -91,9 +103,7 @@ def _require_litellm(
 
         raise ImportError(
             f"{subject}{target} requires the optional LiteLLM provider path, "
-            "but the 'litellm' package is not installed. mcp-mesh bundles native "
-            "SDK adapters for Anthropic, OpenAI and Gemini; every other "
-            "vendor/model dispatches through LiteLLM.\n"
+            f"but the 'litellm' package is not installed. {explanation}\n"
             f"  Install it with:  pip install '{pin}'\n"
             f"  Containerized agents: add  {pin}  to your agent's "
             "requirements.txt so the image build includes it."
@@ -2565,9 +2575,15 @@ def _is_native_dispatch_model(model: str | None) -> bool:
     An empty/unset model is reported as native: nothing is known about it, and
     a guess must not fail an agent that would have worked.
 
-    This is a *static* verdict about the declared model. It does not consult
-    ``MCP_MESH_NATIVE_LLM`` or whether the vendor SDK imports — for that,
-    ``handler.has_native()`` is the runtime question, asked per dispatch.
+    This is a *static* verdict about the declared model, and stays that way on
+    purpose: the Go duplicate below runs in ``meshctl``, which can see neither
+    this process's environment nor its installed SDKs, so anything runtime-
+    dependent added here would drift the two halves apart by construction.
+    Hence it does not consult ``MCP_MESH_NATIVE_LLM`` or whether the vendor
+    SDK imports. That runtime question belongs to the handler
+    (``native_dispatch_blocker()`` / ``has_native()``) and is asked separately
+    — per dispatch, and once at registration by the #1551 startup assertion,
+    which composes the two rather than folding one into the other.
 
     !! CROSS-LANGUAGE DUPLICATE (issue #1383) !!
     ``meshctl scaffold`` re-implements this as ``IsNativeDispatchModel`` in
@@ -2594,6 +2610,54 @@ def _model_requires_litellm(model: str | None) -> bool:
     pin) is what this decides at decoration time (was the pin actually there).
     """
     return not _is_native_dispatch_model(model)
+
+
+def _native_dispatch_fallback_reason(vendor: str) -> str | None:
+    """Why a *natively-adapted* vendor would still dispatch through LiteLLM.
+
+    Returns a sentence for the error message, or None when native dispatch
+    really will happen. The verdict is the handler's
+    ``native_dispatch_blocker()`` — the same one ``has_native()`` reaches at
+    dispatch time — so this asks about the process the provider is actually
+    running in, not about the model string.
+
+    This is the half of the #1551 check that ``_model_requires_litellm``
+    deliberately cannot answer (see its docstring: that predicate is a
+    cross-language duplicate and must stay environment-independent). Both
+    blockers it reports as fallback are ordinary first-call failures when
+    ``litellm`` is also absent:
+
+      * ``MCP_MESH_NATIVE_LLM=0`` — the operator asked for the LiteLLM path
+        explicitly, so the extra it needs is no longer optional for them;
+      * the vendor SDK is not importable — anthropic/openai/google-genai are
+        base dependencies, so this is already a damaged or hand-pruned
+        install; native dispatch is off the table and LiteLLM is the only
+        remaining path.
+
+    ``native_dispatch_blocker()`` rather than ``has_native()`` because the
+    latter fires two once-per-process log latches meant to mark the first
+    dispatch decision, and registration is not one.
+    """
+    blocker = ProviderHandlerRegistry.get_handler(vendor).native_dispatch_blocker()
+    if blocker is None:
+        return None
+
+    if blocker == "disabled-by-env":
+        return (
+            f"MCP_MESH_NATIVE_LLM disables native SDK dispatch for this "
+            f"process, so even '{vendor}' — which ships a bundled adapter — "
+            f"dispatches through LiteLLM."
+        )
+    if blocker == "sdk-missing":
+        return (
+            f"mcp-mesh bundles a native SDK adapter for '{vendor}', but that "
+            f"vendor SDK is not importable here, so this provider falls back "
+            f"to LiteLLM."
+        )
+    return (
+        f"Vendor '{vendor}' resolves to a handler with no bundled native SDK "
+        f"adapter, so this provider dispatches through LiteLLM."
+    )
 
 
 def _sanitize_sampling_params(
@@ -2745,13 +2809,15 @@ def llm_provider(
 
     Raises:
         RuntimeError: If FastMCP 'app' not found in module
-        ImportError: At decoration time, if ``model`` routes to the LiteLLM
-            long-tail path and ``litellm`` is not installed — the agent fails
-            to start rather than registering and failing on a consumer's
-            first call (issue #1551). Anthropic, OpenAI and Gemini models
-            dispatch through the bundled native SDK adapters and do not
-            require it. A model supplied per-request by a consumer is still
-            checked at call time.
+        ImportError: At decoration time, if ``model`` will dispatch through
+            LiteLLM and ``litellm`` is not installed — the agent fails to
+            start rather than registering and failing on a consumer's first
+            call (issue #1551). That covers the long-tail path, and also an
+            Anthropic/OpenAI/Gemini model whose native dispatch is
+            unavailable: ``MCP_MESH_NATIVE_LLM`` disabling it, or the vendor
+            SDK not importable. A big-3 model dispatching natively — the
+            default — does not require it. A model supplied per-request by a
+            consumer is still checked at call time.
     """
 
     def decorator(func):
@@ -2870,25 +2936,53 @@ def llm_provider(
         #
         # Deliberately narrow, on both sides:
         #
-        #  * Big-3 models never reach ``_require_litellm`` here, so the
-        #    optional dependency stays genuinely optional (#1383). The guard
-        #    is the model predicate, evaluated first and importing nothing.
+        #  * A big-3 model that will really dispatch natively never reaches
+        #    ``_require_litellm`` here, so the optional dependency stays
+        #    genuinely optional (#1383). The guard is the model predicate,
+        #    evaluated first and importing nothing.
         #  * The DECLARED model only. A consumer may override the model per
         #    request, so the six lazy ``_require_litellm`` call sites remain
         #    the check for what is actually dispatched; this one cannot
         #    replace them and does not try to.
+        #
+        # The second branch closes the hole the first one leaves. "Needs
+        # LiteLLM" is two questions, and only one of them is about the model:
+        # a big-3 model ALSO takes the LiteLLM path when native dispatch is
+        # switched off (``MCP_MESH_NATIVE_LLM=0``) or when the vendor SDK is
+        # not importable. Those agents fail on a consumer's first call for
+        # exactly the reason #1551 reports. They are asked separately, not
+        # folded into ``_model_requires_litellm``: that predicate is a
+        # cross-language duplicate of the scaffolder's ``IsNativeDispatchModel``,
+        # which runs in ``meshctl`` where neither the environment nor the
+        # installed SDKs of the eventual agent process are visible. An
+        # env-dependent predicate could not be mirrored there, and the sync
+        # test guarding the two halves would be guarding a lie.
         #
         # ``_require_litellm`` (not a bare import) so the actionable message
         # and — the part easy to lose — the transitive-import distinction are
         # the same here as at call time: a broken ``tokenizers`` propagates
         # untouched rather than being relabelled as a missing ``litellm`` and
         # sending the author to an install command that is already satisfied.
+        _startup_subject = "This agent's LLM provider"
         if _model_requires_litellm(model):
             _require_litellm(
                 model=model,
                 vendor=vendor,
-                subject="This agent's LLM provider",
+                subject=_startup_subject,
             )
+        elif model and model.strip():
+            # Unset/blank models are skipped for the same reason
+            # ``_is_native_dispatch_model`` calls them native: nothing is known
+            # about what they will dispatch, and refusing to start on a guess
+            # is worse than the lazy call-site check standing behind this one.
+            _fallback_reason = _native_dispatch_fallback_reason(vendor)
+            if _fallback_reason is not None:
+                _require_litellm(
+                    model=model,
+                    vendor=vendor,
+                    subject=_startup_subject,
+                    explanation=_fallback_reason,
+                )
 
         def _prepare_provider_request(
             request: MeshLlmRequest,

--- a/src/runtime/python/tests/unit/test_llm_provider_litellm_startup_assertion.py
+++ b/src/runtime/python/tests/unit/test_llm_provider_litellm_startup_assertion.py
@@ -17,6 +17,14 @@ them are the ones easy to regress:
     must propagate untouched. Relabelling it as a missing ``litellm`` sends
     the author to an install command that is already satisfied and cannot
     help, while hiding the real cause.
+
+The model is only half the question. A big-3 model ALSO dispatches through
+LiteLLM when native dispatch is unavailable in the process —
+``MCP_MESH_NATIVE_LLM`` switching it off, or the vendor SDK failing to import —
+and such a provider fails on a consumer's first call for the same reason. That
+half is asked at the registration site rather than inside the model predicate,
+which is a cross-language duplicate that must stay environment-independent;
+``TestNativeDispatchUnavailable`` below pins it.
 """
 
 from __future__ import annotations
@@ -31,6 +39,18 @@ import pytest
 # ---------------------------------------------------------------------------
 # Harness
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _native_dispatch_default(monkeypatch):
+    """Every test starts from the default: native dispatch ON.
+
+    ``MCP_MESH_NATIVE_LLM`` is a real operator knob, so a developer running the
+    suite with it exported would otherwise flip the big-3 cases into the
+    LiteLLM path and make them fail for a reason that has nothing to do with
+    the code under test. Tests that want the opt-out set it themselves.
+    """
+    monkeypatch.delenv("MCP_MESH_NATIVE_LLM", raising=False)
 
 
 @contextmanager
@@ -81,6 +101,27 @@ def _hide_litellm(monkeypatch):
     what CPython actually sets.
     """
     monkeypatch.setitem(sys.modules, "litellm", None)
+
+
+def _disable_native_dispatch(monkeypatch, value: str = "0"):
+    """The documented opt-out: force every vendor down the LiteLLM path."""
+    monkeypatch.setenv("MCP_MESH_NATIVE_LLM", value)
+
+
+def _hide_vendor_sdk(monkeypatch, vendor: str = "anthropic"):
+    """The vendor's native SDK is not importable in this process.
+
+    Patched at the adapter's ``is_available`` rather than by hiding the module,
+    because that probe caches its result in a closure cell — a later
+    ``sys.modules`` edit would not be seen. This is the state a damaged or
+    hand-pruned install is in: anthropic/openai/google-genai are base
+    dependencies, so it is not reachable by choosing extras.
+    """
+    from _mcp_mesh.engine.provider_handlers import ProviderHandlerRegistry
+
+    native = ProviderHandlerRegistry.get_handler(vendor)._native_module()
+    monkeypatch.setattr(native, "is_available", lambda: False)
+    return native
 
 
 def _break_litellm_subimport(monkeypatch, missing: str = "tokenizers"):
@@ -240,7 +281,12 @@ class TestLongTailModelWithoutLiteLLM:
         assert str(exc.value).startswith("This agent's LLM provider")
 
     def test_dispatch_time_wording_is_unchanged(self):
-        """The six lazy call sites keep the copy they already had."""
+        """The six lazy call sites keep the copy they already had.
+
+        Both shaped parameters (``subject``, ``explanation``) default to what
+        the message used to hard-code, so a call site that passes neither is
+        unaffected by their existence.
+        """
         from mesh.helpers import _require_litellm
 
         with pytest.raises(ImportError) as exc:
@@ -248,7 +294,12 @@ class TestLongTailModelWithoutLiteLLM:
                 _hide_litellm(mp)
                 _require_litellm(model="ollama/llama3", vendor="ollama")
 
-        assert str(exc.value).startswith("This request for model 'ollama/llama3'")
+        message = str(exc.value)
+        assert message.startswith("This request for model 'ollama/llama3'")
+        assert (
+            "mcp-mesh bundles native SDK adapters for Anthropic, OpenAI and "
+            "Gemini; every other vendor/model dispatches through LiteLLM."
+        ) in message
 
     def test_no_tool_is_registered(self, monkeypatch):
         """The whole point: it must not be discoverable.
@@ -427,3 +478,265 @@ class TestBrokenTransitiveImport:
                 mod, module_name, "anthropic/claude-sonnet-4-5"
             )
             assert decorated is not None
+
+
+# ---------------------------------------------------------------------------
+# A big-3 model that will NOT dispatch natively
+# ---------------------------------------------------------------------------
+
+
+class TestNativeDispatchUnavailable:
+    """ "Needs LiteLLM" is two questions, and the model answers only one.
+
+    A big-3 model is on the LiteLLM path whenever native dispatch is not
+    actually available in the process — ``MCP_MESH_NATIVE_LLM`` switching it
+    off, or the vendor SDK not importing. Such a provider fails on a
+    consumer's first call for precisely the reason #1551 reports, so leaving
+    it out would have left the reported bug reachable through a configuration
+    the operator explicitly asked for.
+
+    The runtime question is asked at the registration site, NOT inside
+    ``_model_requires_litellm``: that predicate is a cross-language duplicate
+    of the scaffolder's ``IsNativeDispatchModel``, which runs in ``meshctl``
+    where this process's environment and installed SDKs do not exist. Making
+    it env-dependent would make the Go/Python sync guard enforce a lie.
+    """
+
+    @pytest.mark.parametrize("flag", ["0", "false", "no", "off", "OFF", " False "])
+    def test_env_opt_out_makes_a_big3_model_require_litellm(self, monkeypatch, flag):
+        _disable_native_dispatch(monkeypatch, flag)
+        _hide_litellm(monkeypatch)
+        module_name = "_test_llm_provider_native_env_off"
+        with _module_with_app(module_name) as mod:
+            with pytest.raises(ImportError) as exc:
+                _declare_provider(mod, module_name, "anthropic/claude-sonnet-4-5")
+
+        message = str(exc.value)
+        assert "anthropic/claude-sonnet-4-5" in message
+        assert "mcp-mesh[litellm]" in message
+        # The cause, named. Without it the message would claim this model is
+        # long-tail — "every other vendor/model dispatches through LiteLLM" —
+        # and send an Anthropic user looking for a typo in a model string that
+        # is perfectly correct.
+        assert "MCP_MESH_NATIVE_LLM" in message
+
+    @pytest.mark.parametrize("flag", ["1", "true", "yes", "on", ""])
+    def test_a_non_opt_out_value_leaves_native_dispatch_alone(self, monkeypatch, flag):
+        """Only the documented opt-out set disables native dispatch.
+
+        The negative control for the parametrization above: if any value of the
+        variable counted, this check would be reading the variable's presence
+        rather than its meaning.
+        """
+        _disable_native_dispatch(monkeypatch, flag)
+        _hide_litellm(monkeypatch)
+        module_name = "_test_llm_provider_native_env_on"
+        with _module_with_app(module_name) as mod:
+            assert (
+                _declare_provider(mod, module_name, "anthropic/claude-sonnet-4-5")
+                is not None
+            )
+
+    def test_env_opt_out_with_litellm_installed_still_starts(self, monkeypatch):
+        """The opt-out is a supported configuration — it just needs the extra."""
+        pytest.importorskip("litellm")
+        _disable_native_dispatch(monkeypatch)
+        module_name = "_test_llm_provider_native_env_off_with_litellm"
+        with _module_with_app(module_name) as mod:
+            assert (
+                _declare_provider(mod, module_name, "anthropic/claude-sonnet-4-5")
+                is not None
+            )
+
+    @pytest.mark.parametrize(
+        "model,vendor",
+        [
+            ("anthropic/claude-sonnet-4-5", "anthropic"),
+            ("openai/gpt-4o", "openai"),
+            ("gemini/gemini-2.5-flash", "gemini"),
+            ("claude-3-haiku", "anthropic"),
+        ],
+    )
+    def test_env_opt_out_covers_every_native_vendor(self, monkeypatch, model, vendor):
+        _disable_native_dispatch(monkeypatch)
+        _hide_litellm(monkeypatch)
+        module_name = "_test_llm_provider_native_env_off_matrix"
+        with _module_with_app(module_name) as mod:
+            with pytest.raises(ImportError) as exc:
+                _declare_provider(mod, module_name, model)
+
+        assert vendor in str(exc.value)
+
+    def test_a_missing_vendor_sdk_is_covered_too(self, monkeypatch):
+        """The deliberate scope decision, stated as a test.
+
+        The check is "will this dispatch through LiteLLM", not "did the
+        operator ask for LiteLLM" — so it covers an unimportable vendor SDK as
+        well as the env opt-out. Both leave the provider with no dispatch path
+        at all when ``litellm`` is absent, which is a first-call failure the
+        decorator can see coming. The vendor SDKs are BASE dependencies
+        (issue #834), so this state is a damaged install rather than a
+        supported one: nobody reaches it by choosing extras, and failing at
+        boot is strictly better than registering healthy and failing later.
+        """
+        _hide_vendor_sdk(monkeypatch, "anthropic")
+        _hide_litellm(monkeypatch)
+        module_name = "_test_llm_provider_native_sdk_missing"
+        with _module_with_app(module_name) as mod:
+            with pytest.raises(ImportError) as exc:
+                _declare_provider(mod, module_name, "anthropic/claude-sonnet-4-5")
+
+        message = str(exc.value)
+        assert "not importable" in message
+        assert "mcp-mesh[litellm]" in message
+        # It must not be described as a long-tail vendor: mcp-mesh does bundle
+        # an adapter for it, and that is the difference between "install the
+        # extra" and "repair your install".
+        assert "every other vendor/model dispatches through LiteLLM" not in message
+
+    def test_a_missing_vendor_sdk_falls_back_when_litellm_is_present(self, monkeypatch):
+        """This is the LiteLLM fallback working as designed, not a failure."""
+        pytest.importorskip("litellm")
+        _hide_vendor_sdk(monkeypatch, "anthropic")
+        module_name = "_test_llm_provider_native_sdk_missing_with_litellm"
+        with _module_with_app(module_name) as mod:
+            assert (
+                _declare_provider(mod, module_name, "anthropic/claude-sonnet-4-5")
+                is not None
+            )
+
+    def test_an_unset_model_never_fails_even_with_native_dispatch_off(
+        self, monkeypatch
+    ):
+        """Nothing is known about it, so there is nothing to refuse over."""
+        _disable_native_dispatch(monkeypatch)
+        _hide_litellm(monkeypatch)
+        module_name = "_test_llm_provider_empty_model_env_off"
+        with _module_with_app(module_name) as mod:
+            assert _declare_provider(mod, module_name, "") is not None
+
+    def test_the_optional_dependency_stays_optional_by_default(self, monkeypatch):
+        """The #1383 guarantee, re-asserted against the wider check.
+
+        With the env unset and the SDK present, the runtime question must
+        return "native" and ``_require_litellm`` must not be consulted at all —
+        "does not raise" is vacuous here because litellm IS installed in this
+        venv.
+        """
+        import mesh.helpers as helpers
+
+        calls = []
+        monkeypatch.setattr(
+            helpers,
+            "_require_litellm",
+            lambda *a, **k: calls.append(k) or object(),
+        )
+        _hide_litellm(monkeypatch)
+        module_name = "_test_llm_provider_native_default_no_import"
+        with _module_with_app(module_name) as mod:
+            _declare_provider(mod, module_name, "anthropic/claude-sonnet-4-5")
+
+        assert calls == []
+
+    def test_the_runtime_question_does_not_burn_the_dispatch_log_latches(
+        self, monkeypatch
+    ):
+        """Registration asks, but must not narrate.
+
+        ``has_native()`` fires two once-per-process latches — the
+        dispatch-status DEBUG record and the SDK-fallback INFO nudge — and both
+        exist to mark the first *dispatch* decision. Asking it at decoration
+        time would move those records away from the event they describe and
+        pre-arm them under the tests that assert on them, which is why the
+        startup check uses ``native_dispatch_blocker()`` instead.
+        """
+        from _mcp_mesh.engine.provider_handlers import claude_handler
+
+        monkeypatch.setattr(claude_handler, "_DISPATCH_STATUS_LOGGED", False)
+        native = _hide_vendor_sdk(monkeypatch, "anthropic")
+        fallback_calls = []
+        monkeypatch.setattr(
+            native, "log_fallback_once", lambda: fallback_calls.append(1)
+        )
+
+        module_name = "_test_llm_provider_latches_untouched"
+        with _module_with_app(module_name) as mod:
+            _declare_provider(mod, module_name, "anthropic/claude-sonnet-4-5")
+
+        assert claude_handler._DISPATCH_STATUS_LOGGED is False
+        assert fallback_calls == []
+
+    def test_the_dispatch_decision_still_logs(self, monkeypatch):
+        """The negative control: the latches are not dead, only unasked.
+
+        ``has_native()`` — what a real dispatch calls — must still fire both.
+        """
+        from _mcp_mesh.engine.provider_handlers import (
+            ProviderHandlerRegistry,
+            claude_handler,
+        )
+
+        monkeypatch.setattr(claude_handler, "_DISPATCH_STATUS_LOGGED", False)
+        native = _hide_vendor_sdk(monkeypatch, "anthropic")
+        fallback_calls = []
+        monkeypatch.setattr(native, "is_fallback_logged", lambda: False)
+        monkeypatch.setattr(
+            native, "log_fallback_once", lambda: fallback_calls.append(1)
+        )
+
+        handler = ProviderHandlerRegistry.get_handler("anthropic")
+        assert handler.has_native() is False
+
+        assert claude_handler._DISPATCH_STATUS_LOGGED is True
+        assert fallback_calls == [1]
+
+
+class TestNativeDispatchBlocker:
+    """The handler-level runtime question, in isolation."""
+
+    def test_reports_none_when_native_dispatch_will_happen(self):
+        from _mcp_mesh.engine.provider_handlers import ProviderHandlerRegistry
+
+        handler = ProviderHandlerRegistry.get_handler("anthropic")
+        assert handler.native_dispatch_blocker() is None
+
+    def test_reports_the_env_opt_out(self, monkeypatch):
+        from _mcp_mesh.engine.provider_handlers import ProviderHandlerRegistry
+
+        _disable_native_dispatch(monkeypatch)
+        handler = ProviderHandlerRegistry.get_handler("openai")
+        assert handler.native_dispatch_blocker() == "disabled-by-env"
+
+    def test_reports_a_missing_sdk(self, monkeypatch):
+        from _mcp_mesh.engine.provider_handlers import ProviderHandlerRegistry
+
+        _hide_vendor_sdk(monkeypatch, "gemini")
+        handler = ProviderHandlerRegistry.get_handler("gemini")
+        assert handler.native_dispatch_blocker() == "sdk-missing"
+
+    def test_the_env_opt_out_outranks_a_missing_sdk(self, monkeypatch):
+        """Same precedence ``has_native()`` has always had: an explicit
+        opt-out is answered without probing the SDK at all."""
+        from _mcp_mesh.engine.provider_handlers import ProviderHandlerRegistry
+
+        _disable_native_dispatch(monkeypatch)
+        _hide_vendor_sdk(monkeypatch, "anthropic")
+        handler = ProviderHandlerRegistry.get_handler("anthropic")
+        assert handler.native_dispatch_blocker() == "disabled-by-env"
+
+    def test_reports_a_vendor_with_no_adapter(self):
+        from _mcp_mesh.engine.provider_handlers import ProviderHandlerRegistry
+
+        handler = ProviderHandlerRegistry.get_handler("cohere")
+        assert handler.native_dispatch_blocker() == "no-adapter"
+
+    def test_has_native_agrees_with_it(self, monkeypatch):
+        """One verdict, two call sites — ``has_native()`` adds only logging."""
+        from _mcp_mesh.engine.provider_handlers import ProviderHandlerRegistry
+
+        handler = ProviderHandlerRegistry.get_handler("openai")
+        assert handler.has_native() is (handler.native_dispatch_blocker() is None)
+
+        _disable_native_dispatch(monkeypatch)
+        assert handler.has_native() is (handler.native_dispatch_blocker() is None)
+        assert handler.has_native() is False

--- a/src/runtime/python/tests/unit/test_llm_provider_litellm_startup_assertion.py
+++ b/src/runtime/python/tests/unit/test_llm_provider_litellm_startup_assertion.py
@@ -1,0 +1,429 @@
+"""A provider that needs LiteLLM and does not have it must fail at startup.
+
+Issue #1551. ``litellm`` left the base install in 3.5.0 (#1383) and every
+``_require_litellm`` call site is lazy on purpose, so a big-3-only install
+stays fully functional without the package. The cost of that laziness was
+that a provider declaring a LONG-TAIL model — which cannot serve a single
+request without the extra — registered, reported healthy, won dependency
+resolution, and raised on a *consumer's* first call.
+
+``@mesh.llm_provider`` has the model at decoration time, so it can settle this
+before the agent exists. These tests pin the four cases that matter, and two of
+them are the ones easy to regress:
+
+  * a big-3 model must NOT trigger the check — if it did, the optional
+    dependency would stop being optional and #1383 would be undone;
+  * a broken TRANSITIVE import (``litellm`` present, ``tokenizers`` broken)
+    must propagate untouched. Relabelling it as a missing ``litellm`` sends
+    the author to an install command that is already satisfied and cannot
+    help, while hiding the real cause.
+"""
+
+from __future__ import annotations
+
+import builtins
+import sys
+import types
+from contextlib import contextmanager
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _module_with_app(module_name: str):
+    """A real ``sys.modules`` entry carrying a FastMCP ``app``.
+
+    ``@mesh.llm_provider`` resolves the app via ``sys.modules[fn.__module__]``,
+    so a decorated function needs a module that actually exists.
+    """
+    from fastmcp import FastMCP
+
+    from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+    mod = types.ModuleType(module_name)
+    mod.app = FastMCP(module_name)
+    sys.modules[module_name] = mod
+    snapshot = dict(DecoratorRegistry._mesh_tools)
+    DecoratorRegistry._mesh_tools.clear()
+    try:
+        yield mod
+    finally:
+        sys.modules.pop(module_name, None)
+        DecoratorRegistry._mesh_tools.clear()
+        DecoratorRegistry._mesh_tools.update(snapshot)
+
+
+def _declare_provider(mod, module_name: str, model: str, func_name: str = "provider"):
+    """Apply ``@mesh.llm_provider(model=...)`` the way an agent module would."""
+    import mesh
+
+    def placeholder():
+        pass
+
+    placeholder.__name__ = func_name
+    placeholder.__qualname__ = func_name
+    placeholder.__module__ = module_name
+    return mesh.llm_provider(model=model, capability="llm")(placeholder)
+
+
+def _hide_litellm(monkeypatch):
+    """Make ``import litellm`` raise exactly what an uninstalled package does.
+
+    ``None`` in ``sys.modules`` is CPython's own "this import is blocked" hook
+    and raises ``ModuleNotFoundError(name="litellm")`` — the same type and the
+    same ``.name`` a real absence produces, which is what ``_require_litellm``
+    branches on. Uninstalling the package in the test venv is not an option,
+    and stubbing the exception by hand would let the ``.name`` drift away from
+    what CPython actually sets.
+    """
+    monkeypatch.setitem(sys.modules, "litellm", None)
+
+
+def _break_litellm_subimport(monkeypatch, missing: str = "tokenizers"):
+    """``litellm`` itself is installed; something it imports is not.
+
+    The real shape of this is an ABI-broken or half-installed transitive
+    dependency: ``import litellm`` raises ``ModuleNotFoundError`` whose
+    ``.name`` is the *inner* module, not ``litellm``.
+    """
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "litellm":
+            raise ModuleNotFoundError(f"No module named '{missing}'", name=missing)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+# Long-tail models: no bundled native adapter, so every request goes through
+# LiteLLM. Kept aligned with the Go table in
+# src/core/cli/scaffold/model_dispatch_test.go (TestRequiresLiteLLM).
+LONG_TAIL_MODELS = [
+    "moonshot/kimi-k2-0905-preview",
+    "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "databricks/anthropic.claude-3-7-sonnet",
+    "cohere/command-r-plus",
+    "ollama/llama3",
+    "groq/llama-3.1-70b-versatile",
+    "acme-llm/frobnicator-9",
+    "llama-3-70b",
+    "mistral-large-latest",
+    "o3xyz",
+]
+
+# Big-3 models: bundled native SDK adapters, litellm never involved.
+NATIVE_MODELS = [
+    "anthropic/claude-sonnet-4-5",
+    "openai/gpt-4o",
+    "gemini/gemini-2.5-flash",
+    "vertex_ai/gemini-2.5-flash",
+    "claude-3-haiku",
+    "gpt-4o",
+    "chatgpt-4o-latest",
+    "o1",
+    "o3-mini",
+    "gemini-3-pro-preview",
+]
+
+
+# ---------------------------------------------------------------------------
+# The predicate
+# ---------------------------------------------------------------------------
+
+
+class TestModelRequiresLiteLLM:
+    """The Python half of a predicate ``meshctl scaffold`` also implements.
+
+    The Go side decides whether a generated ``requirements.txt`` gets the pin;
+    this side decides whether the agent is allowed to start without it. They
+    must agree, or the scaffolder writes an agent that refuses to boot. The
+    model tables above are the Go test's tables; the vendor halves are held
+    together by TestGoNativeVendorsMatchPythonRegistry in Go.
+    """
+
+    @pytest.mark.parametrize("model", LONG_TAIL_MODELS)
+    def test_long_tail_models_require_litellm(self, model):
+        from mesh.helpers import _is_native_dispatch_model, _model_requires_litellm
+
+        assert _model_requires_litellm(model) is True
+        assert _is_native_dispatch_model(model) is False
+
+    @pytest.mark.parametrize("model", NATIVE_MODELS)
+    def test_native_models_do_not_require_litellm(self, model):
+        from mesh.helpers import _is_native_dispatch_model, _model_requires_litellm
+
+        assert _model_requires_litellm(model) is False
+        assert _is_native_dispatch_model(model) is True
+
+    def test_is_case_insensitive(self):
+        from mesh.helpers import _model_requires_litellm
+
+        assert _model_requires_litellm("Anthropic/Claude-Sonnet-5") is False
+        assert _model_requires_litellm("VERTEX_AI/gemini-2.5-flash") is False
+        assert _model_requires_litellm("Bedrock/Anthropic.Claude-3") is True
+
+    @pytest.mark.parametrize("model", ["", "   ", None])
+    def test_unset_model_is_never_reported_as_needing_litellm(self, model):
+        """Nothing is known about it — refusing to start on a guess is worse
+        than the lazy call-site check that still stands behind this one."""
+        from mesh.helpers import _model_requires_litellm
+
+        assert _model_requires_litellm(model) is False
+
+    def test_vendor_half_comes_from_the_handler_registry(self):
+        """Not a second vendor table: the registry is asked.
+
+        Registering a handler with no native adapter must not make its vendor
+        look native — such a handler still dispatches through LiteLLM.
+        """
+        from _mcp_mesh.engine.provider_handlers import ProviderHandlerRegistry
+        from _mcp_mesh.engine.provider_handlers.base_provider_handler import (
+            BaseProviderHandler,
+        )
+        from mesh.helpers import _model_requires_litellm
+
+        assert ProviderHandlerRegistry.native_dispatch_vendors() == frozenset(
+            {"anthropic", "openai", "gemini", "vertex_ai"}
+        )
+
+        class PlainHandler(BaseProviderHandler):
+            pass
+
+        try:
+            ProviderHandlerRegistry.register("acme", PlainHandler)
+            assert "acme" not in ProviderHandlerRegistry.native_dispatch_vendors()
+            assert _model_requires_litellm("acme/frobnicator-9") is True
+        finally:
+            ProviderHandlerRegistry._handlers.pop("acme", None)
+            ProviderHandlerRegistry.clear_cache()
+
+
+# ---------------------------------------------------------------------------
+# The startup assertion
+# ---------------------------------------------------------------------------
+
+
+class TestLongTailModelWithoutLiteLLM:
+    def test_decoration_raises(self, monkeypatch):
+        _hide_litellm(monkeypatch)
+        module_name = "_test_llm_provider_longtail_absent"
+        with _module_with_app(module_name) as mod:
+            with pytest.raises(ImportError) as exc:
+                _declare_provider(mod, module_name, "moonshot/kimi-k2-0905-preview")
+
+        message = str(exc.value)
+        # The existing message quality is the point — this path must not grow
+        # a second, thinner error. Copy is asserted by substring, not in full,
+        # so wording can improve without breaking the test.
+        assert "moonshot/kimi-k2-0905-preview" in message
+        assert "mcp-mesh[litellm]" in message
+        assert "requirements.txt" in message
+
+    def test_the_message_does_not_describe_a_request(self, monkeypatch):
+        """It fires before any request exists, so it must not claim one did.
+
+        The dispatch-time wording opens "This request", and reusing it here
+        would tell the author a call failed when nothing has been called —
+        sending them to look at a consumer that never ran.
+        """
+        _hide_litellm(monkeypatch)
+        module_name = "_test_llm_provider_longtail_subject"
+        with _module_with_app(module_name) as mod:
+            with pytest.raises(ImportError) as exc:
+                _declare_provider(mod, module_name, "ollama/llama3")
+
+        assert str(exc.value).startswith("This agent's LLM provider")
+
+    def test_dispatch_time_wording_is_unchanged(self):
+        """The six lazy call sites keep the copy they already had."""
+        from mesh.helpers import _require_litellm
+
+        with pytest.raises(ImportError) as exc:
+            with pytest.MonkeyPatch.context() as mp:
+                _hide_litellm(mp)
+                _require_litellm(model="ollama/llama3", vendor="ollama")
+
+        assert str(exc.value).startswith("This request for model 'ollama/llama3'")
+
+    def test_no_tool_is_registered(self, monkeypatch):
+        """The whole point: it must not be discoverable.
+
+        A provider that registers and then fails on call is exactly the state
+        #1551 reports — consumers resolve to it and inherit its failure.
+        """
+        from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+        _hide_litellm(monkeypatch)
+        module_name = "_test_llm_provider_longtail_no_registration"
+        with _module_with_app(module_name) as mod:
+            with pytest.raises(ImportError):
+                _declare_provider(mod, module_name, "cohere/command-r-plus")
+
+            assert DecoratorRegistry._mesh_tools == {}
+
+    @pytest.mark.parametrize("model", LONG_TAIL_MODELS)
+    def test_every_long_tail_model_is_caught(self, monkeypatch, model):
+        _hide_litellm(monkeypatch)
+        module_name = "_test_llm_provider_longtail_matrix"
+        with _module_with_app(module_name) as mod:
+            with pytest.raises(ImportError):
+                _declare_provider(mod, module_name, model)
+
+
+class TestNativeModelWithoutLiteLLM:
+    @pytest.mark.parametrize("model", NATIVE_MODELS)
+    def test_decoration_succeeds(self, monkeypatch, model):
+        """#1383's guarantee: a big-3 install works with no litellm at all."""
+        _hide_litellm(monkeypatch)
+        module_name = "_test_llm_provider_native_absent"
+        with _module_with_app(module_name) as mod:
+            decorated = _declare_provider(mod, module_name, model)
+            assert decorated is not None
+
+    @pytest.mark.parametrize("model", NATIVE_MODELS)
+    def test_the_check_is_never_reached(self, monkeypatch, model):
+        """Not merely "does not raise" — must not consult litellm at all.
+
+        ``_require_litellm`` would succeed in this venv (litellm IS installed
+        here), so a gate that ran it and passed would look identical to a gate
+        that skipped it, and would ship an agent that breaks the moment the
+        extra is genuinely absent.
+        """
+        import mesh.helpers as helpers
+
+        calls = []
+
+        def spy(*args, **kwargs):
+            calls.append((args, kwargs))
+            raise AssertionError(
+                f"_require_litellm was consulted for native model {model!r}"
+            )
+
+        monkeypatch.setattr(helpers, "_require_litellm", spy)
+        module_name = "_test_llm_provider_native_no_import"
+        with _module_with_app(module_name) as mod:
+            _declare_provider(mod, module_name, model)
+
+        assert calls == []
+
+    def test_the_check_is_reached_for_a_long_tail_model(self, monkeypatch):
+        """The negative control for the test above: the spy is wired to a gate
+        that really does fire, so ``calls == []`` there means something."""
+        import mesh.helpers as helpers
+
+        calls = []
+
+        def spy(*args, **kwargs):
+            calls.append(kwargs)
+            return object()
+
+        monkeypatch.setattr(helpers, "_require_litellm", spy)
+        module_name = "_test_llm_provider_longtail_spy"
+        with _module_with_app(module_name) as mod:
+            _declare_provider(mod, module_name, "cohere/command-r-plus")
+
+        assert len(calls) == 1
+        assert calls[0]["model"] == "cohere/command-r-plus"
+        # The resolved vendor is passed through to the message so it can name
+        # what it could not dispatch. Not asserted exactly: litellm resolves
+        # this one to "cohere_chat" while prefix extraction yields "cohere",
+        # and which of the two you get depends on whether litellm is present.
+        assert calls[0]["vendor"].startswith("cohere")
+
+
+class TestLongTailModelWithLiteLLMInstalled:
+    @pytest.mark.parametrize("model", ["cohere/command-r-plus", "ollama/llama3"])
+    def test_decoration_succeeds(self, model):
+        """litellm present is the supported configuration — nothing changes."""
+        pytest.importorskip("litellm")
+        module_name = "_test_llm_provider_longtail_present"
+        with _module_with_app(module_name) as mod:
+            decorated = _declare_provider(mod, module_name, model)
+            assert decorated is not None
+
+
+class TestVendorProbeIsBestEffort:
+    """Vendor detection must never be what stops a provider from being built.
+
+    Found while building the matrix above, and present before the startup
+    assertion existed: ``litellm.get_llm_provider`` reports an unresolvable
+    bare name as ``litellm.BadRequestError`` — an ``openai.APIStatusError``
+    subclass, so not a ``ValueError`` — which fell outside the ``except``
+    tuple and crashed decoration. It hit exactly the names RFC #1100 Gap #1
+    added the bare-name inference FOR, and only when litellm was installed:
+    without it, the ``ModuleNotFoundError`` was caught and the inference ran.
+    """
+
+    @pytest.mark.parametrize("model", ["claude-3-haiku", "gemini-3-pro"])
+    def test_bare_big3_name_litellm_cannot_resolve(self, model):
+        pytest.importorskip("litellm")
+        module_name = "_test_llm_provider_bare_big3_probe"
+        with _module_with_app(module_name) as mod:
+            assert _declare_provider(mod, module_name, model) is not None
+
+    def test_a_raising_probe_falls_back_instead_of_crashing(self, monkeypatch):
+        """Any probe failure, not just the one observed."""
+        import litellm
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("probe exploded")
+
+        monkeypatch.setattr(litellm, "get_llm_provider", boom)
+        module_name = "_test_llm_provider_probe_raises"
+        with _module_with_app(module_name) as mod:
+            assert (
+                _declare_provider(mod, module_name, "anthropic/claude-sonnet-4-5")
+                is not None
+            )
+
+    def test_the_fallback_still_reaches_the_startup_assertion(self, monkeypatch):
+        """A crashing probe must not become a way to skip the #1551 gate."""
+        import litellm
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("probe exploded")
+
+        monkeypatch.setattr(litellm, "get_llm_provider", boom)
+        _hide_litellm(monkeypatch)
+        module_name = "_test_llm_provider_probe_raises_longtail"
+        with _module_with_app(module_name) as mod:
+            with pytest.raises(ImportError):
+                _declare_provider(mod, module_name, "cohere/command-r-plus")
+
+
+class TestBrokenTransitiveImport:
+    """``litellm`` is installed; one of ITS imports is broken.
+
+    ``_require_litellm`` branches on ``e.name != "litellm"`` for exactly this,
+    and moving the check to startup is where that distinction is easiest to
+    lose — a naive ``try: import litellm / except ImportError: raise <install
+    litellm>`` at decoration time reports a broken ``tokenizers`` as a missing
+    extra that is in fact already installed.
+    """
+
+    def test_the_real_cause_propagates_for_a_long_tail_model(self, monkeypatch):
+        _break_litellm_subimport(monkeypatch)
+        module_name = "_test_llm_provider_transitive_longtail"
+        with _module_with_app(module_name) as mod:
+            with pytest.raises(ModuleNotFoundError) as exc:
+                _declare_provider(mod, module_name, "cohere/command-r-plus")
+
+        assert exc.value.name == "tokenizers"
+        assert "tokenizers" in str(exc.value)
+        assert "mcp-mesh[litellm]" not in str(exc.value)
+
+    def test_a_native_model_is_unaffected(self, monkeypatch):
+        """Big-3 dispatch does not need litellm, so a broken litellm tree must
+        not stop the agent from starting."""
+        _break_litellm_subimport(monkeypatch)
+        module_name = "_test_llm_provider_transitive_native"
+        with _module_with_app(module_name) as mod:
+            decorated = _declare_provider(
+                mod, module_name, "anthropic/claude-sonnet-4-5"
+            )
+            assert decorated is not None


### PR DESCRIPTION
A provider declaring a long-tail model registered healthy, was resolved by consumers, and failed on its **first LLM call**. It knows its model at decoration time, so it has everything needed to fail immediately.

## The issue blamed the wrong thing

I filed #1551 from a downstream report without reproducing it. The premise — that the scaffold should add the dependency — is wrong: **it already does.** `RequiresLiteLLM(model)` is `!IsNativeDispatchModel(model)`, and the `llm-provider` `requirements.txt` template pins `mcp-mesh[litellm]` when that holds, with a comment predicting this exact failure.

The reporting session **hand-wrote** their agents rather than scaffolding them, which is why they never received it. So the fix belongs in the runtime, where a hand-written agent reaches it.

## Not `startup_check`, and the second reason is the decisive one

The obvious home is the hook RFC #1502 added for "this agent can never serve". It does not work here:

1. **No composition point.** The config holds a single callable, and `@mesh.llm_provider` decorates a function while `@mesh.agent` decorates a class — neither can reliably see the other, so a runtime-supplied check would silently overwrite the user's.
2. **`startup_check` only has teeth under Kubernetes.** Nothing gates registration on it; its only readers are the two `/startupz` handlers. Under `meshctl start` or plain Docker there is no `startupProbe`, so a `startup_check`-based fix would leave the agent registering healthy and failing on first call — **exactly the reported bug**. The report came from a real cluster, but the fix should not work in only one of three deployment modes.

Decoration-time failure gives the same operator-visible outcome (`CrashLoopBackOff`, absent from resolution) with the actionable message in the logs, everywhere.

## The two things that were easy to get wrong

**Big-3 must never reach the import**, or the optional dependency stops being optional — the entire point of #1383. The model predicate is evaluated first and imports nothing. Asserted with a spy counting `_require_litellm` calls across all 10 native models, **plus a negative control proving the spy is wired to a gate that does fire** — "does not raise" would be vacuous here, since `litellm` is installed in the test venv.

**The transitive-import distinction must survive.** `_require_litellm` re-raises when `e.name != "litellm"` so a broken `tokenizers` is not reported as a missing `litellm`, sending users to an install command already satisfied. The check calls that helper rather than importing directly, so the behaviour is unchanged and pinned by test.

## The vendor set is derived, and the drift guard is real

Python had no equivalent of the Go `IsNativeDispatchModel`. Rather than restate the table, `native_dispatch_vendors()` derives it from **which handlers override `_native_module`** — so a user-registered plain `BaseProviderHandler` correctly stays long-tail.

A Go test reads the Python registry, follows the imports to each handler module, reconstructs the set, and fails on any difference. Verified by injecting a bogus `"moonshot": true` into the Go table:

```
--- FAIL: TestGoNativeVendorsMatchPythonRegistry
    actual  : []string{"anthropic", "gemini", "moonshot", "openai", "vertex_ai"}
    Messages: nativeVendorPrefixes has drifted from the Python provider registry.
```

It never skips — an unreadable file is a failure, not a pass.

## A pre-existing crash the model matrix surfaced

`litellm.get_llm_provider` reports an unresolvable bare name as `BadRequestError`, an `openai.APIStatusError` subclass — **not** caught by the `except (ImportError, AttributeError, ValueError, KeyError)` clause. Verified directly:

```
raised   : litellm.exceptions.BadRequestError
caught by main's except (ImportError, AttributeError, ValueError, KeyError)? False
```

So `claude-3-haiku` and `gemini-3-pro` — precisely the two names RFC #1100 Gap #1 added bare-name inference *for* — crashed at decoration, **but only for users who had litellm installed**. Without it the `ModuleNotFoundError` was caught and inference worked. Installing an optional dependency broke a model name that worked without it.

Broadened to `except Exception` (it is a best-effort probe with two documented fallbacks), with a test asserting a crashing probe cannot become a way to skip the new gate. Happy to split this into its own PR if you would rather keep the diffs separate.

## TypeScript and Java

Neither has a LiteLLM path, so this specific issue does not apply — but the *shape* exists in both and is lazy in both. TypeScript's `loadProvider` runs on first `execute`; Java's `getClient` is `computeIfAbsent`, and `isProviderAvailable` exists with **no callers**. Those are the "declared vendor's SDK is absent" generalisation rather than this case, and want a separate issue.

## Known limitation, deliberate

The check is purely model-based, mirroring the Go predicate. `MCP_MESH_NATIVE_LLM=0` forces every model onto LiteLLM, and a big-3 provider in that configuration without the extra is still only caught at call time. The env is kept out of the predicate so both cross-language halves mean the same thing — the scaffolder cannot see env.

## Out of scope

The `HealthStatus.checks` type-strictness half of #1551 is untouched and stays open.

Closes #1551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LLM providers using non-native models now fail during startup when the required LiteLLM support is unavailable, with an actionable error.
  * Native providers no longer require LiteLLM unnecessarily.
  * Per-request model overrides are validated when dispatched, with underlying import errors preserved.

* **Documentation**
  * Updated LLM provider and scaffolding guidance to explain startup and request-time validation behavior.

* **Tests**
  * Added coverage to keep native provider detection consistent across supported tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->