### PR TITLE
fix(registry): harden HTTP listeners, bound request bodies, implement graceful shutdown

### DIFF
--- a/cmd/mcp-mesh-registry/main.go
+++ b/cmd/mcp-mesh-registry/main.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	flag "github.com/spf13/pflag"
 
@@ -19,6 +20,14 @@ import (
 
 // version is injected at build time via ldflags
 var version = "dev"
+
+// shutdownWaitTimeout bounds how long main waits for Server.Stop after
+// the listeners have closed. Stop's own bounded phases are 5s of HTTP
+// drain plus 10s of handler-goroutine drain, so 20s leaves both room to
+// finish and still guarantees the process exits: Stop's tail (tracing
+// shutdown) has no deadline of its own, and by this point the SIGTERM
+// has already been consumed.
+const shutdownWaitTimeout = 20 * time.Second
 
 func main() {
 	// Command line flags
@@ -123,12 +132,13 @@ func main() {
 		TlsKeyFile:              os.Getenv("MCP_MESH_TLS_KEY"),
 		TrustDir:                os.Getenv("MCP_MESH_TRUST_DIR"),
 		AdminPort:               getEnvIntDefault("MCP_MESH_ADMIN_PORT", 0),
+		AdminTLS:                getEnvBoolDefault("MCP_MESH_ADMIN_TLS", false),
 	}
 
 	if registryConfig.TlsMode != "off" {
 		appLogger.Info("🔒 TLS configuration: mode=%s, backend=%s", registryConfig.TlsMode, registryConfig.TrustBackend)
 		if registryConfig.AdminPort > 0 {
-			appLogger.Info("🔒 Admin API port: %d", registryConfig.AdminPort)
+			appLogger.Info("🔒 Admin API port: %d (TLS: %t)", registryConfig.AdminPort, registryConfig.AdminTLS)
 		}
 	}
 
@@ -141,7 +151,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Setup graceful shutdown
+	// Setup graceful shutdown.
+	//
+	// shutdownDone is what makes the drain observable to the main
+	// goroutine: Server.Stop now closes the HTTP listeners and waits for
+	// in-flight requests, and Run returns as soon as they are closed. The
+	// old os.Exit(0) in here raced that wait — the process could exit
+	// while requests were still draining. Main blocks on shutdownDone
+	// instead, so the deferred db.Close also runs (issue #1583).
+	shutdownDone := make(chan struct{})
 	go func() {
 		sigChan := make(chan os.Signal, 1)
 		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
@@ -154,8 +172,7 @@ func main() {
 			appLogger.Error("Error during server shutdown: %v", err)
 		}
 
-		appLogger.Info("✅ Registry service stopped")
-		os.Exit(0)
+		close(shutdownDone)
 	}()
 
 	// Start server
@@ -165,6 +182,23 @@ func main() {
 		appLogger.Error("❌ Failed to start server: %v", err)
 		os.Exit(1)
 	}
+
+	// Run returned without error, which only happens once the listeners
+	// have been shut down. Wait for the rest of Stop (background-goroutine
+	// drain, tracing flush) before returning — but bounded. Stop's own
+	// phases are capped, yet its tail is not: tracingManager.Stop() waits
+	// on the trace-trim WaitGroup and the Redis consumer with no deadline,
+	// so a wedged Redis would otherwise leave a process that has already
+	// consumed its SIGTERM and needs a SIGKILL to die. The bound sits
+	// above Stop's bounded phases (HTTP drain + goroutine drain) so it
+	// never cuts a drain that is still making progress.
+	select {
+	case <-shutdownDone:
+		appLogger.Info("✅ Registry service stopped")
+	case <-time.After(shutdownWaitTimeout):
+		appLogger.Warning("Shutdown did not finish within %s; exiting anyway", shutdownWaitTimeout)
+		os.Exit(0)
+	}
 }
 
 func getEnvDefault(key, defaultValue string) string {
@@ -172,6 +206,23 @@ func getEnvDefault(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+// getEnvBoolDefault parses a boolean env var, accepting the same spellings
+// the rest of the mesh does (true/1/yes). Anything else is the default.
+func getEnvBoolDefault(key string, defaultValue bool) bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	switch value {
+	case "":
+		return defaultValue
+	case "true", "1", "yes":
+		return true
+	case "false", "0", "no":
+		return false
+	default:
+		log.Printf("[registry] invalid %s=%q, using default %t", key, value, defaultValue)
+		return defaultValue
+	}
 }
 
 func getEnvIntDefault(key string, defaultValue int) int {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -144,14 +144,16 @@ meshctl entity rotate "partner-corp"     # Specific entity only
 
 Agents with revoked certificates are automatically evicted in strict TLS mode.
 
-### Admin Port Isolation
+### Admin Port
 
-Separate admin APIs from the agent-facing port for defense in depth:
+Serve the admin APIs on their own port so they can be restricted separately at the network layer:
 
 ```bash
 # Registry listens on 8000 (agents) and 8001 (admin only)
 MCP_MESH_ADMIN_PORT=8001 mcp-mesh-registry
 ```
+
+By default the admin listener is plain `http://` and applies no client-certificate check, whatever `MCP_MESH_TLS_MODE` is set to, so front it with a NetworkPolicy or equivalent — a separate port is not a security boundary on its own. Set `MCP_MESH_ADMIN_TLS=true` to give it the registry's certificate and client-certificate policy; run `meshctl man security` first, since that switches the port to `https://` and `meshctl` cannot present a client certificate.
 
 [:material-arrow-right: CLI Reference](cli/index.md){ .md-button } — Run `meshctl man cli` for the full command reference.
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -205,6 +205,21 @@ export DATABASE_URL=mcp_mesh_registry.db
 
 # Registry service name
 export REGISTRY_NAME=mcp-mesh-registry
+
+# Maximum accepted request body in bytes, on the main and admin
+# listeners. A declared Content-Length over the limit is refused with 413
+# before the body is read. An undeclared (chunked) body is cut off at the
+# limit: JSON endpoints answer 413, while /proxy/* — which streams the
+# body onward — answers 502 after a truncated request has already reached
+# the target agent. Default: 10485760 (10MB), roughly ten times the
+# largest realistic heartbeat (~1MB for a 100-tool agent carrying input
+# and output schemas plus their canonical forms). 0 disables it.
+export MCP_MESH_MAX_REQUEST_BODY_BYTES=10485760
+
+# Opt the admin listener into the main listener's TLS certificate and
+# MCP_MESH_TLS_MODE client-certificate policy. Default false (plaintext,
+# unauthenticated). Enabling it changes the admin port to https.
+export MCP_MESH_ADMIN_TLS=false
 ```
 
 ### TLS and Security
@@ -224,7 +239,8 @@ export MCP_MESH_TRUST_BACKEND=filestore
 # Trust store directory (for filestore backend)
 export MCP_MESH_TRUST_DIR=/path/to/trust/dir
 
-# Admin port isolation (admin endpoints only on this port)
+# Serve /admin/* only on this port (same TLS + client-cert policy as the
+# main port; restrict it at the network layer)
 export MCP_MESH_ADMIN_PORT=8001
 
 # Kubernetes secrets backend

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -239,8 +239,10 @@ export MCP_MESH_TRUST_BACKEND=filestore
 # Trust store directory (for filestore backend)
 export MCP_MESH_TRUST_DIR=/path/to/trust/dir
 
-# Serve /admin/* only on this port (same TLS + client-cert policy as the
-# main port; restrict it at the network layer)
+# Serve /admin/* only on this port. Plaintext and unauthenticated by
+# default, whatever MCP_MESH_TLS_MODE is set to — restrict it at the
+# network layer. See MCP_MESH_ADMIN_TLS to opt it into the main port's
+# TLS certificate and client-certificate policy.
 export MCP_MESH_ADMIN_PORT=8001
 
 # Kubernetes secrets backend

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -499,7 +499,7 @@ export MCP_MESH_K8S_LABEL_SELECTOR="mcp-mesh.io/trust=entity-ca"
 # SPIRE backend
 export MCP_MESH_SPIRE_SOCKET=/run/spire/agent/sockets/agent.sock
 
-# Admin port isolation
+# Admin API on its own port (restrict it at the network layer)
 export MCP_MESH_ADMIN_PORT=9443
 ```
 
@@ -599,6 +599,25 @@ export MCP_MESH_SWEEP_INTERVAL=5m
 # renewed by progress deltas / recvEvent polls — tuning this variable does
 # NOT change how quickly a quiet handler's lease expires.
 export MCP_MESH_JOB_STALE_TIMEOUT=2h
+
+# Maximum request body the registry will accept, in bytes, on both the
+# main and admin listeners. A request whose Content-Length exceeds it is
+# refused with 413 before any of the body is read. A request that does
+# not declare a length is cut off at the limit instead: JSON endpoints
+# answer 413, but /proxy/* streams the body onward as it arrives, so
+# there the caller gets 502 and the target agent has already received a
+# truncated request. Default: 10485760 (10MB) — about ten times the
+# largest realistic heartbeat (a 100-tool agent carrying input and
+# output schemas plus their canonical forms measures ~1MB). Set to 0 to
+# disable the limit.
+export MCP_MESH_MAX_REQUEST_BODY_BYTES=10485760
+
+# Opt the admin listener (MCP_MESH_ADMIN_PORT) into the main listener's
+# TLS certificate and MCP_MESH_TLS_MODE client-certificate policy.
+# Default false: the admin port is plaintext and unauthenticated.
+# Setting this changes the admin port's scheme to https — see
+# `meshctl man security` before enabling it.
+export MCP_MESH_ADMIN_TLS=false
 
 # CORS
 export ENABLE_CORS=true

--- a/src/core/cli/man/content/security.md
+++ b/src/core/cli/man/content/security.md
@@ -192,16 +192,29 @@ If a configured backend fails to initialize at startup, the registry refuses to 
 | `MCP_MESH_TRUST_BACKEND`      | Trust backend(s), comma-separated           | (none; `localca` with `--tls-auto`) |
 | `MCP_MESH_TRUST_DIR`          | Directory for filestore/localca backends    | `~/.mcp-mesh/tls` (local), `/etc/mcp-mesh/trust` (Helm) |
 | `MCP_MESH_ADMIN_PORT`         | Separate admin API port                     | (disabled)       |
+| `MCP_MESH_ADMIN_TLS`          | Admin port inherits main-port TLS + trust   | `false`          |
 | `MCP_MESH_K8S_NAMESPACE`      | Namespace for k8s-secrets backend           | release namespace|
 | `MCP_MESH_K8S_LABEL_SELECTOR` | Label selector for k8s-secrets backend      | `mcp-mesh.io/trust=entity-ca` |
 
-## Admin Port Isolation
+## Admin Port
 
 ```bash
 MCP_MESH_ADMIN_PORT=9443 meshctl start --registry-only --tls-auto -d
 ```
 
-Admin endpoints (`/admin/rotate`, `/admin/entities`) are served only on the admin port when set.
+When set, `/admin/*` (`/admin/rotate`, `/admin/entities`, `/admin/drain`) is served only on this port and the main port returns 404.
+
+By default the admin listener is plain `http://` and applies no client-certificate check, whatever `MCP_MESH_TLS_MODE` is set to. Anyone who can reach the port can call it, and `/admin/rotate` signals every matching healthy agent to rotate its credentials. Restrict the port at the network layer with a NetworkPolicy or equivalent: a separate port is not a security boundary on its own.
+
+### Hardening the admin port
+
+```bash
+MCP_MESH_ADMIN_TLS=true
+```
+
+The admin listener then uses the registry's certificate and the same `MCP_MESH_TLS_MODE` client-certificate policy as the main port: certless callers pass in `auto` and are rejected with 403 in `strict`.
+
+Two things to know before enabling it. The admin port's scheme becomes `https://`, so every existing caller has to be updated — the `http://` admin URLs in `meshctl man registry` and `meshctl man upgrading` assume the default. And `meshctl` cannot present a client certificate, so with `strict` the admin API is reachable only from a cert-capable client such as `curl --cert`; `meshctl registry drain|resume|status` and `meshctl entity rotate` will return 403. Leave it off if `meshctl` is your drain path before upgrades.
 
 ## Docker Compose TLS
 
@@ -349,7 +362,7 @@ meshctl start my_agent.py --tls-auto
 - [ ] `MCP_MESH_TLS_MODE=strict` on registry and all agents
 - [ ] Credential provider configured (file, vault, or spire) — not `--tls-auto`
 - [ ] CA certs distributed to all agents (volume, secret, or SPIRE)
-- [ ] `MCP_MESH_ADMIN_PORT` set on registry (isolates admin API)
+- [ ] `MCP_MESH_ADMIN_PORT` set on registry, and the port restricted by NetworkPolicy (see `MCP_MESH_ADMIN_TLS`)
 - [ ] Certificate rotation tested (`meshctl entity rotate`)
 - [ ] Vault TTL or SPIRE SVID TTL configured for auto-renewal
 - [ ] `--tls-auto` NOT used in production (generates self-signed certs)

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -482,6 +482,36 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // dependency-injection pages did not get it; neither has a Loop topology section
 // to put it in, and the variant golden in `variant_corpus_test.go` is unmoved.
 //
+// Issue #1583 moved this to 1809 (+13) and the list constant to 523
+// (+1). The security page's "Admin Port Isolation" section was two code
+// spans of prose asserting that /admin/* "are served only on the admin
+// port when set" — true, and the whole of what the page said about a
+// listener that is plaintext and applies no client-certificate check.
+// The replacement is 20 spans: what the port serves, that it is
+// `http://` and unauthenticated by DEFAULT and must be
+// network-restricted, and a "Hardening the admin port" subsection for
+// the new `MCP_MESH_ADMIN_TLS` opt-in. Twelve of the thirteen are prose;
+// the thirteenth is the production-checklist line, which is why the list
+// constant moved by exactly one and the markup-list-line constant did
+// not move at all (the line already carried markup).
+//
+// The two caveats in that subsection are the reason it is long, and they
+// are load-bearing rather than padding: enabling the opt-in changes the
+// admin port's scheme to `https://` (the subsection names the two man
+// pages whose `http://` admin URLs assume the default), and `meshctl`
+// cannot present a client certificate (its only TLS flag is --insecure),
+// so `strict` plus the opt-in leaves `meshctl registry drain` — the
+// documented pre-upgrade step — answering 403. A reader who enables the
+// flag without both sentences has broken their drain path.
+//
+// The word "isolation" is gone from the heading on purpose: it was the
+// framing that made a second listener sound like a control.
+//
+// `security.md` has no `_java` or `_typescript` variant (no
+// HasJavaVariant/HasTypeScriptVariant in content.go), so the variant
+// golden did not move — the same edit on a page that had variants would
+// have moved both files.
+//
 // Issue #1500: the sentence most annotations above end on — that the `_java`
 // and `_typescript` files are invisible here, so a review of them cannot lean
 // on this test — is still true of THESE constants and no longer true of this
@@ -495,8 +525,8 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // the starter's POM; a test in this package cannot, and #1499 shipped three
 // false claims through a green run here.
 const (
-	wantInlineCodeSpans = 1790
-	wantListCodeSpans   = 522
+	wantInlineCodeSpans = 1809
+	wantListCodeSpans   = 523
 	wantMarkupListLines = 448
 )
 

--- a/src/core/registry/ent_handlers.go
+++ b/src/core/registry/ent_handlers.go
@@ -199,10 +199,7 @@ func (h *EntBusinessLogicHandlers) GetRoot(c *gin.Context) {
 func (h *EntBusinessLogicHandlers) SendHeartbeat(c *gin.Context) {
 	var req generated.MeshAgentRegistration
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, generated.ErrorResponse{
-			Error:     fmt.Sprintf("Invalid JSON payload: %v", err),
-			Timestamp: time.Now().UTC(),
-		})
+		writeBindError(c, err)
 		return
 	}
 
@@ -1192,14 +1189,18 @@ func getProxyTLSTransport(caPath, certPath, keyPath string) (*http.Transport, er
 // host (e.g., K8s service DNS) — used by the proxy to dial the real endpoint
 // rather than the user-supplied hostPort when matching via Id/Name fallback.
 func (h *EntBusinessLogicHandlers) isRegisteredAgentEndpoint(ctx context.Context, hostPort string) (bool, string, string, error) {
-	// Parse host and port
-	parts := strings.Split(hostPort, ":")
-	if len(parts) != 2 {
+	// Parse host and port. net.SplitHostPort rather than a split on ":"
+	// so an IPv6 literal target ("[::1]:8080", or a K8s pod IP in an
+	// IPv6 cluster) parses at all — the old split saw three-plus fields
+	// and rejected every IPv6 host as malformed. It also unwraps the
+	// brackets, so the host compared against the registered http_host
+	// below is the bare address the agent registered.
+	host, portStr, err := net.SplitHostPort(hostPort)
+	if err != nil || host == "" {
 		return false, "", "", nil // Invalid format
 	}
 
-	host := parts[0]
-	portInt, err := strconv.Atoi(parts[1])
+	portInt, err := strconv.Atoi(portStr)
 	if err != nil || portInt <= 0 {
 		return false, "", "", nil // Invalid port
 	}
@@ -1236,7 +1237,7 @@ func (h *EntBusinessLogicHandlers) isRegisteredAgentEndpoint(ctx context.Context
 	}
 	for _, a := range candidates {
 		if a.HTTPHost == host {
-			return true, schemeFor(a), fmt.Sprintf("%s:%d", a.HTTPHost, a.HTTPPort), nil
+			return true, schemeFor(a), net.JoinHostPort(a.HTTPHost, strconv.Itoa(a.HTTPPort)), nil
 		}
 	}
 
@@ -1252,7 +1253,7 @@ func (h *EntBusinessLogicHandlers) isRegisteredAgentEndpoint(ctx context.Context
 	// directly.
 	for _, a := range candidates {
 		if a.ID == host || a.Name == host {
-			return true, schemeFor(a), fmt.Sprintf("%s:%d", a.HTTPHost, a.HTTPPort), nil
+			return true, schemeFor(a), net.JoinHostPort(a.HTTPHost, strconv.Itoa(a.HTTPPort)), nil
 		}
 	}
 

--- a/src/core/registry/ent_handlers_jobs.go
+++ b/src/core/registry/ent_handlers_jobs.go
@@ -106,10 +106,7 @@ func parseCancelEventGraceFromEnv() time.Duration {
 func (h *EntBusinessLogicHandlers) CreateJob(c *gin.Context) {
 	var req generated.CreateJobRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, generated.ErrorResponse{
-			Error:     fmt.Sprintf("Invalid JSON payload: %v", err),
-			Timestamp: time.Now().UTC(),
-		})
+		writeBindError(c, err)
 		return
 	}
 
@@ -319,10 +316,7 @@ func (h *EntBusinessLogicHandlers) GetJob(c *gin.Context, jobId string) {
 func (h *EntBusinessLogicHandlers) SubmitJobBatch(c *gin.Context) {
 	var req generated.JobBatchRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, generated.ErrorResponse{
-			Error:     fmt.Sprintf("Invalid JSON payload: %v", err),
-			Timestamp: time.Now().UTC(),
-		})
+		writeBindError(c, err)
 		return
 	}
 	if req.InstanceId == "" {
@@ -412,10 +406,7 @@ func (h *EntBusinessLogicHandlers) SubmitJobBatch(c *gin.Context) {
 func (h *EntBusinessLogicHandlers) ClaimJobs(c *gin.Context) {
 	var req generated.ClaimJobsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, generated.ErrorResponse{
-			Error:     fmt.Sprintf("Invalid JSON payload: %v", err),
-			Timestamp: time.Now().UTC(),
-		})
+		writeBindError(c, err)
 		return
 	}
 	if req.Capability == "" {
@@ -499,10 +490,7 @@ func (h *EntBusinessLogicHandlers) ReleaseJob(c *gin.Context, jobId string) {
 
 	var req generated.ReleaseJobRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, generated.ErrorResponse{
-			Error:     fmt.Sprintf("Invalid JSON payload: %v", err),
-			Timestamp: time.Now().UTC(),
-		})
+		writeBindError(c, err)
 		return
 	}
 	if strings.TrimSpace(req.InstanceId) == "" {
@@ -580,10 +568,7 @@ func (h *EntBusinessLogicHandlers) CancelJob(c *gin.Context, jobId string) {
 	var req generated.CancelJobRequest
 	if c.Request.ContentLength > 0 {
 		if err := c.ShouldBindJSON(&req); err != nil {
-			c.JSON(http.StatusBadRequest, generated.ErrorResponse{
-				Error:     fmt.Sprintf("Invalid JSON payload: %v", err),
-				Timestamp: time.Now().UTC(),
-			})
+			writeBindError(c, err)
 			return
 		}
 	}
@@ -1028,10 +1013,7 @@ func (h *EntBusinessLogicHandlers) PostJobEvent(c *gin.Context, jobId string) {
 
 	var req generated.JobEventPostRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, generated.ErrorResponse{
-			Error:     fmt.Sprintf("Invalid JSON payload: %v", err),
-			Timestamp: time.Now().UTC(),
-		})
+		writeBindError(c, err)
 		return
 	}
 	normalizedType := strings.TrimSpace(req.Type)

--- a/src/core/registry/ent_service.go
+++ b/src/core/registry/ent_service.go
@@ -65,6 +65,13 @@ type RegistryConfig struct {
 	TlsKeyFile               string // registry server key — from MCP_MESH_TLS_KEY
 	TrustDir                 string // directory for FileStore backend — from MCP_MESH_TRUST_DIR
 	AdminPort                int    // admin API port — from MCP_MESH_ADMIN_PORT (0 = disabled)
+	// AdminTLS opts the admin listener into the main listener's transport
+	// and trust policy — from MCP_MESH_ADMIN_TLS. Default false, which is
+	// the historical behaviour: the admin port is plaintext and carries no
+	// client-certificate check regardless of MCP_MESH_TLS_MODE. Opting in
+	// changes the admin port's scheme to https and, in strict mode,
+	// requires callers to present a trusted client certificate.
+	AdminTLS bool
 }
 
 // AgentRegistrationRequest matches Python RegisterAgentRequest exactly

--- a/src/core/registry/http_limits.go
+++ b/src/core/registry/http_limits.go
@@ -1,0 +1,190 @@
+package registry
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"mcp-mesh/src/core/registry/generated"
+)
+
+// Connection limits applied to every HTTP listener the registry starts —
+// the TLS listener, the plaintext listener and the admin listener (issue
+// #1583). Before this, all three were built by ``gin.Engine.Run`` /
+// ``http.Server{}`` with zero-valued timeouts, so a client that opened a
+// socket and dribbled headers held a goroutine and a file descriptor for
+// as long as it liked.
+//
+// The two deadlines that are NOT set here are deliberate. ``ReadTimeout``
+// and ``WriteTimeout`` are absolute deadlines measured from the moment
+// the connection is accepted / the header is read, and the registry
+// serves two request shapes that legitimately outlive any value we could
+// pick:
+//
+//   - ``GET /jobs/{id}/events?wait=`` long-polls for up to 60s
+//     (``listJobEventsMaxWait``), and consumers re-poll continuously.
+//   - ``POST|GET /proxy/*`` relays SSE responses from agents
+//     (``isEventStream`` / the flushing copy loop in ent_handlers.go),
+//     which stay open for the life of the stream — unbounded by design.
+//
+// A ``WriteTimeout`` would sever both mid-stream, and a ``ReadTimeout``
+// would cap slow-but-legitimate uploads over a lossy link. The phases
+// with no legitimate long case — receiving the request header, and
+// sitting idle between keep-alive requests — are bounded instead, which
+// is what actually stops slowloris-style connection parking.
+const (
+	// defaultReadHeaderTimeout bounds the header phase only. Every mesh
+	// client sends its headers in one flight, so even a badly congested
+	// link is orders of magnitude inside 10s; anything slower is not a
+	// client we want holding a goroutine.
+	defaultReadHeaderTimeout = 10 * time.Second
+
+	// defaultIdleTimeout bounds a keep-alive connection between
+	// requests. It has to sit above the heartbeat interval
+	// (``HEALTH_CHECK_INTERVAL``, 10s by default, and agents heartbeat
+	// on a similar cadence) or every agent would pay a fresh TCP+TLS
+	// handshake per heartbeat; 120s leaves ~10x headroom for a slow
+	// heartbeat cadence while still reaping sockets from agents that
+	// vanished without a FIN.
+	defaultIdleTimeout = 120 * time.Second
+
+	// defaultMaxHeaderBytes caps the request header. Go's default is
+	// 1MB, which is far past anything the mesh sends: the largest real
+	// header set is a bearer token plus the propagated trace/mesh
+	// headers (``MCP_MESH_PROPAGATE_HEADERS``), a few KB at the top
+	// end. 64KB is still 8x nginx's total header budget
+	// (large_client_header_buffers 4 8k) so no realistic client trips
+	// it, while bounding per-connection memory 16x tighter than Go's
+	// default.
+	defaultMaxHeaderBytes = 64 << 10
+)
+
+// defaultMaxRequestBodyBytes caps a single request body.
+//
+// The largest legitimate payload is a heartbeat: a full
+// ``MeshAgentRegistration`` carrying, per tool, a description, version,
+// tags, dependencies, kwargs, schema warnings and FOUR schema blobs —
+// ``inputSchema`` and ``inputSchemaCanonical``, ``outputSchema`` and
+// ``outputSchemaCanonical`` (see MeshToolRegistration in generated/).
+// Marshalling that full shape for a tool with a 20-parameter input and a
+// 10-parameter output schema measures ~9.8KB per tool: 100 tools ≈ 1MB,
+// 1000 tools ≈ 9.8MB.
+//
+// 10MB therefore admits roughly a thousand fully-schema'd tools on one
+// agent — an order of magnitude past any real agent — while capping what
+// a single POST can make the registry buffer. Raise it with
+// ``MCP_MESH_MAX_REQUEST_BODY_BYTES``; set that to 0 to disable the cap.
+const defaultMaxRequestBodyBytes int64 = 10 << 20
+
+// maxRequestBodyBytesFromEnv reads the ``MCP_MESH_MAX_REQUEST_BODY_BYTES``
+// override. A value of 0 disables the cap; a malformed or negative value
+// falls back to the default rather than leaving the registry uncapped by
+// accident.
+func maxRequestBodyBytesFromEnv() int64 {
+	raw := os.Getenv("MCP_MESH_MAX_REQUEST_BODY_BYTES")
+	if raw == "" {
+		return defaultMaxRequestBodyBytes
+	}
+	n, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || n < 0 {
+		log.Printf("[registry] invalid MCP_MESH_MAX_REQUEST_BODY_BYTES=%q, using default %d bytes", raw, defaultMaxRequestBodyBytes)
+		return defaultMaxRequestBodyBytes
+	}
+	if n == 0 {
+		log.Printf("[registry] MCP_MESH_MAX_REQUEST_BODY_BYTES=0: request body size limit disabled")
+	}
+	return n
+}
+
+// MaxRequestBodyMiddleware caps request bodies at limit bytes.
+//
+// Two layers, because clients can lie about or omit Content-Length:
+// an advertised length over the limit is rejected before a single byte
+// is read, and the body itself is wrapped in ``http.MaxBytesReader`` so
+// a chunked or under-declared upload fails at the limit instead of
+// buffering forever.
+//
+// The status the caller sees depends on which layer trips and on the
+// handler:
+//
+//   - Declared Content-Length over the limit: 413, always, before the
+//     handler runs and before anything is forwarded anywhere.
+//   - Undeclared/chunked body over the limit on a JSON handler: the
+//     decoder returns ``*http.MaxBytesError`` and writeBindError turns
+//     it into 413.
+//   - Undeclared/chunked body over the limit on ``/proxy/*``: the body
+//     is streamed straight into the outbound request
+//     (ent_handlers.go, proxyRequest), so the reader trips inside
+//     ``client.Do`` and the caller gets 502, not 413 — and the first
+//     ``limit`` bytes have already reached the downstream agent, which
+//     sees a truncated MCP request. Declared-length proxy requests (what
+//     every SDK and curl sends) are caught by the pre-check above and
+//     never reach the agent at all.
+//
+// A limit <= 0 disables the middleware entirely.
+func MaxRequestBodyMiddleware(limit int64) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if limit <= 0 {
+			c.Next()
+			return
+		}
+		if c.Request.ContentLength > limit {
+			writeBodyTooLarge(c, limit)
+			c.Abort()
+			return
+		}
+		if c.Request.Body != nil {
+			c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, limit)
+		}
+		c.Next()
+	}
+}
+
+// writeBodyTooLarge writes the 413 used by both the Content-Length
+// pre-check and the streamed-overflow path, so an operator sees the same
+// message and the same knob either way.
+func writeBodyTooLarge(c *gin.Context, limit int64) {
+	c.JSON(http.StatusRequestEntityTooLarge, generated.ErrorResponse{
+		Error:     fmt.Sprintf("Request body exceeds the %d byte limit (raise MCP_MESH_MAX_REQUEST_BODY_BYTES)", limit),
+		Timestamp: time.Now().UTC(),
+	})
+}
+
+// writeBindError writes the error response for a failed
+// ``ShouldBindJSON``. A body that overran MaxRequestBodyMiddleware
+// surfaces as ``*http.MaxBytesError`` from the decoder, and gets a 413;
+// everything else keeps the historical 400 with the byte-identical
+// "Invalid JSON payload" message clients already parse.
+func writeBindError(c *gin.Context, err error) {
+	var tooLarge *http.MaxBytesError
+	if errors.As(err, &tooLarge) {
+		writeBodyTooLarge(c, tooLarge.Limit)
+		return
+	}
+	c.JSON(http.StatusBadRequest, generated.ErrorResponse{
+		Error:     fmt.Sprintf("Invalid JSON payload: %v", err),
+		Timestamp: time.Now().UTC(),
+	})
+}
+
+// newHardenedServer builds an http.Server carrying the connection limits
+// above. Every listener the registry starts goes through here so a new
+// one cannot silently inherit gin's zero-valued timeouts.
+//
+// handler must be ``engine.Handler()`` rather than the engine itself:
+// that is what ``gin.Engine.Run`` passes to ``http.ListenAndServe``, and
+// it is where the h2c wrapper is applied when ``UseH2C`` is set.
+func newHardenedServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: defaultReadHeaderTimeout,
+		IdleTimeout:       defaultIdleTimeout,
+		MaxHeaderBytes:    defaultMaxHeaderBytes,
+	}
+}

--- a/src/core/registry/http_limits_test.go
+++ b/src/core/registry/http_limits_test.go
@@ -1,0 +1,305 @@
+package registry
+
+// Coverage for the listener hardening in issue #1583: the connection
+// limits every registry listener now carries, and the request-body cap
+// that fronts every JSON handler.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestNewHardenedServer_SetsConnectionLimits(t *testing.T) {
+	srv := newHardenedServer(":8000", gin.New())
+
+	if srv.ReadHeaderTimeout != defaultReadHeaderTimeout {
+		t.Errorf("ReadHeaderTimeout = %v, want %v", srv.ReadHeaderTimeout, defaultReadHeaderTimeout)
+	}
+	if srv.IdleTimeout != defaultIdleTimeout {
+		t.Errorf("IdleTimeout = %v, want %v", srv.IdleTimeout, defaultIdleTimeout)
+	}
+	if srv.MaxHeaderBytes != defaultMaxHeaderBytes {
+		t.Errorf("MaxHeaderBytes = %d, want %d", srv.MaxHeaderBytes, defaultMaxHeaderBytes)
+	}
+
+	// ReadTimeout and WriteTimeout are deliberately unset: both would cut
+	// the 60s job-event long-poll and the unbounded SSE relay through
+	// /proxy/*. If someone sets them, that is the regression to catch.
+	if srv.ReadTimeout != 0 {
+		t.Errorf("ReadTimeout = %v, want 0 (would cap slow uploads and long-polls)", srv.ReadTimeout)
+	}
+	if srv.WriteTimeout != 0 {
+		t.Errorf("WriteTimeout = %v, want 0 (would sever proxied SSE streams)", srv.WriteTimeout)
+	}
+}
+
+func TestMaxRequestBodyBytesFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		set  bool
+		val  string
+		want int64
+	}{
+		{name: "unset uses default", want: defaultMaxRequestBodyBytes},
+		{name: "override", set: true, val: "1048576", want: 1048576},
+		{name: "zero disables", set: true, val: "0", want: 0},
+		{name: "negative falls back", set: true, val: "-1", want: defaultMaxRequestBodyBytes},
+		{name: "garbage falls back", set: true, val: "10MB", want: defaultMaxRequestBodyBytes},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("MCP_MESH_MAX_REQUEST_BODY_BYTES", tc.val)
+			} else {
+				t.Setenv("MCP_MESH_MAX_REQUEST_BODY_BYTES", "")
+			}
+			if got := maxRequestBodyBytesFromEnv(); got != tc.want {
+				t.Errorf("maxRequestBodyBytesFromEnv() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// bindEngine mirrors the real handler shape: the body cap middleware in
+// front of a handler that binds JSON and reports errors through
+// writeBindError.
+func bindEngine(limit int64) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	e := gin.New()
+	e.Use(MaxRequestBodyMiddleware(limit))
+	e.POST("/bind", func(c *gin.Context) {
+		var body map[string]interface{}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			writeBindError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"fields": len(body)})
+	})
+	return e
+}
+
+// oversizedJSON returns a syntactically valid JSON object of at least n bytes.
+func oversizedJSON(n int) string {
+	var b strings.Builder
+	b.WriteString(`{"pad":"`)
+	b.WriteString(strings.Repeat("x", n))
+	b.WriteString(`"}`)
+	return b.String()
+}
+
+// unknownLengthBody hides its size from the http client so the request
+// goes out chunked with ContentLength -1, bypassing the Content-Length
+// pre-check and exercising the MaxBytesReader layer.
+type unknownLengthBody struct{ r io.Reader }
+
+func (u unknownLengthBody) Read(p []byte) (int, error) { return u.r.Read(p) }
+func (u unknownLengthBody) Close() error               { return nil }
+
+func TestMaxRequestBodyMiddleware_DeclaredLengthOverLimitIs413(t *testing.T) {
+	srv := httptest.NewServer(bindEngine(1024))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/bind", "application/json", strings.NewReader(oversizedJSON(4096)))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 413; body=%s", resp.StatusCode, body)
+	}
+
+	// The rejection must be a well-formed error document, not a bare
+	// status or a panic-recovery 500.
+	var parsed map[string]interface{}
+	body, _ := io.ReadAll(resp.Body)
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("413 body is not JSON (%v): %s", err, body)
+	}
+	if msg, _ := parsed["error"].(string); !strings.Contains(msg, "MCP_MESH_MAX_REQUEST_BODY_BYTES") {
+		t.Errorf("413 body does not name the knob to raise: %s", body)
+	}
+}
+
+func TestMaxRequestBodyMiddleware_UndeclaredLengthOverLimitIs413(t *testing.T) {
+	srv := httptest.NewServer(bindEngine(1024))
+	defer srv.Close()
+
+	req, err := http.NewRequest("POST", srv.URL+"/bind", unknownLengthBody{strings.NewReader(oversizedJSON(4096))})
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if req.ContentLength != 0 {
+		t.Fatalf("test setup: expected an unknown-length body, got ContentLength=%d", req.ContentLength)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 413; body=%s", resp.StatusCode, body)
+	}
+}
+
+func TestMaxRequestBodyMiddleware_UnderLimitPasses(t *testing.T) {
+	srv := httptest.NewServer(bindEngine(1 << 20))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/bind", "application/json", strings.NewReader(`{"a":1,"b":2}`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+}
+
+func TestMaxRequestBodyMiddleware_MalformedJSONStillIs400(t *testing.T) {
+	srv := httptest.NewServer(bindEngine(1 << 20))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/bind", "application/json", strings.NewReader(`{"a":`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Invalid JSON payload") {
+		t.Errorf("400 message changed shape: %s", body)
+	}
+}
+
+func TestMaxRequestBodyMiddleware_ZeroLimitDisablesTheCap(t *testing.T) {
+	srv := httptest.NewServer(bindEngine(0))
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/bind", "application/json", strings.NewReader(oversizedJSON(2<<20)))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 with the cap disabled", resp.StatusCode)
+	}
+}
+
+// TestHeartbeat_OversizedBodyIs413 exercises the real registration
+// handler behind the real middleware: an over-limit heartbeat must be
+// refused as 413 rather than being buffered and answered 400/500.
+func TestHeartbeat_OversizedBodyIs413(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	service := setupTestService(t)
+	handlers := &EntBusinessLogicHandlers{entService: service}
+
+	engine := gin.New()
+	engine.Use(MaxRequestBodyMiddleware(64 << 10))
+	engine.POST("/heartbeat", handlers.SendHeartbeat)
+
+	srv := httptest.NewServer(engine)
+	defer srv.Close()
+
+	// A registration payload whose tool description alone blows the cap.
+	payload := fmt.Sprintf(`{"agent_id":"big-agent","tools":[{"capability":"c","function_name":"f","description":"%s"}]}`,
+		strings.Repeat("d", 128<<10))
+
+	resp, err := http.Post(srv.URL+"/heartbeat", "application/json", strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 413; body=%s", resp.StatusCode, body)
+	}
+}
+
+// TestHeartbeat_LargeButLegalBodyIsAccepted pins the other side of the
+// limit: the default cap must not reject a heartbeat from a genuinely
+// large agent. ~100 tools of realistic size is well under 10MB.
+func TestHeartbeat_LargeButLegalBodyIsAccepted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	service := setupTestService(t)
+	handlers := &EntBusinessLogicHandlers{entService: service}
+
+	engine := gin.New()
+	engine.Use(MaxRequestBodyMiddleware(defaultMaxRequestBodyBytes))
+	engine.POST("/heartbeat", handlers.SendHeartbeat)
+
+	srv := httptest.NewServer(engine)
+	defer srv.Close()
+
+	tools := make([]string, 0, 100)
+	for i := 0; i < 100; i++ {
+		tools = append(tools, fmt.Sprintf(
+			`{"capability":"cap_%d","function_name":"fn_%d","description":"%s","inputSchema":{"type":"object","properties":{"a":{"type":"string","description":"%s"}}}}`,
+			i, i, strings.Repeat("d", 200), strings.Repeat("p", 200)))
+	}
+	payload := fmt.Sprintf(`{"agent_id":"large-agent","http_host":"localhost","http_port":9100,"tools":[%s]}`,
+		strings.Join(tools, ","))
+	if len(payload) < 50_000 {
+		t.Fatalf("test setup: payload only %d bytes, not exercising size", len(payload))
+	}
+
+	resp, err := http.Post(srv.URL+"/heartbeat", "application/json", strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusRequestEntityTooLarge {
+		t.Fatalf("a %d byte heartbeat was rejected by the %d byte default cap",
+			len(payload), defaultMaxRequestBodyBytes)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+}
+
+// TestMaxRequestBodyMiddleware_DoesNotDelayStreamingReads guards the
+// intent behind leaving ReadTimeout unset: a handler that holds the
+// request open (long-poll shape) is not affected by the body cap.
+func TestMaxRequestBodyMiddleware_DoesNotDelayStreamingReads(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	e := gin.New()
+	e.Use(MaxRequestBodyMiddleware(1024))
+	e.GET("/poll", func(c *gin.Context) {
+		time.Sleep(150 * time.Millisecond)
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/poll")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}

--- a/src/core/registry/proxy_ipv6_test.go
+++ b/src/core/registry/proxy_ipv6_test.go
@@ -1,0 +1,95 @@
+package registry
+
+// Issue #1583: proxy targets were split on ":" with a hard len(parts) == 2
+// check, so an IPv6-literal target ("[::1]:8080") parsed as five fields and
+// was rejected as malformed before any lookup happened — an IPv6-only
+// cluster could never proxy to any agent.
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// newIPv6Downstream starts a downstream agent bound to the IPv6 loopback.
+// Skips the test where IPv6 loopback is unavailable.
+func newIPv6Downstream(t *testing.T) (*httptest.Server, string, int) {
+	t.Helper()
+	l, err := net.Listen("tcp", "[::1]:0")
+	if err != nil {
+		t.Skipf("IPv6 loopback unavailable: %v", err)
+	}
+	srv := &httptest.Server{
+		Listener: l,
+		Config: &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		})},
+	}
+	srv.Start()
+	return srv, "::1", l.Addr().(*net.TCPAddr).Port
+}
+
+func TestIsRegisteredAgentEndpoint_AcceptsIPv6Literal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := setupTestService(t)
+	registerProxyTargetAgent(t, s, "v6-agent", "::1", 9443)
+
+	h := &EntBusinessLogicHandlers{entService: s}
+	ok, scheme, endpointHost, err := h.isRegisteredAgentEndpoint(context.Background(), "[::1]:9443")
+	if err != nil {
+		t.Fatalf("isRegisteredAgentEndpoint: %v", err)
+	}
+	if !ok {
+		t.Fatal("IPv6-literal target was not recognised as a registered agent")
+	}
+	if scheme != "http" {
+		t.Errorf("scheme = %q, want http", scheme)
+	}
+	// The dial host has to come back bracketed or the URL the proxy builds
+	// from it ("http://::1:9443/mcp") is unparseable.
+	if endpointHost != "[::1]:9443" {
+		t.Errorf("endpointHost = %q, want %q", endpointHost, "[::1]:9443")
+	}
+}
+
+func TestIsRegisteredAgentEndpoint_RejectsMalformedTargets(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := setupTestService(t)
+	h := &EntBusinessLogicHandlers{entService: s}
+
+	for _, target := range []string{"nohost", "host:", ":8080", "host:notaport", "host:0", "[::1]"} {
+		ok, _, _, err := h.isRegisteredAgentEndpoint(context.Background(), target)
+		if err != nil {
+			t.Fatalf("isRegisteredAgentEndpoint(%q): %v", target, err)
+		}
+		if ok {
+			t.Errorf("target %q was accepted, want rejected", target)
+		}
+	}
+}
+
+// TestProxyRequest_ForwardsToIPv6Agent is the end-to-end case: a real
+// request proxied to an agent listening on the IPv6 loopback.
+func TestProxyRequest_ForwardsToIPv6Agent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := setupTestService(t)
+
+	downstream, host, port := newIPv6Downstream(t)
+	defer downstream.Close()
+
+	registerProxyTargetAgent(t, s, "v6-agent", host, port)
+	h := &EntBusinessLogicHandlers{entService: s}
+
+	target := net.JoinHostPort(host, strconv.Itoa(port)) + "/mcp/v1/tools/call"
+	w := proxyPost(t, h, target, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("proxy to IPv6 agent returned %d, body=%s", w.Code, w.Body.String())
+	}
+}

