### PR TITLE
docs: fix MeshJob pairing wording in man jobs and dead kwargs link

### DIFF
--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -180,11 +180,12 @@ and [`examples/jobs-java/`](https://github.com/dhyansraj/mcp-mesh/tree/main/exam
     async def commission_report(
         user_id: str,
         sections: list[str],
-        # Param name MUST match the dependency capability — that pairing
-        # is what makes the slot a MeshJobSubmitter (not a McpMeshTool proxy).
-        generate_report: MeshJob = None,
+        # The MeshJob annotation is what makes this a MeshJobSubmitter slot
+        # (not a McpMeshTool proxy); it pairs with the dependency at its
+        # position, so the parameter name is yours to pick.
+        report_job: MeshJob = None,
     ) -> dict:
-        proxy = await generate_report.submit(
+        proxy = await report_job.submit(
             user_id=user_id, sections=sections, max_duration=60,
         )
         return await proxy.wait(timeout_secs=60)
@@ -204,9 +205,9 @@ and [`examples/jobs-java/`](https://github.com/dhyansraj/mcp-mesh/tree/main/exam
       }),
       execute: async (
         { user_id, sections },
-        generateReport: MeshJob | null = null,
+        reportJob: MeshJob | null = null,
       ) => {
-        const proxy = await generateReport!.submit!(
+        const proxy = await reportJob!.submit!(
           { user_id, sections },
           { maxDuration: 60 },
         );
@@ -224,8 +225,8 @@ and [`examples/jobs-java/`](https://github.com/dhyansraj/mcp-mesh/tree/main/exam
     public Map<String, Object> commissionReport(
         @Param("user_id") String userId,
         @Param("sections") List<String> sections,
-        MeshJob generateReport) throws Exception {
-      MeshJobSubmitter submitter = (MeshJobSubmitter) generateReport;
+        MeshJob reportJob) throws Exception {
+      MeshJobSubmitter submitter = (MeshJobSubmitter) reportJob;
       Map<String, Object> payload = new LinkedHashMap<>();
       payload.put("user_id", userId);
       payload.put("sections", sections);
@@ -660,12 +661,16 @@ owner replica and outbound HTTP proxies abort their requests too.
 **DDDI is the injection layer.** The producer's `MeshJob` parameter
 lands at `meshJobParamIndex` (Python and Java auto-detect it from the
 type annotation; TS declares it explicitly in `addTool`). The
-consumer's `MeshJob` parameter — typed identically, but on a slot
-named after a dependency capability — gets a `MeshJobSubmitter`
-instead of an `McpMeshTool` proxy: same DDDI lookup, different
-injection target based on the dep's `task=true` flag. Resolution,
-trust, and tag matching are unchanged from the regular tool path; the
-only difference is the runtime swaps the proxy class at the dep slot.
+consumer's `MeshJob` parameter — typed identically, and likewise
+selected by its annotation rather than its name — gets a
+`MeshJobSubmitter` instead of an `McpMeshTool` proxy. The slot pairs
+with the dependency at its position among the tool's injectable
+parameters, and the injector builds a submitter for any `MeshJob`-typed
+slot whenever a registry URL is configured (otherwise the slot is left
+`None` with a warning, or an error under `MCP_MESH_STRICT_DI`); it never
+consults the provider's `task=true` flag. Resolution, trust, and tag
+matching are unchanged from the regular tool path; the only difference
+is the runtime swaps the proxy class at that slot.
 For the full design rationale and lifecycle diagrams, see
 [`MESHJOB_DESIGN.org`](https://github.com/dhyansraj/mcp-mesh/blob/main/MESHJOB_DESIGN.org)
 and [`MESHJOB_DDDI_CONTRACT.md`](https://github.com/dhyansraj/mcp-mesh/blob/main/MESHJOB_DDDI_CONTRACT.md).

--- a/src/core/cli/man/content/jobs.md
+++ b/src/core/cli/man/content/jobs.md
@@ -25,7 +25,7 @@ behavior change for non-job tools.
 | Surface                    | Producer                          | Consumer                                |
 | -------------------------- | --------------------------------- | --------------------------------------- |
 | Decorator flag             | `@mesh.tool(task=True, ...)`      | (regular `@mesh.tool` w/ dependency)    |
-| Injected type              | `job: MeshJob = None`             | `<dep_name>: MeshJob = None`            |
+| Injected type              | `job: MeshJob = None`             | `report_job: MeshJob = None`            |
 | Concrete injection         | `JobController` (or `None`)       | `MeshJobSubmitter`                      |
 | Progress                   | `await job.update_progress(f, m)` | (read via `__mesh_job_status`)          |
 | Request input              | `await job.request_input(prompt)` | (status → `input_required`; answer via `post_event`) |
@@ -105,16 +105,16 @@ app = FastMCP("Long Task Consumer")
 @app.tool()
 @mesh.tool(
     capability="commission_report",
-    # Param NAME must match the dependency capability — that pairing is
-    # what makes the slot a MeshJobSubmitter (instead of an McpMeshTool).
+    # The MeshJob annotation is what makes the slot a MeshJobSubmitter;
+    # it pairs with the dependency at its position (name is yours to pick).
     dependencies=["generate_report"],
 )
 async def commission_report(
     user_id: str,
     sections: list[str],
-    generate_report: MeshJob = None,        # injected MeshJobSubmitter
+    report_job: MeshJob = None,             # injected MeshJobSubmitter
 ) -> dict:
-    proxy = await generate_report.submit(
+    proxy = await report_job.submit(
         user_id=user_id,
         sections=sections,
         max_duration=60,                    # per-attempt soft timeout (seconds)
@@ -124,10 +124,14 @@ async def commission_report(
 
 **Notes:**
 
-- The SDK swaps `McpMeshTool` for `MeshJobSubmitter` at the slot
-  whose param name matches a dependency that points at a `task=True`
-  capability. Same DDDI lookup pipeline (resolution, trust, tags) —
-  only the proxy class differs.
+- The SDK swaps `McpMeshTool` for `MeshJobSubmitter` at the parameter
+  annotated `MeshJob`. That parameter pairs with the dependency at its
+  position among the tool's injectable parameters — the `McpMeshTool`-
+  and `MeshJob`-typed ones in declaration order, not the raw signature
+  index — exactly like an `McpMeshTool` slot
+  (see `meshctl man dependency-injection`); the parameter name is yours
+  to choose. Same DDDI lookup pipeline (resolution, trust, tags) — only
+  the proxy class differs.
 - `wait(timeout_secs=N)` returns the producer's `complete()` payload
   on success; raises `JobFailedError`, `JobCancelledError`, or
   `JobTimeoutError` on the other terminal states.
@@ -186,7 +190,7 @@ async def report_with_transient_failures(
 
 ```python
 # Caller-side: at most 4 total attempts (1 initial + 3 retries)
-proxy = await generate_report.submit(
+proxy = await report_job.submit(
     user_id="alice",
     sections=["intro"],
     max_duration=30,
@@ -306,8 +310,9 @@ async def submit_user_input(job_id: str, text: str) -> dict:
 the registry from `MCP_MESH_REGISTRY_URL` and reuses a process-cached
 `JobProxy` from a bounded LRU keyed by `(registry_url, job_id)`
 (default cap 256; tune via `MCP_MESH_JOBPROXY_CACHE_MAX`). If the
-calling code already holds a `JobProxy`, use `proxy.send_event(
-event_type, payload)` directly — same wire shape, skip the helper.
+calling code already holds a `JobProxy`, use
+`proxy.send_event(event_type, payload)` directly — same wire shape,
+skip the helper.
 
 **Lifecycle facades by `job_id`.** Same DDDI-clean pattern as
 `post_event` — module-level helpers that take a `job_id` and dispatch
@@ -335,8 +340,8 @@ raise `JobNotFoundError` if the registry has reaped the job.
 - `mesh.JobNotFoundError` — job swept or id typo
 - `mesh.JobTerminalError` — job already terminal, no more events accepted
 
-**Synthetic cancel event**. When a consumer calls `proxy.cancel(
-reason)`, the registry writes a synthetic
+**Synthetic cancel event**. When a consumer calls
+`proxy.cancel(reason)`, the registry writes a synthetic
 `{"type": "cancelled", "payload": {"reason": "..."}}` event into the
 log before forwarding the cancel signal. A handler parked on
 `recv_event(types=["cancelled", ...])` observes it and can return
@@ -673,9 +678,9 @@ except mesh.SupersededError:
 ```
 
 `SupersededError` is distinct from a generic tool failure and from the
-`dependency_unavailable` refusal (an unresolved required dep, `meshctl man
-dependency-injection`) — it means specifically *you are running under a
-superseded claim*. It does **not** change delivery: jobs remain
+`dependency_unavailable` refusal (an unresolved required dep,
+`meshctl man dependency-injection`) — it means specifically *you are
+running under a superseded claim*. It does **not** change delivery: jobs remain
 **at-least-once** and a fenced re-execution still runs under the new claim;
 the typed signal only lets the stale attempt bow out on its first rejected
 write rather than every downstream provider re-checking a string marker.

--- a/src/core/cli/man/content/kwargs.md
+++ b/src/core/cli/man/content/kwargs.md
@@ -59,4 +59,4 @@ shape. See the full reference for typed examples per language.
 - `meshctl man llm` - `@mesh.llm` consumer guide
 
 For the complete kwargs reference including TypeScript/Java examples and
-vendor-by-vendor matrix, see <https://mcp-mesh.io/reference/kwargs>.
+vendor-by-vendor matrix, see <https://mcp-mesh.ai/reference/kwargs/>.

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -418,6 +418,32 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // in `variant_corpus_test.go` is unmoved — the case the note below describes,
 // in reverse.
 //
+// Issues #1561/#1562: +7 / +0 / +0, all of it in `jobs.md`, and it splits into
+// two unrelated halves.
+//
+// +3 is the correction itself. The consumer-side passage said the parameter
+// NAME picks the `MeshJobSubmitter` slot. It does not: `_prepare_injection_kwargs`
+// pairs `dependencies[i]` to the i-th eligible slot positionally and branches on
+// the `MeshJob` annotation alone ("Param NAME does not matter; the binding is
+// positional"), so the Notes bullet was rewritten and gains `MeshJob` twice, a
+// third `McpMeshTool`, and `meshctl man dependency-injection` for the pairing
+// rule, against the `task=True` span the old claim needed and no longer does.
+//
+// +4 is a rendering defect this test could not see. renderStyled styles inline
+// code per LINE, so a span wrapped across a break renders as literal backticks
+// and is not a span at all. This page had four: the two `meshctl man
+// dependency-injection` citations (one of them introduced by the fix above),
+// `proxy.send_event(event_type, payload)` and `proxy.cancel(reason)`. Rewrapping
+// each onto one line is what makes them spans for the first time — the words on
+// the page are unchanged. A page-wide scan for a backtick opened on one line and
+// closed on the next now reports none here.
+//
+// The renamed consumer parameter (`generate_report` to `report_job`, so the
+// example demonstrates the free name) sits inside a fence, and the cheat-sheet
+// cell is a table cell; renderStyled takes other branches for both and neither
+// adds a span. The rewritten bullet is a list item but changes no line's markup
+// shape, so the two list goldens below hold.
+//
 // Issue #1500: the sentence most annotations above end on — that the `_java`
 // and `_typescript` files are invisible here, so a review of them cannot lean
 // on this test — is still true of THESE constants and no longer true of this
@@ -431,7 +457,7 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // the starter's POM; a test in this package cannot, and #1499 shipped three
 // false claims through a green run here.
 const (
-	wantInlineCodeSpans = 1780
+	wantInlineCodeSpans = 1787
 	wantListCodeSpans   = 522
 	wantMarkupListLines = 448
 )


### PR DESCRIPTION
## Summary
- `meshctl man jobs` and its docs-site twin `docs/concepts/jobs.md` said the consumer-side `MeshJob` slot is selected by parameter name matching the capability, and that the swap to `MeshJobSubmitter` is driven by the provider's `task=True` flag. The injector pairs `dependencies[i]` to the i-th `McpMeshTool`/`MeshJob`-typed parameter by position, selects the submitter proxy from the annotation alone, and never reads the parameter name or the provider flag. Both surfaces now say so, with the position qualified as "among injectable parameters, not the raw signature index".
- The consumer example (Python, TypeScript, Java tabs) and the cheat sheet now use a parameter name that differs from the capability, so the example demonstrates the rule instead of inviting the old misreading.
- `meshctl man kwargs` linked the full reference at `mcp-mesh.io`, which does not resolve. Now points at `mcp-mesh.ai/reference/kwargs/`.
- Four inline code spans in `man jobs` were wrapped across a line break and rendered as literal backticks in the terminal, because the renderer styles inline code per line. One was introduced by the first draft of this fix, three were pre-existing. Each is rejoined onto one line; no wording changed. The man corpus golden moves 1780 -> 1787 (+3 from the corrected bullet, +4 from the rejoined spans), annotated in `renderer_test.go` per the file's convention.

## Review Notes
- Zero-context review verified every changed sentence against `dependency_injector.py` (`_prepare_injection_kwargs`) and `signature_analyzer.py`. Its two warnings (stale claim surviving in `docs/concepts/jobs.md`) and follow-up nits are folded in.
- `jobs_typescript.md` / `jobs_java.md` were grepped and do not carry the claim; untouched.
- First CI run failed only on `TestStyleInlineCorpus` (golden), which is what surfaced the wrapped-span rendering defect.

Closes #1561
Closes #1562

## Test plan
- [x] `go test ./src/core/cli/man/` green with the new golden
- [x] `python3 scripts/check_doc_claims.py` passes
- [x] `./bin/meshctl man jobs | grep dependency-injection` shows all four citations styled, no literal backticks
- [x] `./bin/meshctl man --raw kwargs` shows the `.ai` link; `curl` of that URL returns 200
- [x] No `generate_report.`/`generateReport` consumer-slot usages remain in either jobs page (capability strings and producer names intentionally unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GKQG598Ma6EYUrSUjK1LSN