### PR TITLE
fix: a non-bool in `checks` made the agent absent, not unhealthy

### DIFF
--- a/docs/concepts/health-discovery.md
+++ b/docs/concepts/health-discovery.md
@@ -118,6 +118,8 @@ While the check reports `unhealthy` the agent stops heartbeating. The registry's
 
 Only an explicit unhealthy result does that. A check that raises keeps heartbeating and stays in dependency resolution, in all three runtimes: a bug in the health check must not be able to remove a working agent from the mesh.
 
+`checks` maps a check name to `true` or `false`. A value that is not one - a status string, a nested object - is dropped and reported in `errors` alongside a `health_check_checks_type: false` entry, rather than changing the verdict the check returned.
+
 Those verdicts show on the diagnostic surface only, on all three runtimes: `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict.
 
 ### When Every Provider Withdraws
@@ -285,6 +287,7 @@ export DEFAULT_TIMEOUT_THRESHOLD=20
 ```python
 async def health():
     # Report every probe; decide on the ones you cannot serve without.
+    # Each helper returns True or False - `checks` is a map of name to bool.
     checks = {
         "database": await check_db(),
         "cache": await check_cache(),
@@ -293,7 +296,7 @@ async def health():
 
     # A cold cache is slower, not unserving, and a memory warning is not an
     # outage - both stay healthy and ride along in `checks`.
-    if not checks["database"]["ok"]:
+    if not checks["database"]:
         return {"status": "unhealthy", "checks": checks, "errors": ["database unreachable"]}
     return {"status": "healthy", "checks": checks}
 ```

--- a/src/core/cli/man/content/health.md
+++ b/src/core/cli/man/content/health.md
@@ -154,6 +154,8 @@ The verdict drives `/health`, which answers 200 only while the check reports `he
 
 A check that **raises** keeps heartbeating and stays in dependency resolution. So does one that returns something other than a dict, a `bool` or a `HealthStatus`. A bug in a health check must not be able to remove a working agent from the mesh. Return `False` or `{"status": "unhealthy"}` to actually withdraw.
 
+`checks` maps a check name to `True` or `False`. A value that is not one - `"ok"`, a nested dict - is dropped and reported in `errors` alongside a `health_check_checks_type: False` entry, and the verdict the check returned still stands.
+
 Those verdicts show on the diagnostic surface only: `/health` answers 503 while `/ready` is unmoved. Nothing probes `/health`, so its status code is free to carry the verdict; readiness reports the mesh runtime and nothing else.
 
 ### When Every Provider Withdraws

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -396,6 +396,27 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // `observability.md` as a table row and in `environment.md` inside the bash
 // fence; renderStyled takes other branches for both, so neither is sampled
 // here.
+// Issue #1556: +6 / +0 / +0, one added paragraph in `health.md` saying what a
+// `checks` value may be. The page had described the result's `status` in
+// detail and never the map beside it, and a non-bool in there — a status
+// string, a nested dict, both of which this repo's own docs showed — used to
+// escape the health path as a validation error and leave the agent serving
+// `/livez` and `/startupz` 200 while registering nowhere. The runtime now
+// drops the value and reports it, so the page states the type. The six spans
+// are `checks`, the `True`/`False` it maps to, `"ok"` as the value that is
+// neither (the nested dict beside it is named in prose and adds none),
+// `errors` where the rejection lands, and the `health_check_checks_type:
+// False` entry that marks it. The closing clause — the verdict the check
+// returned still stands — is prose and adds none, and is the one place this
+// deviates from #1539's "read the verdict, do not override it": a typo in
+// `checks` must not re-admit an agent that returned unhealthy. Prose, not a
+// list item, so the two list goldens hold.
+//
+// The marker is Python's alone (`health_check_checks_type` exists in
+// `health_check_manager.py` and in no other runtime), so the `_java` and
+// `_typescript` health pages did not get the sentence and the variant golden
+// in `variant_corpus_test.go` is unmoved — the case the note below describes,
+// in reverse.
 //
 // Issue #1500: the sentence most annotations above end on — that the `_java`
 // and `_typescript` files are invisible here, so a review of them cannot lean
@@ -410,7 +431,7 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // the starter's POM; a test in this package cannot, and #1499 shipped three
 // false claims through a green run here.
 const (
-	wantInlineCodeSpans = 1774
+	wantInlineCodeSpans = 1780
 	wantListCodeSpans   = 522
 	wantMarkupListLines = 448
 )

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/fastapiserver_setup.py
@@ -17,8 +17,22 @@ class FastAPIServerSetupStep(PipelineStep):
 
     def __init__(self):
         super().__init__(
+            # Required (issue #1556). This step used to be optional, for
+            # "may not have FastMCP instances to mount" — but having nothing to
+            # mount has never been a FAILURE here. Zero FastMCP servers is a
+            # SUCCESS: the step still builds the FastAPI app, with the minimal
+            # lifespan and the K8s endpoints. Discovering none is reported one
+            # step earlier, by `fastmcp-server-discovery`, as SKIPPED. And
+            # `MCP_MESH_HTTP_ENABLED=false` returns SKIPPED below, which the
+            # pipeline exempts from the required-step abort by design.
+            #
+            # So the flag only ever covered the OTHER case: tried to set the
+            # server up and could not. There is no agent shape that can serve
+            # without this step, so continuing past it produced an agent that
+            # never registered, never became ready, and never restarted —
+            # absent instead of failed. Whatever fails in here is fatal.
             name="fastapi-server-setup",
-            required=False,  # Optional - may not have FastMCP instances to mount
+            required=True,
             description="Prepare FastAPI app with K8s endpoints and mount FastMCP servers",
         )
 
@@ -42,6 +56,10 @@ class FastAPIServerSetupStep(PipelineStep):
             if not self._is_http_enabled():
                 result.status = PipelineStatus.SKIPPED
                 result.message = "HTTP transport disabled"
+                # Recorded so the orchestrator can tell "asked for no server"
+                # from "could not build one" when it finds no app to run — the
+                # first is a configuration, the second is fatal (issue #1556).
+                result.add_context("http_transport_disabled", True)
                 self.logger.info("⚠️ HTTP transport disabled via MCP_MESH_HTTP_ENABLED")
                 return result
 
@@ -795,11 +813,11 @@ mcp_mesh_up{{agent="{agent_name}"}} 1
             self.logger.error(
                 f"❌ SERVER REUSE: Failed to mount on existing server: {e}"
             )
-            result.status = (
-                result.PipelineStatus.FAILED
-                if hasattr(result, "PipelineStatus")
-                else "failed"
-            )
+            # `result.PipelineStatus` never existed, so this always fell through
+            # to the string "failed". It compared unequal to every enum member,
+            # which happened to read as a failure — and left `result.status` a
+            # string that `__str__` and any `.value` read would raise on.
+            result.status = PipelineStatus.FAILED
             result.message = f"Server reuse failed: {e}"
             result.add_error(str(e))
 

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_orchestrator.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_orchestrator.py
@@ -15,6 +15,45 @@ from .startup_pipeline import StartupPipeline
 logger = logging.getLogger(__name__)
 
 
+def abort_agent_process(reason: str, log: logging.Logger = logger) -> None:
+    """Terminate an auto-run MCP agent that cannot serve. Never returns.
+
+    Killing the process is the only honest option here, and raising is not one
+    (issue #1556). This runs on the ``DebounceCoordinator``'s ``threading.Timer``
+    thread, while the ``@mesh.agent`` decorator's immediate uvicorn runs on a
+    NON-daemon thread of its own: an exception raised here dies inside the timer
+    thread and uvicorn keeps serving. That is how "Auto-run enabled but no
+    FastAPI app prepared - exiting" came to be logged by a process that then
+    stayed up indefinitely — answering /livez and /startupz with 200, /ready and
+    /health with 503, and never registering. Under Kubernetes that pod passes
+    liveness, passes startup, never becomes ready, and is never restarted.
+
+    Exiting instead makes the pod restart with the cause in its logs, which is
+    the difference between an agent that is visibly broken and one that looks
+    like it was never deployed.
+
+    ``os._exit`` for the reason ``dual_module_check`` uses it: it is the only
+    process-wide immediate exit available from a non-main thread. It skips
+    finalizers, so the diagnostic is logged and flushed first — and nothing has
+    served traffic at this point, so there is no in-flight state to drain.
+    """
+    log.error(f"💀 {reason}")
+    log.error(
+        "Exiting: this agent cannot serve. Staying up would keep answering "
+        "liveness and startup probes for an agent that will never register."
+    )
+    # Flushed, not `logging.shutdown()`: `os._exit` skips buffer flushing, and
+    # the whole point of exiting here is that the reason reaches the pod's logs.
+    # Closing the handlers would additionally silence anything that runs after
+    # this — which, whenever `os._exit` is patched out, is a test suite.
+    for handler in list(logging.getLogger().handlers) + list(log.handlers):
+        try:
+            handler.flush()
+        except Exception:
+            pass
+    os._exit(1)
+
+
 def wait_for_proven_serving(
     started_check: Any,
     label: str,
@@ -257,6 +296,17 @@ class DebounceCoordinator:
                         f"❌ {pipeline_type.upper()} pipeline failed during startup; "
                         f"aborting: {err_detail}"
                     )
+                    if pipeline_type == "mcp":
+                        # mesh owns this whole process, so aborting means
+                        # exiting — a raise would only kill the timer thread
+                        # and leave the immediate uvicorn serving probes for an
+                        # agent that never registered (issue #1556). An `api` /
+                        # `a2a` service owns its own uvicorn and its own app, so
+                        # a mesh failure there stays a raise.
+                        abort_agent_process(
+                            f"MCP pipeline failed during startup: {err_detail}",
+                            self.logger,
+                        )
                     raise RuntimeError(
                         f"{pipeline_type.upper()} pipeline failed: {err_detail}"
                     )
@@ -478,9 +528,27 @@ class DebounceCoordinator:
                             bound_socket=bound_socket,
                             server_holder=server_holder,
                         )