--- a/src/core/registry/server.go
+++ b/src/core/registry/server.go
@@ -575,7 +575,11 @@ func (s *Server) serverTLSConfig() (*tls.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("loading TLS certificate: %w", err)
 	}
+	// MinVersion is pinned rather than left to Go's server default (TLS
+	// 1.2), which GODEBUG=tls10server=1 can roll back at runtime, and to
+	// match how tlsutil and the CLI build their tls.Config.
 	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
 		ClientAuth:   tls.RequestClientCert,
 		Certificates: []tls.Certificate{cert},
 	}, nil

--- a/src/core/registry/server.go
+++ b/src/core/registry/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -29,6 +30,31 @@ import (
 // transport observes the cancellation, but capped tight enough that
 // shutdown can't hang indefinitely on a wedged owner agent.
 const shutdownDrainTimeout = 10 * time.Second
+
+// shutdownHTTPTimeout caps how long ``Server.Stop`` waits for in-flight
+// HTTP requests to finish before their listeners are closed out from
+// under them.
+//
+// It is deliberately short. The value cannot be sized to "let everything
+// finish": a job-event long-poll runs up to 60s
+// (``listJobEventsMaxWait``) and a proxied SSE stream is unbounded, so
+// any registry with an idle jobs consumer attached would sit out the
+// whole window on every stop. What the window IS sized for is ordinary
+// control-plane traffic — heartbeats, registrations, job deltas — which
+// completes in milliseconds, so 5s is several orders of magnitude of
+// headroom for the requests that can actually be waited out.
+//
+// On the ceilings: Kubernetes' default terminationGracePeriodSeconds is
+// 30s, and Stop's two bounded phases (5s here, then
+// ``shutdownDrainTimeout``'s 10s) fit inside it with room for the
+// tracing flush. They do NOT both fit inside ``meshctl stop``'s default
+// 10s SIGKILL escalation (stop.go --timeout) — 5+10 is 15s. That is
+// accepted rather than papered over: both phases only reach their caps
+// when something is genuinely stuck (a long-poll parked on the socket, a
+// cancel-forward wedged on an unresponsive owner), and in that case a
+// dev-loop SIGKILL is the right outcome. The common path returns in
+// milliseconds.
+const shutdownHTTPTimeout = 5 * time.Second
 
 // Server represents the registry HTTP server
 type Server struct {
@@ -56,6 +82,17 @@ type Server struct {
 	shutdownCtx    context.Context
 	shutdownCancel context.CancelFunc
 	shutdownWG     *sync.WaitGroup
+
+	// httpServers holds every listener ``Run`` started (main + admin) so
+	// ``Shutdown`` can drain all of them; ``httpStopping`` closes the
+	// race where a signal lands between ``NewServer`` and the moment a
+	// listener is registered, which would otherwise leave a listener
+	// serving after ``Stop`` returned. maxBodyBytes is resolved once at
+	// construction so the main and admin engines share one limit.
+	httpMu       sync.Mutex
+	httpServers  []*http.Server
+	httpStopping bool
+	maxBodyBytes int64
 }
 
 // NewServer creates a new registry server using Ent database.
@@ -135,6 +172,11 @@ func NewServer(entDB *database.EntDatabase, config *RegistryConfig, logger *logg
 		engine.Use(TLSVerifyMiddleware(trustChain, config.TlsMode))
 	}
 
+	// Cap request bodies (issue #1583). Installed after the trust check so
+	// an untrusted client in strict mode still sees 403 rather than 413.
+	maxBodyBytes := maxRequestBodyBytesFromEnv()
+	engine.Use(MaxRequestBodyMiddleware(maxBodyBytes))
+
 	// Create server
 	server := &Server{
 		engine:         engine,
@@ -150,6 +192,7 @@ func NewServer(entDB *database.EntDatabase, config *RegistryConfig, logger *logg
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
 		shutdownWG:     shutdownWG,
+		maxBodyBytes:   maxBodyBytes,
 	}
 
 	// Add operational endpoints first (includes wildcard proxy routes that must be registered before generated routes)
@@ -188,24 +231,70 @@ func (s *Server) Run(addr string) error {
 		}
 	}
 
+	// Validate the TLS configuration before any listener binds: the admin
+	// listener mirrors the main one's TLS settings, so a missing cert has
+	// to fail here rather than after a plaintext admin port is already
+	// accepting connections.
+	tlsRequested := s.config.TlsMode != "" && s.config.TlsMode != "off"
+	if tlsRequested && (s.config.TlsCertFile == "" || s.config.TlsKeyFile == "") {
+		return fmt.Errorf("TLS mode %q requires MCP_MESH_TLS_CERT and MCP_MESH_TLS_KEY to be set; use MCP_MESH_TLS_MODE=off to run plaintext", s.config.TlsMode)
+	}
+
 	// Start admin server if configured
 	if s.config.AdminPort > 0 {
 		s.startAdminServer(s.config.AdminPort)
 	}
 
 	// Use TLS listener when TLS mode is enabled
-	if s.config.TlsMode != "" && s.config.TlsMode != "off" {
-		if s.config.TlsCertFile == "" || s.config.TlsKeyFile == "" {
-			return fmt.Errorf("TLS mode %q requires MCP_MESH_TLS_CERT and MCP_MESH_TLS_KEY to be set; use MCP_MESH_TLS_MODE=off to run plaintext", s.config.TlsMode)
-		}
+	if tlsRequested {
 		return s.runWithTLS(addr)
 	}
-	return s.engine.Run(addr)
+	return s.runPlaintext(addr)
 }
 
 // Start starts the HTTP server (alias for compatibility)
 func (s *Server) Start() error {
-	return s.engine.Run(":8080") // Default port
+	return s.runPlaintext(":8080") // Default port
+}
+
+// runPlaintext serves the main engine over plain HTTP.
+//
+// This used to be ``s.engine.Run(addr)``, which builds an ``http.Server``
+// internally with every timeout left at its zero value and no handle on
+// it to shut down. Constructing the server here is what lets the
+// plaintext path carry the same limits as the TLS path and be drained by
+// ``Shutdown`` (issue #1583).
+func (s *Server) runPlaintext(addr string) error {
+	server := newHardenedServer(addr, s.engine.Handler())
+	if !s.registerServer(server) {
+		return nil // Stop() already ran; don't start listening.
+	}
+	return ignoreServerClosed(server.ListenAndServe())
+}
+
+// registerServer records a listener for ``Shutdown`` to drain. Returns
+// false when the server is already stopping, in which case the caller
+// must not start listening — otherwise a signal arriving between
+// ``NewServer`` and this call would leave a listener up that ``Stop``
+// has already walked past.
+func (s *Server) registerServer(srv *http.Server) bool {
+	s.httpMu.Lock()
+	defer s.httpMu.Unlock()
+	if s.httpStopping {
+		return false
+	}
+	s.httpServers = append(s.httpServers, srv)
+	return true
+}
+
+// ignoreServerClosed maps the sentinel returned by a listener that was
+// deliberately shut down onto a nil error, so ``Run`` returning after a
+// graceful ``Stop`` is not reported by main() as a startup failure.
+func ignoreServerClosed(err error) error {
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
 }
 
 // Stop stops the HTTP server and health monitor
@@ -217,6 +306,15 @@ func (s *Server) Stop() error {
 	if s.sweepJob != nil {
 		s.sweepJob.Stop()
 	}
+
+	// Stop accepting new connections and let in-flight requests finish
+	// before the handler-spawned goroutines below are cancelled: a
+	// request that is mid-flight when the process is asked to stop
+	// should complete, and cancelling its background forwards first
+	// would abort work that is still legitimately running (issue #1583).
+	httpCtx, cancelHTTP := context.WithTimeout(context.Background(), shutdownHTTPTimeout)
+	defer cancelHTTP()
+	httpShutdownErr := s.Shutdown(httpCtx)
 
 	// Cancel handler-spawned background goroutines (cancel-forward,
 	// etc.) and wait for them to drain. The cancel propagates into each
@@ -254,8 +352,61 @@ func (s *Server) Stop() error {
 		}
 	}
 
-	// TODO: Implement graceful shutdown for HTTP server
-	return nil
+	return httpShutdownErr
+}
+
+// Shutdown gracefully stops every HTTP listener the registry started
+// (main + admin), waiting for in-flight requests to finish until ctx is
+// done. Callers that want a bound should pass a context with a deadline;
+// ``Stop`` uses shutdownHTTPTimeout.
+//
+// An SSE response being relayed through ``/proxy/*`` and a job-event
+// long-poll both count as in-flight requests, so hitting the deadline
+// with one of them parked is the EXPECTED outcome, not a failure. Note
+// what ``http.Server.Shutdown`` does at the deadline: it has already
+// closed the listeners and idle connections, but it does not terminate
+// the still-active ones — it just returns ``ctx.Err()`` and leaves them
+// running until the process exits. Shutdown therefore logs that case at
+// info and does not report it as an error; only a genuine listener
+// failure is returned.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.httpMu.Lock()
+	s.httpStopping = true
+	servers := s.httpServers
+	s.httpServers = nil
+	s.httpMu.Unlock()
+
+	var firstErr error
+	for _, srv := range servers {
+		err := srv.Shutdown(ctx)
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			// Routine: something long-lived was still attached. Say so
+			// plainly instead of surfacing it to the operator as a
+			// shutdown error on every restart of a registry that has a
+			// jobs consumer long-polling it.
+			s.logShutdown("Registry shutdown: listener %s still had long-lived requests attached after the grace period (long-polls / SSE streams); exiting anyway", srv.Addr)
+			continue
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+		s.logShutdown("Registry shutdown: listener %s failed to shut down: %v", srv.Addr, err)
+	}
+	return firstErr
+}
+
+// logShutdown routes a shutdown message to the structured logger when the
+// server has one and to the stdlib logger otherwise — Shutdown runs on
+// Servers built directly in tests, which have no logger.
+func (s *Server) logShutdown(format string, args ...interface{}) {
+	if s.logger != nil {
+		s.logger.Info(format, args...)
+		return
+	}
+	log.Printf("[registry] "+format, args...)
 }
 
 // SetupGeneratedRoutes configures all routes using the generated OpenAPI interface
