### PR TITLE
ci: compile and test every Rust feature set on PRs; ship spire in the TS artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,31 +61,129 @@ jobs:
       - name: Run Go tests with race detection
         run: go test ./... -race
 
+  # Issue #1586: this job ran `--no-default-features` and nothing else, so
+  # `ffi` — the one feature no other CI job enables — was compiled for the
+  # first time by release.yml, i.e. after merge. `java-test` below runs
+  # `mvn test` with no Rust step at all, so nothing on a PR built it.
+  #
+  # What the `ffi` feature actually gates is narrower than it sounds, and worth
+  # stating so this leg is not mistaken for broader coverage than it has:
+  # `src/ffi.rs` — the core Java native surface — is declared UNGATED at
+  # lib.rs:89 and was already compiled (and its tests already run) by the
+  # existing no-default-features leg. The feature gates exactly two things:
+  # `src/jobs_ffi.rs`, the MeshJob C-ABI surface (its own `#![cfg]`, 25 tests),
+  # and the cbindgen header generation in build.rs, which keys off
+  # CARGO_FEATURE_FFI. Both were release-only until this leg.
+  #
+  # The remaining feature sets were already compiled on every PR, just not
+  # here: `python` + `spire` by `python-test` (maturin, via pyproject's
+  # features = ["pyo3/extension-module", "spire"]) and `typescript` + `spire` by
+  # `typescript-test` (napi, via package.json's `build` script). But both of
+  # those only *build* the crate; neither runs `cargo test`, so the tests behind
+  # those gates never executed anywhere. That was 14 tests for `typescript`
+  # alone (8 in napi.rs, 6 in jobs_napi.rs). The `typescript` and `spire` legs
+  # below close that gap. To be precise about what the `spire` leg buys: it is
+  # not the only thing that *compiles* spire.rs on a PR — both builds above
+  # already do — it is the only thing that *runs* spire.rs's tests.
+  #
+  # Test counts differ per leg, which is the point — if a leg's count drops to
+  # another leg's, a feature gate has stopped doing anything:
+  #   488  --no-default-features
+  #   513  ffi        (+25, jobs_ffi.rs)
+  #   502  typescript (+14, napi.rs + jobs_napi.rs)
+  #   492  spire      (+4,  spire.rs)
+  # The `default` leg does not run tests; see the note on it below.
   rust-test:
-    name: Rust Tests
+    name: Rust Tests (${{ matrix.id }})
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: src/runtime/core
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: no-default-features
+            features: "--no-default-features"
+            cmd: "cargo test --no-default-features -- --test-threads=1"
+          - id: ffi
+            features: "--features ffi --no-default-features"
+            cmd: "cargo test --features ffi --no-default-features -- --test-threads=1"
+          - id: spire
+            features: "--features spire --no-default-features"
+            cmd: "cargo test --features spire --no-default-features -- --test-threads=1"
+          - id: typescript
+            features: "--features typescript --no-default-features"
+            cmd: "cargo test --features typescript --no-default-features -- --test-threads=1"
+          # `cargo check`, not `cargo test`, and not a lapse. The default set is
+          # `python` + `simd`, and `python` pulls pyo3 with `extension-module`
+          # (Cargo.toml:28) unconditionally — which tells pyo3 to leave the
+          # libpython symbols undefined for the interpreter to resolve at import
+          # time. A test harness is an executable with no interpreter to resolve
+          # them, so linking fails on `__Py_NoneStruct` and friends. Making it
+          # link would mean either making the pyo3 feature conditional (a source
+          # change) or platform-specific RUSTFLAGS, neither of which belongs in
+          # a CI change. `--all-targets` still type-checks the test modules, so
+          # this leg catches everything except a genuine runtime failure in a
+          # `python`-gated test; those run for real in `python-test`.
+          - id: default
+            features: ""
+            cmd: "cargo check --all-targets"
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          # Not in the default (minimal) profile dtolnay/rust-toolchain installs.
+          components: clippy
 
