### PR TITLE
fix: X-Mesh-Job-Id is inbound-only in every runtime

### DIFF
--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -406,11 +406,20 @@ requests `max_duration=30`, the child gets 5 seconds. This is enforced
 at submission time so the child's runtime sees a single coherent
 deadline regardless of how deep the chain runs.
 
-The header is on the default `MCP_MESH_PROPAGATE_HEADERS` allowlist
-alongside `X-Mesh-Job-Id`, `X-Mesh-Trace-Id`, etc. — no per-agent
-configuration is needed for propagation to work. Tracing this in
+`X-Mesh-Timeout` is a baked-in default — it propagates with no
+`MCP_MESH_PROPAGATE_HEADERS` configuration, alongside the trace headers
+(`X-Trace-ID` / `X-Parent-Span`). Tracing this in
 [Audit Trail](audit.md) shows the deadline shrinking as it walks the
 chain.
+
+`X-Mesh-Job-Id` is deliberately **not** propagated. It is the inbound
+dispatch discriminator — the producer runtime reads it off the incoming
+request to bind the handler to that job row — so attaching it to an
+outbound call would make a nested `task=True` call dispatch as, and
+auto-complete, its caller's job. Which job invoked the current handler
+is a separate question, answered by the dedicated
+`X-Mesh-Calling-Job-Id` / `X-Mesh-Calling-Claim-Epoch` pair that
+`calling_job()` reads.
 
 ## meshctl
 
@@ -1300,8 +1309,8 @@ MeshJob event-channel variables in
 
 - [Streaming](streaming.md) — token-by-token progress for the request-
   response case where the work fits in a single SSE
-- [Audit Trail](audit.md) — `progressToken`, `X-Mesh-Job-Id`, and
-  `X-Mesh-Timeout` propagation through the audit pipeline
+- [Audit Trail](audit.md) — why the registry wired a job's `task=True`
+  provider to the consumer it did
 - [DDDI](dddi.md) — Distributed Dynamic Dependency Injection overview;
   explains how `MeshJob` slots are resolved
 - [Stateful Agents](stateful-agents.md) — the broader decomposition

--- a/docs/concepts/jobs.md
+++ b/docs/concepts/jobs.md
@@ -414,12 +414,14 @@ chain.
 
 `X-Mesh-Job-Id` is deliberately **not** propagated. It is the inbound
 dispatch discriminator — the producer runtime reads it off the incoming
-request to bind the handler to that job row — so attaching it to an
-outbound call would make a nested `task=True` call dispatch as, and
-auto-complete, its caller's job. Which job invoked the current handler
-is a separate question, answered by the dedicated
-`X-Mesh-Calling-Job-Id` / `X-Mesh-Calling-Claim-Epoch` pair that
-`calling_job()` reads.
+request to bind the handler to that job row — so a call a runtime
+originates never carries it, and a nested `task=True` call cannot
+dispatch as, or auto-complete, its caller's job. The registry proxy is
+the one hop that does forward it: there it is still the *inbound*
+header of a push dispatch on its way to the producer that has to bind
+that row. Which job invoked the current handler is a separate question,
+answered by the dedicated `X-Mesh-Calling-Job-Id` /
+`X-Mesh-Calling-Claim-Epoch` pair that `calling_job()` reads.
 
 ## meshctl
 

--- a/src/core/cli/man/content/jobs.md
+++ b/src/core/cli/man/content/jobs.md
@@ -227,7 +227,9 @@ app). On the producer side, the in-process cancel token fires:
 - `asyncio.CancelledError` is raised at the next `await` point in the
   handler.
 - Outbound `McpMeshTool` proxy calls abort their underlying HTTP
-  request (cancel propagates through `X-Mesh-Job-Id` header binding).
+  request. This is the in-process cancel registry firing on the
+  handler's own job context, not something the outbound request
+  carries — the callee is never bound to the caller's job.
 
 The registry treats cancel as terminal (idempotent — already-terminal
 jobs return ok without re-firing).
@@ -457,9 +459,14 @@ deadline is `min(parent_remaining, child_requested)`. Enforced at
 submission time, so the child's runtime sees a single coherent
 deadline regardless of depth.
 
-The header is on the default `MCP_MESH_PROPAGATE_HEADERS` allowlist
-alongside `X-Mesh-Job-Id` and `X-Mesh-Trace-Id` — no per-agent
-configuration is needed.
+`X-Mesh-Timeout` is a baked-in default: it propagates with no
+`MCP_MESH_PROPAGATE_HEADERS` configuration. `X-Mesh-Job-Id` is
+deliberately NOT propagated — it is the inbound dispatch
+discriminator, read off the incoming request and never attached to an
+outbound call, so a nested call can never dispatch as (and complete)
+its caller's job. Which job invoked the current handler travels
+separately, on the `X-Mesh-Calling-Job-Id` and
+`X-Mesh-Calling-Claim-Epoch` pair.
 
 ## Reaping and lease recovery
 
@@ -773,8 +780,8 @@ mode is future work (tracked in `MESHJOB_DESIGN.org`).
 
 - `meshctl man streaming` — token-by-token progress for the
   request-response case where the work fits in a single SSE