@@ -406,28 +557,47 @@ func (s *Server) handleProxyGetRequest(c *gin.Context) {
 	s.handlers.ProxyMcpGetRequest(c, target)
 }
 
+// tlsEnabled reports whether the registry was configured to serve TLS.
+func (s *Server) tlsEnabled() bool {
+	return s.config.TlsMode != "" && s.config.TlsMode != "off" &&
+		s.config.TlsCertFile != "" && s.config.TlsKeyFile != ""
+}
+
+// serverTLSConfig builds the TLS configuration shared by every listener
+// the registry starts.
+//
+// ClientAuth stays RequestClientCert on purpose: enforcement happens at
+// the application layer in TLSVerifyMiddleware, which needs certless
+// handshakes to succeed so "auto" mode can admit them and "strict" mode
+// can answer 403 rather than dropping the connection mid-handshake.
+func (s *Server) serverTLSConfig() (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(s.config.TlsCertFile, s.config.TlsKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("loading TLS certificate: %w", err)
+	}
+	return &tls.Config{
+		ClientAuth:   tls.RequestClientCert,
+		Certificates: []tls.Certificate{cert},
+	}, nil
+}
+
 // runWithTLS starts the server with TLS configured to request (but not require)
 // client certificates. Enforcement is handled by TLSVerifyMiddleware based on TlsMode.
 func (s *Server) runWithTLS(addr string) error {
 	s.logger.Info("🔒 Starting TLS listener (ClientAuth: RequestClientCert)")
 
-	tlsConfig := &tls.Config{
-		ClientAuth: tls.RequestClientCert,
-	}
-
-	cert, err := tls.LoadX509KeyPair(s.config.TlsCertFile, s.config.TlsKeyFile)
+	tlsConfig, err := s.serverTLSConfig()
 	if err != nil {
-		return fmt.Errorf("loading TLS certificate: %w", err)
-	}
-	tlsConfig.Certificates = []tls.Certificate{cert}
-
-	server := &http.Server{
-		Addr:      addr,
-		Handler:   s.engine,
-		TLSConfig: tlsConfig,
+		return err
 	}
 
-	return server.ListenAndServeTLS("", "")
+	server := newHardenedServer(addr, s.engine.Handler())
+	server.TLSConfig = tlsConfig
+
+	if !s.registerServer(server) {
+		return nil // Stop() already ran; don't start listening.
+	}
+	return ignoreServerClosed(server.ListenAndServeTLS("", ""))
 }
 
 // initTrustChain parses the TrustBackend config and builds a TrustChain
