### PR TITLE
fix(python): gateway dependency selectors reach the wire; auto_run gates the server, not mesh membership

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -187,6 +187,24 @@ export MCP_MESH_HEALTH_INTERVAL=30
 export MCP_MESH_ENABLED=true
 ```
 
+### MCP_MESH_ENABLED — the off switch
+
+`MCP_MESH_ENABLED=false` makes the runtime inert: no startup pipeline, no
+registration, no heartbeat, no dependency injection. Decorators still import and
+still record their metadata, so your module loads normally — mesh simply never
+runs. This is the flag to use in unit tests and in any process that imports an
+agent module without wanting to join a mesh.
+
+It fails **closed**. Unset means enabled; `true`, `1`, `yes` and `on` enable it;
+anything else — including `false`, `0`, `off`, an empty value and a typo —
+disables it and logs why. An empty value is a routine outcome of an unset Helm
+key, and for the one flag whose job is to turn mesh off, "I could not parse
+this" must not mean "on".
+
+Do not use `MCP_MESH_AUTO_RUN=false` for this. It gates the HTTP server and the
+process lifetime only: an agent with auto-run disabled still registers and still
+heartbeats, by design. See `meshctl man decorators` for the full split.
+
 ## Registry Server Configuration
 
 > These variables configure the **Go registry server** (`mcp-mesh-registry`)
@@ -935,7 +953,7 @@ MCP_MESH_HTTP_HOST=api-service.company.com
 # .env.testing
 MCP_MESH_LOG_LEVEL=WARNING
 MCP_MESH_DEBUG_MODE=false
-MCP_MESH_AUTO_RUN=false
+MCP_MESH_ENABLED=false          # Inert: no pipeline, no registration, no heartbeat
 MCP_MESH_REGISTRY_URL=http://test-registry:8000
 MCP_MESH_NAMESPACE=testing
 ```
@@ -1013,7 +1031,7 @@ class MyAgent:
 # Override decorator settings
 export MCP_MESH_AGENT_NAME=overridden-service
 export MCP_MESH_HTTP_PORT=9090
-export MCP_MESH_AUTO_RUN=false
+export MCP_MESH_AUTO_RUN=false   # No server, no blocking — still registers
 export MCP_MESH_NAMESPACE=custom
 
 # Runs with overridden values
@@ -1171,7 +1189,7 @@ python my_agent.py
 
 ```bash
 # Test environment variables
-export MCP_MESH_AUTO_RUN=false          # Don't auto-start in tests
+export MCP_MESH_AUTO_RUN=false          # No server, no blocking (still registers)
 export MCP_MESH_LOG_LEVEL=ERROR         # Minimal logging
 export MCP_MESH_REGISTRY_URL=http://test-registry:8000
 export MCP_MESH_NAMESPACE=ci-${BUILD_ID}

--- a/docs/python/decorators.md
+++ b/docs/python/decorators.md
@@ -57,6 +57,58 @@ class MyAgent:
     pass
 ```
 
+### auto_run: server and process lifetime, not mesh membership
+
+`auto_run` controls who starts the HTTP server and who owns the process. It does
+not control whether the agent joins the mesh.
+
+| | `auto_run=True` (default) | `auto_run=False` |
+|---|---|---|
+| Startup pipeline runs | yes | yes |
+| Registers with the registry | yes | yes |
+| Heartbeats, dependencies resolve | yes | yes |
+| Starts the HTTP server | yes | no — you do |
+| Keeps the process alive | yes | no — your loop does |
+
+Use `auto_run=False` to embed a mesh agent inside a server loop you already own.
+Serve on the configured `http_port`: that is the address the agent registers, so
+a mismatch registers an endpoint nothing answers on.
+
+`MCP_MESH_AUTO_RUN` overrides the decorator argument, so
+`MCP_MESH_AUTO_RUN=false` behaves exactly like `auto_run=False` — including
+still registering. To make mesh inert instead, set `MCP_MESH_ENABLED=false`.
+
+Startup runs on a background timer, after your decorators import and after
+`@mesh.agent` returns, so mesh can neither raise into your code nor exit the
+process it does not own. Poll the outcome:
+
+```python
+import mesh
+
+status = mesh.startup_status()
+# {"state": "pending"|"ready"|"failed", "pipeline_type": ..., "error": ...,
+#  "heartbeat": bool, "warnings": [...]}
+if status["state"] == "failed":
+    raise SystemExit(f"mesh failed to start: {status['error']}")
+```
+
+Check `heartbeat` and `warnings` even on `ready`: a run can succeed and still
+leave the agent unable to stay registered (standalone mode, or heartbeat setup
+failing), and those are reported rather than announced as success.
+
+**Current limits of embedded mode.** Two things auto-run does for you have no
+public equivalent yet:
+
+- **No app accessor.** The MCP pipeline builds a FastAPI app with FastMCP
+  mounted, but it is only reachable inside the pipeline context — there is no
+  supported way to obtain it and serve it yourself. Embedded mode is therefore
+  practical today for `@mesh.route` and `@mesh.a2a` services, where you build
+  and own the app, and for `@mesh.tool` agents whose HTTP surface you do not
+  need to serve.
+- **No graceful deregistration.** Auto-run installs a SIGTERM path that
+  unregisters on shutdown. Embedded mode installs none, so the agent is removed
+  by registry timeout rather than promptly on exit.
+
 ## @mesh.tool
 
 Registers a function as a mesh capability with dependency injection.
@@ -195,7 +247,7 @@ All decorator parameters can be overridden via environment variables:
 export MCP_MESH_AGENT_NAME=custom-name
 export MCP_MESH_HTTP_PORT=9090
 export MCP_MESH_NAMESPACE=production
-export MCP_MESH_AUTO_RUN=false
+export MCP_MESH_AUTO_RUN=false   # No server, no blocking — still registers
 ```
 
 ## See Also

--- a/src/core/cli/man/content/decorators.md
+++ b/src/core/cli/man/content/decorators.md
@@ -52,6 +52,58 @@ class MyAgent:
     pass
 ```
 
+### auto_run: server and process lifetime, not mesh membership
+
+`auto_run` controls who starts the HTTP server and who owns the process. It does
+not control whether the agent joins the mesh.
+
+| | `auto_run=True` (default) | `auto_run=False` |
+|---|---|---|
+| Startup pipeline runs | yes | yes |
+| Registers with the registry | yes | yes |
+| Heartbeats, dependencies resolve | yes | yes |
+| Starts the HTTP server | yes | no — you do |
+| Keeps the process alive | yes | no — your loop does |
+
+Use `auto_run=False` to embed a mesh agent inside a server loop you already own.
+Serve on the configured `http_port`: that is the address the agent registers, so
+a mismatch registers an endpoint nothing answers on.
+
+`MCP_MESH_AUTO_RUN` overrides the decorator argument, so
+`MCP_MESH_AUTO_RUN=false` behaves exactly like `auto_run=False` — including
+still registering. To make mesh inert instead, set `MCP_MESH_ENABLED=false`.
+
+Startup runs on a background timer, after your decorators import and after
+`@mesh.agent` returns, so mesh can neither raise into your code nor exit the
+process it does not own. Poll the outcome:
+
+```python
+import mesh
+
+status = mesh.startup_status()
+# {"state": "pending"|"ready"|"failed", "pipeline_type": ..., "error": ...,
+#  "heartbeat": bool, "warnings": [...]}
+if status["state"] == "failed":
+    raise SystemExit(f"mesh failed to start: {status['error']}")
+```
+
+Check `heartbeat` and `warnings` even on `ready`: a run can succeed and still
+leave the agent unable to stay registered (standalone mode, or heartbeat setup
+failing), and those are reported rather than announced as success.
+
+**Current limits of embedded mode.** Two things auto-run does for you have no
+public equivalent yet:
+
+- **No app accessor.** The MCP pipeline builds a FastAPI app with FastMCP
+  mounted, but it is only reachable inside the pipeline context — there is no
+  supported way to obtain it and serve it yourself. Embedded mode is therefore
+  practical today for `@mesh.route` and `@mesh.a2a` services, where you build
+  and own the app, and for `@mesh.tool` agents whose HTTP surface you do not
+  need to serve.
+- **No graceful deregistration.** Auto-run installs a SIGTERM path that
+  unregisters on shutdown. Embedded mode installs none, so the agent is removed
+  by registry timeout rather than promptly on exit.
+
 ## @mesh.tool
 
 Registers a function as a mesh capability with dependency injection.
@@ -303,7 +355,7 @@ All decorator parameters can be overridden via environment variables:
 export MCP_MESH_AGENT_NAME=custom-name
 export MCP_MESH_HTTP_PORT=9090
 export MCP_MESH_NAMESPACE=production
-export MCP_MESH_AUTO_RUN=false
+export MCP_MESH_AUTO_RUN=false   # No server, no blocking — still registers
 ```
 
 ## See Also

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -51,6 +51,24 @@ export MCP_MESH_HEALTH_INTERVAL=5     # Heartbeat interval to registry (seconds,
 export MCP_MESH_ENABLED=true
 ```
 
+### MCP_MESH_ENABLED — the off switch
+
+`MCP_MESH_ENABLED=false` makes the runtime inert: no startup pipeline, no
+registration, no heartbeat, no dependency injection. Decorators still import and
+still record their metadata, so your module loads normally — mesh simply never
+runs. This is the flag to use in unit tests and in any process that imports an
+agent module without wanting to join a mesh.
+
+It fails **closed**. Unset means enabled; `true`, `1`, `yes` and `on` enable it;
+anything else — including `false`, `0`, `off`, an empty value and a typo —
+disables it and logs why. An empty value is a routine outcome of an unset Helm
+key, and for the one flag whose job is to turn mesh off, "I could not parse
+this" must not mean "on".
+
+Do not use `MCP_MESH_AUTO_RUN=false` for this. It gates the HTTP server and the
+process lifetime only: an agent with auto-run disabled still registers and still
+heartbeats, by design. See `meshctl man decorators` for the full split.
+
 ### Registry Connection
 
 ```bash
@@ -688,7 +706,7 @@ MCP_MESH_VAULT_PKI_PATH=pki_int/issue/mesh-agent
 ```bash
 # .env.testing
 MCP_MESH_LOG_LEVEL=WARNING
