### PR TITLE
fix(ts): sseStream parked on backpressure instead of cutting the stream

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -473,6 +473,21 @@ export MCP_MESH_PROXY_TIMEOUT=120
 export MCP_MESH_CALL_TIMEOUT=600
 ```
 
+**SSE consumer backpressure (TypeScript):**
+
+`mesh.sseStream` treats a consumer slower than the producer as slow, not
+disconnected — it waits for the response to drain before sending the next
+frame, so a browser on a slow link still receives every chunk and the
+`[DONE]` terminator. A consumer that stalls without disconnecting emits
+neither `close` nor `error`, so the wait is bounded; when the budget
+elapses the stream is ended and the upstream iterator released.
+
+```bash
+# Seconds mesh.sseStream waits for a backpressured SSE consumer to drain
+# before abandoning the stream (default: 300, 0 = wait forever)
+export MCP_MESH_SSE_DRAIN_TIMEOUT=300
+```
+
 ## MeshJob event channel
 
 Tunables for the [MeshJob event injection + stream subscription

--- a/src/core/cli/man/content/environment.md
+++ b/src/core/cli/man/content/environment.md
@@ -553,6 +553,18 @@ budget from `MCP_MESH_CALL_TIMEOUT`, else 300s.
 
 Streamed responses (e.g., SSE) routed through the registry proxy are bounded by the same call timeout — the proxy ends the exchange when it elapses, even mid-stream. Send a larger `X-Mesh-Timeout` header (or raise `MCP_MESH_PROXY_TIMEOUT`) for long-lived streams.
 
+On the browser-facing side, `mesh.sseStream` (TypeScript) treats a slow
+consumer as slow, not gone: it waits for the response to drain before
+sending the next frame. A consumer that stalls without ever disconnecting
+is abandoned after the drain budget below, which releases the upstream
+stream it was holding open.
+
+```bash
+# TypeScript only — seconds mesh.sseStream waits for a backpressured SSE
+# consumer to drain before abandoning the stream (default: 300, 0 = forever)
+export MCP_MESH_SSE_DRAIN_TIMEOUT=300
+```
+
 ## MeshJob event channel
 
 Tunables for the MeshJob event injection + stream subscription surface

--- a/src/core/cli/man/renderer_test.go
+++ b/src/core/cli/man/renderer_test.go
@@ -627,8 +627,14 @@ func TestStyleInlineNoStrayItalicBetweenCodeSpans(t *testing.T) {
 // not own), plus the missing app accessor and missing graceful deregistration.
 // Eight new inline spans, and the two limits are markup-carrying list lines.
 // 1862 + 8 = 1870; 450 + 2 = 452.
+//
+// Issue #1567 gave `environment.md` the SSE drain budget under Proxy &
+// Timeout: mesh.sseStream now parks on backpressure instead of cutting the
+// stream, so the bound on that wait needs a documented knob. One new inline
+// span (`mesh.sseStream` in the prose) — the env var itself only appears
+// inside the fenced example. 1870 + 1 = 1871.
 const (
-	wantInlineCodeSpans = 1870
+	wantInlineCodeSpans = 1871
 	wantListCodeSpans   = 531
 	wantMarkupListLines = 452
 )

--- a/src/runtime/typescript/src/__tests__/sse-stream-backpressure.test.ts
+++ b/src/runtime/typescript/src/__tests__/sse-stream-backpressure.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Backpressure tests for sse-stream.ts (mesh.sseStream) — issue #1567.
+ *
+ * These run against a REAL HTTP server and a REAL TCP client socket. A mock
+ * that returns ``false`` on command would pass against a fix that is wrong
+ * about Node stream semantics (when ``drain`` actually fires, what a
+ * destroyed response emits, whether ``end()`` flushes a queued frame), so the
+ * consumer here is a paused socket that genuinely fills the kernel buffer and
+ * makes ``res.write()`` return ``false`` on its own.
+ *
+ * Covered:
+ * - a slow consumer receives every chunk AND the ``[DONE]`` terminator
+ * - a consumer that disconnects while the producer is parked on ``drain``
+ *   terminates promptly with upstream ``return()`` cleanup
+ * - drain listeners do not accumulate across many backpressure cycles
+ * - a consumer that stalls without disconnecting is bounded by
+ *   ``MCP_MESH_SSE_DRAIN_TIMEOUT``
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import http from "node:http";
+import net from "node:net";
+import type { AddressInfo } from "node:net";
+import type { Response } from "express";
+import { sseStream } from "../sse-stream.js";
+
+/** 128 KiB per frame — comfortably past any socket highWaterMark. */
+const CHUNK_BODY = "x".repeat(128 * 1024);
+
+/** Frames are prefixed with ``#<index>#`` so the client can count them. */
+function chunkAt(i: number): string {
+  return `#${i}#${CHUNK_BODY}`;
+}
+
+interface ServerCtx {
+  port: number;
+  /** Resolves when the sseStream() call in the handler returns. */
+  handlerDone: Promise<void>;
+  /** True once handlerDone has settled — used to assert "still streaming". */
+  isDone: () => boolean;
+  /** Resolves the first time res.write() genuinely returned false. */
+  backpressured: Promise<void>;
+  /** Count of write() calls that returned false (real backpressure events). */
+  falseCount: () => number;
+  /** Peak listener counts observed one microtask after each false write. */
+  peakListeners: () => { drain: number; close: number; error: number };
+  /** Listener counts after the handler finished. */
+  finalListeners: () => { drain: number; close: number; error: number };
+  close: () => Promise<void>;
+}
+
+function startSseServer(source: AsyncIterable<string>): Promise<ServerCtx> {
+  let falses = 0;
+  let done = false;
+  const peak = { drain: 0, close: 0, error: 0 };
+  const final = { drain: 0, close: 0, error: 0 };
+  let resolveDone!: () => void;
+  let resolveBackpressured!: () => void;
+  const handlerDone = new Promise<void>((r) => {
+    resolveDone = r;
+  });
+  const backpressured = new Promise<void>((r) => {
+    resolveBackpressured = r;
+  });
+
+  const server = http.createServer((_req, res) => {
+    const counts = (): { drain: number; close: number; error: number } => ({
+      drain: res.listenerCount("drain"),
+      close: res.listenerCount("close"),
+      error: res.listenerCount("error"),
+    });
+    const baseline = counts();
+    const origWrite = res.write.bind(res);
+    // Real write, real return value — only the bookkeeping is ours.
+    res.write = ((data: string) => {
+      const ok = origWrite(data);
+      if (!ok) {
+        falses += 1;
+        resolveBackpressured();
+        // One microtask later the producer has attached its drain/close/error
+        // listeners (waitForDrain runs synchronously after write returns).
+        queueMicrotask(() => {
+          const c = counts();
+          peak.drain = Math.max(peak.drain, c.drain - baseline.drain);
+          peak.close = Math.max(peak.close, c.close - baseline.close);
+          peak.error = Math.max(peak.error, c.error - baseline.error);
+        });
+      }
+      return ok;
+    }) as typeof res.write;
+
+    void sseStream(res as unknown as Response, source).then(() => {
+      const c = counts();
+      final.drain = c.drain - baseline.drain;
+      final.close = c.close - baseline.close;
+      final.error = c.error - baseline.error;
+      done = true;
+      resolveDone();
+    });
+  });
+
+  return new Promise<ServerCtx>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve({
+        port: (server.address() as AddressInfo).port,
+        handlerDone,
+        isDone: () => done,
+        backpressured,
+        falseCount: () => falses,
+        peakListeners: () => ({ ...peak }),
+        finalListeners: () => ({ ...final }),
+        close: () =>
+          new Promise<void>((r) => {
+            server.closeAllConnections?.();
+            server.close(() => r());
+          }),
+      });
+    });
+  });
+}
+
+interface ClientCtx {
+  socket: net.Socket;
+  /** Everything received so far (raw, including chunked-transfer framing). */
+  received: () => string;
+  /**
+   * Resolves once ``marker`` appears in the received bytes.
+   *
+   * Completion is detected from the body rather than from socket close:
+   * sseStream sets ``Connection: keep-alive``, so the server holds the
+   * connection for ``keepAliveTimeout`` (5s) after the response ends.
+   */
+  waitFor: (marker: string) => Promise<void>;
+  /** Resolves when the connection is closed (used for the destroy paths). */
+  closed: Promise<void>;
+}
+
+/**
+ * Connect and send the request, then STOP READING. The socket stays paused
+ * until the caller resumes it, which is what fills the buffer and forces
+ * real backpressure on the server side.
+ */
+function connectPaused(port: number): Promise<ClientCtx> {
+  return new Promise<ClientCtx>((resolve) => {
+    let buf = "";
+    const waiters: { marker: string; resolve: () => void }[] = [];
+    const socket = net.connect(port, "127.0.0.1", () => {
+      socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+      socket.pause();
+      resolve({
+        socket,
+        received: () => buf,
+        waitFor: (marker: string) =>
+          new Promise<void>((r) => {
+            if (buf.includes(marker)) {
+              r();
+              return;
+            }
+            waiters.push({ marker, resolve: r });
+          }),
+        closed,
+      });
+    });
+    socket.on("data", (b: Buffer) => {
+      buf += b.toString("utf8");
+      for (let i = waiters.length - 1; i >= 0; i--) {
+        if (buf.includes(waiters[i].marker)) {
+          waiters.splice(i, 1)[0].resolve();
+        }
+      }
+    });
+    socket.on("error", () => {
+      /* a mid-stream destroy surfaces as ECONNRESET; not a test failure */
+    });
+    const closed = new Promise<void>((r) => socket.on("close", () => r()));
+  });
+}
+
+/** Indices of the ``#<i>#``-prefixed frames present in a raw SSE response. */
+function receivedIndices(raw: string): number[] {
+  return [...raw.matchAll(/^data: #(\d+)#/gm)].map((m) => Number(m[1]));
+}
+
+async function* framesUpTo(n: number): AsyncGenerator<string, void, void> {
+  for (let i = 0; i < n; i++) {
+    yield chunkAt(i);
+  }
+}
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+/** Bound a wait so a regression reports what never happened, not "timed out". */
+async function within<T>(p: Promise<T>, ms: number, what: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const guard = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms: ${what}`)), ms);
+  });
+  try {
+    return await Promise.race([p, guard]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("sseStream backpressure (real socket)", () => {
+  it("delivers every chunk and [DONE] to a consumer slower than the producer", async () => {
+    const N = 24;
+    const server = await startSseServer(framesUpTo(N));
+    const client = await connectPaused(server.port);
+
+    // Consumer reads nothing for 200ms — the producer fills the socket buffer
+    // and res.write() starts returning false for real.
+    await server.backpressured;
+    expect(
+      server.isDone(),
+      "sseStream ended on backpressure instead of parking on drain"
+    ).toBe(false);
+    await delay(200);
+    client.socket.resume();
+
+    await within(server.handlerDone, 3000, "sseStream never finished");
+    await within(
+      client.waitFor("data: [DONE]"),
+      3000,
+      "slow consumer never received the [DONE] terminator"
+    );
+
+    // Guard against a vacuous pass: the run must actually have backpressured.
+    expect(server.falseCount()).toBeGreaterThan(0);
+
+    const raw = client.received();
+    expect(receivedIndices(raw)).toEqual([...Array(N).keys()]);
+    expect(raw).toContain("data: [DONE]");
+
+    await server.close();
+  });
+
+  it("keeps drain/close/error listeners flat across many backpressure cycles", async () => {
+    const N = 24;
+    const server = await startSseServer(framesUpTo(N));
+    const client = await connectPaused(server.port);
+
+    await server.backpressured;
+    await delay(150);
+    client.socket.resume();
+    await within(server.handlerDone, 3000, "sseStream never finished");
+    await within(
+      client.waitFor("data: [DONE]"),
+      3000,
+      "slow consumer never received the [DONE] terminator"
+    );
+
+    // Many cycles, so an un-removed listener would show up as a growing count.
+    expect(server.falseCount()).toBeGreaterThan(3);
+    expect(server.peakListeners()).toEqual({ drain: 1, close: 1, error: 1 });
+    expect(server.finalListeners()).toEqual({ drain: 0, close: 0, error: 0 });
+
+    await server.close();
+  });
+
+  it("terminates promptly with upstream cleanup when the consumer disconnects mid-drain", async () => {
+    let returnCalled = false;
+    let produced = 0;
+
+    async function* tracked(): AsyncGenerator<string, void, void> {
+      try {
+        for (let i = 0; i < 200; i++) {
+          produced += 1;
+          yield chunkAt(i);
+        }
+      } finally {
+        returnCalled = true;
+      }
+    }
+
+    const server = await startSseServer(tracked());
+    const client = await connectPaused(server.port);
+
+    // Never read: the producer parks on 'drain', which will never fire.
+    await server.backpressured;
+    await delay(150);
+    expect(
+      server.isDone(),
+      "sseStream ended on backpressure instead of parking on drain"
+    ).toBe(false);
+    const producedWhileParked = produced;
+
+    client.socket.destroy();
+
+    await within(
+      server.handlerDone,
+      3000,
+      "sseStream did not terminate after the consumer disconnected mid-drain"
+    );
+
+    expect(returnCalled).toBe(true);
+    // No further chunks were pulled from upstream after the disconnect.
+    expect(produced).toBe(producedWhileParked);
+
+    await server.close();
+  });
+
+  it("abandons a consumer that stalls without disconnecting after MCP_MESH_SSE_DRAIN_TIMEOUT", async () => {
+    vi.stubEnv("MCP_MESH_SSE_DRAIN_TIMEOUT", "0.3");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    let returnCalled = false;
+    async function* tracked(): AsyncGenerator<string, void, void> {
+      try {
+        for (let i = 0; i < 200; i++) {
+          yield chunkAt(i);
+        }
+      } finally {
+        returnCalled = true;
+      }
+    }
+
+    const server = await startSseServer(tracked());
+    const client = await connectPaused(server.port);
+
+    // The client stays connected and simply never reads: no 'close', no
+    // 'error', no 'drain'. Only the timeout can release the upstream.
+    await server.backpressured;
+    const started = Date.now();
+    await within(
+      server.handlerDone,
+      4000,
+      "sseStream never gave up on a consumer stalled without disconnecting"
+    );
+
+    expect(Date.now() - started).toBeLessThan(3000);
+    expect(returnCalled).toBe(true);
+    expect(warn.mock.calls.flat().join(" ")).toMatch(
+      /stalled without disconnecting/
+    );
+    // The timeout path destroys the socket so it does not linger. Resume the
+    // client first: a paused socket does not process the teardown.
+    client.socket.resume();
+    await client.closed;
+
+    await server.close();
+  });
+});

--- a/src/runtime/typescript/src/__tests__/sse-stream.test.ts
+++ b/src/runtime/typescript/src/__tests__/sse-stream.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
 import type { Response } from "express";
 import { sseStream } from "../sse-stream.js";
 
@@ -150,7 +151,11 @@ describe("sseStream", () => {
     expect(res.end).toHaveBeenCalledTimes(1);
   });
 
-  it("stops iterating and calls return() on consumer disconnect (write returns false)", async () => {
+  // NOTE (#1567): the disconnect signal is ``writableEnded``, NOT write()
+  // returning false — a bare false is backpressure and must not end the
+  // stream. This fake sets writableEnded inside write(), so it is a genuine
+  // disconnect; see the "resumes after drain" case below for the other half.
+  it("stops iterating and calls return() on consumer disconnect (writableEnded)", async () => {
     const res = makeFakeRes();
     let returnCalled = false;
     let yielded = 0;
@@ -171,7 +176,8 @@ describe("sseStream", () => {
       },
     };
 
-    // After first write, simulate disconnect
+    // After first write, simulate disconnect: the consumer going away is what
+    // flips writableEnded, and that is what must stop iteration.
     res.write = vi.fn(() => {
       res._written.push("first-write");
       res.writableEnded = true; // Simulate consumer disconnect
@@ -197,6 +203,119 @@ describe("sseStream", () => {
     expect(res.flushHeaders).not.toHaveBeenCalled();
     // Still writes data + [DONE]
     expect(res._written).toEqual(["data: a\n\n", "data: [DONE]\n\n"]);
+  });
+
+  // --- backpressure control flow (issue #1567) ---------------------------
+  //
+  // These use an EventEmitter-backed fake to pin the CONTROL FLOW: a write
+  // that reports backpressure pauses, then resumes on drain, and abandons the
+  // wait when the response closes. They deliberately do not try to prove Node
+  // stream semantics — that is what the real-socket suite in
+  // sse-stream-backpressure.test.ts is for.
+
+  interface EmitterRes extends EventEmitter {
+    headersSent: boolean;
+    writableEnded: boolean;
+    destroyed: boolean;
+    setHeader: ReturnType<typeof vi.fn>;
+    write: (data: string) => boolean;
+    end: () => void;
+    flushHeaders: () => void;
+    _written: string[];
+    _backpressure: boolean;
+  }
+
+  function makeEmitterRes(): EmitterRes {
+    const res = new EventEmitter() as EmitterRes;
+    res.headersSent = false;
+    res.writableEnded = false;
+    res.destroyed = false;
+    res._written = [];
+    res._backpressure = false;
+    res.setHeader = vi.fn();
+    res.flushHeaders = (): void => {
+      res.headersSent = true;
+    };
+    res.write = (data: string): boolean => {
+      res._written.push(data);
+      return !res._backpressure;
+    };
+    res.end = (): void => {
+      res.writableEnded = true;
+    };
+    return res;
+  }
+
+  it("pauses on backpressure and resumes on drain instead of cutting the stream", async () => {
+    const res = makeEmitterRes();
+    res._backpressure = true;
+
+    // Release the producer one drain at a time; clear backpressure after the
+    // second frame so the rest of the stream flows normally.
+    let drains = 0;
+    res.on("newListener", (event: string) => {
+      if (event !== "drain") return;
+      queueMicrotask(() => {
+        drains += 1;
+        if (drains >= 2) res._backpressure = false;
+        res.emit("drain");
+      });
+    });
+
+    await sseStream(res as unknown as Response, asyncIter(["a", "b", "c"]));
+
+    expect(res._written).toEqual([
+      "data: a\n\n",
+      "data: b\n\n",
+      "data: c\n\n",
+      "data: [DONE]\n\n",
+    ]);
+    expect(drains).toBe(2);
+    expect(res.writableEnded).toBe(true);
+    // The losers of each drain race are removed — no handler accumulation.
+    expect(res.listenerCount("drain")).toBe(0);
+    expect(res.listenerCount("close")).toBe(0);
+    expect(res.listenerCount("error")).toBe(0);
+  });
+
+  it("abandons the drain wait and releases upstream when the response closes", async () => {
+    const res = makeEmitterRes();
+    res._backpressure = true; // drain will never arrive
+    let returnCalled = false;
+    let pulled = 0;
+
+    async function* tracked(): AsyncGenerator<string, void, void> {
+      try {
+        for (let i = 0; i < 10; i++) {
+          pulled += 1;
+          yield `chunk${i}`;
+        }
+      } finally {
+        returnCalled = true;
+      }
+    }
+
+    let parkedOnDrain = false;
+    res.on("newListener", (event: string) => {
+      if (event !== "close") return;
+      parkedOnDrain = true;
+      queueMicrotask(() => {
+        res.destroyed = true;
+        res.emit("close");
+      });
+    });
+
+    await sseStream(res as unknown as Response, tracked());
+
+    // The producer must have PARKED (raced drain against close) rather than
+    // treating the backpressure as an immediate disconnect.
+    expect(parkedOnDrain).toBe(true);
+    expect(returnCalled).toBe(true);
+    expect(pulled).toBe(1);
+    expect(res._written).toEqual(["data: chunk0\n\n"]);
+    expect(res.listenerCount("drain")).toBe(0);
+    expect(res.listenerCount("close")).toBe(0);
+    expect(res.listenerCount("error")).toBe(0);
   });
 
   it("handles synchronous res.write throwing without crashing", async () => {

--- a/src/runtime/typescript/src/sse-stream.ts
+++ b/src/runtime/typescript/src/sse-stream.ts
@@ -25,6 +25,120 @@
 
 import type { Response } from "express";
 
+/**
+ * Seconds to wait for a backpressured response to drain before giving up on
+ * the consumer. ``0`` disables the bound entirely (wait forever).
+ *
+ * Default matches ``MCP_MESH_CALL_TIMEOUT``'s fallback (300s): a stream that
+ * has not moved a byte for longer than the default mesh call budget is
+ * holding an upstream iterator — and therefore an upstream agent's generator
+ * and connection — for longer than any single mesh call is allowed to take.
+ * Unlike a disconnect, a stalled-but-connected consumer (a zero-window peer
+ * that never sends FIN) emits neither ``close`` nor ``error``, so without a
+ * bound nothing would ever release that upstream.
+ *
+ * Read at call time, not module load, so a process that configures its
+ * environment late (or a test) sees the current value.
+ */
+const DEFAULT_DRAIN_TIMEOUT_SECS = 300;
+
+const warnedDrainTimeoutValues = new Set<string>();
+
+function resolveDrainTimeoutMs(): number {
+  const raw = process.env.MCP_MESH_SSE_DRAIN_TIMEOUT;
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_DRAIN_TIMEOUT_SECS * 1000;
+  }
+  const parsed = Number(raw.trim());
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    if (!warnedDrainTimeoutValues.has(raw)) {
+      warnedDrainTimeoutValues.add(raw);
+      console.warn(
+        `[mcp-mesh] Invalid MCP_MESH_SSE_DRAIN_TIMEOUT value '${raw}' — using default ${DEFAULT_DRAIN_TIMEOUT_SECS}s`
+      );
+    }
+    return DEFAULT_DRAIN_TIMEOUT_SECS * 1000;
+  }
+  return parsed * 1000;
+}
+
+/**
+ * Outcome of one attempted frame write.
+ *
+ * The three states are deliberately distinct: ``res.write()`` returning
+ * ``false`` means the internal buffer passed ``highWaterMark`` — the frame
+ * WAS accepted and queued — not that the consumer went away. Collapsing it
+ * into a single boolean is what made a slow consumer look like a disconnect
+ * (issue #1567).
+ */
+type WriteOutcome = "ok" | "backpressure" | "closed";
+
+/** Outcome of waiting for a backpressured response to drain. */
+type DrainOutcome = "drained" | "closed" | "timeout";
+
+/**
+ * Minimal EventEmitter surface used for the drain race.
+ *
+ * Every real Express/Node ``ServerResponse`` is an EventEmitter; this type
+ * exists so the wait can be skipped (rather than throwing) for a hand-rolled
+ * test double that only implements ``write``/``end``.
+ */
+interface DrainEvents {
+  once(event: string, listener: (...args: unknown[]) => void): unknown;
+  removeListener(event: string, listener: (...args: unknown[]) => void): unknown;
+}
+
+/**
+ * Wait for a backpressured response to drain, racing the connection dying.
+ *
+ * A consumer that disconnects while we are parked here never emits
+ * ``drain``, so ``close`` and ``error`` are raced alongside it — otherwise
+ * the producer (and the upstream iterator it holds open) would hang forever.
+ * Exactly one of the three listeners wins; the losers are removed on every
+ * path, so a stream that backpressures thousands of times does not
+ * accumulate handlers.
+ */
+function waitForDrain(res: Response, timeoutMs: number): Promise<DrainOutcome> {
+  if (res.writableEnded || res.destroyed) {
+    return Promise.resolve("closed");
+  }
+  const emitter = res as unknown as Partial<DrainEvents>;
+  if (typeof emitter.once !== "function" || typeof emitter.removeListener !== "function") {
+    // Not an EventEmitter (test double): drain can never be observed, so
+    // treat the backpressure as terminal rather than parking forever.
+    return Promise.resolve("closed");
+  }
+  const once = emitter.once.bind(emitter) as DrainEvents["once"];
+  const removeListener = emitter.removeListener.bind(emitter) as DrainEvents["removeListener"];
+
+  return new Promise<DrainOutcome>((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (outcome: DrainOutcome): void => {
+      if (settled) return;
+      settled = true;
+      removeListener("drain", onDrain);
+      removeListener("close", onClose);
+      removeListener("error", onError);
+      if (timer !== undefined) clearTimeout(timer);
+      resolve(outcome);
+    };
+    const onDrain = (): void => finish("drained");
+    const onClose = (): void => finish("closed");
+    const onError = (): void => finish("closed");
+    once("drain", onDrain);
+    once("close", onClose);
+    // Also claims the 'error' event for the duration of the wait: an
+    // unhandled 'error' on a ServerResponse would otherwise be thrown.
+    once("error", onError);
+    if (timeoutMs > 0) {
+      timer = setTimeout(() => finish("timeout"), timeoutMs);
+      // Never hold the process open just to time out a drain wait.
+      if (typeof timer.unref === "function") timer.unref();
+    }
+  });
+}
+
 const SSE_HEADERS: Record<string, string> = {
   "Content-Type": "text/event-stream",
   "Cache-Control": "no-cache",
@@ -63,6 +177,13 @@ function frameChunkAsSSE(chunk: string): string {
  * stops cleanly via the iterable's ``return()`` method (so the upstream
  * proxy stream's ``finally`` block can release its underlying reader).
  *
+ * A consumer that is merely SLOW is not a disconnect: when ``res.write()``
+ * reports backpressure the frame is already queued, so iteration pauses
+ * until the response drains (racing ``close``/``error`` so a consumer that
+ * leaves mid-wait still releases the upstream). A consumer that stalls
+ * without disconnecting is abandoned after ``MCP_MESH_SSE_DRAIN_TIMEOUT``
+ * seconds (default 300, ``0`` waits forever).
+ *
  * @param res - Express response object
  * @param source - Async iterable yielding strings
  */
@@ -99,21 +220,32 @@ export async function sseStream(
       // ignore — response may already be torn down
     }
   };
-  const safeWrite = (data: string): boolean => {
-    if (!writable) return false;
+  const safeWrite = (data: string): WriteOutcome => {
+    if (!writable) return "closed";
     if (res.writableEnded || res.destroyed) {
       writable = false;
-      return false;
+      return "closed";
     }
     try {
-      return res.write(data);
+      // false here means the frame was queued but the buffer is over its
+      // highWaterMark — backpressure, NOT a disconnect (issue #1567).
+      return res.write(data) ? "ok" : "backpressure";
     } catch {
       writable = false;
-      return false;
+      return "closed";
     }
   };
 
   const iterator = source[Symbol.asyncIterator]();
+  const releaseUpstream = async (): Promise<void> => {
+    if (typeof iterator.return === "function") {
+      try {
+        await iterator.return();
+      } catch {
+        // upstream cleanup is best-effort
+      }
+    }
+  };
   try {
     while (true) {
       const { value, done } = await iterator.next();
@@ -124,32 +256,53 @@ export async function sseStream(
           error: `sseStream: expected string chunk, got ${typeof value}`,
           type: "TypeError",
         });
+        // Return value ignored: the frame is queued even when write()
+        // reports backpressure, and res.end() flushes whatever is buffered
+        // before sending FIN, so a false here still reaches a live consumer.
         safeWrite(`event: error\ndata: ${errPayload}\n\n`);
         safeEnd();
         // best-effort cleanup of upstream
-        if (typeof iterator.return === "function") {
-          try {
-            await iterator.return();
-          } catch {
-            // ignore
-          }
-        }
+        await releaseUpstream();
         return;
       }
-      const wroteOk = safeWrite(frameChunkAsSSE(value));
-      if (!wroteOk) {
+      const outcome = safeWrite(frameChunkAsSSE(value));
+      if (outcome === "closed") {
         // Consumer disconnected (or write threw) — clean up upstream and end.
-        if (typeof iterator.return === "function") {
-          try {
-            await iterator.return();
-          } catch {
-            // ignore
-          }
-        }
+        await releaseUpstream();
         safeEnd();
         return;
       }
+      if (outcome === "backpressure") {
+        // The frame is already queued; wait for the socket to catch up before
+        // pushing more at it. Racing close/error means a consumer that walks
+        // away mid-wait still releases the upstream iterator promptly.
+        const drain = await waitForDrain(res, resolveDrainTimeoutMs());
+        if (drain !== "drained") {
+          if (drain === "timeout") {
+            console.warn(
+              "[mcp-mesh] sseStream: consumer stalled without disconnecting; " +
+                "abandoning the stream after MCP_MESH_SSE_DRAIN_TIMEOUT"
+            );
+          }
+          writable = false;
+          await releaseUpstream();
+          safeEnd();
+          if (drain === "timeout") {
+            // end() alone cannot help here: the FIN queues behind a buffer
+            // the peer is not reading, so the socket would linger. Destroy it
+            // so the timeout actually reclaims the connection.
+            try {
+              res.destroy();
+            } catch {
+              // ignore — response may already be torn down
+            }
+          }
+          return;
+        }
+      }
     }
+    // Return value ignored for the same reason as the error frame above: a
+    // backpressured [DONE] is still queued, and end() flushes it.
     safeWrite("data: [DONE]\n\n");
     safeEnd();
   } catch (err) {
@@ -163,12 +316,6 @@ export async function sseStream(
     // iterator itself (e.g. safeWrite threw). Without this, an upstream
     // proxy.stream() generator's finally block — which cancels the
     // OkHttp/fetch reader — never runs until GC, leaking the connection.
-    if (typeof iterator.return === "function") {
-      try {
-        await iterator.return();
-      } catch {
-        /* upstream cleanup is best-effort */
-      }
-    }
+    await releaseUpstream();
   }
 }


### PR DESCRIPTION
Issue #1567.

`res.write()` returning `false` means the kernel buffer is full, not that the consumer disconnected. `safeWrite` returned that boolean directly and the loop treated it as a disconnect — so **any consumer slower than the producer** (a browser on a slow link, a buffering proxy) had the stream cut after the first chunk that filled the socket buffer, **with no `[DONE]` frame**. The consumer cannot distinguish a truncated stream from a complete one.

Reproduced standalone before writing any code: **1 of 40 chunks delivered, no `[DONE]`**. After: 40 of 40.

## The root shape

`safeWrite` collapsed four outcomes into one `false`: not-writable, ended/destroyed, write threw, and backpressure. Only the first three are disconnects. It now returns a tri-state (`"ok" | "backpressure" | "closed"`), so the ambiguity cannot be reintroduced by the next caller — patching the loop condition alone would have left the trap in place.

## The issue's suggested fix is incomplete as written

#1567 proposes `await once(res, 'drain')` racing `close`. Taken literally that swaps truncation for a **hang**: it resolves on neither a consumer that disconnects mid-park nor a peer that stalls without sending FIN, and it omits `error` and the `destroyed` recheck. Treated as a direction, not a patch.

The loop now races `drain` against `close`, `error` and a bounded timeout, re-checking `writableEnded || destroyed` up front, and removes all listeners on every exit path.

## The drain wait is bounded — `MCP_MESH_SSE_DRAIN_TIMEOUT`, default 300s, `0` disables

Express and Starlette both wait unbounded, so this needed justifying rather than assuming. `sseStream` is not a plain response: it holds an **upstream async iterator** — a live connection to another mesh agent plus that agent's generator. A zero-window peer that never sends FIN emits neither `close` nor `error`, so an unbounded wait releases nothing on any hop.

300s is the default mesh call budget: a stream idle longer than that is pinning an upstream for longer than any single mesh call is permitted to take.

The timeout path warns, releases upstream, ends — **and destroys the socket**, because `end()` alone queues FIN behind a buffer the peer is not reading, so the connection would linger until the OS gave up. Scoped to the timeout path only; a genuine `close` needs no destroy.

## Tests use a real socket, not a mock

A mock returning `false` on command would pass against a fix that is wrong about real Node stream semantics — which is exactly the failure mode here. The new `sse-stream-backpressure.test.ts` drives a real `http.Server` with a real `net.Socket` client that sends the request and then **stops reading**, so `write()` returns `false` on its own (10–24 genuine backpressure events per run). Every case asserts `falseCount > 0` so none can pass vacuously.

- slow consumer receives all 24 × 128 KiB frames **and** `[DONE]`
- listeners stay flat across many drain cycles — peak `{drain:1, close:1, error:1}`, final `{0,0,0}`, sampled one microtask after each `false`
- disconnect mid-drain: asserts the handler is **still parked** 150 ms in, then destroys the socket and requires termination within 3 s with upstream `return()` and no further `next()` pulls
- stalled-but-connected: never reads, never disconnects, gives up at the configured timeout with upstream released

Two mock-level tests were added alongside, explicitly labelled as pinning control flow rather than proving Node semantics.

All six verified failing against the unfixed source, including:
```
× delivers every chunk and [DONE] to a consumer slower than the producer
  → timed out after 3000ms: slow consumer never received the [DONE] terminator
× terminates promptly with upstream cleanup when the consumer disconnects mid-drain
  → sseStream ended on backpressure instead of parking on drain: expected true to be false
```

## Honest limits

The `[DONE]` frame's own `safeWrite` return is still ignored, which is correct — a backpressured frame is queued and `end()` flushes it before FIN, proven end-to-end by the slow-consumer test whose *first* frame writes under `false` and still arrives. But no deterministic test forces `false` on the `[DONE]` write specifically: after the fix, `drain` only fires once the buffer is empty, so the 14-byte terminator always returns `true`. That frame is covered by inference from the first-frame case, not by its own test. Comments at all three ignoring call sites record why.

## Tests

vitest 1467/1467 across 98 files; `typecheck:all` green on Express 4 and 5; `go test ./src/core/cli/man/` green with the golden bumped 1870 → 1871 and annotated.

`npm run lint` could not run — eslint is not installed in this checkout, pre-existing and unrelated.

Closes #1567

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfukAUDerBUKAfKzUyhvvb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved TypeScript SSE streaming to distinguish slow consumers from disconnected clients.
  - Streams now pause while connected consumers catch up, helping prevent missed or prematurely terminated responses.
  - Added `MCP_MESH_SSE_DRAIN_TIMEOUT` to control how long stalled connections are allowed to recover (default: 300 seconds; `0` waits indefinitely).

- **Documentation**
  - Documented SSE backpressure behavior and the new environment variable in the environment variable references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->