@@ -507,11 +677,36 @@ func initTrustChain(config *RegistryConfig, l *logger.Logger) (*trust.TrustChain
 	return chain, nil
 }
 
-// startAdminServer starts a secondary Gin engine on the admin port with
-// admin-only endpoints. Runs in its own goroutine.
-func (s *Server) startAdminServer(port int) {
+// newAdminEngine builds the engine served on the admin port.
+//
+// Middleware here is deliberately kept in one place: the admin engine is
+// a second, separately-constructed engine, so anything installed on the
+// main engine in NewServer has to be repeated or it silently does not
+// apply to /admin/* when MCP_MESH_ADMIN_PORT is set.
+func (s *Server) newAdminEngine() *gin.Engine {
 	adminEngine := gin.New()
 	adminEngine.Use(gin.Recovery())
+
+	// Request logging, same as the main engine. Without it the privileged
+	// port produced no access log at all — including for rejected calls.
+	adminEngine.Use(gin.Logger())
+
+	// Client-certificate policy, OPT-IN via MCP_MESH_ADMIN_TLS (issue
+	// #1583). The main engine always installs this when a trust chain
+	// exists; the admin engine cannot, because there is no client in the
+	// project that can present a certificate — meshctl's only TLS knob is
+	// --insecure — so installing it unconditionally would make
+	// ``meshctl registry drain`` (the documented pre-upgrade step) return
+	// 403 in strict mode with no workaround. Off by default therefore
+	// means: the admin port behaves exactly as it always has.
+	if s.adminTLSEnabled() && s.trustChain != nil {
+		adminEngine.Use(TLSVerifyMiddleware(s.trustChain, s.config.TlsMode))
+	}
+
+	// Body cap after the trust check, matching the main engine's order so
+	// an untrusted strict-mode caller sees 403 rather than 413. Applied
+	// unconditionally: a size limit breaks no client.
+	adminEngine.Use(MaxRequestBodyMiddleware(s.maxBodyBytes))
 
 	adminEngine.GET("/admin/entities", s.handleListEntities)
 	adminEngine.POST("/admin/rotate", s.handleRotateTrigger)
@@ -519,10 +714,81 @@ func (s *Server) startAdminServer(port int) {
 	adminEngine.DELETE("/admin/drain", s.handleDrainStop)
 	adminEngine.GET("/admin/drain", s.handleDrainStatus)
 
+	return adminEngine
+}
+
+// adminTLSEnabled reports whether the operator opted the admin listener
+// into the main listener's transport and trust policy
+// (MCP_MESH_ADMIN_TLS). It is a single switch on purpose: serving TLS on
+// the admin port without the client-certificate check, or the check
+// without TLS, are both half-configurations no operator asked for.
+//
+// Warns rather than silently doing nothing when the opt-in is set but
+// the registry has no TLS to inherit.
+func (s *Server) adminTLSEnabled() bool {
+	if !s.config.AdminTLS {
+		return false
+	}
+	if !s.tlsEnabled() {
+		return false
+	}
+	return true
+}
+
+// startAdminServer starts a secondary Gin engine on the admin port with
+// admin-only endpoints. Runs in its own goroutine.
+//
+// The listener always carries the connection limits and body cap of the
+// main one (newHardenedServer, MaxRequestBodyMiddleware) — those break no
+// client. Transport and trust are opt-in through MCP_MESH_ADMIN_TLS: with
+// it unset the admin port is plaintext and unauthenticated, exactly as it
+// has always been, and must be restricted at the network layer. With it
+// set the port inherits the registry's certificate and tls.Config, which
+// also changes its scheme to https for every existing admin client
+// (issue #1583).
+func (s *Server) startAdminServer(port int) {
+	adminEngine := s.newAdminEngine()
+
+	addr := fmt.Sprintf(":%d", port)
+	server := newHardenedServer(addr, adminEngine.Handler())
+
+	if s.config.AdminTLS && !s.tlsEnabled() {
+		log.Printf("[admin] MCP_MESH_ADMIN_TLS is set but the registry has no TLS configured (MCP_MESH_TLS_MODE/MCP_MESH_TLS_CERT/MCP_MESH_TLS_KEY); admin port stays plaintext")
+	}
+
+	serveTLS := false
+	if s.adminTLSEnabled() {
+		tlsConfig, err := s.serverTLSConfig()
+		if err != nil {
+			log.Printf("[admin] Admin server not started: %v", err)
+			return
+		}
+		server.TLSConfig = tlsConfig
+		serveTLS = true
+	}
+
+	if !s.registerServer(server) {
+		return // Stop() already ran; don't start listening.
+	}
+
 	go func() {
-		addr := fmt.Sprintf(":%d", port)
-		log.Printf("[admin] Admin API listening on %s", addr)
-		if err := adminEngine.Run(addr); err != nil {
+		scheme := "http"
+		if serveTLS {
+			scheme = "https"
+		}
+		if serveTLS {
+			log.Printf("[admin] Admin API listening on %s (%s, client certs: %s)", addr, scheme, s.config.TlsMode)
+		} else {
+			log.Printf("[admin] Admin API listening on %s (%s, unauthenticated — restrict this port at the network layer)", addr, scheme)
+		}
+
+		var err error
+		if serveTLS {
+			err = server.ListenAndServeTLS("", "")
+		} else {
+			err = server.ListenAndServe()
+		}
+		if err := ignoreServerClosed(err); err != nil {
 			log.Printf("[admin] Admin server error: %v", err)
 		}
 	}()

--- a/src/core/registry/server_listener_test.go
+++ b/src/core/registry/server_listener_test.go
@@ -1,0 +1,448 @@
+package registry
+
+// Coverage for issue #1583's listener work: graceful shutdown of every
+// listener the registry starts, and the admin listener inheriting the
+// main listener's limits, TLS and client-certificate policy.
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"mcp-mesh/src/core/registry/trust"
+)
+
+// freePort returns a port that was free a moment ago. Used where the
+// code under test binds the port itself and gives no way to ask which
+// one it got.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	if err := l.Close(); err != nil {
+		t.Fatalf("closing reservation listener: %v", err)
+	}
+	return port
+}
+
+// waitForListener polls until the address accepts a connection.
+func waitForListener(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("listener at %s never came up", addr)
+}
+
+// writeSelfSignedCert writes a throwaway server cert/key pair and
+// returns their paths.
+func writeSelfSignedCert(t *testing.T) (certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "registry-test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+		DNSNames:              []string{"localhost"},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("creating certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshalling key: %v", err)
+	}
+
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "tls.crt")
+	keyPath = filepath.Join(dir, "tls.key")
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("writing cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600); err != nil {
+		t.Fatalf("writing key: %v", err)
+	}
+	return certPath, keyPath
+}
+
+// newListenerTestServer builds the minimum Server needed to exercise the
+// listener paths: an engine, a config and a logger.
+func newListenerTestServer(t *testing.T, cfg *RegistryConfig) *Server {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	service := setupTestService(t)
+
+	engine := gin.New()
+	engine.GET("/ping", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	engine.GET("/slow", func(c *gin.Context) {
+		time.Sleep(300 * time.Millisecond)
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	return &Server{
+		engine:       engine,
+		service:      service,
+		config:       cfg,
+		logger:       service.logger,
+		maxBodyBytes: defaultMaxRequestBodyBytes,
+	}
+}
+
+func TestRunPlaintext_ShutdownStopsTheListener(t *testing.T) {
+	s := newListenerTestServer(t, &RegistryConfig{TlsMode: "off"})
+	addr := fmt.Sprintf("127.0.0.1:%d", freePort(t))
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- s.runPlaintext(addr) }()
+	waitForListener(t, addr)
+
+	// The listener the plaintext path built must carry the limits — the
+	// bug was that gin's Run built one we never got to configure.
+	s.httpMu.Lock()
+	if len(s.httpServers) != 1 {
+		s.httpMu.Unlock()
+		t.Fatalf("registered %d listeners, want 1", len(s.httpServers))
+	}
+	srv := s.httpServers[0]
+	s.httpMu.Unlock()
+	if srv.ReadHeaderTimeout != defaultReadHeaderTimeout || srv.IdleTimeout != defaultIdleTimeout ||
+		srv.MaxHeaderBytes != defaultMaxHeaderBytes {
+		t.Errorf("plaintext listener not hardened: readHeader=%v idle=%v maxHeader=%d",
+			srv.ReadHeaderTimeout, srv.IdleTimeout, srv.MaxHeaderBytes)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("runPlaintext returned %v, want nil after a graceful shutdown", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runPlaintext did not return after Shutdown")
+	}
+
+	if conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond); err == nil {
+		_ = conn.Close()
+		t.Fatal("listener still accepting connections after Shutdown")
+	}
+}
+
+func TestShutdown_WaitsForInFlightRequest(t *testing.T) {
+	s := newListenerTestServer(t, &RegistryConfig{TlsMode: "off"})
+	addr := fmt.Sprintf("127.0.0.1:%d", freePort(t))
+
+	go func() { _ = s.runPlaintext(addr) }()
+	waitForListener(t, addr)
+
+	type result struct {
+		status int
+		err    error
+	}
+	done := make(chan result, 1)
+	go func() {
+		resp, err := http.Get("http://" + addr + "/slow")
+		if err != nil {
+			done <- result{err: err}
+			return
+		}
+		defer resp.Body.Close()
+		done <- result{status: resp.StatusCode}
+	}()
+
+	// Give the request time to arrive at the handler, then shut down
+	// underneath it. The in-flight call must still complete.
+	time.Sleep(100 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("in-flight request was cut by shutdown: %v", r.err)
+		}
+		if r.status != http.StatusOK {
+			t.Fatalf("in-flight request returned %d, want 200", r.status)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("in-flight request never completed")
+	}
+}
+
+// TestShutdownBeforeRun_DoesNotStartListening closes the window where a
+// signal arrives before Run reaches the listener: without the stopping
+// flag the listener would come up after Shutdown had already walked the
+// (empty) list and returned.
+func TestShutdownBeforeRun_DoesNotStartListening(t *testing.T) {
+	s := newListenerTestServer(t, &RegistryConfig{TlsMode: "off"})
+	addr := fmt.Sprintf("127.0.0.1:%d", freePort(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+
+	if err := s.runPlaintext(addr); err != nil {
+		t.Fatalf("runPlaintext after Shutdown returned %v, want nil", err)
+	}
+	if conn, err := net.DialTimeout("tcp", addr, 300*time.Millisecond); err == nil {
+		_ = conn.Close()
+		t.Fatal("runPlaintext started listening after Shutdown")
+	}
+}
+
+func TestStartAdminServer_HardenedAndShutdownAware(t *testing.T) {
+	port := freePort(t)
+	s := newListenerTestServer(t, &RegistryConfig{TlsMode: "off", AdminPort: port})
+
+	s.startAdminServer(port)
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	waitForListener(t, addr)
+
+	s.httpMu.Lock()
+	if len(s.httpServers) != 1 {
+		s.httpMu.Unlock()
+		t.Fatalf("admin listener not registered for shutdown (%d registered)", len(s.httpServers))
+	}
+	srv := s.httpServers[0]
+	s.httpMu.Unlock()
+
+	if srv.ReadHeaderTimeout != defaultReadHeaderTimeout || srv.IdleTimeout != defaultIdleTimeout ||
+		srv.MaxHeaderBytes != defaultMaxHeaderBytes {
+		t.Errorf("admin listener not hardened: readHeader=%v idle=%v maxHeader=%d",
+			srv.ReadHeaderTimeout, srv.IdleTimeout, srv.MaxHeaderBytes)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond); err == nil {
+		_ = conn.Close()
+		t.Fatal("admin listener still accepting connections after Shutdown")
+	}
+}
+
+// TestStartAdminServer_PlaintextByDefaultOnATLSRegistry is the
+// compatibility case, and it is the shape the tc11 integration test
+// exercises: TLS configured on the main port, MCP_MESH_ADMIN_PORT set,
+// MCP_MESH_ADMIN_TLS unset. The admin port must stay plain http, because
+// every existing admin client (curl in tc11, meshctl registry drain)
+// addresses it as http:// and meshctl cannot present a client cert.
+func TestStartAdminServer_PlaintextByDefaultOnATLSRegistry(t *testing.T) {
+	certPath, keyPath := writeSelfSignedCert(t)
+	port := freePort(t)
+	s := newListenerTestServer(t, &RegistryConfig{
+		TlsMode:     "auto",
+		TlsCertFile: certPath,
+		TlsKeyFile:  keyPath,
+		AdminPort:   port,
+		// AdminTLS deliberately unset.
+	})
+	s.trustChain = trust.NewTrustChain()
+
+	s.startAdminServer(port)
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	waitForListener(t, addr)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = s.Shutdown(ctx)
+	}()
+
+	resp, err := http.Post("http://"+addr+"/admin/rotate", "application/json", nil)
+	if err != nil {
+		t.Fatalf("plaintext POST to the admin port failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("admin rotate over plain http = %d, want 200 (tc11 asserts this); body=%s",
+			resp.StatusCode, body)
+	}
+}
+
+// TestStartAdminServer_ServesTLSWhenAdminTLSOptIn is the opt-in
+// transport-parity case: with MCP_MESH_ADMIN_TLS set, the admin port
+// speaks TLS with the registry's certificate rather than cleartext.
+func TestStartAdminServer_ServesTLSWhenAdminTLSOptIn(t *testing.T) {
+	certPath, keyPath := writeSelfSignedCert(t)
+	port := freePort(t)
+	s := newListenerTestServer(t, &RegistryConfig{
+		TlsMode:     "auto",
+		TlsCertFile: certPath,
+		TlsKeyFile:  keyPath,
+		AdminPort:   port,
+		AdminTLS:    true,
+	})
+
+	s.startAdminServer(port)
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	waitForListener(t, addr)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = s.Shutdown(ctx)
+	}()
+
+	// A plaintext request must NOT be served: before #1583 that was the
+	// only thing the admin port spoke. Go's TLS server answers a cleartext
+	// request with a 400 and a fixed message rather than closing, so the
+	// assertion is "not the handler's response".
+	if resp, err := http.Get("http://" + addr + "/admin/drain"); err == nil {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest || !strings.Contains(string(body), "HTTP request to an HTTPS server") {
+			t.Fatalf("admin port served plaintext HTTP: status=%d body=%s", resp.StatusCode, body)
+		}
+	}
+
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	resp, err := client.Get("https://" + addr + "/admin/drain")
+	if err != nil {
+		t.Fatalf("HTTPS request to the admin port failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("admin drain status over TLS = %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestAdminEngine_TrustMiddlewareIsOptIn covers both halves of the
+// MCP_MESH_ADMIN_TLS switch. Default OFF is the compatibility contract:
+// even in strict mode a certless caller reaches /admin/*, because
+// meshctl has no way to present a client certificate and
+// 'meshctl registry drain' is the documented pre-upgrade step. Opted
+// in, the admin engine follows MCP_MESH_TLS_MODE exactly like the main
+// engine.
+func TestAdminEngine_TrustMiddlewareIsOptIn(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       string
+		adminTLS   bool
+		trustChain *trust.TrustChain
+		wantStatus int
+	}{
+		{
+			name:       "default off: strict still admits a certless admin caller",
+			mode:       "strict",
+			adminTLS:   false,
+			trustChain: trust.NewTrustChain(),
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "opt-in: strict rejects a certless admin caller",
+			mode:       "strict",
+			adminTLS:   true,
+			trustChain: trust.NewTrustChain(),
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "opt-in: auto still admits a certless admin caller",
+			mode:       "auto",
+			adminTLS:   true,
+			trustChain: trust.NewTrustChain(),
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "opt-in without a trust chain leaves the engine unchanged",
+			mode:       "off",
+			adminTLS:   true,
+			trustChain: nil,
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			certPath, keyPath := writeSelfSignedCert(t)
+			s := newListenerTestServer(t, &RegistryConfig{
+				TlsMode:     tc.mode,
+				TlsCertFile: certPath,
+				TlsKeyFile:  keyPath,
+				AdminTLS:    tc.adminTLS,
+			})
+			s.trustChain = tc.trustChain
+
+			srv := httptest.NewServer(s.newAdminEngine())
+			defer srv.Close()
+
+			resp, err := http.Get(srv.URL + "/admin/drain")
+			if err != nil {
+				t.Fatalf("GET /admin/drain: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// TestAdminEngine_CapsRequestBodies pins the second piece of engine
+// parity: the admin engine is constructed separately, so the body cap
+// has to be repeated on it or /admin/* is uncapped.
+func TestAdminEngine_CapsRequestBodies(t *testing.T) {
+	s := newListenerTestServer(t, &RegistryConfig{TlsMode: "off"})
+	s.maxBodyBytes = 1024
+
+	srv := httptest.NewServer(s.newAdminEngine())
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/admin/drain", "application/json",
+		strings.NewReader(oversizedJSON(4096)))
+	if err != nil {
+		t.Fatalf("POST /admin/drain: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", resp.StatusCode)
+	}
+}

--- a/src/core/ui/proxy.go
+++ b/src/core/ui/proxy.go
@@ -10,6 +10,13 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// maxRegistryResponseBytes caps the registry response the UI will buffer
+// and forward. Every proxied endpoint is a bounded JSON document (agent
+// lists, traces, job pages), so 10MB is far past any legitimate reply;
+// past it the request fails with 502 rather than forwarding a body that
+// was cut mid-token.
+const maxRegistryResponseBytes int64 = 10 * 1024 * 1024
+
 // proxyToRegistry forwards an API request to the registry and writes back the response.
 // The /api prefix is stripped before forwarding: /api/health -> {registryURL}/health.
 func (s *Server) proxyToRegistry(c *gin.Context) {
@@ -52,10 +59,24 @@ func (s *Server) proxyToRegistry(c *gin.Context) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024)) // 10MB limit
+	// Read one byte past the cap so an over-large response is detectable.
+	// It used to be a plain LimitReader at the cap, which silently handed
+	// the client a truncated body — invalid JSON carrying the upstream's
+	// 200 — with nothing in the response to say it had been cut (issue
+	// #1583). A response this size is a registry bug or a runaway query,
+	// so fail the request instead of corrupting it.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRegistryResponseBytes+1))
 	if err != nil {
 		log.Printf("proxy: failed to read registry response: %v", err)
 		c.JSON(http.StatusBadGateway, gin.H{"error": "Failed to read registry response"})
+		return
+	}
+	if int64(len(body)) > maxRegistryResponseBytes {
+		log.Printf("proxy: registry response for %s exceeded %d bytes; refusing to forward a truncated body", registryPath, maxRegistryResponseBytes)
+		c.JSON(http.StatusBadGateway, gin.H{
+			"error": fmt.Sprintf("Registry response exceeded the %d byte limit", maxRegistryResponseBytes),
+			"path":  registryPath,
+		})
 		return
 	}
 

--- a/src/core/ui/proxy_test.go
+++ b/src/core/ui/proxy_test.go
@@ -1,0 +1,148 @@
+package ui
+
+// Issue #1583: proxyToRegistry read the registry response through a
+// LimitReader at 10MB and forwarded whatever it got with the upstream's
+// status code. A response over the cap therefore reached the browser as
+// JSON cut mid-token, carrying a 200 — indistinguishable from a valid
+// reply until it failed to parse.
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// newProxyTestServer wires a UI server at an upstream registry stub.
+func newProxyTestServer(t *testing.T, registryURL string) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	s := &Server{
+		config:     &UIConfig{RegistryURL: registryURL},
+		httpClient: &http.Client{},
+	}
+
+	e := gin.New()
+	e.GET("/api/*path", s.proxyToRegistry)
+	return e
+}
+
+func TestProxyToRegistry_ForwardsNormalResponse(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"agents":[]}`)
+	}))
+	defer upstream.Close()
+
+	srv := httptest.NewServer(newProxyTestServer(t, upstream.URL))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/agents")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	if string(body) != `{"agents":[]}` {
+		t.Errorf("body = %s, want the upstream document verbatim", body)
+	}
+}
+
+// TestProxyToRegistry_OverlargeResponseIs502 is the fix: a response past
+// the cap must fail the request rather than forward a truncated body.
+func TestProxyToRegistry_OverlargeResponseIs502(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// A valid JSON document that is one byte past the cap. Truncating
+		// it produces the exact failure mode being fixed: parseable-looking
+		// prefix, no closing quote or brace.
+		_, _ = io.WriteString(w, `{"pad":"`)
+		_, _ = io.WriteString(w, strings.Repeat("x", int(maxRegistryResponseBytes)))
+		_, _ = io.WriteString(w, `"}`)
+	}))
+	defer upstream.Close()
+
+	srv := httptest.NewServer(newProxyTestServer(t, upstream.URL))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/agents")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502 (a truncated body must not be forwarded with the upstream status); body length %d",
+			resp.StatusCode, len(body))
+	}
+
+	// The failure must itself be well-formed JSON — the whole point is
+	// that the client can tell what happened.
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("502 body is not valid JSON (%v): %s", err, body)
+	}
+	if msg, _ := parsed["error"].(string); !strings.Contains(msg, "exceeded") {
+		t.Errorf("502 body does not explain the truncation: %s", body)
+	}
+}
+
+// TestProxyToRegistry_ResponseExactlyAtLimitIsForwarded pins the boundary:
+// the cap is inclusive, so a document exactly at the limit is still a
+// complete document and must be served.
+func TestProxyToRegistry_ResponseExactlyAtLimitIsForwarded(t *testing.T) {
+	padding := int(maxRegistryResponseBytes) - len(`{"pad":""}`)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"pad":"`+strings.Repeat("x", padding)+`"}`)
+	}))
+	defer upstream.Close()
+
+	srv := httptest.NewServer(newProxyTestServer(t, upstream.URL))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/agents")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 for a document exactly at the limit", resp.StatusCode)
+	}
+	if int64(len(body)) != maxRegistryResponseBytes {
+		t.Errorf("forwarded %d bytes, want %d", len(body), maxRegistryResponseBytes)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("forwarded body is not valid JSON: %v", err)
+	}
+}
+
+func TestProxyToRegistry_UnreachableRegistryIs502(t *testing.T) {
+	// Port 1 on loopback: nothing listens there.
+	srv := httptest.NewServer(newProxyTestServer(t, "http://127.0.0.1:1"))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/agents")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	}
+}

--- a/tools/detection/detect_endpoints.py
+++ b/tools/detection/detect_endpoints.py
@@ -67,6 +67,24 @@ class DualContractEndpointDetector:
         return False
 
     @staticmethod
+    def is_test_file(file_path: Path) -> bool:
+        """Check if a file is a test file, which is out of contract scope.
+
+        This detector exists to keep *production* handler implementations in sync
+        with the OpenAPI contracts. A fixture route registered on a throwaway
+        engine/app inside a test is not an endpoint the contract governs, so test
+        files are never scanned.
+        """
+        name = file_path.name
+        if name.endswith("_test.go"):
+            return True
+        if name.endswith("_test.py") or (
+            name.startswith("test_") and name.endswith(".py")
+        ):
+            return True
+        return "tests" in file_path.parts
+
+    @staticmethod
     def normalize_path(path: str) -> str:
         """Normalize path parameters from framework-specific to OpenAPI format.
 
@@ -112,7 +130,9 @@ class DualContractEndpointDetector:
                 continue
 
             for go_file in source_path.rglob("*.go"):
-                # Skip generated files, mocks, and deprecated files
+                # Skip test files, generated files, mocks, and deprecated files
+                if self.is_test_file(go_file):
+                    continue
                 if (
                     "generated" in str(go_file)
                     or "mock" in str(go_file)
@@ -152,11 +172,12 @@ class DualContractEndpointDetector:
                 continue
 
             for py_file in source_path.rglob("*.py"):
-                # Skip generated files, tests, mocks, and deprecated files
+                # Skip test files, generated files, mocks, and deprecated files
+                if self.is_test_file(py_file):
+                    continue
                 if (
                     "generated" in str(py_file)
                     or "mock" in str(py_file)
-                    or "test" in str(py_file)
                     or "deprecated" in str(py_file)
                     or "_old_" in str(py_file)
                 ):
@@ -184,6 +205,8 @@ class DualContractEndpointDetector:
             # Only scan registry paths for Go endpoints
             if "registry" in str(source_path).lower():
                 for go_file in source_path.rglob("*.go"):
+                    if self.is_test_file(go_file):
+                        continue
                     if (
                         "generated" in str(go_file)
                         or "mock" in str(go_file)
@@ -226,10 +249,11 @@ class DualContractEndpointDetector:
                 for term in ["runtime", "agent", "http_wrapper"]
             ):
                 for py_file in source_path.rglob("*.py"):
+                    if self.is_test_file(py_file):
+                        continue
                     if (
                         "generated" in str(py_file)
                         or "mock" in str(py_file)
-                        or "test" in str(py_file)
                         or "deprecated" in str(py_file)
                         or "_old_" in str(py_file)
                     ):


### PR DESCRIPTION
Issue #1583 — registry HTTP hardening.

## Timeouts on every listener

`server.go:424` was the only explicit `http.Server`; the plaintext and admin paths used gin's `Run`, which builds a server internally with **no timeouts at all**. All three now go through one helper.

`ReadHeaderTimeout` 10s, `IdleTimeout` 120s (must exceed the heartbeat cadence or every heartbeat pays a fresh TCP+TLS handshake), `MaxHeaderBytes` 64KB (Go's default is 1MB).

**`ReadTimeout` and `WriteTimeout` are deliberately unset, and a test asserts they stay zero.** Both are absolute deadlines. The registry serves a 60s job-event long-poll (`listJobEventsMaxWait`) and relays unbounded `/proxy/*` SSE — any value severs one of them. This is the kind of thing a future reader will "fix", hence the test.

## Request body cap

`MCP_MESH_MAX_REQUEST_BODY_BYTES`, default 10MB, `0` disables.

The default is measured rather than picked. A `MeshToolRegistration` carrying all four schema blobs (`InputSchema`, `InputSchemaCanonical`, `OutputSchema`, `OutputSchemaCanonical`) plus kwargs, dependencies, tags and warnings marshals to **~9.8KB/tool**, so 1000 fully-schema'd tools ≈ 9.8MB. A test pins a 100-tool payload as acceptable so the default cannot be tightened silently later.

413 is produced two ways: a declared `Content-Length` over the cap is refused before a byte is read; an undeclared/chunked body trips `http.MaxBytesReader` and surfaces as `*http.MaxBytesError`. Malformed JSON still yields a byte-identical 400. All **7** unguarded `ShouldBindJSON` sites were converted — the issue named 2, and 6 of the 7 are in a file it never mentions.

## Graceful shutdown

`Server.Stop` carried `// TODO: Implement graceful shutdown for HTTP server` and never shut the listener, so `os.Exit(0)` cut in-flight proxy streams and long-polls. `Shutdown(ctx)` now drains every registered listener, and `registerServer` refuses to start one after `Stop` has run, closing the signal-before-listen race.

`main.go` waits on a **bounded** select rather than exiting immediately. An unbounded wait would have been a regression: `Stop`'s tail (`tracingManager.Stop()`) has no deadline of its own, and `signal.Notify` stays installed, so a wedged Redis consumer would leave a process that ignores further SIGTERM.

A deadline expiry with long-polls still attached is the *expected* outcome on a busy registry — it is logged as such rather than returned, so a routine restart no longer prints `Error during server shutdown`. See #1606 for why the budget had to be tuned down rather than up.

## Admin listener — opt-in, default unchanged

Timeouts and the body cap apply unconditionally. TLS and `TLSVerifyMiddleware` are **opt-in** via `MCP_MESH_ADMIN_TLS`, default off.

Applying them unconditionally was implemented and then reverted, because it breaks two things:

- It flips the port from `http://` to `https://`, breaking every existing admin client and `tc11_admin_port_isolation`, which asserts `curl http://localhost:8001/admin/rotate` → 200 under `MCP_MESH_TLS_MODE=auto`.
- In `strict` it returns 403 to `meshctl`, which has **no client-certificate support** anywhere in `src/core/cli` (the only TLS knob is `--insecure`). That would remove `meshctl registry drain|resume|status` and `meshctl entity rotate` — the documented drain-before-upgrade path — in exactly the configuration `security.md`'s production checklist recommends.

Both traps are now stated in the man page, so anyone enabling the flag learns them before they trip over them. A Go test asserts plaintext-by-default *on a TLS-configured registry*, so tc11 cannot be broken silently.

Note this leaves the exposure open by default. That is deliberate — it matches the project's strictness-opt-in stance — but the admin port genuinely is unauthenticated, which the docs now say plainly instead of calling it "isolation".

## Also

- `net.SplitHostPort` / `net.JoinHostPort` on the proxy target path. The issue named the split; the same line also built the dial host with `fmt.Sprintf("%s:%d")`, which yields `::1:8080` and an unparseable URL even after the split is fixed. Both halves are needed. (The resolver has the same defect on the DI path — filed as #1604, not fixed here.)
- `src/core/ui/proxy.go` returns 502 on truncation instead of forwarding a body cut mid-token with the upstream status.
- `detect_endpoints.py` now skips test files. It walked `*_test.go` and demanded that fixture routes on throwaway engines appear in the OpenAPI contract, which blocked this change. The detector governs production handlers; verified it still fails on a real unspecified production route.

## Corrections to #1583

Four of its claims did not survive verification: only one of the three cited `http.Server` sites exists; `ent_handlers.go:796` is a 403 block, not a bind; there are 7 bind sites, not 2; and the IPv6 line reference is off by ~18 lines and misses half the bug. The conclusions all hold — the locations and counts did not.

## Tests

`go test ./... -race -count=1` green across 11 packages. New: `http_limits_test.go`, `server_listener_test.go`, `proxy_ipv6_test.go`, `src/core/ui/proxy_test.go`. Man goldens 1796 → 1809 with the arithmetic annotated; `go test ./src/core/cli/man/` passes and `check_doc_claims.py` is clean.

Closes #1583

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfukAUDerBUKAfKzUyhvvb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable registry request-body limits, with clear errors for oversized requests.
  - Added optional TLS and client-certificate enforcement for the admin listener.
  - Added support for IPv6 registry targets.
  - Added response-size protection for UI-to-registry proxy requests.

- **Bug Fixes**
  - Registry shutdown now drains active requests and completes cleanup before exiting.
  - Improved handling of invalid configuration values and malformed JSON requests.

- **Documentation**
  - Updated deployment, security, and environment-variable guidance for admin TLS and request limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->