-MCP_MESH_AUTO_RUN=false
+MCP_MESH_ENABLED=false          # Inert: no pipeline, no registration, no heartbeat
 MCP_MESH_REGISTRY_URL=http://test-registry:8000
 MCP_MESH_NAMESPACE=testing
 ```

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -604,10 +604,33 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // there it is still inbound). That rewording is span-neutral on all three
 // pages — 5 spans before and after — so neither this constant nor the variant
 // golden moved with it. 1843 + 3 = 1846.
+//
+// Issue #1589 added an "auto_run: server and process lifetime, not mesh
+// membership" section to `decorators.md`. The old docstring ("Automatically
+// start service and keep process alive") was the ambiguity that let
+// auto_run=False be read as "do not join the mesh"; the new section states the
+// split explicitly and pins that MCP_MESH_AUTO_RUN=false still registers. Six
+// new spans on that page (the two mode names, http_port, the env var twice and
+// auto_run=False in prose); the table cells are list/markup lines, not inline
+// spans. 1846 + 6 = 1852.
+//
+// Issue #1589 follow-up: MCP_MESH_ENABLED got a real entry on `environment.md`
+// as the inert switch, because the documented CI recipe (MCP_MESH_AUTO_RUN=false)
+// stopped meaning "off" — under the new semantics that recipe registers into
+// whatever MCP_MESH_REGISTRY_URL points at. Ten new spans on that page (the two
+// env var names, the six accepted/rejected literals, and the man cross-ref).
+// 1852 + 10 = 1862.
+//
+// The same issue documented embedded mode's outcome API and its two current
+// limits on `decorators.md`: mesh.startup_status() polling (startup runs on a
+// timer, so mesh can neither raise into caller code nor exit a process it does
+// not own), plus the missing app accessor and missing graceful deregistration.
+// Eight new inline spans, and the two limits are markup-carrying list lines.
+// 1862 + 8 = 1870; 450 + 2 = 452.
 const (
-	wantInlineCodeSpans = 1846
+	wantInlineCodeSpans = 1870
 	wantListCodeSpans   = 531
-	wantMarkupListLines = 450
+	wantMarkupListLines = 452
 )
 
 // assertCorpusSize replaces the t.Logf these tests used to end on.

--- a/src/runtime/python/_mcp_mesh/__init__.py
+++ b/src/runtime/python/_mcp_mesh/__init__.py
@@ -12,7 +12,6 @@ and may break in future versions.
 Public API: import mesh
 """
 
-import os
 import sys
 
 # Type alias for mesh agent proxy injections - use Any for Pydantic compatibility
@@ -37,6 +36,43 @@ __version__ = "3.7.1"
 _runtime_processor = None
 
 
+# Values that mean "on" for MCP_MESH_ENABLED. Deliberately NOT resolved through
+# ``get_config_value``: that helper soft-fails an unparseable value back to its
+# default, so a typo — or ``MCP_MESH_ENABLED=""``, a routine empty-Helm-value
+# outcome — would ENABLE the one flag whose entire job is to turn mesh off.
+# Every other truthy knob can afford to fail open; the master off switch cannot.
+# Widening the accepted spellings beyond the old ``== "true"`` is the fix here;
+# making a typo mean "on" is not.
+_ENABLED_TRUTHY = frozenset({"true", "1", "yes", "on"})
+
+
+def _mesh_enabled() -> bool:
+    """Resolve MCP_MESH_ENABLED. Unset means on; anything unrecognized means off.
+
+    Accepts the same truthy spellings as the rest of the mesh (``true``, ``1``,
+    ``yes``, ``on``, case-insensitive) but fails CLOSED: an unset variable
+    enables mesh, and any other value — ``false``, ``0``, ``off``, ``""`` or a
+    typo — disables it. Disabling is the safe direction: a mesh that did not
+    start is obvious and local, whereas one that started against the wrong
+    ``MCP_MESH_REGISTRY_URL`` registers into someone else's topology.
+    """
+    import os
+
+    raw = os.environ.get("MCP_MESH_ENABLED")
+    if raw is None:
+        return True
+    value = raw.strip().lower()
+    if value in _ENABLED_TRUTHY:
+        return True
+    if value not in {"false", "0", "no", "off", ""}:
+        sys.stderr.write(
+            f"MCP_MESH_ENABLED={raw!r} is not a recognized boolean; "
+            f"treating it as disabled. Use one of "
+            f"{sorted(_ENABLED_TRUTHY)} to enable MCP Mesh.\n"
+        )
+    return False
+
+
 def initialize_runtime():
     """Initialize the MCP Mesh runtime processor."""
     global _runtime_processor
@@ -58,11 +94,27 @@ def initialize_runtime():
         sys.stderr.write(f"MCP Mesh runtime initialization failed: {e}\n")
 
 
-# Auto-initialize runtime if enabled
-if (
-    os.getenv("MCP_MESH_ENABLED", "true").lower() == "true"
-    and os.getenv("MCP_MESH_AUTO_RUN", "true").lower() == "true"
-):
+# Auto-initialize runtime if mesh is enabled.
+#
+# Issue #1589: this gate used to also require MCP_MESH_AUTO_RUN, string-compared
+# against "true", and that was wrong twice over.
+#
+# The comparison disagreed with the decorator and the orchestrator, which both
+# accepted the wider truthy set: "1"/"yes"/"on" started the immediate uvicorn but
+# skipped start_runtime(), so the debounce coordinator never got an orchestrator
+# and the process served /ready with "Mesh runtime has not started yet" forever,
+# never registering.
+#
+# Consulting auto-run here at all was the deeper error. start_runtime() only
+# wires the debounce coordinator to the orchestrator — it starts no server and
+# blocks nothing — but it is the prerequisite for the pipeline that REGISTERS the
+# agent. Gating it on auto-run meant MCP_MESH_AUTO_RUN=false silently kept the
+# agent out of the mesh entirely, rather than merely declining to start a server.
+# Auto-run is decided once, later, in DebounceCoordinator._check_auto_run_enabled,
+# where it gates the server and the keep-alive and nothing else.
+#
+# MCP_MESH_ENABLED remains the switch that turns mesh off completely.
+if _mesh_enabled():
     # Use debounced initialization instead of immediate MCP startup
     # This allows the system to determine MCP vs API pipeline based on decorators
     try:

--- a/src/runtime/python/_mcp_mesh/engine/decorator_registry.py
+++ b/src/runtime/python/_mcp_mesh/engine/decorator_registry.py
@@ -186,12 +186,18 @@ class DecoratorRegistry:
 
     # Route-to-wrapper mapping for @mesh.route dependency injection
     # Key: "METHOD:path" (e.g., "GET:/api/v1/benchmark-services")
-    # Value: {"wrapper": Callable, "dependencies": list[str]}
+    # Value: {"wrapper": Callable, "dependencies": list[str],
+    #         "dependency_specs": list[dict]}
     _route_wrapper_registry: dict[str, dict[str, Any]] = {}
 
     @classmethod
     def register_route_wrapper(
-        cls, method: str, path: str, wrapper: Callable, dependencies: list[str]
+        cls,
+        method: str,
+        path: str,
+        wrapper: Callable,
+        dependencies: list[str],
+        dependency_specs: list[dict[str, Any]] | None = None,
     ) -> None:
         """
         Register a route's wrapper function for dependency injection.
@@ -200,12 +206,24 @@ class DecoratorRegistry:
             method: HTTP method (e.g., "GET", "POST")
             path: Route path (e.g., "/api/v1/benchmark-services")
             wrapper: The injection wrapper function
-            dependencies: List of dependency capability names
+            dependencies: List of dependency capability names. Index-aligned
+                with the wrapper's injection slots — this is what the
+                heartbeat's dependency-change handler matches against.
+            dependency_specs: Issue #1571 — the validated dependency mappings
+                the names were derived from (tags, version, required,
+                match_mode, expected schema). Index-aligned with
+                ``dependencies``. The heartbeat serializes these onto the
+                wire; without them a route edge reaches the registry as a
+                bare capability name and tag/version/required routing is
+                silently lost. Optional so pre-#1571 callers keep working.
         """
         route_id = f"{method}:{path}"
+        if dependency_specs is None:
+            dependency_specs = [{"capability": cap, "tags": []} for cap in dependencies]
         cls._route_wrapper_registry[route_id] = {
             "wrapper": wrapper,
             "dependencies": dependencies,
+            "dependency_specs": dependency_specs,
             "method": method,
             "path": path,
         }
@@ -636,7 +654,11 @@ class DecoratorRegistry:
 
         # Step 3: Fallback to synthetic defaults when no @mesh.agent decorator exists
         # This happens when only @mesh.tool decorators are used and no cached agent_id
-        from ..shared.config_resolver import ValidationRule, get_config_value
+        from ..shared.config_resolver import (
+            ValidationRule,
+            get_config_value,
+            resolve_auto_run,
+        )
         from ..shared.defaults import MeshDefaults
 
         # Check if we're in an API context (have mesh_route decorators)
@@ -685,11 +707,8 @@ class DecoratorRegistry:
                 default=MeshDefaults.HEALTH_INTERVAL,
                 rule=ValidationRule.NONZERO_RULE,
             ),
-            "auto_run": get_config_value(
-                "MCP_MESH_AUTO_RUN",
-                default=MeshDefaults.AUTO_RUN,
-                rule=ValidationRule.TRUTHY_RULE,
-            ),
+            # Issue #1589: one resolver for every MCP_MESH_AUTO_RUN reader.
+            "auto_run": resolve_auto_run(),
             "auto_run_interval": get_config_value(
                 "MCP_MESH_AUTO_RUN_INTERVAL",
                 default=MeshDefaults.AUTO_RUN_INTERVAL,

--- a/src/runtime/python/_mcp_mesh/pipeline/a2a_heartbeat/rust_a2a_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/a2a_heartbeat/rust_a2a_heartbeat.py
@@ -22,6 +22,8 @@ import logging
 import re
 from typing import Any, Optional
 
+from ..shared.dependency_spec import build_dependency_specs, cluster_strict_enabled
+
 # Matches the registry/SDK convention of "{base}-{8-hex-chars}" at the end
 # of a service_id. Used to strip the suffix and recover the base name.
 _A2A_SERVICE_ID_SUFFIX_RE = re.compile(r"-[0-9a-f]{8}$")
@@ -113,24 +115,17 @@ def _build_a2a_agent_spec(
     from ...engine.decorator_registry import DecoratorRegistry
 
     tools = []
+    cluster_strict = cluster_strict_enabled()
     a2a_decorators = DecoratorRegistry.get_all_by_type("mesh_a2a")
     for func_id, decorated in a2a_decorators.items():
         meta = decorated.metadata or {}
         deps_meta = meta.get("dependencies") or []
 
-        deps = []
-        for dep in deps_meta:
-            cap = dep.get("capability") if isinstance(dep, dict) else dep
-            if not cap:
-                continue
-            dep_tags = dep.get("tags", []) if isinstance(dep, dict) else []
-            dep_version = dep.get("version") if isinstance(dep, dict) else None
-            dep_spec = core.DependencySpec(
-                capability=cap,
-                tags=json.dumps(dep_tags),
-                version=dep_version,
-            )
-            deps.append(dep_spec)
+        # Issue #1571: this path used to build its own reduced spec that
+        # carried only capability/tags/version, dropping ``required``,
+        # ``match_mode`` and the expected-schema pair. Share the tool path's
+        # builder so every surface publishes the same selector.
+        deps = build_dependency_specs(core, deps_meta, cluster_strict=cluster_strict)
 
         if not deps:
             continue

--- a/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/rust_api_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_heartbeat/rust_api_heartbeat.py
@@ -18,6 +18,8 @@ import logging
 import re
 from typing import Any, Optional
 
+from ..shared.dependency_spec import build_dependency_specs, cluster_strict_enabled
+
 # Matches the registry/SDK convention of "{base}-{8-hex-chars}" at the end
 # of a service_id. Used to strip the suffix and recover the base name.
 _API_SERVICE_ID_SUFFIX_RE = re.compile(r"-[0-9a-f]{8}$")
@@ -109,6 +111,8 @@ def _build_api_agent_spec(context: dict[str, Any], service_id: str = None) -> An
     tools = []
     route_wrappers = DecoratorRegistry.get_all_route_wrappers()
 
+    cluster_strict = cluster_strict_enabled()
+
     for route_id, route_info in route_wrappers.items():
         dependencies = route_info.get("dependencies", [])
 
@@ -116,16 +120,14 @@ def _build_api_agent_spec(context: dict[str, Any], service_id: str = None) -> An
         if not dependencies:
             continue
 
-        # Build dependency specs
-        deps = []
-        for dep_cap in dependencies:
-            # Tags must be serialized to JSON string (Rust core expects string, not list)
-            dep_spec = core.DependencySpec(
-                capability=dep_cap,
-                tags=json.dumps([]),
-                version=None,
-            )
-            deps.append(dep_spec)
+        # Build dependency specs. Issue #1571: prefer the validated selector
+        # mappings the route decorator produced — building from the flattened
+        # capability names alone drops tags, version, required, match_mode and
+        # the expected schema, so a tag-routed or required route edge reached
+        # the registry as an unqualified capability. Fall back to the names for
+        # wrappers registered before ``dependency_specs`` existed.
+        dep_infos = route_info.get("dependency_specs") or dependencies
+        deps = build_dependency_specs(core, dep_infos, cluster_strict=cluster_strict)
 
         # Create ToolSpec for this route
         # For API routes: function_name is the route_id (METHOD:path)

--- a/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/api_startup/route_integration.py
@@ -550,6 +550,8 @@ class RouteIntegrationStep(PipelineStep):
                     path=path,
                     wrapper=inner_wrapper,
                     dependencies=dependency_names,
+                    # Issue #1571: carry the full selector to the heartbeat.
+                    dependency_specs=dependencies,
                 )
             self.logger.info(
                 f"📡 Route {methods} {path} -> {endpoint_name}() already "
@@ -659,6 +661,8 @@ class RouteIntegrationStep(PipelineStep):
                 path=path,
                 wrapper=wrapped_handler,
                 dependencies=dependency_names,
+                # Issue #1571: carry the full selector to the heartbeat.
+                dependency_specs=dependencies,
             )
 
         if is_stream_route:

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_heartbeat/rust_heartbeat.py
@@ -15,50 +15,24 @@ Python handles:
 import asyncio
 import json
 import logging
-import os
 from typing import Any, Optional
 
 from ...engine.llm_config import DEFAULT_MAX_ITERATIONS
 
+# Issue #1571: the schema-verdict policy and DependencySpec construction live
+# in the shared module so the route and A2A heartbeats build identical specs.
+# The underscore aliases keep this module's existing test surface intact.
+from ..shared.dependency_spec import (
+    build_dependency_specs,
+)
+from ..shared.dependency_spec import (
+    cluster_strict_enabled as _cluster_strict_enabled,
+)
+from ..shared.dependency_spec import (
+    should_refuse_startup as _should_refuse_startup,
+)
+
 logger = logging.getLogger(__name__)
-
-
-def _cluster_strict_enabled() -> bool:
-    """Issue #547 Phase 4: read MCP_MESH_SCHEMA_STRICT env var (cluster-wide knob).
-
-    When true, WARN verdicts are promoted to BLOCK so ops can harden a whole
-    cluster without changing every consumer.
-    """
-    return os.environ.get("MCP_MESH_SCHEMA_STRICT", "").strip().lower() in {
-        "1",
-        "true",
-        "yes",
-    }
-
-
-def _should_refuse_startup(
-    verdict: str, cluster_strict: bool, tool_strict: bool
-) -> bool:
-    """Issue #547 Phase 4: schema verdict policy.
-
-    Composes two knobs:
-      * cluster_strict (env MCP_MESH_SCHEMA_STRICT): promotes WARN→BLOCK.
-      * tool_strict (per-tool output_schema_strict, default True): producer-side
-        escape hatch. When False, BLOCK is demoted to WARN for that tool.
-
-    Truth table:
-      verdict=BLOCK + tool_strict=True  -> refuse
-      verdict=BLOCK + tool_strict=False -> log only (override wins)
-      verdict=WARN  + cluster_strict=True + tool_strict=True  -> refuse
-      verdict=WARN  + cluster_strict=True + tool_strict=False -> log only
-      verdict=WARN  + cluster_strict=False -> log only
-      verdict=OK -> never refuse
-    """
-    if verdict == "BLOCK":
-        return tool_strict
-    if verdict == "WARN":
-        return cluster_strict and tool_strict
-    return False
 
 
 # Lazy import to avoid ImportError if Rust core not built
@@ -184,76 +158,11 @@ def _build_agent_spec(context: dict[str, Any]) -> Any:
         # Issue #547 Phase 4: per-tool override (default True = current behavior).
         tool_strict = bool(tool_metadata.get("output_schema_strict", True))
 
-        # Build dependency specs
-        deps = []
-        for dep_info in tool_metadata.get("dependencies", []):
-            # Serialize tags to JSON to support nested arrays for OR alternatives
-            # e.g., ["addition", ["python", "typescript"]] -> addition AND (python OR typescript)
-            tags_json = json.dumps(dep_info.get("tags", []))
-
-            # Issue #547 Phase 1D: normalize the consumer's expected schema
-            # via the Rust normalizer (deferred from decorator time to keep
-            # import cheap and consistent with producer-side normalization).
-            expected_canonical: str | None = None
-            expected_hash: str | None = None
-            match_mode = dep_info.get("match_mode")
-            expected_raw = dep_info.get("expected_schema_raw")
-            if expected_raw is not None:
-                try:
-                    normalize_fn = getattr(core, "normalize_schema_py", None)
-                    if normalize_fn is None:
-                        raise AttributeError("normalize_schema_py not in mcp_mesh_core")
-                    result = json.loads(
-                        normalize_fn(json.dumps(expected_raw), "python")
-                    )
-                    verdict = result.get("verdict", "OK")
-                    warnings_list = result.get("warnings") or []
-                    # Issue #547 Phase 4: there's no per-tool override on the
-                    # consumer side (the override is producer-side); use
-                    # tool_strict=True so cluster_strict still promotes WARN.
-                    if _should_refuse_startup(verdict, cluster_strict, True):
-                        promoted = (
-                            " (MCP_MESH_SCHEMA_STRICT=true upgraded WARN→BLOCK)"
-                            if verdict == "WARN"
-                            else ""
-                        )
-                        raise RuntimeError(
-                            f"Schema normalization {verdict} for dependency on "
-                            f"'{dep_info.get('capability', '')}'{promoted}: "
-                            f"{warnings_list}. Cannot start agent."
-                        )
-                    if verdict == "WARN":
-                        logger.warning(
-                            f"Schema WARN for dependency on "
-                            f"'{dep_info.get('capability', '')}': {warnings_list}"
-                        )
-                    if result.get("canonical"):
-                        expected_canonical = json.dumps(result["canonical"])
-                        expected_hash = result.get("hash")
-                except RuntimeError:
-                    raise
-                except Exception as e:
-                    logger.warning(
-                        f"Could not normalize expected schema for dep "
-                        f"'{dep_info.get('capability', '')}': {e}"
-                    )
-                    expected_canonical = None
-                    expected_hash = None
-
-            dep_spec = core.DependencySpec(
-                capability=dep_info.get("capability", ""),
-                tags=tags_json,
-                version=dep_info.get("version"),
-                expected_schema_canonical=expected_canonical,
-                expected_schema_hash=expected_hash,
-                match_mode=match_mode,
-                # Issue #1249: opt-in strictness flag (default False). The
-                # registry factors required edges into transitive capability
-                # availability. Absent/false is omitted from the wire payload
-                # by the core's skip_serializing_if.
-                required=bool(dep_info.get("required", False)),
-            )
-            deps.append(dep_spec)
+        # Build dependency specs (issue #1571: one builder for tool, route
+        # and A2A heartbeats so every path carries the full selector).
+        deps = build_dependency_specs(
+            core, tool_metadata.get("dependencies", []), cluster_strict=cluster_strict
+        )
 
         # Extract input schema from FastMCP tool (like heartbeat_preparation.py)
         # This is critical for LLM tool filtering - registry requires inputSchema

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/embedded_status.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/embedded_status.py
@@ -1,0 +1,97 @@
+"""Observable startup outcome for embedded mode (issue #1589).
+
+In auto-run mode mesh owns the process, so a startup failure can be answered by
+``abort_agent_process()`` — exit non-zero and let the orchestrator restart the
+pod (issue #1556). Embedded mode (``auto_run=False``) has neither option:
+
+* Exiting is wrong. The caller owns the process; mesh killing it would take
+  down a server mesh does not manage.
+* Raising is useless. ``_execute_processing`` runs on a ``threading.Timer``
+  thread, so an exception there reaches ``threading.excepthook``, prints a
+  traceback and kills that thread. The caller's server keeps serving, nothing
+  registered, exit status still 0 — the exact #1556 shape.
+
+So embedded mode records its outcome here and the caller polls it:
+
+    import mesh
+
+    status = mesh.startup_status()
+    if status["state"] == "failed":
+        raise SystemExit(f"mesh failed to start: {status['error']}")
+
+A single reader with no callback registry keeps this free of ordering
+questions: the record is written once, on the timer thread, before the log
+line that announces it, and any thread can read it afterwards.
+"""
+
+import threading
+from typing import Any
+
+# No startup has been attempted yet (or the last one is still running).
+PENDING = "pending"
+# The pipeline succeeded. Check ``registered``/``heartbeat`` for what that got
+# you — a "ready" agent with ``heartbeat: False`` is registered at most once
+# and will fall out of the mesh.
+READY = "ready"
+# The pipeline failed. ``error`` says why. Nothing is registered.
+FAILED = "failed"
+
+_lock = threading.Lock()
+_status: dict[str, Any] = {
+    "state": PENDING,
+    "pipeline_type": None,
+    "error": None,
+    "heartbeat": False,
+    "warnings": [],
+}
+
+
+def get_status() -> dict[str, Any]:
+    """Return a snapshot of the last embedded-mode startup outcome."""
+    with _lock:
+        snapshot = dict(_status)
+    snapshot["warnings"] = list(snapshot["warnings"])
+    return snapshot
+
+
+def set_ready(
+    pipeline_type: str, *, heartbeat: bool, warnings: list[str] | None = None
+) -> None:
+    """Record a successful pipeline run.
+
+    ``heartbeat`` is whether a heartbeat thread actually started — it is False
+    in standalone mode and when ``_setup_heartbeat_background`` swallowed an
+    exception, and in both cases the agent will not stay registered.
+    """
+    with _lock:
+        _status.update(
+            state=READY,
+            pipeline_type=pipeline_type,
+            error=None,
+            heartbeat=heartbeat,
+            warnings=list(warnings or []),
+        )
+
+
+def set_failed(pipeline_type: str | None, error: str) -> None:
+    """Record a failed pipeline run. Nothing is registered."""
+    with _lock:
+        _status.update(
+            state=FAILED,
+            pipeline_type=pipeline_type,
+            error=error,
+            heartbeat=False,
+            warnings=[],
+        )
+
+
+def reset() -> None:
+    """Reset to PENDING. For tests."""
+    with _lock:
+        _status.update(
+            state=PENDING,
+            pipeline_type=None,
+            error=None,
+            heartbeat=False,
+            warnings=[],
+        )

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_orchestrator.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_orchestrator.py
@@ -10,6 +10,7 @@ import logging
 import os
 from typing import Any, Optional
 
+from . import embedded_status
 from .startup_pipeline import StartupPipeline
 
 logger = logging.getLogger(__name__)
@@ -551,8 +552,24 @@ class DebounceCoordinator:
                         f"Auto-run is enabled but {missing}.", self.logger
                     )
             else:
-                # Single execution mode (for testing/debugging)
-                self.logger.info("🏁 Auto-run disabled - single execution mode")
+                # Embedded mode (issue #1589). Auto-run gates the SERVER and the
+                # KEEP-ALIVE, not mesh membership: an agent that never registers
+                # is not in the mesh at all, which is the opposite of what
+                # "embed mesh in your own server loop" is for. So the pipeline
+                # still runs (the agent registers) and the background heartbeat
+                # still starts (it stays registered and its dependencies
+                # resolve) — we simply return instead of binding a socket and
+                # blocking, leaving the process lifetime to the caller's loop.
+                #
+                # This is the contract the API and A2A paths have always had:
+                # heartbeat on a daemon thread with its own event loop, then
+                # return. The heartbeat is not tied to uvicorn's loop, so it
+                # does not need the server; being a daemon, it also cannot keep
+                # the process alive on mesh's behalf.
+                self.logger.info(
+                    "🔄 Auto-run disabled - embedded mode: registering and "
+                    "heartbeating without starting a server or blocking"
+                )
 
                 if pipeline_type == "mcp":
                     result = asyncio.run(orchestrator.process_once())
@@ -563,21 +580,127 @@ class DebounceCoordinator:
                 else:
                     raise RuntimeError(f"Unsupported pipeline type: {pipeline_type}")
 
-                # Mirror the auto-run branch: surface pipeline failures so
-                # tests / debug runs don't report success on a broken setup.
+                # Embedded-mode failure contract. The auto-run branch answers
+                # this with abort_agent_process(); neither of its options is
+                # available here. Exiting is wrong — the caller owns the
+                # process and mesh would be killing a server it does not
+                # manage. Raising is USELESS: we are on a threading.Timer
+                # thread, so the exception reaches threading.excepthook, prints
+                # a traceback, kills that thread, and leaves the caller's
+                # server happily serving an agent that never registered with
+                # exit status 0 — the exact #1556 shape. So the outcome is
+                # RECORDED for the caller to poll (mesh.startup_status()) and
+                # announced at ERROR; the raise below only gets the traceback
+                # to stderr, and is explicitly not the contract.
                 if result.get("status") == "failed":
                     err_detail = result.get("message") or "unknown error"
                     errors = result.get("errors") or []
                     if errors:
                         err_detail = f"{err_detail}: {errors}"
+                    embedded_status.set_failed(pipeline_type, err_detail)
                     self.logger.error(
-                        f"❌ {pipeline_type.upper()} pipeline failed in single-execution mode: {err_detail}"
+                        f"❌ {pipeline_type.upper()} pipeline failed in embedded "
+                        f"mode: {err_detail}. This agent is NOT registered and "
+                        f"has NO dependency injection. Mesh cannot exit the "
+                        f"process here because your code owns it — poll "
+                        f"mesh.startup_status() and shut down your server if "
+                        f"state == 'failed'."
                     )
                     raise RuntimeError(
                         f"{pipeline_type.upper()} pipeline failed: {err_detail}"
                     )
 
-                self.logger.info("✅ Pipeline execution completed, exiting")
+                pipeline_context = result.get("context", {}).get("pipeline_context", {})
+                heartbeat_config = pipeline_context.get("heartbeat_config", {})
+
+                # No ``server_started_check`` on any of these branches: mesh is
+                # not starting the server, so there is nothing to gate the first
+                # registration on. The caller's loop owns serving, and the port
+                # registered is the configured one (nothing bound a socket here
+                # to override it) — same contract as the API/A2A paths.
+                if pipeline_type == "api":
+                    from ..api_heartbeat.api_lifespan_integration import (
+                        api_heartbeat_lifespan_task,
+                    )
+
+                    heartbeat_started = self._setup_heartbeat_background(
+                        heartbeat_config,
+                        pipeline_context,
+                        api_heartbeat_lifespan_task,
+                        id_field="service_id",
+                        label="API service",
+                    )
+                elif pipeline_type == "a2a":
+                    from ..a2a_heartbeat.a2a_lifespan_integration import (
+                        a2a_heartbeat_lifespan_task,
+                    )
+
+                    heartbeat_started = self._setup_heartbeat_background(
+                        heartbeat_config,
+                        pipeline_context,
+                        a2a_heartbeat_lifespan_task,
+                        id_field="service_id",
+                        label="A2A service",
+                    )
+                else:
+                    heartbeat_task_fn = heartbeat_config.get("heartbeat_task_fn")
+                    if heartbeat_task_fn is None or not callable(heartbeat_task_fn):
+                        if heartbeat_task_fn is not None:
+                            self.logger.warning(
+                                f"heartbeat_task_fn from config is not callable: "
+                                f"{type(heartbeat_task_fn)}, using Rust heartbeat"
+                            )
+                        from ..mcp_heartbeat.rust_heartbeat import rust_heartbeat_task
+
+                        heartbeat_task_fn = rust_heartbeat_task
+
+                    heartbeat_started = self._setup_heartbeat_background(
+                        heartbeat_config,
+                        pipeline_context,
+                        heartbeat_task_fn,
+                    )
+
+                # Report what actually happened, not what was intended. The
+                # heartbeat is skipped in standalone mode and swallowed on
+                # setup failure, and the MCP pipeline can succeed without
+                # producing an app for the caller to serve — announcing
+                # "registered and heartbeating" unconditionally would paper
+                # over all three.
+                warnings: list[str] = []
+                if not heartbeat_started:
+                    warnings.append(
+                        "no heartbeat thread started (standalone mode, or setup "
+                        "failed) - this agent will not stay registered"
+                    )
+                if pipeline_type == "mcp" and not pipeline_context.get("fastapi_app"):
+                    if pipeline_context.get("http_transport_disabled"):
+                        warnings.append(
+                            "HTTP transport is disabled (MCP_MESH_HTTP_ENABLED), "
+                            "so there is no app to serve"
+                        )
+                    else:
+                        warnings.append(
+                            "the pipeline produced no FastAPI app, so there is "
+                            "nothing for your server loop to serve on the "
+                            "registered port"
+                        )
+
+                embedded_status.set_ready(
+                    pipeline_type, heartbeat=heartbeat_started, warnings=warnings
+                )
+
+                if warnings:
+                    for warning in warnings:
+                        self.logger.warning(f"⚠️ Embedded mode: {warning}")
+                    self.logger.warning(
+                        "⚠️ Embedded mode started with warnings - see "
+                        "mesh.startup_status()['warnings']"
+                    )
+                else:
+                    self.logger.info(
+                        "✅ Embedded mode ready - agent registered and heartbeating; "
+                        "the caller owns the server and the process lifetime"
+                    )
 
         except Exception as e:
             self.logger.error(f"❌ Error in debounced processing: {e}")
@@ -674,7 +797,7 @@ class DebounceCoordinator:
         heartbeat_task_fn: Any,
         id_field: str = "agent_id",
         label: str = "MCP agent",
-    ) -> None:
+    ) -> bool:
         """
         Setup heartbeat to run in background thread.
 
@@ -686,6 +809,12 @@ class DebounceCoordinator:
             heartbeat_task_fn: Async function to run (api or mcp heartbeat task)
             id_field: Config key for ID ("agent_id" or "service_id")
             label: Label for log messages ("MCP agent" or "API service")
+
+        Returns:
+            True if a heartbeat thread was started. False when standalone mode
+            skipped it or setup raised — in both cases the agent will NOT stay
+            registered, which embedded mode (issue #1589) reports rather than
+            announcing a success it did not achieve.
         """
         import asyncio
         import threading
@@ -699,7 +828,7 @@ class DebounceCoordinator:
                 self.logger.info(
                     f"{label} '{entity_id}' configured in standalone mode - no heartbeat"
                 )
-                return
+                return False
 
             self.logger.info(
                 f"Setting up background heartbeat for {label} '{entity_id}'"
@@ -734,27 +863,59 @@ class DebounceCoordinator:
             self.logger.info(
                 f"Background heartbeat thread started for {label} '{entity_id}'"
             )
+            return True
 
         except Exception as e:
             self.logger.warning(f"Could not setup {label} heartbeat: {e}")
+            return False
 
     # Graceful shutdown is now handled by FastAPI lifespan in simple_shutdown.py
 
     def _check_auto_run_enabled(self) -> bool:
-        """Check if auto-run is enabled (defaults to True for persistent service behavior)."""
-        # Check environment variable - defaults to "true" for persistent service behavior
-        env_auto_run = os.getenv("MCP_MESH_AUTO_RUN", "true").lower()
-        self.logger.debug(f"🔍 MCP_MESH_AUTO_RUN='{env_auto_run}' (default: 'true')")
+        """Resolve auto-run as ENV > @mesh.agent(auto_run=...) > True.
 
-        if env_auto_run in ("false", "0", "no"):
-            self.logger.debug(
-                "🔍 Auto-run explicitly disabled via environment variable"
-            )
-            return False
-        else:
-            # Default to True - agents should run persistently by default
-            self.logger.debug("🔍 Auto-run enabled (default behavior)")
-            return True
+        Issue #1589: this used to be an env-only falsy denylist
+        (``in ("false", "0", "no")``), which had two consequences. It disagreed
+        with the other MCP_MESH_AUTO_RUN readers on values like ``off`` and on
+        unparseable input, and it never looked at the decorator argument — so
+        ``@mesh.agent(auto_run=False)``, whose documented use is to embed mesh
+        in your own server loop, still got a blocking uvicorn started on the
+        debounce timer thread. The decorator already merged env over its own
+        argument into ``metadata["auto_run"]``; feeding that back through the
+        shared resolver keeps the documented precedence with one parser.
+        """
+        from ...engine.decorator_registry import DecoratorRegistry
+        from ...shared.config_resolver import resolve_auto_run
+
+        # Read @mesh.agent metadata directly rather than via
+        # get_resolved_agent_config(): that helper synthesizes AND CACHES a
+        # fallback config (including an agent_id) when no @mesh.agent exists,
+        # and priming that cache here — before the API/A2A pipelines have
+        # written their own service identity — would change the registered
+        # service_id. API/A2A processes have no @mesh.agent, so they simply
+        # fall through to the env value.
+        decorator_auto_run = None
+        for decorated_func in DecoratorRegistry.get_mesh_agents().values():
+            value = (decorated_func.metadata or {}).get("auto_run")
+            if value is not None:
+                decorator_auto_run = value
+                break
+
+        enabled = resolve_auto_run(override=decorator_auto_run)
+        # Name the value for what it is. ``decorator_auto_run`` is @mesh.agent's
+        # metadata["auto_run"], which the decorator ALREADY resolved as
+        # ENV > argument — so logging it as "decorator auto_run" made the
+        # precedence unfalsifiable from logs (env and argument look identical
+        # once merged). Log the raw env separately and say which one won.
+        env_raw = os.getenv("MCP_MESH_AUTO_RUN")
+        source = "env" if env_raw is not None else "@mesh.agent metadata/default"
+        self.logger.debug(
+            f"🔍 Auto-run resolved to {enabled} via {source} "
+            f"(MCP_MESH_AUTO_RUN={env_raw!r}, "
+            f"@mesh.agent metadata['auto_run']={decorator_auto_run!r} "
+            f"— already env-merged by the decorator)"
+        )
+        return enabled
 
 
 # Global debounce coordinator instance

--- a/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_orchestrator.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/mcp_startup/startup_orchestrator.py
@@ -571,136 +571,182 @@ class DebounceCoordinator:
                     "heartbeating without starting a server or blocking"
                 )
 
-                if pipeline_type == "mcp":
-                    result = asyncio.run(orchestrator.process_once())
-                elif pipeline_type == "api":
-                    result = asyncio.run(orchestrator.process_api_once())
-                elif pipeline_type == "a2a":
-                    result = asyncio.run(orchestrator.process_a2a_once())
-                else:
-                    raise RuntimeError(f"Unsupported pipeline type: {pipeline_type}")
+                # Every exit from here on has to leave a terminal status
+                # behind. `pending` is worse than `failed` for a caller
+                # polling mesh.startup_status(): it cannot tell "still
+                # starting" from "crashed and never will", so it waits
+                # forever instead of shutting its server down — the same
+                # #1556 shape the failed-result branch below exists to
+                # prevent, reached by a crash instead of a clean failure.
+                status_recorded = False
+                try:
+                    if pipeline_type == "mcp":
+                        result = asyncio.run(orchestrator.process_once())
+                    elif pipeline_type == "api":
+                        result = asyncio.run(orchestrator.process_api_once())
+                    elif pipeline_type == "a2a":
+                        result = asyncio.run(orchestrator.process_a2a_once())
+                    else:
+                        raise RuntimeError(
+                            f"Unsupported pipeline type: {pipeline_type}"
+                        )
 
-                # Embedded-mode failure contract. The auto-run branch answers
-                # this with abort_agent_process(); neither of its options is
-                # available here. Exiting is wrong — the caller owns the
-                # process and mesh would be killing a server it does not
-                # manage. Raising is USELESS: we are on a threading.Timer
-                # thread, so the exception reaches threading.excepthook, prints
-                # a traceback, kills that thread, and leaves the caller's
-                # server happily serving an agent that never registered with
-                # exit status 0 — the exact #1556 shape. So the outcome is
-                # RECORDED for the caller to poll (mesh.startup_status()) and
-                # announced at ERROR; the raise below only gets the traceback
-                # to stderr, and is explicitly not the contract.
-                if result.get("status") == "failed":
-                    err_detail = result.get("message") or "unknown error"
-                    errors = result.get("errors") or []
-                    if errors:
-                        err_detail = f"{err_detail}: {errors}"
-                    embedded_status.set_failed(pipeline_type, err_detail)
-                    self.logger.error(
-                        f"❌ {pipeline_type.upper()} pipeline failed in embedded "
-                        f"mode: {err_detail}. This agent is NOT registered and "
-                        f"has NO dependency injection. Mesh cannot exit the "
-                        f"process here because your code owns it — poll "
-                        f"mesh.startup_status() and shut down your server if "
-                        f"state == 'failed'."
-                    )
-                    raise RuntimeError(
-                        f"{pipeline_type.upper()} pipeline failed: {err_detail}"
-                    )
+                    # Embedded-mode failure contract. The auto-run branch answers
+                    # this with abort_agent_process(); neither of its options is
+                    # available here. Exiting is wrong — the caller owns the
+                    # process and mesh would be killing a server it does not
+                    # manage. Raising is USELESS: we are on a threading.Timer
+                    # thread, so the exception reaches threading.excepthook, prints
+                    # a traceback, kills that thread, and leaves the caller's
+                    # server happily serving an agent that never registered with
+                    # exit status 0 — the exact #1556 shape. So the outcome is
+                    # RECORDED for the caller to poll (mesh.startup_status()) and
+                    # announced at ERROR; the raise below only gets the traceback
+                    # to stderr, and is explicitly not the contract.
+                    if result.get("status") == "failed":
+                        err_detail = result.get("message") or "unknown error"
+                        errors = result.get("errors") or []
+                        if errors:
+                            err_detail = f"{err_detail}: {errors}"
+                        embedded_status.set_failed(pipeline_type, err_detail)
+                        status_recorded = True
+                        self.logger.error(
+                            f"❌ {pipeline_type.upper()} pipeline failed in embedded "
+                            f"mode: {err_detail}. This agent is NOT registered and "
+                            f"has NO dependency injection. Mesh cannot exit the "
+                            f"process here because your code owns it — poll "
+                            f"mesh.startup_status() and shut down your server if "
+                            f"state == 'failed'."
+                        )
+                        raise RuntimeError(
+                            f"{pipeline_type.upper()} pipeline failed: {err_detail}"
+                        )
 
-                pipeline_context = result.get("context", {}).get("pipeline_context", {})
-                heartbeat_config = pipeline_context.get("heartbeat_config", {})
-
-                # No ``server_started_check`` on any of these branches: mesh is
-                # not starting the server, so there is nothing to gate the first
-                # registration on. The caller's loop owns serving, and the port
-                # registered is the configured one (nothing bound a socket here
-                # to override it) — same contract as the API/A2A paths.
-                if pipeline_type == "api":
-                    from ..api_heartbeat.api_lifespan_integration import (
-                        api_heartbeat_lifespan_task,
+                    pipeline_context = result.get("context", {}).get(
+                        "pipeline_context", {}
                     )
+                    heartbeat_config = pipeline_context.get("heartbeat_config", {})
 
-                    heartbeat_started = self._setup_heartbeat_background(
-                        heartbeat_config,
-                        pipeline_context,
-                        api_heartbeat_lifespan_task,
-                        id_field="service_id",
-                        label="API service",
-                    )
-                elif pipeline_type == "a2a":
-                    from ..a2a_heartbeat.a2a_lifespan_integration import (
-                        a2a_heartbeat_lifespan_task,
-                    )
+                    # No ``server_started_check`` on any of these branches: mesh is
+                    # not starting the server, so there is nothing to gate the first
+                    # registration on. The caller's loop owns serving, and the port
+                    # registered is the configured one (nothing bound a socket here
+                    # to override it) — same contract as the API/A2A paths.
+                    if pipeline_type == "api":
+                        from ..api_heartbeat.api_lifespan_integration import (
+                            api_heartbeat_lifespan_task,
+                        )
 
-                    heartbeat_started = self._setup_heartbeat_background(
-                        heartbeat_config,
-                        pipeline_context,
-                        a2a_heartbeat_lifespan_task,
-                        id_field="service_id",
-                        label="A2A service",
-                    )
-                else:
-                    heartbeat_task_fn = heartbeat_config.get("heartbeat_task_fn")
-                    if heartbeat_task_fn is None or not callable(heartbeat_task_fn):
-                        if heartbeat_task_fn is not None:
-                            self.logger.warning(
-                                f"heartbeat_task_fn from config is not callable: "
-                                f"{type(heartbeat_task_fn)}, using Rust heartbeat"
-                            )
-                        from ..mcp_heartbeat.rust_heartbeat import rust_heartbeat_task
+                        heartbeat_started = self._setup_heartbeat_background(
+                            heartbeat_config,
+                            pipeline_context,
+                            api_heartbeat_lifespan_task,
+                            id_field="service_id",
+                            label="API service",
+                        )
+                    elif pipeline_type == "a2a":
+                        from ..a2a_heartbeat.a2a_lifespan_integration import (
+                            a2a_heartbeat_lifespan_task,
+                        )
 
-                        heartbeat_task_fn = rust_heartbeat_task
-
-                    heartbeat_started = self._setup_heartbeat_background(
-                        heartbeat_config,
-                        pipeline_context,
-                        heartbeat_task_fn,
-                    )
-
-                # Report what actually happened, not what was intended. The
-                # heartbeat is skipped in standalone mode and swallowed on
-                # setup failure, and the MCP pipeline can succeed without
-                # producing an app for the caller to serve — announcing
-                # "registered and heartbeating" unconditionally would paper
-                # over all three.
-                warnings: list[str] = []
-                if not heartbeat_started:
-                    warnings.append(
-                        "no heartbeat thread started (standalone mode, or setup "
-                        "failed) - this agent will not stay registered"
-                    )
-                if pipeline_type == "mcp" and not pipeline_context.get("fastapi_app"):
-                    if pipeline_context.get("http_transport_disabled"):
-                        warnings.append(
-                            "HTTP transport is disabled (MCP_MESH_HTTP_ENABLED), "
-                            "so there is no app to serve"
+                        heartbeat_started = self._setup_heartbeat_background(
+                            heartbeat_config,
+                            pipeline_context,
+                            a2a_heartbeat_lifespan_task,
+                            id_field="service_id",
+                            label="A2A service",
                         )
                     else:
-                        warnings.append(
-                            "the pipeline produced no FastAPI app, so there is "
-                            "nothing for your server loop to serve on the "
-                            "registered port"
+                        heartbeat_task_fn = heartbeat_config.get("heartbeat_task_fn")
+                        if heartbeat_task_fn is None or not callable(heartbeat_task_fn):
+                            if heartbeat_task_fn is not None:
+                                self.logger.warning(
+                                    f"heartbeat_task_fn from config is not callable: "
+                                    f"{type(heartbeat_task_fn)}, using Rust heartbeat"
+                                )
+                            from ..mcp_heartbeat.rust_heartbeat import (
+                                rust_heartbeat_task,
+                            )
+
+                            heartbeat_task_fn = rust_heartbeat_task
+
+                        heartbeat_started = self._setup_heartbeat_background(
+                            heartbeat_config,
+                            pipeline_context,
+                            heartbeat_task_fn,
                         )
 
-                embedded_status.set_ready(
-                    pipeline_type, heartbeat=heartbeat_started, warnings=warnings
-                )
+                    # Report what actually happened, not what was intended. The
+                    # heartbeat is skipped in standalone mode and swallowed on
+                    # setup failure, and the MCP pipeline can succeed without
+                    # producing an app for the caller to serve — announcing
+                    # "registered and heartbeating" unconditionally would paper
+                    # over all three.
+                    warnings: list[str] = []
+                    if not heartbeat_started:
+                        warnings.append(
+                            "no heartbeat thread started (standalone mode, or setup "
+                            "failed) - this agent will not stay registered"
+                        )
+                    if pipeline_type == "mcp" and not pipeline_context.get(
+                        "fastapi_app"
+                    ):
+                        if pipeline_context.get("http_transport_disabled"):
+                            warnings.append(
+                                "HTTP transport is disabled (MCP_MESH_HTTP_ENABLED), "
+                                "so there is no app to serve"
+                            )
+                        else:
+                            warnings.append(
+                                "the pipeline produced no FastAPI app, so there is "
+                                "nothing for your server loop to serve on the "
+                                "registered port"
+                            )
 
-                if warnings:
-                    for warning in warnings:
-                        self.logger.warning(f"⚠️ Embedded mode: {warning}")
-                    self.logger.warning(
-                        "⚠️ Embedded mode started with warnings - see "
-                        "mesh.startup_status()['warnings']"
+                    embedded_status.set_ready(
+                        pipeline_type, heartbeat=heartbeat_started, warnings=warnings
                     )
-                else:
-                    self.logger.info(
-                        "✅ Embedded mode ready - agent registered and heartbeating; "
-                        "the caller owns the server and the process lifetime"
-                    )
+                    status_recorded = True
+
+                    if warnings:
+                        for warning in warnings:
+                            self.logger.warning(f"⚠️ Embedded mode: {warning}")
+                        self.logger.warning(
+                            "⚠️ Embedded mode started with warnings - see "
+                            "mesh.startup_status()['warnings']"
+                        )
+                    else:
+                        self.logger.info(
+                            "✅ Embedded mode ready - agent registered and heartbeating; "
+                            "the caller owns the server and the process lifetime"
+                        )
+                except Exception as e:
+                    # The pipeline raised instead of returning a failed
+                    # result. `status_recorded` keeps this from clobbering
+                    # the richer detail the failed-result branch already
+                    # wrote before raising (set_failed is last-write-wins),
+                    # and the re-raise keeps the outer handler's behaviour
+                    # intact — nothing is swallowed, only recorded.
+                    #
+                    # This deliberately also covers the "Unsupported
+                    # pipeline type" RuntimeError above. That one is a mesh
+                    # bug rather than a runtime failure, but the caller's
+                    # situation is identical either way (nothing registered,
+                    # nothing ever will be), and a poll that only terminates
+                    # for the failures mesh anticipated is a poll the caller
+                    # still has to time out. The recorded detail names the
+                    # exception class, so a bug still reads as a bug.
+                    if not status_recorded:
+                        detail = f"{type(e).__name__}: {e}"
+                        embedded_status.set_failed(pipeline_type, detail)
+                        self.logger.error(
+                            f"❌ {pipeline_type.upper()} pipeline crashed in "
+                            f"embedded mode: {detail}. This agent is NOT "
+                            f"registered and has NO dependency injection. "
+                            f"Poll mesh.startup_status() and shut down your "
+                            f"server if state == 'failed'."
+                        )
+                    raise
 
         except Exception as e:
             self.logger.error(f"❌ Error in debounced processing: {e}")

--- a/src/runtime/python/_mcp_mesh/pipeline/shared/dependency_spec.py
+++ b/src/runtime/python/_mcp_mesh/pipeline/shared/dependency_spec.py
@@ -1,0 +1,187 @@
+"""Shared ``DependencySpec`` construction for every heartbeat path.
+
+Issue #1571: the @mesh.tool heartbeat serialized the complete dependency
+selector (tags, version, expected schema, match_mode, required) while the
+@mesh.route and @mesh.a2a heartbeats each built their own reduced spec —
+routes lost everything but the capability name, A2A lost ``required``,
+``match_mode`` and the schema pair. Three copies meant three chances to
+drift, so the construction (including the Issue #547 consumer-side schema
+normalization) lives here and every path calls it.
+"""
+
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def cluster_strict_enabled() -> bool:
+    """Issue #547 Phase 4: read MCP_MESH_SCHEMA_STRICT env var (cluster-wide knob).
+
+    When true, WARN verdicts are promoted to BLOCK so ops can harden a whole
+    cluster without changing every consumer.
+    """
+    return os.environ.get("MCP_MESH_SCHEMA_STRICT", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def should_refuse_startup(
+    verdict: str, cluster_strict: bool, tool_strict: bool
+) -> bool:
+    """Issue #547 Phase 4: schema verdict policy.
+
+    Composes two knobs:
+      * cluster_strict (env MCP_MESH_SCHEMA_STRICT): promotes WARN→BLOCK.
+      * tool_strict (per-tool output_schema_strict, default True): producer-side
+        escape hatch. When False, BLOCK is demoted to WARN for that tool.
+
+    Truth table:
+      verdict=BLOCK + tool_strict=True  -> refuse
+      verdict=BLOCK + tool_strict=False -> log only (override wins)
+      verdict=WARN  + cluster_strict=True + tool_strict=True  -> refuse
+      verdict=WARN  + cluster_strict=True + tool_strict=False -> log only
+      verdict=WARN  + cluster_strict=False -> log only
+      verdict=OK -> never refuse
+    """
+    if verdict == "BLOCK":
+        return tool_strict
+    if verdict == "WARN":
+        return cluster_strict and tool_strict
+    return False
+
+
+def build_dependency_spec(
+    core: Any, dep_info: dict[str, Any], *, cluster_strict: bool | None = None
+) -> Any:
+    """Build one Rust ``DependencySpec`` carrying the complete selector.
+
+    Args:
+        core: The ``mcp_mesh_core`` module (each pipeline resolves it lazily).
+        dep_info: A validated dependency mapping as produced by
+            ``mesh.decorators._validate_dependency_selector`` — ``capability``
+            plus optional ``tags``, ``version``, ``required``, ``match_mode``
+            and ``expected_schema_raw``.
+        cluster_strict: MCP_MESH_SCHEMA_STRICT verdict promotion. Resolved
+            from the environment when omitted; pass it explicitly when
+            building a batch so the env is read once.
+
+    Raises:
+        RuntimeError: when schema normalization returns a verdict that the
+            #547 policy refuses to start on.
+    """
+    if cluster_strict is None:
+        cluster_strict = cluster_strict_enabled()
+
+    capability = dep_info.get("capability", "")
+
+    # Serialize tags to JSON to support nested arrays for OR alternatives
+    # e.g., ["addition", ["python", "typescript"]] -> addition AND (python OR typescript)
+    tags_json = json.dumps(dep_info.get("tags", []))
+
+    # Issue #547 Phase 1D: normalize the consumer's expected schema via the
+    # Rust normalizer (deferred from decorator time to keep import cheap and
+    # consistent with producer-side normalization).
+    expected_canonical: str | None = None
+    expected_hash: str | None = None
+    match_mode = dep_info.get("match_mode")
+    expected_raw = dep_info.get("expected_schema_raw")
+    if expected_raw is not None:
+        try:
+            normalize_fn = getattr(core, "normalize_schema_py", None)
+            if normalize_fn is None:
+                raise AttributeError("normalize_schema_py not in mcp_mesh_core")
+            result = json.loads(normalize_fn(json.dumps(expected_raw), "python"))
+            verdict = result.get("verdict", "OK")
+            warnings_list = result.get("warnings") or []
+            # Issue #547 Phase 4: there's no per-tool override on the consumer
+            # side (the override is producer-side); use tool_strict=True so
+            # cluster_strict still promotes WARN.
+            if should_refuse_startup(verdict, cluster_strict, True):
+                promoted = (
+                    " (MCP_MESH_SCHEMA_STRICT=true upgraded WARN→BLOCK)"
+                    if verdict == "WARN"
+                    else ""
+                )
+                raise RuntimeError(
+                    f"Schema normalization {verdict} for dependency on "
+                    f"'{capability}'{promoted}: {warnings_list}. Cannot start agent."
+                )
+            if verdict == "WARN":
+                logger.warning(
+                    f"Schema WARN for dependency on '{capability}': {warnings_list}"
+                )
+            if result.get("canonical"):
+                expected_canonical = json.dumps(result["canonical"])
+                expected_hash = result.get("hash")
+        except RuntimeError:
+            raise
+        except Exception as e:
+            logger.warning(
+                f"Could not normalize expected schema for dep '{capability}': {e}"
+            )
+            expected_canonical = None
+            expected_hash = None
+
+    return core.DependencySpec(
+        capability=capability,
+        tags=tags_json,
+        version=dep_info.get("version"),
+        expected_schema_canonical=expected_canonical,
+        expected_schema_hash=expected_hash,
+        match_mode=match_mode,
+        # Issue #1249: opt-in strictness flag (default False). The registry
+        # factors required edges into transitive capability availability.
+        # Absent/false is omitted from the wire payload by the core's
+        # skip_serializing_if.
+        required=bool(dep_info.get("required", False)),
+    )
+
+
+def build_dependency_specs(
+    core: Any,
+    dep_infos: list[Any],
+    *,
+    cluster_strict: bool | None = None,
+) -> list[Any]:
+    """Build ``DependencySpec``s for a list of validated dependency mappings.
+
+    Bare strings are accepted (and treated as a capability with no selector) so
+    pre-#1571 callers that only ever held capability names keep working.
+
+    The output is STRICTLY INDEX-ALIGNED with the input: one spec per entry,
+    never dropped, never reordered. The registry resolves dependencies by
+    position (``IndexedResolution.DepIndex``) and the injector applies them by
+    position in the decorator's metadata list, so silently omitting a
+    degenerate entry would shift every later dependency onto the wrong slot —
+    a far worse outcome than publishing an edge that cannot resolve. Degenerate
+    entries are therefore warned about and emitted as-is.
+    """
+    if cluster_strict is None:
+        cluster_strict = cluster_strict_enabled()
+
+    specs = []
+    for index, dep_info in enumerate(dep_infos):
+        if isinstance(dep_info, str):
+            dep_info = {"capability": dep_info, "tags": []}
+        elif not isinstance(dep_info, dict):
+            logger.warning(
+                f"Dependency at index {index} has unsupported type "
+                f"{type(dep_info).__name__}; publishing an empty-capability edge "
+                f"to keep dependency indices aligned. It will never resolve."
+            )
+            dep_info = {"capability": "", "tags": []}
+        if not dep_info.get("capability"):
+            logger.warning(
+                f"Dependency at index {index} has an empty capability; it will "
+                f"never resolve. Publishing it anyway so the indices of later "
+                f"dependencies still line up with the injector."
+            )
+        specs.append(
+            build_dependency_spec(core, dep_info, cluster_strict=cluster_strict)
+        )
+    return specs

--- a/src/runtime/python/_mcp_mesh/shared/config_resolver.py
+++ b/src/runtime/python/_mcp_mesh/shared/config_resolver.py
@@ -273,3 +273,35 @@ def _validate_value(value: Any, rule: ValidationRule, env_var: str) -> Any:
 
     else:
         raise ConfigResolutionError(f"Unknown validation rule: {rule}")
+
+
+def resolve_auto_run(override: Any = None) -> bool:
+    """Resolve MCP_MESH_AUTO_RUN with the documented ENV > decorator > default order.
+
+    Issue #1589: three call sites parsed this env var three different ways —
+    a strict ``== "true"`` gate on the runtime bootstrap, this module's
+    truthy rule in the @mesh.agent decorator, and a falsy denylist in the
+    startup orchestrator. ``MCP_MESH_AUTO_RUN=1`` therefore started the
+    immediate uvicorn but never wired the orchestrator, leaving an agent
+    that serves probes and never registers. Every MCP_MESH_AUTO_RUN reader
+    now calls this: the @mesh.agent decorator, the startup orchestrator and
+    DecoratorRegistry's synthetic fallback config.
+
+    Args:
+        override: The ``auto_run=`` decorator argument, when the caller has
+            one. The env var still wins, per the documented hierarchy.
+
+    Returns:
+        True when auto-run is enabled. Unparseable values fall back to the
+        default (True) after ``get_config_value`` logs the validation error —
+        the same soft-fail every other truthy mesh knob uses.
+    """
+    from .defaults import MeshDefaults
+
+    value = get_config_value(
+        "MCP_MESH_AUTO_RUN",
+        override=override,
+        default=MeshDefaults.AUTO_RUN,
+        rule=ValidationRule.TRUTHY_RULE,
+    )
+    return bool(MeshDefaults.AUTO_RUN if value is None else value)

--- a/src/runtime/python/mesh/__init__.py
+++ b/src/runtime/python/mesh/__init__.py
@@ -249,6 +249,14 @@ def __getattr__(name):
         from _mcp_mesh.engine.llm_errors import ToolExecutionError
 
         return ToolExecutionError
+    elif name == "startup_status":
+        # Issue #1589: the observable outcome of embedded-mode startup
+        # (auto_run=False). Mesh cannot exit the process (the caller owns it)
+        # and cannot usefully raise (startup runs on a threading.Timer), so a
+        # caller that embeds mesh in its own server loop polls this instead.
+        from _mcp_mesh.pipeline.mcp_startup.embedded_status import get_status
+
+        return get_status
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 

--- a/src/runtime/python/mesh/decorators.py
+++ b/src/runtime/python/mesh/decorators.py
@@ -14,7 +14,11 @@ from typing import Any, TypeVar
 # Import from _mcp_mesh for registry and runtime integration
 from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
 from _mcp_mesh.engine.strict_di import StrictDIError
-from _mcp_mesh.shared.config_resolver import ValidationRule, get_config_value
+from _mcp_mesh.shared.config_resolver import (
+    ValidationRule,
+    get_config_value,
+    resolve_auto_run,
+)
 from _mcp_mesh.shared.simple_shutdown import start_blocking_loop_with_shutdown_support
 
 logger = logging.getLogger(__name__)
@@ -755,6 +759,134 @@ def _trigger_debounced_processing():
         logger.debug(f"⚠️ Failed to trigger debounced processing: {e}")
 
 
+def _validate_dependency_selector(dep: Any) -> dict[str, Any]:
+    """Validate one dependency entry and normalize it to the wire mapping.
+
+    Issue #1571: @mesh.tool, @mesh.route and @mesh.a2a each carried their own
+    copy of this validation and the copies had drifted — the route copy
+    silently dropped ``expected_type``/``match_mode`` and the a2a copy dropped
+    ``required`` on top of that, so a selector that validated cleanly at
+    decoration time reached the registry with fields missing. One
+    implementation means one selector contract for every decorator family.
+
+    Accepts a bare capability name or a mapping of
+    ``capability``/``tags``/``version``/``required``/``expected_type``/
+    ``match_mode``. Returns the mapping the heartbeat serializes; optional
+    fields are omitted rather than emitted as null.
+
+    Raises:
+        ValueError: on any malformed field.
+    """
+    if isinstance(dep, str):
+        # Simple string dependency
+        return {"capability": dep, "tags": []}
+
+    if not isinstance(dep, dict):
+        raise ValueError("dependencies must be strings or dictionaries")
+
+    # Complex dependency with metadata
+    if "capability" not in dep:
+        raise ValueError("dependency must have 'capability' field")
+    if not isinstance(dep["capability"], str):
+        raise ValueError("dependency capability must be a string")
+
+    # Validate optional dependency fields
+    # Tags can be strings or arrays of strings (OR alternatives)
+    # e.g., ["required", ["python", "typescript"]] = required AND (python OR typescript)
+    dep_tags = dep.get("tags", [])
+    if not isinstance(dep_tags, list):
+        raise ValueError("dependency tags must be a list")
+    for tag in dep_tags:
+        if isinstance(tag, str):
+            continue  # Simple tag - OK
+        elif isinstance(tag, list):
+            # OR alternative - validate inner tags are all strings
+            for inner_tag in tag:
+                if not isinstance(inner_tag, str):
+                    raise ValueError("OR alternative tags must be strings")
+        else:
+            raise ValueError(
+                "tags must be strings or arrays of strings (OR alternatives)"
+            )
+
+    dep_version = dep.get("version")
+    if dep_version is not None and not isinstance(dep_version, str):
+        raise ValueError("dependency version must be a string")
+
+    # Issue #1249: opt-in strictness per dependency edge. When True, the
+    # registry factors this edge into transitive capability availability, and
+    # on @mesh.route an unavailable proxy trips the perimeter 503 before user
+    # code runs. Default False (soft-fail) keeps the null-proxy behaviour.
+    # Bool-only; string-form deps default to False (handled above).
+    dep_required = dep.get("required", False)
+    if not isinstance(dep_required, bool):
+        raise ValueError("dependency required must be a boolean")
+
+    # Issue #547 Phase 1D: optional consumer-side schema declaration.
+    # expected_type may be a Python type (Pydantic model, dataclass,
+    # TypedDict, primitive, etc.) OR a pre-built JSON Schema dict.
+    # match_mode is "subset" (default opt-in) or "strict".
+    expected_type = dep.get("expected_type")
+    match_mode = dep.get("match_mode")
+
+    if match_mode is not None and match_mode not in ("subset", "strict"):
+        raise ValueError("dependency match_mode must be 'subset' or 'strict'")
+
+    dependency_dict: dict[str, Any] = {
+        "capability": dep["capability"],
+        "tags": dep_tags,
+    }
+    if dep_version is not None:
+        dependency_dict["version"] = dep_version
+    # Only carry ``required`` when opted in (absent → false), matching the
+    # optional-field style of ``version`` above.
+    if dep_required:
+        dependency_dict["required"] = True
+
+    if expected_type is not None:
+        # Default match_mode to "subset" (most permissive opt-in) when the
+        # caller provides expected_type without match_mode.
+        if match_mode is None:
+            match_mode = "subset"
+        if isinstance(expected_type, dict):
+            # Caller supplied a pre-built JSON Schema; pass through.
+            dependency_dict["expected_schema_raw"] = expected_type
+        else:
+            # Defer the Rust-normalizer call to the heartbeat pipeline
+            # (decorator runs at import time; keep it cheap).
+            from _mcp_mesh.utils.fastmcp_schema_extractor import (
+                FastMCPSchemaExtractor,
+            )
+
+            schema = FastMCPSchemaExtractor.extract_type_schema(expected_type)
+            if schema is not None:
+                dependency_dict["expected_schema_raw"] = schema
+            # else: extraction failed; warning already logged.
+    elif match_mode is not None:
+        logger.warning(
+            f"dependency '{dep['capability']}': match_mode set "
+            "but no expected_type; schema check will be skipped"
+        )
+
+    if match_mode is not None:
+        dependency_dict["match_mode"] = match_mode
+
+    return dependency_dict
+
+
+def _validate_dependencies(dependencies: Any) -> list[dict[str, Any]]:
+    """Validate a decorator's ``dependencies`` list (issue #1571).
+
+    Shared by @mesh.tool, @mesh.route and @mesh.a2a so all three accept the
+    same selector fields and publish them identically.
+    """
+    if dependencies is None:
+        return []
+    if not isinstance(dependencies, list):
+        raise ValueError("dependencies must be a list")
+    return [_validate_dependency_selector(dep) for dep in dependencies]
+
+
 def _get_or_create_agent_id(agent_name: str | None = None) -> str:
     """
     Get or create a shared agent ID for all functions in this process.
@@ -1099,123 +1231,9 @@ def tool(
         if description is not None and not isinstance(description, str):
             raise ValueError("description must be a string")
 
-        # Validate and process dependencies
-        if dependencies is not None:
-            if not isinstance(dependencies, list):
-                raise ValueError("dependencies must be a list")
-
-            validated_dependencies = []
-            for dep in dependencies:
-                if isinstance(dep, str):
-                    # Simple string dependency
-                    validated_dependencies.append(
-                        {
-                            "capability": dep,
-                            "tags": [],
-                        }
-                    )
-                elif isinstance(dep, dict):
-                    # Complex dependency with metadata
-                    if "capability" not in dep:
-                        raise ValueError("dependency must have 'capability' field")
-                    if not isinstance(dep["capability"], str):
-                        raise ValueError("dependency capability must be a string")
-
-                    # Validate optional dependency fields
-                    # Tags can be strings or arrays of strings (OR alternatives)
-                    # e.g., ["required", ["python", "typescript"]] = required AND (python OR typescript)
-                    dep_tags = dep.get("tags", [])
-                    if not isinstance(dep_tags, list):
-                        raise ValueError("dependency tags must be a list")
-                    for tag in dep_tags:
-                        if isinstance(tag, str):
-                            continue  # Simple tag - OK
-                        elif isinstance(tag, list):
-                            # OR alternative - validate inner tags are all strings
-                            for inner_tag in tag:
-                                if not isinstance(inner_tag, str):
-                                    raise ValueError(
-                                        "OR alternative tags must be strings"
-                                    )
-                        else:
-                            raise ValueError(
-                                "tags must be strings or arrays of strings (OR alternatives)"
-                            )
-
-                    dep_version = dep.get("version")
-                    if dep_version is not None and not isinstance(dep_version, str):
-                        raise ValueError("dependency version must be a string")
-
-                    # Issue #1249: opt-in strictness per dependency edge. When
-                    # True, the registry factors this edge into transitive
-                    # capability availability. Default False (soft-fail) keeps
-                    # the existing null-proxy behaviour. Bool-only; string-form
-                    # deps default to False (handled above).
-                    dep_required = dep.get("required", False)
-                    if not isinstance(dep_required, bool):
-                        raise ValueError("dependency required must be a boolean")
-
-                    # Issue #547 Phase 1D: optional consumer-side schema declaration.
-                    # expected_type may be a Python type (Pydantic model, dataclass,
-                    # TypedDict, primitive, etc.) OR a pre-built JSON Schema dict.
-                    # match_mode is "subset" (default opt-in) or "strict".
-                    expected_type = dep.get("expected_type")
-                    match_mode = dep.get("match_mode")
-
-                    if match_mode is not None and match_mode not in (
-                        "subset",
-                        "strict",
-                    ):
-                        raise ValueError(
-                            "dependency match_mode must be 'subset' or 'strict'"
-                        )
-
-                    dependency_dict = {
-                        "capability": dep["capability"],
-                        "tags": dep_tags,
-                    }
-                    if dep_version is not None:
-                        dependency_dict["version"] = dep_version
-                    # Only carry ``required`` when opted in (absent → false),
-                    # matching the optional-field style of ``version`` above.
-                    if dep_required:
-                        dependency_dict["required"] = True
-
-                    if expected_type is not None:
-                        # Default match_mode to "subset" (most permissive opt-in)
-                        # when caller provides expected_type without match_mode.
-                        if match_mode is None:
-                            match_mode = "subset"
-                        if isinstance(expected_type, dict):
-                            # Caller supplied a pre-built JSON Schema; pass through.
-                            dependency_dict["expected_schema_raw"] = expected_type
-                        else:
-                            # Defer Rust-normalizer call to the heartbeat pipeline
-                            # (decorator runs at import time; keep it cheap).
-                            from _mcp_mesh.utils.fastmcp_schema_extractor import (
-                                FastMCPSchemaExtractor,
-                            )
-
-                            schema = FastMCPSchemaExtractor.extract_type_schema(
-                                expected_type
-                            )
-                            if schema is not None:
-                                dependency_dict["expected_schema_raw"] = schema
-                            # else: extraction failed; warning already logged.
-                    elif match_mode is not None:
-                        logger.warning(
-                            f"dependency '{dep['capability']}': match_mode set "
-                            "but no expected_type; schema check will be skipped"
-                        )
-
-                    if match_mode is not None:
-                        dependency_dict["match_mode"] = match_mode
-
-                    validated_dependencies.append(dependency_dict)
-                else:
-                    raise ValueError("dependencies must be strings or dictionaries")
-        else:
-            validated_dependencies = []
+        # Validate and process dependencies (issue #1571: one
+        # selector contract shared with @mesh.route and @mesh.a2a).
+        validated_dependencies = _validate_dependencies(dependencies)
 
         # RFC #1280: expand @mesh.service consumer-view parameters into
         # dependency edges appended AFTER the explicit deps — parameter order
@@ -1533,7 +1551,14 @@ def agent(
             ``health_check``, which degrades rather than withdrawing — see
             ``_mcp_mesh.shared.startup_check_manager``). Omitting it passes,
             so this is purely additive.
-        auto_run: Automatically start service and keep process alive (default: True)
+        auto_run: Start the HTTP server and keep the process alive (default: True)
+            auto_run gates the SERVER and the PROCESS LIFETIME — not mesh
+            membership. With auto_run=False the agent still runs its startup
+            pipeline, still registers with the registry, and still heartbeats
+            (so it stays registered and its dependencies resolve); mesh simply
+            does not start a server and does not block, leaving both to your
+            own server loop. Serve on the configured http_port — that is the
+            address the agent registers.
             Environment variable: MCP_MESH_AUTO_RUN (takes precedence)
         auto_run_interval: Keep-alive heartbeat interval in seconds (default: 10)
             Environment variable: MCP_MESH_AUTO_RUN_INTERVAL (takes precedence)
@@ -1552,6 +1577,11 @@ def agent(
     Auto-Run Feature:
         When auto_run=True, the decorator automatically starts the service and keeps
         the process alive. This eliminates the need for manual while True loops.
+
+        When auto_run=False, mesh registers and heartbeats but starts no server
+        and does not block — use this to embed a mesh agent in a server loop you
+        own. The agent is a full mesh member either way; only who owns the
+        server and the process differs.
 
         Example:
             @mesh.agent(name="my-service", auto_run=True)
@@ -1664,12 +1694,9 @@ def agent(
             rule=ValidationRule.NONZERO_RULE,
         )
 
-        final_auto_run = get_config_value(
-            "MCP_MESH_AUTO_RUN",
-            override=auto_run,
-            default=MeshDefaults.AUTO_RUN,
-            rule=ValidationRule.TRUTHY_RULE,
-        )
+        # Issue #1589: one resolver for every MCP_MESH_AUTO_RUN reader
+        # (this decorator, the runtime bootstrap and the startup orchestrator).
+        final_auto_run = resolve_auto_run(override=auto_run)
 
         final_auto_run_interval = get_config_value(
             "MCP_MESH_AUTO_RUN_INTERVAL",
@@ -1880,73 +1907,9 @@ def route(
                 f"McpMeshTool parameters with dependencies=[...] instead."
             )
 
-        # Validate and process dependencies (reuse logic from tool decorator)
-        if dependencies is not None:
-            if not isinstance(dependencies, list):
-                raise ValueError("dependencies must be a list")
-
-            validated_dependencies = []
-            for dep in dependencies:
-                if isinstance(dep, str):
-                    # Simple string dependency
-                    validated_dependencies.append(
-                        {
-                            "capability": dep,
-                            "tags": [],
-                        }
-                    )
-                elif isinstance(dep, dict):
-                    # Complex dependency with metadata
-                    if "capability" not in dep:
-                        raise ValueError("dependency must have 'capability' field")
-                    if not isinstance(dep["capability"], str):
-                        raise ValueError("dependency capability must be a string")
-
-                    # Validate optional dependency fields
-                    # Tags can be strings or arrays of strings (OR alternatives)
-                    # e.g., ["required", ["python", "typescript"]] = required AND (python OR typescript)
-                    dep_tags = dep.get("tags", [])
-                    if not isinstance(dep_tags, list):
-                        raise ValueError("dependency tags must be a list")
-                    for tag in dep_tags:
-                        if isinstance(tag, str):
-                            continue  # Simple tag - OK
-                        elif isinstance(tag, list):
-                            # OR alternative - validate inner tags are all strings
-                            for inner_tag in tag:
-                                if not isinstance(inner_tag, str):
-                                    raise ValueError(
-                                        "OR alternative tags must be strings"
-                                    )
-                        else:
-                            raise ValueError(
-                                "tags must be strings or arrays of strings (OR alternatives)"
-                            )
-
-                    dep_version = dep.get("version")
-                    if dep_version is not None and not isinstance(dep_version, str):
-                        raise ValueError("dependency version must be a string")
-
-                    # Issue #1249: required edge (default False). For routes,
-                    # a required dep whose proxy is unavailable at call time
-                    # trips the perimeter 503 before user code runs.
-                    dep_required = dep.get("required", False)
-                    if not isinstance(dep_required, bool):
-                        raise ValueError("dependency required must be a boolean")
-
-                    dependency_dict = {
-                        "capability": dep["capability"],
-                        "tags": dep_tags,
-                    }
-                    if dep_version is not None:
-                        dependency_dict["version"] = dep_version
-                    if dep_required:
-                        dependency_dict["required"] = True
-                    validated_dependencies.append(dependency_dict)
-                else:
-                    raise ValueError("dependencies must be strings or dictionaries")
-        else:
-            validated_dependencies = []
+        # Validate and process dependencies (issue #1571: one
+        # selector contract shared with @mesh.tool and @mesh.a2a).
+        validated_dependencies = _validate_dependencies(dependencies)
 
         # Build route metadata
         metadata = {
@@ -2293,57 +2256,9 @@ def a2a(
                 if not isinstance(tag, str):
                     raise ValueError("all tags must be strings")
 
-        # Validate and process dependencies (mirrors @mesh.route shape).
-        if dependencies is not None:
-            if not isinstance(dependencies, list):
-                raise ValueError("dependencies must be a list")
-
-            validated_dependencies = []
-            for dep in dependencies:
-                if isinstance(dep, str):
-                    validated_dependencies.append({"capability": dep, "tags": []})
-                elif isinstance(dep, dict):
-                    if "capability" not in dep:
-                        raise ValueError("dependency must have 'capability' field")
-                    if not isinstance(dep["capability"], str):
-                        raise ValueError("dependency capability must be a string")
-                    # Mirror @mesh.tool's tag validation — tags is a list
-                    # whose elements are either strings (AND-tags) or
-                    # nested lists of strings (OR-groups). Without this
-                    # check, malformed shapes (ints, nested ints, dicts)
-                    # would silently propagate to the registry and only
-                    # surface as confusing resolver mismatches at
-                    # capability-binding time.
-                    dep_tags = dep.get("tags", [])
-                    if not isinstance(dep_tags, list):
-                        raise ValueError("dependency tags must be a list")
-                    for tag in dep_tags:
-                        if isinstance(tag, str):
-                            continue
-                        elif isinstance(tag, list):
-                            for inner_tag in tag:
-                                if not isinstance(inner_tag, str):
-                                    raise ValueError(
-                                        "OR alternative tags must be strings"
-                                    )
-                        else:
-                            raise ValueError(
-                                "tags must be strings or arrays of strings (OR alternatives)"
-                            )
-                    dep_version = dep.get("version")
-                    if dep_version is not None and not isinstance(dep_version, str):
-                        raise ValueError("dependency version must be a string")
-                    dep_dict = {
-                        "capability": dep["capability"],
-                        "tags": dep_tags,
-                    }
-                    if dep_version is not None:
-                        dep_dict["version"] = dep_version
-                    validated_dependencies.append(dep_dict)
-                else:
-                    raise ValueError("dependencies must be strings or dictionaries")
-        else:
-            validated_dependencies = []
+        # Validate and process dependencies (issue #1571: one
+        # selector contract shared with @mesh.tool and @mesh.route).
+        validated_dependencies = _validate_dependencies(dependencies)
 
         if len(validated_dependencies) > 1:
             # v1 emits a single agent card per surface with one skill. Multi-

--- a/src/runtime/python/tests/conftest.py
+++ b/src/runtime/python/tests/conftest.py
@@ -11,9 +11,25 @@ Provides shared fixtures and test configuration across all test modules.
 # we ensure they're in place before any mesh code runs.
 import os
 
+# MCP_MESH_ENABLED is the inert switch: it is the only flag that stops
+# _mcp_mesh/__init__.py from calling start_runtime(), which is what hands the
+# debounce coordinator an orchestrator. Without it the suite's own decorators
+# schedule a real process_once() plus a daemon heartbeat thread that runs
+# core.start_agent(spec) and talks HTTP to MCP_MESH_REGISTRY_URL.
+#
+# Issue #1589: MCP_MESH_AUTO_RUN used to do this job as a side effect. It no
+# longer does, and must not — auto_run=False means "you own the server and the
+# process", NOT "stay out of the mesh", so it deliberately still registers.
+# The contamination is invisible if you only watch for red: the pipeline runs
+# on a threading.Timer, so its exceptions never reach pytest.
+os.environ["MCP_MESH_ENABLED"] = "false"
+
+# Still required, and NOT redundant with the above: the immediate uvicorn in
+# @mesh.agent is gated on auto_run alone (decorators.py:1753), independent of
+# both MCP_MESH_ENABLED and MCP_MESH_HTTP_ENABLED. Without this the decorator
+# binds a socket and blocks the collecting thread.
 os.environ["MCP_MESH_AUTO_RUN"] = "false"
 os.environ["MCP_MESH_HTTP_ENABLED"] = "false"
-os.environ["PYTEST_RUNNING"] = "true"
 
 import asyncio
 import shutil

--- a/src/runtime/python/tests/unit/test_auto_run_resolution_1589.py
+++ b/src/runtime/python/tests/unit/test_auto_run_resolution_1589.py
@@ -1,0 +1,151 @@
+"""Issue #1589: one MCP_MESH_AUTO_RUN parser, and honour ``auto_run=False``.
+
+Three call sites parsed the env var three different ways:
+
+* ``_mcp_mesh/__init__.py`` gated ``start_runtime()`` on ``== "true"``
+  (and gated it on auto-run at all, which kept a ``false`` agent out of the
+  mesh entirely rather than merely declining to start a server)
+* ``mesh/decorators.py`` used the truthy rule (``1``/``yes``/``on`` count)
+* ``startup_orchestrator`` used a falsy denylist (``false``/``0``/``no``)
+
+so ``MCP_MESH_AUTO_RUN=1`` started the immediate uvicorn and enabled the
+blocking-server branch, but never handed the debounce coordinator an
+orchestrator — the process served ``/ready`` with "Mesh runtime has not
+started yet" forever and never registered. ``off`` diverged the other way.
+The orchestrator also never consulted ``@mesh.agent(auto_run=False)``.
+"""
+
+from datetime import datetime
+
+import pytest
+
+import _mcp_mesh
+from _mcp_mesh.engine.decorator_registry import DecoratedFunction, DecoratorRegistry
+from _mcp_mesh.pipeline.mcp_startup.startup_orchestrator import DebounceCoordinator
+from _mcp_mesh.shared.config_resolver import resolve_auto_run
+
+TRUTHY = ["true", "TRUE", "True", "1", "yes", "on"]
+FALSY = ["false", "FALSE", "0", "no", "off"]
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    DecoratorRegistry.clear_all()
+    yield
+    DecoratorRegistry.clear_all()
+
+
+def _register_agent(auto_run):
+    def _agent():  # pragma: no cover - never called
+        return None
+
+    DecoratorRegistry._mesh_agents["_agent"] = DecoratedFunction(
+        decorator_type="mesh_agent",
+        function=_agent,
+        metadata={"name": "a", "auto_run": auto_run},
+        registered_at=datetime.now(),
+    )
+
+
+def _orchestrator_verdict():
+    return DebounceCoordinator(delay_seconds=0.01)._check_auto_run_enabled()
+
+
+@pytest.mark.parametrize("value", TRUTHY)
+def test_all_sites_agree_on_truthy_values(monkeypatch, value):
+    monkeypatch.setenv("MCP_MESH_AUTO_RUN", value)
+    assert resolve_auto_run() is True
+    assert _orchestrator_verdict() is True
+
+
+@pytest.mark.parametrize("value", FALSY)
+def test_all_sites_agree_on_falsy_values(monkeypatch, value):
+    monkeypatch.setenv("MCP_MESH_AUTO_RUN", value)
+    assert resolve_auto_run() is False
+    assert _orchestrator_verdict() is False
+
+
+def test_unset_defaults_to_enabled(monkeypatch):
+    monkeypatch.delenv("MCP_MESH_AUTO_RUN", raising=False)
+    assert resolve_auto_run() is True
+    assert _orchestrator_verdict() is True
+
+
+def test_unparseable_value_soft_fails_to_the_default(monkeypatch):
+    """Garbage falls back to the default rather than half-enabling the agent."""
+    monkeypatch.setenv("MCP_MESH_AUTO_RUN", "bogus")
+    assert resolve_auto_run() is True
+    assert _orchestrator_verdict() is True
+
+
+@pytest.mark.parametrize("value", FALSY + TRUTHY + ["bogus"])
+def test_runtime_bootstrap_never_consults_auto_run(monkeypatch, value):
+    """start_runtime() is the prerequisite for REGISTERING, so auto-run — which
+    only decides who owns the server — must not gate it. MCP_MESH_ENABLED is
+    the switch that turns mesh off."""
+    monkeypatch.setenv("MCP_MESH_AUTO_RUN", value)
+    # conftest sets MCP_MESH_ENABLED=false to keep the suite inert; drop it so
+    # this asserts the gate's dependence on auto-run and nothing else.
+    monkeypatch.delenv("MCP_MESH_ENABLED", raising=False)
+    assert _mcp_mesh._mesh_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off"])
+def test_mesh_enabled_is_the_only_off_switch(monkeypatch, value):
+    monkeypatch.setenv("MCP_MESH_ENABLED", value)
+    assert _mcp_mesh._mesh_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "on"])
+def test_mesh_enabled_accepts_truthy_variants(monkeypatch, value):
+    """MCP_MESH_ENABLED had the identical ``== "true"`` bug on the same line."""
+    monkeypatch.setenv("MCP_MESH_ENABLED", value)
+    assert _mcp_mesh._mesh_enabled() is True
+
+
+def test_orchestrator_honours_decorator_auto_run_false(monkeypatch):
+    """@mesh.agent(auto_run=False) must not get a blocking uvicorn."""
+    monkeypatch.delenv("MCP_MESH_AUTO_RUN", raising=False)
+    _register_agent(False)
+    assert _orchestrator_verdict() is False
+
+
+def test_orchestrator_honours_decorator_auto_run_true(monkeypatch):
+    monkeypatch.delenv("MCP_MESH_AUTO_RUN", raising=False)
+    _register_agent(True)
+    assert _orchestrator_verdict() is True
+
+
+@pytest.mark.parametrize("value", TRUTHY)
+def test_env_overrides_decorator_false(monkeypatch, value):
+    """Documented hierarchy: ENV > decorator argument > default."""
+    monkeypatch.setenv("MCP_MESH_AUTO_RUN", value)
+    _register_agent(False)
+    assert _orchestrator_verdict() is True
+
+
+@pytest.mark.parametrize("value", FALSY)
+def test_env_overrides_decorator_true(monkeypatch, value):
+    monkeypatch.setenv("MCP_MESH_AUTO_RUN", value)
+    _register_agent(True)
+    assert _orchestrator_verdict() is False
+
+
+def test_orchestrator_without_mesh_agent_uses_env(monkeypatch):
+    """API/A2A processes have no @mesh.agent; they fall through to the env."""
+    monkeypatch.setenv("MCP_MESH_AUTO_RUN", "off")
+    assert _orchestrator_verdict() is False
+
+
+def test_check_auto_run_does_not_prime_the_agent_config_cache(monkeypatch):
+    """Resolving auto-run must not synthesize (and cache) an agent identity.
+
+    ``get_resolved_agent_config()`` caches a synthetic config with a generated
+    agent_id when no @mesh.agent exists. Priming that cache from the auto-run
+    check — which runs before the API/A2A pipelines write their own service
+    identity — would change the registered service_id.
+    """
+    monkeypatch.delenv("MCP_MESH_AUTO_RUN", raising=False)
+    assert DecoratorRegistry._cached_agent_config is None
+    _orchestrator_verdict()
+    assert DecoratorRegistry._cached_agent_config is None

--- a/src/runtime/python/tests/unit/test_embedded_mode_1589.py
+++ b/src/runtime/python/tests/unit/test_embedded_mode_1589.py
@@ -1,0 +1,394 @@
+"""Issue #1589: ``auto_run=False`` must still join the mesh.
+
+``auto_run`` gates the SERVER and the KEEP-ALIVE, not mesh membership. The
+orchestrator used to treat a disabled auto-run as "single execution mode":
+it ran the pipeline and returned without ever starting a heartbeat, so the
+agent wired dependency injection locally and never registered. An agent that
+does not register is not in the mesh at all, which is the opposite of what
+"embed mesh in your own server loop" is for.
+
+Required behaviour: run the pipeline, start the background heartbeat, do NOT
+start uvicorn, do NOT block.
+"""
+
+import threading
+import time
+from datetime import datetime
+
+import pytest
+
+from _mcp_mesh.engine.decorator_registry import DecoratedFunction, DecoratorRegistry
+from _mcp_mesh.pipeline.mcp_startup import startup_orchestrator as so
+from _mcp_mesh.pipeline.mcp_startup.startup_orchestrator import DebounceCoordinator
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.delenv("MCP_MESH_AUTO_RUN", raising=False)
+    DecoratorRegistry.clear_all()
+    yield
+    DecoratorRegistry.clear_all()
+
+
+def _register_agent(auto_run):
+    def _agent():  # pragma: no cover - never called
+        return None
+
+    DecoratorRegistry._mesh_agents["_agent"] = DecoratedFunction(
+        decorator_type="mesh_agent",
+        function=_agent,
+        metadata={"name": "a", "auto_run": auto_run},
+        registered_at=datetime.now(),
+    )
+
+
+class _UnwritableConfig(dict):
+    """Reads fine, rejects the write _setup_heartbeat_background does first."""
+
+    def __setitem__(self, key, value):
+        raise RuntimeError("cannot stage heartbeat config")
+
+
+class _Recorder:
+    """Stands in for the pipeline + uvicorn so the branch logic is observable."""
+
+    def __init__(self, pipeline_type="mcp", status="success"):
+        self.pipeline_type = pipeline_type
+        self.status = status
+        self.heartbeats_fired = threading.Event()
+        self.server_started = False
+        self.ran_pipeline = False
+        self.heartbeat_thread = None
+        self.standalone = False
+        self.drop_app = False
+        self.break_heartbeat_setup = False
+
+    async def _process(self):
+        self.ran_pipeline = True
+        heartbeat_config = {
+            "agent_id": "agent-1",
+            "service_id": "agent-1",
+            "heartbeat_task_fn": self._heartbeat,
+            "standalone_mode": self.standalone,
+        }
+        if self.break_heartbeat_setup:
+            heartbeat_config = _UnwritableConfig(heartbeat_config)
+        return {
+            "status": self.status,
+            "message": "boom" if self.status == "failed" else "",
+            "context": {
+                "pipeline_context": {
+                    "fastapi_app": None if self.drop_app else object(),
+                    "fastapi_binding_config": {
+                        "bind_host": "127.0.0.1",
+                        "bind_port": 0,
+                    },
+                    "heartbeat_config": heartbeat_config,
+                }
+            },
+        }
+
+    async def _heartbeat(self, heartbeat_config):
+        # Runs ON the heartbeat thread, so this is the thread under test.
+        self.heartbeat_thread = threading.current_thread()
+        self.heartbeats_fired.set()
+
+    def install(self, monkeypatch, coordinator):
+        orchestrator = type(
+            "FakeOrchestrator",
+            (),
+            {
+                "process_once": lambda _self: self._process(),
+                "process_api_once": lambda _self: self._process(),
+                "process_a2a_once": lambda _self: self._process(),
+            },
+        )()
+        coordinator.set_orchestrator(orchestrator)
+        monkeypatch.setattr(
+            coordinator, "_determine_pipeline_type", lambda: self.pipeline_type
+        )
+
+        def _no_server(*args, **kwargs):
+            self.server_started = True
+            time.sleep(30)  # a real blocking server never returns
+
+        monkeypatch.setattr(
+            DebounceCoordinator, "_start_blocking_fastapi_server", _no_server
+        )
+        monkeypatch.setattr(
+            so, "abort_agent_process", lambda *a, **k: pytest.fail("aborted")
+        )
+        return self
+
+
+def _run(coordinator, timeout=10.0):
+    """Execute processing on a worker thread; return True if it RETURNED."""
+    done = threading.Event()
+    error = []
+
+    def _target():
+        try:
+            coordinator._execute_processing()
+        except BaseException as e:  # noqa: BLE001
+            error.append(e)
+        finally:
+            done.set()
+
+    t = threading.Thread(target=_target, daemon=True)
+    t.start()
+    returned = done.wait(timeout)
+    return returned, error
+
+
+class TestEmbeddedMode:
+    def test_auto_run_false_still_starts_the_heartbeat(self, monkeypatch):
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        rec = _Recorder().install(monkeypatch, c)
+
+        returned, error = _run(c)
+
+        assert returned, "_execute_processing blocked; it must return"
+        assert not error, f"unexpected error: {error}"
+        assert rec.ran_pipeline, "pipeline must run so the agent registers"
+        assert rec.heartbeats_fired.wait(5), (
+            "no heartbeat fired with auto_run=False — the agent registered "
+            "once at best and would never stay registered"
+        )
+
+    def test_auto_run_false_does_not_start_a_server(self, monkeypatch):
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        rec = _Recorder().install(monkeypatch, c)
+
+        returned, _ = _run(c)
+
+        assert returned
+        assert not rec.server_started, "auto_run=False must not start uvicorn"
+
+    def test_auto_run_false_does_not_keep_the_process_alive(self, monkeypatch):
+        """The caller's own loop owns process lifetime, so the call returns."""
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        _Recorder().install(monkeypatch, c)
+
+        returned, _ = _run(c, timeout=10.0)
+
+        assert returned, "_execute_processing must not block on a keep-alive"
+
+    def test_heartbeat_thread_is_a_daemon(self, monkeypatch):
+        """A non-daemon heartbeat would keep the process alive on mesh's behalf."""
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        rec = _Recorder().install(monkeypatch, c)
+
+        returned, _ = _run(c)
+        assert returned
+        assert rec.heartbeats_fired.wait(5)
+
+        assert rec.heartbeat_thread is not None
+        assert rec.heartbeat_thread is not threading.main_thread()
+        assert rec.heartbeat_thread.daemon, (
+            "a non-daemon heartbeat thread would keep the interpreter alive, "
+            "which is exactly what auto_run=False asks mesh not to do"
+        )
+
+    def test_auto_run_true_still_starts_the_server(self, monkeypatch):
+        """Regression guard: the auto-run path is unchanged."""
+        _register_agent(True)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        rec = _Recorder().install(monkeypatch, c)
+
+        _run(c, timeout=6.0)
+
+        assert rec.server_started, "auto_run=True must still start uvicorn"
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "off"])
+    def test_env_false_overrides_decorator_true(self, monkeypatch, value):
+        """ENV > decorator: env-disabled behaves exactly like auto_run=False."""
+        monkeypatch.setenv("MCP_MESH_AUTO_RUN", value)
+        _register_agent(True)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        rec = _Recorder().install(monkeypatch, c)
+
+        returned, _ = _run(c)
+
+        assert returned
+        assert not rec.server_started
+        assert rec.heartbeats_fired.wait(5), "env-disabled must still heartbeat"
+
+    @pytest.mark.parametrize("pipeline_type", ["api", "a2a"])
+    def test_gateway_pipelines_heartbeat_when_auto_run_is_disabled(
+        self, monkeypatch, pipeline_type
+    ):
+        """API/A2A never blocked anyway; they must not lose their heartbeat."""
+        monkeypatch.setenv("MCP_MESH_AUTO_RUN", "false")
+        c = DebounceCoordinator(delay_seconds=0.01)
+        rec = _Recorder(pipeline_type=pipeline_type).install(monkeypatch, c)
+
+        fired = threading.Event()
+        module = (
+            "_mcp_mesh.pipeline.api_heartbeat.api_lifespan_integration"
+            if pipeline_type == "api"
+            else "_mcp_mesh.pipeline.a2a_heartbeat.a2a_lifespan_integration"
+        )
+        name = (
+            "api_heartbeat_lifespan_task"
+            if pipeline_type == "api"
+            else "a2a_heartbeat_lifespan_task"
+        )
+        import importlib
+
+        async def _task(cfg):
+            fired.set()
+
+        monkeypatch.setattr(importlib.import_module(module), name, _task)
+
+        returned, _ = _run(c)
+
+        assert returned
+        assert not rec.server_started
+        assert fired.wait(5), f"{pipeline_type} lost its heartbeat with auto_run=false"
+
+    def test_pipeline_failure_still_raises_in_embedded_mode(self, monkeypatch):
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        _Recorder(status="failed").install(monkeypatch, c)
+
+        returned, error = _run(c)
+
+        assert returned
+        assert error and isinstance(error[0], RuntimeError)
+        assert "pipeline failed" in str(error[0])
+
+    def test_embedded_mode_does_not_prime_the_agent_config_cache(self, monkeypatch):
+        monkeypatch.setenv("MCP_MESH_AUTO_RUN", "false")
+        c = DebounceCoordinator(delay_seconds=0.01)
+        _Recorder(pipeline_type="api").install(monkeypatch, c)
+
+        # Keep the real Rust-backed API heartbeat out of a unit test.
+        import _mcp_mesh.pipeline.api_heartbeat.api_lifespan_integration as api_mod
+
+        async def _task(cfg):
+            return None
+
+        monkeypatch.setattr(api_mod, "api_heartbeat_lifespan_task", _task)
+
+        assert DecoratorRegistry._cached_agent_config is None
+        _run(c)
+        assert DecoratorRegistry._cached_agent_config is None
+
+
+class TestEmbeddedFailureContract:
+    """The failure signal must survive the real ``threading.Timer`` path.
+
+    ``_execute_processing`` does not run on the caller's thread — the debounce
+    coordinator schedules it on a ``threading.Timer``. A ``raise`` there reaches
+    ``threading.excepthook`` and kills that thread; the caller's server keeps
+    serving an agent that never registered, and the process still exits 0. That
+    is issue #1556. These tests drive the coordinator the way a decorator does
+    (``trigger_processing()``), never by calling ``_execute_processing``
+    directly, so a contract that only "works" on a collected thread fails here.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_status(self):
+        from _mcp_mesh.pipeline.mcp_startup import embedded_status
+
+        embedded_status.reset()
+        yield
+        embedded_status.reset()
+
+    def _drive_through_timer(self, coordinator, timeout=10.0):
+        """Trigger via the debounce timer and wait for the outcome to land."""
+        from _mcp_mesh.pipeline.mcp_startup import embedded_status
+
+        coordinator.trigger_processing()
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            status = embedded_status.get_status()
+            if status["state"] != embedded_status.PENDING:
+                return status
+            time.sleep(0.05)
+        return embedded_status.get_status()
+
+    def test_failure_is_observable_after_the_timer_thread_dies(self, monkeypatch):
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        _Recorder(status="failed").install(monkeypatch, c)
+
+        status = self._drive_through_timer(c)
+
+        assert status["state"] == "failed", (
+            "the pipeline failed on the timer thread and left no trace the "
+            "caller can see — this is the #1556 shape"
+        )
+        assert "boom" in (status["error"] or "")
+        assert status["heartbeat"] is False
+
+    def test_failure_is_reachable_through_the_public_accessor(self, monkeypatch):
+        import mesh
+
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        _Recorder(status="failed").install(monkeypatch, c)
+
+        self._drive_through_timer(c)
+
+        assert mesh.startup_status()["state"] == "failed"
+
+    def test_success_is_observable_through_the_timer_path(self, monkeypatch):
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        rec = _Recorder().install(monkeypatch, c)
+
+        status = self._drive_through_timer(c)
+
+        assert status["state"] == "ready"
+        assert status["pipeline_type"] == "mcp"
+        assert status["heartbeat"] is True
+        assert status["warnings"] == []
+        assert rec.heartbeats_fired.wait(5)
+
+    def test_standalone_mode_is_reported_not_announced_as_success(self, monkeypatch):
+        """standalone_mode skips the heartbeat, so the agent will not stay in."""
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        rec = _Recorder().install(monkeypatch, c)
+        rec.standalone = True
+
+        status = self._drive_through_timer(c)
+
+        assert status["state"] == "ready"
+        assert status["heartbeat"] is False
+        assert any("will not stay registered" in w for w in status["warnings"])
+
+    def test_missing_app_is_reported(self, monkeypatch):
+        """A pipeline can succeed and still leave nothing for the caller to serve."""
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        rec = _Recorder().install(monkeypatch, c)
+        rec.drop_app = True
+
+        status = self._drive_through_timer(c)
+
+        assert status["state"] == "ready"
+        assert any("nothing for your server loop" in w for w in status["warnings"])
+
+    def test_heartbeat_setup_failure_is_not_reported_as_healthy(self, monkeypatch):
+        """_setup_heartbeat_background swallows exceptions into a warning.
+
+        Exercised through the real swallow path: the config write it does first
+        (``heartbeat_config["context"] = ...``) raises, so setup bails inside
+        its own ``except`` without ever starting a thread.
+        """
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        rec = _Recorder().install(monkeypatch, c)
+        rec.break_heartbeat_setup = True
+
+        status = self._drive_through_timer(c)
+
+        assert status["state"] == "ready"
+        assert status["heartbeat"] is False
+        assert any("will not stay registered" in w for w in status["warnings"])

--- a/src/runtime/python/tests/unit/test_embedded_mode_1589.py
+++ b/src/runtime/python/tests/unit/test_embedded_mode_1589.py
@@ -62,9 +62,12 @@ class _Recorder:
         self.standalone = False
         self.drop_app = False
         self.break_heartbeat_setup = False
+        self.raise_error = None
 
     async def _process(self):
         self.ran_pipeline = True
+        if self.raise_error is not None:
+            raise self.raise_error
         heartbeat_config = {
             "agent_id": "agent-1",
             "service_id": "agent-1",
@@ -374,6 +377,77 @@ class TestEmbeddedFailureContract:
 
         assert status["state"] == "ready"
         assert any("nothing for your server loop" in w for w in status["warnings"])
+
+    def test_pipeline_crash_is_observable_as_failed(self, monkeypatch):
+        """A RAISING pipeline must not leave the caller polling forever.
+
+        The failed-result branch only fires when the pipeline returns
+        ``status == "failed"``. When it raises instead, the exception lands on
+        the timer thread and nothing was ever recorded, so
+        ``startup_status()`` stayed ``pending`` — worse than ``failed``,
+        because a caller cannot tell "still starting" from "crashed and never
+        will" and waits indefinitely instead of shutting down.
+        """
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        rec = _Recorder().install(monkeypatch, c)
+        rec.raise_error = KeyError("registry_url")
+
+        status = self._drive_through_timer(c)
+
+        assert status["state"] == "failed", (
+            "the pipeline raised on the timer thread and left no trace the "
+            "caller can see — startup_status() is still 'pending' forever"
+        )
+        # The class matters: str(KeyError("registry_url")) is just
+        # "'registry_url'", which reads like a stray string on its own.
+        assert "KeyError" in (status["error"] or "")
+        assert "registry_url" in (status["error"] or "")
+        assert status["heartbeat"] is False
+
+    def test_crash_still_propagates_to_the_outer_handler(self, monkeypatch):
+        """Recording the outcome must not swallow the exception."""
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        rec = _Recorder().install(monkeypatch, c)
+        rec.raise_error = KeyError("registry_url")
+
+        returned, error = _run(c)
+
+        assert returned
+        assert error and isinstance(error[0], KeyError)
+
+    def test_failed_result_detail_is_not_overwritten_by_its_own_raise(
+        self, monkeypatch
+    ):
+        """The failed-result branch records, then raises. That raise now passes
+        through the crash handler, which must not replace the pipeline's own
+        message with a paraphrase of the RuntimeError wrapping it."""
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        _Recorder(status="failed").install(monkeypatch, c)
+
+        status = self._drive_through_timer(c)
+
+        assert status["state"] == "failed"
+        assert status["error"] == "boom", (
+            f"the recorded detail was clobbered by the re-raise: {status['error']!r}"
+        )
+
+    def test_unsupported_pipeline_type_is_recorded_too(self, monkeypatch):
+        """A mesh bug leaves the caller in the same place as a runtime failure.
+
+        Nothing registered and nothing ever will be, so it gets a terminal
+        status rather than an indefinite ``pending``.
+        """
+        _register_agent(False)
+        c = DebounceCoordinator(delay_seconds=0.01)
+        _Recorder(pipeline_type="bogus").install(monkeypatch, c)
+
+        status = self._drive_through_timer(c)
+
+        assert status["state"] == "failed"
+        assert "Unsupported pipeline type" in (status["error"] or "")
 
     def test_heartbeat_setup_failure_is_not_reported_as_healthy(self, monkeypatch):
         """_setup_heartbeat_background swallows exceptions into a warning.

--- a/src/runtime/python/tests/unit/test_gateway_dependency_selector_1571.py
+++ b/src/runtime/python/tests/unit/test_gateway_dependency_selector_1571.py
@@ -1,0 +1,344 @@
+"""Issue #1571: route and A2A dependency edges must carry the full selector.
+
+The @mesh.tool heartbeat path serializes ``tags``, ``version``, the expected
+schema pair, ``match_mode`` and ``required`` onto every ``DependencySpec``.
+The @mesh.route and @mesh.a2a paths used to flatten their edges — routes to a
+bare capability name with ``tags="[]"``/``version=None``, A2A to
+capability+tags+version — so a tag-routed or required gateway edge never
+reached the registry.
+"""
+
+import json
+
+import pytest
+
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+from _mcp_mesh.pipeline.a2a_heartbeat import rust_a2a_heartbeat
+from _mcp_mesh.pipeline.api_heartbeat import rust_api_heartbeat
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    # ``clear_all()`` does not touch ``_route_wrapper_registry`` (pre-existing
+    # gap, unrelated to #1571), so wrappers registered by earlier tests leak
+    # into the AgentSpec built here. Clear it explicitly at both ends.
+    def _reset():
+        DecoratorRegistry.clear_all()
+        DecoratorRegistry._route_wrapper_registry.clear()
+
+    _reset()
+    yield
+    _reset()
+
+
+def _dep_of(spec):
+    """Single dependency of the single tool on an AgentSpec."""
+    assert len(spec.tools) == 1, f"expected one tool spec, got {len(spec.tools)}"
+    deps = spec.tools[0].dependencies
+    assert deps is not None and len(deps) == 1, f"expected one dependency, got {deps}"
+    return deps[0]
+
+
+ROUTE_DEP = {
+    "capability": "llm",
+    "tags": ["+claude", ["python", "typescript"]],
+    "version": ">=2.0.0",
+    "required": True,
+    "match_mode": "strict",
+    "expected_schema_raw": {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+    },
+}
+
+
+def test_route_dependency_carries_full_selector():
+    def _handler():  # pragma: no cover - never called
+        return None
+
+    DecoratorRegistry.register_route_wrapper(
+        method="GET",
+        path="/api/v1/ask",
+        wrapper=_handler,
+        dependencies=["llm"],
+        dependency_specs=[ROUTE_DEP],
+    )
+
+    spec = rust_api_heartbeat._build_api_agent_spec(
+        {"agent_config": {"name": "gw"}, "display_config": {}}, service_id="gw-1"
+    )
+    dep = _dep_of(spec)
+
+    assert dep.capability == "llm"
+    assert json.loads(dep.tags) == ["+claude", ["python", "typescript"]]
+    assert dep.version == ">=2.0.0"
+    assert dep.required is True
+    assert dep.match_mode == "strict"
+    assert dep.expected_schema_canonical is not None
+    assert dep.expected_schema_hash is not None
+
+
+def test_route_dependency_capability_is_a_string_not_a_dict():
+    """Regression guard: ``capability`` must never receive the dep mapping."""
+
+    def _handler():  # pragma: no cover - never called
+        return None
+
+    DecoratorRegistry.register_route_wrapper(
+        method="GET",
+        path="/api/v1/ask",
+        wrapper=_handler,
+        dependencies=["llm"],
+        dependency_specs=[ROUTE_DEP],
+    )
+
+    spec = rust_api_heartbeat._build_api_agent_spec(
+        {"agent_config": {"name": "gw"}, "display_config": {}}, service_id="gw-1"
+    )
+    assert isinstance(_dep_of(spec).capability, str)
+
+
+def test_route_dependency_without_specs_still_registers_capability():
+    """Back-compat: a wrapper registered before #1571 has no dependency_specs."""
+
+    def _handler():  # pragma: no cover - never called
+        return None
+
+    DecoratorRegistry.register_route_wrapper(
+        method="GET", path="/api/v1/ask", wrapper=_handler, dependencies=["llm"]
+    )
+
+    spec = rust_api_heartbeat._build_api_agent_spec(
+        {"agent_config": {"name": "gw"}, "display_config": {}}, service_id="gw-1"
+    )
+    dep = _dep_of(spec)
+    assert dep.capability == "llm"
+    assert json.loads(dep.tags) == []
+
+
+def test_a2a_dependency_carries_required_and_schema():
+    """A2A already carried tags+version; ``required``/schema/match_mode were lost."""
+
+    def _handler():  # pragma: no cover - never called
+        return None
+
+    DecoratorRegistry.register_custom_decorator(
+        "mesh_a2a",
+        _handler,
+        {
+            "skill_id": "ask",
+            "dependencies": [ROUTE_DEP],
+        },
+    )
+
+    spec = rust_a2a_heartbeat._build_a2a_agent_spec(
+        {"agent_config": {"name": "gw"}, "display_config": {}}, service_id="gw-1"
+    )
+    dep = _dep_of(spec)
+
+    assert json.loads(dep.tags) == ["+claude", ["python", "typescript"]]
+    assert dep.version == ">=2.0.0"
+    assert dep.required is True
+    assert dep.match_mode == "strict"
+    assert dep.expected_schema_canonical is not None
+    assert dep.expected_schema_hash is not None
+
+
+def test_route_selector_survives_decorator_to_wire_end_to_end():
+    """The real path: @mesh.route -> RouteIntegrationStep -> AgentSpec.
+
+    Asserting on the heartbeat alone would pass even if the integration step
+    never handed the selector over, so drive the whole chain.
+    """
+    from fastapi import FastAPI
+
+    import mesh
+    from _mcp_mesh.pipeline.api_startup.route_integration import RouteIntegrationStep
+    from _mcp_mesh.shared.server_discovery import ServerDiscoveryUtil
+
+    @mesh.route(
+        dependencies=[
+            {
+                "capability": "llm",
+                "tags": ["+claude"],
+                "version": ">=2.0.0",
+                "required": True,
+            }
+        ]
+    )
+    async def ask(llm: mesh.McpMeshTool = None) -> dict:
+        return {"ok": llm is not None}
+
+    app = FastAPI()
+    app.get("/api/v1/ask")(ask)
+
+    route_info = next(
+        r
+        for r in ServerDiscoveryUtil._extract_route_info(app)
+        if r["endpoint_name"] == "ask"
+    )
+    route_info["dependencies"] = ask._mesh_route_metadata["dependencies"]
+
+    step = RouteIntegrationStep()
+    assert step._integrate_single_route(app, route_info, None)["status"] == "integrated"
+
+    spec = rust_api_heartbeat._build_api_agent_spec(
+        {"agent_config": {"name": "gw"}, "display_config": {}}, service_id="gw-1"
+    )
+    dep = _dep_of(spec)
+    assert dep.capability == "llm"
+    assert json.loads(dep.tags) == ["+claude"]
+    assert dep.version == ">=2.0.0"
+    assert dep.required is True
+
+
+class TestUnifiedSelectorValidation:
+    """One ``_validate_dependency_selector`` for all three decorator families.
+
+    The route copy silently dropped ``expected_type``/``match_mode`` and the
+    a2a copy dropped ``required`` on top of that, so a selector that validated
+    cleanly at decoration time reached the registry with fields missing.
+    """
+
+    def _deps(self, decorated):
+        return decorated._mesh_route_metadata["dependencies"]
+
+    def test_route_keeps_expected_type_and_match_mode(self):
+        import mesh
+
+        @mesh.route(
+            dependencies=[
+                {
+                    "capability": "employee",
+                    "expected_type": {"type": "object"},
+                    "match_mode": "strict",
+                }
+            ]
+        )
+        async def handler(employee: mesh.McpMeshTool = None) -> dict:
+            return {}
+
+        dep = self._deps(handler)[0]
+        assert dep["expected_schema_raw"] == {"type": "object"}
+        assert dep["match_mode"] == "strict"
+
+    def test_route_defaults_match_mode_to_subset(self):
+        import mesh
+
+        @mesh.route(
+            dependencies=[
+                {"capability": "employee", "expected_type": {"type": "object"}}
+            ]
+        )
+        async def handler(employee: mesh.McpMeshTool = None) -> dict:
+            return {}
+
+        assert self._deps(handler)[0]["match_mode"] == "subset"
+
+    def test_a2a_keeps_required(self):
+        import mesh
+        from mesh.decorators import a2a as a2a_decorator
+
+        @a2a_decorator(
+            path="/ask", dependencies=[{"capability": "llm", "required": True}]
+        )
+        async def handler(llm: mesh.McpMeshTool = None) -> dict:
+            return {}
+
+        deps = handler._mesh_a2a_metadata["dependencies"]
+        assert deps[0]["required"] is True
+
+    def test_a2a_keeps_expected_type_and_match_mode(self):
+        import mesh
+        from mesh.decorators import a2a as a2a_decorator
+
+        @a2a_decorator(
+            path="/ask",
+            dependencies=[
+                {
+                    "capability": "llm",
+                    "expected_type": {"type": "object"},
+                    "match_mode": "strict",
+                }
+            ],
+        )
+        async def handler(llm: mesh.McpMeshTool = None) -> dict:
+            return {}
+
+        dep = handler._mesh_a2a_metadata["dependencies"][0]
+        assert dep["expected_schema_raw"] == {"type": "object"}
+        assert dep["match_mode"] == "strict"
+
+    @pytest.mark.parametrize(
+        "bad,message",
+        [
+            ({"tags": []}, "dependency must have 'capability' field"),
+            ({"capability": 1}, "dependency capability must be a string"),
+            ({"capability": "c", "tags": "x"}, "dependency tags must be a list"),
+            ({"capability": "c", "tags": [1]}, "tags must be strings or arrays"),
+            ({"capability": "c", "tags": [[1]]}, "OR alternative tags must be strings"),
+            ({"capability": "c", "version": 1}, "dependency version must be a string"),
+            (
+                {"capability": "c", "required": "yes"},
+                "dependency required must be a boolean",
+            ),
+            (
+                {"capability": "c", "match_mode": "loose"},
+                "dependency match_mode must be 'subset' or 'strict'",
+            ),
+            (7, "dependencies must be strings or dictionaries"),
+        ],
+    )
+    def test_all_three_decorators_reject_the_same_shapes(self, bad, message):
+        import mesh
+        from mesh.decorators import a2a as a2a_decorator
+
+        for make in (
+            lambda: mesh.tool(capability="c", dependencies=[bad]),
+            lambda: mesh.route(dependencies=[bad]),
+            lambda: a2a_decorator(path="/p", dependencies=[bad]),
+        ):
+            with pytest.raises(ValueError, match=message):
+
+                @make()
+                async def handler(**kwargs) -> dict:  # pragma: no cover
+                    return {}
+
+
+class TestDependencyIndexAlignment:
+    """Wire specs must be index-aligned with the decorator's dependency list.
+
+    The registry resolves by position (``IndexedResolution.DepIndex``) and the
+    injector applies by position in ``metadata["dependencies"]``. Dropping a
+    degenerate entry from the wire list would shift every later dependency onto
+    the wrong slot — silent cross-wiring, strictly worse than an edge that
+    cannot resolve.
+    """
+
+    def _specs(self, deps):
+        import mcp_mesh_core
+
+        from _mcp_mesh.pipeline.shared.dependency_spec import build_dependency_specs
+
+        return build_dependency_specs(mcp_mesh_core, deps)
+
+    def test_empty_capability_is_published_not_dropped(self):
+        specs = self._specs(
+            [
+                {"capability": "first", "tags": []},
+                {"capability": "", "tags": []},
+                {"capability": "third", "tags": []},
+            ]
+        )
+        assert [s.capability for s in specs] == ["first", "", "third"], (
+            "dropping the empty entry would move 'third' from index 2 to index 1"
+        )
+
+    def test_unsupported_entry_type_keeps_its_slot(self):
+        specs = self._specs([{"capability": "first", "tags": []}, 7, "third"])
+        assert [s.capability for s in specs] == ["first", "", "third"]
+
+    def test_string_and_dict_entries_stay_in_order(self):
+        specs = self._specs(["a", {"capability": "b", "tags": ["x"]}, "c"])
+        assert [s.capability for s in specs] == ["a", "b", "c"]
+        assert json.loads(specs[1].tags) == ["x"]

--- a/src/runtime/python/tests/unit/test_suite_inertness_1589.py
+++ b/src/runtime/python/tests/unit/test_suite_inertness_1589.py
@@ -1,0 +1,69 @@
+"""The test suite must not arm a real pipeline or heartbeat (issue #1589).
+
+Before the auto-run semantics changed, ``MCP_MESH_AUTO_RUN=false`` in
+``conftest.py`` kept the suite inert as a side effect: it stopped
+``_mcp_mesh/__init__.py`` from calling ``start_runtime()``, so the debounce
+coordinator never got an orchestrator and ``_execute_processing`` bailed out.
+
+That side effect is gone by design — ``auto_run=False`` now registers. The
+inert switch is ``MCP_MESH_ENABLED``. These tests assert inertness POSITIVELY,
+because a green suite proves nothing here: the pipeline runs on a
+``threading.Timer``, so a contaminated run raises into ``threading.excepthook``
+and pytest never sees it.
+"""
+
+import os
+import threading
+
+import mesh
+from _mcp_mesh.engine.decorator_registry import DecoratorRegistry
+from _mcp_mesh.pipeline.mcp_startup import get_debounce_coordinator
+
+
+def test_conftest_sets_the_inert_switch():
+    assert os.environ.get("MCP_MESH_ENABLED") == "false", (
+        "conftest must disable mesh outright; MCP_MESH_AUTO_RUN=false no longer "
+        "keeps the runtime from starting (that is the whole point of #1589)"
+    )
+
+
+def test_conftest_still_suppresses_the_immediate_uvicorn():
+    """The @mesh.agent immediate uvicorn is gated on auto_run alone."""
+    assert os.environ.get("MCP_MESH_AUTO_RUN") == "false"
+
+
+def test_no_orchestrator_is_wired_in_the_test_process():
+    """``start_runtime()`` is what sets this; if it ran, the suite registers."""
+    assert get_debounce_coordinator()._orchestrator is None, (
+        "an orchestrator is wired — the suite will run real pipelines and "
+        "heartbeat to MCP_MESH_REGISTRY_URL"
+    )
+
+
+def test_no_heartbeat_thread_is_running():
+    running = [t.name for t in threading.enumerate() if "run_heartbeat" in t.name]
+    assert not running, f"live heartbeat thread(s) in the test process: {running}"
+
+
+def test_decorating_an_agent_does_not_arm_a_pipeline():
+    """Decorators must still register metadata — just not execute anything."""
+    try:
+
+        @mesh.tool(capability="inertness_probe")
+        def _probe() -> str:  # pragma: no cover - never called
+            return "ok"
+
+        @mesh.agent(name="inertness-probe-agent")
+        class _A:  # pragma: no cover - never instantiated
+            pass
+
+        # Metadata registration still works (the suite depends on it)...
+        assert "inertness_probe" in {
+            (d.metadata or {}).get("capability")
+            for d in DecoratorRegistry.get_mesh_tools().values()
+        }
+        # ...but nothing was armed.
+        assert get_debounce_coordinator()._orchestrator is None
+        assert not [t.name for t in threading.enumerate() if "run_heartbeat" in t.name]
+    finally:
+        DecoratorRegistry.clear_all()


### PR DESCRIPTION
Issues #1571 and #1589. **Two breaking changes** — see release notes below.

## #1571 — route and A2A dependency selectors were dropped before the wire

`@mesh.route` edges were reduced to a bare capability name, with `tags`, `version`, `required`, `match_mode` and consumer schemas hardcoded away. `@mesh.a2a` dropped `required`/`match_mode`/schemas while keeping tags and version. Only `@mesh.tool` sent the full selector. All three now build through one shared builder.

**#1571 says the A2A path "does the same" as the route path. It does not** — A2A carried tags and version. Fixed what was actually missing rather than rewriting working code.

### The builder is strictly index-aligned, and that matters more than it looks

The registry resolves by position (`IndexedResolution.DepIndex`) and the injector applies by position in `metadata["dependencies"]`. So dropping a degenerate entry does not merely lose an edge — **it silently rewires every later dependency onto the wrong slot**. Empty capabilities are reachable (the validator accepts `""`), so entries are never dropped or reordered; a placeholder is emitted and a warning logged. Three alignment tests, including `["first", "", "third"]` holding indices 0/1/2.

Dependency validation was copy-pasted three times, each copy dropping different fields. Now one validator.

## #1589 — `MCP_MESH_AUTO_RUN` parsed four different ways

An exact `== "true"` match, a truthy allowlist, a falsy denylist, and one correct site. With `1`/`yes`/`on` the gates disagreed and the agent served `/ready` as 503 forever, never registering.

**The issue describes this backwards.** It says `__init__.py` is permissive and `decorators.py` strict; the reverse is true. It names two sites; there are four. And its "Kubernetes sees a healthy pod that is absent from the mesh" is wrong in the safer direction — the pod never becomes Ready at all.

### `auto_run` now means what it says

No server, no keep-alive. It does **not** mean "stay out of the mesh": the pipeline runs, the agent registers, and the heartbeat keeps it registered on a daemon thread with its own event loop. The decorator argument is honoured; env still wins.

E2E, against a fake registry:

| scenario | registers | heartbeats | mesh serves | blocks caller |
|---|---|---|---|---|
| `auto_run=False` | yes | 4 | no | no |
| `auto_run=True` + `MCP_MESH_AUTO_RUN=false` | yes | 4 | no | no |
| default | yes | 5 | yes | yes |
| `MCP_MESH_ENABLED=false` | no | 0 | no | no |

That required decoupling the import-time gate from auto-run, since `start_runtime()` is the prerequisite for the pipeline that registers. `MCP_MESH_ENABLED` is now the only inert switch, and it **fails closed**: unset enables, truthy enables, anything else — including empty, a routine empty-Helm-value outcome — disables. The old strict comparison had that property; routing it through `get_config_value`'s soft-fail-to-default would have made a typo *enable* the master off switch.

### This repo's own test suite was relying on the old behaviour

`conftest.py` set `MCP_MESH_AUTO_RUN=false` to keep mesh quiet. Under the new semantics that armed a real pipeline and heartbeat during collection — reproduced before fixing:

```
ORCHESTRATOR_SET=True   PENDING_TIMER=True
Background heartbeat thread started for MCP agent 'contamination-probe-agent-...'
mcp_mesh_core: Starting agent with Rust core
NEW_THREADS=['Thread-4 (run_heartbeat)']
mcp_mesh_core::registry: error sending request for url (http://localhost:8000/agents/...)
```

**From a green run** — `_execute_processing` runs on a `threading.Timer`, so its failures never reach pytest. conftest now uses `MCP_MESH_ENABLED=false`, with inertness asserted positively rather than inferred from a passing suite. `PYTEST_RUNNING` was deleted: nothing read it, so it implied a guard that did not exist.

### Embedded startup reports through `mesh.startup_status()`

The first attempt raised on pipeline failure, with a comment claiming it mirrored the auto-run branch. It did not — that branch deliberately calls `abort_agent_process()` because *"a raise would only kill the timer thread and leave the immediate uvicorn serving probes for an agent that never registered (issue #1556)"*. In embedded mode the caller's server is by definition still running, so a raise reproduces #1556 exactly; and `abort_agent_process()` is also wrong, because mesh does not own the process. Failure is now recorded in a pollable status record, tested through the real Timer path.

## Release notes

> **Breaking: `MCP_MESH_AUTO_RUN=false` and `@mesh.agent(auto_run=False)` no longer keep an agent out of the mesh (Python).** `auto_run` gates the HTTP server and process lifetime only. An agent with auto-run disabled now runs its pipeline, registers and heartbeats; mesh starts no server and does not block. **If you used `MCP_MESH_AUTO_RUN=false` to keep mesh quiet in CI, switch to `MCP_MESH_ENABLED=false`** — otherwise those processes will now register into whatever `MCP_MESH_REGISTRY_URL` points at. `MCP_MESH_ENABLED` fails closed: unset or truthy enables, anything else disables.

> **`@mesh.route` and `@mesh.a2a` dependency selectors now reach the registry (Python).** A deployed gateway declaring `tags: ["+claude"]` on a route dependency has been resolving against *any* provider of that capability and will now resolve only against matching ones — intended, but a routing change on upgrade. The shared validator is also stricter: a non-boolean `required`, or a `match_mode` outside `{"subset","strict"}`, now fails at decoration on route/a2a instead of being ignored.

## Known limits, documented not hidden

Embedded MCP mode has no public accessor for the pipeline-built FastAPI app and installs no SIGTERM handler, so removal is by registry timeout rather than prompt deregistration. Practical today for `@mesh.route`/`@mesh.a2a`, where you own the app. Exposing a handle and a shutdown path needs a design decision and is not in this PR.

## Tests

Full Python suite green (deterministic + three randomized orders, 1 pre-existing skip); `ruff check` and `ruff format --check` clean across 270 files; `go build ./...` clean; man goldens 1852 → 1870 inline and 450 → 452 markup list lines, each annotated with its cause.

Closes #1571
Closes #1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfukAUDerBUKAfKzUyhvvb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `MCP_MESH_ENABLED` as a runtime-wide switch to disable mesh activity.
  - Added embedded-mode startup status reporting through `mesh.startup_status()`.
  - `auto_run=False` now supports non-blocking operation while preserving registration and heartbeat behavior.
  - Dependency selectors now retain tags, versions, required flags, match modes, and expected schemas across supported integrations.

- **Documentation**
  - Clarified the differences between `MCP_MESH_ENABLED`, `MCP_MESH_AUTO_RUN`, and embedded mode.
  - Updated testing guidance and examples for the new runtime controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->