+                elif pipeline_context.get("http_transport_disabled"):
+                    # Asked for no HTTP server, so having no app to run is the
+                    # configuration doing what it says. Nothing to serve and
+                    # nothing to abort: the process ends on its own.
+                    self.logger.info(
+                        "🏁 HTTP transport is disabled (MCP_MESH_HTTP_ENABLED) — "
+                        "no server to run"
+                    )
                 else:
-                    self.logger.warning(
-                        "⚠️ Auto-run enabled but no FastAPI app prepared - exiting"
+                    # Reachable when the pipeline reports success/partial and
+                    # still leaves no app to serve. The line used to say
+                    # "exiting" and then return, leaving the process alive
+                    # (issue #1556) — now it exits, and says which half is
+                    # missing rather than always blaming the app.
+                    missing = (
+                        "no FastAPI app was prepared"
+                        if not fastapi_app
+                        else "no server binding configuration was resolved"
+                    )
+                    abort_agent_process(
+                        f"Auto-run is enabled but {missing}.", self.logger
                     )
             else:
                 # Single execution mode (for testing/debugging)

--- a/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
+++ b/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
@@ -49,8 +49,14 @@ _INTEGER_RE = re.compile(r"^[+-]?\d+$", re.ASCII)
 # warning stays one readable line.
 _WARNING_VALUE_LIMIT = 32
 
+# An exception message is not a value being identified, it IS the explanation,
+# so it gets room to be one — still bounded, for the same reason.
+_WARNING_MESSAGE_LIMIT = 200
 
-def _for_warning(value: Any, *, quote: bool = False) -> str:
+
+def _for_warning(
+    value: Any, *, quote: bool = False, limit: int = _WARNING_VALUE_LIMIT
+) -> str:
     """Render a value for a rejection message without raising or flooding the log.
 
     Interpolating a value is not safe by default here. Python 3.11 caps
@@ -74,8 +80,8 @@ def _for_warning(value: Any, *, quote: bool = False) -> str:
             return f"<{type(value).__name__} with ~{digits} digits>"
         return f"<unprintable {type(value).__name__}>"
 
-    if len(text) > _WARNING_VALUE_LIMIT:
-        return f"{text[:_WARNING_VALUE_LIMIT]}… ({len(text)} chars)"
+    if len(text) > limit:
+        return f"{text[:limit]}… ({len(text)} chars)"
     return text
 
 
@@ -310,12 +316,36 @@ def _as_text(value: Any) -> str:
         return f"<unprintable {type(value).__name__}>"
 
 
+def _describe_exception(exc: BaseException) -> str:
+    """Name a raise in a rejection message, without raising in turn.
+
+    ``_as_text`` survives a broken ``__str__`` and ``_for_warning`` caps the
+    length, so an exception carrying a megabyte of context is still one line.
+    """
+    text = _for_warning(_as_text(exc), limit=_WARNING_MESSAGE_LIMIT)
+    return f"{type(exc).__name__}: {text}"
+
+
 def _sanitize_checks(raw: Any) -> tuple[dict[str, bool], list[str]]:
     """Split ``checks`` into what the result can carry and what it cannot.
 
     Returns ``(checks, rejections)``. ``rejections`` is empty for every payload
     that already worked; when it is not, each entry names the offending check
     and its type so the operator can find it in their own code.
+
+    ``isinstance(raw, Mapping)`` passes for any Mapping subclass, including one
+    that computes its entries on demand — so reading it is itself a user code
+    path that can raise, in the same place and with the same consequence as the
+    wrong value type this function exists for. Reading is guarded twice, at two
+    different granularities:
+
+    * enumerating the mapping is all-or-nothing. A mapping that raises part way
+      through has no defined content: what survived is an artifact of iteration
+      order, so keeping it would put a different subset of the checks on
+      /health from one TTL to the next. The whole map is dropped and the raise
+      reported, which is what the non-Mapping branch above already does.
+    * one entry is a boundary the author recognises, so a single unreadable
+      entry costs only that entry — exactly like a single non-bool value.
     """
     if raw is None:
         return {}, []
@@ -326,16 +356,35 @@ def _sanitize_checks(raw: Any) -> tuple[dict[str, bool], list[str]]:
             f"{type(raw).__name__}."
         ]
 
+    try:
+        # Materialized here so a generator that raises half way through counts
+        # as an enumeration failure rather than aborting the loop below.
+        items = list(raw.items())
+    except Exception as e:
+        return {}, [
+            f"Unusable `checks`: reading the {type(raw).__name__} raised "
+            f"{_describe_exception(e)}."
+        ]
+
     checks: dict[str, bool] = {}
     rejections: list[str] = []
-    for key, value in raw.items():
-        name = key if isinstance(key, str) else _as_text(key)
+    for item in items:
+        name = "<unreadable>"
         try:
+            key, value = item
+            name = key if isinstance(key, str) else _as_text(key)
             checks[name] = _CHECK_VALUE_ADAPTER.validate_python(value)
         except ValidationError:
             rejections.append(
                 f"Unusable check '{name}': {_for_warning(value, quote=True)} is "
                 f"a {type(value).__name__}, not a bool."
+            )
+        except Exception as e:
+            # Broad, and deliberately not narrowed to ValidationError: the
+            # message has to describe what happened, and "raised TypeError" is
+            # a different fact from "is a str, not a bool".
+            rejections.append(
+                f"Unusable check '{name}': reading it raised {_describe_exception(e)}."
             )
     return checks, rejections
 
@@ -347,13 +396,26 @@ def _sanitize_errors(raw: Any) -> list[str]:
     a bare string instead of a list — raised in exactly the same place as an
     unusable ``checks`` value. Stringifying is lossless for text and is what
     the author meant, so this coerces quietly rather than reporting.
+
+    ``isinstance(raw, Iterable)`` has the same reach as the Mapping test above:
+    it passes for anything with an ``__iter__``, and consuming it runs user
+    code that can raise. When it does there is nothing left to carry, so the
+    raise itself becomes the one error — visible on /health, which is where an
+    operator looks for what the check reported.
     """
     if raw is None:
         return []
     if isinstance(raw, str):
         return [raw]
     if isinstance(raw, Iterable):
-        return [e if isinstance(e, str) else _as_text(e) for e in raw]
+        try:
+            entries = list(raw)
+        except Exception as e:
+            return [
+                f"Unusable `errors`: reading the {type(raw).__name__} raised "
+                f"{_describe_exception(e)}."
+            ]
+        return [e if isinstance(e, str) else _as_text(e) for e in entries]
     return [_as_text(raw)]
 
 
@@ -372,10 +434,14 @@ def _warn_unusable_checks_once(agent_id: str, rejections: list[str]) -> None:
             return
         _unusable_checks_warning_logged = True
     logger.warning(
-        "Health check for '%s' reported check results that are not booleans: "
-        "%s The agent keeps serving and its status is unchanged; the unusable "
-        "entries are dropped and reported on /health. `checks` maps a check "
-        "name to True or False.",
+        # Not "that are not booleans": a `checks` mapping that RAISED when it
+        # was read reaches here too, and did not report a non-boolean anything.
+        # The rejections carry the specific fact; this line must not contradict
+        # them with a diagnosis of its own.
+        "Health check for '%s' reported check results the runtime could not "
+        "use: %s The agent keeps serving and its status is unchanged; the "
+        "unusable entries are dropped and reported on /health. `checks` maps a "
+        "check name to True or False.",
         agent_id,
         " ".join(rejections),
     )

--- a/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
+++ b/src/runtime/python/_mcp_mesh/shared/health_check_manager.py
@@ -12,9 +12,11 @@ import os
 import re
 import threading
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from datetime import UTC, datetime
 from typing import Any
+
+from pydantic import TypeAdapter, ValidationError
 
 from .support_types import HealthStatus, HealthStatusType
 
@@ -266,6 +268,127 @@ def _reset_null_status_warning() -> None:
 
 
 # =============================================================================
+# Unusable `checks` / `errors` payloads (issue #1556)
+# =============================================================================
+
+# ``HealthStatus.checks`` is ``dict[str, bool]``, so Pydantic raises on a value
+# it cannot read as one — `checks["disk_space"] = "ok"`. That raise happened
+# while BUILDING the result, outside the handler that catches a failing check,
+# so it escaped the whole health path: it took down `fastapi-server-setup`, and
+# with it the agent's registration. The pod then served /livez and /startupz
+# with 200 while never appearing in the registry — absent rather than unhealthy.
+#
+# A wrong value type inside `checks` is an authoring mistake in the same class
+# as a check that raises or returns the wrong type (#1477, #1539), and gets the
+# same treatment: the agent keeps serving and the mistake is reported.
+#
+# What it does NOT do is invent a verdict. `status` is read independently and is
+# perfectly readable here; overriding it would keep an agent that declared
+# itself `unhealthy` in dependency resolution because of an unrelated typo in
+# `checks`. The verdict stands, the unusable detail is dropped and described.
+#
+# Validated through Pydantic rather than `isinstance(v, bool)` so everything
+# that works today keeps working identically: `1`, `0` and `"true"` are all
+# values the model already coerces, and only what it would have REJECTED is
+# treated as unusable here.
+_CHECK_VALUE_ADAPTER = TypeAdapter(bool)
+
+_unusable_checks_warning_logged = False
+_unusable_checks_lock = threading.Lock()
+
+
+def _as_text(value: Any) -> str:
+    """Render a value as an error string without raising.
+
+    ``errors`` entries are human-readable text, so ``str()`` is faithful to
+    what the author meant by putting an exception object in the list. A broken
+    ``__str__`` must not be the thing that takes the agent down.
+    """
+    try:
+        return str(value)
+    except Exception:
+        return f"<unprintable {type(value).__name__}>"
+
+
+def _sanitize_checks(raw: Any) -> tuple[dict[str, bool], list[str]]:
+    """Split ``checks`` into what the result can carry and what it cannot.
+
+    Returns ``(checks, rejections)``. ``rejections`` is empty for every payload
+    that already worked; when it is not, each entry names the offending check
+    and its type so the operator can find it in their own code.
+    """
+    if raw is None:
+        return {}, []
+
+    if not isinstance(raw, Mapping):
+        return {}, [
+            f"Unusable `checks`: expected a dict of name -> bool, got "
+            f"{type(raw).__name__}."
+        ]
+
+    checks: dict[str, bool] = {}
+    rejections: list[str] = []
+    for key, value in raw.items():
+        name = key if isinstance(key, str) else _as_text(key)
+        try:
+            checks[name] = _CHECK_VALUE_ADAPTER.validate_python(value)
+        except ValidationError:
+            rejections.append(
+                f"Unusable check '{name}': {_for_warning(value, quote=True)} is "
+                f"a {type(value).__name__}, not a bool."
+            )
+    return checks, rejections
+
+
+def _sanitize_errors(raw: Any) -> list[str]:
+    """Coerce ``errors`` into the ``list[str]`` the result carries.
+
+    ``errors`` is ``list[StrictStr]``, so an exception object in the list — or
+    a bare string instead of a list — raised in exactly the same place as an
+    unusable ``checks`` value. Stringifying is lossless for text and is what
+    the author meant, so this coerces quietly rather than reporting.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, Iterable):
+        return [e if isinstance(e, str) else _as_text(e) for e in raw]
+    return [_as_text(raw)]
+
+
+def _warn_unusable_checks_once(agent_id: str, rejections: list[str]) -> None:
+    """Warn that part of ``checks`` was dropped. Once per process.
+
+    Once, for the reason the neighbouring warnings are: the check re-runs every
+    TTL, so a per-tick line is thousands of copies a day of one typo. The
+    rejection also rides along in the result's ``errors``, which /health shows
+    on every request — the log is the discovery surface, /health is the durable
+    one.
+    """
+    global _unusable_checks_warning_logged
+    with _unusable_checks_lock:
+        if _unusable_checks_warning_logged:
+            return
+        _unusable_checks_warning_logged = True
+    logger.warning(
+        "Health check for '%s' reported check results that are not booleans: "
+        "%s The agent keeps serving and its status is unchanged; the unusable "
+        "entries are dropped and reported on /health. `checks` maps a check "
+        "name to True or False.",
+        agent_id,
+        " ".join(rejections),
+    )
+
+
+def _reset_unusable_checks_warning() -> None:
+    """Re-arm the once-per-process warning. Tests only."""
+    global _unusable_checks_warning_logged
+    with _unusable_checks_lock:
+        _unusable_checks_warning_logged = False
+
+
+# =============================================================================
 # TTL-Based Health Cache
 # =============================================================================
 
@@ -389,17 +512,59 @@ async def _execute_health_check(
         checks = {}
         errors = []
 
-    return HealthStatus(
-        agent_name=agent_id,
-        status=status_type,
-        capabilities=capabilities,
-        checks=checks,
-        errors=errors,
-        timestamp=datetime.now(UTC),
-        version=agent_config.get("version", "1.0.0"),
-        metadata=agent_config,
-        uptime_seconds=0,
-    )
+    # `checks` and `errors` come straight from the user's check, so they are the
+    # two fields that can carry a shape the model refuses (issue #1556). Reading
+    # them here keeps the refusal from escaping as an exception that no health
+    # handler catches — see the module notes above `_sanitize_checks`.
+    checks, rejections = _sanitize_checks(checks)
+    errors = _sanitize_errors(errors)
+    if rejections:
+        _warn_unusable_checks_once(agent_id, rejections)
+        # Named like `health_check_return_type` / `health_check_execution`: a
+        # runtime-owned check that reports what the runtime found, rather than
+        # a fabricated verdict for the check whose value was unreadable.
+        checks["health_check_checks_type"] = False
+        errors.extend(rejections)
+
+    try:
+        return HealthStatus(
+            agent_name=agent_id,
+            status=status_type,
+            capabilities=capabilities,
+            checks=checks,
+            errors=errors,
+            timestamp=datetime.now(UTC),
+            version=agent_config.get("version", "1.0.0"),
+            metadata=agent_config,
+            uptime_seconds=0,
+        )
+    except ValidationError as e:
+        # The two user-supplied fields are already sanitized, so reaching here
+        # means a runtime-derived field (a capability list, a version) is the
+        # unreadable one. The invariant is what matters: building the result
+        # never raises, because the caller of this function is a pipeline step
+        # whose failure makes the agent vanish rather than report.
+        logger.warning(
+            "Could not build the health result for '%s' (%s) — reporting the "
+            "verdict without its detail.",
+            agent_id,
+            e,
+        )
+        try:
+            safe_capabilities = [_as_text(c) for c in capabilities] or ["default"]
+        except TypeError:
+            safe_capabilities = ["default"]
+        return HealthStatus(
+            agent_name=_as_text(agent_id),
+            status=status_type,
+            capabilities=safe_capabilities,
+            checks={"health_check_result_build": False},
+            errors=[f"Could not build the health result: {e}"],
+            timestamp=datetime.now(UTC),
+            version=None,
+            metadata=None,
+            uptime_seconds=0,
+        )
 
 
 def _get_capabilities(

--- a/src/runtime/python/tests/unit/test_07_fastapi_server_setup.py
+++ b/src/runtime/python/tests/unit/test_07_fastapi_server_setup.py
@@ -24,7 +24,9 @@ class TestFastAPIServerSetupStep:
         step = FastAPIServerSetupStep()
 
         assert step.name == "fastapi-server-setup"
-        assert step.required is False  # Optional - may not have FastMCP instances
+        # Required (#1556): nothing to mount is a success/skip here, so a
+        # FAILED result means the agent cannot serve.
+        assert step.required is True
         assert (
             step.description
             == "Prepare FastAPI app with K8s endpoints and mount FastMCP servers"

--- a/src/runtime/python/tests/unit/test_health_check_checks_type_1556.py
+++ b/src/runtime/python/tests/unit/test_health_check_checks_type_1556.py
@@ -364,9 +364,12 @@ class TestTheStepIsRequired:
         pipeline = MeshPipeline(name="test")
         pipeline.add_step(step)
 
-        with patch.object(
-            step, "_create_fastapi_app", side_effect=Exception("no fastapi")
-        ), patch.dict(os.environ, {"MCP_MESH_HTTP_ENABLED": "true"}):
+        with (
+            patch.object(
+                step, "_create_fastapi_app", side_effect=Exception("no fastapi")
+            ),
+            patch.dict(os.environ, {"MCP_MESH_HTTP_ENABLED": "true"}),
+        ):
             result = await pipeline.execute()
 
         assert result.status == PipelineStatus.FAILED

--- a/src/runtime/python/tests/unit/test_health_check_checks_type_1556.py
+++ b/src/runtime/python/tests/unit/test_health_check_checks_type_1556.py
@@ -1,0 +1,392 @@
+"""A non-bool in ``checks`` must report, not disappear (#1556).
+
+``HealthStatus.checks`` is ``dict[str, bool]``. Writing ``checks["disk"] = "ok"``
+instead of ``True`` used to raise inside Pydantic while the result was being
+BUILT — after the handler that catches a failing check, and inside the
+``fastapi-server-setup`` pipeline step. That step was optional, so the pipeline
+went "partial", auto-run found no app to serve, and the process stayed up
+answering /livez and /startupz with 200 while never registering. The agent was
+absent rather than unhealthy: nothing in the registry, nothing to restart it,
+and the only explanation on stdout.
+
+Three things are pinned here, matching the three places the failure travelled
+through:
+
+1. the value error never reaches the pipeline — the verdict survives, the
+   unusable detail is dropped and reported (#1539's principle, applied to a
+   wrong value type inside ``checks`` rather than a wrong return type);
+2. the verdict is NOT overridden — an author who said ``unhealthy`` and also
+   mistyped a check still withdraws;
+3. ``fastapi-server-setup`` is required, so a failure that genuinely leaves no
+   server is fatal rather than "partial" — and having nothing to mount still
+   succeeds, which is the case the optional flag was written for.
+"""
+
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from _mcp_mesh.pipeline.mcp_startup.fastapiserver_setup import FastAPIServerSetupStep
+from _mcp_mesh.pipeline.shared import PipelineStatus
+from _mcp_mesh.pipeline.shared.health_refresh import refresh_health_once
+from _mcp_mesh.shared.health_check_manager import (
+    clear_health_cache,
+    get_health_status_with_cache,
+)
+from _mcp_mesh.shared.support_types import HealthStatus, HealthStatusType
+
+AGENT_CONFIG: dict[str, Any] = {
+    "name": "checks-agent",
+    "version": "1.0.0",
+    "capabilities": ["test-capability"],
+}
+
+
+def _reset_warning() -> None:
+    """Re-arm the once-per-process warning.
+
+    Resolved through the module rather than imported at the top, so the tests
+    that reproduce the reported failure fail on that failure — not on a missing
+    private helper before any of them run.
+    """
+    from _mcp_mesh.shared import health_check_manager
+
+    health_check_manager._reset_unusable_checks_warning()
+
+
+@pytest.fixture(autouse=True)
+def clean_state():
+    clear_health_cache()
+    yield
+    clear_health_cache()
+
+
+async def run_check(check, agent_id: str = "checks-agent") -> HealthStatus:
+    """Run one uncached health check and return its recorded status."""
+    return await get_health_status_with_cache(
+        agent_id=agent_id,
+        health_check_fn=check,
+        agent_config=AGENT_CONFIG,
+        startup_context={},
+        ttl=15,
+    )
+
+
+class TestTheReproduction:
+    """``checks["disk_space"] = "ok"`` — the reported one-character mistake."""
+
+    @pytest.mark.asyncio
+    async def test_string_check_value_does_not_raise(self):
+        async def health_check() -> dict:
+            return {
+                "status": "healthy",
+                "checks": {"env_key": True, "disk_space": "ok"},
+                "errors": [],
+            }
+
+        status = await run_check(health_check)
+
+        assert status.status == HealthStatusType.HEALTHY
+        # The readable checks survive; the unusable one does not pretend to
+        # have a verdict.
+        assert status.checks["env_key"] is True
+        assert "disk_space" not in status.checks
+        assert status.checks["health_check_checks_type"] is False
+
+    @pytest.mark.asyncio
+    async def test_the_offending_check_is_named_on_health(self):
+        """/health is the durable surface — the log warns once, this stays."""
+
+        async def health_check() -> dict:
+            return {"checks": {"disk_space": "ok"}}
+
+        status = await run_check(health_check)
+
+        reported = " ".join(status.errors)
+        assert "disk_space" in reported
+        assert "str" in reported
+        assert "bool" in reported
+
+    @pytest.mark.asyncio
+    async def test_seed_refresh_stores_a_result(self):
+        """The exact call the pipeline step makes at startup (the crash site).
+
+        ``_add_k8s_endpoints`` seeds ``/health`` with this before anything is
+        mounted; the raise here is what took ``fastapi-server-setup`` down.
+        """
+
+        async def health_check() -> dict:
+            return {"status": "healthy", "checks": {"disk_space": "ok"}}
+
+        result = await refresh_health_once(
+            agent_name="checks-agent",
+            health_check_fn=health_check,
+            agent_config=AGENT_CONFIG,
+            startup_context={},
+            ttl_seconds=15,
+            publish_to_core=False,
+        )
+
+        assert result["status"] == "healthy"
+        assert result["checks"]["health_check_checks_type"] is False
+
+
+class TestTheOperatorIsToldOnce:
+    """The Pydantic traceback was the only explanation anywhere. Replace it.
+
+    Once per process, like the neighbouring health-parse warnings: the check
+    re-runs every TTL, so a per-tick line is thousands of copies of one typo a
+    day. The durable copy is in the result's ``errors``, which /health serves on
+    every request.
+    """
+
+    @pytest.mark.asyncio
+    async def test_warns_once_not_every_refresh(self, caplog):
+        import logging
+
+        async def health_check() -> dict:
+            return {"checks": {"disk_space": "ok"}}
+
+        _reset_warning()
+        try:
+            with caplog.at_level(logging.WARNING):
+                for _ in range(3):
+                    clear_health_cache()
+                    await run_check(health_check)
+        finally:
+            _reset_warning()
+
+        lines = [r for r in caplog.records if "not booleans" in r.getMessage()]
+        assert len(lines) == 1
+        assert "disk_space" in lines[0].getMessage()
+
+
+class TestTheVerdictIsNotOverridden:
+    """An unusable detail must not re-decide routing.
+
+    #1539's indeterminate verdict is for when the runtime cannot READ a
+    verdict. Here it can: ``status`` is parsed independently of ``checks``.
+    Forcing degraded would keep an agent that declared itself unable to serve
+    in dependency resolution because of a typo somewhere else in the payload.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unhealthy_still_withdraws(self):
+        async def health_check() -> dict:
+            return {
+                "status": "unhealthy",
+                "checks": {"vendor_api": "down"},
+                "errors": ["vendor unreachable"],
+            }
+
+        status = await run_check(health_check)
+
+        assert status.status == HealthStatusType.UNHEALTHY
+        assert "vendor unreachable" in status.errors
+
+    @pytest.mark.asyncio
+    async def test_healthy_stays_healthy(self):
+        async def health_check() -> dict:
+            return {"status": "healthy", "checks": {"db": "yes-ish"}}
+
+        assert (await run_check(health_check)).status == HealthStatusType.HEALTHY
+
+
+class TestWhatAlreadyWorkedKeepsWorking:
+    """Only the values the model REJECTED change behaviour.
+
+    ``1``, ``0`` and ``"true"`` are values ``dict[str, bool]`` already coerces,
+    so they are validated through Pydantic here rather than an isinstance test
+    that would quietly start dropping them.
+    """
+
+    @pytest.mark.asyncio
+    async def test_bools_are_untouched(self):
+        async def health_check() -> dict:
+            return {"checks": {"a": True, "b": False}}
+
+        status = await run_check(health_check)
+
+        assert status.checks == {"a": True, "b": False}
+        assert "health_check_checks_type" not in status.checks
+        assert status.errors == []
+
+    @pytest.mark.asyncio
+    async def test_coercible_values_still_coerce(self):
+        async def health_check() -> dict:
+            return {"checks": {"one": 1, "zero": 0, "text": "true"}}
+
+        status = await run_check(health_check)
+
+        assert status.checks == {"one": True, "zero": False, "text": True}
+        assert "health_check_checks_type" not in status.checks
+
+    @pytest.mark.asyncio
+    async def test_no_checks_at_all(self):
+        async def health_check() -> bool:
+            return True
+
+        status = await run_check(health_check)
+
+        assert status.status == HealthStatusType.HEALTHY
+        assert status.checks == {"health_check": True}
+
+
+class TestTheOtherUnusableShapes:
+    """The issue asks whether only ``str`` bites. It is not only ``str``."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "value",
+        [None, {"nested": True}, ["a", "b"], object()],
+    )
+    async def test_every_unreadable_value_reports_instead_of_raising(self, value):
+        async def health_check() -> dict:
+            return {"checks": {"probe": value}}
+
+        status = await run_check(health_check)
+
+        assert status.status == HealthStatusType.HEALTHY
+        assert "probe" not in status.checks
+        assert status.checks["health_check_checks_type"] is False
+
+    @pytest.mark.asyncio
+    async def test_checks_that_is_not_a_dict(self):
+        async def health_check() -> dict:
+            return {"checks": ["db", "cache"]}
+
+        status = await run_check(health_check)
+
+        assert status.checks["health_check_checks_type"] is False
+        assert any("expected a dict" in e for e in status.errors)
+
+    @pytest.mark.asyncio
+    async def test_non_string_check_name(self):
+        async def health_check() -> dict:
+            return {"checks": {7: True}}
+
+        status = await run_check(health_check)
+
+        assert status.checks == {"7": True}
+
+
+class TestErrorsHasTheSameExposure:
+    """``errors`` is ``list[StrictStr]`` and raised in the same place.
+
+    Text is stringified rather than reported: unlike a check value, ``str()``
+    of an exception is exactly what the author meant to put in the list.
+    """
+
+    @pytest.mark.asyncio
+    async def test_exception_objects_in_errors(self):
+        async def health_check() -> dict:
+            return {"status": "unhealthy", "errors": [ValueError("boom")]}
+
+        status = await run_check(health_check)
+
+        assert status.status == HealthStatusType.UNHEALTHY
+        assert status.errors == ["boom"]
+
+    @pytest.mark.asyncio
+    async def test_errors_given_as_a_bare_string(self):
+        async def health_check() -> dict:
+            return {"status": "unhealthy", "errors": "vendor unreachable"}
+
+        status = await run_check(health_check)
+
+        assert status.errors == ["vendor unreachable"]
+
+    @pytest.mark.asyncio
+    async def test_non_text_entries_are_stringified(self):
+        async def health_check() -> dict:
+            return {"errors": [503, None]}
+
+        status = await run_check(health_check)
+
+        assert status.errors == ["503", "None"]
+
+
+class TestTheStepIsRequired:
+    """The class behind the symptom, not just the symptom.
+
+    Any failure inside ``fastapi-server-setup`` left an agent that could not
+    serve and did not stop — a health-check value error was one way in, not the
+    only one.
+    """
+
+    def test_step_is_required(self):
+        assert FastAPIServerSetupStep().required is True
+
+    @pytest.mark.asyncio
+    async def test_nothing_to_mount_still_prepares_an_app(self):
+        """The case ``required=False`` was written for, and it is a SUCCESS.
+
+        Zero FastMCP servers is not a failure here: the step still builds the
+        app, with the minimal lifespan and the K8s endpoints. Making the step
+        required must not change that.
+        """
+        step = FastAPIServerSetupStep()
+        context: dict[str, Any] = {
+            "agent_config": {"name": "empty-agent", "version": "1.0.0"},
+            "fastmcp_servers": {},
+        }
+
+        with patch.dict(os.environ, {"MCP_MESH_HTTP_ENABLED": "true"}):
+            result = await step.execute(context)
+
+        assert result.status == PipelineStatus.SUCCESS
+        assert result.context["fastapi_app"] is not None
+        assert result.context["mcp_wrappers"] == {}
+
+    @pytest.mark.asyncio
+    async def test_http_disabled_skips_and_says_so(self):
+        """Skipped, not failed — and flagged, so no-app-to-run is explicable.
+
+        The pipeline exempts SKIPPED from the required-step abort, which is why
+        a deliberately server-less agent is unaffected by the flag change.
+        """
+        step = FastAPIServerSetupStep()
+
+        with patch.dict(os.environ, {"MCP_MESH_HTTP_ENABLED": "false"}):
+            result = await step.execute({"agent_config": {"name": "a"}})
+
+        assert result.status == PipelineStatus.SKIPPED
+        assert result.context["http_transport_disabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_failing_setup_fails_the_pipeline(self):
+        """It used to be "⚠️ Optional step 11 failed, continuing"."""
+        from _mcp_mesh.pipeline.shared import MeshPipeline
+
+        step = FastAPIServerSetupStep()
+        pipeline = MeshPipeline(name="test")
+        pipeline.add_step(step)
+
+        with patch.object(
+            step, "_create_fastapi_app", side_effect=Exception("no fastapi")
+        ), patch.dict(os.environ, {"MCP_MESH_HTTP_ENABLED": "true"}):
+            result = await pipeline.execute()
+
+        assert result.status == PipelineStatus.FAILED
+        assert result.status != PipelineStatus.PARTIAL
+
+
+class TestTheLogLineDoesNotLie:
+    """ "exiting" now exits.
+
+    The process kept running because the abort ran on the DebounceCoordinator's
+    timer thread while the decorator's immediate uvicorn held a non-daemon
+    thread of its own. A raise there kills the timer thread only.
+    """
+
+    def test_abort_terminates_the_process(self):
+        from _mcp_mesh.pipeline.mcp_startup.startup_orchestrator import (
+            abort_agent_process,
+        )
+
+        with patch("os._exit") as fake_exit:
+            abort_agent_process("no FastAPI app was prepared")
+
+        fake_exit.assert_called_once_with(1)

--- a/src/runtime/python/tests/unit/test_health_check_checks_type_1556.py
+++ b/src/runtime/python/tests/unit/test_health_check_checks_type_1556.py
@@ -23,6 +23,7 @@ through:
 """
 
 import os
+from collections.abc import Mapping
 from typing import Any
 from unittest.mock import patch
 
@@ -158,7 +159,7 @@ class TestTheOperatorIsToldOnce:
         finally:
             _reset_warning()
 
-        lines = [r for r in caplog.records if "not booleans" in r.getMessage()]
+        lines = [r for r in caplog.records if "could not use" in r.getMessage()]
         assert len(lines) == 1
         assert "disk_space" in lines[0].getMessage()
 
@@ -306,6 +307,188 @@ class TestErrorsHasTheSameExposure:
         status = await run_check(health_check)
 
         assert status.errors == ["503", "None"]
+
+
+class TestReadingThePayloadCanItselfRaise:
+    """A ``checks``/``errors`` container that raises when it is READ.
+
+    ``isinstance(raw, Mapping)`` and ``isinstance(raw, Iterable)`` pass for any
+    subclass, so ``raw.items()`` and ``iter(raw)`` are user code — a mapping
+    that computes its entries on demand, or one backed by something that can
+    fail. Both sanitizers run OUTSIDE the handler that catches a failing check,
+    so a raise there escaped into ``fastapi-server-setup`` exactly like the
+    Pydantic one did: an absent agent from a health-check authoring problem,
+    the thing this whole change exists to make impossible.
+    """
+
+    @pytest.mark.asyncio
+    async def test_checks_mapping_whose_items_raises(self):
+        class LazyChecks(Mapping):
+            def items(self):
+                raise RuntimeError("probe results were never computed")
+
+            def __getitem__(self, key):
+                raise RuntimeError("probe results were never computed")
+
+            def __iter__(self):
+                raise RuntimeError("probe results were never computed")
+
+            def __len__(self):
+                return 0
+
+        async def health_check() -> dict:
+            return {"status": "healthy", "checks": LazyChecks()}
+
+        status = await run_check(health_check)
+
+        assert status.status == HealthStatusType.HEALTHY
+        assert status.checks == {"health_check_checks_type": False}
+        reported = " ".join(status.errors)
+        assert "LazyChecks" in reported
+        assert "RuntimeError" in reported
+        assert "never computed" in reported
+
+    @pytest.mark.asyncio
+    async def test_a_mapping_that_raises_part_way_loses_the_whole_map(self):
+        """All-or-nothing, on purpose.
+
+        What survived a half-finished enumeration is an artifact of iteration
+        order, not a subset the author would recognise, and it would differ
+        between one TTL and the next. "None of them, because your mapping
+        raised" is a report; a nondeterministic subset is not.
+        """
+
+        class HalfChecks(Mapping):
+            def items(self):
+                yield ("db", True)
+                raise RuntimeError("cursor died")
+
+            def __getitem__(self, key):
+                raise KeyError(key)
+
+            def __iter__(self):
+                return iter(())
+
+            def __len__(self):
+                return 1
+
+        async def health_check() -> dict:
+            return {"checks": HalfChecks()}
+
+        status = await run_check(health_check)
+
+        assert "db" not in status.checks
+        assert status.checks == {"health_check_checks_type": False}
+
+    @pytest.mark.asyncio
+    async def test_one_unreadable_entry_costs_only_that_entry(self):
+        """An entry is a boundary the author recognises, unlike iteration order.
+
+        So a single bad entry is treated like a single non-bool value: dropped
+        and named, with its neighbours untouched.
+        """
+
+        class MalformedItems(Mapping):
+            def items(self):
+                return [("db", True), ("cache",), ("queue", False)]
+
+            def __getitem__(self, key):
+                raise KeyError(key)
+
+            def __iter__(self):
+                return iter(("db", "cache", "queue"))
+
+            def __len__(self):
+                return 3
+
+        async def health_check() -> dict:
+            return {"checks": MalformedItems()}
+
+        status = await run_check(health_check)
+
+        assert status.checks["db"] is True
+        assert status.checks["queue"] is False
+        assert status.checks["health_check_checks_type"] is False
+        assert len([e for e in status.errors if "Unusable check" in e]) == 1
+
+    @pytest.mark.asyncio
+    async def test_the_message_says_what_happened(self):
+        """A raise is not a type mismatch, and must not be described as one."""
+
+        class LazyChecks(Mapping):
+            def items(self):
+                raise ConnectionError("redis is down")
+
+            def __getitem__(self, key):
+                raise KeyError(key)
+
+            def __iter__(self):
+                return iter(())
+
+            def __len__(self):
+                return 0
+
+        async def health_check() -> dict:
+            return {"checks": LazyChecks()}
+
+        status = await run_check(health_check)
+
+        reported = " ".join(status.errors)
+        assert "ConnectionError: redis is down" in reported
+        assert "not a bool" not in reported
+
+    @pytest.mark.asyncio
+    async def test_errors_iterable_whose_iter_raises(self):
+        class LazyErrors:
+            def __iter__(self):
+                raise RuntimeError("error log was rotated away")
+
+        async def health_check() -> dict:
+            return {"status": "unhealthy", "errors": LazyErrors()}
+
+        status = await run_check(health_check)
+
+        # The verdict still stands — an unreadable detail never re-decides it.
+        assert status.status == HealthStatusType.UNHEALTHY
+        reported = " ".join(status.errors)
+        assert "LazyErrors" in reported
+        assert "rotated away" in reported
+
+    @pytest.mark.asyncio
+    async def test_the_startup_seed_still_produces_a_result(self):
+        """The crash site: the call ``_add_k8s_endpoints`` makes at startup.
+
+        If this raises, the pipeline step dies and the agent never registers —
+        which is the whole failure mode, reached through a different door.
+        """
+
+        class LazyChecks(Mapping):
+            def items(self):
+                raise RuntimeError("probe results were never computed")
+
+            def __getitem__(self, key):
+                raise KeyError(key)
+
+            def __iter__(self):
+                return iter(())
+
+            def __len__(self):
+                return 0
+
+        async def health_check() -> dict:
+            return {"status": "healthy", "checks": LazyChecks()}
+
+        result = await refresh_health_once(
+            agent_name="checks-agent",
+            health_check_fn=health_check,
+            agent_config=AGENT_CONFIG,
+            startup_context={},
+            ttl_seconds=15,
+            publish_to_core=False,
+        )
+
+        assert result["status"] == "healthy"
+        assert result["checks"]["health_check_checks_type"] is False
 
 
 class TestTheStepIsRequired:


### PR DESCRIPTION
A health check returning `{"disk_space": "ok"}` instead of `True` produced an agent that **registered nowhere while serving `/livez` 200 and `/startupz` 200**. In Kubernetes that is a pod which passes liveness and startup, never becomes ready, never registers, and is never restarted. Indefinitely.

An unhealthy agent is visible and diagnosable. An absent one looks like it was never deployed.

Reported by a downstream session on 3.7.0; reproduced here with `examples/simple/health-check-simple.py` and one changed value.

## Root cause

The `HealthStatus(...)` construction sat **outside** the `try/except` that catches a failing check, so Pydantic's `bool_parsing` error escaped the entire health path into `fastapi-server-setup`.

That step was `required=False`, commented *"may not have FastMCP instances to mount"* — but that rationale belongs to a **different step**. Zero FastMCP servers is a `SUCCESS` here: it still builds the FastAPI app and the K8s endpoints, and discovering none is reported one step earlier by `fastmcp-server-discovery` as `SKIPPED`. So nothing could legitimately reach `FAILED` with nothing to mount, and the flag only ever covered "tried and failed".

## It was a class, not a one-off

`MCP_MESH_HTTP_PORT=not-a-port` produced the identical zombie on `main` — nothing to do with health checks. Any failure inside that step behaved the same way.

## The log line was false, and fixing it needed more than the flag

`⚠️ Auto-run enabled but no FastAPI app prepared - exiting` — and the process did not exit. It stayed up serving probes.

The abort runs on the `DebounceCoordinator`'s `threading.Timer` thread while the decorator's immediate uvicorn holds a **non-daemon** thread, so raising kills the timer thread and uvicorn keeps serving. `os._exit(1)` is what makes the line true. **`required=True` alone would not have fixed this** — the pipeline would have gone `FAILED`, hit the existing fail-fast raise, and hung identically with a different message.

Exiting is right: `/livez` and `/startupz` at 200 for a process that will never register is the actual defect. The message now says so:

> Exiting: this agent cannot serve. Staying up would keep answering liveness and startup probes for an agent that will never register.

`MCP_MESH_HTTP_ENABLED=false` is carved out as a configuration rather than a failure, so that path's exit code does not change.

## Both fixes, because they are not alternatives

**The value error no longer reaches the step.** Unusable `checks` values are dropped and named; `errors` entries are stringified (an exception object in that list was equally fatal, since it is `list[StrictStr]`); a final `ValidationError` net guarantees the build never raises.

**Deliberate deviation from #1539:** the verdict is *not* overridden. #1539's indeterminate verdict is for when the runtime cannot **read** a verdict — here it can, `status` parses independently. Forcing `degraded` would keep an agent that returned `{"status": "unhealthy", ...}` in dependency resolution because of a typo in an unrelated field.

Values that work today are unchanged — validation goes through Pydantic's `TypeAdapter(bool)`, not `isinstance`, so `1`, `0` and `"true"` still coerce exactly as before. Only what it already rejected changes.

## Verified end to end

The variant now registers, all four probes return 200, and `/health` names the problem:

```json
"checks": { "env_anthropic_api_key": true, "health_check_checks_type": false },
"errors": ["Unusable check 'disk_space': 'ok' is a str, not a bool."]
```

And the class case exits promptly instead of hanging:

```
💀 Required step 'fastapi-server-setup' failed: invalid literal for int() with base 10: 'not-a-port'
EXIT CODE: 1        (main: 124 — hung)
```

## Also

A latent bug fixed in passing: `_handle_existing_server` referenced `result.PipelineStatus`, which never existed, so it always assigned the **string** `"failed"` — reading as a failure only by accident.

`docs/concepts/health-discovery.md` contained a worked example putting **nested dicts** in `checks` — a documented example that reproduced this bug. Fixed, with one sentence on the contract there and in `man health`. Not added to the `_java`/`_typescript` variants: TypeScript types `checks` as `Record<string, unknown>` and carries any value through, and Java has no dict path — Python was the only runtime that validated strictly and crashed.

19 of 23 new tests fail on `main`; the 4 that pass are the regression guards (`1`/`0`/`"true"` still coerce, empty mount still succeeds).

Closes #1556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now safely handle invalid check and error values without interrupting agent registration.
  * Invalid check entries are reported as errors while preserving the overall health verdict.
  * Startup failures now terminate reliably instead of leaving the agent running in an unusable state.
  * HTTP-disabled configurations are handled cleanly without being treated as failures.

* **Documentation**
  * Clarified that health check values must be Boolean and updated usage examples accordingly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->