### PR TITLE
fix(core): never emit X-Mesh-Timeout as 0; unify the call budget; fix sub-second poll math

### DIFF
--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -1103,9 +1103,12 @@ readability confusion with the inherited `Object.wait()` / `wait(long)`
 / `wait(long, int)` overload family, and to match the existing
 `JobProxy.await(double)` instance method precedent in the SDK. See the
 Javadoc on `MeshJobs.await` and `JobProxy.await` for the detailed
-rationale. `MeshJobs.await(jobId, timeoutSecs)` with `timeoutSecs <= 0.0`
-or non-finite values means "no timeout" (matches the no-arg
-`MeshJobs.await(jobId)` overload).
+rationale. `MeshJobs.await(jobId, timeoutSecs)` treats a NEGATIVE
+`timeoutSecs` as "no timeout" — the sentinel the no-arg
+`MeshJobs.await(jobId)` overload passes. `0.0` is a zero-length budget:
+the registry is polled exactly once, so an already-terminal job returns
+its result and a running one surfaces a timeout. `NaN` / infinity are
+rejected.
 
 If the calling code already holds a `JobProxy`, the same surface is
 on the proxy directly: `proxy.cancel(reason)`, `proxy.status()`,

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -421,6 +421,25 @@ export MCP_MESH_PROXY_TIMEOUT=60
 export MCP_MESH_CALL_TIMEOUT=300
 ```
 
+In every runtime, whichever value wins is used for BOTH the `X-Mesh-Timeout`
+advertised downstream and the local HTTP client timeout, so an agent never
+promises a provider a budget it will not itself wait out. An inbound
+`X-Mesh-Timeout` overrides the local value — that is what makes the
+propagation below work.
+
+Where the local value comes from differs by runtime, because only TypeScript
+has a per-dependency knob the runtime reads:
+
+| Runtime | Per-dependency override | Otherwise |
+| --- | --- | --- |
+| TypeScript | `timeout` on the dependency's kwargs (`streamTimeout` when `streaming: true`) | `MCP_MESH_CALL_TIMEOUT`, else 300s |
+| Python | none today | `MCP_MESH_CALL_TIMEOUT`, else 300s |
+| Java | none | `MCP_MESH_CALL_TIMEOUT`, else 300s (client read timeout adds a 10s buffer over the advertised value) |
+
+Python's `dependency_kwargs` documents a `timeout` entry, but no code path
+reads it yet; the proxy's kwargs are the *producer's* `@mesh.tool` kwargs, so
+a `timeout` there is provider metadata and deliberately does not cap callers.
+
 **How timeout propagation works:**
 
 1. First hop: SDK sets `X-Mesh-Timeout: 300` (from `MCP_MESH_CALL_TIMEOUT`) on the outgoing request

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -514,6 +514,15 @@ export MCP_MESH_PROXY_TIMEOUT=60
 export MCP_MESH_CALL_TIMEOUT=300
 ```
 
+In every runtime the winning value drives BOTH the advertised
+`X-Mesh-Timeout` and the local HTTP client timeout, so an agent never
+promises a provider a budget it will not itself wait out. An inbound
+`X-Mesh-Timeout` overrides the local value.
+
+Only TypeScript has a per-dependency override the runtime reads (`timeout`,
+or `streamTimeout` when `streaming` is set). Python and Java resolve the
+budget from `MCP_MESH_CALL_TIMEOUT`, else 300s.
+
 Streamed responses (e.g., SSE) routed through the registry proxy are bounded by the same call timeout — the proxy ends the exchange when it elapses, even mid-stream. Send a larger `X-Mesh-Timeout` header (or raise `MCP_MESH_PROXY_TIMEOUT`) for long-lived streams.
 
 ## MeshJob event channel

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -524,8 +524,29 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // `scripts/check_doc_claims.py`, which can read the four runtimes' source and
 // the starter's POM; a test in this package cannot, and #1499 shipped three
 // false claims through a green run here.
+//
+// Issue #1584 moved this to 1815 (+6) and neither list constant. Six prose
+// spans on `environment.md`'s "Proxy & Timeout" section, stating that the
+// winning call budget drives BOTH the advertised `X-Mesh-Timeout` and the local
+// HTTP client timeout, and which source wins per runtime. The page already
+// documented the 300s default — true of Python and Java, NOT of TypeScript
+// whose fallback was 30 — so the fix made the existing sentence honest and this
+// paragraph says where the value comes from.
+//
+// The first draft of this paragraph claimed a single precedence chain "in every
+// runtime" (per-dependency kwarg, then env, then 300). Review caught that it is
+// false in two of the three: Java has no per-dependency timeout at all, and
+// Python's documented `dependency_kwargs.timeout` has no reader — its proxy map
+// is the PRODUCER's `@mesh.tool` kwargs, which deliberately must not cap
+// callers. Only TypeScript has the knob. The wording now says exactly that,
+// which is why the delta grew by two rather than shrinking.
+//
+// Prose only, no list item, hence the list constants are unmoved. The `docs/`
+// copy of this section carries a fuller three-row table; only this file is in
+// the man corpus. `environment.md` has no `_java` / `_typescript` variant, so
+// the variant golden did not move either.
 const (
-	wantInlineCodeSpans = 1809
+	wantInlineCodeSpans = 1815
 	wantListCodeSpans   = 523
 	wantMarkupListLines = 448
 )

--- a/src/runtime/core/build.rs
+++ b/src/runtime/core/build.rs
@@ -63,7 +63,15 @@ fn main() {
         }
     }
 
-    // Tell Cargo to re-run if these files change
+    // Tell Cargo to re-run if these files change.
+    //
+    // EVERY module that declares `#[no_mangle] pub extern "C"` symbols has to
+    // be listed: `include/mcp_mesh_core.h` is checked into git, so a module
+    // missing here silently ships a header that disagrees with the source.
+    // `jobs_ffi.rs` was missing and did exactly that — a doc-comment change to
+    // `mesh_run_as_job`'s deadline contract left the committed header
+    // describing the OLD contract (issue #1584 review).
     println!("cargo:rerun-if-changed=src/ffi.rs");
+    println!("cargo:rerun-if-changed=src/jobs_ffi.rs");
     println!("cargo:rerun-if-changed=cbindgen.toml");
 }

--- a/src/runtime/core/include/mcp_mesh_core.h
+++ b/src/runtime/core/include/mcp_mesh_core.h
@@ -972,11 +972,17 @@ int32_t mesh_job_proxy_status(struct JobProxyHandle *handle, char **out_job_json
 // `result` (JSON-encoded) to `*out_result_json`; caller frees via
 // `mesh_free_string`.
 //
-// `timeout_secs`: wall-clock timeout. Any value `<= 0.0` (including
-// `-0.0` and negatives such as `-1`) means "no timeout"; non-finite
-// values (NaN, ±Inf) also fall back to "no timeout". Matches the
-// Python / napi-rs `Optional<f64>` shape and keeps the same policy
-// as [`mesh_run_as_job`] for consistency.
+// `timeout_secs`: wall-clock timeout, under the ONE boundary policy shared
+// by every binding (see the "f64-SECONDS BOUNDARY POLICY" note in
+// `task_backend.rs`, issue #1584): negative (including `-1`, which is how
+// Java expresses `Optional<Duration>::empty()` over a C ABI that has no
+// nullable double) means "no timeout"; `0.0`/`-0.0` is a zero-length budget;
+// NaN / ±Inf are ERRORS (`-1` return, message in the last-error slot).
+//
+// The NaN/±Inf rejection is a #1584 change: this entry point used to alias
+// them to "no timeout" while its sibling `mesh_job_controller_recv_event`
+// rejected them, so the same bad input produced an unbounded wait on one
+// call and a clean error on the other.
 int32_t mesh_job_proxy_wait(struct JobProxyHandle *handle,
                             double timeout_secs,
                             char **out_result_json);
@@ -1082,8 +1088,12 @@ int32_t mesh_current_job(char **out_snapshot_json);
 // active job context, if any.
 //
 // Writes a JSON object `{"X-Mesh-Job-Id": "...", "X-Mesh-Timeout":
-// "<secs>"}` (with `X-Mesh-Timeout` omitted when no deadline is set) to
-// `*out_headers_json`. If no context is active, writes NULL.
+// "<secs>"}` to `*out_headers_json`. If no context is active, writes NULL.
+//
+// `X-Mesh-Timeout` is omitted when the active context has no deadline OR
+// when that deadline has already expired; otherwise it is `ceil(remaining)`
+// floored at 1. It is NEVER `"0"` — see
+// [`crate::job_context::JobContext::timeout_header_seconds`] (issue #1584).
 //
 // Caller frees the JSON string via `mesh_free_string` if it is non-NULL.
 int32_t mesh_inject_job_headers(char **out_headers_json);
@@ -1154,7 +1164,12 @@ int32_t mesh_job_cancel_fired(const char *job_id_ptr);
 // `{"job_id": "...", "deadline_secs": <number>|null}` mirroring the
 // payload Java SDK constructs from inbound `X-Mesh-Job-Id` / `X-Mesh-Timeout`
 // headers. `deadline_secs` is the per-attempt deadline (relative); null /
-// missing / non-positive ≡ no deadline.
+// missing / `0` ≡ no deadline. A NEGATIVE value is an ERROR here, not a
+// sentinel: this payload is JSON, so `null` already expresses absence — the
+// negative-means-absence convention belongs only to the bare-`double` C
+// entry points. NaN / ±Inf and finite-but-out-of-`Duration`-range values are
+// also ERRORS. See the "f64-SECONDS BOUNDARY POLICY" note in
+// `task_backend.rs` (issue #1584).
 //
 // `callback` is invoked synchronously from the runtime's `block_on`,
 // wrapped in [`tokio::task::block_in_place`] so it is legal for the

--- a/src/runtime/core/src/job_context.rs
+++ b/src/runtime/core/src/job_context.rs
@@ -76,12 +76,58 @@ impl JobContext {
 
     /// Seconds remaining until deadline, or `None` if no deadline is set.
     /// Returns `Some(0)` if the deadline has already passed.
+    ///
+    /// This is the INTROSPECTION shape: `Some(0)` is the meaningful "expired"
+    /// answer that `current_job()`-style snapshots expose to SDK callers
+    /// (which test it with `<= 0`). Do NOT use it to build the
+    /// `X-Mesh-Timeout` header — see [`Self::timeout_header_seconds`].
     pub fn remaining_seconds(&self) -> Option<u64> {
         self.deadline.map(|d| {
             d.checked_duration_since(Instant::now())
                 .map(|r| r.as_secs())
                 .unwrap_or(0)
         })
+    }
+
+    /// The value to advertise in an outbound `X-Mesh-Timeout` header, or
+    /// `None` when the header must be OMITTED (issue #1584).
+    ///
+    /// `None` is returned in two cases, and both mean "do not send the
+    /// header":
+    ///
+    /// * no deadline is set (the design-doc default — unlimited), or
+    /// * the deadline has already passed.
+    ///
+    /// Otherwise the remaining time is rounded UP to whole seconds and
+    /// floored at 1.
+    ///
+    /// # Why not `remaining_seconds()`
+    ///
+    /// `remaining_seconds()` truncates, so any budget under a second — and
+    /// every expired one — renders as `0`. `X-Mesh-Timeout` is `minimum: 1`
+    /// in the registry OpenAPI schema (`XMeshTimeoutHeader`), and every
+    /// receiver in the mesh treats a `<= 0` value as "unset" and substitutes
+    /// its OWN default budget (Python `unified_mcp_proxy`, the registry
+    /// proxy, the TS/Java clients). So emitting `0` does not communicate
+    /// "almost out of time" — it communicates "no cap at all", which is the
+    /// exact opposite of what the parent's deadline means, and it silently
+    /// discards the parent-scope cap on every nested call made in the last
+    /// second of a job.
+    ///
+    /// Rounding UP rather than down keeps a sub-second remainder expressible
+    /// (`1` — the tightest budget the wire can carry) instead of collapsing
+    /// it to the "unset" sentinel. Omitting on expiry matches what the Python
+    /// outbound proxy already does today: the parent-scope CANCEL TOKEN, not
+    /// a bogus header, is the authoritative signal that the call should not
+    /// have been made.
+    pub fn timeout_header_seconds(&self) -> Option<u64> {
+        let remaining = self.deadline?.checked_duration_since(Instant::now())?;
+        if remaining.is_zero() {
+            return None;
+        }
+        // ceil to whole seconds; `remaining > 0` so this is always >= 1.
+        let secs = remaining.as_secs() + u64::from(remaining.subsec_nanos() > 0);
+        Some(secs.max(1))
     }
 
     /// Convenience: derive a child context with the same cancel-token but a
@@ -131,10 +177,22 @@ pub fn try_current() -> Option<JobContext> {
     current()
 }
 
-/// Seconds remaining on the active job's deadline, if any. Convenience for
-/// outbound header injection: `X-Mesh-Timeout: <remaining>`.
+/// Seconds remaining on the active job's deadline, if any. Introspection
+/// only — `Some(0)` means "expired". For outbound `X-Mesh-Timeout` header
+/// construction use [`timeout_header_seconds`], which never yields the `0`
+/// every receiver reads as "unset" (issue #1584).
 pub fn remaining_seconds() -> Option<u64> {
     CURRENT_JOB.try_with(|ctx| ctx.remaining_seconds()).ok().flatten()
+}
+
+/// The `X-Mesh-Timeout` value for the active job's deadline, or `None` when
+/// the header must be omitted (no deadline, no active context, or an expired
+/// deadline). See [`JobContext::timeout_header_seconds`].
+pub fn timeout_header_seconds() -> Option<u64> {
+    CURRENT_JOB
+        .try_with(|ctx| ctx.timeout_header_seconds())
+        .ok()
+        .flatten()
 }
 
 /// Run `f` with the given job context bound on the current async task.
@@ -154,7 +212,9 @@ where
 /// current task. No-op otherwise.
 ///
 /// `X-Mesh-Timeout` is only emitted when the active context has a deadline
-/// set (per design doc: deadline is opt-in / unlimited by default).
+/// that is set AND has not yet expired (per design doc: deadline is opt-in /
+/// unlimited by default). The value is `ceil(remaining)` floored at 1 — never
+/// `0`, which every receiver reads as "unset" (issue #1584).
 ///
 /// This is the FFI-friendly hook: language SDKs that build their own
 /// outbound HTTP requests through the Rust core (or wrap reqwest
@@ -165,8 +225,21 @@ pub fn inject_job_headers(builder: reqwest::RequestBuilder) -> reqwest::RequestB
         None => builder,
         Some(ctx) => {
             let mut b = builder.header("X-Mesh-Job-Id", &ctx.job_id);
-            if let Some(remaining) = ctx.remaining_seconds() {
-                b = b.header("X-Mesh-Timeout", remaining.to_string());
+            match ctx.timeout_header_seconds() {
+                Some(secs) => b = b.header("X-Mesh-Timeout", secs.to_string()),
+                None if ctx.deadline.is_some() => {
+                    // Deadline already blown. Omit rather than send "0" —
+                    // "0" reads as "unset" downstream and would hand the
+                    // child an unbounded budget. The parent-scope cancel
+                    // token is the authoritative signal here.
+                    tracing::warn!(
+                        "outbound call under job={} has an expired deadline; \
+                         omitting X-Mesh-Timeout instead of emitting an \
+                         invalid '0' value",
+                        ctx.job_id
+                    );
+                }
+                None => {}
             }
             b
         }
@@ -176,8 +249,45 @@ pub fn inject_job_headers(builder: reqwest::RequestBuilder) -> reqwest::RequestB
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap as Map;
+    use std::sync::Arc;
     use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::Mutex as AMutex;
     use tokio::time::sleep;
+
+    /// Spin up a one-shot HTTP server that records the request headers.
+    /// Returns `(port, captured, join_handle)`.
+    async fn spawn_header_capture_server() -> (
+        u16,
+        Arc<AMutex<Map<String, String>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let captured: Arc<AMutex<Map<String, String>>> = Arc::new(AMutex::new(Map::new()));
+        let captured_clone = captured.clone();
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 8192];
+            let n = sock.read(&mut buf).await.unwrap();
+            let req = String::from_utf8_lossy(&buf[..n]).to_string();
+            let mut hdrs = Map::new();
+            for line in req.lines().skip(1) {
+                if line.is_empty() {
+                    break;
+                }
+                if let Some((k, v)) = line.split_once(':') {
+                    hdrs.insert(k.trim().to_lowercase(), v.trim().to_string());
+                }
+            }
+            *captured_clone.lock().await = hdrs;
+            let resp = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok";
+            sock.write_all(resp).await.unwrap();
+        });
+        (port, captured, server)
+    }
 
     #[tokio::test]
     async fn current_returns_none_outside_scope() {
@@ -210,6 +320,34 @@ mod tests {
             assert!(r1 < r0, "remaining should decrease (r0={}, r1={})", r0, r1);
         })
         .await;
+    }
+
+    /// Issue #1584: the header value never renders as `0` — not for a
+    /// sub-second remainder, not for an expired deadline.
+    #[tokio::test]
+    async fn timeout_header_seconds_never_zero() {
+        // Sub-second remaining: truncation would give 0, we must give 1.
+        let ctx = JobContext::with_timeout("job-subsec", Duration::from_millis(400));
+        assert_eq!(ctx.remaining_seconds(), Some(0), "precondition: truncates to 0");
+        assert_eq!(ctx.timeout_header_seconds(), Some(1));
+
+        // Fractional over a second: rounds UP, never down.
+        let ctx = JobContext::with_timeout("job-frac", Duration::from_millis(2_400));
+        assert_eq!(ctx.remaining_seconds(), Some(2));
+        assert_eq!(ctx.timeout_header_seconds(), Some(3));
+
+        // No deadline: omit.
+        assert_eq!(JobContext::new("job-none").timeout_header_seconds(), None);
+    }
+
+    /// Issue #1584: an expired deadline OMITS the header (returns `None`)
+    /// rather than advertising `0`, which every receiver reads as "unset".
+    #[tokio::test]
+    async fn timeout_header_seconds_none_when_expired() {
+        let ctx = JobContext::with_timeout("job-expired", Duration::from_millis(20));
+        sleep(Duration::from_millis(80)).await;
+        assert_eq!(ctx.remaining_seconds(), Some(0));
+        assert_eq!(ctx.timeout_header_seconds(), None);
     }
 
     #[tokio::test]
@@ -353,6 +491,52 @@ mod tests {
         let h = captured.lock().await;
         assert!(h.get("x-mesh-job-id").is_none());
         assert!(h.get("x-mesh-timeout").is_none());
+    }
+
+    /// Issue #1584 end-to-end over a real request: a job whose deadline has
+    /// blown sends `X-Mesh-Job-Id` and NO `X-Mesh-Timeout`. Before the fix it
+    /// sent `X-Mesh-Timeout: 0`, which the receiver treats as "unset" and
+    /// replaces with its own (much larger) default budget — silently losing
+    /// the parent's deadline cap.
+    #[tokio::test]
+    async fn inject_job_headers_omits_timeout_when_deadline_expired() {
+        let (port, captured, server) = spawn_header_capture_server().await;
+        let url = format!("http://127.0.0.1:{}/echo", port);
+        let client = reqwest::Client::new();
+        let ctx = JobContext::with_timeout("job-blown", Duration::from_millis(20));
+        sleep(Duration::from_millis(80)).await;
+        with_job(ctx, async {
+            let req = inject_job_headers(client.get(&url));
+            let _ = req.send().await.unwrap();
+        })
+        .await;
+        server.await.unwrap();
+        let h = captured.lock().await;
+        assert_eq!(h.get("x-mesh-job-id").map(String::as_str), Some("job-blown"));
+        assert!(
+            h.get("x-mesh-timeout").is_none(),
+            "expired deadline must OMIT X-Mesh-Timeout, got {:?}",
+            h.get("x-mesh-timeout")
+        );
+    }
+
+    /// Issue #1584: a live but sub-second budget is advertised as `1` (the
+    /// tightest value the `minimum: 1` wire schema can carry), never `0`.
+    #[tokio::test]
+    async fn inject_job_headers_floors_sub_second_budget_at_one() {
+        let (port, captured, server) = spawn_header_capture_server().await;
+        let url = format!("http://127.0.0.1:{}/echo", port);
+        let client = reqwest::Client::new();
+        let ctx = JobContext::with_timeout("job-tight", Duration::from_millis(700));
+        with_job(ctx, async {
+            let req = inject_job_headers(client.get(&url));
+            let _ = req.send().await.unwrap();
+        })
+        .await;
+        server.await.unwrap();
+        let h = captured.lock().await;
+        let timeout = h.get("x-mesh-timeout").expect("X-Mesh-Timeout missing");
+        assert_eq!(timeout, "1", "sub-second budget must floor at 1, not 0");
     }
 
     #[tokio::test]

