### PR TITLE
fix: restore two operator signals silenced by 3.7.0 follow-ups

### DIFF
--- a/src/runtime/python/_mcp_mesh/engine/provider_handlers/provider_handler_registry.py
+++ b/src/runtime/python/_mcp_mesh/engine/provider_handlers/provider_handler_registry.py
@@ -135,8 +135,7 @@ class ProviderHandlerRegistry:
             # Get generic fallback
             handler = ProviderHandlerRegistry.get_handler("unknown")
         """
-        # Normalize vendor name (handle None, empty string)
-        vendor = (vendor or "unknown").lower().strip()
+        vendor = cls._normalize_vendor(vendor)
 
         # Check cache first
         if vendor in cls._instances:
@@ -144,28 +143,73 @@ class ProviderHandlerRegistry:
             return cls._instances[vendor]
 
         # Get handler class (or fallback to Generic)
+        handler_class = cls._handler_class(vendor)
         if vendor in cls._handlers:
-            handler_class = cls._handlers[vendor]
             logger.info(f"✅ Selected {handler_class.__name__} for vendor: {vendor}")
+        elif vendor != "unknown":
+            logger.warning(
+                f"⚠️  No specific handler for vendor '{vendor}', using GenericHandler"
+            )
         else:
-            handler_class = GenericHandler
-            if vendor != "unknown":
-                logger.warning(
-                    f"⚠️  No specific handler for vendor '{vendor}', using GenericHandler"
-                )
-            else:
-                logger.debug("Using GenericHandler for unknown vendor")
+            logger.debug("Using GenericHandler for unknown vendor")
 
         # Instantiate and cache
-        handler = (
-            handler_class()
-            if handler_class != GenericHandler
-            else GenericHandler(vendor)
-        )
+        handler = cls._instantiate(handler_class, vendor)
         cls._instances[vendor] = handler
 
         logger.debug(f"🆕 Instantiated handler: {handler}")
         return handler
+
+    @classmethod
+    def probe_handler(cls, vendor: str | None = None) -> BaseProviderHandler:
+        """Get a handler instance for a question asked OUTSIDE a dispatch.
+
+        Same handler :meth:`get_handler` would return, with neither of its two
+        side effects: the cache is not warmed and the "✅ Selected …" INFO line
+        is not emitted. Returns the cached singleton when one already exists,
+        otherwise a transient instance (handlers are stateless — per-request
+        state lives in ContextVars precisely because they are cached as
+        singletons — so a throwaway answers the same questions).
+
+        Why the side effects matter (issue #1558). The selection line is the
+        once-per-vendor record of *which handler will serve*, and it fires on
+        cache miss — so it lands wherever the FIRST caller happens to be. A
+        startup-time question that warms the cache moves that record from the
+        dispatch it describes to import time, and every later dispatch takes
+        the cache-hit branch and logs at DEBUG, which an operator's log does
+        not capture. The #1551 startup assertion in ``mesh.helpers.llm_provider``
+        is exactly such a caller.
+
+        Same shape of reasoning as ``native_dispatch_blocker()`` vs
+        ``has_native()`` in ``BaseProviderHandler``: asking a dispatch-time
+        question early must not consume the dispatch-time record.
+        """
+        vendor = cls._normalize_vendor(vendor)
+        cached = cls._instances.get(vendor)
+        if cached is not None:
+            return cached
+        return cls._instantiate(cls._handler_class(vendor), vendor)
+
+    @staticmethod
+    def _normalize_vendor(vendor: str | None) -> str:
+        """Normalize a vendor name (handles None and empty string)."""
+        return (vendor or "unknown").lower().strip()
+
+    @classmethod
+    def _handler_class(cls, vendor: str) -> type[BaseProviderHandler]:
+        """Handler class registered for a NORMALIZED vendor, else GenericHandler."""
+        return cls._handlers.get(vendor, GenericHandler)
+
+    @classmethod
+    def _instantiate(
+        cls, handler_class: type[BaseProviderHandler], vendor: str
+    ) -> BaseProviderHandler:
+        """Construct a handler. GenericHandler alone needs the vendor name."""
+        return (
+            handler_class()
+            if handler_class is not GenericHandler
+            else GenericHandler(vendor)
+        )
 
     @classmethod
     def list_vendors(cls) -> dict[str, str]:

--- a/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
+++ b/src/runtime/python/_mcp_mesh/engine/signature_analyzer.py
@@ -5,6 +5,7 @@ Function signature analysis for MCP Mesh dependency injection.
 import inspect
 import logging
 import re
+import weakref
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, Optional, get_type_hints
@@ -179,17 +180,30 @@ def _annotation_mentions(param_type: Any, *names: str) -> bool:
     return any(token in names for token in _IDENTIFIER_RE.findall(param_type))
 
 
-def describe_unresolved_annotations(func: Any) -> str:
+def describe_unresolved_annotations(
+    func: Any, resolved: dict[str, Any] | None = None
+) -> str:
     """Render the parameters whose annotations stayed strings after
     :func:`resolve_param_annotations`, or ``""`` when every annotation resolved.
 
     Used to append an accurate cause to "no parameter of type X" errors: a
     string annotation means the name was not importable at module scope, which
     is nothing like the "you forgot the parameter" the bare message implies.
+
+    ``resolved`` lets a caller that already ran the ladder pass its mapping in
+    rather than resolve twice; omitted, it is computed here. A mapping that
+    still carries the ``return`` key (i.e. one from
+    :func:`_resolve_param_annotations`, which does not drop it) reports the
+    **return** annotation too, labelled "return type" so a message listing only
+    that one still reads as an annotation. An unresolvable return is the same
+    authoring error — see :func:`resolve_return_annotation` for what a
+    surviving string does to an ``@mesh.llm`` output type.
     """
+    if resolved is None:
+        resolved = resolve_param_annotations(func)
     unresolved = [
-        f"{name}: {value!r}"
-        for name, value in resolve_param_annotations(func).items()
+        f"{'return type' if name == _RETURN_KEY else name}: {value!r}"
+        for name, value in resolved.items()
         if isinstance(value, str)
     ]
     if not unresolved:
@@ -200,6 +214,75 @@ def describe_unresolved_annotations(func: Any) -> str:
         f"is a string, and the name must be importable at module scope — not "
         f"only under `if TYPE_CHECKING:`."
     )
+
+
+#: Functions already reported by :func:`_warn_unresolved_annotations`, keyed by
+#: IDENTITY. The function object is the stable key: the only caller is
+#: :func:`_scan_params`, which unwraps to the original with
+#: :func:`_get_original_func` BEFORE warning, so the several scans of one
+#: function (once per predicate at decoration, then again on every
+#: dependency-resolution pass) all present the same object however it was
+#: wrapped. ``module.qualname`` would be the collision-prone key, not the safe
+#: one: every closure a factory returns shares one qualname
+#: (``make.<locals>.handler``), and a function built by ``exec`` has
+#: ``__module__`` None — so ten broken generated tools would report as one.
+#: Under-reporting a second authoring error is the silence this warning exists
+#: to remove. Weak, so latching a function does not keep it alive; process-wide,
+#: like the other warn-once latches in the runtime.
+_unresolved_warned: weakref.WeakSet[Any] = weakref.WeakSet()
+
+
+def _warn_unresolved_annotations(func: Any, resolved: dict[str, Any]) -> None:
+    """Warn ONCE per function when an annotation survived the resolution ladder
+    as a bare string.
+
+    Restores the operator signal #1552 removed (issue #1558). Before it,
+    ``get_type_hints`` raised on an unresolvable annotation and the caller's
+    ``except`` logged "Failed to analyze signature for …"; the ladder's last
+    rung — match the annotation as written — means such a parameter now reaches
+    the classifier as a string, matches no mesh type, and is skipped in
+    silence. Keeping that rung is right (without it a ``TYPE_CHECKING``-only
+    import hard-fails at import, which is #1548 relocated), but a broken type
+    hint is an authoring error the author has to be told about.
+
+    Warn-once, not warn-per-scan: this is a startup-time authoring error whose
+    text does not change, and the scan runs several times per function (once
+    per predicate, then again on every dependency-resolution pass). Warning
+    every time would repeat one message for the life of the process.
+
+    The message deliberately keeps the historical "Failed to analyze signature
+    for <func>" prefix: it is the same condition being reported, in the same
+    words operators and the tc24 integration test already grep for.
+
+    ``resolved`` is the mapping from :func:`_resolve_param_annotations`, return
+    annotation included: one message covers every unresolvable annotation on the
+    signature, parameters and return alike.
+
+    Never raises. It is a diagnostic hanging off a scan whose result is a
+    function's typed DI slots; letting it fail that scan would turn a logging
+    call into a functional outage (#1558).
+    """
+    try:
+        if not any(isinstance(value, str) for value in resolved.values()):
+            return
+
+        if func in _unresolved_warned:
+            return
+        try:
+            _unresolved_warned.add(func)
+        except TypeError:
+            # Not weak-referenceable (a ``__slots__`` callable, say). Without a
+            # latch entry the same error is reported on every scan — the right
+            # side to fail on, since the alternative is not reporting it.
+            pass
+
+        logger.warning(
+            "Failed to analyze signature for %s:%s",
+            func,
+            describe_unresolved_annotations(func, resolved),
+        )
+    except Exception as e:
+        logger.debug("Unresolved-annotation diagnostic failed for %r: %s", func, e)
 
 
 def _is_mesh_tool_type(param_type: Any) -> bool:
@@ -404,9 +487,12 @@ def _scan_params(
     classifier predicate and whether positions (0-indexed) or names are
     returned (``want="positions"`` or ``want="names"``).
 
-    Annotations are resolved through :func:`resolve_param_annotations` (#1548)
-    so a module using ``from __future__ import annotations`` — where every
-    annotation is a string — is classified the same as one without it.
+    Annotations are resolved through the ladder behind
+    :func:`resolve_param_annotations` (#1548) so a module using ``from
+    __future__ import annotations`` — where every annotation is a string — is
+    classified the same as one without it. An annotation the ladder could not
+    resolve is reported once per function by
+    :func:`_warn_unresolved_annotations` rather than skipped in silence (#1558).
 
     The broad ``except Exception`` is intentional: any introspection failure
     (weird callables, a signature that cannot be taken at all) is logged at
@@ -416,7 +502,13 @@ def _scan_params(
     """
     try:
         func = _get_original_func(func)
-        resolved_annotations = resolve_param_annotations(func)
+        # The private resolver, because it keeps the ``return`` key: an
+        # unresolvable RETURN annotation is the same authoring error as an
+        # unresolvable parameter, and the diagnostic below is the only thing
+        # that reports it now that ``get_type_hints`` no longer raises out of
+        # here. The key cannot shadow a parameter — ``return`` is a keyword —
+        # so the classification loop is unaffected by carrying it.
+        resolved_annotations = _resolve_param_annotations(func)[0]
         sig = inspect.signature(func)
 
         result: list = []
@@ -425,12 +517,19 @@ def _scan_params(
                 continue
             if predicate(resolved_annotations[param_name]):
                 result.append(i if want == "positions" else param_name)
-        return result
 
     except Exception as e:
         # If we can't analyze the signature, return empty list
         logger.warning(f"Failed to analyze signature for {func}: {e}")
         return []
+
+    # Deliberately outside the ``try`` (#1558): the scan's result is already
+    # final here, so no failure of a *diagnostic* can reach the ``except``
+    # above and drop every typed DI slot on this function. The callee is
+    # additionally raise-proof; both, because a logging call must not be able
+    # to become an outage.
+    _warn_unresolved_annotations(func, resolved_annotations)
+    return result
 
 
 @dataclass(frozen=True)

--- a/src/runtime/python/mesh/helpers.py
+++ b/src/runtime/python/mesh/helpers.py
@@ -2636,9 +2636,14 @@ def _native_dispatch_fallback_reason(vendor: str) -> str | None:
 
     ``native_dispatch_blocker()`` rather than ``has_native()`` because the
     latter fires two once-per-process log latches meant to mark the first
-    dispatch decision, and registration is not one.
+    dispatch decision, and registration is not one. ``probe_handler()`` rather
+    than ``get_handler()`` for the same reason one level up (issue #1558):
+    ``get_handler`` logs "✅ Selected <handler> for vendor: <vendor>" on a cache
+    MISS, so warming the cache here silently relocates that record from the
+    first dispatch to import time and downgrades every dispatch after it to
+    DEBUG.
     """
-    blocker = ProviderHandlerRegistry.get_handler(vendor).native_dispatch_blocker()
+    blocker = ProviderHandlerRegistry.probe_handler(vendor).native_dispatch_blocker()
     if blocker is None:
         return None
 

--- a/src/runtime/python/tests/unit/test_1558_operator_signals.py
+++ b/src/runtime/python/tests/unit/test_1558_operator_signals.py
@@ -1,0 +1,492 @@
+"""Issue #1558 — two operator-visible signals that went silent in 3.7.0.
+
+Neither regression broke behaviour, which is why review missed both and a full
+integration run caught them. Both are the same shape: a change that quietly
+removed a line an operator reads, while the code around it kept working.
+
+  * #1552 added a three-rung annotation-resolution ladder. The last rung —
+    match the annotation as written — means an UNRESOLVABLE annotation no
+    longer raises out of the scan, so a broken type hint stopped being
+    reported at all. The rung stays (without it a ``TYPE_CHECKING``-only
+    import hard-fails at import, which is #1548 relocated); what comes back is
+    the diagnostic on the way past.
+
+  * #1555 asks ``ProviderHandlerRegistry`` for a handler at DECORATION time to
+    reach ``native_dispatch_blocker()``. That warmed the instance cache, so the
+    "✅ Selected <handler> for vendor: <vendor>" line — logged on a cache MISS —
+    moved from the first dispatch to import time, and every dispatch after it
+    took the cache-hit branch at DEBUG.
+
+The integration tests that failed are ``uc02_tools/tc24_invalid_type_hint_warning_py``
+and ``uc04_llm_integration/tc34_vertex_provider_py``. Both grep an agent log, so
+the assertions below pin the same literal substrings those greps use: a
+reworded message is a broken test there and must be a broken test here.
+"""
+
+import logging
+import sys
+import types
+from contextlib import contextmanager
+
+import pytest
+
+from _mcp_mesh.engine import signature_analyzer
+from _mcp_mesh.engine.provider_handlers import ProviderHandlerRegistry
+from _mcp_mesh.engine.signature_analyzer import (
+    get_llm_agent_parameter_names,
+    get_mesh_agent_parameter_names,
+    get_mesh_agent_positions,
+)
+from mesh.types import McpMeshTool
+
+SIGNATURE_LOGGER = "_mcp_mesh.engine.signature_analyzer"
+REGISTRY_LOGGER = "_mcp_mesh.engine.provider_handlers.provider_handler_registry"
+
+#: The literal ``tc24`` greps for (``WARNING.*Failed to analyze signature for``).
+TC24_SUBSTRING = "Failed to analyze signature for"
+
+#: The literal ``tc34`` asserts on.
+TC34_SUBSTRING = "GeminiHandler for vendor: vertex_ai"
+
+
+# ===========================================================================
+# 1. An unresolvable annotation must still be reported
+# ===========================================================================
+
+
+@pytest.fixture
+def scan_warnings(caplog):
+    """WARNING records from the signature analyzer, with the latch re-armed.
+
+    The warning fires once per function per PROCESS, so a test that did not
+    clear the latch would pass or fail depending on what ran before it.
+
+    ``getattr`` rather than a direct reference so a build with no latch at all
+    — main before this fix — fails on the missing WARNING, which is the
+    regression, instead of erroring in setup on a missing private name.
+    """
+    latch = getattr(signature_analyzer, "_unresolved_warned", set())
+    latch.clear()
+    caplog.set_level(logging.WARNING, logger=SIGNATURE_LOGGER)
+    yield caplog
+    latch.clear()
+
+
+def _warnings(caplog):
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == SIGNATURE_LOGGER and r.levelno == logging.WARNING
+    ]
+
+
+class TestUnresolvableAnnotationIsReported:
+    def test_unresolvable_annotation_warns(self, scan_warnings):
+        """The tc24 agent's declaration, verbatim.
+
+        Before #1552 this reached the scan's ``except`` and warned. After it,
+        the annotation resolves to itself, matches no mesh type, and the
+        parameter was skipped in silence — the user's typo reported nowhere.
+        """
+
+        def ping(value: "NonExistentType") -> str:  # noqa: F821
+            return "pong"
+
+        assert get_mesh_agent_parameter_names(ping) == []
+
+        messages = _warnings(scan_warnings)
+        assert len(messages) == 1
+        assert TC24_SUBSTRING in messages[0]
+        assert "NonExistentType" in messages[0]
+
+    def test_resolvable_annotations_do_not_warn(self, scan_warnings):
+        """The signal has to stay rare enough to mean something: a signature
+        whose annotations all resolve must produce nothing."""
+
+        def ok(value: str, dep: McpMeshTool = None) -> str:
+            return value
+
+        assert get_mesh_agent_parameter_names(ok) == ["dep"]
+        assert _warnings(scan_warnings) == []
+
+    def test_warns_once_per_function_across_repeated_scans(self, scan_warnings):
+        """Warn-once, not warn-per-scan.
+
+        A function is scanned several times — once per predicate at decoration
+        (tool / LLM / job), then again on every dependency-resolution pass for
+        the life of the process. The text never changes, so repeating it would
+        turn a startup-time authoring error into recurring noise.
+        """
+
+        def ping(value: "NonExistentType") -> str:  # noqa: F821
+            return "pong"
+
+        for _ in range(3):
+            get_mesh_agent_parameter_names(ping)
+            get_mesh_agent_positions(ping)
+            get_llm_agent_parameter_names(ping)
+
+        assert len(_warnings(scan_warnings)) == 1
+
+    def test_a_second_function_gets_its_own_warning(self, scan_warnings):
+        """The latch is per function, not a global one-shot — two broken
+        signatures are two authoring errors and each has to be reported."""
+
+        def first(value: "MissingOne") -> str:  # noqa: F821
+            return "x"
+
+        def second(value: "MissingTwo") -> str:  # noqa: F821
+            return "x"
+
+        get_mesh_agent_parameter_names(first)
+        get_mesh_agent_parameter_names(second)
+
+        messages = _warnings(scan_warnings)
+        assert len(messages) == 2
+        assert any("MissingOne" in m for m in messages)
+        assert any("MissingTwo" in m for m in messages)
+
+    def test_closures_from_one_factory_each_get_a_warning(self, scan_warnings):
+        """Distinct functions that share a NAME are still distinct errors.
+
+        Every closure a factory returns has the same
+        ``module.qualname`` (``…<locals>.handler``), so a name-keyed latch
+        reports the first and silences the rest — under-reporting exactly the
+        way this warning exists to stop. The latch is keyed on the function
+        object, which ``_scan_params`` has already unwrapped to the original
+        before the diagnostic sees it.
+        """
+
+        def make(missing: str):
+            ns: dict = {}
+            exec(  # noqa: S102 - building N same-named functions is the point
+                f"def handler(value: '{missing}') -> str:\n    return 'x'\n", ns
+            )
+            handler = ns["handler"]
+            handler.__qualname__ = "make.<locals>.handler"
+            handler.__module__ = __name__
+            return handler
+
+        built = [make("MissingA"), make("MissingB"), make("MissingC")]
+        assert len({f.__qualname__ for f in built}) == 1
+
+        for fn in built:
+            get_mesh_agent_parameter_names(fn)
+
+        messages = _warnings(scan_warnings)
+        assert len(messages) == 3
+        for missing in ("MissingA", "MissingB", "MissingC"):
+            assert any(missing in m for m in messages)
+
+    def test_a_function_without_a_module_is_still_latched(self, scan_warnings):
+        """``exec``-built functions have ``__module__`` None.
+
+        Two of them would collide on the name key ``"None.ask"`` and report as
+        one. Identity gets both halves right: a warning each, and still only
+        one per function across repeated scans.
+        """
+        ns_a: dict = {}
+        ns_b: dict = {}
+        exec("def ask(value: 'MissingX') -> str:\n    return 'x'\n", ns_a)  # noqa: S102
+        exec("def ask(value: 'MissingY') -> str:\n    return 'x'\n", ns_b)  # noqa: S102
+        assert ns_a["ask"].__module__ is None
+
+        for _ in range(2):
+            get_mesh_agent_parameter_names(ns_a["ask"])
+            get_mesh_agent_parameter_names(ns_b["ask"])
+
+        messages = _warnings(scan_warnings)
+        assert len(messages) == 2
+        assert any("MissingX" in m for m in messages)
+        assert any("MissingY" in m for m in messages)
+
+    def test_unresolvable_return_annotation_warns(self, scan_warnings):
+        """The return annotation is scanned too.
+
+        ``get_type_hints`` is all-or-nothing including the return, so before
+        #1552 a broken return raised out of the scan and the operator got the
+        warning. It is the half that matters most: a surviving string quietly
+        becomes an ``@mesh.llm`` output type and fails the Pydantic-model check
+        that drives structured output, with nothing logged.
+        """
+
+        def ask(prompt: str) -> "ChatResponse":  # noqa: F821
+            return "x"
+
+        assert get_mesh_agent_parameter_names(ask) == []
+
+        messages = _warnings(scan_warnings)
+        assert len(messages) == 1
+        assert TC24_SUBSTRING in messages[0]
+        assert "ChatResponse" in messages[0]
+        # Reads as an annotation on its own, not as a stray parameter named
+        # "return".
+        assert "return type: 'ChatResponse'" in messages[0]
+
+    def test_broken_return_and_parameter_share_one_warning(self, scan_warnings):
+        """One signature is one authoring error: both halves in one message,
+        not a parameter warning followed by a return warning."""
+
+        def ask(value: "MissingParam") -> "MissingReturn":  # noqa: F821
+            return "x"
+
+        get_mesh_agent_parameter_names(ask)
+
+        messages = _warnings(scan_warnings)
+        assert len(messages) == 1
+        assert "MissingParam" in messages[0]
+        assert "return type: 'MissingReturn'" in messages[0]
+
+    def test_a_resolvable_return_annotation_does_not_warn(self, scan_warnings):
+        """Carrying the return through the scan must not make a healthy
+        signature noisy."""
+
+        def ask(value: str) -> dict[str, int]:
+            return {}
+
+        assert get_mesh_agent_parameter_names(ask) == []
+        assert _warnings(scan_warnings) == []
+
+    def test_a_diagnostic_failure_cannot_empty_the_scan(self, scan_warnings):
+        """The diagnostic is a logging call; it must not be able to become an
+        outage.
+
+        The call used to sit inside ``_scan_params``' ``try``, whose
+        ``except Exception`` returns ``[]`` — so a raise from it would have
+        dropped every typed DI slot on the function, injecting ``None`` where a
+        dependency proxy belongs, and reported it as a signature that could not
+        be analyzed. Two changes: the call moved after the ``try`` so the
+        result is already final, and the diagnostic swallows its own failures.
+        """
+
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("diagnostic exploded")
+
+        def ping(value: "MissingBoom", dep: McpMeshTool = None) -> str:  # noqa: F821
+            return "x"
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(signature_analyzer, "describe_unresolved_annotations", boom)
+            assert get_mesh_agent_parameter_names(ping) == ["dep"]
+            assert get_mesh_agent_positions(ping) == [1]
+
+        assert _warnings(scan_warnings) == []
+
+    def test_type_checking_only_import_still_binds_and_is_reported(self, scan_warnings):
+        """The #1552 rung is not being taken back.
+
+        A ``TYPE_CHECKING``-only mesh import is the case that rung exists for:
+        the parameter must still bind. It is also a degraded resolution — the
+        name matched as text, not as a type — so the operator is told, once.
+        """
+        import __future__
+
+        ns: dict = {}
+        exec(  # noqa: S102 - PEP 563 semantics are the point of the test
+            compile(
+                "def ask(prompt: str, dep: McpMeshTool = None) -> str:\n"
+                "    return 'x'\n",
+                "<pep563>",
+                "exec",
+                flags=__future__.annotations.compiler_flag,
+            ),
+            ns,
+        )
+
+        assert get_mesh_agent_parameter_names(ns["ask"]) == ["dep"]
+
+        messages = _warnings(scan_warnings)
+        assert len(messages) == 1
+        assert TC24_SUBSTRING in messages[0]
+        assert "McpMeshTool" in messages[0]
+
+
+# ===========================================================================
+# 2. The handler-selection line must survive the startup check
+# ===========================================================================
+
+
+@pytest.fixture
+def selection_log(caplog, monkeypatch):
+    """INFO records from the handler registry, against a cold cache and the
+    default dispatch environment.
+
+    ``_instances`` is class-level and process-wide, so an earlier test that
+    resolved ``vertex_ai`` would otherwise pre-warm the very cache these tests
+    are about.
+
+    ``MCP_MESH_NATIVE_LLM`` is deleted for the same reason
+    ``test_llm_provider_litellm_startup_assertion`` deletes it: it is a real
+    operator knob, and a developer running the suite with it exported would
+    flip these vendors onto the LiteLLM path and fail the tests for a reason
+    that has nothing to do with the code under test.
+    """
+    monkeypatch.delenv("MCP_MESH_NATIVE_LLM", raising=False)
+    ProviderHandlerRegistry.clear_cache()
+    caplog.set_level(logging.INFO, logger=REGISTRY_LOGGER)
+    yield caplog
+    ProviderHandlerRegistry.clear_cache()
+
+
+def _dispatches_natively(vendor: str) -> bool:
+    """Whether ``vendor`` would really dispatch through its native SDK in THIS
+    process — i.e. the vendor SDK is importable and native dispatch is not
+    switched off.
+
+    Asked through ``probe_handler`` precisely because a guard must not warm the
+    cache or emit the selection line these tests are about; the probe is
+    verified to answer the same as ``get_handler`` below.
+    """
+    return (
+        ProviderHandlerRegistry.probe_handler(vendor).native_dispatch_blocker() is None
+    )
+
+
+def _selection_lines(caplog):
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == REGISTRY_LOGGER
+        and r.levelno == logging.INFO
+        and "Selected" in r.getMessage()
+    ]
+
+
+@contextmanager
+def _module_with_app(module_name: str):
+    """A real ``sys.modules`` entry carrying a FastMCP ``app``.
+
+    ``@mesh.llm_provider`` resolves the app via ``sys.modules[fn.__module__]``,
+    so a decorated function needs a module that actually exists.
+    """
+    from fastmcp import FastMCP
+
+    from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+
+    mod = types.ModuleType(module_name)
+    mod.app = FastMCP(module_name)
+    sys.modules[module_name] = mod
+    snapshot = dict(DecoratorRegistry._mesh_tools)
+    DecoratorRegistry._mesh_tools.clear()
+    try:
+        yield mod
+    finally:
+        sys.modules.pop(module_name, None)
+        DecoratorRegistry._mesh_tools.clear()
+        DecoratorRegistry._mesh_tools.update(snapshot)
+
+
+class TestSelectionLineSurvivesStartupCheck:
+    def test_startup_check_does_not_consume_the_selection_line(self, selection_log):
+        """The #1555 caller, asked directly.
+
+        ``_native_dispatch_fallback_reason`` runs at decoration time. Its
+        verdict must be unchanged and its cost must be invisible: the record of
+        which handler serves ``vertex_ai`` belongs to the first dispatch.
+
+        The verdict is asserted against this process's actual dispatch state
+        rather than pinned to ``None``: whether ``vertex_ai`` dispatches
+        natively depends on ``google-genai`` being importable, which is a
+        property of the install, not of this change. The selection-line
+        assertions below hold either way, and they are what the test is for.
+        """
+        from mesh.helpers import _native_dispatch_fallback_reason
+
+        reason = _native_dispatch_fallback_reason("vertex_ai")
+        assert _selection_lines(selection_log) == []
+
+        if _dispatches_natively("vertex_ai"):
+            assert reason is None
+        else:
+            assert reason is not None and "LiteLLM" in reason
+
+        ProviderHandlerRegistry.get_handler("vertex_ai")
+        assert [TC34_SUBSTRING in line for line in _selection_lines(selection_log)] == [
+            True
+        ]
+
+    def test_selection_line_logged_once_after_provider_declaration(self, selection_log):
+        """The tc34 path end to end: declare the provider, then dispatch.
+
+        Declaration is where #1555 warmed the cache; the two dispatches after
+        it stand in for a served request and a second one. Exactly one
+        selection line — the signal is restored without becoming per-call
+        noise.
+
+        The declaration is allowed to raise: with ``google-genai`` absent this
+        provider falls back to LiteLLM, and the #1551 startup assertion refuses
+        the declaration when LiteLLM is not installed either. That verdict is
+        the sibling test file's subject; here it is irrelevant, because the
+        assertion — declaration emits no selection line — holds whether the
+        decorator returns or raises, and the ``probe_handler`` call that could
+        have emitted one happens before either outcome.
+        """
+        import mesh
+
+        module_name = "test_1558_vertex_provider_module"
+        with _module_with_app(module_name) as mod:
+
+            def provider():
+                pass
+
+            provider.__module__ = module_name
+            mod.provider = provider
+            try:
+                mesh.llm_provider(model="vertex_ai/gemini-2.5-flash", capability="llm")(
+                    provider
+                )
+            except ImportError:
+                pass
+
+            assert _selection_lines(selection_log) == []
+
+            ProviderHandlerRegistry.get_handler("vertex_ai")
+            ProviderHandlerRegistry.get_handler("vertex_ai")
+
+        lines = _selection_lines(selection_log)
+        assert len(lines) == 1
+        assert TC34_SUBSTRING in lines[0]
+
+    def test_probe_returns_the_cached_instance_when_one_exists(self, selection_log):
+        """A probe after a dispatch must not build a second handler: handlers
+        are cached singletons and callers compare identity in places."""
+        dispatch_handler = ProviderHandlerRegistry.get_handler("vertex_ai")
+        assert ProviderHandlerRegistry.probe_handler("vertex_ai") is dispatch_handler
+        assert len(_selection_lines(selection_log)) == 1
+
+    @pytest.mark.parametrize(
+        "vendor",
+        [
+            "anthropic",
+            "openai",
+            "gemini",
+            "vertex_ai",
+            # Unregistered / unnormalized vendors: the only branch where
+            # ``_instantiate`` passes the vendor string to the constructor, so
+            # the only place probe and dispatch could disagree about ``.vendor``.
+            "moonshot",
+            "acme-llm",
+            None,
+            "",
+            "   ",
+            "VERTEX_AI",
+            " Anthropic ",
+        ],
+    )
+    def test_probe_resolves_the_same_handler_as_dispatch(self, selection_log, vendor):
+        """Silence must not have been bought with a different answer.
+
+        Both sides are resolved from a COLD cache, so the probe returns its
+        transient instance rather than the singleton the dispatch just cached —
+        comparing a warmed probe against the dispatch that warmed it is
+        comparing an object with itself, which would not notice a divergence.
+        """
+        ProviderHandlerRegistry.clear_cache()
+        probed = ProviderHandlerRegistry.probe_handler(vendor)
+
+        ProviderHandlerRegistry.clear_cache()
+        dispatched = ProviderHandlerRegistry.get_handler(vendor)
+
+        assert probed is not dispatched
+        assert type(probed) is type(dispatched)
+        assert probed.vendor == dispatched.vendor


### PR DESCRIPTION
## Summary

Two integration tests fail consistently on `main`. Both are regressions from PRs merged after v3.7.0, both were caught by a full integration run rather than review, and both are the same class: **a change that quietly removed a signal without breaking any behaviour.** Nothing here changes what the runtime does — only what it tells you about it.

### An unresolvable annotation went silent (from #1552)

`uc02_tools/tc24_invalid_type_hint_warning_py` declares `def ping(value: "NonExistentType")`. Before #1552, `get_type_hints` raised, the scan's `except` caught it, and the operator got `WARNING Failed to analyze signature for …`. #1552's resolution ladder ends in a rung that matches the annotation *as written*, so a broken hint no longer reaches that `except` — the parameter is skipped, matches no mesh type, and the author is told nothing.

The rung stays. Without it a `TYPE_CHECKING`-only import hard-fails at import, which is #1548 relocated. What it must not do is swallow the diagnostic on the way past, so an annotation that survives the ladder as a bare string is now reported once per function.

### The handler-selection line dropped to DEBUG (from #1555)

`uc04_llm_integration/tc34_vertex_provider_py` asserts the agent log names the handler serving `vertex_ai`. Routing is unaffected — assertion 6 still passes — but `get_handler` logs `✅ Selected …` only on a cache **miss**, so it lands wherever the *first* caller happens to be. #1555's startup LiteLLM assertion calls `get_handler` at decoration time purely to reach `native_dispatch_blocker()`, warming the cache and relocating that record to import time; every dispatch after it takes the cache-hit branch and logs at DEBUG, which an operator's log does not capture.

New `probe_handler()` answers questions asked outside a dispatch: same handler, neither side effect. Same shape of reasoning as `native_dispatch_blocker()` vs `has_native()` one level down — asking a dispatch-time question early must not consume the dispatch-time record.

## Why fix rather than update the assertions

Both tests assert an operator-visible signal, and in both cases the signal is the point: an unresolvable type hint is a user error that should be reported, and which handler serves a vendor is the fact tc34 exists to prove. Changing the assertions would record the loss.

tc24's own comment anticipated this — it greps the WARNING level together with the message "so a future downgrade to DEBUG/INFO would surface as a test failure." It surfaced a removal instead.

## Review notes

A zero-context review pass found five issues in the first draft, all fixed here. Three are worth calling out because each was a case of the fix being narrower than the bug:

- **The restored warning missed the return annotation.** `resolve_param_annotations` pops the return key, so `-> "Missing"` stayed silent — and that is the half that matters most, since a surviving string return annotation silently becomes the `@mesh.llm` output type and fails the Pydantic check driving structured output. Now resolved through the private variant that keeps the key; params and return are reported in one message.
- **The warn-once latch collided.** It keyed on `module.qualname`, justified by a claim ("a different wrapper each time") that `_get_original_func` makes false — the object is always the stable original. Every closure from a factory shares one qualname, so ten broken generated tools warned once. Now a `WeakSet` on identity: collision-free and self-clearing.
- **The diagnostic sat inside the scan's `try`.** A raise from a logging call would have been caught by the `except Exception` that returns `[]`, silently dropping every typed DI slot on that function. Moved out and independently guarded.

The reviewer verified the statelessness claim `probe_handler` rests on across all five handler modules: the only instance attribute in the package is `self.vendor`, and the once-per-process latches are module-level, so a transient probe instance carries nothing and burns nothing.

**One judgement call left open** (not addressed here, deliberately): the warning fires for any annotation surviving as a string, which includes a deliberate `TYPE_CHECKING`-only import that binds fine by name, and a forward reference to a class defined later in the same module. That matches pre-#1552 noise exactly, minus the breakage — the old path warned for those too *and* dropped every mesh param on the function — and the message tells the author to import at module scope, which is the right nudge. But it does mean one alarming sentence now covers three conditions, one of which is "worked fine".

Closes #1558

## Test plan

- [x] `test_1558_operator_signals.py` — 25 tests, asserting the exact literals the integration tests grep, so a reword breaks here first
- [x] Confirmed failing on `main` in a worktree, for **behavioural** reasons (`assert 0 == 1` for the absent warning; `['✅ Selected GeminiHandler for vendor: vertex_ai'] == []` for the consumed line), not missing-attribute reasons
- [x] Each review fix separately confirmed failing against the pre-review commit: closures `1 == 3`, exec'd functions `1 == 2`, return-only `0 == 1`, and the diagnostic-placement test `[] == ['dep']`
- [x] Real tc24 artifact imported directly — emits one line matching `WARNING.*Failed to analyze signature for`
- [x] `probe_handler` leaves the cache cold; dispatch 1 logs the INFO line, dispatch 2 is quiet
- [x] Full Python suite green in default and `-p no:randomly` order; `ruff check` and `ruff format --check` clean; `go build ./...`; `check_doc_claims.py`
- [ ] tc24 and tc34 green in a full integration run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hsym5TX4sFTLUv9LrxgSjq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored warning messages for unresolved parameter and return type annotations, with duplicate warnings suppressed per function.
  * Preserved dependency scanning even when annotation diagnostics encounter errors.
  * Ensured provider-selection messages appear on first dispatch rather than during setup.
* **Tests**
  * Added regression coverage for annotation warnings, provider selection logging, cache behavior, and handler consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->