-- `meshctl man audit` — `X-Mesh-Job-Id` + `X-Mesh-Timeout` propagation
-  through the audit pipeline
+- `meshctl man audit` — why the registry wired a job's `task=true`
+  provider to the consumer it did
 - `meshctl man dependency-injection` — how DDDI resolves
   `MeshJob`-typed slots
 - [`docs/concepts/jobs.md`](https://github.com/dhyansraj/mcp-mesh/blob/main/docs/concepts/jobs.md) — narrative concept doc with architecture overview

--- a/src/core/cli/man/content/jobs.md
+++ b/src/core/cli/man/content/jobs.md
@@ -462,9 +462,11 @@ deadline regardless of depth.
 `X-Mesh-Timeout` is a baked-in default: it propagates with no
 `MCP_MESH_PROPAGATE_HEADERS` configuration. `X-Mesh-Job-Id` is
 deliberately NOT propagated — it is the inbound dispatch
-discriminator, read off the incoming request and never attached to an
-outbound call, so a nested call can never dispatch as (and complete)
-its caller's job. Which job invoked the current handler travels
+discriminator, so a call a runtime originates never carries it and a
+nested call can never dispatch as (and complete) its caller's job.
+The registry proxy does forward it, because on that hop it is still
+the inbound header of a push dispatch on its way to the producer that
+has to bind that row. Which job invoked the current handler travels
 separately, on the `X-Mesh-Calling-Job-Id` and
 `X-Mesh-Calling-Claim-Epoch` pair.
 

--- a/src/core/cli/man/content/jobs_java.md
+++ b/src/core/cli/man/content/jobs_java.md
@@ -645,9 +645,11 @@ deadline regardless of depth.
 `X-Mesh-Timeout` is a baked-in default: it propagates with no
 `MCP_MESH_PROPAGATE_HEADERS` configuration. `X-Mesh-Job-Id` is
 deliberately NOT propagated — it is the inbound dispatch
-discriminator, read off the incoming request and never attached to an
-outbound call, so a nested call can never dispatch as (and complete)
-its caller's job. Which job invoked the current handler travels
+discriminator, so a call a runtime originates never carries it and a
+nested call can never dispatch as (and complete) its caller's job.
+The registry proxy does forward it, because on that hop it is still
+the inbound header of a push dispatch on its way to the producer that
+has to bind that row. Which job invoked the current handler travels
 separately, on the `X-Mesh-Calling-Job-Id` and
 `X-Mesh-Calling-Claim-Epoch` pair.
 

--- a/src/core/cli/man/content/jobs_java.md
+++ b/src/core/cli/man/content/jobs_java.md
@@ -324,7 +324,9 @@ server). On the producer side, the cancel token fires:
   ...)` to observe the synthetic cancel event (see [Event
   injection](#event-injection) below).
 - Outbound `McpMeshTool` proxy calls abort their underlying HTTP
-  request (cancel propagates through `X-Mesh-Job-Id` header binding).
+  request. This is the per-job cancel watcher firing on the handler's
+  own job context, not something the outbound request carries — the
+  callee is never bound to the caller's job.
 
 The registry treats cancel as terminal (idempotent — already-terminal
 jobs return ok without re-firing).
@@ -640,9 +642,14 @@ deadline is `min(parentRemaining, childRequested)`. Enforced at
 submission time, so the child's runtime sees a single coherent
 deadline regardless of depth.
 
-The header is on the default `MCP_MESH_PROPAGATE_HEADERS` allowlist
-alongside `X-Mesh-Job-Id` and `X-Mesh-Trace-Id` — no per-agent
-configuration is needed.
+`X-Mesh-Timeout` is a baked-in default: it propagates with no
+`MCP_MESH_PROPAGATE_HEADERS` configuration. `X-Mesh-Job-Id` is
+deliberately NOT propagated — it is the inbound dispatch
+discriminator, read off the incoming request and never attached to an
+outbound call, so a nested call can never dispatch as (and complete)
+its caller's job. Which job invoked the current handler travels
+separately, on the `X-Mesh-Calling-Job-Id` and
+`X-Mesh-Calling-Claim-Epoch` pair.
 
 ## Reaping and lease recovery
 
@@ -968,7 +975,8 @@ mode is future work (tracked in `MESHJOB_DESIGN.org`).
 ## See Also
 
 - `meshctl man streaming --java` — token-by-token progress
-- `meshctl man audit` — `X-Mesh-Job-Id` + `X-Mesh-Timeout` propagation
+- `meshctl man audit` — why the registry wired a job's `task=true`
+  provider to the consumer it did
 - `meshctl man dependency-injection --java` — how DDDI resolves
   `MeshJob`-typed slots
 - [`docs/concepts/jobs.md`](https://github.com/dhyansraj/mcp-mesh/blob/main/docs/concepts/jobs.md) — narrative concept doc with architecture overview

--- a/src/core/cli/man/content/jobs_typescript.md
+++ b/src/core/cli/man/content/jobs_typescript.md
@@ -508,9 +508,11 @@ deadline regardless of depth.
 `X-Mesh-Timeout` is a baked-in default: it propagates with no
 `MCP_MESH_PROPAGATE_HEADERS` configuration. `X-Mesh-Job-Id` is
 deliberately NOT propagated — it is the inbound dispatch
-discriminator, read off the incoming request and never attached to an
-outbound call, so a nested call can never dispatch as (and complete)
-its caller's job. Which job invoked the current handler travels
+discriminator, so a call a runtime originates never carries it and a
+nested call can never dispatch as (and complete) its caller's job.
+The registry proxy does forward it, because on that hop it is still
+the inbound header of a push dispatch on its way to the producer that
+has to bind that row. Which job invoked the current handler travels
 separately, on the `X-Mesh-Calling-Job-Id` and
 `X-Mesh-Calling-Claim-Epoch` pair.
 

--- a/src/core/cli/man/content/jobs_typescript.md
+++ b/src/core/cli/man/content/jobs_typescript.md
@@ -254,8 +254,10 @@ server). On the producer side, the cancel token fires:
 
 - The `AbortSignal` exposed via `job?.signal` (if the handler
   subscribed) is aborted.
-- Outbound `McpMeshTool` proxy calls abort their underlying `fetch`
-  (cancel propagates through `X-Mesh-Job-Id` binding).
+- Outbound `McpMeshTool` proxy calls abort their underlying `fetch`.
+  This is `awaitJobCancel` firing on the handler's own job context, not
+  something the outbound request carries — the callee is never bound to
+  the caller's job.
 
 The registry treats cancel as terminal (idempotent — already-terminal
 jobs return ok without re-firing).
@@ -503,9 +505,14 @@ deadline is `min(parentRemaining, childRequested)`. Enforced at
 submission time, so the child's runtime sees a single coherent
 deadline regardless of depth.
 
-The header is on the default `MCP_MESH_PROPAGATE_HEADERS` allowlist
-alongside `X-Mesh-Job-Id` and `X-Mesh-Trace-Id` — no per-agent
-configuration is needed.
+`X-Mesh-Timeout` is a baked-in default: it propagates with no
+`MCP_MESH_PROPAGATE_HEADERS` configuration. `X-Mesh-Job-Id` is
+deliberately NOT propagated — it is the inbound dispatch
+discriminator, read off the incoming request and never attached to an
+outbound call, so a nested call can never dispatch as (and complete)
+its caller's job. Which job invoked the current handler travels
+separately, on the `X-Mesh-Calling-Job-Id` and
+`X-Mesh-Calling-Claim-Epoch` pair.
 
 ## Reaping and lease recovery
 
@@ -831,7 +838,8 @@ mode is future work (tracked in `MESHJOB_DESIGN.org`).
 ## See Also
 
 - `meshctl man streaming --typescript` — token-by-token progress
-- `meshctl man audit` — `X-Mesh-Job-Id` + `X-Mesh-Timeout` propagation
+- `meshctl man audit` — why the registry wired a job's `task=true`
+  provider to the consumer it did
 - `meshctl man dependency-injection --typescript` — how DDDI resolves
   `MeshJob`-typed slots
 - [`docs/concepts/jobs.md`](https://github.com/dhyansraj/mcp-mesh/blob/main/docs/concepts/jobs.md) — narrative concept doc with architecture overview

--- a/src/core/cli/man/content/upgrading.md
+++ b/src/core/cli/man/content/upgrading.md
@@ -2,6 +2,42 @@
 
 > Order of operations, version-skew guarantees, schema migrations, in-flight job safety, and source migrations for upgrading a running mesh
 
+## 3.8.0 — A `task=true` chain no longer inherits the caller's job
+
+**Behaviour change in all three runtimes.** `X-Mesh-Job-Id` is the push-mode dispatch discriminator: a producer reads it off an *incoming* request to bind its handler to that job row. It was also being sent *outbound*, which made a nested `task=true` call dispatch as — and auto-complete — its caller's job.
+
+| Runtime | How it leaked | What a nested `task=true` callee did with it |
+| ------- | ------------- | -------------------------------------------- |
+| Java | On the propagate allowlist, so every outbound call inherited the captured inbound value | Dispatched as the caller's job, then completed the caller's row with the callee's result |
+| Python | Stamped explicitly from the active job context on every outbound mesh call | Nothing — Python discarded it inbound, which is the same filter that made push-mode dispatch over HTTP unreachable |
+| TypeScript | Seeded into the propagated-header store by the claim dispatcher, which the proxy forwards | Misread an ordinary dependency outage as a job dispatch: released the **caller's** lease and returned `""` instead of the `dependency_unavailable` refusal |
+
+As of 3.8.0 the two directions are separate everywhere. The header is read from the raw inbound request and never attached to an outbound call. A nested `task=true` call is an ordinary tool call: `null` in its `MeshJob` slot, its value returned to its caller, and the caller completes its own job. Who invoked the current handler is a separate question, answered as before by the dedicated `X-Mesh-Calling-Job-Id` / `X-Mesh-Calling-Claim-Epoch` pair, which is still propagated.
+
+### Upgrade producers before, or at the same time as, their callers
+
+A pre-3.8 caller still sends its job id. A 3.8 callee reads inbound job ids from the raw request, where it previously ignored them — so during a mixed rollout an old caller can hand a new callee its own job row. The runtime refuses that: a job id arriving **together with** `X-Mesh-Calling-Job-Id` is a leak, not a dispatch (an old peer only ever leaked the id from inside a job context, which stamps calling identity on the same request; a genuine push dispatch carries the id alone). The callee logs it and runs the call normally:
+
+```text
+inbound x-mesh-job-id=<id> arrived together with x-mesh-calling-job-id=<id> — a pre-3.8
+caller leaking its own job id on a nested call, not a push-mode dispatch. Running as a
+plain tool call; upgrade the calling agent to stop this (issue #1570).
+```
+
+Treat that line as an upgrade-completion checklist, not an error. It is safe to leave running — the callee behaves exactly as a fully-upgraded one — but it means a peer is still on the old wire.
+
+### What to check before upgrading
+
+The affected topology is a job handler in **any** runtime calling into a `task=true` tool. Start from the callee side, which is where the corruption landed: for every `task=true` tool, ask whether its `MeshJob` slot was ever non-null on a call that did not come from the registry claim path. If it was, that handler was operating on its *caller's* job, and any progress delta, event or completion it wrote landed on that row. After the upgrade the slot is `null` there, so a handler that dereferences it without a null check throws instead of corrupting the caller's row. Submit a child job explicitly (`MeshJobSubmitter` / `mesh.jobs`) where a second job is actually wanted.
+
+Java carries the extra risk that the leak needed no job context to spread: because the header was allowlisted, a plain (non-`task`) Java tool relayed an inbound job id onto its own downstream calls.
+
+### Also in this change
+
+`X-Mesh-Claim-Epoch` is now read from the raw inbound request in Java, where it was previously read from a map it could never appear in, and the registry proxy forwards it alongside the job id instead of dropping it. Both were prerequisites for out-of-epoch fencing across a proxy hop rather than a fix that changes behaviour on its own: no agent emits that header now that the dispatch names are inbound-only, so it carries a value only when a client supplies one.
+
+Push-mode dispatch over HTTP — a `tools/call` carrying `X-Mesh-Job-Id` — reaches the dispatch gate in Python and Java, where the allowlist filter had made it unreachable. It remains unreachable in TypeScript for an unrelated reason: FastMCP TS does not expose HTTP headers to a tool, so a TypeScript agent only ever sees mesh headers that a caller passed in the `_mesh_headers` argument.
+
 ## 3.5.0 — Helm chart upgrade order: 3.3.x → 3.4.x → 3.5.0
 
 **Do not upgrade the `mcp-mesh-core` chart from 3.3.x straight to 3.5.0.** Chart 3.5.0 changes `namespaceCreate` to default `false`, which drops the release's `Namespace` object from the rendered manifest — and Helm *deletes* a resource that leaves the manifest, cascading to every agent, Service, Secret and PVC in the namespace. What makes the removal safe is `helm.sh/resource-policy: keep` on the live `Namespace`, and chart 3.4.0 is the first version that applies it.

--- a/src/core/cli/man/content/upgrading.md
+++ b/src/core/cli/man/content/upgrading.md
@@ -24,7 +24,9 @@ caller leaking its own job id on a nested call, not a push-mode dispatch. Runnin
 plain tool call; upgrade the calling agent to stop this (issue #1570).
 ```
 
-Treat that line as an upgrade-completion checklist, not an error. It is safe to leave running — the callee behaves exactly as a fully-upgraded one — but it means a peer is still on the old wire.
+Treat that line as an upgrade-completion checklist, not an error: for the calls it names the callee behaves exactly as a fully-upgraded one, but it means a peer is still on the old wire.
+
+**The guard does not cover every skewed call, and the gap it misses is silent.** A pre-3.8 Java tool relayed an inbound `X-Mesh-Job-Id` onto its own downstream calls whether or not it was `task=true`, so a plain Java relay standing between the registry proxy and a `task=true` tool forwards a genuine dispatch's job id with **no** calling identity beside it — which is byte-for-byte what a real push dispatch looks like. The callee honours it and binds to a job row it does not own, and nothing on the wire can tell the two apart, so no warning is logged. Upgrade every pre-3.8 Java agent that sits on a job's call path, or take it off that path, before treating a mixed rollout as safe.
 
 ### What to check before upgrading
 

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -555,9 +555,40 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // asymmetry is now stated. The `environment.md` entry for the same env var sits
 // inside a fenced block, so it adds no spans. `schema-matching.md` has no
 // `_java` / `_typescript` variant, so the variant golden did not move.
+//
+// Issue #1570 moves the inline constant to 1843 and `wantListCodeSpans` to
+// 531. Four edits, all downstream of one contract decision — `X-Mesh-Job-Id`
+// is the inbound dispatch discriminator and is never propagated.
+//
+// +2, `jobs.md` "Timeout propagation": the paragraph claimed the header was on
+// the default `MCP_MESH_PROPAGATE_HEADERS` allowlist alongside a
+// `X-Mesh-Trace-Id` that exists in no runtime (the trace header is
+// `X-Trace-ID`). The replacement names 5 headers where it named 3.
+//
+// +19, the `3.8.0` section in `upgrading.md`: the behaviour change is silent in
+// every runtime — a nested `task=true` call stops inheriting its caller's job
+// row — and a mixed rollout has an ordering constraint, so it belongs on the
+// page whose subtitle promises skew guarantees. Most of the section is a
+// per-runtime table and a fenced log line and this test skips both, so 19 is
+// well under its size.
+//
+// -1, `jobs.md`'s cancel bullet: it credited the outbound abort to
+// "`X-Mesh-Job-Id` header binding". It is the in-process cancel registry firing
+// on the handler's OWN job context; the outbound request carries nothing, and
+// after this issue it demonstrably cannot. That span sat on the bullet's
+// CONTINUATION line, so no list constant moved with it.
+//
+// -1, `jobs.md`'s "See Also" line: it advertised `X-Mesh-Job-Id` +
+// `X-Mesh-Timeout` "propagation through the audit pipeline". `audit.md`
+// mentions neither header and no trace record carries a job id. This one IS a
+// `- ` line, which is why `wantListCodeSpans` moves -1 and is the only list
+// movement in the change.
+//
+// 1824 + 2 + 19 - 1 - 1 = 1843. `jobs.md` has both variants and took three of
+// the four edits, so the variant golden moved with it; `upgrading.md` has none.
 const (
-	wantInlineCodeSpans = 1824
-	wantListCodeSpans   = 532
+	wantInlineCodeSpans = 1843
+	wantListCodeSpans   = 531
 	wantMarkupListLines = 450
 )
 

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -586,8 +586,26 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 //
 // 1824 + 2 + 19 - 1 - 1 = 1843. `jobs.md` has both variants and took three of
 // the four edits, so the variant golden moved with it; `upgrading.md` has none.
+//
+// Review of that change moves the inline constant to 1846 (+3), and neither
+// list constant. All three spans are one added paragraph in the `3.8.0`
+// section of `upgrading.md`, naming `X-Mesh-Job-Id` and `task=true` twice.
+// The section had said the skew warning was "safe to leave running", which is
+// true only of the calls the guard can SEE: a pre-3.8 Java relay forwarded the
+// header whether or not it was `task=true`, so a plain relay between the
+// registry proxy and a `task=true` tool passes a real dispatch's job id along
+// with no calling identity beside it — indistinguishable from a genuine push
+// dispatch, so no warning fires and the callee binds a row it does not own.
+// That is an upgrade-or-isolate instruction, not a log line, and the page's
+// subtitle promises exactly this guarantee.
+//
+// The same review clarified the "not propagated" claim on `jobs.md` and both
+// its variants (the registry proxy DOES forward an inbound job id, because
+// there it is still inbound). That rewording is span-neutral on all three
+// pages — 5 spans before and after — so neither this constant nor the variant
+// golden moved with it. 1843 + 3 = 1846.
 const (
-	wantInlineCodeSpans = 1843
+	wantInlineCodeSpans = 1846
 	wantListCodeSpans   = 531
 	wantMarkupListLines = 450
 )

--- a/src/core/cli/man/variant_corpus_test.go
+++ b/src/core/cli/man/variant_corpus_test.go
@@ -174,7 +174,16 @@ func stripLangHeader(content string) string {
 // the same commit and confirm the delta is the size you intended, the same rule
 // the default corpus follows. Measured across all 34 variant pages at the
 // commit that added this test.
-const wantVariantInlineCodeSpans = 1662
+//
+// Issue #1570 moves this to 1663. Both `jobs.md` variants took the same three
+// edits as the default page: +2 each for the corrected "Timeout
+// propagation" paragraph, -1 each for the "See Also" line that advertised
+// `X-Mesh-Job-Id` propagation through an audit pipeline that has never carried
+// it, and -1 for `jobs_java.md`'s cancel bullet, which credited the outbound
+// abort to the header rather than the per-job cancel watcher.
+// `jobs_typescript.md` names `awaitJobCancel` in the same replacement, so its
+// cancel bullet is span-neutral. 1662 + 4 - 2 - 1 = 1663.
+const wantVariantInlineCodeSpans = 1663
 
 // TestVariantCorpusCodeSpans is TestStyleInlineCorpus plus
 // TestRenderStyledCorpusListItems, run over the pages neither of them sees.

--- a/src/core/registry/ent_handlers.go
+++ b/src/core/registry/ent_handlers.go
@@ -38,7 +38,9 @@ func init() {
 	//   X-Trace-ID, X-Parent-Span, X-Mesh-Timeout, X-Mesh-Job-Id,
 	//   X-Mesh-Claim-Epoch,
 	//   X-Mesh-Calling-Job-Id, X-Mesh-Calling-Claim-Epoch
-	// MCP_MESH_PROPAGATE_HEADERS is purely *additive* on top of the defaults.
+	// MCP_MESH_PROPAGATE_HEADERS is purely *additive* on top of the defaults,
+	// with one exception: X-Mesh-Recv-Cursor is claim-local and is never
+	// forwarded, however it is listed (#1570).
 	// TODO(test): extract this parser into a pure helper so it can be unit-tested
 	// without env-var mutation. Coverage today is via integration tests.
 	if raw := os.Getenv("MCP_MESH_PROPAGATE_HEADERS"); raw != "" {
@@ -859,7 +861,8 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 	// this carries a value only for a client that supplies one explicitly. It
 	// is forwarded rather than dropped so the proxy hop is not the reason the
 	// pair arrives split. The claim-local X-Mesh-Recv-Cursor is deliberately
-	// NOT forwarded: it never travels between agents at all.
+	// NOT forwarded: it never travels between agents at all -- enforced by
+	// neverForwarded below, not by omission here.
 	if claimEpoch := c.Request.Header.Get("X-Mesh-Claim-Epoch"); claimEpoch != "" {
 		proxyReq.Header.Set("X-Mesh-Claim-Epoch", claimEpoch)
 	}
@@ -891,12 +894,24 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 		"x-mesh-calling-claim-epoch": true,
 	}
 
+	// Names that must NEVER cross the proxy hop, whatever the operator put in
+	// MCP_MESH_PROPAGATE_HEADERS (#1570). X-Mesh-Recv-Cursor is claim-local: it
+	// is minted by the registry for ONE claim and consumed by the handler that
+	// claim dispatched, so a resume cursor belonging to one job must never
+	// arrive at another agent and rewind its event consumption. The allowlist
+	// loop below would otherwise forward it on an exact entry or on the
+	// documented "x-mesh-*" prefix form, so the guarantee is enforced here
+	// rather than merely asserted by not setting the header above.
+	neverForwarded := map[string]bool{
+		"x-mesh-recv-cursor": true,
+	}
+
 	// Forward headers matching MCP_MESH_PROPAGATE_HEADERS allowlist (#769, #790).
 	// Entries are exact matches by default; a trailing "*" denotes a prefix.
 	if len(proxyPropagateHeaderEntries) > 0 {
 		for headerName, values := range c.Request.Header {
 			lowerName := strings.ToLower(headerName)
-			if explicitlySet[lowerName] {
+			if explicitlySet[lowerName] || neverForwarded[lowerName] {
 				continue
 			}
 			for _, entry := range proxyPropagateHeaderEntries {

--- a/src/core/registry/ent_handlers.go
+++ b/src/core/registry/ent_handlers.go
@@ -36,6 +36,7 @@ func init() {
 	//
 	// Baked-in defaults (always forwarded, regardless of this env var):
 	//   X-Trace-ID, X-Parent-Span, X-Mesh-Timeout, X-Mesh-Job-Id,
+	//   X-Mesh-Claim-Epoch,
 	//   X-Mesh-Calling-Job-Id, X-Mesh-Calling-Claim-Epoch
 	// MCP_MESH_PROPAGATE_HEADERS is purely *additive* on top of the defaults.
 	// TODO(test): extract this parser into a pure helper so it can be unit-tested
@@ -849,6 +850,20 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 		proxyReq.Header.Set("X-Mesh-Job-Id", meshJobID)
 	}
 
+	// Forward the claim generation alongside it (#1570). The producer's
+	// dispatch gate reads the pair together — job id to bind the row, epoch to
+	// fence out-of-epoch writes — so forwarding one without the other silently
+	// downgrades a proxied dispatch to legacy owner-only fencing. No in-mesh
+	// caller emits this today (both names are inbound-only as of #1570, and a
+	// claim epoch is minted by this registry, not by a peer), so in practice
+	// this carries a value only for a client that supplies one explicitly. It
+	// is forwarded rather than dropped so the proxy hop is not the reason the
+	// pair arrives split. The claim-local X-Mesh-Recv-Cursor is deliberately
+	// NOT forwarded: it never travels between agents at all.
+	if claimEpoch := c.Request.Header.Get("X-Mesh-Claim-Epoch"); claimEpoch != "" {
+		proxyReq.Header.Set("X-Mesh-Claim-Epoch", claimEpoch)
+	}
+
 	// Forward the calling-job identity pair so the downstream producer can
 	// attribute the call to the originating MeshJob (#1263). Baked-in defaults
 	// like X-Mesh-Job-Id above so registry-proxied topologies keep the identity
@@ -871,6 +886,7 @@ func (h *EntBusinessLogicHandlers) proxyRequest(c *gin.Context, target string, m
 		"x-parent-span":              true,
 		"x-mesh-timeout":             true,
 		"x-mesh-job-id":              true,
+		"x-mesh-claim-epoch":         true,
 		"x-mesh-calling-job-id":      true,
 		"x-mesh-calling-claim-epoch": true,
 	}

--- a/src/core/registry/proxy_headers_test.go
+++ b/src/core/registry/proxy_headers_test.go
@@ -182,3 +182,57 @@ func TestProxyRequest_ForwardsPartialCallingIdentity(t *testing.T) {
 		t.Errorf("X-Mesh-Calling-Claim-Epoch synthesized when absent: got %q", got)
 	}
 }
+
+// TestProxyRequest_NeverForwardsRecvCursor asserts the claim-local resume
+// cursor cannot cross the proxy hop, whatever the operator put in
+// MCP_MESH_PROPAGATE_HEADERS (#1570). X-Mesh-Recv-Cursor is minted by the
+// registry for ONE claim and consumed by the handler that claim dispatched, so
+// leaking it onto a downstream call would rewind another agent's event
+// consumption to a cursor belonging to someone else's job.
+//
+// Both matcher forms are covered because both are reachable from documented
+// configuration: an exact entry, and the "x-mesh-*" prefix form. X-Mesh-Job-Id
+// travels in the same request as the control — it IS forwarded, and the deny
+// must not be a blanket x-mesh block.
+func TestProxyRequest_NeverForwardsRecvCursor(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	for _, tc := range []struct {
+		name    string
+		entries []string
+	}{
+		{"exact allowlist entry", []string{"x-mesh-recv-cursor"}},
+		{"prefix allowlist entry", []string{"x-mesh-*"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			saved := proxyPropagateHeaderEntries
+			proxyPropagateHeaderEntries = tc.entries
+			defer func() { proxyPropagateHeaderEntries = saved }()
+
+			s := setupTestService(t)
+
+			var received http.Header
+			srv, host, port := newProxyDownstream(t, &received)
+			defer srv.Close()
+
+			registerProxyTargetAgent(t, s, "echo-agent", host, port)
+			h := &EntBusinessLogicHandlers{entService: s}
+
+			target := host + ":" + strconv.Itoa(port) + "/mcp/v1/tools/call"
+			w := proxyPost(t, h, target, map[string]string{
+				"X-Mesh-Job-Id":      "job-123",
+				"X-Mesh-Recv-Cursor": `{"work":7}`,
+			})
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("proxy returned %d, body=%s", w.Code, w.Body.String())
+			}
+			if got := received.Get("X-Mesh-Recv-Cursor"); got != "" {
+				t.Errorf("X-Mesh-Recv-Cursor crossed the proxy hop: got %q", got)
+			}
+			if got := received.Get("X-Mesh-Job-Id"); got != "job-123" {
+				t.Errorf("X-Mesh-Job-Id no longer forwarded: got %q", got)
+			}
+		})
+	}
+}

--- a/src/core/registry/proxy_headers_test.go
+++ b/src/core/registry/proxy_headers_test.go
@@ -120,6 +120,39 @@ func TestProxyRequest_ForwardsCallingJobIdentityPair(t *testing.T) {
 	}
 }
 
+// TestProxyRequest_ForwardsDispatchPairTogether asserts the push-mode dispatch
+// pair survives the proxy hop INTACT (issue #1570). The producer's dispatch
+// gate reads the two together — job id to bind the row, epoch to fence
+// out-of-epoch writes — so forwarding the id while dropping the epoch silently
+// downgrades a proxied dispatch to legacy owner-only fencing.
+func TestProxyRequest_ForwardsDispatchPairTogether(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := setupTestService(t)
+
+	var received http.Header
+	srv, host, port := newProxyDownstream(t, &received)
+	defer srv.Close()
+
+	registerProxyTargetAgent(t, s, "echo-agent", host, port)
+	h := &EntBusinessLogicHandlers{entService: s}
+
+	target := host + ":" + strconv.Itoa(port) + "/mcp/v1/tools/call"
+	w := proxyPost(t, h, target, map[string]string{
+		"X-Mesh-Job-Id":      "job-123",
+		"X-Mesh-Claim-Epoch": "9",
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("proxy returned %d, body=%s", w.Code, w.Body.String())
+	}
+	if got := received.Get("X-Mesh-Job-Id"); got != "job-123" {
+		t.Errorf("X-Mesh-Job-Id not forwarded: got %q", got)
+	}
+	if got := received.Get("X-Mesh-Claim-Epoch"); got != "9" {
+		t.Errorf("X-Mesh-Claim-Epoch not forwarded: got %q", got)
+	}
+}
+
 // TestProxyRequest_ForwardsPartialCallingIdentity asserts the pair is forwarded
 // atomically as "forward what arrived": when only X-Mesh-Calling-Job-Id is
 // present, the epoch header is NOT synthesized.

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/McpHttpClient.java
@@ -471,6 +471,9 @@ public class McpHttpClient {
                     }
                 }
             }
+            // Issue #1570: the inbound-only dispatch trio never rides an
+            // outbound call, whatever put it in the propagated store.
+            TraceContext.stripDispatchHeaders(mergedHeaders);
 
             // Inject trace context into arguments via Rust core bridge
             // (FastMCP doesn't expose HTTP headers to tool handlers)
@@ -1017,6 +1020,9 @@ public class McpHttpClient {
                     }
                 }
             }
+            // Issue #1570: the inbound-only dispatch trio never rides an
+            // outbound call, whatever put it in the propagated store.
+            TraceContext.stripDispatchHeaders(mergedHeaders);
 
             // Inject trace context into arguments via Rust core (parity with callTool)
             Map<String, Object> argsWithTrace;

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshLlmAgentProxy.java
@@ -267,7 +267,8 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
      * ({@code ${ctx.*}} template variables set by {@link MeshToolWrapper} on
      * the servlet thread) read null, and {@link TraceContext} was empty — so
      * outbound calls carried neither trace headers nor propagated headers
-     * (X-Mesh-Job-Id, X-Mesh-Timeout, allowlisted auth).
+     * (X-Mesh-Timeout, X-Mesh-Calling-Job-Id, allowlisted auth — never
+     * X-Mesh-Job-Id, which is inbound-only per issue #1570).
      *
      * <p>The returned supplier layers {@link TraceContext#wrapSupplier} (trace
      * info + propagated headers, with restore-previous semantics) and a
@@ -933,8 +934,10 @@ public class MeshLlmAgentProxy implements MeshLlmAgent {
                     // Parallel execution via CompletableFuture.
                     // Issue #1164 MED-4: wrap each task with TraceContext so
                     // parallel tool calls carry trace headers AND propagated
-                    // headers (X-Mesh-Job-Id, X-Mesh-Timeout, allowlisted auth)
-                    // on outbound calls — matching the sequential branch, which
+                    // headers (X-Mesh-Timeout, X-Mesh-Calling-Job-Id,
+                    // allowlisted auth — never X-Mesh-Job-Id, which is
+                    // inbound-only per #1570) on outbound calls — matching
+                    // the sequential branch, which
                     // runs on the caller thread and inherits them implicitly.
                     log.info("Executing {} tool calls in parallel", toolCalls.size());
                     List<CompletableFuture<Map<String, Object>>> futures = new ArrayList<>();

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/MeshToolWrapper.java
@@ -993,6 +993,28 @@ public class MeshToolWrapper implements McpToolHandler {
         if (meshHeadersObj instanceof Map) {
             @SuppressWarnings("unchecked")
             Map<String, Object> meshHeaders = (Map<String, Object>) meshHeadersObj;
+
+            // Issue #1570: the push-mode dispatch trio rides the args channel
+            // too (FastMCP hides HTTP headers from non-Java callers), and is
+            // read RAW — it is deliberately absent from the propagate
+            // allowlist, so filtering it here would leave a genuine inbound
+            // job dispatch undetectable. HTTP wins over args, matching the
+            // propagated-header merge below.
+            Map<String, String> rawDispatch = new HashMap<>();
+            for (Map.Entry<String, Object> entry : meshHeaders.entrySet()) {
+                if (entry.getKey() == null || !(entry.getValue() instanceof String)) continue;
+                String name = entry.getKey().toLowerCase();
+                if (TraceContext.DISPATCH_HEADERS.contains(name)) {
+                    rawDispatch.put(name, (String) entry.getValue());
+                }
+            }
+            if (!rawDispatch.isEmpty()) {
+                Map<String, String> existingDispatch = TraceContext.getDispatchHeaders();
+                Map<String, String> mergedDispatch = new HashMap<>(rawDispatch);
+                mergedDispatch.putAll(existingDispatch);
+                TraceContext.setDispatchHeaders(mergedDispatch);
+            }
+
             Map<String, String> filtered = new HashMap<>();
             if (!TraceContext.getPropagateHeaderNames().isEmpty()) {
                 for (Map.Entry<String, Object> entry : meshHeaders.entrySet()) {
@@ -1026,11 +1048,36 @@ public class MeshToolWrapper implements McpToolHandler {
      */
     private Object invokeInternal(Map<String, Object> cleanArgs) throws Exception {
         // Phase B MeshJob substrate: detect inbound job dispatch.
-        // X-Mesh-Job-Id is captured by TracingFilter (we register it as a
-        // propagation header in MeshAutoConfiguration), so it lands in
-        // TraceContext.getPropagatedHeaders() with a lowercased key.
+        // Issue #1570: X-Mesh-Job-Id is captured from the RAW inbound request
+        // (TracingFilter) or the raw _mesh_headers argument map, NOT from the
+        // propagate allowlist. The allowlist drives the OUTBOUND forward too,
+        // so allowlisting the discriminator made every nested call look like a
+        // job dispatch to its callee. Both keys are lowercased at capture.
+        Map<String, String> dispatchHeaders = TraceContext.getDispatchHeaders();
         Map<String, String> propagated = TraceContext.getPropagatedHeaders();
-        String jobIdHeader = propagated != null ? propagated.get("x-mesh-job-id") : null;
+        String jobIdHeader = dispatchHeaders != null ? dispatchHeaders.get("x-mesh-job-id") : null;
+
+        // Version-skew guard (issue #1570). A pre-3.8 peer forwarded
+        // x-mesh-job-id on ordinary nested calls, and only ever from inside a
+        // bound job context — which seeds x-mesh-calling-job-id on the SAME
+        // request. A genuine push-mode dispatch carries the job id WITHOUT
+        // calling identity (the submitter is not itself executing that job),
+        // so the two arriving together identifies a leaked nested call from an
+        // old caller. Dispatching on it would bind this handler to the
+        // CALLER's job row and auto-complete it with this tool's result — the
+        // very corruption this issue removes. Refuse the dispatch, run as a
+        // plain call, and say so loudly: the fix is to finish the upgrade.
+        if (jobIdHeader != null && !jobIdHeader.isEmpty() && propagated != null) {
+            String callingJobId = propagated.get(TraceContext.CALLING_JOB_ID_HEADER);
+            if (callingJobId != null && !callingJobId.isEmpty()) {
+                log.warn("Inbound x-mesh-job-id={} for tool {} arrived together with "
+                    + "x-mesh-calling-job-id={} — a pre-3.8 caller leaking its own job id "
+                    + "on a nested call, not a push-mode dispatch. Running as a plain tool "
+                    + "call; upgrade the calling agent to stop this (issue #1570).",
+                    jobIdHeader, funcId, callingJobId);
+                jobIdHeader = null;
+            }
+        }
         // Issue #1164 MED-5: parse the propagated X-Mesh-Timeout budget for
         // EVERY inbound call (not only job dispatch) so CompletableFuture-
         // returning tools are awaited against the caller's actual budget
@@ -1060,29 +1107,32 @@ public class MeshToolWrapper implements McpToolHandler {
         // both Java + native contexts, inject the controller at
         // meshJobParamIndex, auto-complete on successful return.
         //
-        // Gate is intentionally narrow — only `task=true` + a present
-        // `X-Mesh-Job-Id` header. Whether a JobController gets injected
+        // Gate is intentionally narrow — only `task=true` + a present RAW
+        // inbound `X-Mesh-Job-Id` header (never a propagated one — the name is
+        // inbound-only, issue #1570). Whether a JobController gets injected
         // (requires meshJobParamIndex + instanceId + registryUrl) is
         // decided INSIDE dispatchAsJob; if any of those is missing, we
-        // still bind the JobContext snapshot so outbound calls
-        // propagate the right job-id headers, but invoke the user
-        // method without the controller. The previous all-or-nothing
+        // still bind the JobContext snapshot so outbound calls carry
+        // the right calling-identity headers and deadline (never the
+        // job id itself — #1570), but invoke the user method without
+        // the controller. The previous all-or-nothing
         // gate silently skipped the wrap when the wiring was partial,
         // leaving downstream calls headerless. (PR #891 review.)
         if (task && jobIdHeader != null && !jobIdHeader.isEmpty()) {
             // Claim generation minted by the registry on POST /jobs/claim
             // (issue #1252). Java's own claim path (ClaimDispatcher) invokes
             // handlers directly and fences via JobController.open(..., epoch) —
-            // it never writes this header. So x-mesh-claim-epoch is currently
-            // populated only by cross-runtime propagation, i.e. a Python/TS
-            // claim dispatcher (which re-enters its wrapper and seeds the
-            // header) forwarding into a Java tool. Absent ⇒ null ⇒ legacy
-            // owner-only fencing; never fabricate a 0. Parse kept regardless
-            // (harmless, future-proof). NOTE (#1263): the calling-job identity
-            // carrier (x-mesh-calling-*) is intentionally SEPARATE from this
-            // protocol pair and never feeds this dispatch gate.
+            // it never writes this header. So x-mesh-claim-epoch reaches a Java
+            // tool only when the inbound request carries it. Read from the RAW
+            // dispatch store alongside the job id (#1570) — it was previously
+            // read off the allowlist-filtered map, where it could never appear
+            // (unlike x-mesh-job-id, it was never allowlisted), so the epoch
+            // was unconditionally null here. Absent ⇒ null ⇒ legacy owner-only
+            // fencing; never fabricate a 0. NOTE (#1263): the calling-job
+            // identity carrier (x-mesh-calling-*) is intentionally SEPARATE
+            // from this protocol pair and never feeds this dispatch gate.
             Long claimEpoch = parseClaimEpochHeader(
-                propagated != null ? propagated.get("x-mesh-claim-epoch") : null);
+                dispatchHeaders != null ? dispatchHeaders.get("x-mesh-claim-epoch") : null);
             return dispatchAsJob(cleanArgs, jobIdHeader, deadlineSecs, claimEpoch);
         }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TraceContext.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TraceContext.java
@@ -57,15 +57,14 @@ public class TraceContext {
         if (!names.contains("x-mesh-timeout")) {
             names.add("x-mesh-timeout");
         }
-        // Phase B MeshJob substrate: x-mesh-job-id is captured here so the
-        // inbound MeshToolWrapper can dispatch task=true tools through the
-        // job pipeline (build a JobController + bind both Java/native
-        // contexts). Adding it to the propagate list also means outbound
-        // calls forward it to downstream task=true tools — matching the
-        // Python / TypeScript propagation behavior.
-        if (!names.contains("x-mesh-job-id")) {
-            names.add("x-mesh-job-id");
-        }
+        // Issue #1570: x-mesh-job-id is NOT added here. It is the push-mode
+        // dispatch DISCRIMINATOR, and this allowlist drives BOTH the inbound
+        // capture and the outbound forward — so allowlisting it to make
+        // inbound dispatch work also made every outbound call forward it,
+        // which is the self-dispatch hazard the callingJobHeaders() javadoc
+        // below warns about. The inbound side now reads the dispatch trio
+        // from the RAW inbound request instead (see DISPATCH_HEADERS /
+        // TracingFilter), so the two concerns no longer share a switch.
         // Issue #1263: the calling job's identity rides a DEDICATED carrier —
         // x-mesh-calling-job-id + x-mesh-calling-claim-epoch — kept strictly
         // separate from the push-dispatch protocol pair (x-mesh-job-id /
@@ -87,6 +86,27 @@ public class TraceContext {
     }
 
     static final ThreadLocal<Map<String, String>> PROPAGATED_HEADERS =
+        ThreadLocal.withInitial(Collections::emptyMap);
+
+    /**
+     * Issue #1570: the push-mode dispatch protocol headers. INBOUND-ONLY —
+     * read from the raw inbound request (or the raw {@code _mesh_headers}
+     * argument map) to decide whether THIS call is a job dispatch, and never
+     * emitted on an outbound call. {@code x-mesh-job-id} doubles as the
+     * dispatch discriminator, so forwarding it makes a nested same-instance
+     * {@code task=true} call self-dispatch as the CALLER's job (owner + epoch
+     * match) and auto-complete it with the wrong result. Calling identity
+     * rides the dedicated {@code x-mesh-calling-*} pair instead.
+     */
+    public static final List<String> DISPATCH_HEADERS = List.of(
+        "x-mesh-job-id", "x-mesh-claim-epoch", "x-mesh-recv-cursor");
+
+    /**
+     * Inbound-only dispatch headers for the current request thread
+     * (issue #1570). Deliberately a SEPARATE store from
+     * {@link #PROPAGATED_HEADERS}: nothing here is ever forwarded downstream.
+     */
+    static final ThreadLocal<Map<String, String>> DISPATCH_HEADERS_STORE =
         ThreadLocal.withInitial(Collections::emptyMap);
 
     /**
@@ -177,6 +197,54 @@ public class TraceContext {
 
     public static void clearPropagatedHeaders() {
         PROPAGATED_HEADERS.set(Collections.emptyMap());
+    }
+
+    /** Issue #1570: inbound-only job-dispatch headers for this thread. */
+    public static Map<String, String> getDispatchHeaders() {
+        return DISPATCH_HEADERS_STORE.get();
+    }
+
+    /**
+     * Set the inbound job-dispatch headers for this thread. Keys are
+     * lowercased; only names in {@link #DISPATCH_HEADERS} are retained — this
+     * store must never become a general header channel, because nothing in it
+     * is forwarded downstream.
+     */
+    public static void setDispatchHeaders(Map<String, String> headers) {
+        if (headers == null || headers.isEmpty()) {
+            DISPATCH_HEADERS_STORE.set(Collections.emptyMap());
+            return;
+        }
+        Map<String, String> kept = new LinkedHashMap<>();
+        for (Map.Entry<String, String> e : headers.entrySet()) {
+            if (e.getKey() == null || e.getValue() == null) continue;
+            String name = e.getKey().toLowerCase();
+            if (DISPATCH_HEADERS.contains(name)) {
+                kept.put(name, e.getValue());
+            }
+        }
+        DISPATCH_HEADERS_STORE.set(Collections.unmodifiableMap(kept));
+    }
+
+    /** Clear the inbound job-dispatch headers. */
+    public static void clearDispatchHeaders() {
+        DISPATCH_HEADERS_STORE.set(Collections.emptyMap());
+    }
+
+    /**
+     * Issue #1570: strip the inbound-only dispatch trio from an outbound
+     * header map. Defense in depth — the names are not on the propagate
+     * allowlist, so they should never be in a captured map to begin with, but
+     * an operator-widened {@code MCP_MESH_PROPAGATE_HEADERS} (a
+     * {@code x-mesh-*} prefix entry, say) must not be able to reopen the
+     * self-dispatch hazard.
+     */
+    public static void stripDispatchHeaders(Map<String, String> headers) {
+        if (headers == null || headers.isEmpty()) {
+            return;
+        }
+        headers.keySet().removeIf(name ->
+            name != null && DISPATCH_HEADERS.contains(name.toLowerCase()));
     }
 
     /** Issue #1263: dedicated calling-job identity carrier header names. */

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TracingFilter.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/main/java/io/mcpmesh/spring/tracing/TracingFilter.java
@@ -65,6 +65,7 @@ public class TracingFilter implements Filter {
             // Thread pools reuse threads, so previous request context must be cleared
             TraceContext.clear();
             TraceContext.clearPropagatedHeaders();
+            TraceContext.clearDispatchHeaders();
 
             // Extract trace context from headers
             String traceId = httpRequest.getHeader(TRACE_ID_HEADER);
@@ -93,6 +94,25 @@ public class TracingFilter implements Filter {
                 log.trace("No trace headers found, deferring context creation to MeshToolWrapper");
             }
 
+            // Issue #1570: capture the push-mode dispatch protocol headers
+            // from the RAW inbound request, independently of the propagate
+            // allowlist. They are the dispatch discriminator and are
+            // deliberately NOT allowlisted (this same allowlist drives the
+            // OUTBOUND forward, and forwarding the job id self-dispatches a
+            // nested task=true call as the caller's job), so the inbound
+            // dispatch gate reads them from here instead.
+            Map<String, String> dispatch = new HashMap<>();
+            for (String name : TraceContext.DISPATCH_HEADERS) {
+                String value = httpRequest.getHeader(name);
+                if (value != null && !value.isEmpty()) {
+                    dispatch.put(name, value);
+                }
+            }
+            if (!dispatch.isEmpty()) {
+                TraceContext.setDispatchHeaders(dispatch);
+                log.trace("Captured {} inbound dispatch headers", dispatch.size());
+            }
+
             // Capture configured propagation headers from incoming request
             if (!TraceContext.getPropagateHeaderNames().isEmpty()) {
                 Map<String, String> captured = new HashMap<>();
@@ -118,6 +138,7 @@ public class TracingFilter implements Filter {
             // Always clear context after request completes
             TraceContext.clear();
             TraceContext.clearPropagatedHeaders();
+            TraceContext.clearDispatchHeaders();
         }
     }
 }

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshJobIdContractTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshJobIdContractTest.java
@@ -1,0 +1,225 @@
+package io.mcpmesh.spring;
+
+import io.mcpmesh.MeshTool;
+import io.mcpmesh.Param;
+import io.mcpmesh.spring.tracing.TraceContext;
+import io.mcpmesh.spring.tracing.TracingFilter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #1570 — the cross-runtime {@code x-mesh-job-id} contract.
+ *
+ * <p>{@code x-mesh-job-id} is the push-mode dispatch DISCRIMINATOR. Java used
+ * to put it on the propagate allowlist, which is a single switch driving BOTH
+ * the inbound capture and the outbound forward — so making inbound dispatch
+ * work also made every outbound call forward it, and a nested same-instance
+ * {@code task=true} call self-dispatched as the CALLER's job (owner + epoch
+ * match) and auto-completed it with the wrong result. That is the hazard
+ * {@code TraceContext.callingJobHeaders()}' own javadoc warns about.
+ *
+ * <p>The two concerns are now separate: the dispatch trio is captured from the
+ * RAW inbound request into its own store, and is stripped from every outbound
+ * header map.
+ */
+class MeshJobIdContractTest {
+
+    @AfterEach
+    void clearContext() {
+        TraceContext.clearPropagatedHeaders();
+        TraceContext.clearDispatchHeaders();
+    }
+
+    // ---- allowlist ---------------------------------------------------------
+
+    @Test
+    void dispatchTrioIsNotOnThePropagateAllowlist() {
+        for (String name : TraceContext.DISPATCH_HEADERS) {
+            assertFalse(TraceContext.matchesPropagateHeader(name),
+                name + " must never be allowlisted — the allowlist drives the OUTBOUND "
+                    + "forward, and forwarding the discriminator self-dispatches nested calls");
+        }
+        // The calling-identity carrier is unaffected.
+        assertTrue(TraceContext.matchesPropagateHeader("x-mesh-calling-job-id"));
+        assertTrue(TraceContext.matchesPropagateHeader("x-mesh-calling-claim-epoch"));
+    }
+
+    @Test
+    void stripDispatchHeaders_removesTheTrioCaseInsensitively() {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("X-Mesh-Job-Id", "job-leaked");
+        headers.put("x-mesh-claim-epoch", "9");
+        headers.put("x-mesh-recv-cursor", "{\"work\":4}");
+        headers.put("x-mesh-timeout", "30");
+        headers.put("x-mesh-calling-job-id", "job-caller");
+
+        TraceContext.stripDispatchHeaders(headers);
+
+        assertFalse(headers.containsKey("X-Mesh-Job-Id"));
+        assertFalse(headers.containsKey("x-mesh-claim-epoch"));
+        assertFalse(headers.containsKey("x-mesh-recv-cursor"));
+        assertEquals("30", headers.get("x-mesh-timeout"),
+            "a genuinely propagated header is untouched");
+        assertEquals("job-caller", headers.get("x-mesh-calling-job-id"));
+    }
+
+    // ---- inbound capture ---------------------------------------------------
+
+    @Test
+    void tracingFilterCapturesTheTrioFromTheRawRequest() throws Exception {
+        // TracingFilter holds the HttpServletRequest, so the raw header read is
+        // reachable there without any new plumbing.
+        Map<String, String> inbound = new LinkedHashMap<>();
+        inbound.put("X-Mesh-Job-Id", "job-inbound-1570");
+        inbound.put("X-Mesh-Claim-Epoch", "7");
+        inbound.put("X-Mesh-Timeout", "30");
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeaderNames()).thenAnswer(inv ->
+            Collections.enumeration(inbound.keySet()));
+        when(request.getHeader(any(String.class))).thenAnswer(inv -> {
+            String name = inv.getArgument(0);
+            for (Map.Entry<String, String> e : inbound.entrySet()) {
+                if (e.getKey().equalsIgnoreCase(name)) return e.getValue();
+            }
+            return null;
+        });
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        AtomicReference<Map<String, String>> dispatchSeen = new AtomicReference<>();
+        AtomicReference<Map<String, String>> propagatedSeen = new AtomicReference<>();
+        FilterChain chain = (req, res) -> {
+            dispatchSeen.set(new LinkedHashMap<>(TraceContext.getDispatchHeaders()));
+            propagatedSeen.set(new LinkedHashMap<>(TraceContext.getPropagatedHeaders()));
+        };
+
+        new TracingFilter().doFilter(request, response, chain);
+
+        assertEquals("job-inbound-1570", dispatchSeen.get().get("x-mesh-job-id"),
+            "the dispatch gate must see the raw inbound job id");
+        assertEquals("7", dispatchSeen.get().get("x-mesh-claim-epoch"),
+            "the claim epoch was previously read off the allowlist-filtered map, "
+                + "where it could never appear");
+        assertFalse(propagatedSeen.get().containsKey("x-mesh-job-id"),
+            "the propagated map is what rides outbound — it must not carry the discriminator");
+        assertEquals("30", propagatedSeen.get().get("x-mesh-timeout"));
+    }
+
+    // ---- dispatch gate -----------------------------------------------------
+
+    public static class TaskProbe {
+        final AtomicReference<String> jobScope = new AtomicReference<>();
+
+        @MeshTool(capability = "probe", task = true)
+        public String probe(@Param("input") String input) {
+            io.mcpmesh.JobContext.Snapshot snap = io.mcpmesh.JobContext.current();
+            jobScope.set(snap == null ? null : snap.jobId);
+            return "ok:" + input;
+        }
+    }
+
+    private static MeshToolWrapper taskProbeWrapper(TaskProbe bean) throws Exception {
+        Method m = TaskProbe.class.getMethod("probe", String.class);
+        return new MeshToolWrapper(
+            "TaskProbe.probe", "probe", "test", bean, m,
+            List.of(), JsonMapper.builder().build(), true);
+    }
+
+    @Test
+    void dispatchGateReadsTheRawStore_notThePropagatedOne() throws Exception {
+        TaskProbe bean = new TaskProbe();
+        MeshToolWrapper wrapper = taskProbeWrapper(bean);
+
+        TraceContext.setDispatchHeaders(Map.of("x-mesh-job-id", "job-dispatch"));
+        Object result = wrapper.invoke(Map.of("input", "x"));
+
+        assertEquals("ok:x", result);
+        assertEquals("job-dispatch", bean.jobScope.get(),
+            "a raw inbound job id must bind the JobContext for the handler");
+    }
+
+    @Test
+    void aStalePropagatedJobIdDoesNotDispatch() throws Exception {
+        // Nothing emits x-mesh-job-id outbound any more, but an operator who
+        // widens MCP_MESH_PROPAGATE_HEADERS must not be able to reopen the
+        // self-dispatch hazard: the gate does not consult this map at all.
+        TaskProbe bean = new TaskProbe();
+        MeshToolWrapper wrapper = taskProbeWrapper(bean);
+
+        TraceContext.setPropagatedHeaders(Map.of("x-mesh-job-id", "job-caller"));
+        Object result = wrapper.invoke(Map.of("input", "x"));
+
+        assertEquals("ok:x", result);
+        assertNull(bean.jobScope.get(),
+            "an inherited/propagated job id must NOT dispatch — that is the "
+                + "self-dispatch hazard (the callee would auto-complete the caller's row)");
+    }
+
+    // ---- version-skew guard -----------------------------------------------
+
+    @Test
+    void aJobIdArrivingWithCallingIdentityIsRefused() throws Exception {
+        // A pre-3.8 caller DID forward its job id, and only ever from inside a
+        // bound job context — which seeds x-mesh-calling-job-id on the same
+        // request. The pair together is a leak, not a dispatch: honouring it
+        // would bind this handler to the old caller's row for the length of
+        // the skew window, which is precisely the corruption being removed.
+        TaskProbe bean = new TaskProbe();
+        MeshToolWrapper wrapper = taskProbeWrapper(bean);
+
+        TraceContext.setDispatchHeaders(Map.of("x-mesh-job-id", "job-caller"));
+        TraceContext.setPropagatedHeaders(Map.of("x-mesh-calling-job-id", "job-caller"));
+        Object result = wrapper.invoke(Map.of("input", "x"));
+
+        assertEquals("ok:x", result);
+        assertNull(bean.jobScope.get(),
+            "an old caller's leaked job id must not bind this handler to its row");
+    }
+
+    @Test
+    void aGenuinePushDispatchCarriesNoCallingIdentityAndStillDispatches() throws Exception {
+        TaskProbe bean = new TaskProbe();
+        MeshToolWrapper wrapper = taskProbeWrapper(bean);
+
+        TraceContext.setDispatchHeaders(Map.of("x-mesh-job-id", "job-push"));
+        wrapper.invoke(Map.of("input", "x"));
+
+        assertEquals("job-push", bean.jobScope.get(),
+            "the skew guard must not cost a real push-mode dispatch");
+    }
+
+    @Test
+    void rawMeshHeadersArgumentChannelAlsoFeedsTheGate() throws Exception {
+        // Non-Java callers pass headers in the _mesh_headers argument because
+        // FastMCP hides HTTP headers; the raw read must cover that channel too.
+        TaskProbe bean = new TaskProbe();
+        MeshToolWrapper wrapper = taskProbeWrapper(bean);
+
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("input", "x");
+        args.put("_mesh_headers", Map.of("x-mesh-job-id", "job-from-args"));
+
+        Object result = wrapper.invoke(args);
+
+        assertEquals("ok:x", result);
+        assertEquals("job-from-args", bean.jobScope.get());
+        assertFalse(TraceContext.getPropagatedHeaders().containsKey("x-mesh-job-id"),
+            "the args channel must not smuggle the discriminator into the outbound map");
+    }
+}

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRequiredDepGuardTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperRequiredDepGuardTest.java
@@ -352,7 +352,9 @@ class MeshToolWrapperRequiredDepGuardTest {
 
         MeshSettleState.resetForTests(); // settled — no grace
         try {
-            TraceContext.setPropagatedHeaders(Map.of("x-mesh-job-id", "job-123"));
+            // Issue #1570: an inbound job dispatch is signalled through the
+            // RAW dispatch-header store, not the propagate allowlist.
+            TraceContext.setDispatchHeaders(Map.of("x-mesh-job-id", "job-123"));
             Object result = wrapper.invoke(Map.of("user_id", "frank"));
 
             assertNull(result,
@@ -361,7 +363,7 @@ class MeshToolWrapperRequiredDepGuardTest {
             assertFalse(bean.handlerRan.get(),
                 "the handler MUST NOT run with an unresolved required dep on the job path");
         } finally {
-            TraceContext.clearPropagatedHeaders();
+            TraceContext.clearDispatchHeaders();
         }
     }
 

--- a/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperSupersededTest.java
+++ b/src/runtime/java/mcp-mesh-spring-boot-starter/src/test/java/io/mcpmesh/spring/MeshToolWrapperSupersededTest.java
@@ -141,10 +141,15 @@ class MeshToolWrapperSupersededTest {
             "SupersedingJobBean.jobMutate", "job_mutate", "test", bean, m,
             List.of(), JsonMapper.builder().build(), true);
 
-        TraceContext.setPropagatedHeaders(Map.of("x-mesh-job-id", "job-xyz"));
-        Object result = wrapper.invoke(Map.of("detail", "job-stale"));
+        // Issue #1570: the dispatch discriminator rides the RAW dispatch store.
+        TraceContext.setDispatchHeaders(Map.of("x-mesh-job-id", "job-xyz"));
+        try {
+            Object result = wrapper.invoke(Map.of("detail", "job-stale"));
 
-        assertEquals("{\"error\":\"claim_superseded\",\"detail\":\"job-stale\"}", textOf(result),
-            "a superseded rejection on the job-dispatch path must emit the reserved envelope");
+            assertEquals("{\"error\":\"claim_superseded\",\"detail\":\"job-stale\"}", textOf(result),
+                "a superseded rejection on the job-dispatch path must emit the reserved envelope");
+        } finally {
+            TraceContext.clearDispatchHeaders();
+        }
     }
 }

--- a/src/runtime/python/_mcp_mesh/engine/claim_dispatcher.py
+++ b/src/runtime/python/_mcp_mesh/engine/claim_dispatcher.py
@@ -317,24 +317,32 @@ class PythonClaimDispatcher:
         if not isinstance(payload, dict):
             payload = {}
 
-        # Set propagated headers for this task so maybe_dispatch_as_job
-        # picks up the job_id (mirrors how the inbound HTTP path delivers
-        # it via the FastMCP middleware).
+        # Seed the inbound header contextvars for this task so
+        # maybe_dispatch_as_job picks up the job id (mirrors how the inbound
+        # HTTP path delivers it via the FastMCP middleware).
+        #
+        # Issue #1570: the dispatch protocol trio (job id / claim epoch /
+        # recv cursor) goes into the DISPATCH store, which is inbound-only and
+        # never rides an outbound call — forwarding x-mesh-job-id would make a
+        # nested task=True call self-dispatch as this job and auto-complete it
+        # with the wrong result. Only x-mesh-timeout (a genuinely propagated
+        # header) is seeded into the propagated store.
         try:
             from ..tracing.context import TraceContext
 
-            existing = TraceContext.get_propagated_headers() or {}
-            merged = dict(existing)
-            merged["x-mesh-job-id"] = job_id
+            dispatch: dict[str, str] = {"x-mesh-job-id": job_id}
             max_dur = claimed.get("max_duration")
             if max_dur:
-                merged["x-mesh-timeout"] = str(int(max_dur))
+                existing = TraceContext.get_propagated_headers() or {}
+                TraceContext.set_propagated_headers(
+                    {**existing, "x-mesh-timeout": str(int(max_dur))}
+                )
             # Seed the claim generation (issue #1252) so the dispatched
             # handler's JobController fences its deltas + executor reads and a
             # supersession aborts it. Absent on an old registry ⇒ legacy path.
             claim_epoch = _valid_claim_epoch(claimed.get("claim_epoch"))
             if claim_epoch is not None:
-                merged["x-mesh-claim-epoch"] = str(claim_epoch)
+                dispatch["x-mesh-claim-epoch"] = str(claim_epoch)
             # Seed the persisted per-filter receive cursor (issue #1277) so a
             # tool that opted into resume (`@mesh.tool(resume_cursor=True)`)
             # resumes its recv_event consumption instead of replaying from
@@ -346,7 +354,7 @@ class PythonClaimDispatcher:
             recv_cursor = claimed.get("recv_cursor")
             if isinstance(recv_cursor, dict) and recv_cursor:
                 try:
-                    merged["x-mesh-recv-cursor"] = json.dumps(recv_cursor)
+                    dispatch["x-mesh-recv-cursor"] = json.dumps(recv_cursor)
                 except (TypeError, ValueError) as e:
                     logger.debug(
                         "claim_dispatcher: could not serialize recv_cursor "
@@ -354,10 +362,10 @@ class PythonClaimDispatcher:
                         recv_cursor,
                         e,
                     )
-            TraceContext.set_propagated_headers(merged)
+            TraceContext.set_dispatch_headers(dispatch)
         except Exception as e:
             logger.debug(
-                "claim_dispatcher: could not seed propagated headers (%s); "
+                "claim_dispatcher: could not seed inbound headers (%s); "
                 "dispatching without job context",
                 e,
             )

--- a/src/runtime/python/_mcp_mesh/engine/http_wrapper.py
+++ b/src/runtime/python/_mcp_mesh/engine/http_wrapper.py
@@ -475,10 +475,29 @@ class HttpMcpWrapper:
 
                     # Capture configured propagation headers from incoming request
                     from ..tracing.context import (
+                        DISPATCH_HEADERS,
                         PROPAGATE_HEADERS,
                         matches_propagate_header,
                     )
                     from ..tracing.context import TraceContext as _TC
+
+                    # Issue #1570: capture the push-mode dispatch protocol
+                    # headers from the RAW inbound request, independently of
+                    # the propagate allowlist. They are the dispatch
+                    # discriminator, deliberately NOT allowlisted (a nested
+                    # outbound call must not look like a job dispatch to every
+                    # downstream) — so reading them off the filtered map would
+                    # leave push-mode dispatch over HTTP unreachable.
+                    dispatch = {
+                        name.lower(): value
+                        for name, value in request.headers.items()
+                        if name.lower() in DISPATCH_HEADERS and value
+                    }
+                    if dispatch:
+                        _TC.set_dispatch_headers(dispatch)
+                        self.logger.debug(
+                            f"Captured {len(dispatch)} inbound dispatch headers"
+                        )
 
                     if PROPAGATE_HEADERS:
                         captured = {}

--- a/src/runtime/python/_mcp_mesh/engine/job_dispatch.py
+++ b/src/runtime/python/_mcp_mesh/engine/job_dispatch.py
@@ -4,9 +4,12 @@ This module wires the producer-side dispatch path: when a tool decorated
 with ``@mesh.tool(task=True)`` receives an inbound ``tools/call`` bearing
 ``X-Mesh-Job-Id``, the wrapper:
 
-1. Reads ``X-Mesh-Job-Id`` and (optionally) ``X-Mesh-Timeout`` from the
-   active propagated-headers contextvar (populated by the FastMCP session
-   middleware in ``http_wrapper.py``).
+1. Reads ``X-Mesh-Job-Id`` from the active dispatch-headers contextvar
+   (captured from the RAW inbound request by the FastMCP session middleware
+   in ``http_wrapper.py``, or seeded by the claim dispatcher) and
+   (optionally) ``X-Mesh-Timeout`` from the propagated-headers contextvar.
+   The dispatch protocol headers deliberately live in their own store: they
+   are inbound-only and must never ride an outbound call (issue #1570).
 2. Builds a :class:`mcp_mesh_core.JobController` bound to that job id and
    the running agent's instance id.
 3. Sets both the Python :data:`CURRENT_JOB` contextvar and (via
@@ -54,7 +57,9 @@ except ImportError:
 
 # Header names — lowercased to match how the FastMCP middleware stores
 # captured inbound headers (via ``str.lower()`` in
-# ``http_wrapper.py::MCPSessionRoutingMiddleware.dispatch``).
+# ``http_wrapper.py::MCPSessionRoutingMiddleware.dispatch``). The dispatch
+# trio (job id / claim epoch / recv cursor) is INBOUND-ONLY — see
+# ``tracing.context.DISPATCH_HEADERS`` (issue #1570).
 _HDR_JOB_ID = "x-mesh-job-id"
 _HDR_TIMEOUT = "x-mesh-timeout"
 # Claim generation minted by the registry on POST /jobs/claim (issue #1252).
@@ -64,12 +69,26 @@ _HDR_CLAIM_EPOCH = "x-mesh-claim-epoch"
 # dispatcher as a JSON-serialized ``dict[str, int]``; absent on the push-mode
 # inbound path and whenever the reclaimed row had no prior consumption.
 _HDR_RECV_CURSOR = "x-mesh-recv-cursor"
+# Calling-job identity (issue #1263). Read here only as the version-skew
+# discriminator described in ``_read_job_headers``; the accessor users call is
+# ``mesh.calling_job()``.
+_HDR_CALLING_JOB_ID = "x-mesh-calling-job-id"
 
 
 def _read_job_headers() -> tuple[str | None, float | None, int | None, dict | None]:
     """Pull ``X-Mesh-Job-Id`` / ``X-Mesh-Timeout`` / ``X-Mesh-Claim-Epoch`` /
-    ``X-Mesh-Recv-Cursor`` from the propagated-headers contextvar populated by
-    the MCP session middleware (or seeded by the claim dispatcher).
+    ``X-Mesh-Recv-Cursor`` from the inbound contextvars.
+
+    The dispatch protocol trio (job id / claim epoch / recv cursor) is read
+    ONLY from the DISPATCH-headers contextvar — captured from the RAW inbound
+    request by the MCP session middleware, or seeded by the claim dispatcher.
+    The propagated map is never consulted for it, matching TypeScript and
+    Java: those names are deliberately off the propagate allowlist
+    (issue #1570 — forwarding ``x-mesh-job-id`` makes a nested ``task=True``
+    call self-dispatch as the caller's job), and reading a fallback out of the
+    propagated map would let an operator who widens
+    ``MCP_MESH_PROPAGATE_HEADERS`` re-arm exactly that hazard. The propagated
+    map remains the source for ``X-Mesh-Timeout``, which genuinely propagates.
 
     Returns ``(job_id, deadline_secs_remaining, claim_epoch, recv_cursor)`` —
     any may be ``None``. ``claim_epoch`` and ``recv_cursor`` are present only
@@ -84,14 +103,40 @@ def _read_job_headers() -> tuple[str | None, float | None, int | None, dict | No
     except Exception:
         return None, None, None, None
 
-    headers = TraceContext.get_propagated_headers() or {}
-    if not headers:
-        return None, None, None, None
+    propagated = TraceContext.get_propagated_headers() or {}
+    dispatch = TraceContext.get_dispatch_headers() or {}
 
-    # Header dict is lowercased by the middleware before storing.
-    job_id = headers.get(_HDR_JOB_ID)
+    # Header dicts are lowercased by the middleware before storing. The
+    # dispatch trio comes from the raw store; only x-mesh-timeout is read off
+    # the propagated one.
+    job_id = dispatch.get(_HDR_JOB_ID)
     if not job_id:
         return None, None, None, None
+
+    # Version-skew guard (issue #1570). A pre-3.8 peer forwarded
+    # x-mesh-job-id on ordinary nested calls, and it only ever did so from
+    # inside a bound job context — which seeds x-mesh-calling-job-id on the
+    # SAME request. A genuine push-mode dispatch carries the job id WITHOUT
+    # calling identity (the submitter is not itself executing that job), so
+    # the two arriving together identifies a leaked nested call from an old
+    # caller. Dispatching on it would bind this handler to the CALLER's job
+    # row and auto-complete it with this tool's result — the very corruption
+    # this issue removes. Refuse the dispatch, run as a plain call, and say
+    # so loudly: the fix is to finish the upgrade.
+    if propagated.get(_HDR_CALLING_JOB_ID):
+        logger.warning(
+            "job_dispatch: inbound %s=%s arrived together with %s=%s — a "
+            "pre-3.8 caller leaking its own job id on a nested call, not a "
+            "push-mode dispatch. Running as a plain tool call; upgrade the "
+            "calling agent to stop this (issue #1570).",
+            _HDR_JOB_ID,
+            job_id,
+            _HDR_CALLING_JOB_ID,
+            propagated.get(_HDR_CALLING_JOB_ID),
+        )
+        return None, None, None, None
+
+    headers = {**propagated, **dispatch}
 
     timeout_raw = headers.get(_HDR_TIMEOUT)
     deadline_secs: float | None = None
@@ -668,9 +713,10 @@ async def maybe_dispatch_as_job(
             # (e.g. older mcp-mesh-core .so), still run the user
             # function with the Python contextvar set. Outbound HTTP
             # via the unified proxy reads the Python contextvar
-            # directly, so X-Mesh-Job-Id propagation still works for
-            # Python-originated downstream calls — only the Rust-core
-            # task-local is missing.
+            # directly, so the calling-job identity (x-mesh-calling-*)
+            # and the nested deadline cap still ride downstream calls —
+            # only the Rust-core task-local is missing. The dispatch id
+            # itself is never forwarded either way (issue #1570).
             logger.debug(
                 "job_dispatch: with_job_async not available; running with "
                 "Python contextvar only (Rust task-local will not be set)"

--- a/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
+++ b/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
@@ -1346,8 +1346,17 @@ class UnifiedMCPProxy:
                     and snap.job_id
                     and snap.deadline_secs_remaining is not None
                 ):
+                    # Read the current budget from EITHER casing: the
+                    # propagated store can deliver a lowercase
+                    # `x-mesh-timeout`, and looking only at the canonical
+                    # name would read 0 ("unset") and tighten against
+                    # nothing.
                     try:
-                        cur_timeout = int(headers.get("X-Mesh-Timeout", "0"))
+                        cur_timeout = int(
+                            headers.get("X-Mesh-Timeout")
+                            or headers.get("x-mesh-timeout")
+                            or "0"
+                        )
                     except (TypeError, ValueError):
                         cur_timeout = 0
                     raw_remaining = float(snap.deadline_secs_remaining)
@@ -1394,6 +1403,12 @@ class UnifiedMCPProxy:
                         headers.pop("X-Mesh-Timeout", None)
                         headers.pop("x-mesh-timeout", None)
                     elif cur_timeout == 0 or remaining < cur_timeout:
+                        # Drop the lowercase twin before assigning the
+                        # canonical name, exactly as the expired branch above
+                        # does. Leaving it would put BOTH the parent's larger
+                        # value and this tightened one on the wire, and a
+                        # receiver taking the first loses the parent's cap.
+                        headers.pop("x-mesh-timeout", None)
                         headers["X-Mesh-Timeout"] = str(remaining)
             except Exception as e:
                 self.logger.debug(

--- a/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
+++ b/src/runtime/python/_mcp_mesh/engine/unified_mcp_proxy.py
@@ -760,21 +760,24 @@ class UnifiedMCPProxy:
           propagate allowlist. Caller is responsible for setting
           ``_outbound_headers_var`` so the httpx event hook picks them up.
         """
-        from ..tracing.context import matches_propagate_header
+        from ..tracing.context import DISPATCH_HEADERS, matches_propagate_header
 
         current_trace = TraceContext.get_current()
         merged_headers: dict[str, str] = dict(TraceContext.get_propagated_headers())
 
-        # Issue #1277: the persisted recv-cursor is CLAIM-LOCAL — it is read
-        # once by job_dispatch (from the contextvar, before this outbound call)
-        # to seed the handler's controller, and is meaningless (and wasteful —
-        # it's a serialized map) downstream. Unlike x-mesh-job-id /
-        # x-mesh-claim-epoch (which propagate intentionally for calling-job
-        # identity, #1263), scrub ONLY this key from the outbound base. The
-        # inbound claim→handler seed is unaffected — that read already happened
-        # against the contextvar, not this outbound copy.
-        merged_headers.pop("x-mesh-recv-cursor", None)
-
+        # Issue #1570: the push-mode dispatch protocol trio (x-mesh-job-id,
+        # x-mesh-claim-epoch, x-mesh-recv-cursor) is INBOUND-ONLY and is
+        # scrubbed from every outbound call. x-mesh-job-id is the dispatch
+        # DISCRIMINATOR: forwarding it makes a nested same-instance task=True
+        # call self-dispatch as the CALLER's job (owner + epoch match) and
+        # auto-complete it with the wrong result. The claim-local recv-cursor
+        # (#1277) is additionally meaningless downstream. Calling identity
+        # rides the dedicated x-mesh-calling-* pair overlaid below (#1263).
+        # The inbound claim→handler seed is unaffected — that read already
+        # happened against the contextvar, not this outbound copy. The scrub
+        # runs AFTER the custom / per-call merges below (matching Java's
+        # McpHttpClient and TypeScript's buildMcpRequest) so neither channel
+        # can reintroduce a name the contract forbids on the wire.
         if self.custom_headers:
             for k, v in self.custom_headers.items():
                 if matches_propagate_header(k):
@@ -784,6 +787,9 @@ class UnifiedMCPProxy:
             for k, v in per_call_headers.items():
                 if matches_propagate_header(k):
                     merged_headers[k.lower()] = v
+
+        for _dispatch_only in DISPATCH_HEADERS:
+            merged_headers.pop(_dispatch_only, None)
 
         # Issue #1263: overlay the CALLING job's identity so a nested outbound
         # call made from within a job execution context carries who invoked the
@@ -1320,84 +1326,79 @@ class UnifiedMCPProxy:
             if "X-Mesh-Timeout" not in headers and "x-mesh-timeout" not in headers:
                 headers["X-Mesh-Timeout"] = str(enhanced_timeout)
 
-            # Phase 1 MeshJob substrate: when a tool is executing under
-            # an active job context (set by the inbound dispatch wrapper
-            # in job_dispatch.maybe_dispatch_as_job), attach
-            # X-Mesh-Job-Id to every outbound mesh→mesh call so the
-            # downstream producer can bind its execution to the same job
-            # row. Mirrors the Rust core's `inject_job_headers` helper —
-            # this Python-side variant covers calls that originate in
-            # Python user code (vs Rust-originated outbound, e.g. from
-            # the agentic-loop LLM provider).
-            if "X-Mesh-Job-Id" not in headers and "x-mesh-job-id" not in headers:
-                try:
-                    from .job_context import current_job
+            # Phase 1 MeshJob substrate: when a tool is executing under an
+            # active job context (set by the inbound dispatch wrapper in
+            # job_dispatch.maybe_dispatch_as_job), cap the outbound budget at
+            # the parent's remaining deadline (parent-scope deadline cap — see
+            # "Nested jobs: strict deadline cap" in MESHJOB_DESIGN.org).
+            #
+            # Issue #1570: X-Mesh-Job-Id is NOT attached here. It is the
+            # push-mode dispatch DISCRIMINATOR, so forwarding it would make a
+            # nested task=True call dispatch as — and auto-complete — the
+            # CALLER's job row. Who invoked the downstream travels on the
+            # dedicated x-mesh-calling-* pair instead (#1263).
+            try:
+                from .job_context import current_job
 
-                    snap = current_job()
-                    if snap is not None and snap.job_id:
-                        headers["X-Mesh-Job-Id"] = snap.job_id
-                        # Also override X-Mesh-Timeout with the
-                        # remaining-on-deadline value if the active
-                        # context has a tighter budget than what's
-                        # already in headers (parent-scope deadline cap
-                        # — see "Nested jobs: strict deadline cap" in
-                        # MESHJOB_DESIGN.org).
-                        if snap.deadline_secs_remaining is not None:
-                            try:
-                                cur_timeout = int(headers.get("X-Mesh-Timeout", "0"))
-                            except (TypeError, ValueError):
-                                cur_timeout = 0
-                            raw_remaining = float(snap.deadline_secs_remaining)
-                            # NOTE: unlike the Rust `JobContext`, this value is
-                            # a STATIC dispatch-time snapshot -- job_dispatch
-                            # reads the inbound `X-Mesh-Timeout` once and never
-                            # decrements it -- so it is the budget the parent
-                            # granted, not live remaining time.
-                            #
-                            # Round UP and floor at 1 (issue #1584). Reachable:
-                            # an inbound header of "0.5" used to become
-                            # `int(0.5)` == 0 and get DROPPED as expired,
-                            # handing the child an unbounded budget instead of
-                            # the tightest one the wire can express.
-                            #
-                            # The `<= 0` arm below is defensive rather than
-                            # reachable from dispatch (job_dispatch already
-                            # normalises a `<= 0` header to None), but
-                            # `CURRENT_JOB` is public API that user code and
-                            # tests can set directly.
-                            remaining = (
-                                0
-                                if raw_remaining <= 0
-                                else max(1, math.ceil(raw_remaining))
-                            )
-                            if remaining <= 0:
-                                # Already past the parent deadline. The
-                                # OpenAPI schema requires X-Mesh-Timeout
-                                # >= 1, so we MUST NOT emit the header
-                                # with "0" — downstream behaviour at the
-                                # registry proxy is undefined. Drop any
-                                # propagated header value and let the
-                                # downstream apply its server-side
-                                # default; the parent-scope cancel token
-                                # (already wired through job_context) is
-                                # the authoritative signal that this
-                                # call shouldn't have been made.
-                                self.logger.warning(
-                                    "outbound %s under job=%s has expired deadline "
-                                    "(granted=%ss); omitting X-Mesh-Timeout instead "
-                                    "of emitting an invalid '0' value",
-                                    name,
-                                    snap.job_id,
-                                    raw_remaining,
-                                )
-                                headers.pop("X-Mesh-Timeout", None)
-                                headers.pop("x-mesh-timeout", None)
-                            elif cur_timeout == 0 or remaining < cur_timeout:
-                                headers["X-Mesh-Timeout"] = str(remaining)
-                except Exception as e:
-                    self.logger.debug(
-                        f"job_context lookup failed for outbound headers: {e}"
+                snap = current_job()
+                if (
+                    snap is not None
+                    and snap.job_id
+                    and snap.deadline_secs_remaining is not None
+                ):
+                    try:
+                        cur_timeout = int(headers.get("X-Mesh-Timeout", "0"))
+                    except (TypeError, ValueError):
+                        cur_timeout = 0
+                    raw_remaining = float(snap.deadline_secs_remaining)
+                    # NOTE: unlike the Rust `JobContext`, this value is
+                    # a STATIC dispatch-time snapshot -- job_dispatch
+                    # reads the inbound `X-Mesh-Timeout` once and never
+                    # decrements it -- so it is the budget the parent
+                    # granted, not live remaining time.
+                    #
+                    # Round UP and floor at 1 (issue #1584). Reachable:
+                    # an inbound header of "0.5" used to become
+                    # `int(0.5)` == 0 and get DROPPED as expired,
+                    # handing the child an unbounded budget instead of
+                    # the tightest one the wire can express.
+                    #
+                    # The `<= 0` arm below is defensive rather than
+                    # reachable from dispatch (job_dispatch already
+                    # normalises a `<= 0` header to None), but
+                    # `CURRENT_JOB` is public API that user code and
+                    # tests can set directly.
+                    remaining = (
+                        0 if raw_remaining <= 0 else max(1, math.ceil(raw_remaining))
                     )
+                    if remaining <= 0:
+                        # Already past the parent deadline. The
+                        # OpenAPI schema requires X-Mesh-Timeout
+                        # >= 1, so we MUST NOT emit the header
+                        # with "0" — downstream behaviour at the
+                        # registry proxy is undefined. Drop any
+                        # propagated header value and let the
+                        # downstream apply its server-side
+                        # default; the parent-scope cancel token
+                        # (already wired through job_context) is
+                        # the authoritative signal that this
+                        # call shouldn't have been made.
+                        self.logger.warning(
+                            "outbound %s under job=%s has expired deadline "
+                            "(granted=%ss); omitting X-Mesh-Timeout instead "
+                            "of emitting an invalid '0' value",
+                            name,
+                            snap.job_id,
+                            raw_remaining,
+                        )
+                        headers.pop("X-Mesh-Timeout", None)
+                        headers.pop("x-mesh-timeout", None)
+                    elif cur_timeout == 0 or remaining < cur_timeout:
+                        headers["X-Mesh-Timeout"] = str(remaining)
+            except Exception as e:
+                self.logger.debug(
+                    f"job_context lookup failed for outbound headers: {e}"
+                )
 
             # Use X-Mesh-Timeout to set client-side timeout (authoritative override)
             mesh_timeout_val = headers.get("X-Mesh-Timeout") or headers.get(

--- a/src/runtime/python/_mcp_mesh/tracing/context.py
+++ b/src/runtime/python/_mcp_mesh/tracing/context.py
@@ -30,6 +30,17 @@ for _infra in ("x-mesh-calling-job-id", "x-mesh-calling-claim-epoch"):
         PROPAGATE_HEADERS.append(_infra)
 PROPAGATE_HEADERS_CSV: str = ",".join(PROPAGATE_HEADERS)
 
+# Issue #1570: the push-mode dispatch protocol headers. These are INBOUND-ONLY
+# — read from the raw inbound request (or seeded by the claim dispatcher) to
+# decide whether THIS call is a job dispatch, and never emitted on an outbound
+# call. Forwarding ``x-mesh-job-id`` would make a nested ``task=True`` call
+# self-dispatch as the CALLER's job (owner + epoch match) and auto-complete it
+# with the wrong result. Calling identity travels on the dedicated
+# ``x-mesh-calling-*`` pair instead.
+DISPATCH_HEADERS: frozenset[str] = frozenset(
+    {"x-mesh-job-id", "x-mesh-claim-epoch", "x-mesh-recv-cursor"}
+)
+
 
 def matches_propagate_header(name: str) -> bool:
     """Check if a header name matches the propagate headers allowlist.
@@ -127,6 +138,13 @@ class TraceContext:
     _propagated_headers: contextvars.ContextVar[dict[str, str] | None] = (
         contextvars.ContextVar("propagated_headers", default=None)
     )
+    # Issue #1570: inbound-only dispatch protocol headers (see
+    # DISPATCH_HEADERS). Deliberately a SEPARATE store from the propagated
+    # headers so they can be read for dispatch without ever riding an
+    # outbound call.
+    _dispatch_headers: contextvars.ContextVar[dict[str, str] | None] = (
+        contextvars.ContextVar("dispatch_headers", default=None)
+    )
 
     @classmethod
     def set_current(
@@ -163,6 +181,28 @@ class TraceContext:
     def clear_propagated_headers(cls):
         """Clear propagated headers"""
         cls._propagated_headers.set({})
+
+    @classmethod
+    def get_dispatch_headers(cls) -> dict[str, str]:
+        """Inbound-only job-dispatch headers for this async context (#1570)."""
+        return cls._dispatch_headers.get() or {}
+
+    @classmethod
+    def set_dispatch_headers(cls, headers: dict[str, str]):
+        """Set the inbound job-dispatch headers for this async context.
+
+        Keys are expected lowercased. Only names in :data:`DISPATCH_HEADERS`
+        are retained — this store must never become a general header channel,
+        because nothing in it is ever forwarded downstream.
+        """
+        cls._dispatch_headers.set(
+            {k: v for k, v in headers.items() if k in DISPATCH_HEADERS}
+        )
+
+    @classmethod
+    def clear_dispatch_headers(cls):
+        """Clear the inbound job-dispatch headers."""
+        cls._dispatch_headers.set({})
 
     @classmethod
     def generate_new(cls) -> TraceInfo:

--- a/src/runtime/python/_mcp_mesh/tracing/trace_context_helper.py
+++ b/src/runtime/python/_mcp_mesh/tracing/trace_context_helper.py
@@ -160,9 +160,19 @@ class TraceContextHelper:
                 headers["X-Trace-ID"] = trace_context.trace_id
                 headers["X-Parent-Span"] = trace_context.span_id
 
-            # Inject propagated headers (independent of tracing)
+            # Inject propagated headers (independent of tracing).
+            #
+            # Issue #1570: the push-mode dispatch trio is INBOUND-ONLY and is
+            # skipped here even if it somehow reached the propagated store —
+            # forwarding x-mesh-job-id makes a nested task=True call
+            # self-dispatch as the CALLER's job and auto-complete it with the
+            # wrong result. Calling identity rides x-mesh-calling-* instead.
+            from .context import DISPATCH_HEADERS
+
             propagated = TraceContext.get_propagated_headers()
             for key, value in propagated.items():
+                if key.lower() in DISPATCH_HEADERS:
+                    continue
                 headers[key] = value
         except Exception as e:
             # Tracing injection should never break MCP calls

--- a/src/runtime/python/tests/unit/test_1277_resume_cursor.py
+++ b/src/runtime/python/tests/unit/test_1277_resume_cursor.py
@@ -307,7 +307,12 @@ class TestDispatchSetsRecvCursorHeader:
         seen: dict = {}
 
         async def handler(**kwargs):
-            seen["headers"] = dict(TraceContext.get_propagated_headers())
+            # Issue #1570: assert against the DISPATCH store, which is where
+            # the cursor now lands. Reading the propagated store here would
+            # pass even if the empty-cursor branch DID seed a cursor, because
+            # nothing seeds that store with one any more.
+            seen["headers"] = dict(TraceContext.get_dispatch_headers())
+            seen["propagated"] = dict(TraceContext.get_propagated_headers())
 
         d = self._make_dispatcher(handler)
         try:
@@ -322,6 +327,7 @@ class TestDispatchSetsRecvCursorHeader:
             _clear_inbound()
 
         assert "x-mesh-recv-cursor" not in seen["headers"]
+        assert "x-mesh-recv-cursor" not in seen["propagated"]
 
 
 # ===========================================================================

--- a/src/runtime/python/tests/unit/test_1277_resume_cursor.py
+++ b/src/runtime/python/tests/unit/test_1277_resume_cursor.py
@@ -22,6 +22,31 @@ import mesh
 from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
 
 
+def _seed_inbound(headers: dict) -> None:
+    """Deliver ``headers`` the way the inbound path does (issue #1570).
+
+    The dispatch protocol trio lands on the RAW dispatch store (captured from
+    the inbound request / seeded by the claim dispatcher); everything else
+    lands on the propagated store, which is what rides outbound calls. The two
+    are separate precisely so the discriminator can never be forwarded.
+    """
+    from _mcp_mesh.tracing.context import DISPATCH_HEADERS, TraceContext
+
+    TraceContext.set_dispatch_headers(
+        {k: v for k, v in headers.items() if k in DISPATCH_HEADERS}
+    )
+    TraceContext.set_propagated_headers(
+        {k: v for k, v in headers.items() if k not in DISPATCH_HEADERS}
+    )
+
+
+def _clear_inbound() -> None:
+    from _mcp_mesh.tracing.context import TraceContext
+
+    TraceContext.set_propagated_headers({})
+    TraceContext.clear_dispatch_headers()
+
+
 @pytest.fixture(autouse=True)
 def _clean_registry():
     # Several cases here declare a tool function named ``handler``. Those are
@@ -124,11 +149,11 @@ class TestReadJobHeadersRecvCursor:
         from _mcp_mesh.engine.job_dispatch import _read_job_headers
         from _mcp_mesh.tracing.context import TraceContext
 
-        TraceContext.set_propagated_headers(headers)
+        _seed_inbound(headers)
         try:
             return _read_job_headers()
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
 
     def test_parses_recv_cursor_to_dict(self):
         cursor = {"work": 7, "answer": 3}
@@ -231,7 +256,9 @@ class TestDispatchSetsRecvCursorHeader:
         seen: dict = {}
 
         async def handler(**kwargs):
-            seen["headers"] = dict(TraceContext.get_propagated_headers())
+            # Issue #1570: the cursor rides the inbound-only DISPATCH store.
+            seen["headers"] = dict(TraceContext.get_dispatch_headers())
+            seen["propagated"] = dict(TraceContext.get_propagated_headers())
 
         d = self._make_dispatcher(handler)
         cursor = {"work": 4, "signal": 1}
@@ -245,10 +272,13 @@ class TestDispatchSetsRecvCursorHeader:
                 }
             )
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
+            TraceContext.clear_dispatch_headers()
 
         assert "x-mesh-recv-cursor" in seen["headers"]
         assert json.loads(seen["headers"]["x-mesh-recv-cursor"]) == cursor
+        # ...and never on the propagated (outbound-eligible) store.
+        assert "x-mesh-recv-cursor" not in seen["propagated"]
 
     @pytest.mark.asyncio
     async def test_dispatch_without_recv_cursor_sets_no_header(self):
@@ -257,7 +287,7 @@ class TestDispatchSetsRecvCursorHeader:
         seen: dict = {}
 
         async def handler(**kwargs):
-            seen["headers"] = dict(TraceContext.get_propagated_headers())
+            seen["headers"] = dict(TraceContext.get_dispatch_headers())
 
         d = self._make_dispatcher(handler)
         try:
@@ -265,7 +295,8 @@ class TestDispatchSetsRecvCursorHeader:
                 {"id": "job-2", "submitted_payload": {}, "claim_epoch": 2}
             )
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
+            TraceContext.clear_dispatch_headers()
 
         assert "x-mesh-recv-cursor" not in seen["headers"]
 
@@ -288,7 +319,7 @@ class TestDispatchSetsRecvCursorHeader:
                 }
             )
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
 
         assert "x-mesh-recv-cursor" not in seen["headers"]
 
@@ -318,7 +349,7 @@ class TestResumeGate:
         headers = {"x-mesh-job-id": "job-1", "x-mesh-claim-epoch": "5"}
         if header_cursor is not None:
             headers["x-mesh-recv-cursor"] = json.dumps(header_cursor)
-        TraceContext.set_propagated_headers(headers)
+        _seed_inbound(headers)
         monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
         monkeypatch.setenv("MCP_MESH_AGENT_ID", "agent-1")
 
@@ -351,7 +382,7 @@ class TestResumeGate:
             ):
                 await maybe_dispatch_as_job(fn, invoke, {"user": "alice"})
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
         return seen
 
     @pytest.mark.asyncio
@@ -413,7 +444,7 @@ class TestOutboundScrub:
     def teardown_method(self):
         from _mcp_mesh.tracing.context import TraceContext
 
-        TraceContext.set_propagated_headers({})
+        _clear_inbound()
 
     def _merged(self):
         from _mcp_mesh.engine.unified_mcp_proxy import UnifiedMCPProxy
@@ -425,7 +456,7 @@ class TestOutboundScrub:
     def test_recv_cursor_scrubbed_from_outbound(self):
         from _mcp_mesh.tracing.context import TraceContext
 
-        TraceContext.set_propagated_headers(
+        _seed_inbound(
             {
                 "x-mesh-job-id": "job-1",
                 "x-mesh-claim-epoch": "3",
@@ -442,7 +473,7 @@ class TestOutboundScrub:
         from _mcp_mesh.engine.job_dispatch import _read_job_headers
         from _mcp_mesh.tracing.context import TraceContext
 
-        TraceContext.set_propagated_headers(
+        _seed_inbound(
             {
                 "x-mesh-job-id": "job-1",
                 "x-mesh-recv-cursor": json.dumps({"work": 5}),

--- a/src/runtime/python/tests/unit/test_1570_job_id_contract.py
+++ b/src/runtime/python/tests/unit/test_1570_job_id_contract.py
@@ -1,0 +1,300 @@
+"""Issue #1570 — the cross-runtime ``x-mesh-job-id`` contract.
+
+``x-mesh-job-id`` is the push-mode dispatch DISCRIMINATOR. It is read from the
+RAW inbound request (or seeded by the claim dispatcher) and is never emitted on
+an outbound call: forwarding it makes a nested ``task=True`` call self-dispatch
+as the CALLER's job (owner + epoch match) and auto-complete it with the wrong
+result. Calling identity rides the dedicated ``x-mesh-calling-*`` pair.
+
+Two properties are pinned here:
+
+1. **Inbound capture works.** A raw ``X-Mesh-Job-Id`` HTTP header reaches
+   ``job_dispatch`` even though it is not on the propagate allowlist — push-mode
+   dispatch over HTTP used to be unreachable because the dispatch gate read the
+   allowlist-FILTERED map.
+2. **Outbound never carries it.** Neither the propagated-header base nor the
+   active job context puts ``x-mesh-job-id`` on a downstream request.
+"""
+
+import json
+from unittest import mock
+
+import pytest
+
+from _mcp_mesh.engine.job_context import CURRENT_JOB, JobContextSnapshot
+from _mcp_mesh.engine.unified_mcp_proxy import UnifiedMCPProxy
+from _mcp_mesh.tracing.context import (
+    DISPATCH_HEADERS,
+    TraceContext,
+    matches_propagate_header,
+)
+
+
+class TestAllowlistExcludesTheDispatchTrio:
+    def test_dispatch_headers_are_not_allowlisted(self):
+        for name in DISPATCH_HEADERS:
+            assert matches_propagate_header(name) is False, name
+
+
+class TestInboundCapture:
+    """The MCP session middleware must capture the dispatch trio from the RAW
+    inbound request, independently of the propagate allowlist."""
+
+    def teardown_method(self):
+        TraceContext.set_propagated_headers({})
+        TraceContext.clear_dispatch_headers()
+
+    def _middleware_class(self):
+        from _mcp_mesh.engine.http_wrapper import HttpMcpWrapper
+
+        class _CapturingApp:
+            def __init__(self):
+                self.middleware_cls = None
+
+            def add_middleware(self, cls, **kwargs):
+                self.middleware_cls = cls
+
+        wrapper = HttpMcpWrapper.__new__(HttpMcpWrapper)
+        wrapper._mcp_app = _CapturingApp()
+        wrapper._add_session_routing_middleware()
+        return wrapper._mcp_app.middleware_cls
+
+    def test_raw_job_headers_reach_the_dispatch_gate(self):
+        from starlette.applications import Starlette
+        from starlette.responses import JSONResponse
+        from starlette.routing import Route
+        from starlette.testclient import TestClient
+
+        from _mcp_mesh.engine.job_dispatch import _read_job_headers
+
+        seen: dict = {}
+
+        async def endpoint(request):
+            seen["job"] = _read_job_headers()
+            seen["propagated"] = dict(TraceContext.get_propagated_headers())
+            return JSONResponse({"ok": True})
+
+        class _StubWrapper:
+            async def _extract_session_id_from_body(self, body):
+                return None
+
+        app = Starlette(routes=[Route("/mcp", endpoint, methods=["POST"])])
+        app.add_middleware(self._middleware_class(), http_wrapper=_StubWrapper())
+
+        body = json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {}}
+        )
+        with TestClient(app) as client:
+            resp = client.post(
+                "/mcp",
+                content=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Mesh-Job-Id": "job-inbound-1570",
+                    "X-Mesh-Claim-Epoch": "7",
+                    "X-Mesh-Timeout": "30",
+                },
+            )
+        assert resp.status_code == 200
+
+        job_id, deadline, claim_epoch, _cursor = seen["job"]
+        assert job_id == "job-inbound-1570"
+        assert deadline == 30.0
+        assert claim_epoch == 7
+        # …and the allowlist-filtered map that rides outbound never sees it.
+        assert "x-mesh-job-id" not in seen["propagated"]
+        assert "x-mesh-claim-epoch" not in seen["propagated"]
+
+
+class TestGateIsRawOnly:
+    """The gate reads the dispatch store and nothing else — matching Java and
+    TypeScript. An operator who widens ``MCP_MESH_PROPAGATE_HEADERS`` must not
+    be able to re-arm self-dispatch through the propagated map."""
+
+    def teardown_method(self):
+        TraceContext.set_propagated_headers({})
+        TraceContext.clear_dispatch_headers()
+
+    def test_propagated_job_id_alone_does_not_dispatch(self):
+        from _mcp_mesh.engine.job_dispatch import _read_job_headers
+
+        TraceContext.set_propagated_headers({"x-mesh-job-id": "job-widened"})
+        assert _read_job_headers() == (None, None, None, None)
+
+    def test_dispatch_store_job_id_dispatches(self):
+        from _mcp_mesh.engine.job_dispatch import _read_job_headers
+
+        TraceContext.set_dispatch_headers({"x-mesh-job-id": "job-raw"})
+        TraceContext.set_propagated_headers({"x-mesh-timeout": "42"})
+        job_id, deadline, _epoch, _cursor = _read_job_headers()
+        assert job_id == "job-raw"
+        assert deadline == 42.0
+
+
+class TestVersionSkewGuard:
+    """A pre-3.8 peer forwarded x-mesh-job-id on ordinary nested calls, and
+    only ever from inside a bound job context — which seeds
+    x-mesh-calling-job-id on the same request. A genuine push dispatch carries
+    the job id WITHOUT calling identity, so the pair arriving together is a
+    leaked nested call from an old caller, not a dispatch."""
+
+    def teardown_method(self):
+        TraceContext.set_propagated_headers({})
+        TraceContext.clear_dispatch_headers()
+
+    def test_job_id_with_calling_identity_is_refused(self, caplog):
+        from _mcp_mesh.engine.job_dispatch import _read_job_headers
+
+        TraceContext.set_dispatch_headers({"x-mesh-job-id": "job-caller"})
+        TraceContext.set_propagated_headers(
+            {"x-mesh-calling-job-id": "job-caller", "x-mesh-timeout": "30"}
+        )
+        with caplog.at_level("WARNING"):
+            assert _read_job_headers() == (None, None, None, None)
+        assert "pre-3.8 caller leaking its own job id" in caplog.text
+
+    def test_job_id_without_calling_identity_still_dispatches(self):
+        from _mcp_mesh.engine.job_dispatch import _read_job_headers
+
+        TraceContext.set_dispatch_headers({"x-mesh-job-id": "job-push"})
+        TraceContext.set_propagated_headers({"x-mesh-timeout": "30"})
+        assert _read_job_headers()[0] == "job-push"
+
+
+class TestSkewWireEndToEnd(TestInboundCapture):
+    """The exact request a 3.7 peer emits, driven through the real inbound
+    middleware. A 3.7 caller under job J sent BOTH x-mesh-job-id: J (from its
+    job context / its claim seed) and x-mesh-calling-job-id: J (from #1263's
+    carrier) on every nested call. A 3.8 callee captures raw job ids where it
+    used to drop them, so without the guard this request would bind the callee
+    to J and auto-complete the caller's row."""
+
+    def test_a_37_shaped_nested_call_does_not_dispatch(self):
+        from starlette.applications import Starlette
+        from starlette.responses import JSONResponse
+        from starlette.routing import Route
+        from starlette.testclient import TestClient
+
+        from _mcp_mesh.engine.job_dispatch import _read_job_headers
+
+        seen: dict = {}
+
+        async def endpoint(request):
+            seen["job"] = _read_job_headers()
+            return JSONResponse({"ok": True})
+
+        class _StubWrapper:
+            async def _extract_session_id_from_body(self, body):
+                return None
+
+        app = Starlette(routes=[Route("/mcp", endpoint, methods=["POST"])])
+        app.add_middleware(self._middleware_class(), http_wrapper=_StubWrapper())
+
+        body = json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {}}
+        )
+        with TestClient(app) as client:
+            resp = client.post(
+                "/mcp",
+                content=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Mesh-Job-Id": "job-caller",
+                    "X-Mesh-Calling-Job-Id": "job-caller",
+                    "X-Mesh-Calling-Claim-Epoch": "2",
+                    "X-Mesh-Timeout": "30",
+                },
+            )
+        assert resp.status_code == 200
+        assert seen["job"] == (None, None, None, None)
+
+
+class _CapturingClient:
+    """Minimal httpx client stand-in: records headers, then aborts the call."""
+
+    def __init__(self):
+        self.headers = None
+
+    async def post(self, url, content=None, headers=None, timeout=None):
+        self.headers = dict(headers or {})
+        raise RuntimeError("stop-after-capture")
+
+
+class TestOutboundNeverCarriesTheDispatchTrio:
+    def teardown_method(self):
+        TraceContext.set_propagated_headers({})
+        TraceContext.clear_dispatch_headers()
+
+    async def _capture(self):
+        proxy = UnifiedMCPProxy("http://downstream:8000", "some_tool", {})
+        client = _CapturingClient()
+        with mock.patch(
+            "_mcp_mesh.engine.unified_mcp_proxy._get_httpx_client_sync",
+            return_value=client,
+        ):
+            with pytest.raises(RuntimeError, match="stop-after-capture"):
+                await proxy._http_call("some_tool", {})
+        return client
+
+    @pytest.mark.asyncio
+    async def test_active_job_context_does_not_stamp_the_job_id(self):
+        """The self-dispatch hazard: a task=True handler executing job J calls
+        a downstream task=True tool. If J rides along, the downstream binds a
+        controller for J and auto-completes the CALLER's row with its own
+        result."""
+        token = CURRENT_JOB.set(
+            JobContextSnapshot(
+                job_id="job-caller",
+                deadline_secs_remaining=None,
+                claim_epoch=3,
+            )
+        )
+        try:
+            client = await self._capture()
+        finally:
+            CURRENT_JOB.reset(token)
+
+        lowered = {k.lower() for k in client.headers}
+        assert "x-mesh-job-id" not in lowered
+        assert "x-mesh-claim-epoch" not in lowered
+
+    @pytest.mark.asyncio
+    async def test_calling_identity_still_travels_on_its_own_carrier(self):
+        proxy = UnifiedMCPProxy("http://downstream:8000", "some_tool")
+        token = CURRENT_JOB.set(
+            JobContextSnapshot(
+                job_id="job-caller",
+                deadline_secs_remaining=None,
+                claim_epoch=3,
+            )
+        )
+        try:
+            _args, merged = proxy._inject_trace_into_args({}, None)
+        finally:
+            CURRENT_JOB.reset(token)
+
+        assert merged["x-mesh-calling-job-id"] == "job-caller"
+        assert merged["x-mesh-calling-claim-epoch"] == "3"
+        assert "x-mesh-job-id" not in merged
+
+    @pytest.mark.asyncio
+    async def test_propagated_store_is_scrubbed_of_the_dispatch_trio(self):
+        """Defense in depth: even if the trio somehow lands in the propagated
+        store (a hand-seeded contextvar, an operator-widened allowlist), the
+        outbound header build drops it."""
+        TraceContext.set_propagated_headers(
+            {
+                "x-mesh-job-id": "job-leaked",
+                "x-mesh-claim-epoch": "9",
+                "x-mesh-recv-cursor": '{"work": 4}',
+                "x-mesh-timeout": "30",
+            }
+        )
+        client = await self._capture()
+
+        lowered = {k.lower() for k in client.headers}
+        assert "x-mesh-job-id" not in lowered
+        assert "x-mesh-claim-epoch" not in lowered
+        assert "x-mesh-recv-cursor" not in lowered
+        # A genuinely propagated header is untouched.
+        assert client.headers["x-mesh-timeout"] == "30"

--- a/src/runtime/python/tests/unit/test_call_timeout_budget_1584.py
+++ b/src/runtime/python/tests/unit/test_call_timeout_budget_1584.py
@@ -272,8 +272,10 @@ class TestJobDeadlineOverride:
     @pytest.mark.asyncio
     async def test_tighter_deadline_replaces_the_default(self):
         client = await self._capture_under_job(20.0)
-        assert client.headers["X-Mesh-Job-Id"] == "job-1584"
         assert client.headers["X-Mesh-Timeout"] == "20"
+        # Issue #1570: the dispatch discriminator never rides outbound.
+        assert "X-Mesh-Job-Id" not in client.headers
+        assert "x-mesh-job-id" not in client.headers
 
     @pytest.mark.asyncio
     async def test_sub_second_grant_advertises_one_not_zero(self):
@@ -290,6 +292,5 @@ class TestJobDeadlineOverride:
         # `<= 0` header to None. CURRENT_JOB is public API, so user code and
         # tests can still produce this snapshot directly.
         client = await self._capture_under_job(-3.0)
-        assert client.headers["X-Mesh-Job-Id"] == "job-1584"
         assert "X-Mesh-Timeout" not in client.headers
         assert "x-mesh-timeout" not in client.headers

--- a/src/runtime/python/tests/unit/test_call_timeout_budget_1584.py
+++ b/src/runtime/python/tests/unit/test_call_timeout_budget_1584.py
@@ -294,3 +294,63 @@ class TestJobDeadlineOverride:
         client = await self._capture_under_job(-3.0)
         assert "X-Mesh-Timeout" not in client.headers
         assert "x-mesh-timeout" not in client.headers
+
+
+class TestTightenedBudgetIsNotDuplicated:
+    """The parent-scope cap must leave exactly ONE timeout header on the wire.
+
+    The propagated store is lowercased, so an inbound budget arrives as
+    ``x-mesh-timeout``. The expired branch pops both casings; the tighten
+    branch only assigned the canonical name, so a tightened call went out
+    carrying the parent's larger ``x-mesh-timeout`` AND the tightened
+    ``X-Mesh-Timeout``. A receiver taking the first header wins loses the
+    parent's cap — the same duplicate-header class as issue #1611.
+    """
+
+    async def _capture(self, *, inbound: dict, deadline_secs_remaining: float):
+        from _mcp_mesh.engine.job_context import CURRENT_JOB, JobContextSnapshot
+        from _mcp_mesh.engine.unified_mcp_proxy import _outbound_headers_var
+
+        proxy = UnifiedMCPProxy("http://downstream:8000", "some_tool", {})
+        client = _CapturingClient()
+        hdr_token = _outbound_headers_var.set(dict(inbound))
+        job_token = CURRENT_JOB.set(
+            JobContextSnapshot(
+                job_id="job-1613",
+                deadline_secs_remaining=deadline_secs_remaining,
+                claim_epoch=None,
+            )
+        )
+        try:
+            with mock.patch(
+                "_mcp_mesh.engine.unified_mcp_proxy._get_httpx_client_sync",
+                return_value=client,
+            ):
+                with pytest.raises(RuntimeError, match="stop-after-capture"):
+                    await proxy._http_call("some_tool", {})
+        finally:
+            CURRENT_JOB.reset(job_token)
+            _outbound_headers_var.reset(hdr_token)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_tightening_a_lowercase_inbound_leaves_one_header(self):
+        client = await self._capture(
+            inbound={"x-mesh-timeout": "30"}, deadline_secs_remaining=20.0
+        )
+        assert client.headers["X-Mesh-Timeout"] == "20"
+        assert "x-mesh-timeout" not in client.headers
+        assert client.timeout.read == 20
+
+    @pytest.mark.asyncio
+    async def test_a_tighter_lowercase_inbound_is_not_widened(self):
+        # The inbound cap is already tighter than what this job has left, so
+        # the tighten branch must not fire at all. Reading only the canonical
+        # casing saw "0" here — "unset" — and replaced a 5s parent cap with a
+        # 20s advertisement.
+        client = await self._capture(
+            inbound={"x-mesh-timeout": "5"}, deadline_secs_remaining=20.0
+        )
+        assert client.headers.get("x-mesh-timeout") == "5"
+        assert "X-Mesh-Timeout" not in client.headers
+        assert client.timeout.read == 5

--- a/src/runtime/python/tests/unit/test_calling_job_identity.py
+++ b/src/runtime/python/tests/unit/test_calling_job_identity.py
@@ -174,6 +174,7 @@ class TestClaimHandlerSeesNoCallingJob:
         async def handler(**kwargs):
             seen["calling"] = calling_job()
             seen["headers"] = dict(TraceContext.get_propagated_headers())
+            seen["dispatch"] = dict(TraceContext.get_dispatch_headers())
 
         d = PythonClaimDispatcher(
             capability="cap",
@@ -182,7 +183,12 @@ class TestClaimHandlerSeesNoCallingJob:
             handler=handler,
         )
         await d._dispatch({"id": "job-self", "submitted_payload": {}, "claim_epoch": 4})
-        # The claim dispatcher seeds the dispatch pair (job context)…
-        assert seen["headers"].get("x-mesh-job-id") == "job-self"
+        # The claim dispatcher seeds the dispatch pair (job context) into the
+        # inbound-only DISPATCH store — never the propagated one, which is what
+        # rides outbound calls (#1570).
+        assert seen["dispatch"].get("x-mesh-job-id") == "job-self"
+        assert seen["dispatch"].get("x-mesh-claim-epoch") == "4"
+        assert "x-mesh-job-id" not in seen["headers"]
+        assert "x-mesh-claim-epoch" not in seen["headers"]
         # …but calling_job() reads the calling-* pair → None here.
         assert seen["calling"] is None

--- a/src/runtime/python/tests/unit/test_meshjob_dispatch.py
+++ b/src/runtime/python/tests/unit/test_meshjob_dispatch.py
@@ -18,6 +18,31 @@ from unittest import mock
 import pytest
 
 
+def _seed_inbound(headers: dict) -> None:
+    """Deliver ``headers`` the way the inbound path does (issue #1570).
+
+    The dispatch protocol trio lands on the RAW dispatch store (captured from
+    the inbound request / seeded by the claim dispatcher); everything else
+    lands on the propagated store, which is what rides outbound calls. The two
+    are separate precisely so the discriminator can never be forwarded.
+    """
+    from _mcp_mesh.tracing.context import DISPATCH_HEADERS, TraceContext
+
+    TraceContext.set_dispatch_headers(
+        {k: v for k, v in headers.items() if k in DISPATCH_HEADERS}
+    )
+    TraceContext.set_propagated_headers(
+        {k: v for k, v in headers.items() if k not in DISPATCH_HEADERS}
+    )
+
+
+def _clear_inbound() -> None:
+    from _mcp_mesh.tracing.context import TraceContext
+
+    TraceContext.set_propagated_headers({})
+    TraceContext.clear_dispatch_headers()
+
+
 @pytest.fixture(autouse=True)
 def _reset_decorator_registry_state():
     """Clear cached DecoratorRegistry / shared agent_id state between tests.
@@ -189,7 +214,7 @@ class TestMaybeDispatchAsJob:
         fn._mesh_tool_metadata = {"task": True}
 
         # Seed propagated headers as the FastMCP middleware would.
-        TraceContext.set_propagated_headers(
+        _seed_inbound(
             {
                 "x-mesh-job-id": "job-test-123",
                 "x-mesh-timeout": "60",
@@ -230,7 +255,7 @@ class TestMaybeDispatchAsJob:
             assert captured["job"].job_id == "job-test-123"
             assert captured["job"].instance_id == "test-agent-1"
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
 
     @pytest.mark.asyncio
     async def test_claim_epoch_header_flows_to_controller_and_context(
@@ -246,7 +271,7 @@ class TestMaybeDispatchAsJob:
         fn = _fixture_with_job
         fn._mesh_tool_metadata = {"task": True}
 
-        TraceContext.set_propagated_headers(
+        _seed_inbound(
             {
                 "x-mesh-job-id": "job-epoch-1",
                 "x-mesh-claim-epoch": "5",
@@ -282,7 +307,7 @@ class TestMaybeDispatchAsJob:
             assert seen["with_job_async_epoch"] == 5
             assert seen["snapshot_epoch"] == 5
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
 
     @pytest.mark.asyncio
     async def test_missing_claim_epoch_header_yields_none(self, monkeypatch):
@@ -293,7 +318,7 @@ class TestMaybeDispatchAsJob:
 
         fn = _fixture_with_job
         fn._mesh_tool_metadata = {"task": True}
-        TraceContext.set_propagated_headers({"x-mesh-job-id": "job-noepoch"})
+        _seed_inbound({"x-mesh-job-id": "job-noepoch"})
         monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
         monkeypatch.setenv("MCP_MESH_AGENT_ID", "test-agent-1")
         try:
@@ -319,7 +344,7 @@ class TestMaybeDispatchAsJob:
             assert seen["controller_epoch"] is None
             assert seen["with_job_async_epoch"] is None
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
 
     @pytest.mark.asyncio
     async def test_python_contextvar_set_during_invoke(self, monkeypatch):
@@ -332,9 +357,7 @@ class TestMaybeDispatchAsJob:
         fn = _fixture_with_job
         fn._mesh_tool_metadata = {"task": True}
 
-        TraceContext.set_propagated_headers(
-            {"x-mesh-job-id": "job-ctx-test", "x-mesh-timeout": "30"}
-        )
+        _seed_inbound({"x-mesh-job-id": "job-ctx-test", "x-mesh-timeout": "30"})
         monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://localhost:9999")
         monkeypatch.setenv("MCP_MESH_AGENT_ID", "ctx-agent")
 
@@ -367,7 +390,7 @@ class TestMaybeDispatchAsJob:
             # After exit, contextvar reset.
             assert current_job() is None
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
 
     @pytest.mark.asyncio
     async def test_auto_complete_fires_when_handler_returns_without_explicit_complete(
@@ -383,9 +406,7 @@ class TestMaybeDispatchAsJob:
         fn = _fixture_with_job
         fn._mesh_tool_metadata = {"task": True}
 
-        TraceContext.set_propagated_headers(
-            {"x-mesh-job-id": "job-auto-1", "x-mesh-timeout": "30"}
-        )
+        _seed_inbound({"x-mesh-job-id": "job-auto-1", "x-mesh-timeout": "30"})
         monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://r:9999")
         monkeypatch.setenv("MCP_MESH_AGENT_ID", "auto-agent")
 
@@ -422,7 +443,7 @@ class TestMaybeDispatchAsJob:
                 "auto-complete must fire exactly once with the handler return"
             )
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
 
     @pytest.mark.asyncio
     async def test_auto_complete_skipped_when_handler_called_complete_itself(
@@ -436,9 +457,7 @@ class TestMaybeDispatchAsJob:
         fn = _fixture_with_job
         fn._mesh_tool_metadata = {"task": True}
 
-        TraceContext.set_propagated_headers(
-            {"x-mesh-job-id": "job-noauto", "x-mesh-timeout": "30"}
-        )
+        _seed_inbound({"x-mesh-job-id": "job-noauto", "x-mesh-timeout": "30"})
         monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://r:9999")
         monkeypatch.setenv("MCP_MESH_AGENT_ID", "noauto-agent")
 
@@ -474,7 +493,7 @@ class TestMaybeDispatchAsJob:
                 "no double-flush — only the explicit complete call should land"
             )
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
 
 
 # ===========================================================================
@@ -501,9 +520,7 @@ class TestRetryOnDispatch:
         fn = _fixture_with_job
         fn._mesh_tool_metadata = {"task": True, "retry_on": (OSError,)}
 
-        TraceContext.set_propagated_headers(
-            {"x-mesh-job-id": "job-retry-1", "x-mesh-timeout": "30"}
-        )
+        _seed_inbound({"x-mesh-job-id": "job-retry-1", "x-mesh-timeout": "30"})
         monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://r:9999")
         monkeypatch.setenv("MCP_MESH_AGENT_ID", "retry-agent")
 
@@ -549,7 +566,7 @@ class TestRetryOnDispatch:
             assert "connection refused" in release_calls[0]
             assert fail_calls == [], "fail() must NOT be called when retry_on matches"
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
             fn._mesh_tool_metadata = {"task": True}
 
     @pytest.mark.asyncio
@@ -563,9 +580,7 @@ class TestRetryOnDispatch:
         fn = _fixture_with_job
         fn._mesh_tool_metadata = {"task": True, "retry_on": (OSError,)}
 
-        TraceContext.set_propagated_headers(
-            {"x-mesh-job-id": "job-nomatch-1", "x-mesh-timeout": "30"}
-        )
+        _seed_inbound({"x-mesh-job-id": "job-nomatch-1", "x-mesh-timeout": "30"})
         monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://r:9999")
         monkeypatch.setenv("MCP_MESH_AGENT_ID", "nomatch-agent")
 
@@ -607,7 +622,7 @@ class TestRetryOnDispatch:
                 "non-matching exception must NOT trigger release_lease"
             )
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
             fn._mesh_tool_metadata = {"task": True}
 
     @pytest.mark.asyncio
@@ -621,9 +636,7 @@ class TestRetryOnDispatch:
         fn = _fixture_with_job
         fn._mesh_tool_metadata = {"task": True, "retry_on": (OSError,)}
 
-        TraceContext.set_propagated_headers(
-            {"x-mesh-job-id": "job-fallback-1", "x-mesh-timeout": "30"}
-        )
+        _seed_inbound({"x-mesh-job-id": "job-fallback-1", "x-mesh-timeout": "30"})
         monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://r:9999")
         monkeypatch.setenv("MCP_MESH_AGENT_ID", "fallback-agent")
 
@@ -665,7 +678,7 @@ class TestRetryOnDispatch:
             assert "OSError" in fail_calls[0]
             assert "release_lease failed" in fail_calls[0]
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
             fn._mesh_tool_metadata = {"task": True}
 
     @pytest.mark.asyncio
@@ -681,9 +694,7 @@ class TestRetryOnDispatch:
         # No retry_on set — equivalent to the pre-#879 contract.
         fn._mesh_tool_metadata = {"task": True}
 
-        TraceContext.set_propagated_headers(
-            {"x-mesh-job-id": "job-default-1", "x-mesh-timeout": "30"}
-        )
+        _seed_inbound({"x-mesh-job-id": "job-default-1", "x-mesh-timeout": "30"})
         monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://r:9999")
         monkeypatch.setenv("MCP_MESH_AGENT_ID", "default-agent")
 
@@ -723,7 +734,7 @@ class TestRetryOnDispatch:
             # release_lease NEVER called.
             assert release_calls == []
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
 
 
 # ===========================================================================
@@ -755,9 +766,7 @@ class TestCancelObservability:
         fn._mesh_tool_metadata = {"task": True}
 
         job_id = "job-cancel-obs-1"
-        TraceContext.set_propagated_headers(
-            {"x-mesh-job-id": job_id, "x-mesh-timeout": "30"}
-        )
+        _seed_inbound({"x-mesh-job-id": job_id, "x-mesh-timeout": "30"})
         monkeypatch.setenv("MCP_MESH_REGISTRY_URL", "http://r:9999")
         monkeypatch.setenv("MCP_MESH_AGENT_ID", "cancel-obs-agent")
 
@@ -839,7 +848,7 @@ class TestCancelObservability:
             assert release_calls == []
             assert complete_calls == []
         finally:
-            TraceContext.set_propagated_headers({})
+            _clear_inbound()
             fn._mesh_tool_metadata = {"task": True}
 
 

--- a/src/runtime/typescript/src/__tests__/claim-dispatcher.spec.ts
+++ b/src/runtime/typescript/src/__tests__/claim-dispatcher.spec.ts
@@ -177,7 +177,7 @@ describe("ClaimDispatcher", () => {
     expect(handler.mock.calls[0][1].jobId).toBe("real-job");
   });
 
-  it("seeds the propagated-headers ALS with x-mesh-job-id (and x-mesh-timeout when present)", async () => {
+  it("seeds the propagated-headers ALS with x-mesh-timeout only, never the dispatch pair (#1570)", async () => {
     // Verifies follow-up #2: claim-path dispatches must seed the
     // propagated-headers AsyncLocalStorage so outbound calls made by
     // the handler continue the submitter's trace tree (Python parity
@@ -218,8 +218,12 @@ describe("ClaimDispatcher", () => {
 
     expect(handler).toHaveBeenCalledOnce();
     expect(observed).not.toBeNull();
-    expect(observed!["x-mesh-job-id"]).toBe("job-trace-1");
     expect(observed!["x-mesh-timeout"]).toBe("45");
+    // Issue #1570: the dispatch pair is NOT seeded into the propagated store —
+    // that store is what every outbound call forwards, and a forwarded job id
+    // makes a nested task:true callee treat the call as an inbound dispatch.
+    expect(observed!["x-mesh-job-id"]).toBeUndefined();
+    expect(observed!["x-mesh-claim-epoch"]).toBeUndefined();
   });
 
   it("omits x-mesh-timeout when claim has no max_duration", async () => {
@@ -252,7 +256,7 @@ describe("ClaimDispatcher", () => {
 
     expect(handler).toHaveBeenCalledOnce();
     expect(observed).not.toBeNull();
-    expect(observed!["x-mesh-job-id"]).toBe("job-no-timeout");
+    expect(observed!["x-mesh-job-id"]).toBeUndefined();
     expect(observed!["x-mesh-timeout"]).toBeUndefined();
   });
 

--- a/src/runtime/typescript/src/__tests__/job-id-contract-1570.spec.ts
+++ b/src/runtime/typescript/src/__tests__/job-id-contract-1570.spec.ts
@@ -156,6 +156,36 @@ describe("inbound dispatch reads the RAW header map (#1570)", () => {
     expect(seen[0]).not.toBeNull();
   });
 
+  // The strip that removes `_trace_id` / `_parent_span` / `_mesh_headers` from
+  // the tool's arguments used to be gated on the ALLOWLIST-FILTERED map being
+  // non-empty. A genuine push dispatch carries `x-mesh-job-id` and nothing
+  // else, which allowlist-filters to empty — so the strip never ran and the
+  // tool's `execute` was handed an internal `_mesh_headers` field alongside
+  // its own parameters.
+  it("never hands the tool its internal _mesh_headers", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, { name: "strip-agent", httpPort: 0 });
+    const seenArgs: unknown[] = [];
+    agent.addTool({
+      name: "render",
+      task: true,
+      parameters: z.object({}),
+      meshJobParamIndex: 1,
+      execute: async (args: unknown) => {
+        seenArgs.push(args);
+        return "ran";
+      },
+    });
+    const execute = captureExecute(fastmcp);
+
+    await execute({
+      payload: 1,
+      _mesh_headers: { "x-mesh-job-id": "job-dispatch-only" },
+    });
+
+    expect(seenArgs[0]).toEqual({ payload: 1 });
+  });
+
   it("a task tool called WITHOUT the header still runs controller-less", async () => {
     const fastmcp = makeFastMCPStub();
     const agent = new MeshAgent(fastmcp, { name: "sync-agent", httpPort: 0 });
@@ -440,6 +470,85 @@ describe("outbound never carries the dispatch trio (#1570)", () => {
       expect(meshHeaders[name]).toBeUndefined();
     }
     // A genuinely propagated header is untouched.
+    expect(meshHeaders["x-mesh-timeout"]).toBe("30");
+  });
+
+  // `options.customHeaders` is spread into the FINAL header map, downstream of
+  // the allowlist filter and of the merged-header scrub, and nothing lowercases
+  // its keys. It was therefore the one path by which user code could put the
+  // dispatch discriminator on the wire — and a 3.8 callee reads the header raw,
+  // so it would have dispatched on it.
+  it("scrubs the trio from customHeaders, whatever the casing", async () => {
+    mockFetch();
+    await callMcpTool(
+      "http://d:9000",
+      "t",
+      { a: 1 },
+      {
+        ...DEFAULT_CALL_OPTIONS,
+        customHeaders: {
+          "X-Mesh-Job-Id": "job-from-user-code",
+          "x-mesh-claim-epoch": "9",
+          "X-MESH-RECV-CURSOR": '{"work":4}',
+          "X-Api-Key": "keep-me",
+        },
+      },
+      "cap",
+    );
+
+    const headers = (captured?.headers ?? {}) as Record<string, string>;
+    for (const name of Object.keys(headers)) {
+      expect([
+        "x-mesh-job-id",
+        "x-mesh-claim-epoch",
+        "x-mesh-recv-cursor",
+      ]).not.toContain(name.toLowerCase());
+    }
+    // A caller's own header is untouched — this is a targeted deny, not a
+    // customHeaders blocklist.
+    expect(headers["X-Api-Key"]).toBe("keep-me");
+  });
+
+  // `runWithPropagatedHeaders` is exported from the package index, so the
+  // propagated store is reachable from user code with arbitrary casing even
+  // though every in-runtime writer lowercases. The merged map becomes
+  // `_mesh_headers` in the request BODY and the callee lowercases those keys,
+  // so a case-sensitive scrub would leave the dispatch reachable through the
+  // body even with the wire header clean.
+  it("scrubs a mixed-case propagated entry from both the wire and the body", async () => {
+    mockFetch();
+    await runWithPropagatedHeaders(
+      {
+        "X-Mesh-Job-Id": "job-mixed-case",
+        "X-Mesh-Claim-Epoch": "9",
+        "x-mesh-timeout": "30",
+      },
+      async () => {
+        await callMcpTool(
+          "http://d:9000",
+          "t",
+          { a: 1 },
+          DEFAULT_CALL_OPTIONS,
+          "cap",
+        );
+      },
+    );
+
+    const headers = (captured?.headers ?? {}) as Record<string, string>;
+    const body = JSON.parse((captured?.body as string) ?? "{}");
+    const meshHeaders = (body?.params?.arguments?._mesh_headers ?? {}) as Record<
+      string,
+      string
+    >;
+    for (const map of [headers, meshHeaders]) {
+      for (const name of Object.keys(map)) {
+        expect([
+          "x-mesh-job-id",
+          "x-mesh-claim-epoch",
+          "x-mesh-recv-cursor",
+        ]).not.toContain(name.toLowerCase());
+      }
+    }
     expect(meshHeaders["x-mesh-timeout"]).toBe("30");
   });
 });

--- a/src/runtime/typescript/src/__tests__/job-id-contract-1570.spec.ts
+++ b/src/runtime/typescript/src/__tests__/job-id-contract-1570.spec.ts
@@ -1,0 +1,445 @@
+/**
+ * Issue #1570: the cross-runtime `x-mesh-job-id` contract.
+ *
+ * `x-mesh-job-id` is the push-mode dispatch DISCRIMINATOR. It is read from the
+ * RAW inbound `_mesh_headers` map and is never emitted on an outbound call.
+ *
+ * Two defects are pinned here:
+ *
+ * 1. The dispatch site read the allowlist-FILTERED map while the required-dep
+ *    guard read the raw one, so a genuine inbound job dispatch never built a
+ *    JobController (push-mode dispatch over HTTP was unreachable).
+ * 2. The claim dispatcher seeded `x-mesh-job-id` into the propagated store that
+ *    every outbound call forwards, so a nested call into a `task:true` tool
+ *    whose required dependency was down released the CALLER's lease and
+ *    returned `""` instead of the `dependency_unavailable` refusal.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { z } from "zod";
+import { UserError } from "fastmcp";
+
+const h = vi.hoisted(() => {
+  const completeMock = vi.fn(async () => {});
+  const releaseLeaseMock = vi.fn(async () => {});
+  const makeJobControllerMock = vi.fn(() => ({
+    complete: completeMock,
+    releaseLease: releaseLeaseMock,
+    close: vi.fn(async () => {}),
+  }));
+  return { completeMock, releaseLeaseMock, makeJobControllerMock };
+});
+
+vi.mock("../inbound-job-dispatch.js", async (importActual) => {
+  const actual =
+    await importActual<typeof import("../inbound-job-dispatch.js")>();
+  return {
+    ...actual,
+    makeJobController:
+      h.makeJobControllerMock as unknown as typeof actual.makeJobController,
+    // Bind CURRENT_JOB (so outbound calls seed calling identity exactly as in
+    // production) without touching the napi job context / cancel watcher.
+    runWithJobContext: (async (
+      jobId: string | null,
+      deadlineSecs: number | null,
+      _controller: unknown,
+      body: () => Promise<unknown>,
+      _retryOn?: unknown,
+      claimEpoch?: number | null,
+    ) => {
+      const { CURRENT_JOB } = await import("../job-context.js");
+      if (!jobId) return body();
+      return CURRENT_JOB.run(
+        {
+          jobId,
+          deadlineSecsRemaining: deadlineSecs,
+          claimEpoch: claimEpoch ?? null,
+        },
+        body,
+      );
+    }) as unknown as typeof actual.runWithJobContext,
+  };
+});
+
+import { MeshAgent } from "../agent.js";
+import { RouteRegistry } from "../route.js";
+import { resetSettleStateForTests } from "../settle.js";
+import { callMcpTool, DEFAULT_CALL_OPTIONS, runWithPropagatedHeaders } from "../proxy.js";
+import { ClaimDispatcher } from "../claim-dispatcher.js";
+
+function makeFastMCPStub() {
+  return {
+    addTool: vi.fn(),
+    start: vi.fn(),
+    getApp: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function captureExecute(fastmcp: any): (args: unknown) => Promise<string> {
+  return fastmcp.addTool.mock.calls[0][0].execute as (
+    args: unknown,
+  ) => Promise<string>;
+}
+
+let autoStartSpy: ReturnType<typeof vi.spyOn> | null = null;
+let warnSpy: ReturnType<typeof vi.spyOn> | null = null;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  h.completeMock.mockClear();
+  h.releaseLeaseMock.mockClear();
+  h.makeJobControllerMock.mockClear();
+  autoStartSpy = vi
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .spyOn(MeshAgent.prototype as any, "_autoStart")
+    .mockImplementation(async () => {
+      /* no-op */
+    });
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {
+    /* swallow */
+  });
+  savedEnv.MCP_MESH_SETTLE_TIMEOUT = process.env.MCP_MESH_SETTLE_TIMEOUT;
+  savedEnv.MCP_MESH_TOOL_ISOLATION = process.env.MCP_MESH_TOOL_ISOLATION;
+  process.env.MCP_MESH_TOOL_ISOLATION = "false";
+  process.env.MCP_MESH_SETTLE_TIMEOUT = "0";
+  resetSettleStateForTests();
+  RouteRegistry.reset();
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => process.nextTick(resolve));
+  autoStartSpy?.mockRestore();
+  autoStartSpy = null;
+  warnSpy?.mockRestore();
+  warnSpy = null;
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetSettleStateForTests();
+  RouteRegistry.reset();
+  vi.restoreAllMocks();
+});
+
+describe("inbound dispatch reads the RAW header map (#1570)", () => {
+  it("builds a JobController for a task tool carrying x-mesh-job-id", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, { name: "dispatch-agent", httpPort: 0 });
+    const seen: unknown[] = [];
+    agent.addTool({
+      name: "render",
+      task: true,
+      parameters: z.object({}),
+      meshJobParamIndex: 1,
+      execute: async (_args: unknown, job: unknown) => {
+        seen.push(job);
+        return "ran";
+      },
+    });
+    const execute = captureExecute(fastmcp);
+
+    await execute({
+      _mesh_headers: {
+        "x-mesh-job-id": "job-inbound-1570",
+        "x-mesh-claim-epoch": "4",
+        "x-mesh-timeout": "30",
+      },
+    });
+
+    expect(h.makeJobControllerMock).toHaveBeenCalledTimes(1);
+    const [jobId, , , claimEpoch] = h.makeJobControllerMock.mock.calls[0] as
+      unknown as [string, string, string, number | null];
+    expect(jobId).toBe("job-inbound-1570");
+    expect(claimEpoch).toBe(4);
+    // The controller reached the handler's MeshJob slot.
+    expect(seen[0]).not.toBeNull();
+  });
+
+  it("a task tool called WITHOUT the header still runs controller-less", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, { name: "sync-agent", httpPort: 0 });
+    const seen: unknown[] = [];
+    agent.addTool({
+      name: "render",
+      task: true,
+      parameters: z.object({}),
+      meshJobParamIndex: 1,
+      execute: async (_args: unknown, job: unknown) => {
+        seen.push(job);
+        return "ran";
+      },
+    });
+    const execute = captureExecute(fastmcp);
+
+    expect(await execute({})).toBe("ran");
+    expect(h.makeJobControllerMock).not.toHaveBeenCalled();
+    expect(seen[0]).toBeNull();
+  });
+});
+
+describe("nested required-dep failure is not a job dispatch (#1570)", () => {
+  /**
+   * End-to-end caller→callee. The caller is a job handler (the ALS shape the
+   * claim dispatcher establishes: propagated headers + an active job context);
+   * the wire it produces is captured off a mocked fetch and handed VERBATIM to
+   * the callee's `execute` as `_mesh_headers`. Nothing is hand-crafted, so the
+   * test fails if EITHER half regresses — the claim dispatcher re-seeding the
+   * job id, or `buildMcpRequest` no longer scrubbing it.
+   */
+  it("the caller's own wire, replayed into the callee, gets a refusal not a lease release", async () => {
+    // Caller side is the REAL ClaimDispatcher: it claims a job, binds the job
+    // context, seeds the propagated-headers ALS, and the handler makes a
+    // nested mesh call. Both halves of the root cause are therefore live —
+    // the seeding in claim-dispatcher.ts and the forward in buildMcpRequest.
+    let callerWire: Record<string, string> = {};
+    let claimCalls = 0;
+    globalThis.fetch = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const href = String(url);
+      if (href.endsWith("/jobs/claim")) {
+        // Hand out the job ONCE; the poll loop must not keep re-claiming it.
+        claimCalls += 1;
+        if (claimCalls > 1) {
+          return { status: 204, json: async () => ({}) } as unknown as Response;
+        }
+        return {
+          status: 200,
+          json: async () => ({
+            claimed: [
+              { id: "job-caller", submitted_payload: {}, claim_epoch: 2 },
+            ],
+          }),
+        } as unknown as Response;
+      }
+      if (href.endsWith("/mcp")) {
+        callerWire = (JSON.parse((init?.body as string) ?? "{}")?.params
+          ?.arguments?._mesh_headers ?? {}) as Record<string, string>;
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: async () =>
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: "x",
+              result: { content: [{ type: "text", text: "{}" }] },
+            }),
+          headers: {
+            get: (n: string) =>
+              n.toLowerCase() === "content-type" ? "application/json" : null,
+          },
+        } as unknown as Response;
+      }
+      return { status: 204, json: async () => ({}) } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const dispatcher = new ClaimDispatcher(
+      "cap",
+      "instance-1",
+      "http://reg",
+      async () => {
+        await callMcpTool(
+          "http://d:9000",
+          "render",
+          {},
+          DEFAULT_CALL_OPTIONS,
+          "cap",
+        );
+        return null;
+      },
+    );
+    dispatcher.start();
+    await new Promise((r) => setTimeout(r, 100));
+    await dispatcher.stop();
+
+    // The caller identifies itself, and does NOT hand over its dispatch id.
+    expect(callerWire["x-mesh-calling-job-id"]).toBe("job-caller");
+    expect(callerWire["x-mesh-job-id"]).toBeUndefined();
+
+    // Callee side: that exact wire, into a task tool whose required dep is down.
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, { name: "nested-agent", httpPort: 0 });
+    const calls: unknown[] = [];
+    agent.addTool({
+      name: "render",
+      task: true,
+      parameters: z.object({}),
+      dependencies: [{ capability: "lookup", required: true }],
+      execute: async (_args: unknown, dep: unknown) => {
+        calls.push(dep);
+        return "ran";
+      },
+    });
+    const execute = captureExecute(fastmcp);
+
+    let thrown: unknown;
+    try {
+      await execute({ _mesh_headers: callerWire });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(UserError);
+    expect(JSON.parse((thrown as Error).message)).toEqual({
+      error: "dependency_unavailable",
+      capability: "lookup",
+    });
+    expect(h.releaseLeaseMock).not.toHaveBeenCalled();
+    expect(calls).toHaveLength(0);
+  });
+
+  it("refuses with dependency_unavailable — it does not release a lease", async () => {
+    // The post-fix wire shape, asserted directly.
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, { name: "nested-agent", httpPort: 0 });
+    const calls: unknown[] = [];
+    agent.addTool({
+      name: "render",
+      task: true,
+      parameters: z.object({}),
+      dependencies: [{ capability: "lookup", required: true }],
+      execute: async (_args: unknown, dep: unknown) => {
+        calls.push(dep);
+        return "ran";
+      },
+    });
+    const execute = captureExecute(fastmcp);
+
+    let thrown: unknown;
+    try {
+      await execute({
+        _mesh_headers: {
+          "x-mesh-calling-job-id": "job-caller",
+          "x-mesh-calling-claim-epoch": "2",
+        },
+      });
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(UserError);
+    expect(JSON.parse((thrown as Error).message)).toEqual({
+      error: "dependency_unavailable",
+      capability: "lookup",
+    });
+    expect(h.releaseLeaseMock).not.toHaveBeenCalled();
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("version-skew guard (#1570)", () => {
+  // A pre-3.8 caller DID forward its job id, and only ever from inside a bound
+  // job context — which seeds x-mesh-calling-job-id on the same request. The
+  // pair arriving together is a leak, not a dispatch: honouring it would bind
+  // this handler to the old caller's row for the length of the skew window.
+  it("ignores an inbound job id that arrives with calling identity", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, { name: "skew-agent", httpPort: 0 });
+    const seen: unknown[] = [];
+    agent.addTool({
+      name: "render",
+      task: true,
+      parameters: z.object({}),
+      meshJobParamIndex: 1,
+      execute: async (_args: unknown, job: unknown) => {
+        seen.push(job);
+        return "ran";
+      },
+    });
+    const execute = captureExecute(fastmcp);
+
+    expect(
+      await execute({
+        _mesh_headers: {
+          "x-mesh-job-id": "job-caller",
+          "x-mesh-calling-job-id": "job-caller",
+        },
+      }),
+    ).toBe("ran");
+
+    expect(h.makeJobControllerMock).not.toHaveBeenCalled();
+    expect(seen[0]).toBeNull();
+  });
+
+  it("still dispatches a genuine push call, which carries no calling identity", async () => {
+    const fastmcp = makeFastMCPStub();
+    const agent = new MeshAgent(fastmcp, { name: "push-agent", httpPort: 0 });
+    agent.addTool({
+      name: "render",
+      task: true,
+      parameters: z.object({}),
+      meshJobParamIndex: 1,
+      execute: async () => "ran",
+    });
+    const execute = captureExecute(fastmcp);
+
+    await execute({ _mesh_headers: { "x-mesh-job-id": "job-push" } });
+
+    expect(h.makeJobControllerMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("outbound never carries the dispatch trio (#1570)", () => {
+  let captured: RequestInit | undefined;
+
+  function mockFetch(): void {
+    captured = undefined;
+    globalThis.fetch = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      captured = init;
+      const body = JSON.stringify({
+        jsonrpc: "2.0",
+        id: "x",
+        result: { content: [{ type: "text", text: "{}" }] },
+      });
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: async () => body,
+        headers: {
+          get: (n: string) =>
+            n.toLowerCase() === "content-type" ? "application/json" : null,
+        },
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+  }
+
+  it("scrubs the trio from both the HTTP headers and _mesh_headers", async () => {
+    mockFetch();
+    await runWithPropagatedHeaders(
+      {
+        "x-mesh-job-id": "job-leaked",
+        "x-mesh-claim-epoch": "9",
+        "x-mesh-recv-cursor": '{"work":4}',
+        "x-mesh-timeout": "30",
+      },
+      async () => {
+        await callMcpTool(
+          "http://d:9000",
+          "t",
+          { a: 1 },
+          DEFAULT_CALL_OPTIONS,
+          "cap",
+        );
+      },
+    );
+
+    const headers = (captured?.headers ?? {}) as Record<string, string>;
+    const body = JSON.parse((captured?.body as string) ?? "{}");
+    const meshHeaders = (body?.params?.arguments?._mesh_headers ?? {}) as Record<
+      string,
+      string
+    >;
+
+    for (const name of [
+      "x-mesh-job-id",
+      "x-mesh-claim-epoch",
+      "x-mesh-recv-cursor",
+    ]) {
+      expect(headers[name]).toBeUndefined();
+      expect(meshHeaders[name]).toBeUndefined();
+    }
+    // A genuinely propagated header is untouched.
+    expect(meshHeaders["x-mesh-timeout"]).toBe("30");
+  });
+});

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -959,8 +959,13 @@ export class MeshAgent {
             }
           }
         }
-        // Remove trace context and mesh headers from args before passing to tool
-        if (incomingTraceId || incomingParentSpan || Object.keys(propagatedHeaders).length > 0) {
+        // Remove trace context and mesh headers from args before passing to tool.
+        // Keyed on `rawMeshHeaders`, not `propagatedHeaders` (issue #1570): a
+        // request whose only mesh header is `x-mesh-job-id` — a genuine push
+        // dispatch — allowlist-filters to an EMPTY propagated map, and gating
+        // on that would hand the tool's `execute` an internal `_mesh_headers`
+        // field in its arguments.
+        if (incomingTraceId || incomingParentSpan || rawMeshHeaders !== null) {
           const { _trace_id, _parent_span, _mesh_headers, ...rest } = argsObj;
           cleanArgs = rest as z.infer<T>;
         }

--- a/src/runtime/typescript/src/agent.ts
+++ b/src/runtime/typescript/src/agent.ts
@@ -966,6 +966,42 @@ export class MeshAgent {
         }
       }
 
+      // Issue #1570: the push-mode dispatch protocol headers (x-mesh-job-id /
+      // x-mesh-claim-epoch) are read ONCE, from the RAW inbound map — never
+      // from the allowlist-filtered `propagatedHeaders`. They are deliberately
+      // kept OUT of the propagate allowlist (forwarding the job id makes a
+      // nested task:true call self-dispatch as the CALLER's job and
+      // auto-complete it with the wrong result), so reading them off the
+      // filtered map leaves push-mode dispatch over HTTP unreachable and
+      // misclassifies a genuine inbound job dispatch as a plain tools/call.
+      // The required-dep guard below and the dispatch site further down both
+      // consume THIS result, so they can never disagree about the flavor.
+      // Version-skew guard (#1570). A pre-3.8 peer forwarded x-mesh-job-id on
+      // ordinary nested calls, and only ever from inside a bound job context —
+      // which seeds x-mesh-calling-job-id on the SAME request. A genuine
+      // push-mode dispatch carries the job id WITHOUT calling identity (the
+      // submitter is not itself executing that job), so the two arriving
+      // together identifies a leaked nested call from an old caller.
+      // Dispatching on it would bind this handler to the CALLER's job row and
+      // auto-complete it with this tool's result. Refuse, run as a plain call,
+      // and say so loudly: the fix is to finish the upgrade.
+      const leakedFromOldCaller =
+        !!rawMeshHeaders?.["x-mesh-job-id"] &&
+        !!rawMeshHeaders?.["x-mesh-calling-job-id"];
+      if (leakedFromOldCaller) {
+        console.warn(
+          `[mesh-jobs] tool '${toolName}': inbound x-mesh-job-id=` +
+            `${rawMeshHeaders?.["x-mesh-job-id"]} arrived together with ` +
+            `x-mesh-calling-job-id — a pre-3.8 caller leaking its own job id ` +
+            `on a nested call, not a push-mode dispatch. Running as a plain ` +
+            `tool call; upgrade the calling agent to stop this (issue #1570).`,
+        );
+      }
+      const [inboundJobId, inboundDeadlineSecs, inboundClaimEpoch] =
+        leakedFromOldCaller
+          ? ([null, null, null] as [null, null, null])
+          : readJobHeaders(rawMeshHeaders);
+
       // Use incoming trace context or generate new one
       const traceId = incomingTraceId ?? generateTraceId();
       const spanId = generateSpanId();
@@ -988,28 +1024,23 @@ export class MeshAgent {
       //     (UserError → isError result) so the caller classifies it as
       //     retryable topology, not application failure.
       if (missingRequiredCap !== null) {
-        // Read job headers from the RAW inbound map (not the allowlist-filtered
-        // propagatedHeaders), so a genuine inbound job dispatch is classified as
-        // one — and released, not refused — even though x-mesh-job-id is not in
-        // the propagate allowlist.
-        const [guardJobId, , guardClaimEpoch] = readJobHeaders(rawMeshHeaders);
         const isJobDispatch =
           isTaskTool &&
-          guardJobId !== null &&
+          inboundJobId !== null &&
           !!this.config.registryUrl &&
           !!this.agentId;
         if (isJobDispatch) {
           console.warn(
-            `[mesh-jobs] releasing job=${guardJobId} for tool '${toolName}' — ` +
+            `[mesh-jobs] releasing job=${inboundJobId} for tool '${toolName}' — ` +
               `required dependency '${missingRequiredCap}' unavailable at ` +
               `invocation time; releasing lease for retry (not invoking, not failing)`,
           );
           try {
             const controller = makeJobController(
-              guardJobId as string,
+              inboundJobId as string,
               this.agentId as string,
               this.config.registryUrl as string,
-              guardClaimEpoch,
+              inboundClaimEpoch,
             );
             await controller.releaseLease(
               `required dependency '${missingRequiredCap}' unavailable at ` +
@@ -1017,7 +1048,7 @@ export class MeshAgent {
             );
           } catch (err) {
             console.debug(
-              `[mesh-jobs] release-lease for job=${guardJobId} raised:`,
+              `[mesh-jobs] release-lease for job=${inboundJobId} raised:`,
               err,
             );
           }
@@ -1119,16 +1150,19 @@ export class MeshAgent {
           // unconditionally for job-bound tools (see isJobBound above).
           //
           // Phase 1 MeshJob substrate: when this tool is task=true and the
-          // inbound headers carry X-Mesh-Job-Id, build a JobController,
+          // RAW inbound headers carry X-Mesh-Job-Id, build a JobController,
           // splice it into the call args at meshJobParamIndex, and run the
           // user function inside both the JS-side ALS (CURRENT_JOB) and the
           // Rust-side task-local (withJobAsync) so cancel-registry binding
-          // + outbound header injection work transparently.
+          // works transparently. The job context does NOT put X-Mesh-Job-Id
+          // on outbound calls — it is inbound-only (#1570); what it does seed
+          // outbound is the calling-identity pair.
           result = await runWithTraceContext(traceContext, async () => {
             return await runWithPropagatedHeaders(propagatedHeaders, async () => {
               if (isTaskTool) {
-                const [jobId, deadlineSecs, claimEpoch] =
-                  readJobHeaders(propagatedHeaders);
+                const jobId = inboundJobId;
+                const deadlineSecs = inboundDeadlineSecs;
+                const claimEpoch = inboundClaimEpoch;
                 let controller = null;
                 if (jobId && this.config.registryUrl && this.agentId) {
                   try {

--- a/src/runtime/typescript/src/claim-dispatcher.ts
+++ b/src/runtime/typescript/src/claim-dispatcher.ts
@@ -539,23 +539,29 @@ export class ClaimDispatcher {
 
     // Seed the propagated-headers ALS so outbound calls made by the
     // handler continue the submitter's trace tree and carry the job
-    // context onward. Mirrors Python's
+    // budget onward. Mirrors Python's
     // `TraceContext.set_propagated_headers` block in
     // `_mcp_mesh.engine.claim_dispatcher.PythonClaimDispatcher._dispatch`.
     //
     // Trace headers (`x-trace-id`, `x-parent-span`) are not echoed by
     // the registry's claim response in the current wire (see
-    // `src/core/registry/ent_handlers_jobs.go::ClaimJobs`), so we only
-    // seed `x-mesh-job-id` + `x-mesh-timeout` here. If a future schema
-    // adds `trace_id` to ClaimedJob, fold it in alongside.
-    const headers: Record<string, string> = {
-      "x-mesh-job-id": jobId,
-    };
+    // `src/core/registry/ent_handlers_jobs.go::ClaimJobs`), so only
+    // `x-mesh-timeout` is seeded here. If a future schema adds
+    // `trace_id` to ClaimedJob, fold it in alongside.
+    //
+    // Issue #1570: the dispatch protocol pair (`x-mesh-job-id` /
+    // `x-mesh-claim-epoch`) is deliberately NOT seeded. This store is what
+    // `buildMcpRequest` forwards on every outbound call, so seeding the job id
+    // here made a nested call into a `task:true` tool look like an inbound job
+    // dispatch to the callee — which, when that callee had a required
+    // dependency down, released the CALLER's lease and returned `""` instead
+    // of the `dependency_unavailable` refusal. The claim path passes the
+    // controller to the handler directly and binds `currentJob()` via
+    // `runWithJobContext`, so nothing on this side needs the header; calling
+    // identity rides the dedicated `x-mesh-calling-*` pair (#1263).
+    const headers: Record<string, string> = {};
     if (deadlineSecs !== null && deadlineSecs > 0) {
       headers["x-mesh-timeout"] = String(deadlineSecs);
-    }
-    if (claimEpoch !== null) {
-      headers["x-mesh-claim-epoch"] = String(claimEpoch);
     }
 
     try {

--- a/src/runtime/typescript/src/inbound-job-dispatch.ts
+++ b/src/runtime/typescript/src/inbound-job-dispatch.ts
@@ -46,7 +46,13 @@ const _HDR_CLAIM_EPOCH = "x-mesh-claim-epoch";
 /**
  * Read `X-Mesh-Job-Id` / `X-Mesh-Timeout` / `X-Mesh-Claim-Epoch` from a
  * header dict (case normalised to lowercase). Returns
- * `[null, null, null]` when the job id is absent. `claimEpoch` is present
+ * `[null, null, null]` when the job id is absent.
+ *
+ * Issue #1570: pass the RAW inbound `_mesh_headers` map, never the
+ * allowlist-filtered one. `x-mesh-job-id` is the dispatch DISCRIMINATOR and is
+ * deliberately not propagatable (forwarding it self-dispatches nested
+ * `task: true` calls as the caller's job), so a filtered map never carries it
+ * and every call would look like a plain `tools/call`. `claimEpoch` is present
  * only on the claim path; a push-mode inbound job leaves it `null` (legacy
  * owner-only fencing) — a non-negative integer is required (never fabricate
  * a `0` the registry didn't mint).

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -180,11 +180,30 @@ const HDR_CALLING_CLAIM_EPOCH = "x-mesh-calling-claim-epoch";
  * with the wrong result. The claim-local recv cursor is additionally
  * meaningless downstream.
  */
-const DISPATCH_ONLY_HEADERS = [
+const DISPATCH_ONLY_HEADERS: ReadonlySet<string> = new Set([
   "x-mesh-job-id",
   "x-mesh-claim-epoch",
   "x-mesh-recv-cursor",
-] as const;
+]);
+
+/**
+ * Delete every dispatch-protocol header from `map`, IN PLACE, matching
+ * case-insensitively.
+ *
+ * Case-insensitive because not every map this runs over is lowercased. HTTP
+ * header names are case-insensitive on the wire, the callee lowercases the
+ * `_mesh_headers` keys it receives, and `options.customHeaders` /
+ * `runWithPropagatedHeaders` are both reachable from user code with arbitrary
+ * casing — so an exact-name delete would let `X-Mesh-Job-Id` through and the
+ * callee would dispatch on it.
+ */
+function scrubDispatchHeaders(map: Record<string, string>): void {
+  for (const key of Object.keys(map)) {
+    if (DISPATCH_ONLY_HEADERS.has(key.toLowerCase())) {
+      delete map[key];
+    }
+  }
+}
 
 /**
  * Identity of the job whose handler made the CURRENT inbound call
@@ -439,7 +458,8 @@ interface BuiltMcpRequest {
  *
  * Header insertion order is byte-identical to the pre-extraction code:
  * customHeaders → Content-Type/Accept → trace headers → mergedHeaders →
- * conditional X-Mesh-Timeout.
+ * conditional X-Mesh-Timeout. The dispatch-header scrub (#1570) sits between
+ * the last two and only DELETES, so it moves nothing.
  *
  * `defaultTimeout` is the per-path fallback applied when the resolved timeout is
  * non-positive (DEFAULT_CALL_OPTIONS.timeout for buffered,
@@ -477,10 +497,10 @@ function buildMcpRequest(
   }
 
   // Issue #1570: the dispatch protocol headers never ride an outbound call,
-  // whatever put them in the propagated store or a per-call override.
-  for (const name of DISPATCH_ONLY_HEADERS) {
-    delete mergedHeaders[name];
-  }
+  // whatever put them in the propagated store or a per-call override. This map
+  // also becomes `_mesh_headers` in the request BODY, so the scrub has to
+  // happen here as well as on the final header map below.
+  scrubDispatchHeaders(mergedHeaders);
 
   // Issue #1263: overlay the CALLING job's identity so a nested outbound call
   // made from within a job execution context carries who invoked the
@@ -567,6 +587,14 @@ function buildMcpRequest(
   for (const [key, value] of Object.entries(mergedHeaders)) {
     headers[key] = value;
   }
+  // Issue #1570: last-line scrub of the FINAL map. The `mergedHeaders` scrub
+  // above cannot reach `options.customHeaders`, which is spread straight into
+  // this map — downstream of everything, allowlist-unfiltered, and with its
+  // caller-supplied casing intact. Without this, user code could put
+  // `X-Mesh-Job-Id` on the wire and a 3.8 callee would dispatch on it, which
+  // is exactly the self-dispatch corruption this contract removes. Matched
+  // case-insensitively because nothing lowercases `customHeaders` keys.
+  scrubDispatchHeaders(headers);
   // Set X-Mesh-Timeout for the registry proxy (#769). If already propagated,
   // keep it — an inbound budget always wins over a locally derived one.
   //

--- a/src/runtime/typescript/src/proxy.ts
+++ b/src/runtime/typescript/src/proxy.ts
@@ -172,6 +172,21 @@ const HDR_CALLING_JOB_ID = "x-mesh-calling-job-id";
 const HDR_CALLING_CLAIM_EPOCH = "x-mesh-calling-claim-epoch";
 
 /**
+ * Push-mode dispatch protocol headers (issue #1570). INBOUND-ONLY: read from
+ * the raw inbound `_mesh_headers` map to decide whether THIS call is a job
+ * dispatch, never emitted on an outbound call. `x-mesh-job-id` doubles as the
+ * dispatch discriminator, so forwarding it makes a nested `task:true` call
+ * self-dispatch as the CALLER's job (owner + epoch match) and auto-complete it
+ * with the wrong result. The claim-local recv cursor is additionally
+ * meaningless downstream.
+ */
+const DISPATCH_ONLY_HEADERS = [
+  "x-mesh-job-id",
+  "x-mesh-claim-epoch",
+  "x-mesh-recv-cursor",
+] as const;
+
+/**
  * Identity of the job whose handler made the CURRENT inbound call
  * (issue #1263). Returned by {@link callingJob}.
  */
@@ -459,6 +474,12 @@ function buildMcpRequest(
         mergedHeaders[key.toLowerCase()] = value;
       }
     }
+  }
+
+  // Issue #1570: the dispatch protocol headers never ride an outbound call,
+  // whatever put them in the propagated store or a per-call override.
+  for (const name of DISPATCH_ONLY_HEADERS) {
+    delete mergedHeaders[name];
   }
 
   // Issue #1263: overlay the CALLING job's identity so a nested outbound call


### PR DESCRIPTION
Issue #1570. **Breaking for job chains in all three runtimes** — see the upgrading entry added in this PR.

`X-Mesh-Job-Id` is the push-mode dispatch discriminator: a producer reads it off the **incoming** request to bind its handler to a job row. Forwarding it makes a nested same-instance `task=true` call self-dispatch as the *caller's* job — owner and epoch match — and complete the caller's row with the callee's result, before the caller finishes.

## The issue's framing was wrong in both halves, and verifying it changed the fix

#1570 presents this as Java-only, with Python's contract as the model to adopt. Neither holds:

- **Python propagated it too.** `unified_mcp_proxy.py:1332` stamped `X-Mesh-Job-Id` on every outbound mesh→mesh call under an active job context. Python looked safe only because its inbound gate discarded the header — the same filter that made push-mode dispatch over HTTP unreachable there. **Implementing the issue as written — fix Python's inbound gate — would have activated the hazard in Python.** A third leak (`trace_context_helper` copying the propagated store) surfaced only because the first regression test still failed after the obvious one was fixed.
- **Java already seeds `x-mesh-calling-claim-epoch`**, and has since the audit base `4b4cb00f1`. The real epoch defect was inbound: the dispatch gate parsed it off the allowlist-filtered map where it was never allowlisted, so it was unconditionally `null` and every Java executor silently fell back to owner-only fencing.

The allowlist conflated two concerns — capture-for-dispatch and propagate-outbound. Those are now separate stores in each runtime: read raw inbound, scrub on the way out. Java's own source contained both halves of this bug twelve lines apart: `TraceContext.java:66-68` added the header claiming parity with Python/TS, while `:69-81` warned in detail about the self-dispatch hazard that addition creates.

## Rolling upgrades needed a guard, not a paragraph

A 3.7 caller still forwards the header, and a 3.8 callee now reads raw — so **old→new would reproduce the corruption this PR removes**, silently. Previously-safe pairs (old-Java → Python, old-TS → TS) become unsafe for the length of the skew window. Doc guidance can't carry that: "upgrade callers first" is unactionable in a mesh where every agent is both, and the failure mode is data corruption rather than an error.

Every pre-3.8 leak path emits the job id from inside a bound job context, and that context stamps `x-mesh-calling-job-id` on the same request (`McpHttpClient:466`, Python `_inject_trace_into_args`, `proxy.ts:370-374`). A genuine push dispatch cannot carry calling identity — the submitter isn't executing that job, and per-call headers are allowlist-filtered so user code can't set either name. The signal also survives a relay hop, since a 3.7 intermediary allowlisted both names together.

**So job id + calling job id ⇒ leak, not dispatch.** The callee ignores the job id, runs the call normally, and warns naming the fix.

Verified by deleting the guard and replaying a 3.7-shaped request through the real Python middleware:
```
assert seen["job"] == (None, None, None, None)
E  AssertionError: assert ('job-caller', 30.0, None, None) == (None, None, None, None)
```

**Residual, documented rather than hidden**: a pre-3.8 *non-`task`* Java tool that received a proxied dispatch relays the job id with no calling identity, since it never bound a job context. That is indistinguishable from a genuine proxied dispatch by any wire signal, predates this change, and needs a client-originated push into a non-task Java relay.

## Also

- **Registry proxy forwards `X-Mesh-Claim-Epoch`** alongside the job id (`ent_handlers.go:851-864`). It forwarded the id but not the epoch, so the one HTTP path carrying a dispatch job id split the pair and the newly-fixed raw epoch read still degraded to owner-only fencing.
- **All three runtimes now agree on the gate.** Python's originally kept the propagated store as a fallback, which meant widening `MCP_MESH_PROPAGATE_HEADERS` could re-arm self-dispatch there — Java's own test asserts the gate "does not consult this map at all".
- **Python's outbound scrub moved after the header merges**, matching Java and TS; it previously ran before, so a `custom_headers` or per-call `headers=` kwarg could put the trio back on the wire.
- Six stale comments asserting outbound propagation that no longer exists, and four "See Also" lines advertising it, are corrected. `docs/concepts/jobs.md` contradicted itself 900 lines apart.
- `X-Mesh-Trace-Id`, named in the old jobs pages, exists in no runtime. The real header is `X-Trace-ID`.

## Tests

Python full unit suite + `ruff check`/`format --check` clean; Go 10 packages `-race`; TypeScript 1458 across 97 files + `typecheck:all`; Java `mvn test` 924. Man goldens 1824→1843 inline, 532→531 list, 1662→1663 variant — derived and annotated, including why the delta shrank.

Regression tests (raw read, outbound scrub, e2e caller→callee replay through the real `ClaimDispatcher`, registry proxy) all fail against unfixed code. The skew-guard tests pin *new* behaviour and can't fail against the old tree, so that vector was proven the other way — by removing the guard from the fixed tree and watching a 3.7-shaped request dispatch.

Closes #1570

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfukAUDerBUKAfKzUyhvvb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented inbound job-dispatch headers from being forwarded on outbound calls, avoiding incorrect nested job dispatch.
  - Ensured timeout and caller identity continue to propagate through their dedicated headers.
  - Improved mixed-version compatibility by treating legacy header combinations as ordinary tool calls.
  - Preserved required dispatch headers across registry push requests while blocking receive cursors from crossing proxy boundaries.

- **Documentation**
  - Updated job cancellation, timeout propagation, audit references, and 3.8.0 upgrade guidance across runtime documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->