+      # Two entries, deliberately. The downloaded crates are decided by
+      # Cargo.lock alone — feature-independent and byte-identical across the
+      # five legs — so they share one entry keyed without the matrix id. Packing
+      # them per-leg would store five near-identical copies of the registry
+      # against this repo's 10 GB LRU budget, on top of the `-cargo-py-` and
+      # `-cargo-ts-` entries other jobs restore; the likely victim of that
+      # eviction is those other jobs, not these legs.
+      #
+      # target/ is the part that genuinely differs per feature set, so it keeps
+      # the matrix id. Note the reason is speed, not correctness: `actions/cache`
+      # entries are immutable, and a save against an existing key does not
+      # clobber it — it no-ops with "Cache already exists". Under one shared key
+      # the first leg to finish would simply win, and the other four would
+      # restore a tree whose cargo fingerprints do not match their feature set
+      # and rebuild from scratch anyway.
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            src/runtime/core/target
-          key: ${{ runner.os }}-cargo-rust-${{ hashFiles('src/runtime/core/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-rust-registry-${{ hashFiles('src/runtime/core/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-rust-
+            ${{ runner.os }}-cargo-rust-registry-
+
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: src/runtime/core/target
+          key: ${{ runner.os }}-cargo-rust-target-${{ matrix.id }}-${{ hashFiles('src/runtime/core/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-rust-target-${{ matrix.id }}-
 
       - name: Run Rust tests
-        run: cargo test --no-default-features -- --test-threads=1
+        run: ${{ matrix.cmd }}
+
+      # ADVISORY, NOT A GATE — `continue-on-error: true` and no `-D warnings`.
+      # The crate has 26-45 style warnings depending on the feature set, most of
+      # them the dead code issue #1594 removes. Gating on them today would mean
+      # either a red wall on every PR or turning this CI change into a Rust
+      # cleanup. Once #1594 lands, drop `continue-on-error` and append
+      # `-- -D warnings` here; until then this exists so the count is visible in
+      # the log and a *new* warning is at least readable in the diff of a run.
+      - name: Clippy (advisory)
+        continue-on-error: true
+        run: cargo clippy ${{ matrix.features }} --all-targets
 
   typescript-test:
     name: TypeScript Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -574,6 +574,15 @@ jobs:
         working-directory: src/runtime/core/typescript
         run: npm install
 
+      # KEEP THE FEATURE LIST IN SYNC with the `build` / `build:debug` scripts in
+      # src/runtime/core/typescript/package.json. This step is the only thing
+      # that decides what actually ships to npm; those scripts are what CI, the
+      # Makefile and every developer compile locally. Issue #1586: the two had
+      # drifted — the scripts carried `typescript,spire` while this line shipped
+      # `typescript` alone — so SPIRE was present in every build except the
+      # released one, and tc17_spire_typescript was passing against a binary no
+      # user ever received. Changing either side without the other reopens that
+      # gap silently.
       - name: Build native bindings
         working-directory: src/runtime/core/typescript
         env:
@@ -582,7 +591,7 @@ jobs:
           npx napi build --platform --release \
             --target ${{ matrix.target }} \
             --manifest-path ../Cargo.toml \
-            --features typescript --no-default-features -o .
+            --features typescript,spire --no-default-features -o .
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What

Replaces the single `rust-test` job (which ran `--no-default-features` and nothing else) with a five-leg feature matrix, and fixes a CI-vs-release feature drift found while verifying it.

| leg | command | tests |
|---|---|---|
| `no-default-features` | `cargo test` | 488 |
| `ffi` | `cargo test` | 513 (+25, `jobs_ffi.rs`) |
| `typescript` | `cargo test` | 502 (+14, `napi.rs` + `jobs_napi.rs`) |
| `spire` | `cargo test` | 492 (+4, `spire.rs`) |
| `default` | `cargo check --all-targets` | — |

All five verified locally, all pass.

## The issue's premise was narrower than filed

#1586 says the `ffi`, `typescript` and `spire` features "are never compiled in CI". Verified against the workflows, that is only true of `ffi`:

| feature | compiled on PRs before this change? | how |
|---|---|---|
| `python` | **yes** | `python-test` runs `maturin build --release`; `core/pyproject.toml:36` sets `features = ["pyo3/extension-module", "spire"]` |
| `typescript` | **yes** | `typescript-test` runs `npm run build` → `napi build --features typescript,spire` |
| `spire` | **yes** | via both of the above |
| `ffi` | **no** | `java-test` runs only `mvn test`; no Rust build on PRs |

And the issue's claim that `jobs_ffi.rs` *and* `ffi.rs` were uncompiled is wrong for `ffi.rs`: it is declared **ungated** at `src/runtime/core/src/lib.rs:89`, so the pre-existing `--no-default-features` leg already compiled it and ran its 30 tests. The `ffi` feature gates exactly two things — `jobs_ffi.rs` (its own `#![cfg]`, 25 tests) and cbindgen header generation in `build.rs`.

The real gap is different and larger: those maturin/napi builds only *build* the crate, never `cargo test`. **43 tests behind feature gates ran nowhere.** They run now.

## SPIRE: a shipping gap, not a missing capability

While verifying the above: `src/runtime/core/typescript/package.json:23` builds `--features typescript,spire`, but `release.yml` built `--features typescript` alone. So SPIRE was present in every build — CI, `make`, the integration suite — **except the one published to npm**, and `tc17_spire_typescript` was passing against a binary no user ever received.

`release.yml` is aligned **up** to `typescript,spire`. Cross-compile risk is nil: the Python wheel already builds `spiffe` with `spire` across a strict superset of the four napi targets (it adds `x86_64-pc-windows-msvc`), and `maturin-action`'s args do not override `pyproject`'s feature list.

`package.json` is unchanged.

## Java is deliberately untouched

`release.yml`'s `--features ffi` build is left alone. Java genuinely cannot use `MCP_MESH_TLS_PROVIDER=spire`: it is built without the feature in both `tc04a_build_java_sdk/test.yaml:67` and `release.yml`, and `strings` on the shipped `libmcp_mesh_core.so` has zero occurrences of `SPIREProvider`. `tc18_spire_java` does not contradict this — it never sets `MCP_MESH_TLS_PROVIDER`, so it defaults to the `file` provider and feeds it pre-exported SVIDs. Adding the build flag would not be sufficient anyway; #607 records that Spring Boot's `EnvironmentPostProcessor` runs before the FFI loads. Filed separately.

## Clippy is advisory

`continue-on-error: true`, no `-D warnings`. There are 26–45 pre-existing style warnings depending on the leg, most of them the dead code #1594 removes. Once that lands, drop `continue-on-error` and append `-- -D warnings`.

## Notes for review

- Cache is split into a shared `~/.cargo/registry` + `~/.cargo/git` entry (keyed **without** the matrix id) and a per-leg `target/` entry, so five legs do not store five redundant registry copies against the 10 GB LRU budget. Key prefixes changed, so the first run after merge is a cold miss.
- The check name changes from `Rust Tests` to `Rust Tests (<id>)`. Neither `main` nor `dev` has branch protection, so nothing breaks; worth knowing if required checks are added later.
- The `default` leg runs `cargo check`, not `cargo test`: `Cargo.toml:28` enables pyo3's `extension-module` unconditionally, so a test harness has no interpreter to resolve `__Py_NoneStruct` against and cannot link. Reason is documented inline.
- `actionlint` is clean on `ci.yml`; `release.yml`'s 89 findings are byte-identical to the `dev` baseline.

Closes #1586

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfukAUDerBUKAfKzUyhvvb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node.js native bindings now include Spire support in release builds.

* **Tests**
  * CI now validates multiple Cargo feature configurations, including FFI, Spire, TypeScript, and default builds.
  * Added advisory Clippy checks and improved build caching for more consistent validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->