--- a/src/runtime/core/src/jobs.rs
+++ b/src/runtime/core/src/jobs.rs
@@ -8,7 +8,7 @@
 //! v1"). TODO(phase 2/3): SQLite backing for crash-survival across replica
 //! restarts.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -302,6 +302,65 @@ async fn flush_once(
 /// match at seq N no longer skips a type-B event at seq < N. A NEW
 /// controller for the same `job_id` starts every cursor at seq=0 — replay
 /// is per-instance, per filter.
+// =============================================================================
+// JobController event-read tuning (issue #1585)
+// =============================================================================
+
+/// Per-round long-poll cap. Matches the registry's server-side ceiling
+/// (`wait` query param `maximum: 60`); requesting longer is silently
+/// truncated there, so `recv_event` loops client-side instead.
+const REGISTRY_LONG_POLL_CAP: Duration = Duration::from_secs(60);
+
+/// Page size for `GET /jobs/{id}/events` reads. Matches the OpenAPI `limit`
+/// maximum, and is shared by [`JobController::recv_event`] and
+/// [`JobProxy::list_events`] so the two cannot drift.
+///
+/// `recv_event` hands the handler ONE event per call but keeps the rest of the
+/// page in [`JobController::pending`], so a full page costs one round trip
+/// instead of one per event (issue #1585). `list_events` returns the whole
+/// page to its caller.
+const JOB_EVENTS_FETCH_LIMIT: usize = 100;
+
+/// Maximum age of a [`JobController::pending`] read-ahead buffer before
+/// `recv_event` discards it and does a real registry round trip instead —
+/// applied ONLY to controllers that carry a claim epoch, i.e. whose reads
+/// carry executor identity.
+///
+/// This exists because such a read renews `lease_expires_at` server-side
+/// (`AuthorizeExecutorRead` → `ExecutorReadExtended`) and is the only place
+/// a superseding claim is detected. Nothing else renews the lease on a
+/// schedule. The bound is what keeps the buffer from starving that signal.
+///
+/// 2s is deliberately far below the smallest lease the registry grants: the
+/// window is `max_duration` when declared and `defaultClaimLeaseSeconds`
+/// (300s) otherwise, so the worst case this adds is 2s of extra exposure on
+/// top of the handler's own gap between `recv_event` calls — under 1% of the
+/// default window. The trade lands where it should: a handler draining a page
+/// faster than 2s pays ONE round trip for the whole page (the #1585 win),
+/// while a handler slow enough for the lease to matter reads at least every
+/// 2s, which is no worse than the per-call read it had before #1585.
+///
+/// The one shape this does not cover is a job declaring `max_duration` below
+/// 2s. Such a job is already a coin flip — a single long-poll round trip can
+/// outlive its whole lease — and the controller is not told `max_duration`
+/// (it is not on `JobController`, only on the claim response), so deriving an
+/// exact fraction would mean threading it through the pyo3/napi/C constructors
+/// of all three bindings. Left as a documented edge rather than an ABI change.
+const RECV_READAHEAD_MAX_AGE: Duration = Duration::from_secs(2);
+
+/// Client-side floor between two [`JobController::recv_event`] round trips
+/// when the registry answered an empty page earlier than the wait we asked
+/// for.
+///
+/// The `wait` query param is whole seconds, so a sub-second long-poll budget
+/// goes out as `wait=0` and comes straight back. Without this floor the last
+/// sub-second of every budget — and the whole of any `timeout_secs < 1` —
+/// was a tight GET loop against the registry (issue #1585). 100ms matches the
+/// registry's own inner long-poll resolution
+/// (`listJobEventsPollResolution` in `ent_service_jobs.go`), so pacing here
+/// costs no wake-up latency the server side wasn't already imposing.
+const EMPTY_PAGE_POLL_PACE: Duration = Duration::from_millis(100);
+
 #[derive(Clone)]
 pub struct JobController {
     job_id: String,
@@ -380,6 +439,47 @@ pub struct JobController {
     /// small entry per distinct filter the handler uses (bounded), never per
     /// event.
     recv_locks: Arc<std::sync::Mutex<HashMap<String, Arc<Mutex<()>>>>>,
+    /// Per-filter READ-AHEAD buffer over the tail of the last fetched page
+    /// (issue #1585), paired with the [`Instant`] of the round trip that
+    /// filled it. `list_job_events` returns up to [`JOB_EVENTS_FETCH_LIMIT`]
+    /// events per round trip but `recv_event` hands back exactly one; before
+    /// #1585 the other 99 were thrown away and re-fetched — a job that posts
+    /// N events cost N registry round trips to drain, each transferring up to
+    /// 100 rows. The tail now stays here and later calls on the SAME filter
+    /// drain it locally.
+    ///
+    /// # Why the timestamp is not optional
+    ///
+    /// An executor read (one carrying `(instance_id, claim_epoch)`) is not
+    /// just a read — it is this execution's LIVENESS SIGNAL. The registry's
+    /// `AuthorizeExecutorRead` extends `lease_expires_at` on every such read
+    /// (`ent_service_jobs.go`, `ExecutorReadExtended`) and it is also where a
+    /// stale `(owner, epoch)` pair is fenced as `claim_superseded`. Nothing
+    /// else in this controller renews the lease on a schedule: only
+    /// `update_progress` / `request_input` deltas extend it, and neither is
+    /// mandatory. So "a healthy handler renews its lease on every poll" — the
+    /// registry says exactly that at `ent_handlers_jobs.go` — was load-bearing,
+    /// and an unbounded buffer would have broken it: a handler spending 5s per
+    /// event on a 100-event page would go ~500s without a read against a 300s
+    /// default lease (`defaultClaimLeaseSeconds`), get reclaimed mid-flight by
+    /// the expired-lease sweep, and only discover it was fenced once the
+    /// buffer drained.
+    ///
+    /// [`RECV_READAHEAD_MAX_AGE`] bounds that: a buffer older than it is
+    /// discarded and the page refetched, which renews the lease and re-checks
+    /// fencing. The refetch is free of correctness risk because `cursors[K]`
+    /// sits at the last RETURNED event, so it returns exactly the discarded
+    /// events again (plus anything new).
+    ///
+    /// # Interaction with the cursors above
+    ///
+    /// `cursors[K]` is advanced ONLY when an event is RETURNED to the handler,
+    /// never at fetch time. So the durable-resume contract is unchanged — a
+    /// crash with a full buffer leaves both cursors behind the buffered seqs
+    /// and the re-claim replays them from the registry (at-least-once, never
+    /// skip). Access is under filter K's `recv_locks` entry, same as the
+    /// cursor window.
+    pending: Arc<std::sync::Mutex<HashMap<String, (Instant, VecDeque<JobEvent>)>>>,
 }
 
 impl JobController {
@@ -430,7 +530,56 @@ impl JobController {
             cursors: Arc::new(std::sync::Mutex::new(seed.clone())),
             durable_cursors: Arc::new(std::sync::Mutex::new(seed)),
             recv_locks: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            pending: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Pop the next read-ahead event for filter `key`, if the previous round
+    /// trip left one buffered AND that buffer is still fresh enough to serve
+    /// (issue #1585). Removes the map entry once the buffer drains — or as
+    /// soon as it goes stale — so the map stays bounded by the number of
+    /// distinct filters in use, not by event volume.
+    ///
+    /// `renew_by` is the age at which the buffer must be abandoned in favour
+    /// of a real round trip. It is `Some` exactly when this controller sends
+    /// executor identity on reads (`claim_epoch.is_some()`), because that is
+    /// the case where a read has REGISTRY-SIDE EFFECTS — lease renewal and
+    /// claim fencing — that serving from a local buffer would skip. See the
+    /// `pending` field docs. A push-mode / legacy controller reads
+    /// anonymously (no lease, no fencing), so its buffer has no expiry.
+    ///
+    /// Callers MUST hold filter `key`'s `recv_locks` entry — the pop and the
+    /// subsequent `cursors[key]` advance have to be atomic with respect to a
+    /// concurrent same-filter `recv_event`, exactly as the fetch path's
+    /// load→list→store window is.
+    fn take_pending(&self, key: &str, renew_by: Option<Duration>) -> Option<JobEvent> {
+        let mut pending = self.pending.lock().expect("pending poisoned");
+        let (filled_at, buf) = pending.get_mut(key)?;
+        if let Some(max_age) = renew_by {
+            if filled_at.elapsed() >= max_age {
+                // Stale: drop it and let the caller do a real round trip, which
+                // renews the lease and re-checks fencing. `cursors[key]` still
+                // points at the last RETURNED event, so the refetch re-reads
+                // exactly what we are throwing away.
+                pending.remove(key);
+                return None;
+            }
+        }
+        let ev = buf.pop_front();
+        if buf.is_empty() {
+            pending.remove(key);
+        }
+        ev
+    }
+
+    /// The age at which this controller's read-ahead buffers must be
+    /// abandoned in favour of a real registry round trip, or `None` when they
+    /// never need to be.
+    ///
+    /// `Some` iff this controller carries a claim epoch, i.e. iff its reads
+    /// carry executor identity and therefore renew the lease / can be fenced.
+    fn readahead_max_age(&self) -> Option<Duration> {
+        self.claim_epoch.map(|_| RECV_READAHEAD_MAX_AGE)
     }
 
     /// Canonical identity of a `recv_event` type filter, used as the
@@ -516,6 +665,15 @@ impl JobController {
                 *e = v;
             }
         }
+    }
+
+    /// Test-only snapshot of the RECEIPT cursors (the ones that advance when
+    /// an event is handed to the handler). Used by the #1585 read-ahead tests
+    /// to prove the page buffer never runs the cursor past an unreturned
+    /// event.
+    #[cfg(test)]
+    fn cursors_snapshot(&self) -> HashMap<String, i64> {
+        self.cursors.lock().expect("cursors poisoned").clone()
     }
 
     /// Snapshot the lagging durable cursors to stamp onto an outgoing
@@ -848,6 +1006,14 @@ impl JobController {
     /// the registry's 60s cap until an event arrives). `Some(d)` returns
     /// `Ok(None)` once roughly `d` has elapsed without a matching event.
     ///
+    /// `Some(0)` — and any budget already spent by the time the call arrives —
+    /// is a SINGLE IMMEDIATE READ (issue #1585): one non-blocking round trip,
+    /// then `Ok(None)` if it found nothing. Before #1585 it did no read at
+    /// all, so an event already sitting in the log was invisible to it. The
+    /// one qualification: with no budget left there is nothing to wait for the
+    /// per-filter serialization lock with, so if a concurrent same-filter call
+    /// already holds it, this returns `Ok(None)` without reading.
+    ///
     /// Trace context: when an event with `trace_context` is returned, the
     /// field is passed through verbatim on [`JobEvent::trace_context`].
     /// TODO: wire OpenTelemetry child-span creation when the core crate
@@ -888,13 +1054,6 @@ impl JobController {
         types: Option<Vec<String>>,
         timeout: Option<Duration>,
     ) -> Result<Option<JobEvent>, JobError> {
-        // Per-round long-poll cap. Matches the registry's server-side
-        // ceiling (`wait` query param ≤ 60s); requesting longer is
-        // silently truncated, so we loop client-side instead.
-        const REGISTRY_LONG_POLL_CAP: Duration = Duration::from_secs(60);
-        // Server-side limit (matches OpenAPI `limit` maximum).
-        const FETCH_LIMIT: usize = 100;
-
         // Per-filter cursor + serialization (issue #1252 Phase 3). This
         // filter's identity keys BOTH its cursor and its serialization lock.
         // Hold ONLY this filter's lock across the load→list→store window:
@@ -938,7 +1097,26 @@ impl JobController {
         // `timeout` is `None` — so an untimed, uncancellable call simply awaits
         // the lock. Once acquired, the loop below derives every poll's budget
         // from `deadline`, so wait-on-lock time is already subtracted.
-        let _guard = {
+        //
+        // Special case: a budget that is ALREADY spent on arrival — `timeout =
+        // Some(0)` (the "single immediate read" shape), or a caller whose
+        // budget elapsed before it got here. The `select!` below is `biased`
+        // and would poll the already-elapsed `deadline_sleep` before the lock,
+        // so routing that case through it makes the single read a RACE: it
+        // only happens when tokio's ms-granularity sleep rounding leaves the
+        // timer not-yet-ready, which under real same-filter contention it
+        // won't be. Decide it explicitly instead: take the lock if it is free
+        // and do the one read, otherwise return `Ok(None)` immediately —
+        // there is by definition no budget left to wait for the lock with.
+        // (A fired cancel still wins: the loop below re-reads the cancel token
+        // and returns `Cancelled` before issuing any read.)
+        let already_spent = deadline.is_some_and(|d| Instant::now() >= d);
+        let _guard = if already_spent {
+            match filter_lock.try_lock() {
+                Ok(g) => g,
+                Err(_) => return Ok(None),
+            }
+        } else {
             let deadline_sleep = async {
                 match deadline {
                     Some(d) => tokio::time::sleep_until(d).await,
@@ -975,6 +1153,14 @@ impl JobController {
         // `POLL_MAX_MS` — same shape as `JobProxy::wait_with_config`.
         let mut backoff_ms = POLL_INITIAL_MS;
 
+        // Round-trip counter, paired with the `already_spent` branch above:
+        // `timeout = Some(0)` (and any budget elapsed on arrival) still gets
+        // ONE non-blocking read (issue #1585). Before that, an expired budget
+        // returned `Ok(None)` having never looked at the log, so
+        // `recv_event(timeout_secs=0)` could not observe an event that was
+        // already sitting there.
+        let mut rounds: u64 = 0;
+
         loop {
             // Honour the caller's overall timeout BEFORE issuing the next
             // long-poll round-trip so a tight `timeout` doesn't get one
@@ -983,9 +1169,15 @@ impl JobController {
                 Some(d) => {
                     let now = Instant::now();
                     if now >= d {
-                        return Ok(None);
+                        if rounds > 0 {
+                            return Ok(None);
+                        }
+                        // First pass on an already-spent budget: fall through
+                        // with a zero-length wait (a single immediate read).
+                        Some(Duration::ZERO)
+                    } else {
+                        Some(d - now)
                     }
-                    Some(d - now)
                 }
                 None => None,
             };
@@ -1025,6 +1217,25 @@ impl JobController {
                 }
             }
 
+            // Read-ahead buffer first (issue #1585): the previous round trip
+            // fetched up to JOB_EVENTS_FETCH_LIMIT events and returned one;
+            // the rest are here. Serve them locally instead of re-fetching the
+            // same page — but only while the buffer is younger than
+            // `readahead_max_age()`, because for a claimed controller a real
+            // read is what renews the lease and re-checks claim fencing (see
+            // the `pending` field docs). Deliberately AFTER the cancel check
+            // above so a fired cancel still wins over a buffered event.
+            // `cursors[K]` advances here — at RETURN — exactly as it does on
+            // the fetch path, so the durable-resume contract is untouched.
+            if let Some(ev) = self.take_pending(&key, self.readahead_max_age()) {
+                let mut cursors = self.cursors.lock().expect("cursors poisoned");
+                let cur = cursors.entry(key.clone()).or_insert(0);
+                if ev.seq > *cur {
+                    *cur = ev.seq;
+                }
+                return Ok(Some(ev));
+            }
+
             // Read THIS filter's cursor (default 0 for a never-consumed
             // filter). The per-filter lock above serializes same-filter
             // callers, so the load→list→store window is race-free.
@@ -1043,12 +1254,23 @@ impl JobController {
             let identity = self
                 .claim_epoch
                 .map(|epoch| (self.instance_id.as_str(), epoch));
-            let list_fut =
-                self.backend
-                    .list_job_events(&self.job_id, after, types_ref, wait, FETCH_LIMIT, identity);
+            rounds += 1;
+            let list_fut = self.backend.list_job_events(
+                &self.job_id,
+                after,
+                types_ref,
+                wait,
+                JOB_EVENTS_FETCH_LIMIT,
+                identity,
+            );
             // Race the long-poll against the cancel token so a cancel fired
             // mid-poll returns immediately instead of after the registry's
             // 60s cap. Poll cadence / backoff are otherwise unchanged.
+            //
+            // `round_started` feeds the empty-page pacing below: it tells us
+            // whether the registry actually held the request for the `wait`
+            // we asked for, or answered early (issue #1585).
+            let round_started = Instant::now();
             let list_result = match &cancel_token {
                 Some(tok) => {
                     tokio::select! {
@@ -1071,7 +1293,25 @@ impl JobController {
                     // the head and advance THIS filter's cursor to its seq so
                     // the next same-filter call picks up strictly after it.
                     // Advance monotonically (never retreat).
-                    if let Some(ev) = resp.events.into_iter().next() {
+                    let mut page = resp.events.into_iter();
+                    if let Some(ev) = page.next() {
+                        // Park the REST of the page (issue #1585) so the next
+                        // same-filter `recv_event` serves it locally instead
+                        // of re-requesting the identical rows. Only `cursors`
+                        // — advanced below for the event we actually return —
+                        // is durable state; the buffer is best-effort and
+                        // simply re-fetched if this process dies.
+                        let tail: VecDeque<JobEvent> = page.collect();
+                        if !tail.is_empty() {
+                            // Stamp the buffer with the time of THIS round
+                            // trip: that is the moment the lease was last
+                            // renewed, and the clock `take_pending` measures
+                            // staleness against.
+                            self.pending
+                                .lock()
+                                .expect("pending poisoned")
+                                .insert(key.clone(), (round_started, tail));
+                        }
                         let mut cursors = self.cursors.lock().expect("cursors poisoned");
                         let cur = cursors.entry(key.clone()).or_insert(0);
                         if ev.seq > *cur {
@@ -1103,8 +1343,53 @@ impl JobController {
                             *cur = resp.next_after;
                         }
                     }
-                    // No event yet — loop. The deadline check at the top
-                    // of the next iteration returns Ok(None) if expired.
+                    // No event yet — pace, then loop. The deadline check at
+                    // the top of the next iteration returns Ok(None) if
+                    // expired.
+                    //
+                    // Pacing exists because the round trip can come back
+                    // EARLIER than the wait we asked for, and when it does
+                    // this loop had nothing to stop it re-requesting
+                    // immediately. The routine case is the wire format: the
+                    // `wait` query param is whole seconds, so
+                    // `RegistryHttpBackend` truncates and any `wait` under one
+                    // second goes out as `wait=0` and is answered instantly —
+                    // which made `timeout_secs < 1`, and the last sub-second
+                    // of EVERY budget, a tight GET loop against the registry
+                    // (issue #1585). Keying off "returned early" rather than
+                    // "wait < 1s" also covers a registry (or an ingress in
+                    // front of it) that short-circuits a longer long-poll.
+                    //
+                    // Sleep at most one poll interval, bounded by both the
+                    // unserved part of this round's wait and whatever is left
+                    // of the caller's budget, so pacing never overshoots the
+                    // deadline. Race the cancel token so a cancel during the
+                    // nap is still prompt.
+                    let served = round_started.elapsed();
+                    if served < wait {
+                        let mut nap = EMPTY_PAGE_POLL_PACE.min(wait - served);
+                        if let Some(d) = deadline {
+                            let now = Instant::now();
+                            if now >= d {
+                                // Budget spent; the next iteration returns
+                                // Ok(None) without sleeping at all.
+                                continue;
+                            }
+                            nap = nap.min(d - now);
+                        }
+                        if !nap.is_zero() {
+                            match &cancel_token {
+                                Some(tok) => {
+                                    tokio::select! {
+                                        biased;
+                                        _ = tok.cancelled() => return Err(JobError::Cancelled),
+                                        _ = sleep(nap) => {}
+                                    }
+                                }
+                                None => sleep(nap).await,
+                            }
+                        }
+                    }
                 }
                 Err(BackendError::ClaimSuperseded(_)) => {
                     // The registry fenced this executor read: a newer claim
@@ -1316,21 +1601,37 @@ impl JobProxy {
         types: Option<Vec<String>>,
         wait: Option<Duration>,
     ) -> Result<(Vec<JobEvent>, i64), JobError> {
-        // Server-side limit (matches OpenAPI `limit` maximum).
-        const FETCH_LIMIT: usize = 100;
+        let requested = wait.unwrap_or_default();
         let resp = self
             .backend
             .list_job_events(
                 &self.job_id,
                 after,
                 types.as_deref(),
-                wait.unwrap_or_default(),
-                FETCH_LIMIT,
+                requested,
+                JOB_EVENTS_FETCH_LIMIT,
                 // Observer read: JobProxy never claims — no executor identity,
                 // no lease side-effects (A2A / UI / meshctl all rely on this).
                 None,
             )
             .await?;
+        // The registry's `wait` query param is WHOLE SECONDS, so a fractional
+        // budget loses its sub-second remainder on the wire: `Some(500ms)`
+        // goes out as `wait=0` and comes straight back empty, turning the
+        // caller's `subscribe_events` loop into a tight GET loop (issue
+        // #1585). Absorb ONLY the truncated remainder here, and only on an
+        // empty page. Two things this deliberately does NOT do: it never
+        // sleeps for a whole-second budget (30.0 has no remainder, so an
+        // in-process/mock backend answering instantly still returns
+        // instantly), and it never turns `Some(0)` — the documented
+        // "single immediate read" / tight-poll opt-in — into a wait.
+        if resp.events.is_empty() {
+            let capped = requested.min(REGISTRY_LONG_POLL_CAP);
+            let remainder = capped - Duration::from_secs(capped.as_secs());
+            if !remainder.is_zero() {
+                sleep(remainder).await;
+            }
+        }
         Ok((resp.events, resp.next_after))
     }
 
@@ -1338,6 +1639,13 @@ impl JobProxy {
     /// payload, or surfaces an error. Convenience wrapper around
     /// [`Self::wait_with_config`] that uses [`WaitConfig::default`] for
     /// the resilience window (60s).
+    ///
+    /// `timeout`: `None` blocks until the job is terminal. `Some(0)` — and
+    /// any already-elapsed budget — performs a SINGLE immediate `get_job`
+    /// and then reports `JobError::Timeout` if the job is still running
+    /// (issue #1584); it is not "no timeout". Only the C-ABI surfaces use a
+    /// NEGATIVE value to mean "absent", and they convert it to `None` before
+    /// it reaches here.
     ///
     /// Honours:
     /// 1. Caller-supplied `timeout` (returns `JobError::Timeout`).
@@ -1386,11 +1694,21 @@ impl JobProxy {
         // Tracks the start of the current contiguous transient-failure
         // window. `None` after every successful poll.
         let mut transient_failure_started: Option<Instant> = None;
+        // Round-trip counter. A zero-length (or already-elapsed) budget still
+        // gets ONE `get_job` before timing out — the same "single immediate
+        // read" semantics `recv_event` has for `Some(0)` (issue #1584/#1585).
+        // Without it the deadline check below ran BEFORE the first poll, so
+        // `wait(Some(ZERO))` reported a timeout on a job that had already
+        // completed, and the Java `await(id, 0.0)` surface documented a
+        // behaviour ("no timeout, block until terminal") that no longer held
+        // once the C-ABI sentinel was narrowed to negatives only.
+        let mut rounds: u64 = 0;
 
         loop {
-            // Check absolute deadline first (cheap).
+            // Check absolute deadline first (cheap) — but never before the
+            // first poll; see `rounds`.
             if let Some(d) = effective_deadline {
-                if Instant::now() >= d {
+                if rounds > 0 && Instant::now() >= d {
                     return Err(JobError::Timeout(config.timeout.unwrap_or_default()));
                 }
             }
@@ -1403,6 +1721,7 @@ impl JobProxy {
             }
 
             // Poll the registry.
+            rounds += 1;
             match self.backend.get_job(&self.job_id).await {
                 Ok(job) => {
                     // Recovered: drop any in-flight transient window.
@@ -3057,6 +3376,38 @@ mod tests {
 
     /// Build a working JobController against a fresh MockBackend with the
     /// given job_id pre-created in the backend's job map.
+    /// Seed a bare job row on the mock so `JobProxy` tests can drive
+    /// `get_job` without hand-rolling the whole struct each time.
+    fn seed_job(
+        backend: &Arc<MockBackend>,
+        job_id: &str,
+        status: JobStatus,
+        result: Option<serde_json::Value>,
+    ) {
+        backend.jobs.lock().unwrap().insert(
+            job_id.to_string(),
+            Job {
+                id: job_id.to_string(),
+                capability: "cap".into(),
+                owner_instance_id: None,
+                status,
+                progress: None,
+                progress_message: None,
+                result,
+                error: None,
+                submitted_payload: serde_json::json!({}),
+                attempt_count: 0,
+                max_retries: 1,
+                max_duration: None,
+                total_deadline: None,
+                lease_expires_at: None,
+                last_heartbeat_at: None,
+                submitted_at: 0,
+                submitted_by: "client-1".into(),
+            },
+        );
+    }
+
     async fn make_controller(job_id: &str) -> (Arc<MockBackend>, JobController) {
         let backend = MockBackend::new();
         backend.jobs.lock().unwrap().insert(
@@ -3474,6 +3825,311 @@ mod tests {
             .await
             .unwrap();
         assert!(result.is_none(), "expected timeout (None), got {:?}", result);
+    }
+
+    // ---- issue #1585: sub-second waits / page read-ahead --------------------
+
+    /// A sub-second `timeout` used to be a tight GET loop: the wire's `wait`
+    /// param is whole seconds, so anything under 1s went out as `wait=0`, the
+    /// registry answered instantly, and `recv_event` immediately re-requested
+    /// with no pacing at all. The mock reproduces that exactly (it never
+    /// long-polls), so the round-trip count is a direct measurement.
+    ///
+    /// With `EMPTY_PAGE_POLL_PACE` = 100ms, a 500ms budget is ~5 round trips.
+    /// The pre-fix loop managed thousands. The bound here is deliberately
+    /// generous (25) so it measures "paced" vs "unpaced", not scheduler jitter.
+    #[tokio::test]
+    async fn recv_event_sub_second_timeout_does_not_hot_loop() {
+        let (backend, ctrl) = make_controller("j-1585-subsec").await;
+
+        let result = ctrl
+            .recv_event(None, Some(Duration::from_millis(500)))
+            .await
+            .unwrap();
+        assert!(result.is_none(), "expected timeout, got {:?}", result);
+
+        let rounds = backend.list_identities().len();
+        assert!(
+            rounds <= 25,
+            "sub-second recv_event must be paced, not a hot loop; \
+             issued {rounds} registry round trips for a 500ms budget"
+        );
+        assert!(rounds >= 1, "must issue at least one read");
+    }
+
+    /// Same defect, different entry: the LAST sub-second of any budget. A
+    /// whole-second budget spends its final <1s remainder at `wait=0`, so the
+    /// pacing has to apply there too.
+    #[tokio::test]
+    async fn recv_event_multi_second_timeout_paces_its_sub_second_tail() {
+        let (backend, ctrl) = make_controller("j-1585-tail").await;
+
+        let result = ctrl
+            .recv_event(None, Some(Duration::from_millis(1_200)))
+            .await
+            .unwrap();
+        assert!(result.is_none());
+
+        let rounds = backend.list_identities().len();
+        assert!(
+            rounds <= 40,
+            "sub-second tail must be paced; issued {rounds} round trips"
+        );
+    }
+
+    /// `timeout = Some(0)` is the documented "single immediate read". Before
+    /// #1585 the deadline check ran BEFORE the first round trip, so a
+    /// zero-length budget returned `Ok(None)` having never looked at the
+    /// event log — even when a matching event was already sitting in it.
+    #[tokio::test]
+    async fn recv_event_zero_timeout_still_reads_once() {
+        let (backend, ctrl) = make_controller("j-1585-zero").await;
+        backend.push_event("j-1585-zero", "ping", serde_json::json!({"n": 1}));
+
+        let ev = ctrl
+            .recv_event(None, Some(Duration::ZERO))
+            .await
+            .unwrap()
+            .expect("timeout=0 must still perform one immediate read");
+        assert_eq!(ev.seq, 1);
+        assert_eq!(backend.list_identities().len(), 1, "exactly one round trip");
+    }
+
+    /// `JobProxy::wait(Some(0))` is the same single-immediate-read shape as
+    /// `recv_event(Some(0))` (issue #1584). Before the fix the deadline check
+    /// ran BEFORE the first `get_job`, so a zero-length budget reported a
+    /// timeout on a job that had already completed — and the Java
+    /// `await(id, 0.0)` surface still documented it as "no timeout, block
+    /// until terminal", which stopped being true once the C-ABI absence
+    /// sentinel was narrowed to negatives only.
+    #[tokio::test]
+    async fn proxy_wait_zero_timeout_still_polls_once() {
+        let backend = MockBackend::new();
+        seed_job(&backend, "j-1584-wait-zero", JobStatus::Completed, Some(serde_json::json!({"n": 7})));
+        let proxy = JobProxy::new("j-1584-wait-zero", backend.clone() as Arc<dyn TaskBackend>);
+
+        let out = proxy
+            .wait(Some(Duration::ZERO))
+            .await
+            .expect("a terminal job must be observed by the single immediate read");
+        assert_eq!(out, serde_json::json!({"n": 7}));
+    }
+
+    /// ...and a zero budget on a job that is still running times out after
+    /// exactly one poll rather than looping.
+    #[tokio::test]
+    async fn proxy_wait_zero_timeout_times_out_after_one_poll() {
+        let backend = MockBackend::new();
+        seed_job(&backend, "j-1584-wait-zero-run", JobStatus::Working, None);
+        let proxy = JobProxy::new("j-1584-wait-zero-run", backend.clone() as Arc<dyn TaskBackend>);
+
+        let err = proxy.wait(Some(Duration::ZERO)).await.unwrap_err();
+        assert!(matches!(err, JobError::Timeout(_)), "got {err:?}");
+    }
+
+    /// ...and that single read must not turn into a loop when the log is
+    /// empty: `timeout = Some(0)` reads once and gives up.
+    #[tokio::test]
+    async fn recv_event_zero_timeout_reads_exactly_once_when_empty() {
+        let (backend, ctrl) = make_controller("j-1585-zero-empty").await;
+
+        let result = ctrl.recv_event(None, Some(Duration::ZERO)).await.unwrap();
+        assert!(result.is_none());
+        assert_eq!(backend.list_identities().len(), 1);
+    }
+
+    /// The registry returns up to 100 events per round trip; `recv_event`
+    /// hands back one. Before #1585 the other 99 were discarded and
+    /// re-fetched, so draining N events cost N round trips. They are now
+    /// buffered per filter: N events, ONE round trip.
+    #[tokio::test]
+    async fn recv_event_serves_the_rest_of_the_page_without_re_fetching() {
+        let (backend, ctrl) = make_controller("j-1585-page").await;
+        for i in 1..=5 {
+            backend.push_event("j-1585-page", "tick", serde_json::json!({"n": i}));
+        }
+
+        for expected_seq in 1..=5i64 {
+            let ev = ctrl
+                .recv_event(None, Some(Duration::from_secs(2)))
+                .await
+                .unwrap()
+                .expect("event");
+            assert_eq!(ev.seq, expected_seq);
+            assert_eq!(ev.payload, Some(serde_json::json!({"n": expected_seq})));
+        }
+        assert_eq!(
+            backend.list_identities().len(),
+            1,
+            "five events from one page must cost ONE registry round trip"
+        );
+    }
+
+    /// Issue #1585 BLOCKER: the read-ahead buffer must not starve the
+    /// executor's liveness signal.
+    ///
+    /// An identity-carrying `GET /jobs/{id}/events` is what renews
+    /// `lease_expires_at` server-side (`AuthorizeExecutorRead` →
+    /// `ExecutorReadExtended`) and the only place a superseding claim is
+    /// detected. Nothing else in `JobController` renews on a schedule. An
+    /// unbounded buffer therefore turned a 100-event page into ONE liveness
+    /// signal for the whole drain — a handler spending seconds per event would
+    /// be reclaimed mid-flight by the expired-lease sweep and only find out
+    /// when the buffer ran dry.
+    ///
+    /// Drain five buffered events slowly (past `RECV_READAHEAD_MAX_AGE` each
+    /// time) and assert every one of them cost a real identity-carrying read.
+    #[tokio::test(start_paused = true)]
+    async fn recv_event_read_ahead_still_renews_the_lease_on_a_slow_drain() {
+        let (backend, ctrl) = make_controller_with_epoch("j-1585-lease", Some(1), 1).await;
+        for _ in 0..5 {
+            backend.push_event("j-1585-lease", "tick", serde_json::json!({}));
+        }
+
+        for expected_seq in 1..=5i64 {
+            let ev = ctrl
+                .recv_event(None, Some(Duration::from_secs(2)))
+                .await
+                .unwrap()
+                .expect("event");
+            assert_eq!(ev.seq, expected_seq);
+            // Handler work: long enough that a lease renewal is due.
+            sleep(RECV_READAHEAD_MAX_AGE + Duration::from_millis(100)).await;
+        }
+
+        let identity_reads = backend
+            .list_identities()
+            .into_iter()
+            .filter(|i| i.is_some())
+            .count();
+        assert_eq!(
+            identity_reads, 5,
+            "a slow drain must renew the lease per event, not serve 4 of 5 \
+             events from a stale buffer"
+        );
+    }
+
+    /// The other half of the trade: a FAST drain still collapses to one round
+    /// trip even for a claimed (identity-carrying) controller, because the
+    /// buffer never goes stale within the drain.
+    #[tokio::test(start_paused = true)]
+    async fn recv_event_read_ahead_still_saves_round_trips_on_a_fast_drain() {
+        let (backend, ctrl) = make_controller_with_epoch("j-1585-fast", Some(1), 1).await;
+        for _ in 0..5 {
+            backend.push_event("j-1585-fast", "tick", serde_json::json!({}));
+        }
+
+        for expected_seq in 1..=5i64 {
+            let ev = ctrl
+                .recv_event(None, Some(Duration::from_secs(2)))
+                .await
+                .unwrap()
+                .expect("event");
+            assert_eq!(ev.seq, expected_seq);
+            // Well inside RECV_READAHEAD_MAX_AGE.
+            sleep(Duration::from_millis(10)).await;
+        }
+
+        assert_eq!(
+            backend.list_identities().len(),
+            1,
+            "a drain faster than the renewal window must still cost ONE read"
+        );
+    }
+
+    /// A push-mode / legacy controller (no claim epoch) reads anonymously —
+    /// no lease, no fencing — so its buffer has no expiry and a slow drain
+    /// still costs one round trip.
+    #[tokio::test(start_paused = true)]
+    async fn recv_event_read_ahead_has_no_expiry_without_an_epoch() {
+        let (backend, ctrl) = make_controller("j-1585-anon").await;
+        for _ in 0..3 {
+            backend.push_event("j-1585-anon", "tick", serde_json::json!({}));
+        }
+
+        for expected_seq in 1..=3i64 {
+            let ev = ctrl
+                .recv_event(None, Some(Duration::from_secs(2)))
+                .await
+                .unwrap()
+                .expect("event");
+            assert_eq!(ev.seq, expected_seq);
+            sleep(RECV_READAHEAD_MAX_AGE * 3).await;
+        }
+
+        assert_eq!(backend.list_identities().len(), 1);
+        assert!(
+            backend.list_identities().iter().all(|i| i.is_none()),
+            "a legacy controller must read anonymously"
+        );
+    }
+
+    /// The read-ahead buffer is PER FILTER — draining filter A must not
+    /// consume or reorder filter B's stream, and each filter keeps its own
+    /// cursor exactly as before.
+    #[tokio::test]
+    async fn recv_event_read_ahead_buffer_is_per_filter() {
+        let (backend, ctrl) = make_controller("j-1585-page-filter").await;
+        backend.push_event("j-1585-page-filter", "A", serde_json::json!({}));
+        backend.push_event("j-1585-page-filter", "B", serde_json::json!({}));
+        backend.push_event("j-1585-page-filter", "A", serde_json::json!({}));
+        backend.push_event("j-1585-page-filter", "B", serde_json::json!({}));
+
+        let a1 = ctrl
+            .recv_event(Some(vec!["A".into()]), Some(Duration::from_secs(2)))
+            .await
+            .unwrap()
+            .expect("A1");
+        assert_eq!(a1.seq, 1);
+        // Served from filter A's buffer — no new round trip.
+        let a2 = ctrl
+            .recv_event(Some(vec!["A".into()]), Some(Duration::from_secs(2)))
+            .await
+            .unwrap()
+            .expect("A2");
+        assert_eq!(a2.seq, 3);
+        // Filter B has its own cursor and its own (empty) buffer, so it still
+        // sees seq=2 first even though A consumed past it.
+        let b1 = ctrl
+            .recv_event(Some(vec!["B".into()]), Some(Duration::from_secs(2)))
+            .await
+            .unwrap()
+            .expect("B1");
+        assert_eq!(b1.seq, 2);
+        let b2 = ctrl
+            .recv_event(Some(vec!["B".into()]), Some(Duration::from_secs(2)))
+            .await
+            .unwrap()
+            .expect("B2");
+        assert_eq!(b2.seq, 4);
+    }
+
+    /// The buffer must never advance a cursor past an event the handler has
+    /// not been handed — that is what keeps the durable-resume contract
+    /// (#1277) at-least-once. After ONE `recv_event` off a 3-event page, the
+    /// cursor sits at seq=1, not seq=3.
+    #[tokio::test]
+    async fn recv_event_read_ahead_does_not_advance_cursor_past_unreturned_events() {
+        let (backend, ctrl) = make_controller("j-1585-cursor").await;
+        for _ in 0..3 {
+            backend.push_event("j-1585-cursor", "tick", serde_json::json!({}));
+        }
+
+        let ev = ctrl
+            .recv_event(None, Some(Duration::from_secs(2)))
+            .await
+            .unwrap()
+            .expect("event");
+        assert_eq!(ev.seq, 1);
+        assert_eq!(
+            ctrl.cursors_snapshot().get(""),
+            Some(&1),
+            "cursor must track the RETURNED event, not the fetched page"
+        );
+        // The lagging durable cursor is still behind that, so a crash here
+        // replays seq 1..=3 from the registry rather than skipping the two
+        // events that only ever existed in the local buffer.
+        assert_eq!(ctrl.durable_snapshot().and_then(|m| m.get("").copied()), Some(0));
     }
 
     #[tokio::test]
@@ -4642,6 +5298,86 @@ mod tests {
         let proxy = JobProxy::new("j-list-empty", backend.clone() as Arc<dyn TaskBackend>);
         let (events, _next_after) = proxy.list_events(0, None, None).await.unwrap();
         assert!(events.is_empty());
+    }
+
+    /// Issue #1585: the registry's `wait` param is whole seconds, so a
+    /// fractional long-poll budget lost its sub-second remainder on the wire
+    /// and came straight back — turning a `subscribe_events(long_poll_secs=0.5)`
+    /// loop into a tight GET loop. `list_events` now absorbs the truncated
+    /// remainder itself when the page came back empty.
+    #[tokio::test]
+    async fn list_events_absorbs_the_truncated_sub_second_wait() {
+        let backend = MockBackend::new();
+        let proxy = JobProxy::new("j-1585-frac", backend.clone() as Arc<dyn TaskBackend>);
+        let started = std::time::Instant::now();
+        let (events, _) = proxy
+            .list_events(0, None, Some(Duration::from_millis(400)))
+            .await
+            .unwrap();
+        let elapsed = started.elapsed();
+        assert!(events.is_empty());
+        assert!(
+            elapsed >= Duration::from_millis(350),
+            "a 400ms budget must actually wait ~400ms, not return instantly; \
+             took {elapsed:?}"
+        );
+    }
+
+    /// The compensation is EXACTLY the truncated remainder — never more.
+    /// A whole-second budget has no remainder, so a backend that answers
+    /// instantly still returns instantly (this is what keeps in-process and
+    /// mock backends usable), and `Some(0)` stays the documented tight-poll
+    /// opt-in.
+    #[tokio::test]
+    async fn list_events_does_not_pad_whole_second_or_zero_waits() {
+        let backend = MockBackend::new();
+        let proxy = JobProxy::new("j-1585-whole", backend.clone() as Arc<dyn TaskBackend>);
+
+        let started = std::time::Instant::now();
+        let _ = proxy
+            .list_events(0, None, Some(Duration::from_secs(30)))
+            .await
+            .unwrap();
+        assert!(
+            started.elapsed() < Duration::from_millis(200),
+            "whole-second budget must not be padded client-side"
+        );
+
+        let started = std::time::Instant::now();
+        let _ = proxy
+            .list_events(0, None, Some(Duration::ZERO))
+            .await
+            .unwrap();
+        assert!(
+            started.elapsed() < Duration::from_millis(200),
+            "Some(0) is the documented single-immediate-read"
+        );
+
+        let started = std::time::Instant::now();
+        let _ = proxy.list_events(0, None, None).await.unwrap();
+        assert!(
+            started.elapsed() < Duration::from_millis(200),
+            "None must stay a single immediate read"
+        );
+    }
+
+    /// A non-empty page returns as soon as it has data — the sub-second
+    /// compensation only applies when there was nothing to hand back.
+    #[tokio::test]
+    async fn list_events_does_not_pad_a_non_empty_page() {
+        let backend = MockBackend::new();
+        backend.push_event("j-1585-hit", "e", serde_json::json!({}));
+        let proxy = JobProxy::new("j-1585-hit", backend.clone() as Arc<dyn TaskBackend>);
+        let started = std::time::Instant::now();
+        let (events, _) = proxy
+            .list_events(0, None, Some(Duration::from_millis(900)))
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(
+            started.elapsed() < Duration::from_millis(200),
+            "an event was available; do not pad"
+        );
     }
 
     #[tokio::test]

--- a/src/runtime/core/src/jobs_ffi.rs
+++ b/src/runtime/core/src/jobs_ffi.rs
@@ -157,13 +157,10 @@ fn jobs_set_err(err: JobError) -> i32 {
     -1
 }
 
-// Stricter timeout-policy than mesh_job_proxy_wait's predicate (which
-// silently aliases NaN/Inf to "no timeout" for back-compat). New FFI
-// surfaces should adopt this form: surface callers' invalid inputs as
-// errors rather than aliasing — matches the napi/pyo3 `parse_timeout_secs`
-// helpers in jobs_napi.rs / jobs_py.rs. The two policies coexist
-// intentionally; do not unify without coordinating a deprecation cycle
-// for mesh_job_proxy_wait.
+// THE timeout policy for every FFI surface, `mesh_job_proxy_wait` included
+// (issue #1584 unified the last holdout, which used to alias NaN/Inf to "no
+// timeout"). Invalid inputs surface as errors rather than aliasing — matches
+// the napi/pyo3 `parse_timeout_secs` helpers in jobs_napi.rs / jobs_py.rs.
 /// Parse an FFI-supplied `timeout_secs` f64 into an `Option<Duration>`,
 /// using the negative-sentinel convention to bridge `Option<Duration>` over
 /// the C ABI (which cannot pass `null` doubles).
@@ -952,11 +949,17 @@ pub unsafe extern "C" fn mesh_job_proxy_status(
 /// `result` (JSON-encoded) to `*out_result_json`; caller frees via
 /// `mesh_free_string`.
 ///
-/// `timeout_secs`: wall-clock timeout. Any value `<= 0.0` (including
-/// `-0.0` and negatives such as `-1`) means "no timeout"; non-finite
-/// values (NaN, ±Inf) also fall back to "no timeout". Matches the
-/// Python / napi-rs `Optional<f64>` shape and keeps the same policy
-/// as [`mesh_run_as_job`] for consistency.
+/// `timeout_secs`: wall-clock timeout, under the ONE boundary policy shared
+/// by every binding (see the "f64-SECONDS BOUNDARY POLICY" note in
+/// `task_backend.rs`, issue #1584): negative (including `-1`, which is how
+/// Java expresses `Optional<Duration>::empty()` over a C ABI that has no
+/// nullable double) means "no timeout"; `0.0`/`-0.0` is a zero-length budget;
+/// NaN / ±Inf are ERRORS (`-1` return, message in the last-error slot).
+///
+/// The NaN/±Inf rejection is a #1584 change: this entry point used to alias
+/// them to "no timeout" while its sibling `mesh_job_controller_recv_event`
+/// rejected them, so the same bad input produced an unbounded wait on one
+/// call and a clean error on the other.
 #[no_mangle]
 pub unsafe extern "C" fn mesh_job_proxy_wait(
     handle: *mut JobProxyHandle,
@@ -969,23 +972,15 @@ pub unsafe extern "C" fn mesh_job_proxy_wait(
         return -1;
     }
     let handle = &*handle;
-    // Uniform "no timeout" policy with mesh_run_as_job: `secs <= 0.0`
-    // (covers -0.0 which `< 0.0` would miss in IEEE-754) or non-finite.
-    // Use try_from_secs_f64 — `from_secs_f64` panics on overflow (e.g.
-    // `f64::MAX`); we surface the failure cleanly via the last-error
-    // slot so a buggy caller can't crash the host process. (PR #891 review.)
-    let timeout = if !timeout_secs.is_finite() || timeout_secs <= 0.0 {
-        None
-    } else {
-        match Duration::try_from_secs_f64(timeout_secs) {
-            Ok(d) => Some(d),
-            Err(e) => {
-                set_last_error(format!(
-                    "mesh_job_proxy_wait: invalid timeout_secs ({}): {}",
-                    timeout_secs, e
-                ));
-                return -1;
-            }
+    // One shared policy with `mesh_job_controller_recv_event` /
+    // `mesh_job_proxy_list_events` (issue #1584): negative ⇒ None (the C-ABI
+    // absence sentinel), NaN / ±Inf ⇒ error, finite-but-huge ⇒ error via
+    // `try_from_secs_f64` rather than the panic `from_secs_f64` would raise.
+    let timeout = match parse_ffi_timeout_secs(timeout_secs) {
+        Ok(t) => t,
+        Err(msg) => {
+            set_last_error(format!("mesh_job_proxy_wait: {}", msg));
+            return -1;
         }
     };
     let inner = handle.inner.clone();
@@ -1294,8 +1289,12 @@ pub unsafe extern "C" fn mesh_current_job(out_snapshot_json: *mut *mut c_char) -
 /// active job context, if any.
 ///
 /// Writes a JSON object `{"X-Mesh-Job-Id": "...", "X-Mesh-Timeout":
-/// "<secs>"}` (with `X-Mesh-Timeout` omitted when no deadline is set) to
-/// `*out_headers_json`. If no context is active, writes NULL.
+/// "<secs>"}` to `*out_headers_json`. If no context is active, writes NULL.
+///
+/// `X-Mesh-Timeout` is omitted when the active context has no deadline OR
+/// when that deadline has already expired; otherwise it is `ceil(remaining)`
+/// floored at 1. It is NEVER `"0"` — see
+/// [`crate::job_context::JobContext::timeout_header_seconds`] (issue #1584).
 ///
 /// Caller frees the JSON string via `mesh_free_string` if it is non-NULL.
 #[no_mangle]
@@ -1311,7 +1310,19 @@ pub unsafe extern "C" fn mesh_inject_job_headers(out_headers_json: *mut *mut c_c
             0
         }
         Some(ctx) => {
-            let remaining = ctx.remaining_seconds();
+            // `timeout_header_seconds`, NOT `remaining_seconds` (issue #1584):
+            // the latter truncates, so a sub-second or expired budget renders
+            // as "0" — which every receiver reads as "unset" and replaces with
+            // its own (larger) default, losing the parent's cap entirely.
+            let remaining = ctx.timeout_header_seconds();
+            if remaining.is_none() && ctx.deadline.is_some() {
+                tracing::warn!(
+                    "mesh_inject_job_headers: job={} has an expired deadline; \
+                     omitting X-Mesh-Timeout instead of emitting an invalid \
+                     '0' value",
+                    ctx.job_id
+                );
+            }
             let mut map = serde_json::Map::new();
             map.insert(
                 "X-Mesh-Job-Id".to_string(),
@@ -1449,7 +1460,12 @@ pub unsafe extern "C" fn mesh_job_cancel_fired(job_id_ptr: *const c_char) -> i32
 /// `{"job_id": "...", "deadline_secs": <number>|null}` mirroring the
 /// payload Java SDK constructs from inbound `X-Mesh-Job-Id` / `X-Mesh-Timeout`
 /// headers. `deadline_secs` is the per-attempt deadline (relative); null /
-/// missing / non-positive ≡ no deadline.
+/// missing / `0` ≡ no deadline. A NEGATIVE value is an ERROR here, not a
+/// sentinel: this payload is JSON, so `null` already expresses absence — the
+/// negative-means-absence convention belongs only to the bare-`double` C
+/// entry points. NaN / ±Inf and finite-but-out-of-`Duration`-range values are
+/// also ERRORS. See the "f64-SECONDS BOUNDARY POLICY" note in
+/// `task_backend.rs` (issue #1584).
 ///
 /// `callback` is invoked synchronously from the runtime's `block_on`,
 /// wrapped in [`tokio::task::block_in_place`] so it is legal for the
@@ -1511,38 +1527,40 @@ pub unsafe extern "C" fn mesh_run_as_job(
         }
     };
 
-    // Reject non-finite deadlines explicitly (NaN / ±Inf indicate an
-    // upstream bug — silently aliasing them to "no deadline" would
-    // paper over it). Any finite value `<= 0.0` (including -0.0 and
-    // negatives) is treated as "no deadline" for uniformity with
-    // [`mesh_job_proxy_wait`]. The two functions previously diverged
-    // on -0.0 handling (`is_sign_negative` vs `< 0.0`); a single
-    // policy avoids future drift.
-    if let Some(secs) = wire.deadline_secs {
-        if !secs.is_finite() {
-            set_last_error(format!(
-                "mesh_run_as_job: invalid deadline_secs ({}) for job {} — must be a finite number or null",
-                secs, wire.job_id
-            ));
-            return -1;
-        }
-    }
-
-    // `try_from_secs_f64` rather than `from_secs_f64` — the latter panics
-    // for very-large finite values (e.g. `f64::MAX`); a buggy caller
-    // shouldn't be able to abort the host process. (PR #891 review.)
-    let ctx = match wire.deadline_secs {
-        Some(secs) if secs > 0.0 => match Duration::try_from_secs_f64(secs) {
-            Ok(d) => JobContext::with_timeout(wire.job_id, d),
-            Err(e) => {
+    // ONE deadline policy for all three bindings (issue #1584) — see the
+    // "f64-SECONDS BOUNDARY POLICY" note in `task_backend.rs`.
+    //
+    // `negative_is_none = FALSE`, even though this is an FFI entry point. The
+    // policy allows the negative-means-absence sentinel ONLY where absence is
+    // otherwise inexpressible, and that is not the case here: the deadline
+    // arrives inside a JSON snapshot as `Option<f64>`, so `null` says "no
+    // deadline" directly and the `None` arm above already handles it. Using
+    // the sentinel anyway would reopen exactly the hole the policy argues
+    // against — a caller whose `deadline - now` went negative gets an
+    // unbounded job instead of an error. (The C-ABI exception applies to
+    // `mesh_job_proxy_wait` / `mesh_job_controller_recv_event`, whose timeout
+    // really is a bare `double` with no way to send null.)
+    //
+    // All three inbound SDK paths already normalise before serialising —
+    // `MeshToolWrapper` clamps with `Math.max(1L, ...)`, `ClaimDispatcher`
+    // sends the claim's positive `max_duration` or null, and the TS/Python
+    // header readers drop `<= 0` — so nothing in-tree sends a negative here.
+    let deadline = match wire.deadline_secs {
+        None => None,
+        Some(secs) => match crate::task_backend::validate_deadline_secs(secs, false) {
+            Ok(d) => d,
+            Err(msg) => {
                 set_last_error(format!(
-                    "mesh_run_as_job: invalid deadline_secs ({}) for job {}: {}",
-                    secs, wire.job_id, e
+                    "mesh_run_as_job: {} (job {})",
+                    msg, wire.job_id
                 ));
                 return -1;
             }
         },
-        _ => JobContext::new(wire.job_id),
+    };
+    let ctx = match deadline {
+        Some(d) => JobContext::with_timeout(wire.job_id, d),
+        None => JobContext::new(wire.job_id),
     };
     // Carry the claim generation so `mesh_current_job` exposes it (#1252).
     let ctx = ctx.with_claim_epoch(wire.claim_epoch);
@@ -1623,6 +1641,60 @@ mod tests {
         let rc = unsafe { mesh_inject_job_headers(&mut out as *mut _) };
         assert_eq!(rc, 0);
         assert!(out.is_null());
+    }
+
+    /// Issue #1584: inside a job scope, `X-Mesh-Timeout` is `ceil(remaining)`
+    /// floored at 1 for a live budget and OMITTED once the deadline has
+    /// blown. It is never `"0"` — every receiver in the mesh reads a `<= 0`
+    /// value as "unset" and substitutes its own, larger default, so `"0"`
+    /// silently discards the parent's deadline cap instead of tightening it.
+    #[test]
+    fn inject_job_headers_never_emits_zero_timeout() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        // Sub-second but LIVE: floors at 1 (truncation would have said "0").
+        let map = rt.block_on(job_context::with_job(
+            crate::job_context::JobContext::with_timeout(
+                "j-1584-tight",
+                Duration::from_millis(300),
+            ),
+            async {
+                let mut out: *mut c_char = ptr::null_mut();
+                let rc = unsafe { mesh_inject_job_headers(&mut out as *mut _) };
+                assert_eq!(rc, 0);
+                assert!(!out.is_null());
+                let json = unsafe { CStr::from_ptr(out) }.to_str().unwrap().to_string();
+                unsafe { crate::ffi::mesh_free_string(out) };
+                serde_json::from_str::<serde_json::Value>(&json).unwrap()
+            },
+        ));
+        assert_eq!(map["X-Mesh-Job-Id"], "j-1584-tight");
+        assert_eq!(map["X-Mesh-Timeout"], "1");
+
+        // Expired: the key is absent entirely.
+        let map = rt.block_on(async {
+            let ctx = crate::job_context::JobContext::with_timeout(
+                "j-1584-blown",
+                Duration::from_millis(10),
+            );
+            tokio::time::sleep(Duration::from_millis(60)).await;
+            job_context::with_job(ctx, async {
+                let mut out: *mut c_char = ptr::null_mut();
+                let rc = unsafe { mesh_inject_job_headers(&mut out as *mut _) };
+                assert_eq!(rc, 0);
+                assert!(!out.is_null());
+                let json = unsafe { CStr::from_ptr(out) }.to_str().unwrap().to_string();
+                unsafe { crate::ffi::mesh_free_string(out) };
+                serde_json::from_str::<serde_json::Value>(&json).unwrap()
+            })
+            .await
+        });
+        assert_eq!(map["X-Mesh-Job-Id"], "j-1584-blown");
+        assert!(
+            map.get("X-Mesh-Timeout").is_none(),
+            "expired deadline must omit the header, got {:?}",
+            map.get("X-Mesh-Timeout")
+        );
     }
 
     /// `mesh_cancel_active_job` returns 0 when no active job — same
@@ -1756,18 +1828,17 @@ mod tests {
         assert_eq!(rc, -1, "+Inf deadline must be rejected");
     }
 
-    /// Boundary policy for `mesh_run_as_job`: zero, -0.0, and finite
-    /// negative deadlines all collapse to "no deadline" and the callback
-    /// runs successfully. Mirrors the same policy in
-    /// `mesh_job_proxy_wait` so future maintainers don't have to choose
-    /// between two operators.
+    /// Boundary policy for `mesh_run_as_job`: an absent or zero-length
+    /// deadline means "no deadline" and the callback runs successfully.
     #[test]
-    fn run_as_job_treats_zero_and_negative_deadline_as_no_deadline() {
+    fn run_as_job_treats_absent_and_zero_deadline_as_no_deadline() {
         extern "C" fn cb(_: *mut c_void) -> i32 { 0 }
         for snap_json in [
+            r#"{"job_id":"j-absent"}"#,
+            r#"{"job_id":"j-null","deadline_secs":null}"#,
             r#"{"job_id":"j-zero","deadline_secs":0.0}"#,
+            // -0.0 is NOT `< 0.0` in IEEE-754; it is zero, not a sentinel.
             r#"{"job_id":"j-negzero","deadline_secs":-0.0}"#,
-            r#"{"job_id":"j-neg","deadline_secs":-5.0}"#,
         ] {
             let snap = CString::new(snap_json).unwrap();
             let rc = unsafe { mesh_run_as_job(snap.as_ptr(), cb, ptr::null_mut()) };
@@ -1775,25 +1846,100 @@ mod tests {
         }
     }
 
-    /// Boundary policy for `mesh_job_proxy_wait`'s timeout argument:
-    /// zero, -0.0, and negative values all map to "no timeout"
-    /// (Option::None passed to the inner wait), and non-finite values
-    /// (NaN, ±Inf) map to "no timeout" too. We can't easily call the
-    /// wait FFI without a real handle here, so we exercise the same
-    /// predicate the FFI uses.
+    /// Issue #1584 warning 1: a NEGATIVE `deadline_secs` is an error on this
+    /// entry point, NOT the C-ABI absence sentinel. The snapshot is JSON, so
+    /// `null` already expresses absence (asserted above); accepting a negative
+    /// as "unlimited" here would reopen the hole the shared policy exists to
+    /// close — a caller whose `deadline - now` went negative would get an
+    /// unbounded job rather than a diagnosable failure.
     #[test]
-    fn wait_treats_zero_and_negative_as_no_timeout() {
-        fn would_be_no_timeout(secs: f64) -> bool {
-            !secs.is_finite() || secs <= 0.0
+    fn run_as_job_rejects_negative_deadline() {
+        extern "C" fn cb(_: *mut c_void) -> i32 { 0 }
+        for snap_json in [
+            r#"{"job_id":"j-neg","deadline_secs":-5.0}"#,
+            r#"{"job_id":"j-tiny-neg","deadline_secs":-0.001}"#,
+        ] {
+            let snap = CString::new(snap_json).unwrap();
+            let rc = unsafe { mesh_run_as_job(snap.as_ptr(), cb, ptr::null_mut()) };
+            assert_eq!(rc, -1, "negative deadline must reject: {}", snap_json);
+            let err = take_last_error().expect("last_error must be populated");
+            assert!(
+                err.contains("deadline_secs") && err.contains("non-negative"),
+                "unexpected message: {err}"
+            );
         }
-        assert!(would_be_no_timeout(0.0));
-        assert!(would_be_no_timeout(-0.0));
-        assert!(would_be_no_timeout(-1.0));
-        assert!(would_be_no_timeout(f64::NAN));
-        assert!(would_be_no_timeout(f64::INFINITY));
-        assert!(would_be_no_timeout(f64::NEG_INFINITY));
-        assert!(!would_be_no_timeout(0.001));
-        assert!(!would_be_no_timeout(60.0));
+    }
+
+    /// Boundary policy for `mesh_job_proxy_wait`'s timeout argument. Since
+    /// #1584 it is the SAME policy as every other FFI timeout surface, so
+    /// this asserts the shared helper the FFI actually calls rather than a
+    /// re-implementation of the predicate (the previous version of this test
+    /// copied the condition, so it would have kept passing after the FFI
+    /// changed underneath it).
+    ///
+    /// Two deliberate changes from the pre-#1584 behaviour, both narrowing
+    /// "unlimited":
+    /// * NaN / ±Inf now ERROR instead of silently meaning "no timeout" —
+    ///   they are caller bugs, and `mesh_job_controller_recv_event` already
+    ///   rejected them.
+    /// * `0.0` / `-0.0` are now a ZERO-LENGTH budget, not "no timeout". Only
+    ///   a NEGATIVE value is the C-ABI absence sentinel (Java's no-arg
+    ///   `await()` passes `-1.0`); `0.0` landing in the sentinel bucket was
+    ///   the `<= 0.0` predicate over-reaching into the value space.
+    #[test]
+    fn wait_timeout_policy_matches_every_other_ffi_surface() {
+        // Negative: the C-ABI "absent" sentinel.
+        assert_eq!(parse_ffi_timeout_secs(-1.0).unwrap(), None);
+        assert_eq!(parse_ffi_timeout_secs(f64::MIN).unwrap(), None);
+        // Zero: a real, zero-length budget.
+        assert_eq!(
+            parse_ffi_timeout_secs(0.0).unwrap(),
+            Some(Duration::from_secs(0))
+        );
+        assert_eq!(
+            parse_ffi_timeout_secs(-0.0).unwrap(),
+            Some(Duration::from_secs(0)),
+            "-0.0 is not `< 0.0` in IEEE-754; it is zero, not the sentinel"
+        );
+        // Positive finite: that budget.
+        assert_eq!(
+            parse_ffi_timeout_secs(0.001).unwrap(),
+            Some(Duration::from_millis(1))
+        );
+        assert_eq!(
+            parse_ffi_timeout_secs(60.0).unwrap(),
+            Some(Duration::from_secs(60))
+        );
+        // Non-finite: error, not "unlimited".
+        assert!(parse_ffi_timeout_secs(f64::NAN).is_err());
+        assert!(parse_ffi_timeout_secs(f64::INFINITY).is_err());
+        assert!(parse_ffi_timeout_secs(f64::NEG_INFINITY).is_err());
+    }
+
+    /// `mesh_job_proxy_wait` must reach the shared policy, not just declare
+    /// it: a NaN timeout returns `-1` with a message in the last-error slot
+    /// instead of parking forever. A null handle short-circuits first, so
+    /// drive the check through a real (never-resolving) proxy handle.
+    #[test]
+    fn proxy_wait_rejects_non_finite_timeout() {
+        let url = CString::new("http://127.0.0.1:1/registry").unwrap();
+        let job = CString::new("j-1584-nan").unwrap();
+        let mut handle: *mut JobProxyHandle = ptr::null_mut();
+        let rc = unsafe {
+            mesh_job_proxy_new(job.as_ptr(), url.as_ptr(), &mut handle as *mut _)
+        };
+        assert_eq!(rc, 0, "proxy construction should succeed (no I/O yet)");
+        assert!(!handle.is_null());
+
+        let mut out: *mut c_char = ptr::null_mut();
+        let rc = unsafe { mesh_job_proxy_wait(handle, f64::NAN, &mut out as *mut _) };
+        assert_eq!(rc, -1, "NaN timeout must be an error, not 'no timeout'");
+        let err = take_last_error().expect("last_error must be populated");
+        assert!(
+            err.contains("mesh_job_proxy_wait") && err.contains("finite"),
+            "unexpected message: {err}"
+        );
+        unsafe { mesh_job_proxy_free(handle) };
     }
 
     /// `f64::MAX` deadline must NOT panic — `Duration::from_secs_f64`

--- a/src/runtime/core/src/jobs_napi.rs
+++ b/src/runtime/core/src/jobs_napi.rs
@@ -580,8 +580,10 @@ pub fn current_job_napi() -> Option<JsJobContextSnapshot> {
 pub struct JsJobHeaders {
     /// `X-Mesh-Job-Id` header value.
     pub x_mesh_job_id: String,
-    /// `X-Mesh-Timeout` header value (seconds remaining as decimal string),
-    /// or `None` if the active context has no deadline.
+    /// `X-Mesh-Timeout` header value (`ceil(remaining)` floored at 1, as a
+    /// decimal string), or `None` when the header must be OMITTED: the active
+    /// context has no deadline, or that deadline has already expired. Never
+    /// `"0"` — see `JobContext::timeout_header_seconds` (issue #1584).
     pub x_mesh_timeout: Option<String>,
 }
 
@@ -600,7 +602,18 @@ pub struct JsJobHeaders {
 #[napi(js_name = "injectJobHeaders")]
 pub fn inject_job_headers_napi() -> Option<JsJobHeaders> {
     job_context::current().map(|ctx| {
-        let timeout = ctx.remaining_seconds().map(|s| s.to_string());
+        // `timeout_header_seconds`, NOT `remaining_seconds` (issue #1584):
+        // the latter truncates, so a sub-second or expired budget renders as
+        // "0" — which every receiver reads as "unset" and replaces with its
+        // own (larger) default, losing the parent's cap entirely.
+        let timeout = ctx.timeout_header_seconds().map(|s| s.to_string());
+        if timeout.is_none() && ctx.deadline.is_some() {
+            tracing::warn!(
+                "injectJobHeaders: job={} has an expired deadline; omitting \
+                 X-Mesh-Timeout instead of emitting an invalid '0' value",
+                ctx.job_id
+            );
+        }
         JsJobHeaders {
             x_mesh_job_id: ctx.job_id,
             x_mesh_timeout: timeout,
@@ -695,8 +708,10 @@ pub async fn await_job_cancel_napi(job_id: String) {
 /// Arguments:
 ///   * `jobId` — server-assigned job UUID this call is bound to.
 ///   * `deadlineSecs` — optional per-attempt deadline in seconds.
-///     `null` / `undefined` means no deadline (unlimited per design-doc
-///     default).
+///     `null` / `undefined` (and `0`) mean no deadline (unlimited per
+///     design-doc default). A negative, NaN or infinite value rejects — see
+///     the "f64-SECONDS BOUNDARY POLICY" note in `task_backend.rs`
+///     (issue #1584).
 ///   * `body` — in-flight JS Promise resolving to a JSON value. The
 ///     SDK's TS wrapper typically constructs this with the user
 ///     function's return value already JSON-serialised.
@@ -705,17 +720,19 @@ pub async fn await_job_cancel_napi(job_id: String) {
 /// underlying JS Promise settles. The `run_as_job` scope keeps the
 /// cancel registry entry alive for that whole window, then drops it
 /// (panic-safe via the internal drop guard).
-/// Validate `deadline_secs` for [`with_job_async_napi`]. Returns the
-/// [`napi::Error`] message that would be propagated to JS, or `None`
-/// when the input is acceptable. Extracted from `with_job_async_napi`
-/// so it can be unit-tested without the napi `Promise<T>` boundary.
-fn validate_deadline_secs(deadline_secs: Option<f64>, job_id: &str) -> Option<String> {
+/// Validate a JS-supplied job `deadlineSecs` against the ONE boundary policy
+/// shared by every binding (see the "f64-SECONDS BOUNDARY POLICY" note in
+/// `task_backend.rs`, issue #1584). `null`/`undefined` in, `None` out (no
+/// deadline); `0` is also "no deadline"; NaN / Inf / negative are errors.
+///
+/// Extracted from `with_job_async_napi` so it can be unit-tested without the
+/// napi `Promise<T>` boundary.
+fn parse_deadline_secs(deadline_secs: Option<f64>, job_id: &str) -> Result<Option<Duration>> {
     match deadline_secs {
-        Some(secs) if !secs.is_finite() || secs < 0.0 => Some(format!(
-            "withJobAsync: invalid deadline_secs ({}) for job {} — must be a non-negative finite number or null",
-            secs, job_id,
-        )),
-        _ => None,
+        None => Ok(None),
+        Some(secs) => crate::task_backend::validate_deadline_secs(secs, false).map_err(|e| {
+            Error::from_reason(format!("withJobAsync: {} (job {})", e, job_id))
+        }),
     }
 }
 
@@ -727,27 +744,13 @@ pub async fn with_job_async_napi(
     claim_epoch: Option<i64>,
 ) -> Result<serde_json::Value> {
     // Reject negative / NaN / Inf deadlines explicitly: silently aliasing
-    // them to "no deadline" (the previous behaviour) papers over upstream
-    // bugs where a caller arithmetic'd a negative remaining-time or
-    // produced NaN through a buggy clock computation.
-    if let Some(msg) = validate_deadline_secs(deadline_secs, &job_id) {
-        return Err(Error::from_reason(msg));
-    }
-    let ctx = match deadline_secs {
-        Some(secs) if secs > 0.0 => {
-            // `validate_deadline_secs` already rejects NaN / Inf / negative,
-            // but a finite-but-huge `secs` (e.g. `f64::MAX`) would still
-            // panic in `Duration::from_secs_f64`. Use the fallible variant
-            // and surface a clean napi error instead.
-            let dur = Duration::try_from_secs_f64(secs).map_err(|e| {
-                Error::from_reason(format!(
-                    "withJobAsync: deadline_secs ({}) out of range for job {} — {}",
-                    secs, job_id, e
-                ))
-            })?;
-            JobContext::with_timeout(job_id, dur)
-        }
-        _ => JobContext::new(job_id),
+    // them to "no deadline" papers over upstream bugs where a caller
+    // arithmetic'd a negative remaining-time or produced NaN through a buggy
+    // clock computation. Since #1584 all three bindings share this rule via
+    // `task_backend::validate_deadline_secs`.
+    let ctx = match parse_deadline_secs(deadline_secs, &job_id)? {
+        Some(dur) => JobContext::with_timeout(job_id, dur),
+        None => JobContext::new(job_id),
     };
     // Carry the claim generation so `currentJob()` exposes it (issue #1252).
     let ctx = ctx.with_claim_epoch(claim_epoch);
@@ -756,7 +759,7 @@ pub async fn with_job_async_napi(
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_timeout_secs, validate_deadline_secs};
+    use super::{parse_deadline_secs, parse_timeout_secs};
 
     #[test]
     fn parse_timeout_secs_accepts_none_and_valid() {
@@ -795,29 +798,46 @@ mod tests {
 
 
     #[test]
-    fn validate_deadline_secs_accepts_none_and_zero_and_positive() {
-        assert!(validate_deadline_secs(None, "j-1").is_none());
-        assert!(validate_deadline_secs(Some(0.0), "j-1").is_none());
-        assert!(validate_deadline_secs(Some(1.5), "j-1").is_none());
-        assert!(validate_deadline_secs(Some(60.0), "j-1").is_none());
+    fn parse_deadline_secs_accepts_none_and_zero_and_positive() {
+        assert_eq!(parse_deadline_secs(None, "j-1").unwrap(), None);
+        // Zero is "no deadline", NOT an already-expired context.
+        assert_eq!(parse_deadline_secs(Some(0.0), "j-1").unwrap(), None);
+        assert_eq!(parse_deadline_secs(Some(-0.0), "j-1").unwrap(), None);
+        assert_eq!(
+            parse_deadline_secs(Some(1.5), "j-1").unwrap(),
+            Some(std::time::Duration::from_millis(1500))
+        );
+        assert_eq!(
+            parse_deadline_secs(Some(60.0), "j-1").unwrap(),
+            Some(std::time::Duration::from_secs(60))
+        );
     }
 
     #[test]
-    fn validate_deadline_secs_rejects_negative() {
-        let msg = validate_deadline_secs(Some(-0.001), "j-neg").expect("should reject");
-        assert!(msg.contains("invalid deadline_secs"));
-        assert!(msg.contains("j-neg"));
-        assert!(msg.contains("-0.001"));
+    fn parse_deadline_secs_rejects_negative() {
+        let err = parse_deadline_secs(Some(-0.001), "j-neg").expect_err("should reject");
+        let msg = err.reason.as_str();
+        assert!(msg.contains("deadline_secs"), "got: {msg}");
+        assert!(msg.contains("j-neg"), "got: {msg}");
+        assert!(msg.contains("-0.001"), "got: {msg}");
 
-        let msg = validate_deadline_secs(Some(-30.0), "abc").expect("should reject");
-        assert!(msg.contains("-30"));
-        assert!(msg.contains("abc"));
+        let err = parse_deadline_secs(Some(-30.0), "abc").expect_err("should reject");
+        let msg = err.reason.as_str();
+        assert!(msg.contains("-30"), "got: {msg}");
+        assert!(msg.contains("abc"), "got: {msg}");
     }
 
     #[test]
-    fn validate_deadline_secs_rejects_nan_and_inf() {
-        assert!(validate_deadline_secs(Some(f64::NAN), "j-nan").is_some());
-        assert!(validate_deadline_secs(Some(f64::INFINITY), "j-inf").is_some());
-        assert!(validate_deadline_secs(Some(f64::NEG_INFINITY), "j-ninf").is_some());
+    fn parse_deadline_secs_rejects_nan_and_inf() {
+        assert!(parse_deadline_secs(Some(f64::NAN), "j-nan").is_err());
+        assert!(parse_deadline_secs(Some(f64::INFINITY), "j-inf").is_err());
+        assert!(parse_deadline_secs(Some(f64::NEG_INFINITY), "j-ninf").is_err());
+    }
+
+    #[test]
+    fn parse_deadline_secs_rejects_overflow_finite() {
+        let err = parse_deadline_secs(Some(f64::MAX), "j-big").expect_err("should reject");
+        let msg = err.reason.as_str();
+        assert!(msg.contains("out of range"), "got: {msg}");
     }
 }

--- a/src/runtime/core/src/jobs_py.rs
+++ b/src/runtime/core/src/jobs_py.rs
@@ -53,6 +53,19 @@ fn parse_timeout_secs(secs: Option<f64>) -> PyResult<Option<Duration>> {
     }
 }
 
+/// Validate a Python-supplied job ``deadline_secs`` against the ONE boundary
+/// policy shared by every binding (see the "f64-SECONDS BOUNDARY POLICY" note
+/// in `task_backend.rs`). `None` in, `None` out (no deadline); `0` is also
+/// "no deadline"; NaN / Inf / negative raise ``ValueError``.
+fn parse_deadline_secs(secs: Option<f64>, job_id: &str) -> PyResult<Option<Duration>> {
+    match secs {
+        None => Ok(None),
+        Some(s) => crate::task_backend::validate_deadline_secs(s, false).map_err(|e| {
+            PyValueError::new_err(format!("with_job_async: {} (job {})", e, job_id))
+        }),
+    }
+}
+
 /// Build an `Arc<dyn TaskBackend>` from a registry URL. Returns a Python
 /// exception on transport-construction failure (mirrors the pattern in
 /// `lib.rs::call_tool_py`).
@@ -637,7 +650,9 @@ pub fn await_job_cancel_py<'py>(
 /// Arguments:
 ///   * `job_id` — server-assigned job UUID this call is bound to.
 ///   * `deadline_secs` — optional per-attempt deadline (relative). `None`
-///     means no deadline (unlimited per design-doc default).
+///     (and `0`) mean no deadline (unlimited per design-doc default). A
+///     negative, NaN or infinite value raises `ValueError` — see the
+///     "f64-SECONDS BOUNDARY POLICY" note in `task_backend.rs` (issue #1584).
 ///   * `awaitable` — Python coroutine. Awaited inside the
 ///     `run_as_job` scope; its result (or raised exception) becomes the
 ///     return value of the returned coroutine.
@@ -655,26 +670,17 @@ pub fn with_job_async_py<'py>(
     // Build the JobContext on the Rust side (the deadline is set relative
     // to "now" on the Tokio runtime, which matches the semantics of the
     // SDK reading `X-Mesh-Timeout: <secs>` from the inbound request).
-    let ctx = match deadline_secs {
-        Some(secs) if secs.is_nan() || secs.is_infinite() => {
-            return Err(PyValueError::new_err(format!(
-                "with_job_async: deadline_secs ({}) must be a finite number or None",
-                secs
-            )));
-        }
-        Some(secs) if secs > 0.0 => {
-            // Finite-but-huge `secs` (e.g. `sys.float_info.max`) would
-            // panic in `Duration::from_secs_f64`. Use the fallible variant
-            // and surface a clean `ValueError` instead.
-            let dur = Duration::try_from_secs_f64(secs).map_err(|e| {
-                PyValueError::new_err(format!(
-                    "with_job_async: deadline_secs ({}) out of range for job {} — {}",
-                    secs, job_id, e
-                ))
-            })?;
-            JobContext::with_timeout(job_id.clone(), dur)
-        }
-        _ => JobContext::new(job_id.clone()),
+    // ONE deadline policy for all three bindings (issue #1584) — see the
+    // "f64-SECONDS BOUNDARY POLICY" note in `task_backend.rs`. Python can
+    // express absence as `None`, so `negative_is_none = false`: a negative
+    // deadline is an ERROR here, not a silent alias for "unlimited". Before
+    // #1584 this binding was the odd one out — it swallowed negatives into
+    // `JobContext::new` (unlimited) while napi rejected them, so the same
+    // buggy `deadline - now` produced an unbounded job in Python and a clean
+    // error in TypeScript.
+    let ctx = match parse_deadline_secs(deadline_secs, &job_id)? {
+        Some(dur) => JobContext::with_timeout(job_id.clone(), dur),
+        None => JobContext::new(job_id.clone()),
     };
     // Carry the claim generation so `current_job()` can expose it (issue
     // #1252). Additive — `None` leaves the surface unchanged.

--- a/src/runtime/core/src/task_backend.rs
+++ b/src/runtime/core/src/task_backend.rs
@@ -714,8 +714,14 @@ impl TaskBackend for RegistryHttpBackend {
         identity: Option<(&str, i64)>,
     ) -> Result<JobEventListResponse, BackendError> {
         let url = format!("{}/jobs/{}/events", self.base_url, job_id);
-        // Registry caps `wait` at 60s — clamp client-side so we don't
-        // round-trip a value the registry will silently truncate.
+        // The `wait` query param is WHOLE SECONDS (OpenAPI: integer, max 60),
+        // so this truncates: a sub-second `wait` goes out as `wait=0` and the
+        // registry answers immediately. That is a wire constraint, not a bug
+        // to fix here — the callers compensate for the lost remainder
+        // client-side (`JobController::recv_event` paces at
+        // `EMPTY_PAGE_POLL_PACE`, `JobProxy::list_events` sleeps the
+        // remainder). Clamping at 60 client-side avoids round-tripping a
+        // value the registry would silently truncate anyway. See issue #1585.
         let wait_secs = wait.as_secs().min(60);
         let mut req = self.client.get(&url).query(&[
             ("after", after.to_string()),
@@ -806,6 +812,48 @@ impl TaskBackend for RegistryHttpBackend {
 // Shared helpers
 // =============================================================================
 
+// -----------------------------------------------------------------------------
+// THE f64-SECONDS BOUNDARY POLICY (issue #1584)
+// -----------------------------------------------------------------------------
+//
+// Exactly two kinds of value cross the language boundary as "a number of
+// seconds": a WAIT BUDGET (`recv_event` / `list_events` / `JobProxy::wait`)
+// and a JOB DEADLINE (`with_job_async` / `mesh_run_as_job`). Before #1584 each
+// of the three bindings had its own opinion about the edge values, so the same
+// input meant "unlimited" in one runtime and "error" in another. This module
+// is the single place that policy lives; every binding delegates here.
+//
+//   input             wait budget                deadline
+//   ---------------   ------------------------   -------------------------
+//   absent (None)     no timeout (block)         no deadline (unlimited)
+//   NaN / +-Inf       ERROR (all bindings)       ERROR (all bindings)
+//   negative          ERROR where the language   ERROR where the language
+//                     can express absence;       can express absence;
+//                     absence over the C ABI     absence over the C ABI
+//   0.0 / -0.0        zero-length budget         no deadline (unlimited)
+//   > 0, out of
+//   Duration range    ERROR                      ERROR
+//   > 0, in range      that budget                that deadline
+//
+// Why negative is an ERROR rather than "unlimited": "unlimited" is the
+// UNBOUNDED direction. A caller that arithmetic'd a remaining-time into the
+// negatives (`deadline - now` after the deadline passed is the common case)
+// has a bug; aliasing it to "never time out" upgrades that bug into a job that
+// runs until a sweep reaps it, silently. Erroring puts the failure at the call
+// site where the bad arithmetic is. The C ABI is the ONE exception, and only
+// because it has no nullable double: there the negative is a TRANSPORT
+// ENCODING OF ABSENCE (Java passes -1.0 for `Optional.empty()`), not a value.
+//
+// Why 0.0 means "unlimited" for a DEADLINE but "zero-length" for a WAIT: they
+// are different questions. `recv_event(timeout_secs=0.0)` is the documented
+// "single immediate read" (see `JobProxy::list_events`), so zero has to be a
+// real budget there. A zero-length DEADLINE, by contrast, is not reachable
+// from the wire at all -- `X-Mesh-Timeout` is `minimum: 1` in the OpenAPI
+// schema and every SDK normalises a `<= 0` header to "absent" before it gets
+// here (e.g. `job_dispatch.py::_read_job_headers`) -- so 0 only ever arrives
+// from a caller that means "no deadline". All three bindings already agreed on
+// that reading; #1584 keeps it and writes down why.
+
 /// Validate a caller-supplied `timeout_secs` (`f64`) and convert it into an
 /// `Option<Duration>`. Shared by the three binding-layer `parse_*timeout_secs`
 /// helpers (`jobs_py.rs`, `jobs_napi.rs`, `jobs_ffi.rs`) so the
@@ -825,18 +873,51 @@ pub(crate) fn validate_secs_to_duration(
     secs: f64,
     negative_is_none: bool,
 ) -> Result<Option<Duration>, String> {
+    validate_secs_to_duration_labeled(secs, negative_is_none, "timeout_secs")
+}
+
+/// [`validate_secs_to_duration`] with a caller-chosen field name in the error
+/// messages, so the deadline path can say `deadline_secs` instead of
+/// `timeout_secs` without forking the policy.
+pub(crate) fn validate_secs_to_duration_labeled(
+    secs: f64,
+    negative_is_none: bool,
+    label: &str,
+) -> Result<Option<Duration>, String> {
     if secs.is_nan() || secs.is_infinite() {
-        return Err(format!("timeout_secs must be a finite number, got {secs}"));
+        return Err(format!("{label} must be a finite number, got {secs}"));
     }
     if secs < 0.0 {
         if negative_is_none {
             return Ok(None);
         }
-        return Err(format!("timeout_secs must be non-negative, got {secs}"));
+        return Err(format!("{label} must be non-negative, got {secs}"));
     }
     Duration::try_from_secs_f64(secs)
         .map(Some)
-        .map_err(|e| format!("timeout_secs out of range: {e} (got {secs})"))
+        .map_err(|e| format!("{label} out of range: {e} (got {secs})"))
+}
+
+/// Validate a caller-supplied job `deadline_secs` (`f64`) and convert it into
+/// the `Option<Duration>` that [`crate::job_context::JobContext`] wants, where
+/// `None` means "no deadline / unlimited".
+///
+/// Same NaN / Inf / negative / overflow policy as
+/// [`validate_secs_to_duration`] (see the module note above); the ONE
+/// difference is that a zero-length deadline collapses to `None` rather than
+/// to `Duration::ZERO` -- an already-expired context is not what a caller
+/// passing `0` means, and all three bindings already read it this way.
+///
+/// `negative_is_none` has the same meaning as in [`validate_secs_to_duration`]:
+/// `true` only for the C ABI, which cannot pass a null double.
+pub(crate) fn validate_deadline_secs(
+    secs: f64,
+    negative_is_none: bool,
+) -> Result<Option<Duration>, String> {
+    match validate_secs_to_duration_labeled(secs, negative_is_none, "deadline_secs")? {
+        Some(d) if !d.is_zero() => Ok(Some(d)),
+        _ => Ok(None),
+    }
 }
 
 // =============================================================================
@@ -1338,6 +1419,41 @@ mod tests {
         assert!(validate_secs_to_duration(f64::INFINITY, true).is_err());
         // Finite-but-huge overflows Duration; message must say "out of range".
         let err = validate_secs_to_duration(f64::MAX, false).expect_err("overflow");
+        assert!(
+            err.contains("out of range"),
+            "expected 'out of range', got: {err}"
+        );
+    }
+
+    /// Issue #1584: the one deadline policy, exercised through the shared
+    /// helper every binding now delegates to.
+    #[test]
+    fn validate_deadline_secs_policy() {
+        // Positive finite: a real deadline.
+        assert_eq!(
+            validate_deadline_secs(1.5, false).unwrap(),
+            Some(Duration::from_millis(1500))
+        );
+        // Zero (and -0.0, which is NOT `< 0.0` in IEEE-754): no deadline,
+        // never an already-expired one.
+        assert_eq!(validate_deadline_secs(0.0, false).unwrap(), None);
+        assert_eq!(validate_deadline_secs(-0.0, false).unwrap(), None);
+        assert_eq!(validate_deadline_secs(-0.0, true).unwrap(), None);
+        // Negative: error where absence is expressible, absence over the C ABI.
+        let err = validate_deadline_secs(-1.0, false).expect_err("negative must reject");
+        assert!(
+            err.contains("deadline_secs"),
+            "message must name the field, got: {err}"
+        );
+        assert_eq!(validate_deadline_secs(-1.0, true).unwrap(), None);
+        // NaN / Inf: always an error, both policies.
+        for neg_is_none in [false, true] {
+            assert!(validate_deadline_secs(f64::NAN, neg_is_none).is_err());
+            assert!(validate_deadline_secs(f64::INFINITY, neg_is_none).is_err());
+            assert!(validate_deadline_secs(f64::NEG_INFINITY, neg_is_none).is_err());
+        }
+        // Finite-but-huge: overflow error, not a panic.
+        let err = validate_deadline_secs(f64::MAX, false).expect_err("overflow must reject");
         assert!(
             err.contains("out of range"),
             "expected 'out of range', got: {err}"

--- a/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
+++ b/src/runtime/java/mcp-mesh-core/src/main/java/io/mcpmesh/core/MeshCore.java
@@ -754,7 +754,11 @@ public interface MeshCore {
      * job result (JSON-encoded) to outResultJson.
      *
      * @param handle         Proxy handle
-     * @param timeoutSecs    Wall-clock timeout (negative = no timeout)
+     * @param timeoutSecs    Wall-clock timeout. Negative = no timeout (the
+     *                       C-ABI absence sentinel); {@code 0.0} is a
+     *                       zero-length budget; NaN / Infinity are errors
+     *                       (issue #1584 — this entry point used to accept
+     *                       them as "no timeout").
      * @param outResultJson  Out-param: receives the JSON string (caller frees via mesh_free_string)
      * @return 0 on success, -1 on error
      */

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/JobProxy.java
@@ -148,14 +148,27 @@ public final class JobProxy implements MeshJob, AutoCloseable {
      *
      * @param timeoutSecs Wall-clock timeout in seconds.
      *                    <ul>
-     *                      <li>Negative or zero (including {@code -0.0})
-     *                          → no timeout (block until terminal).</li>
+     *                      <li>Negative → no timeout (block until
+     *                          terminal). This is the core's C-ABI
+     *                          "absent" sentinel: the boundary cannot
+     *                          pass a null double.</li>
+     *                      <li>Zero (including {@code -0.0}) → a
+     *                          zero-length budget: the registry is polled
+     *                          EXACTLY ONCE, so a job that is already
+     *                          terminal returns its result and one that is
+     *                          still running surfaces a timeout error.</li>
      *                      <li>Positive finite → wait that many
      *                          seconds, then surface a timeout error.</li>
-     *                      <li>Non-finite (NaN, ±Inf) → no timeout.</li>
+     *                      <li>Non-finite (NaN, ±Inf) → a caller bug;
+     *                          throws {@link MeshException}.</li>
      *                    </ul>
      *                    The {@link #await()} no-arg overload uses
      *                    {@code -1.0} to opt into the no-timeout branch.
+     *                    <p>Changed in issue #1584: {@code 0.0} used to
+     *                    mean "no timeout" and NaN / ±Inf used to be
+     *                    silently accepted as "no timeout". Only a
+     *                    NEGATIVE value is the absence sentinel now, and
+     *                    every core timeout surface agrees on it.
      * @return The job result payload
      * @throws MeshException on timeout, cancellation, or non-success terminal
      *                       (the message starts with the variant name —

--- a/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJobs.java
+++ b/src/runtime/java/mcp-mesh-sdk/src/main/java/io/mcpmesh/MeshJobs.java
@@ -330,13 +330,26 @@ public final class MeshJobs {
      * @param jobId       Target job's server-assigned id
      * @param timeoutSecs Wall-clock timeout in seconds.
      *                    <ul>
-     *                      <li>{@code <= 0.0} (including {@code -0.0})
-     *                          → no timeout (block until terminal).</li>
+     *                      <li>Negative → no timeout (block until
+     *                          terminal). This is the core's C-ABI
+     *                          "absent" sentinel; the no-arg
+     *                          {@link #await(String)} overload passes
+     *                          {@code -1.0}.</li>
+     *                      <li>Zero (including {@code -0.0}) → a
+     *                          zero-length budget: the registry is polled
+     *                          EXACTLY ONCE, so a job that is already
+     *                          terminal returns its result and one that is
+     *                          still running surfaces a timeout error.</li>
      *                      <li>Positive finite → wait that many seconds,
      *                          then surface a timeout error.</li>
-     *                      <li>Non-finite (NaN, ±Inf) → no timeout.</li>
+     *                      <li>Non-finite (NaN, ±Inf) → a caller bug;
+     *                          throws {@link MeshException}.</li>
      *                    </ul>
      *                    Matches {@link JobProxy#await(double)}'s contract.
+     *                    <p>Changed in issue #1584: {@code 0.0} used to
+     *                    mean "no timeout" and NaN / ±Inf used to be
+     *                    silently accepted as "no timeout". Only a
+     *                    NEGATIVE value is the absence sentinel now.
      * @return The job's result payload (whatever the handler passed to
      *         {@code complete()}). Shape is application-defined —
      *         typically a {@code Map<String, Object>}, but any JSON-shaped

--- a/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
+++ b/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
@@ -1366,7 +1366,9 @@ class UnifiedMCPProxy:
                             # `CURRENT_JOB` is public API that user code and
                             # tests can set directly.
                             remaining = (
-                                0 if raw_remaining <= 0 else max(1, math.ceil(raw_remaining))
+                                0
+                                if raw_remaining <= 0
+                                else max(1, math.ceil(raw_remaining))
                             )
                             if remaining <= 0:
                                 # Already past the parent deadline. The

--- a/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
+++ b/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
@@ -8,6 +8,7 @@ import asyncio
 import contextvars
 import json
 import logging
+import math
 import os
 import threading
 import uuid
@@ -29,6 +30,52 @@ from ..tracing.utils import generate_span_id
 from .superseded import SupersededError, parse_superseded_envelope
 
 logger = logging.getLogger(__name__)
+
+
+#: Fallback per-call budget in seconds when neither the ``timeout`` kwarg nor
+#: ``MCP_MESH_CALL_TIMEOUT`` says otherwise. 300 across all three runtimes
+#: (issue #1584).
+FALLBACK_CALL_TIMEOUT_SECS = 300
+
+
+def _default_call_timeout_secs() -> int:
+    """Resolve the default per-call budget, in seconds, from the environment.
+
+    Whatever this returns is used for BOTH the httpx client timeout and the
+    ``X-Mesh-Timeout`` header, so this process can never advertise one budget
+    downstream while abandoning the request at another (issue #1584). An
+    explicit ``timeout`` kwarg on the dependency overrides it -- also for both.
+
+    Read at call time (not import time) so a late environment change is
+    honoured. Mirrors Java's ``McpHttpClient.parseTimeoutSecs`` and
+    TypeScript's ``resolveDefaultCallTimeoutSecs``: unset / blank /
+    unparseable / non-positive all fall back to
+    :data:`FALLBACK_CALL_TIMEOUT_SECS`.
+    """
+    raw = os.environ.get("MCP_MESH_CALL_TIMEOUT")
+    if raw is None or not raw.strip():
+        return FALLBACK_CALL_TIMEOUT_SECS
+    try:
+        parsed = float(raw.strip())
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid MCP_MESH_CALL_TIMEOUT value %r - using default %ds",
+            raw,
+            FALLBACK_CALL_TIMEOUT_SECS,
+        )
+        return FALLBACK_CALL_TIMEOUT_SECS
+    if not math.isfinite(parsed) or parsed <= 0:
+        logger.warning(
+            "Invalid or non-positive MCP_MESH_CALL_TIMEOUT value %r - using default %ds",
+            raw,
+            FALLBACK_CALL_TIMEOUT_SECS,
+        )
+        return FALLBACK_CALL_TIMEOUT_SECS
+    # HALF-UP, deliberately not ``round()``: Python's built-in is banker's
+    # rounding, so ``round(2.5)`` is 2 while TypeScript's ``Math.round`` and
+    # Java's ``Math.round`` both give 3. The three runtimes have to agree on
+    # what ``MCP_MESH_CALL_TIMEOUT=2.5`` means (issue #1584).
+    return max(1, math.floor(parsed + 0.5))
 
 
 def _create_ssl_context_for_endpoint(endpoint: str):
@@ -437,7 +484,24 @@ class UnifiedMCPProxy:
 
     def _configure_from_kwargs(self):
         """Auto-configure proxy settings from kwargs."""
-        # Basic configuration
+        # Basic configuration.
+        #
+        # NOTE (issue #1584): `self.timeout` is NOT the per-call budget and
+        # must not be used as one. `kwargs_config` is the PRODUCER's
+        # `@mesh.tool` kwargs, travelling back from the registry on the
+        # resolved dependency (`rust_heartbeat.py` says so explicitly: "must
+        # be the *producer's* @mesh.tool kwargs, not the consumer's dep
+        # declaration"), and for an LLM provider proxy it is the provider's
+        # kwargs, where `timeout` means the vendor SDK's per-call timeout --
+        # a different concept entirely. Letting either drive this proxy's HTTP
+        # budget would let a provider cap every one of its consumers.
+        #
+        # The consumer-side knob that WOULD belong here, `dependency_kwargs`,
+        # has no reader anywhere in this runtime today; wiring one is a
+        # separate feature. Until then Python resolves its budget exactly like
+        # Java does -- `MCP_MESH_CALL_TIMEOUT`, else 300 -- see
+        # `effective_call_timeout_secs`. `self.timeout` survives only as
+        # advertised producer metadata.
         self.timeout = self.kwargs_config.get("timeout", 30)
         self.retry_count = self.kwargs_config.get("retry_count", 1)
         self.custom_headers = self.kwargs_config.get("custom_headers", {})
@@ -458,9 +522,25 @@ class UnifiedMCPProxy:
         )
 
         self.logger.info(
-            f"🔧 Unified MCP proxy configured - timeout: {self.timeout}s, "
+            f"🔧 Unified MCP proxy configured - timeout: "
+            f"{self.effective_call_timeout_secs()}s, "
             f"streaming: {self.streaming_capable}, session_required: {self.session_required}"
         )
+
+    def effective_call_timeout_secs(self) -> int:
+        """The single per-call budget for this proxy, in whole seconds.
+
+        Used for the httpx client timeout AND the outgoing ``X-Mesh-Timeout``
+        header, so the two can never disagree (issue #1584).
+
+        There is deliberately no per-dependency override branch here: the only
+        map this proxy holds is the PRODUCER's kwargs (see
+        ``_configure_from_kwargs``), and honouring a `timeout` from it would
+        let a provider dictate every consumer's client timeout. Python
+        therefore matches Java exactly -- ``MCP_MESH_CALL_TIMEOUT``, else 300.
+        An inbound ``X-Mesh-Timeout`` still overrides this at the call site.
+        """
+        return _default_call_timeout_secs()
 
     def _configure_telemetry(self):
         """Configure telemetry and tracing settings."""
@@ -560,7 +640,7 @@ class UnifiedMCPProxy:
                 "target_tool_name": tool_name,
                 "request_fingerprint": arg_fingerprint,
                 "proxy_config": {
-                    "timeout": self.timeout,
+                    "timeout": self.effective_call_timeout_secs(),
                     "retry_count": self.retry_count,
                     "streaming_capable": self.streaming_capable,
                     "session_required": self.session_required,
@@ -622,7 +702,7 @@ class UnifiedMCPProxy:
                         "endpoint": self.endpoint,
                         "proxy_type": "http_with_fastmcp_fallback",
                         "streaming_capable": self.streaming_capable,
-                        "timeout": self.timeout,
+                        "timeout": self.effective_call_timeout_secs(),
                         "retry_count": self.retry_count,
                     }
 
@@ -787,7 +867,8 @@ class UnifiedMCPProxy:
         # Log cross-agent call - summary line
         arg_keys = list(arguments.keys()) if arguments else []
         self.logger.debug(
-            f"{tp}🔄 Cross-agent call: {self.endpoint}/{name} (timeout: {self.timeout}s, args={arg_keys})"
+            f"{tp}🔄 Cross-agent call: {self.endpoint}/{name} "
+            f"(timeout: {self.effective_call_timeout_secs()}s, args={arg_keys})"
         )
         # Log full args (will be TRACE later)
         self.logger.debug(
@@ -1225,19 +1306,19 @@ class UnifiedMCPProxy:
                 for key, value in outbound.items():
                     headers[key] = value
 
-            # Enhanced timeout for large content processing
-            enhanced_timeout = max(
-                self.timeout, 300
-            )  # At least 5 minutes for large files
+            # ONE per-call budget for both halves of the call (issue #1584):
+            # an explicit `timeout` kwarg if the dependency declared one,
+            # otherwise MCP_MESH_CALL_TIMEOUT, otherwise 300. It becomes the
+            # httpx client timeout below AND the advertised X-Mesh-Timeout,
+            # so this process cannot promise the provider a budget it is not
+            # itself willing to wait out.
+            enhanced_timeout = self.effective_call_timeout_secs()
 
             # Set X-Mesh-Timeout for registry proxy (#769). If already
-            # propagated from an incoming request, keep that value;
-            # otherwise use env/default. Also use it for client timeout.
+            # propagated from an incoming request, keep that value -- an
+            # inbound budget always wins over a locally derived one.
             if "X-Mesh-Timeout" not in headers and "x-mesh-timeout" not in headers:
-                call_timeout = os.environ.get(
-                    "MCP_MESH_CALL_TIMEOUT", str(int(enhanced_timeout))
-                )
-                headers["X-Mesh-Timeout"] = call_timeout
+                headers["X-Mesh-Timeout"] = str(enhanced_timeout)
 
             # Phase 1 MeshJob substrate: when a tool is executing under
             # an active job context (set by the inbound dispatch wrapper
@@ -1266,7 +1347,27 @@ class UnifiedMCPProxy:
                                 cur_timeout = int(headers.get("X-Mesh-Timeout", "0"))
                             except (TypeError, ValueError):
                                 cur_timeout = 0
-                            remaining = int(snap.deadline_secs_remaining)
+                            raw_remaining = float(snap.deadline_secs_remaining)
+                            # NOTE: unlike the Rust `JobContext`, this value is
+                            # a STATIC dispatch-time snapshot -- job_dispatch
+                            # reads the inbound `X-Mesh-Timeout` once and never
+                            # decrements it -- so it is the budget the parent
+                            # granted, not live remaining time.
+                            #
+                            # Round UP and floor at 1 (issue #1584). Reachable:
+                            # an inbound header of "0.5" used to become
+                            # `int(0.5)` == 0 and get DROPPED as expired,
+                            # handing the child an unbounded budget instead of
+                            # the tightest one the wire can express.
+                            #
+                            # The `<= 0` arm below is defensive rather than
+                            # reachable from dispatch (job_dispatch already
+                            # normalises a `<= 0` header to None), but
+                            # `CURRENT_JOB` is public API that user code and
+                            # tests can set directly.
+                            remaining = (
+                                0 if raw_remaining <= 0 else max(1, math.ceil(raw_remaining))
+                            )
                             if remaining <= 0:
                                 # Already past the parent deadline. The
                                 # OpenAPI schema requires X-Mesh-Timeout
@@ -1281,11 +1382,11 @@ class UnifiedMCPProxy:
                                 # call shouldn't have been made.
                                 self.logger.warning(
                                     "outbound %s under job=%s has expired deadline "
-                                    "(remaining=%ds); omitting X-Mesh-Timeout instead "
+                                    "(granted=%ss); omitting X-Mesh-Timeout instead "
                                     "of emitting an invalid '0' value",
                                     name,
                                     snap.job_id,
-                                    remaining,
+                                    raw_remaining,
                                 )
                                 headers.pop("X-Mesh-Timeout", None)
                                 headers.pop("x-mesh-timeout", None)

--- a/src/runtime/python/tests/unit/test_call_timeout_budget_1584.py
+++ b/src/runtime/python/tests/unit/test_call_timeout_budget_1584.py
@@ -1,0 +1,289 @@
+"""Issue #1584 — one per-call budget, enforced locally and advertised on the wire.
+
+The budget a proxy enforces (the httpx client timeout) and the budget it
+advertises downstream (``X-Mesh-Timeout``) must be the same number, and the
+default must be identical in Python, TypeScript and Java.
+
+Before the fix Python computed them from two different expressions::
+
+    enhanced_timeout = max(self.timeout, 300)
+    X-Mesh-Timeout   = MCP_MESH_CALL_TIMEOUT or str(int(enhanced_timeout))
+
+so setting ``MCP_MESH_CALL_TIMEOUT`` overrode the header only, advertising a
+budget this client would not itself wait out.
+
+A note on what "explicit" means in Python, because it is the trap this file
+exists to pin down: ``UnifiedMCPProxy.kwargs_config`` is the **producer's**
+``@mesh.tool`` kwargs, shipped back from the registry on the resolved
+dependency (``rust_heartbeat._handle_dependency_change``), NOT the consumer's
+dependency declaration. So there is no consumer-side per-call timeout the
+runtime reads, and a ``timeout`` appearing in that map must NOT become the
+consumer's budget — otherwise a provider (or, worse, an ``@mesh.llm`` provider
+whose ``timeout`` means the vendor SDK's timeout) would cap every caller.
+Python therefore matches Java: env, else 300.
+"""
+
+import itertools
+import json
+import os
+from unittest import mock
+
+import pytest
+
+from _mcp_mesh.engine.unified_mcp_proxy import (
+    FALLBACK_CALL_TIMEOUT_SECS,
+    UnifiedMCPProxy,
+    _default_call_timeout_secs,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env():
+    saved = os.environ.pop("MCP_MESH_CALL_TIMEOUT", None)
+    yield
+    os.environ.pop("MCP_MESH_CALL_TIMEOUT", None)
+    if saved is not None:
+        os.environ["MCP_MESH_CALL_TIMEOUT"] = saved
+
+
+class TestDefaultCallTimeoutSecs:
+    def test_unset_and_blank_fall_back_to_300(self):
+        assert _default_call_timeout_secs() == 300
+        assert FALLBACK_CALL_TIMEOUT_SECS == 300
+        os.environ["MCP_MESH_CALL_TIMEOUT"] = "   "
+        assert _default_call_timeout_secs() == 300
+
+    def test_valid_value_is_used(self):
+        os.environ["MCP_MESH_CALL_TIMEOUT"] = "600"
+        assert _default_call_timeout_secs() == 600
+
+    @pytest.mark.parametrize("bad", ["abc", "0", "-5", "nan", "inf"])
+    def test_unparseable_or_non_positive_falls_back(self, bad):
+        os.environ["MCP_MESH_CALL_TIMEOUT"] = bad
+        assert _default_call_timeout_secs() == 300
+
+    def test_read_at_call_time_not_import_time(self):
+        os.environ["MCP_MESH_CALL_TIMEOUT"] = "120"
+        assert _default_call_timeout_secs() == 120
+        os.environ["MCP_MESH_CALL_TIMEOUT"] = "45"
+        assert _default_call_timeout_secs() == 45
+
+    def test_rounds_half_up_like_typescript_and_java(self):
+        # Python's built-in round() is banker's rounding — round(2.5) == 2 —
+        # while Math.round is half-up in both TS and Java. The three runtimes
+        # have to agree on what MCP_MESH_CALL_TIMEOUT=2.5 means.
+        os.environ["MCP_MESH_CALL_TIMEOUT"] = "2.5"
+        assert _default_call_timeout_secs() == 3
+        os.environ["MCP_MESH_CALL_TIMEOUT"] = "3.5"
+        assert _default_call_timeout_secs() == 4
+        os.environ["MCP_MESH_CALL_TIMEOUT"] = "0.4"
+        assert _default_call_timeout_secs() == 1
+
+
+_DI_SEQ = itertools.count()
+
+
+async def _build_proxy_through_di(producer_kwargs: dict | None):
+    """Build a dependency proxy the way the runtime actually builds one.
+
+    Goes through ``_handle_dependency_change``, so ``kwargs_config`` is
+    populated from the PRODUCER kwargs JSON exactly as the Rust core delivers
+    it. Constructing ``UnifiedMCPProxy`` directly is what hid the
+    producer-vs-consumer confusion in the first place.
+
+    Each call uses a fresh ``requesting_function`` so the #1314 idempotency
+    guard (which skips a rebuild when endpoint/function/kwargs/agent_id are
+    unchanged) doesn't swallow the second and later builds in this file.
+    """
+    from _mcp_mesh.engine.dependency_injector import get_global_injector
+    from _mcp_mesh.pipeline.mcp_heartbeat.rust_heartbeat import (
+        _handle_dependency_change,
+    )
+
+    injector = get_global_injector()
+    captured: dict = {}
+
+    real_register = injector.register_dependency
+
+    async def _capture(dep_key, proxy):
+        captured["proxy"] = proxy
+        return await real_register(dep_key, proxy)
+
+    with mock.patch.object(injector, "register_dependency", _capture):
+        await _handle_dependency_change(
+            capability="downstream_cap",
+            endpoint="http://downstream:8000",
+            function_name="some_tool",
+            agent_id="provider-agent",
+            available=True,
+            context={},
+            requesting_function=f"consumer_tool_{next(_DI_SEQ)}",
+            dep_index=0,
+            producer_kwargs=json.dumps(producer_kwargs) if producer_kwargs else None,
+        )
+    assert "proxy" in captured, "DI did not register a proxy"
+    return captured["proxy"]
+
+
+class TestProducerKwargsCannotDictateTheBudget:
+    """The regression this file is named for.
+
+    ``kwargs_config`` carries the producer's kwargs. A ``timeout`` in it must
+    not become the consumer's client timeout or advertised header.
+    """
+
+    @pytest.mark.asyncio
+    async def test_producer_timeout_does_not_override_the_default(self):
+        proxy = await _build_proxy_through_di({"timeout": 45})
+        # The producer's value is visible as advertised metadata...
+        assert proxy.kwargs_config.get("timeout") == 45
+        # ...but it is NOT this consumer's budget.
+        assert proxy.effective_call_timeout_secs() == 300
+
+    @pytest.mark.asyncio
+    async def test_producer_timeout_does_not_override_the_env_var(self):
+        os.environ["MCP_MESH_CALL_TIMEOUT"] = "600"
+        proxy = await _build_proxy_through_di({"timeout": 45})
+        assert proxy.effective_call_timeout_secs() == 600
+
+    @pytest.mark.asyncio
+    async def test_env_var_governs_when_producer_declares_nothing(self):
+        os.environ["MCP_MESH_CALL_TIMEOUT"] = "600"
+        proxy = await _build_proxy_through_di(None)
+        assert proxy.effective_call_timeout_secs() == 600
+
+    @pytest.mark.asyncio
+    async def test_default_when_neither_is_set(self):
+        proxy = await _build_proxy_through_di(None)
+        assert proxy.effective_call_timeout_secs() == 300
+
+
+class _CapturingClient:
+    """Minimal stand-in for the pooled httpx client: records what was sent."""
+
+    def __init__(self):
+        self.headers = None
+        self.timeout = None
+
+    async def post(self, url, content=None, headers=None, timeout=None):
+        self.headers = dict(headers or {})
+        self.timeout = timeout
+        raise RuntimeError("stop-after-capture")
+
+
+async def _capture_call(proxy):
+    client = _CapturingClient()
+    with mock.patch(
+        "_mcp_mesh.engine.unified_mcp_proxy._get_httpx_client_sync",
+        return_value=client,
+    ):
+        with pytest.raises(Exception):
+            await proxy._http_call("some_tool", {})
+    return client
+
+
+class TestOutboundHeaderMatchesClientTimeout:
+    """The two halves of the budget are read off the same real call."""
+
+    @pytest.mark.asyncio
+    async def test_default_is_300_on_both_halves(self):
+        client = await _capture_call(await _build_proxy_through_di(None))
+        assert client.headers["X-Mesh-Timeout"] == "300"
+        assert client.timeout.read == 300
+
+    @pytest.mark.asyncio
+    async def test_env_var_moves_both_halves(self):
+        os.environ["MCP_MESH_CALL_TIMEOUT"] = "600"
+        client = await _capture_call(await _build_proxy_through_di(None))
+        assert client.headers["X-Mesh-Timeout"] == "600"
+        assert client.timeout.read == 600
+
+    @pytest.mark.asyncio
+    async def test_producer_timeout_moves_neither_half(self):
+        client = await _capture_call(await _build_proxy_through_di({"timeout": 45}))
+        assert client.headers["X-Mesh-Timeout"] == "300"
+        assert client.timeout.read == 300
+
+    @pytest.mark.asyncio
+    async def test_inbound_header_wins_over_the_local_default(self):
+        from _mcp_mesh.tracing.context import TraceContext
+
+        proxy = UnifiedMCPProxy("http://downstream:8000", "some_tool", {})
+        TraceContext.set_propagated_headers({})
+        try:
+            proxy._inject_trace_headers  # noqa: B018 — attribute presence check
+            client = _CapturingClient()
+            with mock.patch(
+                "_mcp_mesh.engine.unified_mcp_proxy._get_httpx_client_sync",
+                return_value=client,
+            ):
+                with mock.patch.object(
+                    proxy,
+                    "_inject_trace_headers",
+                    lambda h: {**h, "X-Mesh-Timeout": "12"},
+                ):
+                    with pytest.raises(Exception):
+                        await proxy._http_call("some_tool", {})
+            assert client.headers["X-Mesh-Timeout"] == "12"
+            assert client.timeout.read == 12
+        finally:
+            TraceContext.set_propagated_headers({})
+
+
+class TestJobDeadlineOverride:
+    """The parent-scope deadline cap tightens the header, and never renders
+    as the "0" every receiver reads as "unset".
+
+    ``deadline_secs_remaining`` is a STATIC dispatch-time snapshot of the
+    inbound ``X-Mesh-Timeout`` (``job_dispatch`` reads it once and never
+    decrements it), so these cases are about the value the parent GRANTED, not
+    live remaining time.
+    """
+
+    async def _capture_under_job(self, deadline_secs_remaining):
+        from _mcp_mesh.engine.job_context import CURRENT_JOB, JobContextSnapshot
+
+        proxy = UnifiedMCPProxy("http://downstream:8000", "some_tool", {})
+        client = _CapturingClient()
+        token = CURRENT_JOB.set(
+            JobContextSnapshot(
+                job_id="job-1584",
+                deadline_secs_remaining=deadline_secs_remaining,
+                claim_epoch=None,
+            )
+        )
+        try:
+            with mock.patch(
+                "_mcp_mesh.engine.unified_mcp_proxy._get_httpx_client_sync",
+                return_value=client,
+            ):
+                with pytest.raises(Exception):
+                    await proxy._http_call("some_tool", {})
+        finally:
+            CURRENT_JOB.reset(token)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_tighter_deadline_replaces_the_default(self):
+        client = await self._capture_under_job(20.0)
+        assert client.headers["X-Mesh-Job-Id"] == "job-1584"
+        assert client.headers["X-Mesh-Timeout"] == "20"
+
+    @pytest.mark.asyncio
+    async def test_sub_second_grant_advertises_one_not_zero(self):
+        # An inbound header of "0.5" reaches the snapshot intact (job_dispatch
+        # only normalises `<= 0`). `int(0.5)` is 0, and 0 reads as "unset"
+        # downstream — which handed the child an unbounded budget instead of
+        # the tightest one the wire can express.
+        client = await self._capture_under_job(0.5)
+        assert client.headers["X-Mesh-Timeout"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_expired_grant_omits_the_header_entirely(self):
+        # Defensive rather than dispatch-reachable: job_dispatch normalises a
+        # `<= 0` header to None. CURRENT_JOB is public API, so user code and
+        # tests can still produce this snapshot directly.
+        client = await self._capture_under_job(-3.0)
+        assert client.headers["X-Mesh-Job-Id"] == "job-1584"
+        assert "X-Mesh-Timeout" not in client.headers
+        assert "x-mesh-timeout" not in client.headers

--- a/src/runtime/python/tests/unit/test_call_timeout_budget_1584.py
+++ b/src/runtime/python/tests/unit/test_call_timeout_budget_1584.py
@@ -159,7 +159,13 @@ class TestProducerKwargsCannotDictateTheBudget:
 
 
 class _CapturingClient:
-    """Minimal stand-in for the pooled httpx client: records what was sent."""
+    """Minimal stand-in for the pooled httpx client: records what was sent.
+
+    ``post`` raises a sentinel once it has captured, and every caller asserts
+    on THAT sentinel rather than a bare ``Exception``: a failure earlier in
+    ``_http_call`` would otherwise satisfy the assertion and leave the
+    remaining checks reading a client that captured nothing.
+    """
 
     def __init__(self):
         self.headers = None
@@ -177,7 +183,7 @@ async def _capture_call(proxy):
         "_mcp_mesh.engine.unified_mcp_proxy._get_httpx_client_sync",
         return_value=client,
     ):
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError, match="stop-after-capture"):
             await proxy._http_call("some_tool", {})
     return client
 
@@ -222,7 +228,7 @@ class TestOutboundHeaderMatchesClientTimeout:
                     "_inject_trace_headers",
                     lambda h: {**h, "X-Mesh-Timeout": "12"},
                 ):
-                    with pytest.raises(Exception):
+                    with pytest.raises(RuntimeError, match="stop-after-capture"):
                         await proxy._http_call("some_tool", {})
             assert client.headers["X-Mesh-Timeout"] == "12"
             assert client.timeout.read == 12
@@ -257,7 +263,7 @@ class TestJobDeadlineOverride:
                 "_mcp_mesh.engine.unified_mcp_proxy._get_httpx_client_sync",
                 return_value=client,
             ):
-                with pytest.raises(Exception):
+                with pytest.raises(RuntimeError, match="stop-after-capture"):
                     await proxy._http_call("some_tool", {})
         finally:
             CURRENT_JOB.reset(token)

--- a/src/runtime/typescript/src/__tests__/proxy-call-timeout-budget.test.ts
+++ b/src/runtime/typescript/src/__tests__/proxy-call-timeout-budget.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Issue #1584 — the per-call budget a TypeScript caller enforces locally and
+ * the one it advertises downstream in `X-Mesh-Timeout` must be the same
+ * number, and its default must match Python's and Java's.
+ *
+ * Before the fix these were two independent computations:
+ *
+ *   effectiveTimeout = options.timeout                 // (kwargs.timeout ?? 30) * 1000
+ *   X-Mesh-Timeout   = MCP_MESH_CALL_TIMEOUT || floor(options.timeout / 1000)
+ *
+ * so (a) the default budget was 30s in TypeScript against 300s in
+ * Python/Java for the identical tool, and (b) setting MCP_MESH_CALL_TIMEOUT
+ * moved only the ADVERTISED value — the client still gave up at its own,
+ * unchanged deadline, leaving the provider working on a request nobody was
+ * waiting for.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  createProxy,
+  resolveDefaultCallTimeoutSecs,
+  DEFAULT_CALL_OPTIONS,
+} from "../proxy.js";
+
+vi.mock("@mcpmesh/core", () => ({
+  generateTraceId: () => "trace-mock",
+  generateSpanId: () => "span-mock",
+  injectTraceContext: (argsJson: string) => argsJson,
+  publishSpan: vi.fn(async () => false),
+  parseSseResponse: (s: string) => s,
+  parseSseResponseToObject: (s: string) => JSON.parse(s),
+  awaitJobCancel: vi.fn(() => new Promise<void>(() => {})),
+  matchesPropagateHeader: () => false,
+}));
+
+vi.mock("../http-pool.js", () => ({
+  getDispatcher: () => undefined,
+}));
+
+const ENDPOINT = "http://producer.local:9000";
+
+function jsonResponse(): Response {
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: "x",
+    result: { content: [{ type: "text", text: "ok" }] },
+  });
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => body,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/json" : null,
+    },
+  } as unknown as Response;
+}
+
+/**
+ * Call a proxy built from `kwargs` and report both halves of the budget:
+ * what went out on the wire, and what the local abort timer was armed for.
+ */
+async function callAndCapture(
+  kwargs?: Parameters<typeof createProxy>[3],
+): Promise<{ header: string | undefined; abortMs: number | undefined }> {
+  let header: string | undefined;
+  globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) => {
+    const h = (init.headers ?? {}) as Record<string, string>;
+    header = h["X-Mesh-Timeout"] ?? h["x-mesh-timeout"];
+    return jsonResponse();
+  }) as unknown as typeof fetch;
+
+  // The local budget is whatever `setTimeout(() => abort(), N)` is armed with.
+  let abortMs: number | undefined;
+  const realSetTimeout = globalThis.setTimeout;
+  const spy = vi
+    .spyOn(globalThis, "setTimeout")
+    .mockImplementation(((fn: () => void, ms?: number, ...rest: unknown[]) => {
+      if (abortMs === undefined && typeof ms === "number" && ms > 0) {
+        abortMs = ms;
+      }
+      return (realSetTimeout as unknown as (...a: unknown[]) => unknown)(
+        fn,
+        ms,
+        ...rest,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any);
+
+  try {
+    const proxy = createProxy(ENDPOINT, "echoer", "echo", kwargs);
+    await proxy({ foo: 1 });
+  } finally {
+    spy.mockRestore();
+  }
+  return { header, abortMs };
+}
+
+describe("#1584 per-call budget: header and abort timer agree", () => {
+  let originalFetch: typeof fetch;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalEnv = process.env.MCP_MESH_CALL_TIMEOUT;
+    delete process.env.MCP_MESH_CALL_TIMEOUT;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEnv === undefined) {
+      delete process.env.MCP_MESH_CALL_TIMEOUT;
+    } else {
+      process.env.MCP_MESH_CALL_TIMEOUT = originalEnv;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to 300s — matching Python and Java — not 30s", async () => {
+    const { header, abortMs } = await callAndCapture();
+    expect(header).toBe("300");
+    expect(abortMs).toBe(300_000);
+  });
+
+  it("honours MCP_MESH_CALL_TIMEOUT for BOTH halves of the budget", async () => {
+    process.env.MCP_MESH_CALL_TIMEOUT = "600";
+    const { header, abortMs } = await callAndCapture();
+    expect(header).toBe("600");
+    // The pre-fix bug: the header moved to 600 while this stayed at 30_000.
+    expect(abortMs).toBe(600_000);
+  });
+
+  it("lets an explicit per-call timeout override the env var, for both halves", async () => {
+    process.env.MCP_MESH_CALL_TIMEOUT = "600";
+    const { header, abortMs } = await callAndCapture({ timeout: 45 });
+    expect(header).toBe("45");
+    expect(abortMs).toBe(45_000);
+  });
+
+  it("keeps an explicit timeout of 30 meaning 30 — not the 300 default", async () => {
+    // The pre-fix `kwargs?.timeout ?? 30` collapsed "asked for 30" and "asked
+    // for nothing"; raising the default without separating them would have
+    // silently promoted every explicit 30 to 300.
+    const { header, abortMs } = await callAndCapture({ timeout: 30 });
+    expect(header).toBe("30");
+    expect(abortMs).toBe(30_000);
+  });
+
+  it("never advertises a sub-second budget as 0", async () => {
+    // 0.4s would floor to "0", which every receiver reads as "unset" and
+    // replaces with its own (much larger) default.
+    const { header, abortMs } = await callAndCapture({ timeout: 0.4 });
+    expect(header).toBe("1");
+    expect(abortMs).toBe(1_000);
+  });
+
+  it("rounds a fractional budget UP on BOTH halves, never down", async () => {
+    // Review catch: advertising 3s while aborting at 2400ms leaves the
+    // provider working 600ms past the point anyone is listening. The wire
+    // carries whole seconds, so the abort timer is quantised to match.
+    const { header, abortMs } = await callAndCapture({ timeout: 2.4 });
+    expect(header).toBe("3");
+    expect(abortMs).toBe(3_000);
+  });
+
+  it("keeps a propagated inbound X-Mesh-Timeout instead of overwriting it", async () => {
+    const { runWithPropagatedHeaders } = await import("../proxy.js");
+    let header: string | undefined;
+    globalThis.fetch = vi.fn(async (_url: string, init: RequestInit) => {
+      const h = (init.headers ?? {}) as Record<string, string>;
+      header = h["X-Mesh-Timeout"] ?? h["x-mesh-timeout"];
+      return jsonResponse();
+    }) as unknown as typeof fetch;
+
+    const proxy = createProxy(ENDPOINT, "echoer", "echo");
+    await runWithPropagatedHeaders({ "x-mesh-timeout": "12" }, async () => {
+      await proxy({ foo: 1 });
+    });
+    expect(header).toBe("12");
+  });
+});
+
+describe("#1584 streaming budgets still follow MCP_MESH_CALL_TIMEOUT", () => {
+  let originalFetch: typeof fetch;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalEnv = process.env.MCP_MESH_CALL_TIMEOUT;
+    delete process.env.MCP_MESH_CALL_TIMEOUT;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEnv === undefined) {
+      delete process.env.MCP_MESH_CALL_TIMEOUT;
+    } else {
+      process.env.MCP_MESH_CALL_TIMEOUT = originalEnv;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("raises a streaming dependency's budget when the env var is raised", async () => {
+    // docs/environment-variables.md tells operators to raise
+    // MCP_MESH_CALL_TIMEOUT for long-running chains. Deriving the stream
+    // budget from a hard-coded 300 would have silently broken that.
+    process.env.MCP_MESH_CALL_TIMEOUT = "900";
+    const { header, abortMs } = await callAndCapture({ streaming: true });
+    expect(header).toBe("900");
+    expect(abortMs).toBe(900_000);
+  });
+
+  it("still defaults a streaming dependency to 300", async () => {
+    const { header, abortMs } = await callAndCapture({ streaming: true });
+    expect(header).toBe("300");
+    expect(abortMs).toBe(300_000);
+  });
+
+  it("lets an explicit streamTimeout win over the env var", async () => {
+    process.env.MCP_MESH_CALL_TIMEOUT = "900";
+    const { header, abortMs } = await callAndCapture({
+      streaming: true,
+      streamTimeout: 120,
+    });
+    expect(header).toBe("120");
+    expect(abortMs).toBe(120_000);
+  });
+
+  it("documents that `timeout` does not apply to a streaming dependency", async () => {
+    // Pre-existing behaviour, asserted so the carve-out in the
+    // DependencyKwargs docs stays honest.
+    const { header, abortMs } = await callAndCapture({
+      streaming: true,
+      timeout: 45,
+    });
+    expect(header).toBe("300");
+    expect(abortMs).toBe(300_000);
+  });
+});
+
+describe("#1584 resolveDefaultCallTimeoutSecs", () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.MCP_MESH_CALL_TIMEOUT;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.MCP_MESH_CALL_TIMEOUT;
+    } else {
+      process.env.MCP_MESH_CALL_TIMEOUT = originalEnv;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("falls back to 300 when unset or blank", () => {
+    delete process.env.MCP_MESH_CALL_TIMEOUT;
+    expect(resolveDefaultCallTimeoutSecs()).toBe(300);
+    process.env.MCP_MESH_CALL_TIMEOUT = "   ";
+    expect(resolveDefaultCallTimeoutSecs()).toBe(300);
+  });
+
+  it("falls back to 300 (with a warning) on unparseable or non-positive values", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    for (const bad of ["abc", "0", "-5", "NaN"]) {
+      process.env.MCP_MESH_CALL_TIMEOUT = bad;
+      expect(resolveDefaultCallTimeoutSecs()).toBe(300);
+    }
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("is read at call time, so DEFAULT_CALL_OPTIONS tracks the env var", () => {
+    process.env.MCP_MESH_CALL_TIMEOUT = "120";
+    expect(resolveDefaultCallTimeoutSecs()).toBe(120);
+    expect(DEFAULT_CALL_OPTIONS.timeout).toBe(120_000);
+    process.env.MCP_MESH_CALL_TIMEOUT = "45";
+    expect(DEFAULT_CALL_OPTIONS.timeout).toBe(45_000);
+  });
+});

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -38,9 +38,83 @@ export interface CallOptions {
   maxResponseSize: number;
 }
 
-/** Default CallOptions for internal callers that don't go through createProxy. */
+/**
+ * Fallback per-call budget in seconds when neither the caller nor
+ * `MCP_MESH_CALL_TIMEOUT` says otherwise. 300 across all three runtimes
+ * (issue #1584) — TypeScript used to fall back to 30, so the same tool got a
+ * 10x smaller budget depending on the caller's language.
+ */
+const FALLBACK_CALL_TIMEOUT_SECS = 300;
+
+/** Bad `MCP_MESH_CALL_TIMEOUT` values already warned about (de-spam). */
+const warnedCallTimeoutValues = new Set<string>();
+
+/**
+ * Resolve the default per-call budget, in seconds, from
+ * `MCP_MESH_CALL_TIMEOUT`.
+ *
+ * This is the ONLY source of a default budget in this module: whatever it
+ * returns is used for BOTH the local abort timer and the `X-Mesh-Timeout`
+ * header, so a TypeScript caller can never advertise one budget downstream
+ * while abandoning the request at another (issue #1584). An explicit
+ * per-call `timeout` kwarg overrides it — also for both.
+ *
+ * Read at call time, not at module load, so a test (or a process that
+ * configures its environment late) sees the current value. Mirrors Java's
+ * `McpHttpClient.parseTimeoutSecs` and Python's `_default_call_timeout_secs`:
+ * unset / blank / unparseable / non-positive all fall back to
+ * {@link FALLBACK_CALL_TIMEOUT_SECS}, with a warning for the values that
+ * look like a misconfiguration rather than an absence.
+ */
+export function resolveDefaultCallTimeoutSecs(): number {
+  const raw = process.env.MCP_MESH_CALL_TIMEOUT;
+  if (raw === undefined || raw.trim() === "") {
+    return FALLBACK_CALL_TIMEOUT_SECS;
+  }
+  const parsed = Number(raw.trim());
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    // Warn once per distinct bad value: this runs on every outbound call, and
+    // a misconfigured env var is a startup-shaped problem, not a per-call one.
+    if (!warnedCallTimeoutValues.has(raw)) {
+      warnedCallTimeoutValues.add(raw);
+      console.warn(
+        `[mcp-mesh] Invalid MCP_MESH_CALL_TIMEOUT value '${raw}' — using default ${FALLBACK_CALL_TIMEOUT_SECS}s`,
+      );
+    }
+    return FALLBACK_CALL_TIMEOUT_SECS;
+  }
+  return Math.max(1, Math.round(parsed));
+}
+
+/**
+ * Round a caller-declared budget (in SECONDS) to the whole seconds the
+ * `X-Mesh-Timeout` wire format can carry: up, and never below 1.
+ *
+ * Applied at declaration time so the local abort timer and the advertised
+ * header are the same number for every dependency proxy (issue #1584). A
+ * non-finite or non-positive input falls back to the resolved default rather
+ * than producing a 1s budget out of a typo.
+ */
+function quantiseBudgetSecs(secs: number): number {
+  if (!Number.isFinite(secs) || secs <= 0) {
+    return resolveDefaultCallTimeoutSecs();
+  }
+  return Math.max(1, Math.ceil(secs));
+}
+
+/**
+ * Default CallOptions for internal callers that don't go through createProxy.
+ *
+ * `timeout` is a GETTER, not a fixed number: it resolves
+ * `MCP_MESH_CALL_TIMEOUT` on every read so these internal callers follow the
+ * same rule as a user-declared dependency (issue #1584). Spreading
+ * (`{ ...DEFAULT_CALL_OPTIONS, timeout: X }`) evaluates the getter and then
+ * overrides it, which is exactly what those call sites want.
+ */
 export const DEFAULT_CALL_OPTIONS: CallOptions = {
-  timeout: 30_000,
+  get timeout(): number {
+    return resolveDefaultCallTimeoutSecs() * 1000;
+  },
   maxAttempts: 1,
   streamTimeout: 300_000,
   retryDelay: 100,
@@ -188,15 +262,44 @@ export function createProxy(
   kwargs?: DependencyKwargs
 ): McpMeshTool {
   const options: CallOptions = {
-    timeout: (kwargs?.timeout ?? 30) * 1000,
+    // An explicit per-call `timeout` is authoritative for BOTH the local
+    // abort timer and the emitted `X-Mesh-Timeout`; when absent, both come
+    // from `MCP_MESH_CALL_TIMEOUT` (default 300s). Resolving it HERE — rather
+    // than defaulting to 30 here and consulting the env separately when
+    // building the header — is what removes the #1584 split-brain: previously
+    // `kwargs?.timeout ?? 30` collapsed "caller asked for 30" and "caller
+    // asked for nothing", and the header was then built from the env var, so
+    // setting MCP_MESH_CALL_TIMEOUT=600 advertised a 600s budget downstream
+    // while this client still aborted at 30s.
+    // Quantised to whole seconds (rounded up, floored at 1) because that is
+    // all `X-Mesh-Timeout` can carry: a `timeout: 2.4` that aborted at 2400ms
+    // while advertising 3s would leave the provider working 600ms past the
+    // point anyone was listening — the same defect, smaller, that #1584 is
+    // about. Python quantises identically in `effective_call_timeout_secs`.
+    timeout: quantiseBudgetSecs(kwargs?.timeout ?? resolveDefaultCallTimeoutSecs()) * 1000,
     maxAttempts: kwargs?.maxAttempts ?? 1,
-    streamTimeout: (kwargs?.streamTimeout ?? 300) * 1000,
+    // `streamTimeout` shares the same fallback chain (issue #1584 review).
+    // Its literal default was also 300, so this is a no-op when the env var
+    // is unset — but leaving it hard-coded would have silently broken the
+    // workaround `docs/environment-variables.md` prescribes for long-lived
+    // streams ("raise MCP_MESH_CALL_TIMEOUT"): before this PR the stream
+    // header was `env || floor(timeout/1000)`, so raising the env var raised
+    // it. An explicit `streamTimeout` kwarg still wins.
+    streamTimeout:
+      quantiseBudgetSecs(
+        kwargs?.streamTimeout ?? resolveDefaultCallTimeoutSecs(),
+      ) * 1000,
     customHeaders: kwargs?.customHeaders,
     retryDelay: (kwargs?.retryDelay ?? 0.1) * 1000,
     retryBackoff: kwargs?.retryBackoff ?? 2.0,
     maxResponseSize: kwargs?.maxResponseSize ?? 10 * 1024 * 1024,
   };
-  // Use streamTimeout when streaming is enabled
+  // Use streamTimeout when streaming is enabled. NOTE this is the documented
+  // exception to "an explicit `timeout` is authoritative": a `streaming: true`
+  // dependency is by definition long-lived, so it runs on `streamTimeout` and
+  // an explicit `timeout` does not apply to it. Pre-existing behaviour, called
+  // out here (and on `DependencyKwargs.timeout`) because #1584 otherwise reads
+  // as though `timeout` always wins.
   if (kwargs?.streaming) {
     options.timeout = options.streamTimeout;
   }
@@ -408,6 +511,21 @@ function buildMcpRequest(
   if (typeof effectiveTimeout !== "number" || effectiveTimeout <= 0) {
     effectiveTimeout = defaultTimeout;
   }
+  // The whole-second budget to advertise. `X-Mesh-Timeout` is `minimum: 1` and
+  // integer-valued, so this rounds UP and floors at 1 (issue #1584).
+  //
+  // For every budget that ARRIVES in seconds this is the same number the abort
+  // timer below is armed with, by construction — `createProxy` quantises the
+  // declared/env seconds, `DEFAULT_CALL_OPTIONS` derives from the env, and a
+  // propagated inbound `X-Mesh-Timeout` is whole seconds already. The one gap
+  // is an internal caller hand-building `CallOptions` with a SUB-SECOND
+  // millisecond budget: the wire cannot express it, so such a call advertises
+  // 1s while aborting earlier. That over-advertises by under a second, which
+  // is the lesser evil against the alternatives — advertising `0` reads as
+  // "unset" downstream and hands the provider an unbounded budget, and
+  // inflating the local timer to 1s would silently multiply a deliberate
+  // 50ms internal budget by twenty.
+  const budgetSecs = Math.max(1, Math.ceil(effectiveTimeout / 1000));
 
   const bodyStr = JSON.stringify(payload);
   const requestBytes = Buffer.byteLength(bodyStr, "utf8");
@@ -428,10 +546,14 @@ function buildMcpRequest(
   for (const [key, value] of Object.entries(mergedHeaders)) {
     headers[key] = value;
   }
-  // Set X-Mesh-Timeout for registry proxy (#769). If already propagated, keep it.
+  // Set X-Mesh-Timeout for the registry proxy (#769). If already propagated,
+  // keep it — an inbound budget always wins over a locally derived one.
+  //
+  // See `budgetSecs` above for why this equals the abort timer for every
+  // seconds-declared budget, and for the one sub-second exception (issue
+  // #1584).
   if (!headers["X-Mesh-Timeout"] && !headers["x-mesh-timeout"]) {
-    const callTimeout = process.env.MCP_MESH_CALL_TIMEOUT || String(Math.floor(options.timeout / 1000));
-    headers["X-Mesh-Timeout"] = callTimeout;
+    headers["X-Mesh-Timeout"] = String(budgetSecs);
   }
 
   return { mcpEndpoint, bodyStr, requestId: payload.id, requestBytes, headers, effectiveTimeout, traceCtx, spanId, startTime };

--- a/src/runtime/typescript/src/types.ts
+++ b/src/runtime/typescript/src/types.ts
@@ -382,7 +382,19 @@ export interface ResolvedAgentConfig {
  * Proxy configuration for a dependency.
  */
 export interface DependencyKwargs {
-  /** Request timeout in seconds. Defaults to 30 */
+  /**
+   * Request timeout in seconds. When set it is authoritative for BOTH the
+   * local abort timer and the `X-Mesh-Timeout` budget advertised downstream.
+   * When omitted, both come from `MCP_MESH_CALL_TIMEOUT`, defaulting to 300
+   * (issue #1584 — this used to default to 30 in TypeScript only).
+   *
+   * Fractional values are rounded UP to whole seconds, because that is all
+   * `X-Mesh-Timeout` can carry and both halves of the budget have to be the
+   * same number.
+   *
+   * Does not apply when `streaming: true` — a streaming dependency runs on
+   * {@link DependencyKwargs.streamTimeout} instead.
+   */
   timeout?: number;
   /** Total number of attempts (1 = one attempt with zero retries). Defaults to 1 */
   maxAttempts?: number;
@@ -390,7 +402,12 @@ export interface DependencyKwargs {
   streaming?: boolean;
   /** Require session affinity. Defaults to false */
   sessionRequired?: boolean;
-  /** Timeout for streaming/LLM responses in seconds. Defaults to 300 */
+  /**
+   * Timeout for streaming/LLM responses in seconds. When omitted it follows
+   * the same fallback chain as {@link DependencyKwargs.timeout} —
+   * `MCP_MESH_CALL_TIMEOUT`, else 300 — so raising that env var raises
+   * long-lived stream budgets too.
+   */
   streamTimeout?: number;
   /** Extra headers to send with every request to this dependency */
   customHeaders?: Record<string, string>;


### PR DESCRIPTION
Issues #1584 and #1585.

## ⚠️ Behaviour changes — read before merging

**TypeScript default call budget moves 30s → 300s.** A TS agent that gives up after 30s today will wait up to 300s. Per-runtime before/after:

| case | before | after |
|---|---|---|
| no `timeout`, no env | header 30, aborts 30s | header 300, aborts 300s |
| no `timeout`, `MCP_MESH_CALL_TIMEOUT=600` | header 600, **aborts 30s** | header 600, aborts 600s |
| `timeout: 45`, no env | header 45, aborts 45s | unchanged |
| `timeout: 45`, `MCP_MESH_CALL_TIMEOUT=600` | header **600**, aborts 45s | header 45, aborts 45s |
| `timeout: 2.4` | header **0** (reads as unset) | header 3, aborts 3000ms |

Rows 2 and 4 were actively harmful: raising the env var moved only what was *advertised*, so a provider kept working for up to 600s on a request the caller abandoned at 30s.

**Python**: `MCP_MESH_CALL_TIMEOUT` now wins outright instead of being floored by `max(…, 300)`, and a producer-declared `timeout` no longer influences any consumer's budget in either direction (see below).

**Java**: unchanged for calls. `MeshJobs.await(id, 0.0)` moves from "block until terminal" to "poll once" — the docs said the former and the code already did neither.

## #1584 — `X-Mesh-Timeout` emitted as 0

The remaining deadline was floored to whole seconds, so anything under 1s emitted `0`. Every receiver treats `<= 0` as unset — and `api/mcp-mesh-registry.openapi.yaml:1105-1108` declares `minimum: 1` — so the child silently fell back to its own default and the parent's cap was lost. Now `ceil` floored at 1, omitted entirely when expired. `remaining_seconds()` is retained, truncating, for `current_job()` snapshots where `Some(0)` = "expired" is the meaningful answer.

**#1584's impact statement is wrong.** It says the path "is used by TypeScript and Java". `injectJobHeaders` (napi) has zero TS callers, and `mesh_inject_job_headers` is declared at `MeshCore.java:882` but never invoked — both are dead surface. The live consumer is `mcp_client.rs:228`, the core's own outbound MCP client on the agentic-loop/LLM path, which all three runtimes reach. Same fix, same location, different blast radius.

## #1584 — one boundary policy across three bindings

Negative is an error, not "unlimited" — unlimited is the *unbounded* direction, and aliasing a negative turns a caller's bug into a job only a sweep will reap. The C ABI is the sole exception, because it has no nullable double (Java sends `-1.0` for `Optional.empty()`). `mesh_run_as_job` does **not** get that exception: it takes a JSON snapshot where `deadline_secs` is `Option<f64>` and `null` is expressible, so the sentinel bought nothing and reopened the hole the policy argues against.

`0.0` means a zero-length budget for a wait, and "no deadline" for a deadline — reachable only from the former, since the wire enforces `minimum: 1`.

## #1584 — the call budget

All three runtimes already read `MCP_MESH_CALL_TIMEOUT`; only the fallback diverged. Java already had the target shape and needed no change.

**Python deliberately gets no explicit-timeout branch.** `kwargs_config` is the *producer's* `@mesh.tool` kwargs (`rust_heartbeat.py:770`), not a consumer declaration, and `dependency_kwargs` — the consumer knob documented in `docs/reference/kwargs.md:274` — has **zero readers** in `src/runtime/python`. Honouring a `timeout` from that map would let a provider dictate every consumer's client timeout and override their env var. Filed separately.

## #1585 — sub-second waits became a zero-wait poll loop

The wire caps `wait` at `integer, 0..60` (`openapi.yaml:781-790`), so any budget under a second truncated to 0 and `recv_event` had no client-side pacing — a tight GET loop. Now paced on empty pages (100ms, matching the registry's own `listJobEventsPollResolution`), with per-filter read-ahead over the fetched page instead of refetching 99 of 100 events.

**#1585's prescribed fix is not implementable as written.** "Compute the wait in milliseconds" needs a wire and registry change given that schema; compensated client-side instead. Its registry line refs are also wrong (`ent_service_jobs.go:1677` is inside `PostJobEvent`), and the "single SQLite connection" framing overstates it — the 100ms sleep happens outside the query, so a parked caller holds no connection.

### The read-ahead is bounded against the claim lease

This is the part worth reviewing closely. An identity-carrying `list_job_events` is not just a read: `ent_service_jobs.go:118-140` extends `lease_expires_at` on it and it is the sole detector of `ExecutorReadSuperseded` → `ClaimSuperseded`. Serving a whole 100-event page from one fetch means one renewal instead of 100 — so a handler doing 5s of work per event would run ~500s against `defaultClaimLeaseSeconds = 300` and have a *healthy* execution reclaimed. There is no background lease heartbeat; only optional `update_progress`/`request_input` deltas extend it.

The buffer therefore expires (`RECV_READAHEAD_MAX_AGE = 2s`, <1% of the lease), and only for controllers that actually send identity — a push-mode/legacy controller reads anonymously and keeps an unexpiring buffer. `recv_event_read_ahead_still_renews_the_lease_on_a_slow_drain` fails without the bound (1 read instead of 5).

Residual, documented at `jobs.rs:368-374`: a job declaring `max_duration < 2s`. The controller isn't told `max_duration`, so an exact fraction would mean an ABI change across all three bindings; such a job is already a coin flip, since one long-poll round trip can outlive its whole lease.

## Also fixed

`build.rs` watched only `src/ffi.rs`, so the tracked `include/mcp_mesh_core.h` silently shipped stale whenever `jobs_ffi.rs` changed — and it had already gone stale here, describing the old deadline contract while the source said the opposite.

## Tests

All four Rust legs: **508 / 536 / 523 / 512** (from 503/530/518/507). TS 1451, Python 2942 (+7 skipped), Java BUILD SUCCESS, Go clean, `check_doc_claims.py` clean. Man golden 1809 → 1815, annotated.

Every assertion guarding a review fix was verified to fail against the unfixed code — the lease-renewal test, both zero-budget `proxy_wait` tests, all four Python producer-kwargs tests, and the three TS budget assertions.

Closes #1584
Closes #1585

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfukAUDerBUKAfKzUyhvvb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Unified call-timeout budgets across TypeScript, Python, and Java so local HTTP timeouts match the advertised `X-Mesh-Timeout`.
  - Standardized handling for zero, negative, fractional, invalid, and expired timeout values.
  - Expired job deadlines no longer advertise a zero-second timeout.
  - Job waits and event polling now perform an immediate check before timing out and handle batched events more reliably.

- **Documentation**
  - Clarified timeout configuration, precedence, rounding, and runtime-specific behavior across guides, references, and API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->